### PR TITLE
fix(ui5-checkbox): cursor over text

### DIFF
--- a/packages/main/src/themes/base/CheckBox.less
+++ b/packages/main/src/themes/base/CheckBox.less
@@ -328,6 +328,7 @@ span[dir="rtl"] {
 .sapWCLabelInCheckBox {
 	overflow: hidden;
 	align-self: center;
+	cursor: default;
 }
 
 .sapMCbWrapped .sapWCLabelInCheckBox {


### PR DESCRIPTION
The cursor over the ui5-checkbox text
is changed from type text to default in order to full-fill the visual design.
