### PR TITLE
fix(ui5-input): playground sample with labels

### DIFF
--- a/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
@@ -142,17 +142,17 @@
 		<h3>Input with Label</h3>
 		<div class="snippet">
 			<div class="flex-column samples-margin">
-				<ui5-label class="samples-big-margin-right" for="myInput" design="Bold" required>Name</ui5-label>
+				<ui5-label class="samples-big-margin-right" for="myInput" required>Name</ui5-label>
 				<ui5-input class="input-width" id="myInput" placeholder="Enter your Name"></ui5-input>
 			</div>
 			<div class="flex-column">
-				<ui5-label class="samples-big-margin-right" for="myInput" design="Bold" required>Secret Code</ui5-label>
+				<ui5-label class="samples-big-margin-right" for="myPassword" required>Secret Code</ui5-label>
 				<ui5-input class="input-width" id="myPassword" type="Password" value-state="Error" placeholder="Enter your Secret Code"></ui5-input>
 			</div>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-label for="myInput" design="Bold">Label for Input</ui5-label>
-<ui5-input id="myInput" value="Value of Input"></ui5-input>
+<ui5-label class="samples-big-margin-right" for="myInput" required>Name</ui5-label>
+<ui5-input class="input-width" id="myInput" placeholder="Enter your Name"></ui5-input>
 		</xmp></pre>
 	</section>
 


### PR DESCRIPTION
Issue
One of the ui5-label components within the "Input with Labels" section
used to reference a wrong ui5-input through its 'for' attribute.

Solution
Changing the ui5-label 'for' attribute to point the expected ui5-input field.

Fixes https://github.com/SAP/ui5-webcomponents/issues/28