### PR TITLE
docs(playground): improve the ACC of the popover sample

### DIFF
--- a/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
@@ -44,8 +44,8 @@
 			<ui5-popover id="hello-popover" header-text="Newsletter subscription">
 				<div class="popover-content">
 					<div class="flex-column">
-						<ui5-label required>Email: </ui5-label>
-						<ui5-input class="samples-margin-top" placeholder="Enter Email"></ui5-input>
+						<ui5-label for="emailInput" required>Email: </ui5-label>
+						<ui5-input id="emailInput" class="samples-margin-top" placeholder="Enter Email"></ui5-input>
 					</div>
 				</div>
 				<div data-ui5-slot="footer"	class="popover-footer">

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
@@ -77,8 +77,8 @@
 	</div>
 	<div class="popover-content">
 		<div class="flex-column">
-			<ui5-label required>Email: </ui5-label>
-			<ui5-input class="samples-margin-top" placeholder="Enter Email"></ui5-input>
+			<ui5-label for="emailInput" required>Email: </ui5-label>
+			<ui5-input id="emailInput" class="samples-margin-top" placeholder="Enter Email"></ui5-input>
 		</div>
 	</div>
 	<div data-ui5-slot="footer" class="popover-footer">


### PR DESCRIPTION
Improve the accessibility inside the ui5-popover by
referencing the 'email' ui5-input with the 'Email' label
with the use of the 'for' attribute.