### PR TITLE
docs(playground): update DatePicker code snippet in home page

### DIFF
--- a/packages/playground/webapp/index.html
+++ b/packages/playground/webapp/index.html
@@ -69,10 +69,10 @@
                     <h2>Test the UI5 Web Components</h2>
                     <div class="example-wrapper flex-center space-around flex-wrap">
                         <div class="datepicker-wrapper">
-                            <ui5-datepicker popover-horizontal-align="Left"></ui5-datepicker>
+                            <ui5-datepicker></ui5-datepicker>
                         </div>
                         <pre class="code"><xmp>
-<ui5-datepicker popover-horizontal-align="Left"></ui5-datepicker>
+<ui5-datepicker></ui5-datepicker>
                         </xmp></pre>
                     </div>
                     <a href="./playground.html" target="_blank" class="custom-button main-button">Get Started</a>


### PR DESCRIPTION
Remove unnecessary attribute "popover-horizontal-align" both from the code section 
and the ui5-datepicker itself.