### PR TITLE
docs(playground): fix configuration button appearance on phone

### DIFF
--- a/packages/playground/webapp/css/style.css
+++ b/packages/playground/webapp/css/style.css
@@ -244,13 +244,13 @@ html.sap-desktop .sapContrast .sapMLnk:focus:not(.sapMLnkDsbl) {
 	padding-bottom: 0 !important;
 }
 
-.switch-container .sapMBtnDefault.sapMBtnHoverable.sapMBtnInner.sapMBtnText.sapMFocusable {
+.switch-container .sapMBtnDefault.sapMBtnInner.sapMBtnText.sapMFocusable {
 	border: 2px solid #fff !important;
 	background-color: transparent;
     border: none;
 }
 
-.switch-container .sapMBtnDefault.sapMBtnHoverable.sapMBtnInner.sapMBtnText.sapMFocusable:hover {
+.switch-container .sapMBtnDefault.sapMBtnInner.sapMBtnText.sapMFocusable:hover {
 	background-color: rgba(179, 179, 179, 0.5);
     border-color: rgba(179, 179, 179, 0.5);
 }


### PR DESCRIPTION
Update styling of the 'apply' button within the configuration panel.

from:
<img width="227" alt="screenshot 2019-02-14 at 21 54 15" src="https://user-images.githubusercontent.com/15702139/52814345-92f7e480-30a4-11e9-84c2-e9e3999eb607.png">

to:
<img width="227" alt="screenshot 2019-02-14 at 21 53 56" src="https://user-images.githubusercontent.com/15702139/52814350-95f2d500-30a4-11e9-929d-1d2179bec98a.png">

Change:
Removing the 'sapMBtnHoverable' clas, as on phone the components do not have hover and the class is never added.