### PR TITLE
fix(ui5-datepicker): icon color in pressed state

### DIFF
--- a/packages/main/src/themes/base/DatePicker.less
+++ b/packages/main/src/themes/base/DatePicker.less
@@ -14,16 +14,6 @@
 :host(ui5-datepicker) {
 	display: inline-block;
 	width: 100%;
-
-	& ui5-input ui5-icon {
-		color: @sapUiContentIconColor;
-		outline: none;
-
-		&:active {
-			background-color: @sapUiButtonLiteActiveBackground;
-			color: @sapUiButtonActiveTextColor;
-		}
-	}
 }
 
 // required for browsers without native shadow dom
@@ -33,9 +23,15 @@ ui5-datepicker {
 }
 
 .sapWCDPIcon {
+	color: @sapUiContentIconColor;
 	width: @sap_wc_dp_icon_width;
 	cursor: pointer;
-	color: @sapUiContentIconColor;
+	outline: none;
+
+	&:active {
+		background-color: @sapUiButtonLiteActiveBackground;
+		color: @sapUiButtonActiveTextColor;
+	}
 
 	&.sapWCDPIconPressed,
 	&.sapWCDPIconPressed:active {
@@ -45,10 +41,5 @@ ui5-datepicker {
 
 	&:not(.sapWCDPIconPressed):not(:active):hover {
 		background: @sapUiButtonLiteHoverBackground;
-	}
-
-	&:active {
-		background-color: @sapUiButtonLiteActiveBackground;
-		color: @sapUiButtonActiveTextColor;
 	}
 }


### PR DESCRIPTION
The correct selector, defining the icon`s color,
was not used to be applied.