### PR TITLE
fix: broken bundle on Edge

### DIFF
--- a/packages/base/src/sap/ui/webcomponents/base/events/PolymerGestures.js
+++ b/packages/base/src/sap/ui/webcomponents/base/events/PolymerGestures.js
@@ -1,3 +1,4 @@
+import WCPolyfill from '../thirdparty/webcomponents-polyfill';
 import * as PolymerGestures from "@polymer/polymer/lib/utils/gestures";
 import {injectGesturesProvider} from "./DefaultGestures";
 


### PR DESCRIPTION
gestures depends on the polyfills loaded before it runs.