### PR TITLE
docs(playground): improve configuration openning on small sizes

### DIFF
--- a/packages/playground/webapp/css/style.css
+++ b/packages/playground/webapp/css/style.css
@@ -16,8 +16,7 @@
     padding: 0 .2rem;
     box-sizing: border-box;
     height: 100%;
-    display: flex;
-    align-items: center;
+	line-height: 3rem;
 }
 
 /* Override tnt tool header hamburger */
@@ -378,12 +377,18 @@ html[data-sap-ui-os^="iOS"] .customToolPage .sapTntToolPageMainContentWrapper {
 	-webkit-overflow-scrolling: touch;
 }
 
+.version-label-in-settings {
+	display: none !important;
+}
+
 @media screen and (max-width: 600px) {
 	.side-links {
 		display: none !important; 
 	}
-
-	.sapMPopoverScroll > .version-label {
+	.version-label {
 		display: none !important;
+	}
+	.version-label-in-settings {
+		display: inline-block !important;
 	}
 }

--- a/packages/playground/webapp/view/Main.view.xml
+++ b/packages/playground/webapp/view/Main.view.xml
@@ -18,8 +18,17 @@
 
 				<ToolbarSpacer></ToolbarSpacer>
 
-				<Label class="version-label" text="v0.7.0" />
-				<Button class="settings-button" type="Transparent" icon="sap-icon://action-settings" press="toggleSettingsMenu"></Button>
+				<Label class="version-label" text="v0.7.0">
+					<layoutData>
+						<OverflowToolbarLayoutData priority="NeverOverflow" />
+					</layoutData>
+				</Label>
+
+				<Button class="settings-button" type="Transparent" icon="sap-icon://action-settings" press="toggleSettingsMenu">
+					<layoutData>
+						<OverflowToolbarLayoutData priority="NeverOverflow" />
+					</layoutData>
+				</Button>
 			</tnt:ToolHeader>
 		</tnt:header>
 		<tnt:sideContent>
@@ -64,10 +73,14 @@
 						</ComboBox>
 					</FlexBox>
 				</FlexBox>
-				<FlexBox class="settings-buttons-wrapper" width="100%" justifyContent="End">
-					<Button type="Transparent" text="Close" press="closeSettingsMenu" class="margin-end custom-button-height"></Button>
-					<Button text="Apply" press="applyChangeSettings" class="custom-button-height"></Button>
-				</FlexBox>
+
+				<HBox width="100%" justifyContent="SpaceBetween" alignItems="Center">
+					<Label class="version-label-in-settings" text="v0.7.0" />
+					<HBox class="settings-buttons-wrapper" width="100%" justifyContent="End">
+						<Button type="Transparent" text="Close" press="closeSettingsMenu" class="margin-end custom-button-height" />
+						<Button text="Apply" press="applyChangeSettings" class="custom-button-height" />
+					</HBox>
+				</HBox>
 			</FlexBox>
 
 			<FlexBox direction="Row" width="100%" height="100%" id="main-content-wrapper">


### PR DESCRIPTION
There is no overflow menu any more. The configuration button is always present
and opens the configuration panel.
On small sizes the version label goes inside the configuration panel.

After
<img width="298" alt="screenshot 2019-02-15 at 17 01 51" src="https://user-images.githubusercontent.com/15702139/52865045-44018c00-3144-11e9-82d7-711bdc9d17b3.png">

Before
<img width="302" alt="screenshot 2019-02-15 at 17 07 22" src="https://user-images.githubusercontent.com/15702139/52865046-44018c00-3144-11e9-924a-6f7af6468898.png">

