### PR TITLE
docs(playground): add new card sample with ui5-list

### DIFF
--- a/packages/main/test/sap/ui/webcomponents/main/samples/Card.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Card.sample.html
@@ -50,6 +50,13 @@
 			margin-bottom: 1rem;
 		}
 
+		.card-content {
+			display: flex;
+			justify-content: space-around;
+			flex-wrap: wrap;
+			width: 100%;
+		}
+
 		.item {
 			display: flex;
 			width: 100%;
@@ -77,6 +84,8 @@
 		.content-padding {
 			padding: 0.5rem 1rem 0 1rem;
 		}
+
+		
 	</style>
 </head>
 <body class="sapUiBody example-wrapper">
@@ -89,83 +98,48 @@
 	<section>
 		<h3>Card with List</h3>
 		<div class="snippet card-container">
-			<ui5-card
-				heading="Project Cloud Transformation"
-				subtitle="Revenue per Product | EUR"
-				status="3 of 3"
-				class="small">
-				<ui5-list separators="None" class="content-padding">
-					<ui5-li-custom>
-						<div class="item">
-							<div class="item-content-begin">
-								<ui5-title level="H5" class="item-content-begin-title">Avantel</ui5-title>
-								<ui5-label>ID234522566-D44</ui5-label>
-							</div>
-							<div class="item-content-end">
-								<span class="status-success">27.25K EUR</span>
-							</div>
-						</div>
-					</ui5-li-custom>
-
-					<ui5-li-custom>
-						<div class="item">
-							<div class="item-content-begin">
-								<ui5-title level="H5" class="item-content-begin-title">Tecum</ui5-title>
-								<ui5-label>ID782545256-D47</ui5-label>
-							</div>
-							<div class="item-content-end">
-								<span class="status-error">7.35K EUR</span>
-							</div>
-						</div>
-					</ui5-li-custom>
-
-					<ui5-li-custom>
-						<div class="item">
-							<div class="item-content-begin">
-								<ui5-title level="H5" class="item-content-begin-title">Telecomunicaciones Star</ui5-title>
-								<ui5-label>ID7125852785-A51</ui5-label>
-							</div>
-							<div class="item-content-end">
-								<span class="status-warning">22.89K EUR</span>
-							</div>
-						</div>
-					</ui5-li-custom>
-				</ui5-list>
+			<ui5-card avatar="sap-icon://group" heading="Team 6" subtitle="Direct Reports" status="6 of 6">
+				<div class="card-content">
+					<ui5-list separators="None" class="card-content-child">
+						<ui5-li image="../../../../../../www/samples/images/man_avatar_1.png"" description="User Researcher">Alain Chevalier</ui5-li>
+						<ui5-li image="../../../../../../www/samples/images/woman_avatar_1.png"" description="Artist">Monique Legrand</ui5-li>
+						<ui5-li image="../../../../../../www/samples/images/woman_avatar_2.png"" description="UX Specialist">Michael Adams</ui5-li>
+					</ui5-list>
+					<ui5-list separators="None" class="card-content-child">
+						<ui5-li image="../../../../../../www/samples/images/man_avatar_2.png"" description="Software Architect">Richard Wilson</ui5-li>
+						<ui5-li image="../../../../../../www/samples/images/woman_avatar_3.png"" description="Visual Designer">Elena Petrova</ui5-li>
+						<ui5-li image="../../../../../../www/samples/images/man_avatar_3.png"" description="Quality Specialist">John Miller</ui5-li>
+					</ui5-list>
 			</ui5-card>
 		</div>
 
 		<pre class="prettyprint lang-html">
 <xmp>
 <style>
-.item {display: flex;width: 100%;justify-content: space-between;}
-.item-content-begin {display: flex;flex-direction: column;}
-.item-content-begin-title {padding-bottom: 0.25rem;}
-
-.status-error {color: #b00;}
-.status-warning {color: #e9730c;}
-.status-success {color: #107e3e;}
+.card-content {
+	display: flex;
+	justify-content: space-around;
+	flex-wrap: wrap;
+}
 </style>
 
 <ui5-card
-	heading="Project Cloud Transformation"
-	subtitle="Revenue per Product | EUR"
-	status="3 of 3"
-	class="small">
-	<ui5-list separators="None" class="content-padding">
-		<ui5-li-custom>
-			<div class="item">
-				<div class="item-content-begin">
-					<ui5-title level="H5" class="item-content-begin-title">Avantel</ui5-title>
-					<ui5-label>ID234522566-D44</ui5-label>
-				</div>
-				<div class="item-content-end">
-					<span class="status-success">27.25K EUR</span>
-				</div>
-			</div>
-		</ui5-li-custom>
-
-		...
-	</ui5-list>
+	avatar="sap-icon://group"
+	heading="Team 6"
+	subtitle="Direct Reports"
+	status="6 of 6">
+	<div class="card-content">
+		<ui5-list separators="None">
+			<ui5-li image="../../../../../../www/samples/images/man_avatar_1.png"" description="User Researcher">Alain Chevalier</ui5-li>
+			<ui5-li image="../../../../../../www/samples/images/woman_avatar_1.png"" description="Artist">Monique Legrand</ui5-li>
+			<ui5-li image="../../../../../../www/samples/images/woman_avatar_2.png"" description="UX Specialist">Michael Adams</ui5-li>
+		</ui5-list>
+		<ui5-list separators="None">
+			<ui5-li image="../../../../../../www/samples/images/man_avatar_2.png"" description="Software Architect">Richard Wilson</ui5-li>
+			<ui5-li image="../../../../../../www/samples/images/woman_avatar_3.png"" description="Visual Designer">Elena Petrova</ui5-li>
+			<ui5-li image="../../../../../../www/samples/images/man_avatar_3.png"" description="Quality Specialist">John Miller</ui5-li>
+		</ui5-list>
+	</div>
 </ui5-card>
 </xmp>
 		</pre>
@@ -336,8 +310,60 @@
 	</section>
 
 	<section>
-		<h3>Card with entirely custom content</h3>
+		<h3>More Cards</h3>
 		<div class="snippet card-container">
+			<ui5-card avatar="../../../../../../www/samples/images/man_avatar_1.png" heading="David Willams" subtitle="Sales Manager" class="small">
+				<ui5-list separators="Inner" class="content-padding">
+					<ui5-li icon="sap-icon://competitor" icon-end>Personal Development</ui5-li>
+					<ui5-li icon="sap-icon://wallet" icon-end>Finance</ui5-li>
+					<ui5-li icon="sap-icon://collaborate" icon-end>Communications Skills</ui5-li>
+				</ui5-list>
+			</ui5-card>
+
+			<ui5-card
+				heading="Project Cloud Transformation"
+				subtitle="Revenue per Product | EUR"
+				status="3 of 3"
+				class="small">
+				<ui5-list separators="None" class="content-padding">
+					<ui5-li-custom>
+						<div class="item">
+							<div class="item-content-begin">
+								<ui5-title level="H5" class="item-content-begin-title">Avantel</ui5-title>
+								<ui5-label>ID234522566-D44</ui5-label>
+							</div>
+							<div class="item-content-end">
+								<span class="status-success">27.25K EUR</span>
+							</div>
+						</div>
+					</ui5-li-custom>
+
+					<ui5-li-custom>
+						<div class="item">
+							<div class="item-content-begin">
+								<ui5-title level="H5" class="item-content-begin-title">Telecomunicaciones Star</ui5-title>
+								<ui5-label>ID7125852785-A51</ui5-label>
+							</div>
+							<div class="item-content-end">
+								<span class="status-warning">22.89K EUR</span>
+							</div>
+						</div>
+					</ui5-li-custom>
+
+					<ui5-li-custom>
+						<div class="item">
+							<div class="item-content-begin">
+								<ui5-title level="H5" class="item-content-begin-title">Talpa</ui5-title>
+								<ui5-label>ID123555587-I05</ui5-label>
+							</div>
+							<div class="item-content-end">
+								<span class="status-error">7.85K EUR</span>
+							</div>
+						</div>
+					</ui5-li-custom>
+				</ui5-list>
+			</ui5-card>
+
 			<ui5-card avatar="../../../../../../www/samples/images/woman_avatar_1.png" heading="Dona Maria Moore" subtitle="Senior Sales Executive" class="small">
 				<div class="content content-padding">
 					<ui5-title level="H5" style="padding-bottom: 1rem;">Contact details</ui5-title>
@@ -362,14 +388,19 @@
 
 		<pre class="prettyprint lang-html">
 <xmp>
+<ui5-card avatar="../../../../../../www/samples/images/man_avatar_1.png" heading="David Willams" subtitle="Sales Manager" class="small">
+	<ui5-list separators="Inner" class="content-padding">
+		<ui5-li icon="sap-icon://competitor" icon-end>Personal Development</ui5-li>
+		<ui5-li icon="sap-icon://wallet" icon-end>Finance</ui5-li>
+		<ui5-li icon="sap-icon://collaborate" icon-end>Communications Skills</ui5-li>
+	</ui5-list>
+</ui5-card>
+
 <style>
 .content,
 .content-group {
 	display: flex;
 	flex-direction: column;
-}
-
-.content-group {
 	padding-bottom: 1rem;
 }
 </style>
@@ -392,32 +423,33 @@
 		</div>
 	</div>
 </ui5-card>
-</xmp>
-		</pre>
-	</section>
 
-	<section>
-		<h3>Basic Card</h3>
+<style>
+.item {display: flex;width: 100%;justify-content: space-between;}
+.item-content-begin {display: flex;flex-direction: column;}
+.item-content-begin-title {padding-bottom: 0.25rem;}
 
-		<div class="snippet card-container">
-			<ui5-card avatar="../../../../../../www/samples/images/man_avatar_1.png" heading="David Willams" subtitle="Sales Manager" class="small">
-				<ui5-list separators="Inner" class="content-padding">
-					<ui5-li icon="sap-icon://competitor" icon-end>Personal Development</ui5-li>
-					<ui5-li icon="sap-icon://wallet" icon-end>Finance</ui5-li>
-					<ui5-li icon="sap-icon://collaborate" icon-end>Communications Skills</ui5-li>
-				</ui5-list>
-			</ui5-card>
-		</div>
+.status-error {color: #b00;}
+.status-warning {color: #e9730c;}
+.status-success {color: #107e3e;}
+</style>
 
-		<pre class="prettyprint lang-html">
-<xmp>
-	<ui5-card avatar="../../../../../../www/samples/images/man_avatar_1.png" heading="David Willams" subtitle="Sales Manager" class="small">
-		<ui5-list separators="Inner" class="content-padding">
-			<ui5-li icon="sap-icon://competitor" icon-end>Personal Development</ui5-li>
-			<ui5-li icon="sap-icon://wallet" icon-end>Finance</ui5-li>
-			<ui5-li icon="sap-icon://collaborate" icon-end>Communications Skills</ui5-li>
-		</ui5-list>
-	</ui5-card>
+<ui5-card heading="Project Cloud Transformation" subtitle="Revenue per Product | EUR" status="3 of 3" class="small">
+	<ui5-list separators="None" class="content-padding">
+		<ui5-li-custom>
+			<div class="item">
+				<div class="item-content-begin">
+					<ui5-title level="H5" class="item-content-begin-title">Avantel</ui5-title>
+					<ui5-label>ID234522566-D44</ui5-label>
+				</div>
+				<div class="item-content-end">
+					<span class="status-success">27.25K EUR</span>
+				</div>
+			</div>
+		</ui5-li-custom>
+		...
+	</ui5-list>
+</ui5-card>
 </xmp>
 		</pre>
 	</section>


### PR DESCRIPTION
Make use of ui5-list and the standard ui5-li only to accomplish the following sample:

<img width="658" alt="screenshot 2019-02-15 at 19 37 35" src="https://user-images.githubusercontent.com/15702139/52874184-81bcdf80-3159-11e9-8b15-a50bec099b82.png">

and gather up other cards in one section

<img width="900" alt="screenshot 2019-02-15 at 19 42 33" src="https://user-images.githubusercontent.com/15702139/52874363-fb54cd80-3159-11e9-8975-f2a46f20e97b.png">

