### PR TITLE
refactor(ui5-tabcontainer): item selection and itemSelect event

### DIFF
--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -50,16 +50,6 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the item key.
-		 * @type {String}
-		 * @public
-		 */
-		key: {
-			type: String,
-			defaultValue: "",
-		},
-
-		/**
 		 * Represents the "count" text, which is displayed in the tab filter.
 		 * @type {String}
 		 * @public

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -35,35 +35,49 @@ const metadata = {
 		 * @type {String}
 		 * @public
 		 */
-		text: { type: String, group: "Misc", defaultValue: "" },
+		text: {
+			type: String,
+			defaultValue: "",
+		},
 
 		/**
 		 * Enabled items can be selected.
 		 * @type {Boolean}
 		 * @public
 		 */
-		disabled: { type: Boolean, group: "Misc" },
+		disabled: {
+			type: Boolean,
+		},
 
 		/**
-		 * Can be used as input for subsequent actions.
+		 * Defines the item key.
 		 * @type {String}
 		 * @public
 		 */
-		key: { type: String, group: "Data", defaultValue: "" },
+		key: {
+			type: String,
+			defaultValue: "",
+		},
 
 		/**
 		 * Represents the "count" text, which is displayed in the tab filter.
 		 * @type {String}
 		 * @public
 		 */
-		count: { type: String, group: "Data", defaultValue: "" },
+		count: {
+			type: String,
+			defaultValue: "",
+		},
 
 		/**
 		 * Specifies the icon to be displayed for the tab filter.
 		 * @type {URI}
 		 * @public
 		 */
-		icon: { type: URI, group: "Misc", defaultValue: "" },
+		icon: {
+			type: URI,
+			defaultValue: "",
+		},
 
 		/**
 		 * Specifies the icon color.
@@ -76,14 +90,20 @@ const metadata = {
 		 * @type {IconColor}
 		 * @public
 		 */
-		iconColor: { type: IconColor, group: "Appearance", defaultValue: IconColor.Default },
+		iconColor: {
+			type: IconColor,
+			defaultValue: IconColor.Default,
+		},
 
 		/**
 		 * Specifies whether the icon and the texts are placed vertically or horizontally.
 		 * @type {TabDesignMode}
 		 * @public
 		 */
-		design: { type: TabDesignMode, group: "Appearance", defaultValue: TabDesignMode.Vertical },
+		design: {
+			type: TabDesignMode,
+			defaultValue: TabDesignMode.Vertical,
+		},
 
 		_showAll: { type: Boolean },
 		_isSelected: { type: Boolean, defaultValue: false },
@@ -126,20 +146,6 @@ class Tab extends TabBase {
 
 	constructor(state) {
 		super(state);
-	}
-
-	/**
-	 * If the Tab doesn't have a key, the function returns the ID of the Tab,
-	 * so the TabContainer can remember the selected Tab.
-	 *
-	 * @private
-	 */
-	_getUniqueKey() {
-		if (this.key) {
-			return this.key;
-		}
-
-		return this._id;
 	}
 
 	static get calculateTemplateContext() {

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -42,7 +42,7 @@
 					 horizontal-align="Right">
 			<ui5-list @itemPress="{{ctr._overflowList.onItemPress}}">
 				{{#each ctr._overflowList.items}}
-					<ui5-li-custom id="{{this.key}}"
+					<ui5-li-custom id="{{this.id}}"
 								   type="{{this.type}}"
 								   selected="{{this.selected}}"
 								   class="{{this.classes}}">

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -596,7 +596,7 @@ class TabContainer extends WebComponent {
 		const tabs = this.getTabs();
 		const selectedTab = tabs.filter(item => item._id === pressedItem.id)[0];
 
-		this.setSelectedTab(selectedTab, true /*user interaction */);
+		this.setSelectedTab(selectedTab, true /* user interaction */);
 
 		const popover = this.getDomRef().querySelector("ui5-popover");
 		popover.close();

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -86,7 +86,9 @@ const metadata = {
 		 * @type {Boolean}
 		 * @public
 		 */
-		fixed: { type: Boolean, group: "Misc" },
+		fixed: {
+			type: Boolean,
+		},
 
 		/**
 		 * Determines whether the tab content is collapsed.
@@ -94,7 +96,9 @@ const metadata = {
 		 * @type {Boolean}
 		 * @public
 		 */
-		collapsed: { type: Boolean, group: "Misc" },
+		collapsed: {
+			type: Boolean,
+		},
 
 		/**
 		 * Defines the key of the selected tab item.
@@ -105,7 +109,10 @@ const metadata = {
 		 * @type {String}
 		 * @public
 		 */
-		selectedKey: { type: String, group: "Data", defaultValue: null },
+		selectedKey: {
+			type: String,
+			defaultValue: null,
+		},
 
 		/**
 		 * Specifies the background color of the IconTabBar.
@@ -119,21 +126,24 @@ const metadata = {
 		 */
 		backgroundDesign: {
 			type: BackgroundDesign,
-			group: "Appearance",
 			defaultValue: BackgroundDesign.Solid,
 		},
 
 		/**
-		 * Specifies the header mode.
+		 * Specifies the header mode. Available options are: <code>Standard</code> and <code>Inline</code>.
 		 * <br><br>
-		 * <b>Note:</b> The Inline mode works only if no icons are set.
+		 * In <code>Standard</code> mode the <code>count</code> and the <code>text</code>
+		 * are displayed in two separate lines.
+		 * In <code>Inline</code> mode the <code>count</code> and the <code>text</code>
+		 * are displayed in single line.
+		 * <br><br>
+		 * <b>Note:</b> The <code>Inline</code> mode works only when no icons are set.
 		 *
 		 * @type {TabContainerHeaderMode}
 		 * @public
 		 */
 		headerMode: {
 			type: TabContainerHeaderMode,
-			group: "Appearance",
 			defaultValue: TabContainerHeaderMode.Standard,
 		},
 
@@ -146,7 +156,9 @@ const metadata = {
 		 * @type {Boolean}
 		 * @public
 		 */
-		showOverflow: { type: Boolean, group: "Appearance" },
+		showOverflow: {
+			type: Boolean,
+		 },
 
 		/**
 		 * Specifies the background color of the header.
@@ -159,7 +171,6 @@ const metadata = {
 		 */
 		headerBackgroundDesign: {
 			type: BackgroundDesign,
-			group: "Appearance",
 			defaultValue: BackgroundDesign.Solid,
 		},
 
@@ -199,11 +210,11 @@ const metadata = {
 		 * Fired when an item is selected.
 		 *
 		 * @event
-		 * @param {string} key The <code>key</code> of the selected item.
+		 * @param {HTMLElement} item The selected <code>item</code>.
 		 * @public
 		 */
 		itemSelect: {
-			key: { type: String },
+			item: { type: HTMLElement },
 		},
 	},
 };
@@ -585,7 +596,7 @@ class TabContainer extends WebComponent {
 		const tabs = this.getTabs();
 		const selectedTab = tabs.filter(item => item._id === pressedItem.id)[0];
 
-		this.setSelectedTab(selectedTab);
+		this.setSelectedTab(selectedTab, true /*user interaction */);
 
 		const popover = this.getDomRef().querySelector("ui5-popover");
 		popover.close();
@@ -703,7 +714,7 @@ class TabContainer extends WebComponent {
 
 		if (userInteraction) {
 			this.fireEvent("itemSelect", {
-				key: this.selectedKey,
+				item: this._selectedTab,
 			});
 		}
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
@@ -164,21 +164,17 @@
 	</span>
 
 	<script>
-		var inputEventCounter = document.querySelector("#field");
-		var inputItemKey = document.querySelector("#field2");
-		var inputItemText= document.querySelector("#field3");
 		var counter = 0;
 
-		var tabContainer = document.getElementById('tabContainer1');
-		tabContainer.addEventListener('itemSelect', function (event) {
+		tabContainer1.addEventListener('itemSelect', function (event) {
 			var item = event.detail.item;
 			var selectedKey = item.getAttribute("data-key");
 			var selectedItemText = item.getAttribute("text");
 
 			document.getElementById('selectedKey').innerText = selectedKey;
-			inputEventCounter.value = ++counter;
-			inputItemKey.value = selectedKey;
-			inputItemText.value = selectedItemText;
+			field.value = ++counter;
+			field2.value = selectedKey;
+			field3.value = selectedItemText;
 		});
 </script>
 </body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
@@ -67,7 +67,7 @@
 	<section class="group_colored">
 		<h3 class="group-title">Web Components</h3>
 		<h5>Filter</h5>
-		<ui5-tabcontainer id="tabContainer1" fixed show-overflow="true" selected-key="4">
+		<ui5-tabcontainer id="tabContainer1" fixed show-overflow="true" selected-index="3">
 			<ui5-tab data-key="item1" text="Products" count="123">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -84,17 +84,13 @@
 			</ui5-tab>
 			<ui5-button data-ui5-slot="content">Default Content</ui5-button>
 		</ui5-tabcontainer>
-		<div>
-			<span>Selected key:</span>
-			<span id="selectedKey"></span>
-		</div>
 
 		<ui5-input id="field"></ui5-input>
 		<ui5-input id="field2"></ui5-input>
 		<ui5-input id="field3"></ui5-input>
 
 		<h5>Horizontal design</h5>
-		<ui5-tabcontainer show-overflow="true" selected-key="item1">
+		<ui5-tabcontainer show-overflow="true" selected-index="2">
 			<ui5-tab design="Horizontal" key="item1" icon="sap-icon://card" text="Tab 1" count="12343455">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -107,7 +103,7 @@
 		</ui5-tabcontainer>
 
 		<h5>Icons only</h5>
-		<ui5-tabcontainer show-overflow="true" selected-key="item1">
+		<ui5-tabcontainer show-overflow="true" selected-index="1">
 			<ui5-tab key="item1" icon="sap-icon://employee" count="12343455">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -121,7 +117,7 @@
 
 
 		<h5>Text Only</h5>
-		<ui5-tabcontainer show-overflow="true" selected-key="item1">
+		<ui5-tabcontainer show-overflow="true" selected-index="3">
 			<ui5-tab key="item1" text="Tab 1">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -134,7 +130,7 @@
 		</ui5-tabcontainer>
 
 		<h5>Text and Count</h5>
-		<ui5-tabcontainer show-overflow="true" selected-key="item1">
+		<ui5-tabcontainer show-overflow="true" selected-index="3">
 			<ui5-tab key="item1" text="Tab 1" count="12346">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -148,7 +144,7 @@
 		</ui5-tabcontainer>
 
 		<h5>Text and Count Inline Mode</h5>
-		<ui5-tabcontainer show-overflow="true" header-mode="Inline" selected-key="item1">
+		<ui5-tabcontainer show-overflow="true" header-mode="Inline" selected-index="2">
 			<ui5-tab key="item1" text="Tab 1" count="12346">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -171,7 +167,6 @@
 			var selectedKey = item.getAttribute("data-key");
 			var selectedItemText = item.getAttribute("text");
 
-			document.getElementById('selectedKey').innerText = selectedKey;
 			field.value = ++counter;
 			field2.value = selectedKey;
 			field3.value = selectedItemText;

--- a/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
@@ -68,19 +68,19 @@
 		<h3 class="group-title">Web Components</h3>
 		<h5>Filter</h5>
 		<ui5-tabcontainer id="tabContainer1" fixed show-overflow="true" selected-key="4">
-			<ui5-tab key="item1" text="Products" count="123">
+			<ui5-tab data-key="item1" text="Products" count="123">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
 			</ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
-			<ui5-tab icon="sap-icon://menu2" text="Tab 2" icon-color="Positive" count="12343455">
+			<ui5-tab data-key="item2" icon="sap-icon://menu2" text="Tab 2" icon-color="Positive" count="12343455">
 				<ui5-button>Button 3</ui5-button>
 			</ui5-tab>
-			<ui5-tab icon="sap-icon://menu" text="Tab 3"  icon-color="Critical" count="12343455">
+			<ui5-tab data-key="item3" icon="sap-icon://menu" text="Tab 3"  icon-color="Critical" count="12343455">
 			</ui5-tab>
-			<ui5-tab key="4" icon="sap-icon://menu2" text="Tab 4"  icon-color="Negative" count="12343455">
+			<ui5-tab data-key="item4" icon="sap-icon://menu2" text="Tab 4"  icon-color="Negative" count="12343455">
 			</ui5-tab>
-			<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  icon-color="Negative" count="12343455">
+			<ui5-tab data-key="item5" icon="sap-icon://menu2" disabled="true" text="Disabled"  icon-color="Negative" count="12343455">
 			</ui5-tab>
 			<ui5-button data-ui5-slot="content">Default Content</ui5-button>
 		</ui5-tabcontainer>
@@ -88,12 +88,10 @@
 			<span>Selected key:</span>
 			<span id="selectedKey"></span>
 		</div>
-		<script>
-			var tabContainer = document.getElementById('tabContainer1');
-			tabContainer.addEventListener('itemSelect', function (event) {
-				document.getElementById('selectedKey').innerText = event.detail.key;
-			});
-		</script>
+
+		<ui5-input id="field"></ui5-input>
+		<ui5-input id="field2"></ui5-input>
+		<ui5-input id="field3"></ui5-input>
 
 		<h5>Horizontal design</h5>
 		<ui5-tabcontainer show-overflow="true" selected-key="item1">
@@ -162,13 +160,26 @@
 			</ui5-tab>
 		</ui5-tabcontainer>
 
-
-
 	</section>
-
-
-
-
 	</span>
+
+	<script>
+		var inputEventCounter = document.querySelector("#field");
+		var inputItemKey = document.querySelector("#field2");
+		var inputItemText= document.querySelector("#field3");
+		var counter = 0;
+
+		var tabContainer = document.getElementById('tabContainer1');
+		tabContainer.addEventListener('itemSelect', function (event) {
+			var item = event.detail.item;
+			var selectedKey = item.getAttribute("data-key");
+			var selectedItemText = item.getAttribute("text");
+
+			document.getElementById('selectedKey').innerText = selectedKey;
+			inputEventCounter.value = ++counter;
+			inputItemKey.value = selectedKey;
+			inputItemText.value = selectedItemText;
+		});
+</script>
 </body>
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/TabContainer.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/TabContainer.qunit.js
@@ -6,17 +6,17 @@ TestHelper.ready(function () {
 
 	QUnit.module("Web Components", {
 		beforeEach: function () {
-			var html = '<ui5-tabcontainer id="myTabContainer" fixed show-overflow="true" selected-key="4">'
-					+ '<ui5-tab key="item1" text="Products" count="123">'
+			var html = '<ui5-tabcontainer id="myTabContainer" fixed show-overflow="true" selected-index="3">'
+					+ '<ui5-tab text="Products" count="123">'
 						+ '<ui5-button>Button 11</ui5-button>'
 					+ '</ui5-tab>'
 					+ '<ui5-tab-separator></ui5-tab-separator>'
 					+ '<ui5-tab icon="sap-icon://employee" text="Tab 2" icon-color="Positive" count="12343455">'
 						+ '<ui5-button>Button 3</ui5-button>'
 					+ '</ui5-tab>'
-					+ '<ui5-tab icon="sap-icon://menu" text="Tab 3" key="item2"  icon-color="Critical" count="12343455">'
+					+ '<ui5-tab icon="sap-icon://menu" text="Tab 3" icon-color="Critical" count="12343455">'
 					+ '</ui5-tab>'
-					+ '<ui5-tab key="4" icon="sap-icon://menu2" text="Tab 4"  icon-color="Negative" count="12343455">'
+					+ '<ui5-tab icon="sap-icon://menu2" text="Tab 4"  icon-color="Negative" count="12343455">'
 					+ '</ui5-tab>'
 					+ '<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  icon-color="Negative" count="12343455">'
 					+ '</ui5-tab>'
@@ -51,7 +51,7 @@ TestHelper.ready(function () {
 
 		var done = assert.async();
 
-		this.tabContainer.setAttribute('selected-key', 'item1');
+		this.tabContainer.setAttribute('selected-index', '0');
 
 		RenderScheduler.whenFinished().then(function () {
 
@@ -80,7 +80,7 @@ TestHelper.ready(function () {
 
 			RenderScheduler.whenFinished().then(function () {
 
-				assert.strictEqual(this.tabContainer.getAttribute('selected-key'), 'item2', 'selected tab is correct');
+				assert.strictEqual(this.tabContainer.getAttribute('selected-index'), '2', 'selected tab is correct');
 
 				var overflowBtn = this.tabContainer.shadowRoot.querySelector('.sapMITHBtn');
 				var header = this.tabContainer.shadowRoot.querySelector('.sapMITH');

--- a/packages/main/test/sap/ui/webcomponents/main/samples/TabContainer.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/TabContainer.sample.html
@@ -39,41 +39,41 @@
 	<section>
 		<h3>Basic TabContainer</h3>
 		<div class="snippet">
-			<ui5-tabcontainer class="full-width" show-overflow selected-key="item2">
-				<ui5-tab icon="sap-icon://menu" key="item1" text="Tab 1">
+			<ui5-tabcontainer class="full-width" show-overflow selected-index="2">
+				<ui5-tab icon="sap-icon://menu" text="Tab 1">
 					<ui5-label>Quibusdam, veniam! Architecto debitis iusto ad et, asperiores quisquam perferendis reprehenderit ipsa voluptate minus minima, perspiciatis cum. Totam harum necessitatibus numquam voluptatum.</ui5-label>
 				</ui5-tab>
-				<ui5-tab icon="sap-icon://activities" key="item2" text="Tab 2">
+				<ui5-tab icon="sap-icon://activities" text="Tab 2">
 					<ui5-label>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fuga magni facere error dicta beatae optio repudiandae vero, quidem voluptatibus perferendis eum maiores rem tempore voluptates aperiam eos enim delectus unde.</ui5-label>
 				</ui5-tab>
-				<ui5-tab icon="sap-icon://add" key="item3" text="Tab 3">
+				<ui5-tab icon="sap-icon://add" text="Tab 3">
 					<ui5-label>Dignissimos debitis architecto temporibus doloribus reiciendis libero rem nemo, nobis quidem dolor praesentium, beatae voluptatum iste eveniet, nam voluptatem obcaecati ducimus dolore.</ui5-label>
 				</ui5-tab>
-				<ui5-tab icon="sap-icon://calendar" key="item4" text="Tab 4">
+				<ui5-tab icon="sap-icon://calendar" text="Tab 4">
 					<ui5-label>Possimus ipsa eos impedit aut nisi repellendus recusandae, temporibus ducimus, necessitatibus tenetur facere, minima vero fugit rem reiciendis natus ratione quia numquam?</ui5-label>
 				</ui5-tab>
 				<ui5-tab-separator></ui5-tab-separator>
-				<ui5-tab icon="sap-icon://action-settings" key="item5" text="Tab 5">
+				<ui5-tab icon="sap-icon://action-settings" text="Tab 5">
 					<ui5-label>Explicabo laboriosam ab consequuntur, qui dignissimos inventore sapiente ullam quaerat ratione libero vero, beatae laudantium! Aperiam numquam tempore, laudantium perferendis recusandae autem.</ui5-label>
 				</ui5-tab>
 			</ui5-tabcontainer>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-tabcontainer show-overflow="true" selected-key="item2">
-	<ui5-tab icon="sap-icon://menu" key="item1" key="item1" text="Tab 1">
+<ui5-tabcontainer class="full-width" show-overflow selected-index="2">
+	<ui5-tab icon="sap-icon://menu" text="Tab 1">
 		<ui5-label>Quibusdam, veniam! Architecto debitis iusto ad et, asperiores quisquam perferendis reprehenderit ipsa voluptate minus minima, perspiciatis cum. Totam harum necessitatibus numquam voluptatum.</ui5-label>
 	</ui5-tab>
-	<ui5-tab icon="sap-icon://activities" key="item2" text="Tab 2">
+	<ui5-tab icon="sap-icon://activities" text="Tab 2">
 		<ui5-label>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fuga magni facere error dicta beatae optio repudiandae vero, quidem voluptatibus perferendis eum maiores rem tempore voluptates aperiam eos enim delectus unde.</ui5-label>
 	</ui5-tab>
-	<ui5-tab icon="sap-icon://add" key="item3" text="Tab 3">
+	<ui5-tab icon="sap-icon://add" text="Tab 3">
 		<ui5-label>Dignissimos debitis architecto temporibus doloribus reiciendis libero rem nemo, nobis quidem dolor praesentium, beatae voluptatum iste eveniet, nam voluptatem obcaecati ducimus dolore.</ui5-label>
 	</ui5-tab>
-	<ui5-tab icon="sap-icon://calendar" key="item4" text="Tab 4">
+	<ui5-tab icon="sap-icon://calendar" text="Tab 4">
 		<ui5-label>Possimus ipsa eos impedit aut nisi repellendus recusandae, temporibus ducimus, necessitatibus tenetur facere, minima vero fugit rem reiciendis natus ratione quia numquam?</ui5-label>
 	</ui5-tab>
-    <ui5-tab-separator></ui5-tab-separator>
-	<ui5-tab icon="sap-icon://action-settings" key="item5" text="Tab 5">
+	<ui5-tab-separator></ui5-tab-separator>
+	<ui5-tab icon="sap-icon://action-settings" text="Tab 5">
 		<ui5-label>Explicabo laboriosam ab consequuntur, qui dignissimos inventore sapiente ullam quaerat ratione libero vero, beatae laudantium! Aperiam numquam tempore, laudantium perferendis recusandae autem.</ui5-label>
 	</ui5-tab>
 </ui5-tabcontainer>
@@ -83,21 +83,21 @@
 	<section>
 		<h3>Text Only TabContainer</h3>
 		<div class="snippet">
-			<ui5-tabcontainer class="full-width" collapsed fixed show-overflow selected-key="item2">
-				<ui5-tab key="item1" text="Home"></ui5-tab>
-				<ui5-tab key="item2" text="What's new"></ui5-tab>
-				<ui5-tab key="item3" text="Who are we"></ui5-tab>
-				<ui5-tab key="item4" text="About"></ui5-tab>
-				<ui5-tab key="item5" text="Contacts"></ui5-tab>
+			<ui5-tabcontainer class="full-width" collapsed fixed show-overflow selected-index="2">
+				<ui5-tab text="Home"></ui5-tab>
+				<ui5-tab text="What's new"></ui5-tab>
+				<ui5-tab text="Who are we"></ui5-tab>
+				<ui5-tab text="About"></ui5-tab>
+				<ui5-tab text="Contacts"></ui5-tab>
 			</ui5-tabcontainer>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-tabcontainer collapsed fixed show-overflow selected-key="item2">
-	<ui5-tab key="item1" text="Home"></ui5-tab>
-	<ui5-tab key="item2" text="What's new"></ui5-tab>
-	<ui5-tab key="item3" text="Who are we"></ui5-tab>
-	<ui5-tab key="item4" text="About"></ui5-tab>
-	<ui5-tab key="item5" text="Contacts"></ui5-tab>
+<ui5-tabcontainer class="full-width" collapsed fixed show-overflow selected-index="2">
+	<ui5-tab text="Home"></ui5-tab>
+	<ui5-tab text="What's new"></ui5-tab>
+	<ui5-tab text="Who are we"></ui5-tab>
+	<ui5-tab text="About"></ui5-tab>
+<ui5-tab text="Contacts"></ui5-tab>
 </ui5-tabcontainer>
 		</xmp></pre>
 	</section>

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -1,1 +1,21 @@
 const assert = require('assert');
+
+describe("TabContainer general interaction", () => {
+	browser.url("http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/TabContainer.html");
+
+	it("tests itemSelect event", () => {
+		const item = browser.findElementDeep("#tabContainer1 >>> .sapMITBItem:nth-child(3)");
+		const field = browser.$("#field");
+		const field2 = browser.$("#field2");
+		const field3 = browser.$("#field3");
+
+		const SELECTED_TAB_KEY = "item2";
+		const SELECTED_TAB_TEXT = "Tab 2";
+
+		item.click();
+
+		assert.strictEqual(field.getProperty("value"), "1", "itemSelect event should be fired once");
+		assert.strictEqual(field2.getProperty("value"), SELECTED_TAB_KEY, "Item data-key is retrieved correctly");
+		assert.strictEqual(field3.getProperty("value"), SELECTED_TAB_TEXT, "Item text is retrieved correctly.");
+	});
+});


### PR DESCRIPTION
The following changes are applied:
* remove the selectedKey property
* remove the key property
* introduce selectedIndex to substitute selectedKey and key pair for selection purposes
* change itemSelect event param to provide the selected item, instead of
  the tab container internal key to make app development easier.
  Furthermore, in React, the key is reserved for the purpose of VDOM optimisations.
* start firing itemSelect when item is selected from the overflow menu as well.
* add simple interaction test

BREAKING CHANGE: The TabContainer selected-key and Tab key properties are removed.