### PR TITLE
improvement: inline theme imports

### DIFF
--- a/packages/base/src/sap/ui/webcomponents/base/compatibility/ShadowDOM.js
+++ b/packages/base/src/sap/ui/webcomponents/base/compatibility/ShadowDOM.js
@@ -20,8 +20,8 @@ class ShadowDOM {
 		throw new Error("Static class");
 	}
 
-	static registerStyle(theme, styleName, styleObj) {
-		registerStyle(theme, styleName, styleObj);
+	static registerStyle(theme, styleName, styleContent) {
+		registerStyle(theme, styleName, styleContent);
 	}
 
 	static async updateStyle(tag, shadowRoot, styleUrls) {

--- a/packages/base/src/sap/ui/webcomponents/base/theming/ThemeBundle.js
+++ b/packages/base/src/sap/ui/webcomponents/base/theming/ThemeBundle.js
@@ -15,12 +15,13 @@ const fetchThemeBundle = async (packageName, themeName) => {
 	return bundle;
 };
 
-const registerStyle = (theme, styleName, styleObj) => {
-	if (typeof (styleObj) === "object" && styleObj._) {
+const registerStyle = (theme, styleName, styleContent) => {
+	if (typeof (styleContent) === "string" && styleContent.length) {
+		// is inlined string
 		if (!styles.has(theme)) {
 			styles.set(theme, {});
 		}
-		styles.get(theme)[styleName] = styleObj._;
+		styles.get(theme)[styleName] = styleContent;
 	}
 };
 
@@ -45,7 +46,7 @@ const getStyles = async (theme, styleNames) => {
 		const themeData = await fetchThemeBundle("@ui5/webcomponents", theme);
 
 		Object.entries(themeData).forEach(([key, value]) => {
-			registerStyle(theme, key, { _: value });
+			registerStyle(theme, key, value);
 		});
 	}
 

--- a/packages/main/lib/less-to-json-imports/index.js
+++ b/packages/main/lib/less-to-json-imports/index.js
@@ -20,7 +20,7 @@ const convertImports = (srcPath) => {
 	tree.body.forEach(node => {
 		if (node.type === "ImportDeclaration" && node.source.value.endsWith(".less")) {
 			let importee = node.source.value;
-			node.source.value = importee.replace(".less", ".json");
+			node.source.value = importee.replace(".less", "-css.js");
 			changed = true;
 			// console.log(importee, "from", importer);
 		}
@@ -34,4 +34,4 @@ const convertImports = (srcPath) => {
 const fileNames = glob.sync(basePath + "**/*.js");
 // console.log(fileNames);
 fileNames.forEach(convertImports);
-console.log("Success: Converted .less imports to .json for path: ", basePath);
+console.log("Success: Converted .less imports to -css.js for path: ", basePath);

--- a/packages/main/rollup.config.js
+++ b/packages/main/rollup.config.js
@@ -146,17 +146,15 @@ const getPlugins = ({ transpile }) => {
 
 			// generate json in DIST for app consumption
 			filePath = filePath.replace(path.normalize("main/src"), path.normalize("main/dist"));
-			const filePathPlayGround = filePath.replace(path.normalize("/dist"), path.normalize("/dist/resources/sap/ui/webcomponents/main"));
-
 
 			mkdirp.sync(path.dirname(filePath));
-			mkdirp.sync(path.dirname(filePathPlayGround));
-			// json is for app consumption
-			fs.writeFileSync(filePath.replace(".less", ".json"), JSON.stringify({ _: css }));
-			fs.writeFileSync(filePathPlayGround.replace(".less", ".json"), JSON.stringify({ _: css }));
+			// use JSON.stringify to escape the string content
+			const data = JSON.stringify({ _: css }).replace('{"_":', '').replace(/}$/, "");
+			// inline the string in a .js file with ES6 export for app consumption
+			fs.writeFileSync(filePath.replace(".less", "-css.js"), `export default ${data};`);
+
 			// CSS is for dev comparison only
 			fs.writeFileSync(filePath.replace(".less", ".css"), css);
-			fs.writeFileSync(filePathPlayGround.replace(".less", ".css"), css);
 
 			return "";
 		}


### PR DESCRIPTION
- generate a -css.js file for each imported .less file
- this file exports the generated CSS as a string value
- rewrite the imports from .less to -css.js
- more compatible for build tools as these files are supposed to be
  inlined anyway and no longer force a json configuration at build time
  which makes it easier for less capable build tools.
