### PR TITLE
fix: prevent throwing exception if slotted child does not have listenFor

### DIFF
--- a/packages/base/src/sap/ui/webcomponents/base/WebComponent.js
+++ b/packages/base/src/sap/ui/webcomponents/base/WebComponent.js
@@ -355,7 +355,7 @@ class WebComponent extends HTMLElement {
 
 		const propsMetadata = this.parentNode._monitoredChildProps.get(this.getAttribute("data-ui5-slot"));
 
-		if (!metadata) {
+		if (!propsMetadata) {
 			return;
 		}
 		const { observedProps, notObservedProps } = propsMetadata;

--- a/packages/base/src/sap/ui/webcomponents/base/WebComponent.js
+++ b/packages/base/src/sap/ui/webcomponents/base/WebComponent.js
@@ -353,7 +353,12 @@ class WebComponent extends HTMLElement {
 			return;
 		}
 
-		const { observedProps, notObservedProps } = this.parentNode._monitoredChildProps.get(prop.target.getAttribute("data-ui5-slot"));
+		const propsMetadata = this.parentNode._monitoredChildProps.get(this.getAttribute("data-ui5-slot"));
+
+		if (!metadata) {
+			return;
+		}
+		const { observedProps, notObservedProps } = propsMetadata;
 
 		if (observedProps.includes(prop.detail.name) && !notObservedProps.includes(prop.detail.name)) {
 			this.parentNode._invalidate("_parent_", this);


### PR DESCRIPTION
Certain child should inform their parents for property change and make the parent invalidate.

This is done through a listenFor in the metadata. However, when two such components are used inside each other, the metadata for the inner one was get for the first time incorrectly (prop.target was wrong).

* Now the correct element is used (this)
* Early return is performed if for some reason the listenFor is empty (not needed for the fix)

This fixes the ui5-table inside a ui5-tabcontainer