### PR TITLE
build: suppress rollup error

### DIFF
--- a/packages/main/rollup.config.js
+++ b/packages/main/rollup.config.js
@@ -194,6 +194,12 @@ const getES5Config = () => {
 			extend: "true",	// Whether or not to extend the global variable defined by the name option in umd or iife formats.
 			sourcemap: true
 		},
+		moduleContext: (id) => {
+			if (id.includes("url-search-params-polyfill")) {
+				// suppress the rollup error for this module as it uses this in the global scope correctly even without changing the context here
+				return "window";
+			}
+		},
 		watch: {
 			clearScreen: false
 		},


### PR DESCRIPTION
url-search-params-polyfill causes rollup to report an error although it still works.