### PR TITLE
docs: display since info for properties

### DIFF
--- a/lib/documentation/templates/api-properties-section.js
+++ b/lib/documentation/templates/api-properties-section.js
@@ -17,7 +17,12 @@ module.exports = {
             <div class="cell api-table-content-cell api-table-content-cell-bold">{{this.name}} <br> <code>{{toKebabCase this.name}}</code></div>
             <div class="cell api-table-content-cell">{{this.type}}</div>
             <div class="cell api-table-content-cell">{{this.defaultValue}}</div>
-            <div class="cell api-table-content-cell api-table-content-cell-description">{{{this.description}}}</div>
+            <div class="cell api-table-content-cell api-table-content-cell-description">
+                {{{this.description}}}
+                {{#if this.since}}
+                    <div class="api-table-content-cell-bold api-table-content-cell-since">since v{{{this.since}}}</div>
+                {{/if}}
+            </div>
           </div>
         {{/each}}
 

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -21,6 +21,7 @@ const metadata = {
 		 * Defines the description displayed right under the item text, if such is present.
 		 * @type {String}
 		 * @public
+		 * @since 0.8.0
 		 */
 		description: {
 			type: String,

--- a/packages/main/test/playground/css/api.css
+++ b/packages/main/test/playground/css/api.css
@@ -271,6 +271,11 @@ pre.prettyprint>xmp {
 	color: #333333;
 }
 
+.api-table-content-cell-since {
+	padding-top: 1rem;
+	color: #008EFF;
+}
+
 .api-table-event-description {
 	margin-top: 8px;
 	display: inline-block;


### PR DESCRIPTION

<img width="974" alt="screenshot 2019-02-27 at 16 40 31" src="https://user-images.githubusercontent.com/15702139/53498628-5918dc00-3aaf-11e9-9862-4032d70da751.png">

