### PR TITLE
docs: enable component since info

### DIFF
--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -1,5 +1,6 @@
 const api = require('../../packages/main/dist/api.json');
 const template = require('./templates/template').template;
+const sinceTemplate = require('./templates/api-component-since').template;
 const propertiesTemplate = require('./templates/api-properties-section').template;
 const slotsTemplate = require('./templates/api-slots-section').template;
 const eventsTemplate = require('./templates/api-events-section').template;
@@ -10,7 +11,9 @@ const mkdirp = require('mkdirp');
 
 const entries = api['symbols'];
 const compiledHandlebars = Handlebars.compile(template);
+const compiledSinceTemplate = Handlebars.compile(sinceTemplate);
 const linkMatcher = /{@link(\s)(\w+)\s*}/gi;
+const sinceMarker = "<!--since_tag_marker-->";
 
 const getComponentByName = name => {
 	return entries.find(element => {
@@ -83,8 +86,11 @@ entries.forEach((entry, index) => {
 		</script>
 		`;
 		const APIReference = compiledHandlebars(entry).replace(/\[\]/g, " [0..n]");
+		const EntitySince = compiledSinceTemplate(entry).replace(/\[\]/g, " [0..n]");
+
 		content = content.replace('</body', APIReference + '</body');
 		content = content.replace('</body', fnRedirect + '</body');
+		content = content.replace(sinceMarker, EntitySince);
 
 		content = content.replace(linkMatcher, match => {
 			const component = linkMatcher.exec(match)[2];

--- a/lib/documentation/templates/api-component-since.js
+++ b/lib/documentation/templates/api-component-since.js
@@ -1,0 +1,3 @@
+module.exports = {
+	template: `{{#if this.since}}v{{this.since}}{{/if}}`
+};

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -127,6 +127,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.WebComponent
  * @tagname ui5-input
  * @public
+ * @since 0.8.0
  */
 class Select extends WebComponent {
 	static get metadata() {

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -251,6 +251,7 @@ const metadata = {
  * @tagname ui5-shellbar
  * @appenddocs ShellBarItem
  * @public
+ * @since 0.8.0
  */
 class ShellBar extends WebComponent {
 	static get metadata() {

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -124,6 +124,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.WebComponent
  * @tagname ui5-switch
  * @public
+ * @since 0.8.0
  */
 class Switch extends WebComponent {
 	static get metadata() {

--- a/packages/main/src/Timeline.js
+++ b/packages/main/src/Timeline.js
@@ -61,6 +61,7 @@ const metadata = {
  * @tagname ui5-timeline
  * @appenddocs TimelineItem
  * @public
+ * @since 0.8.0
  */
 class Timeline extends WebComponent {
 	static get metadata() {

--- a/packages/main/test/playground/css/api.css
+++ b/packages/main/test/playground/css/api.css
@@ -16,6 +16,12 @@ body {
 	padding: 0.625rem 1.25rem;
 }
 
+.component-heading {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+}
+
 .flex-align-center {
 	align-items: center;
 }
@@ -29,6 +35,7 @@ body {
 	font-size: 3rem;
 	margin: 2rem 0 0 0;
 	color: #333333;
+	padding-right: 0.5rem;
 }
 
 .snippet {
@@ -261,6 +268,7 @@ pre.prettyprint>xmp {
 	font-family: "72-Regular";	
 }
 
+.component-heading-since,
 .api-table-content-cell-bold {
 	font-family: "72-Bold";
 }
@@ -273,6 +281,10 @@ pre.prettyprint>xmp {
 
 .api-table-content-cell-since {
 	padding-top: 1rem;
+}
+
+.component-heading-since,
+.api-table-content-cell-since {
 	color: #008EFF;
 }
 
@@ -453,6 +465,10 @@ pre.prettyprint>xmp {
 
 	.api-table .row .cell:nth-child(3) {
 		flex: 1 100%;
+	}
+
+	.component-heading-release-status {
+		display: none;
 	}
 }
 

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Select.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Select.sample.html
@@ -46,11 +46,15 @@
 </head>
 <body class="sapUiBody example-wrapper">
 
-	<header>
+	<header class="component-heading">
 		<h2 class="control-header">Select</h2>
-		<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-select&gt;</div>
+		<div class="component-heading-since">
+			<span><!--since_tag_marker--></span>
+			<span class="component-heading-release-status">(next release)</span>
+		</div>
 	</header>
-
+	
+	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-select&gt;</div>
 	<section>
 		<h3>Basic Select</h3>
 		<div class="snippet">

--- a/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
@@ -35,10 +35,15 @@
 </head>
 <body class="sapUiBody example-wrapper">
 
-	<header>
+	<header class="component-heading">
 		<h2 class="control-header">ShellBar</h2>
-		<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-shellbar&gt;</div>
+		<div class="component-heading-since">
+			<span><!--since_tag_marker--></span>
+			<span class="component-heading-release-status">(next release)</span>
+		</div>
 	</header>
+
+	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-shellbar&gt;</div>
 
 	<!-- ShellBar -->
 	<section>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
@@ -37,11 +37,15 @@
 </head>
 <body class="sapUiBody example-wrapper">
 
-	<header>
+	<header class="component-heading">
 		<h2 class="control-header">Switch</h2>
-		<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-switch&gt;</div>
+		<div class="component-heading-since">
+			<span><!--since_tag_marker--></span>
+			<span class="component-heading-release-status">(next release)</span>
+		</div>
 	</header>
-
+	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-switch&gt;</div>
+	
 	<!-- Basic Switch -->
 	<section>
 		<h3>Basic Switch</h3>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Timeline.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Timeline.sample.html
@@ -39,10 +39,15 @@
 </head>
 <body class="sapUiBody example-wrapper">
 
-	<header>
-		<div class="control-header">Timeline</div>
-		<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-timeline&gt;</div>
+	<header class="component-heading">
+		<h2 class="control-header">Timeline</h2>
+		<div class="component-heading-since">
+			<span><!--since_tag_marker--></span>
+			<span class="component-heading-release-status">(next release)</span>
+		</div>
 	</header>
+
+	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-timeline&gt;</div>
 
 	<section>
 		<h3>Basic Timeline</h3>


### PR DESCRIPTION
<img width="1275" alt="screenshot 2019-02-27 at 21 16 39" src="https://user-images.githubusercontent.com/15702139/53516473-1538cd80-3ad5-11e9-96d5-5e1a6842609c.png">

<img width="373" alt="screenshot 2019-02-27 at 21 17 03" src="https://user-images.githubusercontent.com/15702139/53516467-12d67380-3ad5-11e9-8f1f-667c015d716c.png">

On small devices the "next release" label hides, instead of wrapping together with the since version.