### PR TITLE
revert: ui5-list keyboard handling improvement

### DIFF
--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -169,7 +169,6 @@ class CheckBox extends WebComponent {
 
 	onBeforeRendering() {
 		this.syncLabel();
-		this.tabIndex = this.getAttribute("tabindex");
 	}
 
 	syncLabel() {

--- a/packages/main/src/CheckBoxTemplateContext.js
+++ b/packages/main/src/CheckBoxTemplateContext.js
@@ -4,16 +4,11 @@ class CheckBoxTemplateContext {
 	static calculate(state) {
 		const mainClasses = CheckBoxTemplateContext.getMainClasses(state);
 		const innerClasses = CheckBoxTemplateContext.getInnerClasses(state);
-		let tabIndex;
-
-		if (!state.disabled) {
-			tabIndex = state._control.tabIndex ? state._control.tabIndex.toString() : "0";
-		}
 
 		const context = {
 			ctr: state,
 			readOnly: !state.disabled,
-			tabIndex,
+			tabIndex: state.disabled ? undefined : "0",
 			classes: { main: mainClasses, inner: innerClasses },
 			styles: {
 				main: {},

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -30,7 +30,6 @@
 		<ui5-radiobutton
 				id="{{ctr._id}}-singleSelectionControl"
 				class="radioButtonInListItem"
-				tabindex="-1"
 				selected="{{ctr.selected}}">
 		</ui5-radiobutton>
 	{{/if}}
@@ -38,8 +37,7 @@
 	{{#if modeMultiSelect}}
 		<ui5-checkbox
 				id="{{ctr._id}}-multiSelectionControl"
-				checked="{{ctr.selected}}"
-				tabindex="-1">
+				checked="{{ctr.selected}}">
 		</ui5-checkbox>
 	{{/if}}
 

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -160,7 +160,6 @@ class RadioButton extends WebComponent {
 	onBeforeRendering() {
 		this.syncLabel();
 		this.syncGroup();
-		this.tabIndex = this.getAttribute("tabindex");
 	}
 
 	syncLabel() {

--- a/packages/main/src/RadioButtonTemplateContext.js
+++ b/packages/main/src/RadioButtonTemplateContext.js
@@ -19,18 +19,13 @@ const SVGConfig = {
 class RadioButtonTemplateContext {
 	static calculate(state) {
 		const compact = getCompactSize();
-		let tabIndex;
-
-		if (!state.disabled) {
-			tabIndex = state._control.tabIndex ? state._control.tabIndex.toString() : "0";
-		}
 
 		const mainClasses = RadioButtonTemplateContext.getMainClasses(state),
 			innerClasses = RadioButtonTemplateContext.getInnerClasses(state),
 			context = {
 				ctr: state,
 				readOnly: state.disabled || state.readOnly,
-				tabIndex,
+				tabIndex: state.disabled ? undefined : "0",
 				circle: compact ? SVGConfig.compact : SVGConfig.default,
 				classes: { main: mainClasses, inner: innerClasses },
 				styles: {

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
@@ -35,7 +35,6 @@
 		<ui5-li image="./img/HT-2002.jpg" type="Active" icon="sap-icon://navigation-right-arrow">DVD set</ui5-li>
 	</ui5-list>
 
-	<button id="btnAfter">After</button>
 	<label id="lblResult">0</label>
 
 	<ui5-list id="listWithDesc">

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -87,30 +87,6 @@ describe("Date Picker Tests", () => {
 		assert.equal(browser.$('#lblResult').getHTML(false), "Laptop HP: 1", "itemDelete event was fired for the right item");
 	});
 
-	it("inner multi-selection checkbox is skipped on tab", () => {
-		browser.url("http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/List_test_page.html");
-		list.root.setProperty("mode", "MultiSelect");
-
-		const firstItem = list.getItem(0);
-		firstItem.click();
-
-		browser.keys("Tab");
-
-		assert.ok(browser.$('#btnAfter').isFocused(), "focus is outside the list");
-	});
-
-	it("inner single selection radio button checkbox is skipped on tab", () => {
-		browser.url("http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/List_test_page.html");
-		list.root.setProperty("mode", "SingleSelect");
-
-		const firstItem = list.getItem(0);
-		firstItem.click();
-
-		browser.keys("Tab");
-
-		assert.ok(browser.$('#btnAfter').isFocused(), "focus is outside the list");
-	});
-
 	it("item size and classed, when an item has both text and description", () => {
 		const ITEM_WITH_DESCRIPTION_AND_TITLE_HEIGHT = 80;
 		const firstItem =  $("#listWithDesc ui5-li[slot=items-1]");

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -1,7 +1,7 @@
 const list = require("../pageobjects/ListTestPage");
 const assert = require("assert");
 
-describe("List Tests", () => {
+describe("Date Picker Tests", () => {
 	before(() => {
 		browser.url("http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/List_test_page.html");
 	});


### PR DESCRIPTION
This commits reverts: a30577ee8ab3fe978a520c9d42380a1c668e0462
It introduced an issue that ui5-checkbox and ui5-radiobutton
have two tab stops.
Another change will come after this one to implemented the
keyboard handling improvement for the ui5-list