### PR TITLE
Typo: Standard Link

### DIFF
--- a/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
@@ -39,15 +39,15 @@
 	<section>
 		<h3>Different Link Types</h3>
 		<div class="snippet">
-			<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank">Standart Link</ui5-link>
+			<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank">Standard Link</ui5-link>
 			<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" type="Subtle">Subtle link</ui5-link>
 			<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" disabled>Disabled</ui5-link>
 			<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" type="Emphasized">Emphasized</ui5-link>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-link href="https://www.sap.com" target="_blank">Standart Link</ui5-link>
+<ui5-link href="https://www.sap.com" target="_blank">Standard Link</ui5-link>
 <ui5-link href="https://www.sap.com" target="_blank" type="Subtle">Subtle link</ui5-link>
-<ui5-link href="https://www.sap.com" target="_blank" disabled>Disabled</ui5-link>
+<ui5-link href="https://www.sap.com" target="_blank" disabled>Disabled </ui5-link>
 <ui5-link href="https://www.sap.com" target="_blank" type="Emphasized">Emphasized</ui5-link>
 		</xmp></pre>
 	</section>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
@@ -47,7 +47,7 @@
 		<pre class="prettyprint lang-html"><xmp>
 <ui5-link href="https://www.sap.com" target="_blank">Standard Link</ui5-link>
 <ui5-link href="https://www.sap.com" target="_blank" type="Subtle">Subtle link</ui5-link>
-<ui5-link href="https://www.sap.com" target="_blank" disabled>Disabled </ui5-link>
+<ui5-link href="https://www.sap.com" target="_blank" disabled>Disabled</ui5-link>
 <ui5-link href="https://www.sap.com" target="_blank" type="Emphasized">Emphasized</ui5-link>
 		</xmp></pre>
 	</section>


### PR DESCRIPTION
There is a typo in the link documentation: ```Standart Link```
https://sap.github.io/ui5-webcomponents/playground.html#/components/Link