### PR TITLE
refactor: make SwitchType enum keys compliant with the type values

### DIFF
--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -88,7 +88,7 @@ const metadata = {
 		 * <b>Note:</b> If <code>Graphical</code> type is set,
 		 * positive and negative icons will replace the <code>textOn</code> and <code>textOff</code>.
 		 * @type {string}
-		 * @default Standard
+		 * @default Textual
 		 * @public
 		 */
 		type: {

--- a/packages/main/src/SwitchTemplateContext.js
+++ b/packages/main/src/SwitchTemplateContext.js
@@ -2,9 +2,9 @@ import SwitchType from "./types/SwitchType";
 
 class SwitchTemplateContext {
 	static calculate(state) {
-		const semantic = state.type === SwitchType.Semantic;
-		const textOn = semantic ? "" : state.textOn;
-		const textOff = semantic ? "" : state.textOff;
+		const graphical = state.type === SwitchType.Graphical;
+		const textOn = graphical ? "" : state.textOn;
+		const textOff = graphical ? "" : state.textOff;
 		const mainClasses = SwitchTemplateContext.getMainClasses(state);
 
 		const context = {
@@ -23,7 +23,7 @@ class SwitchTemplateContext {
 			"ui5-switch": true,
 			"ui5-switch--disabled": state.disabled,
 			"ui5-switch--checked": state.checked,
-			"ui5-switch--semantic": state.type === SwitchType.Semantic,
+			"ui5-switch--semantic": state.type === SwitchType.Graphical,
 		};
 	}
 }

--- a/packages/main/src/types/SwitchType.js
+++ b/packages/main/src/types/SwitchType.js
@@ -7,12 +7,12 @@ const SwitchTypes = {
 	/**
 	 * The Textual type includes the default styling and user provided texts.
 	 */
-	Standard: "Textual",
+	Textual: "Textual",
 
 	/**
 	 * The Graphical type - positive/negative icons and colors are displayed.
 	 */
-	Semantic: "Graphical",
+	Graphical: "Graphical",
 };
 
 class SwitchType extends DataType {


### PR DESCRIPTION
The displayed default value for the property "type"
is changed from Standard to Textual as the real type options are.
