### PR TITLE
fix: fix HCB colours for Icon, TextArea and Table sample

### DIFF
--- a/packages/main/src/themes/base/Icon.less
+++ b/packages/main/src/themes/base/Icon.less
@@ -13,12 +13,14 @@
 :host(ui5-icon) {
 	display: inline-block;
 	outline: none;
+	color: @sapUiContentNonInteractiveIconColor;
 }
 
 // required for browsers without native shadow dom
 ui5-icon {
 	display: inline-block;
 	outline: none;
+	color: @sapUiContentNonInteractiveIconColor;
 
 	// workaround for IE
 	// pressing on the span does not propagate active state to the web component

--- a/packages/main/src/themes/base/TableCell.less
+++ b/packages/main/src/themes/base/TableCell.less
@@ -9,12 +9,14 @@
 	display: inline-block;
 	width: 100%;
 	height: 100%;
+	color: @sapUiContentLabelColor;
 }
 
 ui5-table-cell {
 	display: inline-block;
 	width: 100%;
 	height: 100%;
+	color: @sapUiContentLabelColor;
 }
 
 .sapWCTableCell {

--- a/packages/main/src/themes/base/TextArea.less
+++ b/packages/main/src/themes/base/TextArea.less
@@ -142,6 +142,7 @@ ui5-textarea {
 		overflow: hidden;
 		align-self: flex-end;
 		padding: 0.125rem 0.125rem 0.5rem;
+		color: @sapUiContentLabelColor;
 		font-family: @sapUiFontFamily;
 		font-size: @sapMFontSmallSize;
 	}

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
@@ -45,7 +45,7 @@
 		display: none;
 	}
 
-	.hcb-background ui5-table-cell > * {
+	.hcb-background .headerToolbar {
 		color: #fff;
 	}
 	</style>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
@@ -45,6 +45,9 @@
 		display: none;
 	}
 
+	.hcb-background ui5-table-cell > * {
+		color: #fff;
+	}
 	</style>
 </head>
 <body class="sapUiBody example-wrapper">


### PR DESCRIPTION
Fixes Icon colour, TextArea exceeded text and Table sample in HCB.
Before:
<img width="209" alt="screenshot 2019-03-04 at 12 00 19" src="https://user-images.githubusercontent.com/15702139/53726024-d197e800-3e75-11e9-8f3f-6e8febe221eb.png">
After:
<img width="243" alt="screenshot 2019-03-04 at 11 59 56" src="https://user-images.githubusercontent.com/15702139/53726053-db215000-3e75-11e9-9ef8-413cf1af044d.png">
Before:
<img width="378" alt="screenshot 2019-03-04 at 11 53 44" src="https://user-images.githubusercontent.com/15702139/53726088-ed02f300-3e75-11e9-89af-07c64a6ed865.png">
After:
<img width="381" alt="screenshot 2019-03-04 at 11 50 54" src="https://user-images.githubusercontent.com/15702139/53726134-06a43a80-3e76-11e9-9296-0a8da92f4e03.png">
Before:
<img width="1003" alt="screenshot 2019-03-04 at 11 54 12" src="https://user-images.githubusercontent.com/15702139/53726144-0c018500-3e76-11e9-8727-8612afe1d16e.png">
After:
<img width="1001" alt="screenshot 2019-03-04 at 11 54 24" src="https://user-images.githubusercontent.com/15702139/53726151-115ecf80-3e76-11e9-9d4f-6a4295413d83.png">

