### PR TITLE
refactor(ui5-link): keep all CSS selectors in the Base Less file only

### DIFF
--- a/packages/main/src/themes/base/Link.less
+++ b/packages/main/src/themes/base/Link.less
@@ -9,14 +9,25 @@
 /* CSS for ui5-link            */
 /* Base theme                  */
 /* =========================== */
-:host(ui5-link),
+@ui5_link_opacity: 0.5;
+@ui5_link_outline_element_size: calc(~"100% - 0.125rem");
+
+:host(ui5-link) {
+	display: inline-block;
+	max-width: 100%;
+}
+
+:host(ui5-link) span[data-sap-ui-wc-root] {
+	display: flex;
+}
+
 ui5-link {
 	display: inline-block;
 	max-width: 100%;
+}
 
-	& span[data-sap-ui-wc-root] {
-		display: flex;
-	}
+ui5-link span[data-sap-ui-wc-root] {
+	display: flex;
 }
 
 .sapMLnk {
@@ -34,52 +45,55 @@ ui5-link {
 	align-items: center;
 	position: relative;
 	outline: none;
-	
-	&:not(.sapMLnkDsbl):hover {
-		text-decoration: underline;
-		color: @sapUiLinkHover;
-	}
+}
 
-	&.sapMLnkDsbl {
-		text-shadow: none;
-		outline: none;
-		cursor: default;
-		pointer-events: none;
-	}
+.sapMLnk:not(.sapMLnkDsbl):hover,
+.sapMLnk.sapMLnkSubtle:not(.sapMLnkDsbl):hover {
+	text-decoration: underline;
+	color: @sapUiLinkHover;
+}
 
-	&.sapMLnkSubtle {
-		color: darken(@sapUiLink, 15);
-	}
+.sapMLnk:visited {
+	color: @sapUiLinkVisited;
+}
 
-	&.sapMLnkEmphasized {
-		font-weight: bold;
-	}
-	
-	&.sapMLnkSubtle:focus {
-		color: @sapUiLink;
-	}
+.sapMLnk.sapMLnkDsbl {
+	text-shadow: none;
+	outline: none;
+	cursor: default;
+	pointer-events: none;
+	opacity: @ui5_link_opacity;
+}
 
-	&:visited {
-		color: @sapUiLinkVisited;
-	}
+.sapMLnk.sapMLnkEmphasized {
+	font-weight: bold;
+}
 
-	&:focus {
-		text-decoration: underline;
+.sapMLnk.sapMLnkSubtle,
+.sapMLnk.sapMLnkSubtle:visited {
+	color: darken(@sapUiLink, 15);
+}
 
-		&::after {
-			content: "";
-			width: calc(~"100% - 0.125rem");
-			height: calc(~"100% - 0.125rem");
-			position: absolute;
-			left: 0px;
-			border: 1px dotted @sapUiContentFocusColor;
-			top: 0;
-			outline: none;
-		}
-	}
+.sapMLnk.sapMLnkSubtle:focus {
+	color: @sapUiLink;
 }
 
 .sapMLnk.sapMLnkWrapping {
 	white-space: normal;
 	word-wrap: break-word;
+}
+
+.sapMLnk:focus {
+	text-decoration: underline;
+}
+
+.sapMLnk:focus::after {
+	content: "";
+	width: @ui5_link_outline_element_size;
+	height: @ui5_link_outline_element_size;
+	position: absolute;
+	left: 0px;
+	border: 1px dotted @sapUiContentFocusColor;
+	top: 0;
+	outline: none;
 }

--- a/packages/main/src/themes/sap_belize/Link.less
+++ b/packages/main/src/themes/sap_belize/Link.less
@@ -10,10 +10,6 @@
 @import "./global.less";
 
 /* =========================== */
-/* CSS for control sap.m/Link  */
+/* CSS for ui5-link            */
 /* Belize theme                */
 /* =========================== */
-
-.sapMLnkDsbl {
-	opacity: 0.5;
-}

--- a/packages/main/src/themes/sap_belize_hcb/Link.less
+++ b/packages/main/src/themes/sap_belize_hcb/Link.less
@@ -10,8 +10,8 @@
 @import "./base.less";
 @import "./global.less";
 
-.sapMLnk:focus::after {
-	width: calc(~"100% - 0.1875rem");
-	height: calc(~"100% - 0.1875rem");
-	border-width: 0.125rem;
-}
+/* =========================== */
+/* CSS for ui5-link            */
+/* Belize HCB theme            */
+/* =========================== */
+@ui5_link_outline_element_size: calc(~"100% - 0.1875rem");

--- a/packages/main/src/themes/sap_fiori_3/Link.less
+++ b/packages/main/src/themes/sap_fiori_3/Link.less
@@ -4,20 +4,13 @@
 @import "../base/Link.less";
 
 /* ============================= */
-/* Global Belize parameters      */
+/* Global Fiori 3 parameters     */
 /* ============================= */
 @import "./base.less";
 @import "./global.less";
 
 /* =========================== */
-/* CSS for control sap.m/Link  */
-/* Belize theme                */
+/* CSS for ui5-link            */
+/* Fiori 3 theme               */
 /* =========================== */
-
-.sapMLnkDsbl {
-	opacity: 0.4;
-}
-
-.sapMLnk:visited {
-	color: @sapUiLink;
-}
+@ui5_link_opacity: 0.4;


### PR DESCRIPTION
Remove style nesting and move all the selectors in the base file
an overwrite local variables, where needed, to make the path to css variables smoother.
