### PR TITLE
refactor(ui5-checkbox): keep styles in base LESS only

### DIFF
--- a/packages/main/src/themes/base/CheckBox.less
+++ b/packages/main/src/themes/base/CheckBox.less
@@ -9,7 +9,29 @@
 /* CSS for control sap.m/CheckBox  */
 /* Base theme                      */
 /* =============================== */
-@_sap_m_CheckBox_SelectedWarningColor: darken(@sapUiFieldWarningColor, 100);
+@_ui5_checkbox_height: 3rem;
+@_ui5_checkbox_compact_height: 2rem;
+@_ui5_checkbox_square_hover_bg: @sapUiFieldHoverBackground;
+@_ui5_checkbox_square_hover_border_color: @sapUiFieldHoverBorderColor;
+@_ui5_checkbox_square_outline_width: 1px;
+@_ui5_checkbox_square_border_width: 0.125rem;
+@_ui5_checkbox_square_error_border_width: 0.125rem;
+@_ui5_checkbox_square_warning_border_width: 0.125rem;
+@_ui5_checkbox_square_error_border_style: solid;
+@_ui5_checkbox_square_warning_border_style: solid;
+@_ui5_checkbox_square_disabled_border_color: @sapUiFieldBorderColor;
+@_ui5_checkbox_square_disabled_bg_color: @sapUiFieldBackground;
+@_ui5_checkbox_square_disabled_error_border_color: @sapUiFieldInvalidColor;
+@_ui5_checkbox_square_border_radius: 0;
+@_ui5_checkbox_checkmark_color: @sapUiSelected;
+@_ui5_checkbox_checkmark_warning_color: darken(@sapUiFieldWarningColor, 100);
+@_ui5_checkbox_checkmark_line_height: inherit;
+@_ui5_checkbox_checkmark_compact_line_height: inherit;
+@_ui5_checkbox_checkmark_compact_height: 0.75rem;
+@_ui5_checkbox_checkmark_compact_width: 0.75rem;
+@_ui5_checkbox_focus_border_width: 1px;
+@_ui5_checkbox_focus_outline_element_top: 0.6875rem;
+@_ui5_checkbox_focus_outline_element_bottom: 0.6875rem;
 
 :host(ui5-checkbox) {
 	display: inline-block;
@@ -30,35 +52,36 @@ ui5-checkbox {
 	position: relative;
 	box-sizing: border-box;
 	height: 100%;
-	min-height: 3rem;
+	min-height: @_ui5_checkbox_height;
 	padding: 0 .875rem;
 	max-width: 100%;
 	max-height: 100%;
 	cursor: default;
+}
 
-	&:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-		pointer-events: none;
-	}
+.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
+	pointer-events: none;
+}
 
-	&:focus {
-		outline: none;
-	}
+.sapMCb:focus {
+	outline: none;
+}
 
+.sapMCb:after {
 	/* 
-	 * this is a hack for a bug in IE 
-	 * https://github.com/philipwalton/flexbugs/issues/231
+	* this is a hack for a bug in IE 
+	* https://github.com/philipwalton/flexbugs/issues/231
 	*/
-	&:after {
-		content: '';
-		min-height: inherit;
-		font-size: 0;
-	}
+	content: '';
+	min-height: inherit;
+	font-size: 0;
 }
 
 .sapMCbBg {
 	background-color: @sapUiFieldBackground;
-	border-width: 0.125rem;
+	border-width: @_ui5_checkbox_square_border_width;
 	border-style: solid;
+	border-radius: @_ui5_checkbox_square_border_radius;
 	border-color: @sapUiFieldBorderColor;
 	display: inline-block;
 	position: relative;
@@ -68,37 +91,31 @@ ui5-checkbox {
 	min-width: 1.125rem;
 	text-align: center;
 	pointer-events: none;
+}
 
-	&.sapMCbMarkChecked:before {
-		content: "\e05b";
-		font-family: "SAP-icons";
-		display: inline-block;
-		color: @sapUiSelected;
-		width: 100%;
-	}
+.sapMCbBg.sapMCbMarkChecked:before {
+	content: "\e05b";
+	font-family: "SAP-icons";
+	display: inline-block;
+	color: @_ui5_checkbox_checkmark_color;
+	width: 100%;
+	line-height: @_ui5_checkbox_checkmark_line_height;
+}
 
-	& > input {
-		-webkit-appearance: none;
-		visibility: hidden;
-		width: 0;
-	}
-
-	&.sapMCbMark,
-	&.sapMCbMark > input {
-		font-size: inherit;
-	}
+.sapMCbBg.sapMCbMark {
+	font-size: inherit;
 }
 
 /* ChekBox With Label */
 .sapMCb.sapMCbHasLabel {
 	padding-right: 0;
+}
 
-	& .sapWCLabelInCheckBox {
-		padding-left: 0.875rem;
-		vertical-align: bottom;
-		cursor: default;
-		pointer-events: none;
-	}
+.sapMCb.sapMCbHasLabel .sapWCLabelInCheckBox {
+	padding-left: 0.875rem;
+	vertical-align: bottom;
+	cursor: default;
+	pointer-events: none;
 }
 
 /* ChekBox With Wrapping */
@@ -118,14 +135,26 @@ ui5-checkbox {
 }
 
 /* Read only */
-.sapMCbRo .sapMCbBg {
+.sapMCb.sapMCbRo .sapMCbBg,
+.sapMCb.sapMCbRo.sapMCbWarn .sapMCbBg {
 	background-color: @sapUiFieldReadOnlyBackground;
+}
+
+.sapMCb.sapMCbRo .sapMCbBg {
 	border-color: @sapUiFieldReadOnlyBorderColor;
+}
+.sapMCb.sapMCbRo.sapMCbWarn .sapMCbBg {
+	border-color: @sapUiFieldWarningColor;
 }
 
 /* Disabled */
 .sapMCbBgDis {
 	opacity: @sapUiContentDisabledOpacity;
+}
+
+.sapMCbBgDis > .sapMCbBg {
+	border-color: @_ui5_checkbox_square_disabled_border_color;
+	background-color: @_ui5_checkbox_square_disabled_bg_color;
 }
 
 /* Disabled and Checked */
@@ -134,39 +163,49 @@ ui5-checkbox {
 }
 
 /* Hover */
-.sapMCbHoverable:hover{
-	border-color: @sapUiFieldHoverBorderColor;
-	background: @sapUiFieldHoverBackground;
+.sapMCb:not(.sapMCbWarn):not(.sapMCbErr):hover .sapMCbBg.sapMCbHoverable {
+	border-color: @_ui5_checkbox_square_hover_border_color;
+	background: @_ui5_checkbox_square_hover_bg;
 }
 
 /* Value State Warning */
 .sapMCb.sapMCbWarn .sapMCbBg {
 	background-color: @sapUiFieldWarningBackground;
 	border-color: @sapUiFieldWarningColor;
-	&.sapMCbMarkChecked:before {
-		color: @_sap_m_CheckBox_SelectedWarningColor;
-	}
+	border-width: @_ui5_checkbox_square_warning_border_width;
+	border-style: @_ui5_checkbox_square_warning_border_style;
+}
+
+.sapMCb.sapMCbWarn .sapMCbBg.sapMCbMarkChecked:before {
+	color: @_ui5_checkbox_checkmark_warning_color;
 }
 
 /* Value State Error */
 .sapMCb.sapMCbErr .sapMCbBg {
 	background-color: @sapUiFieldInvalidBackground;
 	border-color: @sapUiFieldInvalidColor;
-	&.sapMCbMarkChecked:before {
-		color: @sapUiFieldInvalidColor;
-	}
+	border-width: @_ui5_checkbox_square_error_border_width;
+	border-style: @_ui5_checkbox_square_error_border_style;
+}
+
+.sapMCb.sapMCbErr .sapMCbBg.sapMCbMarkChecked:before {
+	color: @sapUiFieldInvalidColor;
+}
+
+.sapMCb.sapMCbErr.sapMCbBgDis .sapMCbBg {
+	border-color: @_ui5_checkbox_square_disabled_error_border_color;
 }
 
 /* CheckBox focus */
 .sapMCbBg:focus,
 .sapMCbBg:active,
-.sap-desktop .sapMCbBg.sapMCbBgDis:focus {
+.sapMCbBg.sapMCbBgDis:focus {
 	-webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 	outline: none;
 }
 
 .sapMCb:not(.sapMCbBgDis):not(.sapMCbHasLabel):focus > .sapMCbBg {
-	outline-width: 1px;
+	outline-width: @_ui5_checkbox_square_outline_width;
 	outline-style: dotted;
 	outline-color: @sapUiContentFocusColor;
 }
@@ -175,11 +214,11 @@ ui5-checkbox {
 	content: "";
 	display: block;
 	position: absolute;
-	top: 0.6875rem;
-	bottom: 0.6875rem;
+	top: @_ui5_checkbox_focus_outline_element_top;
+	bottom: @_ui5_checkbox_focus_outline_element_bottom;
 	left: 0.75rem;
 	right: 0;
-	border: 1px dotted @sapUiContentFocusColor;
+	border: @_ui5_checkbox_focus_border_width dotted @sapUiContentFocusColor;
 }
 
 .sapMCb.sapMCbWrapped:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
@@ -189,10 +228,15 @@ ui5-checkbox {
 	right: 0;
 }
 
-[data-sap-ui-wc-root][data-sap-ui-browser^=ff] .sapMCbBg > input {
-	/* in FF the input needs to be positioned exactly behind the visible checkbox for the focus outline */
+.sapMCbBg > input {
+	-webkit-appearance: none;
+	visibility: hidden;
+	width: 0;
+	// In FF the input needs to be positioned exactly behind the visible checkbox
+	// for the focus outline without effect on the rest of the browsers
 	left: 0;
 	position: absolute;
+	font-size: inherit;
 }
 
 /* TODO remove after 1.62 version */
@@ -202,7 +246,7 @@ ui5-checkbox {
 		outline-style: dashed;
 	}
 	.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-		border: 1px dashed @sapUiContentFocusColor;
+		border: @_ui5_checkbox_focus_border_width dashed @sapUiContentFocusColor;
 	}
 }
 
@@ -210,20 +254,23 @@ ui5-checkbox {
 .sapUiSizeCompact {
 
 	.sapMCb {
-		min-height: 2rem;
-		min-height: 2rem;
+		min-height: @_ui5_checkbox_compact_height;
 		padding: 0 .5rem;
 	}
 
 	.sapMCbBg {
 		left: 0.025rem;
 		top: 0.025rem;
-		height: 0.75rem;
-		width: 0.75rem;
-		min-width: 0.75rem;
-		min-height: 0.75rem;
+		height: @_ui5_checkbox_checkmark_compact_height;
+		width: @_ui5_checkbox_checkmark_compact_width;
+		min-width: @_ui5_checkbox_checkmark_compact_width;
+		min-height: @_ui5_checkbox_checkmark_compact_height;
 		line-height: 0.75rem;
 		font-size: 0.625rem;
+	}
+
+	.sapMCbBg.sapMCbMarkChecked:before {
+		line-height: @_ui5_checkbox_checkmark_compact_line_height;
 	}
 
 	/* ChekBox With Label */

--- a/packages/main/src/themes/base/CheckBox.less
+++ b/packages/main/src/themes/base/CheckBox.less
@@ -233,21 +233,21 @@ ui5-checkbox {
 	visibility: hidden;
 	width: 0;
 	// In FF the input needs to be positioned exactly behind the visible checkbox
-	// for the focus outline without effect on the rest of the browsers
+	// for the focus outline.
 	left: 0;
 	position: absolute;
 	font-size: inherit;
 }
 
 /* TODO remove after 1.62 version */
-[data-sap-ui-wc-root][data-sap-ui-browser^="ie"].sap-desktop,
-[data-sap-ui-wc-root][data-sap-ui-browser^="ed"].sap-desktop {
-	.sapMCb:not(.sapMCbBgDis):not(.sapMCbHasLabel):focus > .sapMCbBg {
-		outline-style: dashed;
-	}
-	.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-		border: @_ui5_checkbox_focus_border_width dashed @sapUiContentFocusColor;
-	}
+[data-sap-ui-wc-root][data-sap-ui-browser^="ed"].sap-desktop .sapMCb:not(.sapMCbBgDis):not(.sapMCbHasLabel):focus > .sapMCbBg,
+[data-sap-ui-wc-root][data-sap-ui-browser^="ie"].sap-desktop .sapMCb:not(.sapMCbBgDis):not(.sapMCbHasLabel):focus > .sapMCbBg {
+	outline-style: dashed;
+}
+
+[data-sap-ui-wc-root][data-sap-ui-browser^="ie"].sap-desktop .sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before,
+[data-sap-ui-wc-root][data-sap-ui-browser^="ed"].sap-desktop .sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
+	border: @_ui5_checkbox_focus_border_width dashed @sapUiContentFocusColor;
 }
 
 /* Compact */
@@ -280,15 +280,13 @@ ui5-checkbox {
 	}
 
 	/* ChekBox With Wrapping */
-	.sapMCb.sapMCbWrapped.sapMCbHasLabel {
-		.sapMCbBg {
-			top: 0.5rem;
-		}
+	.sapMCb.sapMCbWrapped.sapMCbHasLabel .sapMCbBg {
+		top: 0.5rem;
+	}
 
-		.sapWCLabelInCheckBox {
-			line-height: 2rem;
-			margin: .25rem 0;
-		}
+	.sapMCb.sapMCbWrapped.sapMCbHasLabel .sapWCLabelInCheckBox {
+		line-height: 2rem;
+		margin: .25rem 0;
 	}
 
 	.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
@@ -299,18 +297,16 @@ ui5-checkbox {
 }
 
 /* RTL */
-[dir="rtl"] {
-	& .sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-		left: 0;
-		right: 0.675rem;
-	}
+[dir="rtl"] .sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
+	left: 0;
+	right: 0.675rem;
+}
 
-	& .sapMCb.sapMCbHasLabel {
-		padding: 0 .875rem;
-		padding-left: 0;
+[dir="rtl"] .sapMCb.sapMCbHasLabel {
+	padding: 0 .875rem;
+	padding-left: 0;
+}
 
-		& .sapWCLabelInCheckBox {
-			padding: 0 .875rem 0 0;
-		}
-	}
+[dir="rtl"] .sapMCb.sapMCbHasLabel .sapWCLabelInCheckBox {
+	padding: 0 .875rem 0 0;
 }

--- a/packages/main/src/themes/base/Popover.less
+++ b/packages/main/src/themes/base/Popover.less
@@ -95,5 +95,5 @@
 }
 
 .sapMPopover {
-	transform: translate3d(0,0,0); // fixes z-index issue on iOS within iframe without harm in the rest browsers
+	transform: translate3d(0,0,0); // fixes z-index issue on iOS within iframe without side effect in the rest of the browsers
 }

--- a/packages/main/src/themes/base/Popover.less
+++ b/packages/main/src/themes/base/Popover.less
@@ -94,6 +94,6 @@
 	display: none;
 }
 
-.sap-ios .sapMPopover {
-	transform: translate3d(0,0,0); // fixes z-index issue on iOS within iframe
+.sapMPopover {
+	transform: translate3d(0,0,0); // fixes z-index issue on iOS within iframe without harm in the rest browsers
 }

--- a/packages/main/src/themes/sap_belize_hcb/CheckBox.less
+++ b/packages/main/src/themes/sap_belize_hcb/CheckBox.less
@@ -10,85 +10,18 @@
 @import "./base.less";
 @import "./global.less";
 
-.sapMCb.sapMCbWarn .sapMCbBg {
-	background-color: @sapUiFieldWarningBackground;
-	border: 0.125rem dashed @sapUiFieldWarningColor;
-}
-
-.sapMCb.sapMCbErr .sapMCbBg {
-	background-color: @sapUiFieldInvalidBackground;
-	border: 0.125rem dashed @sapUiFieldInvalidColor;
-}
-
-.sapMCb.sapMCbInfo .sapMCbBg {
-	background-color: @sapUiFieldBackground;
-	border: 0.125rem dashed @sapUiFieldWarningColor;
-}
-
-.sapMCb.sapMCbBgDis.sapMCbWarn .sapMCbBg.sapMCbMarkChecked:before {
-	color: @sapUiFieldWarningColor;
-}
-
-.sapMCb.sapMCbBgDis.sapMCbInfo .sapMCbBg.sapMCbMarkChecked:before {
-	color: @sapUiFieldWarningColor;
-}
-
-.sapMCb.sapMCbBgDis.sapMCbErr .sapMCbBg {
-	border-color: @sapUiHcReducedForeground;
-	&.sapMCbMarkChecked:before {
-		color: @sapUiFieldInvalidColor;
-	}
-}
-
-.sapMCbBg.sapMCbMarkChecked:before {
-	color: @sapUiContentIconColor;
-}
-
-.sapMCbBg > input {
-	left: 0;
-	-webkit-appearance: none;
-	visibility: hidden;
-}
-
-html[data-sap-ui-browser^=ff] .sapMCbBg > input {
-	/* in FF the input needs to be positioned exactly behind the visible checkbox for the focus outline */
-	position: absolute;
-}
-
-.sapMCb:not(.sapMCbWarn):not(.sapMCbErr):not(.sapMCbInfo) .sapMCbBg.sapMCbHoverable:hover {
-	background-color: @sapUiSelected;
-}
-
-/* disabled state */
-.sapMCbBgDis > .sapMCbBg {
-	border-color: @sapUiHcReducedForeground;
-	background-color: @sapUiHcReducedBackground;
-}
-
-.sapMCbBgDis > .sapMCbBg.sapMCbMarkChecked:before {
-	color: @sapUiHcReducedForeground;
-}
-
-.sapMCb:focus,
-.sapMCbBgDis > .sapMCbBg:focus {
-	outline: 0;
-}
-
-.sapMCbBgDis > .sapMCbLabel {
-	color: @sapUiContentDisabledTextColor;
-}
-
-/* Compact size */
-.sapUiSizeCompact {
-	.sapUiForm .sapMCbBg { /* In forms, align left with '0.125rem' ( the focus width) */
-		left: 0.125rem;
-	}
-}
-
-.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-	border: 0.125rem dotted @sapUiContentFocusColor;
-}
-
-.sapMCb:not(.sapMCbBgDis):not(.sapMCbHasLabel):focus > .sapMCbBg {
-	outline-width: 0.125rem;
-}
+/* =============================== */
+/* CSS for ui5-checkbox            */
+/* HCB parameters                  */
+/* =============================== */
+@_ui5_checkbox_focus_border_width: 0.125rem;
+@_ui5_checkbox_square_hover_bg: @sapUiSelected;
+@_ui5_checkbox_square_hover_border_color: @sapUiFieldBorderColor;
+@_ui5_checkbox_square_outline_width: 0.125rem;
+@_ui5_checkbox_square_error_border_style: dashed;
+@_ui5_checkbox_square_warning_border_style: dashed;
+@_ui5_checkbox_square_disabled_border_color: @sapUiHcReducedForeground;
+@_ui5_checkbox_square_disabled_bg_color: @sapUiHcReducedBackground;
+@_ui5_checkbox_square_disabled_error_border_color: @sapUiHcReducedForeground;
+@_ui5_checkbox_checkmark_color: @sapUiContentIconColor;
+@_ui5_checkbox_checkmark_warning_color: @sapUiFieldWarningColor;

--- a/packages/main/src/themes/sap_fiori_3/CheckBox.less
+++ b/packages/main/src/themes/sap_fiori_3/CheckBox.less
@@ -4,64 +4,21 @@
 @import "../base/CheckBox.less";
 
 /* ============================= */
-/* Global Belize parameters      */
+/* Global Fiori 3 parameters     */
 /* ============================= */
 @import "./base.less";
 @import "./global.less";
 
 /* =============================== */
-/* CSS for control ui5-checkbox    */
-/* sap_fiori_3 theme               */
+/* CSS for ui5-checkbox            */
+/* Fiori 3 parameters              */
 /* =============================== */
-
-.sapMCb {
-	min-height: 2.75rem;
-}
-
-.sapMCb:not(.sapMCbBgDis).sapMCbHasLabel:focus:before {
-	top: 0.5875rem;
-    bottom: 0.5875rem;
-}
-
-.sapMCbBg {
-    border-width: 0.0625rem;
-    border-radius: 0.125rem;
-
-    &.sapMCbMarkChecked:before {
-        line-height: 1.125rem;
-    }
-}
-
-/* Value State Warning */
-.sapMCb.sapMCbWarn .sapMCbBg {
-    border-width: 0.125rem;
-}
-
-/* Value State Error */
-.sapMCb.sapMCbErr .sapMCbBg {
-	border-width: 0.125rem;
-}
-
-
-/*Compact*/
-
-.sapUiSizeCompact {
-
-	.sapMCb {
-		min-height: 2rem;
-		min-height: 2rem;
-		padding: 0 .5rem;
-	}
-
-	.sapMCbBg {
-		height: 0.875rem;
-        width: 0.875rem;
-        min-height: 0.875rem;
-        min-width: 0.875rem;
-        border-radius: 0.125rem;
-
-        &.sapMCbMarkChecked:before {
-			line-height: 0.875rem;
-		}
-    }
-}
+@_ui5_checkbox_height: 2.75rem;
+@_ui5_checkbox_square_border_width: 0.0625rem;
+@_ui5_checkbox_square_border_radius: 0.125rem;
+@_ui5_checkbox_focus_outline_element_top: 0.5875rem;
+@_ui5_checkbox_focus_outline_element_bottom: 0.5875rem;
+@_ui5_checkbox_checkmark_line_height: 1.125rem;
+@_ui5_checkbox_checkmark_compact_height: 0.875rem;
+@_ui5_checkbox_checkmark_compact_width: 0.875rem;
+@_ui5_checkbox_checkmark_compact_line_height: 0.875rem;

--- a/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
@@ -41,28 +41,38 @@
 		<div class="snippet">
 			<ui5-checkbox text="Chocolate" checked></ui5-checkbox>
 			<ui5-checkbox text="Strawberry" checked></ui5-checkbox>
-			<ui5-checkbox text="Waffles" checked></ui5-checkbox>
-			<ui5-checkbox text="Cake" checked></ui5-checkbox>
-			<ui5-checkbox text="Pie(unavailable)" disabled></ui5-checkbox>
+			<ui5-checkbox text="Waffles" checked value-state="Error"></ui5-checkbox>
+			<ui5-checkbox text="Cake" checked value-state="Warning"></ui5-checkbox>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
 <ui5-checkbox text="Chocolate" checked></ui5-checkbox>
 <ui5-checkbox text="Strawberry" checked></ui5-checkbox>
-<ui5-checkbox text="Waffles" checked></ui5-checkbox>
-<ui5-checkbox text="Cake" checked></ui5-checkbox>
-<ui5-checkbox text="Pie(unavailable)" disabled></ui5-checkbox>
+<ui5-checkbox text="Waffles" checked value-state="Error"></ui5-checkbox>
+<ui5-checkbox text="Cake" checked value-state="Warning"></ui5-checkbox>
 		</xmp></pre>
 	</section>
 
 	<section>
-		<h3>CheckBox with ValueStates</h3>
+		<h3>CheckBox states</h3>
 		<div class="snippet">
-			<ui5-checkbox text="CheckBox Error" value-state="Error" name="test"></ui5-checkbox>
-			<ui5-checkbox text="CheckBox Warning" value-state="Warning"></ui5-checkbox>
+			<ui5-checkbox text="Error" value-state="Error"></ui5-checkbox>
+			<ui5-checkbox text="Warning" value-state="Warning"></ui5-checkbox>
+			<ui5-checkbox text="Disabled" disabled checked></ui5-checkbox>
+			<ui5-checkbox text="Read-only" read-only checked></ui5-checkbox>
+			<ui5-checkbox text="Error disabled" disabled value-state="Error" checked></ui5-checkbox>
+			<ui5-checkbox text="Warning disabled " disabled value-state="Warning" checked></ui5-checkbox>
+			<ui5-checkbox text="Error read-only" read-only value-state="Error" checked></ui5-checkbox>
+			<ui5-checkbox text="Warning read-only" read-only value-state="Warning" checked></ui5-checkbox>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-checkbox text="CheckBox Error" value-state="Error" name="test"></ui5-checkbox>
-<ui5-checkbox text="CheckBox Warning" value-state="Warning"></ui5-checkbox>
+<ui5-checkbox text="Error" value-state="Error"></ui5-checkbox>
+<ui5-checkbox text="Warning" value-state="Warning"></ui5-checkbox>
+<ui5-checkbox text="Disabled" disabled checked></ui5-checkbox>
+<ui5-checkbox text="Read-only" read-only checked></ui5-checkbox>
+<ui5-checkbox text="Error disabled" disabled value-state="Error" checked></ui5-checkbox>
+<ui5-checkbox text="Warning disabled " disabled value-state="Warning" checked></ui5-checkbox>
+<ui5-checkbox text="Error read-only" read-only value-state="Error" checked></ui5-checkbox>
+<ui5-checkbox text="Warning read-only" read-only value-state="Warning" checked></ui5-checkbox>
 		</xmp></pre>
 	</section>
 

--- a/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
@@ -80,7 +80,7 @@
 		<h3>CheckBox with Text Wrapping</h3>
 		<div class="snippet">
 			<ui5-checkbox text="ui5-checkbox with 'wrap' set and some long text." wrap style="width:200px"></ui5-checkbox>
-			<ui5-checkbox text="Another ui5-checkbox with ver long text here" wrap style="width:200px"></ui5-checkbox>
+			<ui5-checkbox text="Another ui5-checkbox with very long text here" wrap style="width:200px"></ui5-checkbox>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
 <ui5-checkbox text="ui5-checkbox with 'wrap' set and some long text." wrap ></ui5-checkbox>


### PR DESCRIPTION
Introduce local variables per theme and move all the selectors in the base less.
Add more checkbox examples in the playground sample. And, In addition provide small improvement in the Popover.less, removing the "sap-ios" dependant css without side effect in the rest of the browsers.