### PR TITLE
fix: stop calling non-existing method

### DIFF
--- a/packages/core/overlay/sap/ui/Device.js
+++ b/packages/core/overlay/sap/ui/Device.js
@@ -601,7 +601,7 @@ const _setSupport = () => {
 	}
 
 	if (!Device.browser) {
-		setBrowser();
+		_setBrowser();
 	}
 
 	Device.support = {};


### PR DESCRIPTION
Call the _setBrowser method, that exist, instead of previously available setBrowser.
