### PR TITLE
refactor: modularize configuration and locales

### DIFF
--- a/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
+++ b/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
@@ -1,6 +1,3 @@
-import "./shims/Core-shim";
-import "./shims/jquery-shim";
-
 import whenDOMReady from "./util/whenDOMReady";
 import EventEnrichment from "./events/EventEnrichment";
 import { insertIconFontFace } from "./IconFonts";

--- a/packages/base/src/sap/ui/webcomponents/base/Configuration.js
+++ b/packages/base/src/sap/ui/webcomponents/base/Configuration.js
@@ -1,15 +1,4 @@
-import { isAndroid } from "@ui5/webcomponents-core/dist/sap/ui/Device";
 import CalendarType from "@ui5/webcomponents-core/dist/sap/ui/core/CalendarType";
-import Locale from "./Locale";
-import {
-	setConfiguration,
-	getFormatLocale,
-	getLegacyDateFormat,
-	getLegacyDateCalendarCustomizing,
-	getCustomLocaleData,
-} from "./FormatSettings";
-
-let LocaleData;
 
 const getDesigntimePropertyAsArray = sValue => {
 	const m = /\$([-a-z0-9A-Z._]+)(?::([^$]*))?\$/.exec(sValue);
@@ -18,32 +7,10 @@ const getDesigntimePropertyAsArray = sValue => {
 
 const supportedLanguages = getDesigntimePropertyAsArray("$core-i18n-locales:,ar,bg,ca,cs,da,de,el,en,es,et,fi,fr,hi,hr,hu,it,iw,ja,ko,lt,lv,nl,no,pl,pt,ro,ru,sh,sk,sl,sv,th,tr,uk,vi,zh_CN,zh_TW$");
 
-const detectLanguage = () => {
-	const browserLanguages = navigator.languages;
-
-	const navigatorLanguage = () => {
-		if (isAndroid()) {
-			// on Android, navigator.language is hardcoded to 'en', so check UserAgent string instead
-			const match = navigator.userAgent.match(/\s([a-z]{2}-[a-z]{2})[;)]/i);
-			if (match) {
-				return match[1];
-			}
-			// okay, we couldn't find a language setting. It might be better to fallback to 'en' instead of having no language
-		}
-		return navigator.language;
-	};
-
-	const rawLocale = (browserLanguages && browserLanguages[0]) || navigatorLanguage() || navigator.userLanguage || navigator.browserLanguage;
-
-	return rawLocale || "en";
-};
-
-const language = detectLanguage();
-
 const CONFIGURATION = {
 	theme: "sap_fiori_3",
 	rtl: null,
-	language: new Locale(language),
+	language: null,
 	compactSize: false,
 	supportedLanguages,
 	calendarType: null,
@@ -51,8 +18,6 @@ const CONFIGURATION = {
 	"xx-wc-force-default-gestures": false,
 	"xx-wc-no-conflict": false, // no URL
 };
-
-setConfiguration(CONFIGURATION);
 
 /* General settings */
 const getTheme = () => {
@@ -64,7 +29,7 @@ const getRTL = () => {
 };
 
 const getLanguage = () => {
-	return CONFIGURATION.language.sLocaleId;
+	return CONFIGURATION.language;
 };
 
 const getCompactSize = () => {
@@ -94,13 +59,6 @@ const getCalendarType = () => {
 		}
 	}
 
-	/* In order to have a locale based calendar type - LocaleData should be injected to the configuration
-		- check #injectLocaleData
-	*/
-	if (LocaleData) {
-		return LocaleData.getInstance(getLocale()).getPreferredCalendarType();
-	}
-
 	return CalendarType.Gregorian;
 };
 
@@ -108,15 +66,6 @@ const getOriginInfo = () => {};
 
 const getLocale = () => {
 	return CONFIGURATION.language;
-};
-
-const getFormatSettings = () => {
-	return {
-		getFormatLocale,
-		getLegacyDateFormat,
-		getLegacyDateCalendarCustomizing,
-		getCustomLocaleData,
-	};
 };
 
 const _setTheme = themeName => {
@@ -129,39 +78,6 @@ const booleanMapping = new Map([
 ]);
 
 let runtimeConfig = {};
-
-const convertToLocaleOrNull = lang => {
-	try {
-		if (lang && typeof lang === "string") {
-			return new Locale(lang);
-		}
-	} catch (e) {
-		// ignore
-	}
-};
-
-const check = (condition, sMessage) => {
-	if (!condition) {
-		throw new Error(sMessage);
-	}
-};
-
-const getLanguageTag = () => {
-	return CONFIGURATION.language.toString();
-};
-
-const setLanguage = newLanguage => {
-	const locale = convertToLocaleOrNull(newLanguage);
-
-	check(locale, "Configuration.setLanguage: newLanguage must be a valid BCP47 language tag");
-
-	if (locale.toString() !== getLanguageTag()) {
-		CONFIGURATION.language = locale;
-		CONFIGURATION.derivedRTL = Locale._impliesRTL(locale);
-	}
-
-	return CONFIGURATION;
-};
 
 const parseConfigurationScript = () => {
 	const configScript = document.querySelector("[data-id='sap-ui-config']");
@@ -202,16 +118,8 @@ const parseURLParameters = () => {
 
 const applyConfigurations = () => {
 	Object.keys(runtimeConfig).forEach(key => {
-		if (key === "language") {
-			setLanguage(runtimeConfig[key]);
-		} else {
-			CONFIGURATION[key] = runtimeConfig[key];
-		}
+		CONFIGURATION[key] = runtimeConfig[key];
 	});
-};
-
-const injectLocaleData = localeData => {
-	LocaleData = localeData;
 };
 
 parseConfigurationScript();
@@ -227,9 +135,7 @@ export {
 	getWCNoConflict,
 	getCalendarType,
 	getLocale,
-	getFormatSettings,
 	_setTheme,
 	getSupportedLanguages,
 	getOriginInfo,
-	injectLocaleData,
 };

--- a/packages/base/src/sap/ui/webcomponents/base/FormatSettings.js
+++ b/packages/base/src/sap/ui/webcomponents/base/FormatSettings.js
@@ -1,10 +1,11 @@
 import Locale from "./Locale";
+import { getLocale } from "./LocaleProvider";
 
 const mSettings = {};
 
 const getFormatLocale = () => {
 	const fallback = () => {
-		let oLocale = SETTINGS.configuration.language;
+		let oLocale = getLocale();
 		// if any user settings have been defined, add the private use subtag "sapufmt"
 		if (!Object.keys(mSettings).length === 0) {
 			// TODO move to Locale/LocaleData
@@ -19,7 +20,8 @@ const getFormatLocale = () => {
 		return oLocale;
 	};
 
-	return SETTINGS.configuration.formatLocale || fallback();
+	// we do not support setting of locale, so we just leave the default behaviour
+	return fallback();
 };
 
 const SETTINGS = {

--- a/packages/base/src/sap/ui/webcomponents/base/LocaleDataConfigurationProvider.js
+++ b/packages/base/src/sap/ui/webcomponents/base/LocaleDataConfigurationProvider.js
@@ -1,4 +1,0 @@
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import { injectLocaleData } from "./Configuration";
-
-injectLocaleData(LocaleData);

--- a/packages/base/src/sap/ui/webcomponents/base/LocaleProvider.js
+++ b/packages/base/src/sap/ui/webcomponents/base/LocaleProvider.js
@@ -1,0 +1,48 @@
+import Locale from "./Locale";
+import { getLanguage as getConfigLanguage } from "./Configuration";
+
+const convertToLocaleOrNull = lang => {
+	try {
+		if (lang && typeof lang === "string") {
+			return new Locale(lang);
+		}
+	} catch (e) {
+		// ignore
+	}
+};
+
+/**
+ * Detects the language based on locale of the browser
+ */
+const detectLanguage = () => {
+	const browserLanguages = navigator.languages;
+
+	const navigatorLanguage = () => {
+		return navigator.language;
+	};
+
+	const rawLocale = (browserLanguages && browserLanguages[0]) || navigatorLanguage() || navigator.userLanguage || navigator.browserLanguage;
+
+	return rawLocale || "en";
+};
+
+/**
+ * Returns the locale based on the configured language Configuration#getLanguage
+ * If no language has been configured - a new locale based on browser language is returned
+ */
+const getLocale = () => {
+	if (getConfigLanguage()) {
+		return new Locale(getConfigLanguage());
+	}
+
+	return convertToLocaleOrNull(detectLanguage());
+};
+
+/**
+ * Returns the language of #getLocale return value
+ */
+const getLanguage = () => {
+	return getLocale().sLanguage;
+};
+
+export { getLocale, getLanguage };

--- a/packages/base/src/sap/ui/webcomponents/base/ResourceBundle.js
+++ b/packages/base/src/sap/ui/webcomponents/base/ResourceBundle.js
@@ -1,5 +1,5 @@
 import ResourceBundle from "@ui5/webcomponents-core/dist/sap/base/i18n/ResourceBundle";
-import { getLanguage } from "./Configuration";
+import { getLanguage } from "./LocaleProvider";
 import { registerModuleContent } from "./ResourceLoaderOverrides";
 import { fetchJsonOnce } from "./util/FetchHelper";
 

--- a/packages/base/src/sap/ui/webcomponents/base/ResourceLoaderOverrides.js
+++ b/packages/base/src/sap/ui/webcomponents/base/ResourceLoaderOverrides.js
@@ -5,6 +5,9 @@ const resources = new Map();
 // date formatters from the core do not know about this new mechanism of fetching assets,
 // but we can use the sap.ui.loader._.getModuleContent as a hook and provide the preloaded data,
 // so that a sync request via jQuery is never triggered.
+window.sap = window.sap || {};
+window.sap.ui = window.sap.ui || {};
+
 sap.ui.loader = sap.ui.loader || {};
 sap.ui.loader._ = sap.ui.loader._ || {};
 const getModulecontentOrig = sap.ui.loader._.getModuleContent;

--- a/packages/base/src/sap/ui/webcomponents/base/dates/CalendarUtils.js
+++ b/packages/base/src/sap/ui/webcomponents/base/dates/CalendarUtils.js
@@ -1,4 +1,3 @@
-import "../LocaleDataConfigurationProvider";
 import UniversalDate from "@ui5/webcomponents-core/dist/sap/ui/core/date/UniversalDate";
 import Locale from "@ui5/webcomponents-core/dist/sap/ui/core/Locale";
 import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";

--- a/packages/base/src/sap/ui/webcomponents/base/shims/Core-shim.js
+++ b/packages/base/src/sap/ui/webcomponents/base/shims/Core-shim.js
@@ -1,10 +1,12 @@
 import { inject as injectCore } from "@ui5/webcomponents-core/dist/sap/ui/core/Core";
 import * as Configuration from "../Configuration";
+import * as FormatSettings from "../FormatSettings";
 
 /**
  * Shim for the OpenUI5 core
  * @deprecated - do not add new functionality
  */
+
 const Core = {
 	/**
 	 * @deprecated - must be here for compatibility
@@ -18,13 +20,14 @@ const Core = {
 	 */
 	getLibraryResourceBundle() {
 	},
+
+	getFormatSettings() {
+		return FormatSettings;
+	},
 };
 
-if (!window.sap) {
-	window.sap = {
-		ui: {},
-	};
-}
+window.sap = window.sap || {};
+window.sap.ui = window.sap.ui || {};
 
 /**
  * @deprecated

--- a/packages/base/src/sap/ui/webcomponents/base/shims/jquery-shim.js
+++ b/packages/base/src/sap/ui/webcomponents/base/shims/jquery-shim.js
@@ -71,9 +71,6 @@ var jQuery = {
 		// Return the modified object
 		return target;
 	},
-	isEmptyObject: function(obj) {
-		return Object.keys(obj).length === 0;
-	},
 	ajaxSettings: {
 		converters: {
 			"text json": (data) => JSON.parse( data + "" )

--- a/packages/core/overlay/sap/ui/core/LocaleData.js
+++ b/packages/core/overlay/sap/ui/core/LocaleData.js
@@ -1906,7 +1906,7 @@ sap.ui.define(['sap/ui/thirdparty/jquery', 'sap/ui/base/Object', './CalendarType
 	var CustomLocaleData = LocaleData.extend("sap.ui.core.CustomLocaleData", {
 		constructor: function(oLocale) {
 			LocaleData.apply(this, arguments);
-			this.mCustomData = sap.ui.getCore().getConfiguration().getFormatSettings().getCustomLocaleData();
+			this.mCustomData = sap.ui.getCore().getFormatSettings().getCustomLocaleData();
 		},
 
 		/**

--- a/packages/core/overlay/sap/ui/core/date/Islamic.js
+++ b/packages/core/overlay/sap/ui/core/date/Islamic.js
@@ -207,8 +207,8 @@ sap.ui.define(['./UniversalDate', '../CalendarType', './CalendarClassRegistry', 
 
 		oCustomizationMap = {};
 
-		sDateFormat = sap.ui.getCore().getConfiguration().getFormatSettings().getLegacyDateFormat();
-		oCustomizationJSON = sap.ui.getCore().getConfiguration().getFormatSettings().getLegacyDateCalendarCustomizing();
+		sDateFormat = sap.ui.getCore().getFormatSettings().getLegacyDateFormat();
+		oCustomizationJSON = sap.ui.getCore().getFormatSettings().getLegacyDateCalendarCustomizing();
 		oCustomizationJSON = oCustomizationJSON || [];
 
 		if (!sDateFormat && !oCustomizationJSON.length) {//working with no customization

--- a/packages/core/overlay/sap/ui/core/date/UniversalDate.js
+++ b/packages/core/overlay/sap/ui/core/date/UniversalDate.js
@@ -203,7 +203,7 @@ sap.ui.define(['sap/ui/base/Object', 'sap/ui/core/LocaleData', 'sap/ui/core/date
 	var iMillisecondsInWeek = 7 * 24 * 60 * 60 * 1000;
 
 	UniversalDate.getWeekByDate = function(sCalendarType, iYear, iMonth, iDay) {
-		var oLocale = sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale(),
+		var oLocale = sap.ui.getCore().getFormatSettings().getFormatLocale(),
 			clDate = this.getClass(sCalendarType),
 			oFirstDay = getFirstDayOfFirstWeek(clDate, iYear),
 			oDate = new clDate(clDate.UTC(iYear, iMonth, iDay)),
@@ -234,7 +234,7 @@ sap.ui.define(['sap/ui/base/Object', 'sap/ui/core/LocaleData', 'sap/ui/core/date
 	};
 
 	UniversalDate.getFirstDateOfWeek = function(sCalendarType, iYear, iWeek) {
-		var oLocale = sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale(),
+		var oLocale = sap.ui.getCore().getFormatSettings().getFormatLocale(),
 			clDate = this.getClass(sCalendarType),
 			oFirstDay = getFirstDayOfFirstWeek(clDate, iYear),
 			oDate = new clDate(oFirstDay.valueOf() + iWeek * iMillisecondsInWeek);
@@ -255,7 +255,7 @@ sap.ui.define(['sap/ui/base/Object', 'sap/ui/core/LocaleData', 'sap/ui/core/date
 	};
 
 	function getFirstDayOfFirstWeek(clDate, iYear) {
-		var oLocale = sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale(),
+		var oLocale = sap.ui.getCore().getFormatSettings().getFormatLocale(),
 			oLocaleData = LocaleData.getInstance(oLocale),
 			iMinDays = oLocaleData.getMinimalDaysInFirstWeek(),
 			iFirstDayOfWeek = oLocaleData.getFirstDayOfWeek(),
@@ -314,7 +314,7 @@ sap.ui.define(['sap/ui/base/Object', 'sap/ui/core/LocaleData', 'sap/ui/core/date
 	};
 
 	function getEras(sCalendarType) {
-		var oLocale = sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale(),
+		var oLocale = sap.ui.getCore().getFormatSettings().getFormatLocale(),
 			oLocaleData = LocaleData.getInstance(oLocale),
 			aEras = mEras[sCalendarType];
 		if (!aEras) {

--- a/packages/core/overlay/sap/ui/core/format/DateFormat.js
+++ b/packages/core/overlay/sap/ui/core/format/DateFormat.js
@@ -246,7 +246,7 @@ sap.ui.define([
 
 		// Get Locale and LocaleData to use
 		if (!oLocale) {
-			oLocale = sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale();
+			oLocale = sap.ui.getCore().getFormatSettings().getFormatLocale();
 		}
 		oFormat.oLocale = oLocale;
 		oFormat.oLocaleData = LocaleData.getInstance(oLocale);
@@ -2180,7 +2180,7 @@ sap.ui.define([
 	DateFormat.prototype._adaptDayOfWeek = function(iDayOfWeek) {
 		// day of week depends on the format locale
 		// the DateFormat's locale is independent
-		var iFirstDayOfWeek = LocaleData.getInstance(sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale()).getFirstDayOfWeek();
+		var iFirstDayOfWeek = LocaleData.getInstance(sap.ui.getCore().getFormatSettings().getFormatLocale()).getFirstDayOfWeek();
 		var iDayNumberOfWeek = iDayOfWeek - (iFirstDayOfWeek - 1);
 
 		if (iDayNumberOfWeek <= 0) {

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -1,7 +1,11 @@
+import "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/shims/jquery-shim";
+import "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/shims/Core-shim";
 import WebComponent from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/WebComponent";
 import { fetchCldrData } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/CLDR";
 import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
-import { getLocale, getCalendarType, getFormatSettings } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
+import { getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/FormatSettings";
 import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
 import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
 import CalendarDate from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarDate";
@@ -14,6 +18,9 @@ import DayPicker from "./DayPicker";
 import MonthPicker from "./MonthPicker";
 import YearPicker from "./YearPicker";
 import CalendarRenderer from "./build/compiled/CalendarRenderer.lit";
+
+// default calendar for bundling
+import "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian";
 
 // Styles
 import belize from "./themes/sap_belize/Calendar.less";
@@ -121,7 +128,7 @@ class Calendar extends WebComponent {
 
 	constructor(state) {
 		super(state);
-		this._oLocale = getFormatSettings().getFormatLocale();
+		this._oLocale = getFormatLocale();
 		this._oLocaleData = new LocaleData(this._oLocale);
 		this._header = {};
 		this._header.onPressPrevious = this._handlePrevious.bind(this);
@@ -186,7 +193,7 @@ class Calendar extends WebComponent {
 	}
 
 	get _primaryCalendarType() {
-		return this.primaryCalendarType || getCalendarType();
+		return this.primaryCalendarType || getCalendarType() || LocaleData.getInstance(getLocale()).getPreferredCalendarType();
 	}
 
 	get _formatPattern() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -1,9 +1,13 @@
+import "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/shims/jquery-shim";
+import "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/shims/Core-shim";
 import WebComponent from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/WebComponent";
 import { fetchCldrData } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/CLDR";
 import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
 import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import { getCalendarType, getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
 import { getIconURI } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/IconPool";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
 import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
 import CalendarType from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarType";
 import CalendarDate from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarDate";
@@ -321,6 +325,7 @@ class DatePicker extends WebComponent {
 			nextValue = this.normalizeValue(nextValue);
 		}
 
+
 		this.value = nextValue;
 		this.fireEvent("change", { value: nextValue, valid: isValid });
 	}
@@ -365,7 +370,7 @@ class DatePicker extends WebComponent {
 	}
 
 	get _primaryCalendarType() {
-		return this.primaryCalendarType || getCalendarType() || CalendarType.Gregorian;
+		return this.primaryCalendarType || getCalendarType() || LocaleData.getInstance(getLocale()).getPreferredCalendarType();
 	}
 
 	get _formatPattern() {

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -1,6 +1,8 @@
 import WebComponent from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/WebComponent";
 import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
-import { getFormatSettings, getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
+import { getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/FormatSettings";
 import ItemNavigation from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/delegate/ItemNavigation";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/events/PseudoEvents";
 import Integer from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/Integer";
@@ -121,7 +123,7 @@ class DayPicker extends WebComponent {
 
 	constructor(state) {
 		super(state);
-		this._oLocale = getFormatSettings().getFormatLocale();
+		this._oLocale = getFormatLocale();
 		this._oLocaleData = new LocaleData(this._oLocale);
 
 		this._itemNav = new ItemNavigation(this, { rowSize: 7 });
@@ -327,7 +329,7 @@ class DayPicker extends WebComponent {
 	}
 
 	get _primaryCalendarType() {
-		return this.primaryCalendarType || getCalendarType();
+		return this.primaryCalendarType || getCalendarType() || LocaleData.getInstance(getLocale()).getPreferredCalendarType();
 	}
 
 	_modifySelectionAndNotifySubscribers(sNewDate, bAdd) {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -1,10 +1,12 @@
 import WebComponent from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/WebComponent";
 import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
-import { getFormatSettings, getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/FormatSettings";
 import ItemNavigation from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/delegate/ItemNavigation";
 import Integer from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/Integer";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/events/PseudoEvents";
 import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
 import CalendarType from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarType";
 import CalendarDate from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarDate";
 import ShadowDOM from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/compatibility/ShadowDOM";
@@ -89,7 +91,7 @@ class MonthPicker extends WebComponent {
 
 	constructor(state) {
 		super(state);
-		this._oLocale = getFormatSettings().getFormatLocale();
+		this._oLocale = getFormatLocale();
 		this._oLocaleData = new LocaleData(this._oLocale);
 
 		this._itemNav = new ItemNavigation(this, { rowSize: 3, cyclic: true });
@@ -158,7 +160,7 @@ class MonthPicker extends WebComponent {
 	}
 
 	get _primaryCalendarType() {
-		return this.primaryCalendarType || getCalendarType();
+		return this.primaryCalendarType || getCalendarType() || LocaleData.getInstance(getLocale()).getPreferredCalendarType();
 	}
 
 	onclick(event) {

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -5,7 +5,7 @@ import URI from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/URI
 import Integer from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/Integer";
 import Function from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/Function";
 import { fetchCldrData } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/CLDR";
-import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
 import Icon from "./Icon";
 import Link from "./Link";
 import TimelineItemTemplateContext from "./TimelineItemTemplateContext";

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -1,8 +1,11 @@
 import WebComponent from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/WebComponent";
 import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
-import { getFormatSettings, getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
+import { getCalendarType } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Configuration";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/FormatSettings";
 import { isEnter, isSpace } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/events/PseudoEvents";
 import ItemNavigation from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/delegate/ItemNavigation";
+import { getLocale } from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/LocaleProvider";
 import Integer from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/types/Integer";
 import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
 import CalendarType from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/dates/CalendarType";
@@ -90,7 +93,7 @@ class YearPicker extends WebComponent {
 	constructor(state) {
 		super(state);
 
-		this._oLocale = getFormatSettings().getFormatLocale();
+		this._oLocale = getFormatLocale();
 
 		this._itemNav = new ItemNavigation(this, { rowSize: 4 });
 		this._itemNav.getItemsCallback = function getItemsCallback() {
@@ -182,7 +185,7 @@ class YearPicker extends WebComponent {
 	}
 
 	get _primaryCalendarType() {
-		return this.primaryCalendarType || getCalendarType();
+		return this.primaryCalendarType || getCalendarType() || LocaleData.getInstance(getLocale()).getPreferredCalendarType();
 	}
 
 	onclick(event) {

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
@@ -6,11 +6,6 @@
 	<meta charset="utf-8">
 
 	<script src="diffable-html.js"></script>
-	<script data-id="sap-ui-config" type="application/json">
-		{
-			"language": "EN"
-		}
-	</script>
 
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"

--- a/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
@@ -14,13 +14,6 @@
 
 	<link href="../../../../../../test-resources/playground/css/api.css" type="text/css" rel="stylesheet">
 
-	<script data-id="sap-ui-config" type="application/json">
-		{
-			"theme": "sap_fiori_3",
-			"language": "EN"
-		}
-	</script>
-
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>


### PR DESCRIPTION
- configuration is now set only from url or JSON script
- locale is required for all controls that need it, not on central level as it used to be
- new module LocaleProvider is added - it returns the locale from the configuration or locale based on browser
- all compatibility core-shim and jQuery levels are moved to Calendar and DatePicker
- bundle size for a single CheckBox reduced to ~ 15kb