### PR TITLE
fix(ui5-input): fire change in sync with the native input

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -15,6 +15,7 @@
 			.value="{{ctr.value}}"
 			placeholder="{{ctr.placeholder}}"
 			@input="{{ctr._input.onInput}}"
+			@change="{{ctr._input.change}}"
 			data-sap-no-tab-ref
 			data-sap-focus-ref
 	/>

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -285,8 +285,6 @@ class Input extends WebComponent {
 		// Indicates if there is selected suggestionItem.
 		this.hasSuggestionItemSelected = false;
 
-
-
 		// Represents the value before user moves selection between the suggestion items.
 		// Used to register and fire "input" event upon [SPACE] or [ENTER].
 		// Note: the property "value" is updated upon selection move and can`t be used.

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -289,7 +289,10 @@ class Input extends WebComponent {
 		// Used to ignore the Input "focusedOut" and thus preventing firing "change" event.
 		this.hasSuggestionItemFocused = false;
 
+		// tracks the value between input focusin and focusout to determine if change event should be fired..
 		this.previousValue = undefined;
+		// tracks live value state and used to detect when the value is changed by the API.
+		this.previousLiveValue = undefined;
 
 		// Represents the value before user moves selection between the suggestion items.
 		// Used to register and fire "input" event upon [SPACE] or [ENTER].
@@ -328,6 +331,7 @@ class Input extends WebComponent {
 			this.Suggestions.toggle(this.shouldOpenSuggestions());
 		}
 		this.checkFocusOut();
+		this.checkValueChanges();
 		this.firstRendering = false;
 	}
 
@@ -454,6 +458,7 @@ class Input extends WebComponent {
 			this.value = itemText;
 			this.valueBeforeItemSelection = itemText;
 			this.fireEvent(this.EVENT_INPUT);
+			this.fireEvent(this.EVENT_CHANGE);
 		}
 	}
 
@@ -473,6 +478,7 @@ class Input extends WebComponent {
 		const isUserInput = action === this.ACTION_USER_INPUT;
 
 		this.value = inputValue;
+		this.previousLiveValue = inputValue;
 
 		const valueChanged = (this.previousValue !== undefined) && (this.previousValue !== this.value);
 
@@ -488,6 +494,13 @@ class Input extends WebComponent {
 
 		if (isSubmit) { // submit
 			this.fireEvent(this.EVENT_SUBMIT);
+		}
+	}
+
+	checkValueChanges() {
+		if (this.previousLiveValue !== this.value) { // value has been changed via API
+			this.previousLiveValue = this.value;
+			this.previousValue = this.value;
 		}
 	}
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_test_page.html
@@ -32,20 +32,22 @@
 	<ui5-datepicker id="dp10" disabled></ui5-datepicker>
 	<ui5-datepicker id="dp11"></ui5-datepicker>
 	<ui5-datepicker id="dp12"></ui5-datepicker>
+	<ui5-datepicker id="dp13"></ui5-datepicker>
 	<label id='lbl'>0</label>
 	<label for="inputTimezone">Timezone:</label>
 	<input id="inputTimezone" type="number"/>
 	<button id="btnApplyTimezone" onclick="stubTimezone();">Apply</button>
 	<button id="btnRestoreTimezone" onclick="restore();">Restore</button>
 	<button id="downThere" style="position:absolute; top:3000px;"></button>
-
+	<label id='lblTomorrow'>0</label>
+	<label id='lblTomorrowDate'></label>
 	<script>
-		const originalGetDate = Date.prototype.getDate;
+		var originalGetDate = Date.prototype.getDate;
 
 		function stubTimezone() {
-			const timezone = parseInt(document.querySelector("#inputTimezone").value, 10);
+			var timezone = parseInt(document.querySelector("#inputTimezone").value, 10);
 			Date.prototype.getDate = function() {
-				const stubedDate = new Date(this.getTime() + timezone * 60 * 60 * 1000);
+				var stubedDate = new Date(this.getTime() + timezone * 60 * 60 * 1000);
 				return stubedDate.getUTCDate();
 			};
 		}
@@ -55,13 +57,18 @@
 			document.querySelector("#inputTimezone").value = "";
 		};
 
-		let counter = 0;
+		var counter = 0;
+		var counterTomorrow = 0;
 		function increaseCounter() {
 			document.querySelector('#lbl').innerHTML = ++counter;
 		}
 
 		document.querySelector("#dp5").addEventListener("change", increaseCounter);
 		document.querySelector("#dp8").addEventListener("change", increaseCounter);
+		document.querySelector("#dp13").addEventListener("change", function(e) {
+			document.querySelector('#lblTomorrow').innerHTML = ++counterTomorrow;
+			document.querySelector('#lblTomorrowDate').innerHTML = e.target.value;
+		});
 	</script>
 </body>
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
@@ -53,8 +53,12 @@
 	</ui5-input>
 
 	<h3> Input</h3>
-	<ui5-input id="inputResult" style="width:100%">
-	</ui5-input>
+	<ui5-input id="inputResult" style="width:100%"></ui5-input>
+
+	<h3> Input test change</h3>
+	<ui5-input id="inputChange" style="width:100%">	</ui5-input>
+	<h3> Input test change result</h3>
+	<ui5-input id="inputChangeResult" style="width:100%"></ui5-input>
 
 	<h3> Input readonly</h3>
 	<ui5-input style="width:100%" value="Value can`t be changed" readonly></ui5-input>
@@ -146,6 +150,15 @@
 			var item = event.detail.item;
 			suggestionSelectedCounter += 1;
 			inputResult.value = suggestionSelectedCounter;
+		});
+
+		var inputChangeResultCounter = 0;
+
+		inputChange.addEventListener("submit", function (event) {
+			inputChange.value = "Changed via API";
+		});
+		inputChange.addEventListener("change", function (event) {
+			inputChangeResult.value = ++inputChangeResultCounter;
 		});
 	</script>
 </body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
@@ -37,23 +37,26 @@
 		<ui5-icon data-ui5-slot="icon" src="sap-icon://appointment-2"></ui5-icon>
 	</ui5-input>
 
-	<h3> Input valueState Warning</h3>
-	<ui5-input id="input1" style="width:100%" value-state="Warning" placeholder="Warning state ...">
-		<ui5-icon data-ui5-slot="icon" src="sap-icon://message-warning" functional></ui5-icon>
-	</ui5-input>
-
-	<h3> Input valueState Error</h3>
-	<ui5-input id="input2" style="width:100%" value-state="Error" placeholder="Error state ...">
-		<ui5-icon data-ui5-slot="icon" src="sap-icon://message-error"></ui5-icon>
-	</ui5-input>
-
 	<h3> Input valueState Success</h3>
 	<ui5-input id="input3" style="width:100%" value-state="Success" placeholder="Success state ...">
 		<ui5-icon data-ui5-slot="icon" src="sap-icon://message-success"></ui5-icon>
 	</ui5-input>
 
-	<h3> Input</h3>
+	<h3> Test 'change' event</h3>
+	<ui5-input id="input1" style="width:100%" value-state="Warning" placeholder="Warning state ...">
+		<ui5-icon data-ui5-slot="icon" src="sap-icon://message-warning" functional></ui5-icon>
+	</ui5-input>
+	<h3> 'change' event result</h3>
 	<ui5-input id="inputResult" style="width:100%"></ui5-input>
+
+	<h3> Test 'input' event</h3>
+	<ui5-input id="input2" style="width:100%" value-state="Error" placeholder="Error state ...">
+		<ui5-icon data-ui5-slot="icon" src="sap-icon://message-error"></ui5-icon>
+	</ui5-input>
+	<h3> 'input' test result</h3>
+	<ui5-input id="inputLiveChangeResult" style="width:100%"></ui5-input>
+
+	
 
 	<h3> Input test change</h3>
 	<ui5-input id="inputChange" style="width:100%">	</ui5-input>
@@ -143,7 +146,7 @@
 
 		input2.addEventListener("input", function (event) {
 			inputCounter += 1;
-			inputResult.value = inputCounter;
+			inputLiveChangeResult.value = inputCounter;
 		});
 
 		myInput2.addEventListener("suggestionItemSelect", function (event) {

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/Input.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/Input.qunit.js
@@ -269,40 +269,5 @@ TestHelper.ready(function() {
 			fixture.innerHTML = "";
 			this.input = null;
 		});
-
-		QUnit.test("type in input fires change onfocusout", function(assert) {
-			assert.expect(1);
-
-			var input = this.getInput();
-			var done = assert.async();
-
-			input.addEventListener("change", function(e){
-				assert.ok(true, "change fired, when onfocusout");
-				done();
-			});
-
-			input.value = "abc";
-			input.onfocusout();
-		});
-
-		QUnit.test("type in input does not fire change when the initial value remains the same", function(assert) {
-			assert.expect(1);
-
-			var input = this.getInput();
-			var done = assert.async();
-
-			input.addEventListener("change", function(e){
-				assert.ok(false, "change fired incorreclty, when onfocusout");
-			});
-
-			input.value = "abc";
-			input.value = "";
-			input.onfocusout();
-
-			setTimeout(function() {
-				assert.ok(true, "change event not fired on onfocusout, when the value did not changed");
-				done();
-			}, 200)
-		});
 	});
 });

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -241,6 +241,31 @@ describe("Date Picker Tests", () => {
 		assert.equal(browser.findElementDeep("#lbl").getHTML(false), "2", 'change has fired once');
 	});
 
+	it("change fires every time tomorrow is typed and normalized", () => {
+		let tomorrowDate;
+		const lblChangeCounter = browser.$("#lblTomorrow");
+		const lblTomorrowDate = browser.$("#lblTomorrowDate");
+
+		datepicker.id = "#dp13";
+
+		// Type tomorrow.
+		datepicker.innerInput.click();
+		datepicker.innerInput.keys("tomorrow");
+
+		// Press Enter, store the date and delete it.
+		datepicker.innerInput.keys("Enter");
+		tomorrowDate = lblTomorrowDate.getHTML(false);
+		browser.keys("\b\b\b\b\b\b\b\b\b\b\b\b\b");
+
+		// Type tomorrow and press Enter for the second time.
+		datepicker.innerInput.keys("tomorrow");
+		datepicker.innerInput.keys("Enter");
+
+		// Two change events should be fired and the date should twice normalized
+		assert.equal(lblChangeCounter.getHTML(false), "2", 'change event is being fired twice');
+		assert.equal(lblTomorrowDate.getHTML(false), tomorrowDate, 'tomorrow is normalazid to date twice as well');
+	});
+
 	it("today value is normalized and correctly rounded to 00:00:00", () => {
 		datepicker.id = "#dp9";
 

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -228,14 +228,14 @@ describe("Date Picker Tests", () => {
 
 		datepicker.innerInput.click();
 		browser.keys("\b\b\b\b\b\b\b\b\b\b\b");
-		datepicker.innerInput.setValue("Jan 8, 2015");
+		datepicker.innerInput.keys("Jan 8, 2015");
 		browser.findElementDeep("#dp1 >>> ui5-input >>> input").click(); //click elsewhere to focusout
 
 		assert.equal(browser.findElementDeep("#lbl").getHTML(false), "1", 'change has fired once');
 
 		datepicker.innerInput.click();
 		browser.keys("\b\b\b\b\b\b\b\b\b\b\b");
-		datepicker.innerInput.setValue("Jan 6, 2015");
+		datepicker.innerInput.keys("Jan 6, 2015");
 		browser.findElementDeep("#dp1 >>> ui5-input >>> input").click(); //click elsewhere to focusout
 
 		assert.equal(browser.findElementDeep("#lbl").getHTML(false), "2", 'change has fired once');

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -7,15 +7,31 @@ describe("Input general interaction", () => {
 		const input1 = browser.findElementDeep("#input1 >>> input");
 		const inputResult = browser.findElementDeep("#inputResult >>> input");
 
+		// Start typing.
 		input1.click();
-		input1.setValue("abc");
+		input1.keys("abc");
+
+		// Click somewhere else to focus out - should fire change event.
 		inputResult.click();
 
+		// Get back and continue typing.
 		input1.click();
-		input1.setValue("def");
+		input1.keys("def");
+
+		// Click somewhere else to force focus out - should fire change event.
 		inputResult.click();
 
 		assert.strictEqual(inputResult.getProperty("value"), "2", "change is called twice");
+	});
+
+	it("fires input", () => {
+		const input2 = browser.findElementDeep("#input2 >>> input");
+		const inputLiveChangeResult = browser.findElementDeep("#inputLiveChangeResult >>> input");
+
+		input2.click();
+		input2.setValue("abc");
+
+		assert.strictEqual(inputLiveChangeResult.getProperty("value"), "3", "input is fired 3 times");
 	});
 
 	it("fires change when same value typed, but value is mutated via API in between", () => {
@@ -23,30 +39,20 @@ describe("Input general interaction", () => {
 		const inputChangeResult = browser.findElementDeep("#inputChangeResult >>> input");
 
 		inputChange.click();
-		inputChange.setValue("tomorrow");
+		inputChange.keys("abc");
 
 		// The submit event listener mutates the value via the API
 		// Note: along with the sumbit event - the first change event is fired.
 		inputChange.keys("Enter");
-		
+
 		// Type the same value once again.
-		inputChange.setValue("tomorrow");
+		inputChange.keys("abc");
 
 		// Clicking on another input to force focus out,
 		// which should trigger second change event, although same value is typed in.
 		inputChangeResult.click();
 
 		assert.strictEqual(inputChangeResult.getProperty("value"), "2", "change is called twice");
-	});
-
-	it("fires input", () => {
-		const input2 = browser.findElementDeep("#input2 >>> input");
-		const inputResult = browser.findElementDeep("#inputResult >>> input");
-
-		input2.click();
-		input2.keys("abc");
-
-		assert.strictEqual(inputResult.getProperty("value"), "3", "input is fired 3 times");
 	});
 
 	it("handles suggestions", () => {
@@ -93,6 +99,5 @@ describe("Input general interaction", () => {
 
 		assert.strictEqual(suggestionsInput.getProperty("value"), "Condensed", "First item has been selected");
 		assert.strictEqual(inputResult.getProperty("value"), "4", "suggestionItemSelected event called once");
-
-	});	
+	});
 });

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -18,6 +18,27 @@ describe("Input general interaction", () => {
 		assert.strictEqual(inputResult.getProperty("value"), "2", "change is called twice");
 	});
 
+	it("fires change when same value typed, but value is mutated via API in between", () => {
+		const inputChange = browser.findElementDeep("#inputChange >>> input");
+		const inputChangeResult = browser.findElementDeep("#inputChangeResult >>> input");
+
+		inputChange.click();
+		inputChange.setValue("tomorrow");
+
+		// The submit event listener mutates the value via the API
+		// Note: along with the sumbit event - the first change event is fired.
+		inputChange.keys("Enter");
+		
+		// Type the same value once again.
+		inputChange.setValue("tomorrow");
+
+		// Clicking on another input to force focus out,
+		// which should trigger second change event, although same value is typed in.
+		inputChangeResult.click();
+
+		assert.strictEqual(inputChangeResult.getProperty("value"), "2", "change is called twice");
+	});
+
 	it("fires input", () => {
 		const input2 = browser.findElementDeep("#input2 >>> input");
 		const inputResult = browser.findElementDeep("#inputResult >>> input");


### PR DESCRIPTION
Bind to the native input "change" event and fire the ui5-input semantic one.
Manually fire "change", when suggestion item is selected.
Fixes: #154