### PR TITLE
improvement: externalise webcomponents polyfill

### DIFF
--- a/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
+++ b/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
@@ -2,6 +2,7 @@ import whenDOMReady from "./util/whenDOMReady";
 import EventEnrichment from "./events/EventEnrichment";
 import { insertIconFontFace } from "./IconFonts";
 import DOMEventHandler from "./DOMEventHandler";
+import RenderScheduler from "./RenderScheduler";
 
 EventEnrichment.run();
 
@@ -18,7 +19,17 @@ const Bootstrap = {
 			whenDOMReady().then(() => {
 				insertIconFontFace();
 				DOMEventHandler.start();
-				resolve();
+
+				if (window.WebComponents && window.WebComponents.waitFor) {
+					// the polyfill loader is present
+					window.WebComponents.waitFor(() => {
+						// the polyfills are loaded, safe to execute code depending on their APIs
+						resolve();
+					});
+				} else {
+					// polyfill loader missing, modern browsers only
+					resolve();
+				}
 			});
 		});
 

--- a/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
+++ b/packages/base/src/sap/ui/webcomponents/base/Bootstrap.js
@@ -2,7 +2,6 @@ import whenDOMReady from "./util/whenDOMReady";
 import EventEnrichment from "./events/EventEnrichment";
 import { insertIconFontFace } from "./IconFonts";
 import DOMEventHandler from "./DOMEventHandler";
-import RenderScheduler from "./RenderScheduler";
 
 EventEnrichment.run();
 

--- a/packages/base/src/sap/ui/webcomponents/base/browsersupport/Edge.js
+++ b/packages/base/src/sap/ui/webcomponents/base/browsersupport/Edge.js
@@ -1,9 +1,6 @@
 // URLSearchParams
 import "url-search-params-polyfill";
 
-// Web Components polyfills
-import "../thirdparty/shadydom.min";
-import "../thirdparty/custom-elements.min";
 
 // "pseudo mutation observer" fix for nodeValue
 import "../compatibility/patchNodeValue";

--- a/packages/base/src/sap/ui/webcomponents/base/browsersupport/IE11.js
+++ b/packages/base/src/sap/ui/webcomponents/base/browsersupport/IE11.js
@@ -2,11 +2,9 @@
 import "@ui5/webcomponents-core/dist/sap/ui/thirdparty/es6-string-methods";
 
 // Object
-import "../thirdparty/Object.assign";
 import "../thirdparty/Object.entries";
 
 // Array
-import "../thirdparty/Array.from";
 import "../thirdparty/Array.prototype.fill";
 import "../thirdparty/Array.prototype.includes";
 
@@ -15,27 +13,15 @@ import "../thirdparty/Number.isInteger";
 import "../thirdparty/Number.isNaN";
 import "../thirdparty/Number.parseInt";
 
-// Symbol
-import "../thirdparty/Symbol";
-
 // Element
 import "../thirdparty/Element.prototype.matches";
 import "../thirdparty/Element.prototype.closest";
-
-// Promise
-import "@ui5/webcomponents-core/dist/sap/ui/thirdparty/es6-promise";
 
 // WeakSet
 import "../thirdparty/WeakSet";
 
 // fetch
 import "../thirdparty/fetch";
-
-// template
-import "../thirdparty/template";
-
-// Various event polyfills - preventDefault, window.Event, window.CustomEvent, window.MouseEvent
-import "../thirdparty/events-polyfills";
 
 // async - await
 import "regenerator-runtime/runtime";

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -44,7 +44,7 @@
     }
   },
   "scripts": {
-    "build": "npm-run-all --sequential clean lint build:templates build:samples build:less copy:src build:bundle copy:i18n",
+    "build": "npm-run-all --sequential clean lint build:templates build:samples build:less copy:src build:bundle copy:i18n copy:webcomponents-polyfill ",
     "build:less": "rollup -c rollup.config.less.js",
     "build:bundle": "rollup -c --environment ES5_BUILD",
     "build:templates": "mkdirp src/build/compiled && node ./lib/hbs2ui5/index.js -d src/ -o src/build/compiled",
@@ -59,7 +59,8 @@
     "copy:test": "cpx \"test/**/*.*\" dist/test-resources",
     "copy:pages": "cpx \"test/**/pages/*.*\" dist/test-resources",
     "copy:qunit": "cpx \"test/**/qunit/*.*\" dist/test-resources",
-    "dev": "npm-run-all --parallel watch:less watch:templates watch:samples watch:pages watch:qunit watch:src watch:bundle",
+    "copy:webcomponents-polyfill": "cpx \"../../node_modules/@webcomponents/webcomponentsjs/**/*.*\" dist/webcomponentsjs/",
+    "dev": "npm-run-all --parallel watch:less watch:templates watch:samples watch:pages watch:qunit watch:src watch:bundle copy:webcomponents-polyfill",
     "start": "npm-run-all --parallel serve:static dev",
     "lint": "eslint .",
     "test:wdio": "npm-run-all --parallel --race serve:static test:wdio-run",
@@ -97,6 +98,7 @@
     "@wdio/mocha-framework": "^5.4.13",
     "@wdio/spec-reporter": "^5.4.3",
     "@wdio/sync": "^5.4.13",
+    "@webcomponents/webcomponentsjs": "^2.2.7",
     "chromedriver": "^2.45.0",
     "clean-css": "^4.2.1",
     "copy-and-watch": "^0.1.2",

--- a/packages/main/src/Suggestions.js
+++ b/packages/main/src/Suggestions.js
@@ -1,3 +1,4 @@
+import Bootstrap from "@ui5/webcomponents-base/src/sap/ui/webcomponents/base/Bootstrap";
 import List from "./List";
 import Popover from "./Popover";
 import StandardListItem from "./StandardListItem"; // ensure <ui5-li> is loaded
@@ -274,7 +275,9 @@ Suggestions.SCROLL_STEP = 48;
 
 // The List and Popover components would be rendered
 // by the issuer component`s template.
-List.define();
-Popover.define();
+Bootstrap.boot().then(() => {
+	List.define();
+	Popover.define();
+});
 
 export default Suggestions;

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Button.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Button.html
@@ -13,11 +13,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Calendar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Calendar.html
@@ -13,11 +13,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-	        type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Card.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Card.html
@@ -13,11 +13,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-	        type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 	<style>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/CheckBox.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/CheckBox.html
@@ -6,11 +6,8 @@
 
 	<title>ui5-checkbox</title>
 
-	<script
-		src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	></script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script	src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 
 	<style>
@@ -18,11 +15,6 @@
 			border: 1px solid red;
 		}
 	</style>
-
-	<script data-id="sap-ui-config" type="application/json">
-		{
-		}
-	</script>
 </head>
 
 <body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
@@ -7,11 +7,8 @@
 
 	<script src="diffable-html.js"></script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_fg.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_fg.html
@@ -13,9 +13,8 @@
 		}
 	</script>
 
-	<script type="module" src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js">
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module" src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_test_page.html
@@ -11,10 +11,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 </head>
 <body>
 	<ui5-datepicker id="dp"></ui5-datepicker>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Dialog.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Dialog.html
@@ -13,11 +13,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Eventing.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Eventing.html
@@ -12,11 +12,8 @@
         }
     </script>
 
-    <script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-            type="module"
-    >
-    </script>
-
+    <script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module" ></script>
     <script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
     </script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/HCB.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/HCB.html
@@ -13,11 +13,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Icon.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Icon.html
@@ -14,11 +14,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Input.html
@@ -4,11 +4,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<title>ui5-input</title>
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 </head>
 
@@ -56,7 +53,7 @@
 	<h3> 'input' test result</h3>
 	<ui5-input id="inputLiveChangeResult" style="width:100%"></ui5-input>
 
-	
+
 
 	<h3> Input test change</h3>
 	<ui5-input id="inputChange" style="width:100%">	</ui5-input>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
@@ -15,12 +15,8 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-		id="sap-ui-bootstrap"
-	>
-	</script>
-
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 </head>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.openui5.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.openui5.html
@@ -27,13 +27,9 @@
 			new sap.m.DatePicker().placeAt("sapMDatePicker");
 		})
 	</script>
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-		type="module"
-	>
-	</script>
-
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 </head>
 
 <body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Label.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Label.html
@@ -16,11 +16,9 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module">
-	</script>
-
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 
 	<style>
 		html,

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Link.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Link.html
@@ -16,11 +16,9 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module">
-	</script>
-
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 
 	<style>
 		html,

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List.html
@@ -5,13 +5,9 @@
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-			type="module"
-	>
-	</script>
-
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 </head>
 
 <body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List_keyboard_support.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List_keyboard_support.html
@@ -13,13 +13,10 @@
 		}
 	</script>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-	        type="module"
-	>
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 
 	<style>
 		#myList {width: 700px;}

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
@@ -5,13 +5,10 @@
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>
 
-	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
-			type="module"
-	>
-	</script>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 
-	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
-	</script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
 </head>
 
 <body>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Panel.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Panel.html
@@ -18,6 +18,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module">
 	</script>
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Popover.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Popover.html
@@ -13,6 +13,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Popups.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Popups.html
@@ -13,6 +13,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
@@ -6,6 +6,7 @@
 
 	<title>ui5-radiobutton</title>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 			type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Select.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Select.html
@@ -4,6 +4,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<title>ui5-select</title>
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 		id="sap-ui-bootstrap">

--- a/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
@@ -13,6 +13,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 		id="sap-ui-bootstrap"

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Simple.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Simple.html
@@ -17,6 +17,7 @@
         }
     </script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
     <script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
             type="module"
     >

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Switch.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Switch.html
@@ -6,6 +6,7 @@
 
 	<title>ui5-switch</title>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script
 		src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"

--- a/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/TabContainer.html
@@ -14,6 +14,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 			type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Table.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Table.html
@@ -12,6 +12,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/TextArea.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/TextArea.html
@@ -16,6 +16,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Timeline.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Timeline.html
@@ -17,6 +17,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	        id="sap-ui-bootstrap"

--- a/packages/main/test/sap/ui/webcomponents/main/pages/ToggleButton.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/ToggleButton.html
@@ -16,6 +16,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Toolbar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Toolbar.html
@@ -12,6 +12,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Button.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Button.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Card.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Card.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script
 		src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
@@ -89,7 +90,7 @@
 			padding: 0.5rem 1rem 0 1rem;
 		}
 
-		
+
 	</style>
 </head>
 <body class="sapUiBody example-wrapper">
@@ -161,13 +162,13 @@
 							<ui5-label>Sales Order</ui5-label>
 						</div>
 					</ui5-table-column>
-			
+
 					<ui5-table-column data-ui5-slot="columns">
 						<div data-ui5-slot="header">
 							<ui5-label>Customer</ui5-label>
 						</div>
 					</ui5-table-column>
-			
+
 					<ui5-table-column data-ui5-slot="columns">
 						<div data-ui5-slot="header">
 							<ui5-label>Net Amount</ui5-label>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/CheckBox.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
@@ -14,6 +14,7 @@
 
 	<link href="../../../../../../test-resources/playground/css/api.css" type="text/css" rel="stylesheet">
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Dialog.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Dialog.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Icon.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Icon.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -69,8 +70,8 @@
 	<script>
 		window.prettyPrint();
 	</script>
-	
-	<script defer src="../../../../../../www/samples/settings.js"></script>	
+
+	<script defer src="../../../../../../www/samples/settings.js"></script>
 </body>
 
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -224,7 +225,7 @@
 		window.prettyPrint();
 	</script>
 
-	<script defer src="../../../../../../www/samples/settings.js"></script>	
+	<script defer src="../../../../../../www/samples/settings.js"></script>
 </body>
 
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Label.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Label.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -80,7 +81,7 @@
 		window.prettyPrint();
 	</script>
 
-	<script defer src="../../../../../../www/samples/settings.js"></script>	
+	<script defer src="../../../../../../www/samples/settings.js"></script>
 </body>
 
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Link.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/List.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/List.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -129,13 +130,13 @@
 					<ui5-li image="../../../../../../www/samples/images/man_avatar_1.png" type="Active"  icon="sap-icon://navigation-right-arrow" icon-end>Clark</ui5-li>
 					<ui5-li image="../../../../../../www/samples/images/woman_avatar_1.png" type="Active" icon="sap-icon://navigation-right-arrow" icon-end>Ellen</ui5-li>
 					<ui5-li image="../../../../../../www/samples/images/man_avatar_2.png" type="Active" icon="sap-icon://navigation-right-arrow" icon-end>Adam</ui5-li>
-			
+
 					<ui5-li-groupheader>FullStack Developers</ui5-li-groupheader>
 					<ui5-li image="../../../../../../www/samples/images/woman_avatar_2.png" type="Active" icon="sap-icon://navigation-right-arrow" icon-end>Susan</ui5-li>
 					<ui5-li image="../../../../../../www/samples/images/man_avatar_3.png" type="Active" icon="sap-icon://navigation-right-arrow" icon-end>David</ui5-li>
 					<ui5-li image="../../../../../../www/samples/images/woman_avatar_3.png" type="Active" icon="sap-icon://navigation-right-arrow" icon-end>Natalie</ui5-li>
 				</ui5-list>
-	
+
 			<pre class="prettyprint lang-html">
 				<xmp>
 <ui5-list header-text="Team Members" mode="MultiSelect">

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Panel.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Panel.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Popover.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Select.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Select.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -52,7 +53,7 @@
 			<span><!--since_tag_marker--></span>
 		</div>
 	</header>
-	
+
 	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-select&gt;</div>
 	<section>
 		<h3>Basic Select</h3>
@@ -124,7 +125,7 @@
 		window.prettyPrint();
 	</script>
 
-	<script defer src="../../../../../../www/samples/settings.js"></script>	
+	<script defer src="../../../../../../www/samples/settings.js"></script>
 </body>
 
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script
 		src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>
@@ -44,7 +45,7 @@
 		</div>
 	</header>
 	<div style="margin-bottom: 2rem; font-weight: 300; font-size: 1.1rem; color: #666666;">&lt;ui5-switch&gt;</div>
-	
+
 	<!-- Basic Switch -->
 	<section>
 		<h3>Basic Switch</h3>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/TabContainer.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/TabContainer.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Table.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/TextArea.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/TextArea.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Timeline.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Timeline.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 		type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Title.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Title.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/ToggleButton.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/ToggleButton.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Toolbar.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Toolbar.sample.html
@@ -21,6 +21,7 @@
 		}
 	</script>
 
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js"
 	        type="module"
 	>

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@
   resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.9.0.tgz#8450465037370d4f5c32e801bb2554a7cf2f5037"
   integrity sha512-g8Xa+6RSEME4g/wLJW4YII0eq15rvXp76RxPAuv7hx+Bdoi7GzZJ/EoZOUfyIbqAsQbII1TcWD4/+Xhs5NcM1w==
 
+"@webcomponents/webcomponentsjs@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.7.tgz#1f1a7a7aa083db5ae6aadaeda68caa8fd8657462"
+  integrity sha512-kPPjzV+5kpoWpTniyvBSPcXS33f3j/C6HvNOJ3YecF3pvz3XwVeU4ammbxtVy/osF3z7hr1DYNptIf4oPEvXZA==
+
 "@zeit/schemas@2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.6.0.tgz#004e8e553b4cd53d538bd38eac7bcbf58a867fe3"


### PR DESCRIPTION
The polyfill is now loaded via the official webcomponents-loader, instead of imports
This allows users of web components to provide their own version and copy of the polyfill
This also decreases the bundle size for the playground for modern browsers
