### PR TITLE
fix(ui5-list): correct backward navigation with SHIFT+TAB

### DIFF
--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -81,7 +81,7 @@ class ListItemBase extends WebComponent {
 		}
 	}
 
-	onsaptabprevious(event) {
+	_handleTabPrevious(event) {
 		const target = event.target.shadowRoot.activeElement;
 
 		if (this.shouldForwardTabBefore(target)) {


### PR DESCRIPTION
After the refactoring of the Pseudo events onsaptabprevious stopped working.
It`s now replaced by _handleTabPrevious.
Fixes: https://github.com/SAP/ui5-webcomponents/issues/192