### PR TITLE
fix(ui5-checkbox): correct setting of aria-readonly

### DIFF
--- a/packages/main/src/CheckBoxTemplateContext.js
+++ b/packages/main/src/CheckBoxTemplateContext.js
@@ -7,7 +7,7 @@ class CheckBoxTemplateContext {
 
 		const context = {
 			ctr: state,
-			ariaReadonly: state.readOnly ? "true" : undefined,
+			ariaReadonly: state.readOnly,
 			tabIndex: state.disabled ? undefined : "0",
 			classes: { main: mainClasses, inner: innerClasses },
 			styles: {

--- a/packages/main/src/CheckBoxTemplateContext.js
+++ b/packages/main/src/CheckBoxTemplateContext.js
@@ -7,15 +7,13 @@ class CheckBoxTemplateContext {
 
 		const context = {
 			ctr: state,
-			readOnly: !state.disabled,
+			ariaReadonly: state.readOnly ? "true" : undefined,
 			tabIndex: state.disabled ? undefined : "0",
 			classes: { main: mainClasses, inner: innerClasses },
 			styles: {
 				main: {},
 			},
 		};
-
-		context.ariaReadonly = context.readOnly ? "true" : undefined;
 
 		return context;
 	}


### PR DESCRIPTION
Set aria-readonly, when readOnly property is set (previously checking for the disabled property, which is not correct).
