### PR TITLE
fix: add missing dependency to jquery-shim in resource bundle

### DIFF
--- a/packages/base/src/ResourceBundle.js
+++ b/packages/base/src/ResourceBundle.js
@@ -1,3 +1,4 @@
+import "./shims/jquery-shim";
 import ResourceBundle from "@ui5/webcomponents-core/dist/sap/base/i18n/ResourceBundle";
 import { getLanguage } from "./LocaleProvider";
 import { registerModuleContent } from "./ResourceLoaderOverrides";


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/237