### PR TITLE
refactor(ui5-shellbar): rename press handlers param

### DIFF
--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -182,12 +182,12 @@ const metadata = {
 		 * Fired, when the primaryTitle is pressed.
 		 *
 		 * @event
-		 * @param {HTMLElement} iconRef dom ref of the clicked icon
+		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
 		titlePress: {
 			detail: {
-				iconRef: { type: HTMLElement },
+				targetRef: { type: HTMLElement },
 			},
 		},
 
@@ -197,12 +197,12 @@ const metadata = {
 		 *
 		 *
 		 * @event
-		 * @param {HTMLElement} iconRef dom ref of the clicked icon
+		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
 		notificationsPress: {
 			detail: {
-				iconRef: { type: HTMLElement },
+				targetRef: { type: HTMLElement },
 			},
 		},
 
@@ -210,12 +210,12 @@ const metadata = {
 		 * Fired, when the profile icon is pressed.
 		 *
 		 * @event
-		 * @param {HTMLElement} iconRef dom ref of the clicked icon
+		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
 		profilePress: {
 			detail: {
-				iconRef: { type: HTMLElement },
+				targetRef: { type: HTMLElement },
 			},
 		},
 
@@ -223,12 +223,12 @@ const metadata = {
 		 * Fired, when the product switch icon is pressed.
 		 *
 		 * @event
-		 * @param {HTMLElement} iconRef dom ref of the clicked icon
+		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
 		productSwitchPress: {
 			detail: {
-				iconRef: { type: HTMLElement },
+				targetRef: { type: HTMLElement },
 			},
 		},
 	},
@@ -306,7 +306,7 @@ class ShellBar extends WebComponent {
 		this._header = {
 			press: event => {
 				this.fireEvent("titlePress", {
-					iconRef: this.shadowRoot.querySelector(".sapWCShellBarMenuButton"),
+					targetRef: this.shadowRoot.querySelector(".sapWCShellBarMenuButton"),
 				});
 			},
 		};
@@ -610,19 +610,19 @@ class ShellBar extends WebComponent {
 
 	_handleNotificationsPress(event) {
 		this.fireEvent("notificationsPress", {
-			iconRef: this.shadowRoot.querySelector(".sapWCShellBarBellIcon"),
+			targetRef: this.shadowRoot.querySelector(".sapWCShellBarBellIcon"),
 		});
 	}
 
 	_handleProfilePress(event) {
 		this.fireEvent("profilePress", {
-			iconRef: this.shadowRoot.querySelector(".sapWCShellBarImageButton"),
+			targetRef: this.shadowRoot.querySelector(".sapWCShellBarImageButton"),
 		});
 	}
 
 	_handleProductSwitchPress(event) {
 		this.fireEvent("productSwitchPress", {
-			iconRef: this.shadowRoot.querySelector(".sapWCShellBarIconProductSwitch"),
+			targetRef: this.shadowRoot.querySelector(".sapWCShellBarIconProductSwitch"),
 		});
 	}
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
@@ -158,12 +158,12 @@
 
 	<script>
 		shellbar.addEventListener("profilePress", function(event) {
-			popover.openBy(event.detail.iconRef);
+			popover.openBy(event.detail.targetRef);
 			window["press-input"].value = "Profile";
 		});
 
 		shellbar.addEventListener("titlePress", function(event) {
-			window["app-list-popover"].openBy(event.detail.iconRef);
+			window["app-list-popover"].openBy(event.detail.targetRef);
 			window["press-input"].value = "Title";
 		});
 

--- a/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
@@ -97,11 +97,11 @@
 
 <script>
 	shellbar.addEventListener("profilePress", function(event) {
-		window["action-popover"].openBy(event.detail.iconRef);
+		window["action-popover"].openBy(event.detail.targetRef);
 	});
 
 	shellbar.addEventListener("titlePress", function(event) {
-		window["app-list-popover"].openBy(event.detail.iconRef);
+		window["app-list-popover"].openBy(event.detail.targetRef);
 	});
 </script>
 				</div>
@@ -156,11 +156,11 @@
 
 <script>
 	shellbar.addEventListener("profilePress", function(event) {
-		popover.openBy(event.detail.iconRef);
+		popover.openBy(event.detail.targetRef);
 	});
 
 	shellbar.addEventListener("titlePress", function(event) {
-		window["app-list-popover"].openBy(event.detail.iconRef);
+		window["app-list-popover"].openBy(event.detail.targetRef);
 	});
 </script>
 		</xmp>


### PR DESCRIPTION
BREAKING CHANGE: press handlers used to have param "iconRef". As not always
an Icon is pressed (e.g. title is not an icon) - the parameter is renamed to targetRef.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/297