### PR TITLE
feat: allow message strips to contain HTML elements

### DIFF
--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -39,6 +39,14 @@ Handlebars.registerHelper('checkEven', function (iIndex) {
 	return (iIndex % 2 === 0) ? "api-table-roll-even" : "api-table-roll-odd";
 });
 
+Handlebars.registerHelper('eq', function (a, b) {
+	return a === b;
+});
+
+Handlebars.registerHelper('or', function (a, b) {
+	return a || b;
+});
+
 Handlebars.registerPartial('properties', propertiesTemplate);
 Handlebars.registerPartial('slots', slotsTemplate);
 Handlebars.registerPartial('events', eventsTemplate);

--- a/lib/documentation/templates/api-slots-section.js
+++ b/lib/documentation/templates/api-slots-section.js
@@ -1,7 +1,16 @@
 module.exports = {
   template: `
-  {{#if slots}}
+  {{#if (or usesTextContent slots)}}
     <h3 class="comment-api-title space-top" >Children</h3>
+  {{/if}}
+  {{#if usesTextContent}}
+    <p class="small-space-top" >
+        The content of this Web Component is interpreted as text and shown to the user. 
+        Unless the content is provided in the content slot, all HTML Elements inside the Web Component are ignored - only their text is used.
+        If a content slot is found, it will be used instead of the text content.
+    </p>
+  {{/if}}
+  {{#if slots}}
 	<p class="small-space-top" >
 	  This Web Component accepts other HTML Elements as children. 
 	  Use the <code>data-ui5-slot</code> attribute to define the category of each child, if more than one category is accepted.
@@ -25,8 +34,5 @@ module.exports = {
 
     </div>
   {{/if}}
-  {{#if usesTextContent}}
-    <h3 class="comment-api-title space-top" >Children</h3>
-    <p class="small-space-top" >The content of this Web Component is interpreted as text and shown to the user. All HTML Elements inside the Web Component are ignored - only their text is used.</p>
-  {{/if}}`
+`
 };

--- a/packages/base/src/WebComponent.js
+++ b/packages/base/src/WebComponent.js
@@ -144,7 +144,8 @@ class WebComponent extends HTMLElement {
 		const hasChildren = this.constructor.getMetadata().hasSlots();
 		if (usesNodeText) {
 			this._updateNodeText();
-		} else if (hasChildren) {
+		}
+		if (hasChildren) {
 			this._updateSlots();
 		}
 		this.onChildrenChanged(mutations);

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -3,7 +3,12 @@
 		<ui5-icon class="ui5-messagestrip-icon" src="{{icon}}"></ui5-icon>
 	{{/unless}}
 
-	<span class="{{classes.label}}">{{ctr._nodeText}}</span> 
+	{{#unless ctr.content}}
+		<span class="{{classes.label}}">{{ctr._nodeText}}</span>
+	{{/unless}}
+	{{#if ctr.content}}
+		<span class="{{classes.label}}"><slot name="{{ctr.content._slot}}"></slot></span>
+	{{/if}}
 
 	{{#unless ctr.hideCloseButton}}
 		<ui5-icon

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -23,6 +23,19 @@ const metadata = {
 		"MessageStrip.css",
 	],
 	usesNodeText: true,
+	slots: /** @lends sap.ui.webcomponents.main.MessageStrip.prototype */ {
+		/**
+		 * Defines the content of the message strip.
+		 * Use this if you need to use elements other than text within the message bar.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @public
+		 */
+		content: {
+			type: HTMLElement,
+			multiple: false,
+		},
+	},
 	properties: /** @lends sap.ui.webcomponents.main.MessageStrip.prototype */ {
 
 		/**

--- a/packages/main/test/sap/ui/webcomponents/main/samples/MessageStrip.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/MessageStrip.sample.html
@@ -48,12 +48,22 @@
 			<ui5-messagestrip class="samples-margin-bottom" type="Positive">Positive MessageStrip</ui5-messagestrip>
 			<ui5-messagestrip class="samples-margin-bottom" type="Negative">Negative MessageStrip</ui5-messagestrip>
 			<ui5-messagestrip class="samples-margin-bottom" type="Warning">Warning MessageStrip</ui5-messagestrip>
+			<ui5-messagestrip class="samples-margin-bottom" type="Information">
+				<div class="messagestrip-content" data-ui5-slot="content">
+					A message strip with a link <ui5-link target="_blank" href="https://github.com/SAP/ui5-webcomponents">to Github</ui5-link>
+				</div>
+			</ui5-messagestrip>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
 <ui5-messagestrip type="Information">Information MessageStrip</ui5-messagestrip>
 <ui5-messagestrip type="Positive">Positive MessageStrip</ui5-messagestrip>
 <ui5-messagestrip type="Negative">Negative MessageStrip</ui5-messagestrip>
 <ui5-messagestrip type="Warning">Warning MessageStrip</ui5-messagestrip>
+<ui5-messagestrip type="Information">
+	<div class="messagestrip-content" data-ui5-slot="content">
+		A message strip with a link <ui5-link target="_blank" href="https://github.com/SAP/ui5-webcomponents">to Github</ui5-link>
+	</div>
+</ui5-messagestrip>
 <script>
 	document.querySelectorAll("ui5-messagestrip").forEach(function(messageStrip) {
 		messageStrip.addEventListener("close", function() {


### PR DESCRIPTION
# What this solves
ATM it isn't possible to use any non-text elements within a message strip. 

We currently have a use case where we want to display a warning to the user with a link to related content.

This merge request implements the possibility to use a content slot for the message bar content.

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [X] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
