### PR TITLE
fix(ui5-li-custom): enable setting height of the custom content

### DIFF
--- a/packages/main/src/themes-next/CustomListItem.css
+++ b/packages/main/src/themes-next/CustomListItem.css
@@ -16,7 +16,6 @@ ui5-li-custom .sap-phone .sapMLIB {
 
 .sapMLIB.sapMCustomLI {
 	height: 100%;
-	min-height: 3rem;
 	padding: 0;
 }
 
@@ -24,13 +23,15 @@ ui5-checkbox.multiSelectionCheckBox,
 ui5-radiobutton.singleSelectionRadioButton {
 	display: flex;
 	align-items: center;
+}
+
+.sapMLIB.sapMCustomLI,
+ui5-checkbox.multiSelectionCheckBox,
+ui5-radiobutton.singleSelectionRadioButton {
 	min-width: 3rem;
 }
 
-.sapUiSizeCompact .sapMLIB.sapMCustomLI {
-	min-height: 2rem;
-}
-
+.sapUiSizeCompact .sapMLIB.sapMCustomLI,
 .sapUiSizeCompact ui5-checkbox.multiSelectionCheckBox,
 .sapUiSizeCompact ui5-radiobutton.singleSelectionRadioButton {
 	min-width: 2rem;

--- a/packages/main/src/themes-next/CustomListItem.css
+++ b/packages/main/src/themes-next/CustomListItem.css
@@ -15,7 +15,7 @@ ui5-li-custom .sap-phone .sapMLIB {
 }
 
 .sapMLIB.sapMCustomLI {
-	height: auto;
+	height: 100%;
 	min-height: 3rem;
 	padding: 0;
 }

--- a/packages/main/src/themes-next/CustomListItem.css
+++ b/packages/main/src/themes-next/CustomListItem.css
@@ -15,12 +15,20 @@ ui5-li-custom .sap-phone .sapMLIB {
 }
 
 .sapMLIB.sapMCustomLI {
+	height: auto;
+	min-height: 3rem;
 	padding: 0;
 }
 
 ui5-checkbox.multiSelectionCheckBox,
 ui5-radiobutton.singleSelectionRadioButton {
+	display: flex;
+	align-items: center;
 	min-width: 3rem;
+}
+
+.sapUiSizeCompact .sapMLIB.sapMCustomLI {
+	min-height: 2rem;
 }
 
 .sapUiSizeCompact ui5-checkbox.multiSelectionCheckBox,

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
@@ -390,19 +390,19 @@
 		<section class="row">
 			<ui5-list header-text="Products" mode="SingleSelectEnd">
 				<ui5-li-custom type="Active">
-					<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+					<div style="width: 100%; height: 5rem; display: flex; align-items: center; justify-content: space-between">
 						<span>Laptop HP 2GB RAM Dual-core</span>
 						<ui5-link>Go to SAP</ui5-link>
 					</div>
 				</ui5-li-custom>
 				<ui5-li-custom type="Active">
-					<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+					<div style="width: 100%; height: 5rem; display: flex; align-items: center; justify-content: space-between">
 						<span>Laptop HP 2GB RAM Dual-core</span>
 						<ui5-link>Go to SAP</ui5-link>
 					</div>
 				</ui5-li-custom>
 				<ui5-li-custom type="Active">
-					<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+					<div style="width: 100%; height: 5rem; display: flex; align-items: center; justify-content: space-between">
 						<span>Laptop HP 2GB RAM Dual-core</span>
 						<ui5-link>Go to SAP</ui5-link>
 					</div>
@@ -411,19 +411,19 @@
 
 			<ui5-list header-text="Products" mode="MultiSelect">
 					<ui5-li-custom type="Active">
-						<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+						<div style="width: 100%; height: 8rem; display: flex; align-items: center; justify-content: space-between">
 							<span>Laptop HP 2GB RAM Dual-core</span>
 							<ui5-link>Go to SAP</ui5-link>
 						</div>
 					</ui5-li-custom>
 					<ui5-li-custom type="Active">
-						<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+						<div style="width: 100%; height: 8rem; display: flex; align-items: center; justify-content: space-between">
 							<span>Laptop HP 2GB RAM Dual-core</span>
 							<ui5-link>Go to SAP</ui5-link>
 						</div>
 					</ui5-li-custom>
 					<ui5-li-custom type="Active">
-						<div style="width: 100%; height: 3rem; display: flex; align-items: center; justify-content: space-between">
+						<div style="width: 100%; height: 8rem; display: flex; align-items: center; justify-content: space-between">
 							<span>Laptop HP 2GB RAM Dual-core</span>
 							<ui5-link>Go to SAP</ui5-link>
 						</div>


### PR DESCRIPTION
Provide min-height and height: auto to the custom list item,  so the consumers can set a custom height to their content.
Fixes: https://github.com/SAP/ui5-webcomponents/issues/310