### PR TITLE
 fix(ui5-card): remove header double border if no content

### DIFF
--- a/packages/main/src/Card.hbs
+++ b/packages/main/src/Card.hbs
@@ -1,4 +1,4 @@
-<div {{> controlData}} class="sapFCard">
+<div {{> controlData}} class="{{classes.main}}">
 	<header class="{{classes.header}}"
 		@click="{{ctr._headerClick}}"
 		@keydown="{{ctr._headerKeydown}}"

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -155,6 +155,7 @@ class Card extends WebComponent {
 		const hasAvatar = !!state.avatar;
 		const icon = hasAvatar && isIconURI(state.avatar);
 		const image = hasAvatar && !icon;
+		const hasContent = !!state.content.length;
 
 		return {
 			icon,
@@ -162,6 +163,10 @@ class Card extends WebComponent {
 			ctr: state,
 			renderIcon: state.icon && !state.image,
 			classes: {
+				main: {
+					"sapFCard": true,
+					"sapFCardNoContent": !hasContent,
+				},
 				header: {
 					"sapFCardHeader": true,
 					"sapFCardHeaderActive": state._headerActive,

--- a/packages/main/src/themes-next/Card.css
+++ b/packages/main/src/themes-next/Card.css
@@ -30,6 +30,12 @@ ui5-card {
 	padding: var(--_ui5_card_content_padding);
 }
 
+
+.sapFCard.sapFCardNoContent .sapFCardHeader {
+	height: calc(100% - 2*var(--_ui5_card_content_padding));
+	border-bottom: none;
+}
+
 .sapFCardHeader:focus {
 	outline: none;
 }

--- a/packages/main/src/themes-next/Card.css
+++ b/packages/main/src/themes-next/Card.css
@@ -30,9 +30,12 @@ ui5-card {
 	padding: var(--_ui5_card_content_padding);
 }
 
+/* Card with no content */
+.sapFCard.sapFCardNoContent {
+	height: auto;
+}
 
 .sapFCard.sapFCardNoContent .sapFCardHeader {
-	height: calc(100% - 2*var(--_ui5_card_content_padding));
 	border-bottom: none;
 }
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
@@ -113,6 +113,21 @@
 					<ui5-li icon="sap-icon://syntax">Algorithms</ui5-li>
 				</ui5-list>
 			</ui5-card>
+
+			<ui5-card
+				style="flex-basis:20%;"
+				avatar="sap-icon://employee"
+				heading="Goerge M."
+				subtitle="Visioner">
+			</ui5-card>
+
+			<ui5-card
+				style="flex-basis:20%;"
+				avatar="sap-icon://employee"
+				heading="Linda M."
+				subtitle="Enthusiast"
+				status="1 of 3">
+			</ui5-card>
 		</section>
 
 		<section class="row row-centered">

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Kitchen.html
@@ -19,6 +19,7 @@
 	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body>


### PR DESCRIPTION
* Issue: Both the card root element and its header provides border, but in case no content is added, bottom border gets doubled.
* Solution: Remove the header bottom border, if no content is set.