### PR TITLE
feat(ui5-shellbar): menuItems slot and menuItemPress event

### DIFF
--- a/packages/main/src/ShellBar.hbs
+++ b/packages/main/src/ShellBar.hbs
@@ -26,6 +26,14 @@
 			</button>
 		{{/if}}
 
+		<ui5-popover class="sapWCShellBarMenuPopover" hide-header placement-type="Bottom">
+			<ui5-list separators="None" mode="SingleSelect" @itemPress={{ctr._menuItemPress}}>
+				{{#each ctr.menuItems}}
+					<slot name="{{this._slot}}"></slot>
+				{{/each}}
+			</ui5-list>
+		</ui5-popover>
+
 		<h2 class="{{classes.secondaryTitle}}">{{ctr.secondaryTitle}}</h2>
 	</div>
 
@@ -67,7 +75,7 @@
 		</div>
 	</div>
 
-	<ui5-popover placement-type="Bottom" horizontal-align="{{popoverHorizontalAlign}}" hide-header hide-arrow>
+	<ui5-popover class="sapWCShellBarOverflowPopover" placement-type="Bottom" horizontal-align="{{popoverHorizontalAlign}}" hide-header hide-arrow>
 		<ui5-list separators="None" @itemPress="{{ctr._actionList.itemPress}}">
 			{{#each _hiddenIcons}}
 				<ui5-li

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -145,6 +145,10 @@ const metadata = {
 		_coPilotPress: {
 			type: Function,
 		},
+
+		_menuItemPress: {
+			type: Function,
+		},
 	},
 
 	slots: /** @lends  sap.ui.webcomponents.main.ShellBar.prototype */ {
@@ -159,6 +163,22 @@ const metadata = {
 		 * @public
 		 */
 		items: {
+			type: HTMLElement,
+			multiple: true,
+		},
+
+			/**
+		 * Defines the items displayed in menu after a click on the primary title.
+		 * </br></br>
+		 * <b>Note:</b>
+		 * You can use the &nbsp;&lt;ui5-li>&lt;/ui5-li> and its ancestors.
+		 *
+		 * @type {HTMLElement}
+		 * @slot
+		 * @since 0.10
+		 * @public
+		 */
+		menuItems: {
 			type: HTMLElement,
 			multiple: true,
 		},
@@ -187,19 +207,6 @@ const metadata = {
 	},
 	defaultSlot: "items",
 	events: /** @lends sap.ui.webcomponents.main.ShellBar.prototype */ {
-		/**
-		 * Fired, when the primaryTitle is pressed.
-		 *
-		 * @event
-		 * @param {HTMLElement} targetRef dom ref of the clicked element
-		 * @public
-		 */
-		titlePress: {
-			detail: {
-				targetRef: { type: HTMLElement },
-			},
-		},
-
 		/**
 		 *
 		 * Fired, when the notification icon is pressed.
@@ -246,6 +253,7 @@ const metadata = {
 		 *
 		 * @event
 		 * @param {HTMLElement} targetRef dom ref of the clicked element
+		 * @since 0.10
 		 * @public
 		 */
 		logoPress: {
@@ -259,11 +267,26 @@ const metadata = {
 		 *
 		 * @event
 		 * @param {HTMLElement} targetRef dom ref of the clicked element
+		 * @since 0.10
 		 * @public
 		 */
 		coPilotPress: {
 			detail: {
 				targetRef: { type: HTMLElement },
+			},
+		},
+
+		/**
+		 * Fired, when a menu item is selected
+		 *
+		 * @event
+		 * @param {HTMLElement} item dom ref of the clicked list item
+		 * @since 0.10
+		 * @public
+		 */
+		menuItemPress: {
+			detail: {
+				item: { type: HTMLElement },
 			},
 		},
 	},
@@ -332,7 +355,7 @@ class ShellBar extends WebComponent {
 
 		this._actionList = {
 			itemPress: event => {
-				const popover = this.shadowRoot.querySelector("ui5-popover");
+				const popover = this.shadowRoot.querySelector(".sapWCShellBarOverflowPopover");
 
 				popover.close();
 			},
@@ -340,10 +363,18 @@ class ShellBar extends WebComponent {
 
 		this._header = {
 			press: event => {
-				this.fireEvent("titlePress", {
-					targetRef: this.shadowRoot.querySelector(".sapWCShellBarMenuButton"),
-				});
+				const menuPopover = this.shadowRoot.querySelector(".sapWCShellBarMenuPopover");
+
+				if (this.menuItems.length) {
+					menuPopover.openBy(this.shadowRoot.querySelector(".sapWCShellBarMenuButton"));
+				}
 			},
+		};
+
+		this._menuItemPress = event => {
+			this.fireEvent("menuItemPress",  {
+				item: event.detail.item,
+			});
 		};
 
 		this._itemNav = new ItemNavigation(this);
@@ -406,7 +437,7 @@ class ShellBar extends WebComponent {
 		};
 
 		this._handleResize = event => {
-			this.shadowRoot.querySelector("ui5-popover").close();
+			this.shadowRoot.querySelector(".sapWCShellBarOverflowPopover").close();
 			this._overflowActions();
 		};
 
@@ -571,7 +602,7 @@ class ShellBar extends WebComponent {
 	}
 
 	_toggleActionPopover() {
-		const popover = this.shadowRoot.querySelector("ui5-popover");
+		const popover = this.shadowRoot.querySelector(".sapWCShellBarOverflowPopover");
 		const overflowButton = this.shadowRoot.querySelector(".sapWCShellBarOverflowIcon");
 		popover.openBy(overflowButton);
 	}

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -167,7 +167,7 @@ const metadata = {
 			multiple: true,
 		},
 
-			/**
+		/**
 		 * Defines the items displayed in menu after a click on the primary title.
 		 * </br></br>
 		 * <b>Note:</b>
@@ -372,7 +372,7 @@ class ShellBar extends WebComponent {
 		};
 
 		this._menuItemPress = event => {
-			this.fireEvent("menuItemPress",  {
+			this.fireEvent("menuItemPress", {
 				item: event.detail.item,
 			});
 		};

--- a/packages/main/src/ShellBarTemplateContext.js
+++ b/packages/main/src/ShellBarTemplateContext.js
@@ -44,6 +44,7 @@ class ShellBarTemplateContext {
 					"sapWCShellBarMenuButtonNoTitle": !state.primaryTitle,
 					"sapWCShellBarMenuButtonNoLogo": !state.logo,
 					"sapWCShellBarMenuButtonMerged": state._breakpointSize === "S",
+					"sapWCShellBarMenuButtonInteractive": !!state.menuItems.length,
 					"sapWCShellBarMenuButton": true,
 				},
 				buttonTitle: {

--- a/packages/main/src/themes-next/ShellBar.css
+++ b/packages/main/src/themes-next/ShellBar.css
@@ -40,20 +40,20 @@ ui5-shellbar {
 	font-weight: bold;
 }
 
-.sapWCShellBarMenuButton:hover,
+.sapWCShellBarMenuButton.sapWCShellBarMenuButtonInteractive:hover,
 .sapWCShellBarIconButton:hover,
 .sapWCShellBarImageButton:hover {
 	background: var(--sapUiShellHoverBackground);
 }
 
-.sapWCShellBarMenuButton:active,
+.sapWCShellBarMenuButton.sapWCShellBarMenuButtonInteractive:active,
 .sapWCShellBarIconButton:active,
 .sapWCShellBarImageButton:active {
 	background: var(--sapUiShellActiveBackground);
 	color: var(--sapUiShellActiveTextColor);
 }
 
-.sapWCShellBarMenuButton:focus::after,
+.sapWCShellBarMenuButton.sapWCShellBarMenuButtonInteractive:focus::after,
 .sapWCShellBarIconButton:focus::after,
 .sapWCShellBarImageButton:focus::after {
 	content: "";
@@ -67,7 +67,7 @@ ui5-shellbar {
 	z-index: 1;
 }
 
-.sapWCShellBarMenuButton::-moz-focus-inner {
+.sapWCShellBarMenuButton.sapWCShellBarMenuButtonInteractive::-moz-focus-inner {
 	border: none;
 }
 
@@ -107,7 +107,7 @@ ui5-shellbar {
 	overflow: hidden;
 }
 
-.sapWCShellBarMenuButtonArrow {
+.sapWCShellBarMenuButtonInteractive .sapWCShellBarMenuButtonArrow {
 	display: inline-block;
 	margin-left: 0.5rem;
 	width: 10px;
@@ -197,6 +197,10 @@ ui5-shellbar {
 	height: 1.675rem;
 }
 
+.sapWCShellBarLogo:not([src]) {
+	display: none;
+}
+
 .sapWCShellBarIconButton {
 	min-width: 2.25rem;
 	font-size: 1rem;
@@ -232,6 +236,19 @@ ui5-shellbar {
 	display: flex;
 	align-items: center;
 	padding: 0.25rem 0.5rem;
+	cursor: text;
+	-webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+	user-select: text;
+}
+
+.sapWCShellBarMenuButton.sapWCShellBarMenuButtonInteractive {
+	-webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+	user-select: none;
+	cursor: pointer;
 }
 
 .sapWCShellBarMenuButton.sapWCShellBarMenuButtonNoLogo {
@@ -379,7 +396,7 @@ span[dir=rtl] .sapWCShellBarMenuButton {
 	margin-left: 0;
 }
 
-span[dir=rtl] .sapWCShellBarMenuButtonArrow {
+span[dir=rtl] .sapWCShellBarMenuButtonInteractive .sapWCShellBarMenuButtonArrow {
 	margin-right: .5rem;
 	margin-left: 0;
 }

--- a/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
@@ -124,6 +124,12 @@
 		<ui5-shellbar-item data-ui5-slot="items" id="call" src="sap-icon://incoming-call" text="Incoming Calls"></ui5-shellbar-item>
 
 		<ui5-input data-ui5-slot="searchField"></ui5-input>
+
+		<ui5-li id="menu-item-1" data-ui5-slot="menuItems" type="Active">Application 1</ui5-li>
+		<ui5-li id="menu-item-2" data-ui5-slot="menuItems" type="Active">Application 2</ui5-li>
+		<ui5-li data-ui5-slot="menuItems" type="Active">Application 3</ui5-li>
+		<ui5-li data-ui5-slot="menuItems" type="Active">Application 4</ui5-li>
+		<ui5-li data-ui5-slot="menuItems" type="Active">Application 5</ui5-li>
 	</ui5-shellbar>
 
 	<ui5-popover id="popover" hide-header placement-type="Bottom">
@@ -162,11 +168,6 @@
 			window["press-input"].value = "Profile";
 		});
 
-		shellbar.addEventListener("titlePress", function(event) {
-			window["app-list-popover"].openBy(event.detail.targetRef);
-			window["press-input"].value = "Title";
-		});
-
 		shellbar.addEventListener("notificationsPress", function(event) {
 			window["press-input"].value = "Notifications"
 		});
@@ -181,6 +182,10 @@
 
 		shellbar.addEventListener("coPilotPress", function(event) {
 			window["press-input"].value = "CoPilot"
+		});
+
+		shellbar.addEventListener("menuItemPress", function(event) {
+			window["press-input"].value = event.detail.item.textContent;
 		});
 
 		["disc", "call"].forEach(function(id) {

--- a/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/ShellBar.sample.html
@@ -67,6 +67,12 @@
 	<ui5-shellbar-item data-ui5-slot="items" id="call" src="sap-icon://incoming-call" text="Incoming Calls"></ui5-shellbar-item>
 
 	<ui5-input data-ui5-slot="searchField"></ui5-input>
+
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 1</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 2</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 3</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 4</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 5</ui5-li>
 </ui5-shellbar>
 
 <ui5-popover id="action-popover" hide-header placement-type="Bottom">
@@ -85,24 +91,11 @@
 	</div>
 </ui5-popover>
 
-<ui5-popover id="app-list-popover" hide-header placement-type="Bottom">
-	<ui5-list separators="None">
-		<ui5-li type="Active">Application 1</ui5-li>
-		<ui5-li type="Active">Application 2</ui5-li>
-		<ui5-li type="Active">Application 3</ui5-li>
-		<ui5-li type="Active">Application 4</ui5-li>
-		<ui5-li type="Active">Application 5</ui5-li>
-	</ui5-list>
-</ui5-popover>
-
 <script>
 	shellbar.addEventListener("profilePress", function(event) {
 		window["action-popover"].openBy(event.detail.targetRef);
 	});
 
-	shellbar.addEventListener("titlePress", function(event) {
-		window["app-list-popover"].openBy(event.detail.targetRef);
-	});
 </script>
 				</div>
 
@@ -126,6 +119,13 @@
 	<ui5-shellbar-item data-ui5-slot="items" id="call" src="sap-icon://incoming-call" text="Incoming Calls"></ui5-shellbar-item>
 
 	<ui5-input data-ui5-slot="searchField"></ui5-input>
+
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 1</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 2</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 3</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 4</ui5-li>
+	<ui5-li data-ui5-slot="menuItems" type="Active">Application 5</ui5-li>
+
 </ui5-shellbar>
 
 <ui5-popover id="popover" hide-header placement-type="Bottom">
@@ -144,24 +144,11 @@
 	</div>
 </ui5-popover>
 
-<ui5-popover id="app-list-popover" hide-header placement-type="Bottom">
-	<ui5-list separators="None">
-		<ui5-li type="Active">Application 1</ui5-li>
-		<ui5-li type="Active">Application 2</ui5-li>
-		<ui5-li type="Active">Application 3</ui5-li>
-		<ui5-li type="Active">Application 4</ui5-li>
-		<ui5-li type="Active">Application 5</ui5-li>
-	</ui5-list>
-</ui5-popover>
-
 <script>
 	shellbar.addEventListener("profilePress", function(event) {
 		popover.openBy(event.detail.targetRef);
 	});
 
-	shellbar.addEventListener("titlePress", function(event) {
-		window["app-list-popover"].openBy(event.detail.targetRef);
-	});
 </script>
 		</xmp>
 				</pre>

--- a/packages/main/test/specs/ShellBar.spec.js
+++ b/packages/main/test/specs/ShellBar.spec.js
@@ -87,9 +87,9 @@ describe("Component Behaviour", () => {
 			const notificationsIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarBellIcon");
 			const profileIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarImageButton");
 			const productSwitchIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarIconProductSwitch");
-			const overflowPopover = browser.findElementDeep("#shellbar >>> ui5-popover");
-			const overflowPopoverItem1 = browser.findElementDeep("#shellbar >>> ui5-popover ui5-li:first-child");
-			const overflowPopoverItem2 = browser.findElementDeep("#shellbar >>> ui5-popover ui5-li:nth-child(2)");
+			const overflowPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover");
+			const overflowPopoverItem1 = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover ui5-li:first-child");
+			const overflowPopoverItem2 = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover ui5-li:nth-child(2)");
 			const html = shellbarWrapper.getHTML();
 
 			overflowButton.click();
@@ -120,7 +120,7 @@ describe("Component Behaviour", () => {
 			const shellbarWrapper = browser.findElementDeep("#shellbar >>> div");
 			const html = shellbarWrapper.getHTML();
 			const productSwitchIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarIconProductSwitch");
-			const overflowPopover = browser.findElementDeep("#shellbar >>> ui5-popover");
+			const overflowPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover");
 
 			assert.strictEqual(html.indexOf("sapWCShellBarSizeM") !== -1, true, "M Breakpoint class should be set");
 
@@ -136,7 +136,7 @@ describe("Component Behaviour", () => {
 			const shellbarWrapper = browser.findElementDeep("#shellbar >>> div");
 			const html = shellbarWrapper.getHTML();
 			const productSwitchIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarIconProductSwitch");
-			const overflowPopover = browser.findElementDeep("#shellbar >>> ui5-popover");
+			const overflowPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover");
 			const notificationsIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarBellIcon");
 
 			assert.strictEqual(html.indexOf("sapWCShellBarSizeM") !== -1, true, "M Breakpoint class should be set");
@@ -171,7 +171,7 @@ describe("Component Behaviour", () => {
 			const notificationsIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarBellIcon");
 			const profileIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarImageButton");
 			const productSwitchIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarIconProductSwitch");
-			const overflowPopover = browser.findElementDeep("#shellbar >>> ui5-popover");
+			const overflowPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarOverflowPopover");
 			const listItemsCount = overflowPopover.getHTML().split("</ui5-li>").length - 1;
 
 			assert.strictEqual(html.indexOf("sapWCShellBarSizeS") !== -1, true, "S Breakpoint class should be set");
@@ -194,12 +194,12 @@ describe("Component Behaviour", () => {
 				browser.setWindowSize(1920, 1080);
 			});
 
-			it("tests titlePress event", () => {
+			it("tests opening of menu", () => {
 				const primaryTitle = browser.findElementDeep("#shellbar >>> .sapWCShellBarMenuButton");
-				const input = browser.findElementDeep("#press-input");
-
+				const menuPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarMenuPopover");
+	
 				primaryTitle.click();
-				assert.strictEqual(input.getValue(), "Title", "Input value is set by click event of Title");
+				assert.ok(menuPopover.isDisplayedInViewport(), "Menu should be shown");
 			});
 
 			it("tests notificationsPress event", () => {
@@ -244,6 +244,22 @@ describe("Component Behaviour", () => {
 				assert.strictEqual(input.getValue(), "CoPilot", "Input value is set by click event of CoPilot");
 			});
 
+			it("tests menuItemPress event", () => {
+				const primaryTitle = browser.findElementDeep("#shellbar >>> .sapWCShellBarMenuButton");
+				const firstMenuItem = browser.findElementDeep("#shellbar #menu-item-1");
+				const secondMenuItem = browser.findElementDeep("#shellbar #menu-item-2");
+				const input = browser.findElementDeep("#press-input");
+	
+				primaryTitle.click();
+				firstMenuItem.click();
+
+				assert.strictEqual(input.getValue(), "Application 1", "Input value is set by click event of the first menu item");
+
+				secondMenuItem.click();
+
+				assert.strictEqual(input.getValue(), "Application 2", "Input value is set by click event of the second menu item");
+			});
+
 			it("tests if searchfield appears when clicking on search icon", () => {
 				const searchIcon = browser.findElementDeep("#shellbar >>> .sapWCShellBarSearchIcon");
 				const searchField = browser.findElementDeep("#shellbar ui5-input");
@@ -265,12 +281,12 @@ describe("Component Behaviour", () => {
 				browser.setWindowSize(510, 1080);
 			});
 
-			it("tests titlePress event", () => {
+			it("tests opening of menu", () => {
 				const primaryTitle = browser.findElementDeep("#shellbar >>> .sapWCShellBarMenuButton");
-				const input = browser.findElementDeep("#press-input");
-
+				const menuPopover = browser.findElementDeep("#shellbar >>> .sapWCShellBarMenuPopover");
+	
 				primaryTitle.click();
-				assert.strictEqual(input.getValue(), "Title", "Input value is set by click event of Title");
+				assert.ok(menuPopover.isDisplayedInViewport(), "Menu should be shown");
 			});
 
 			it("tests notificationsPress event", () => {


### PR DESCRIPTION
- menuItems renders list items in a popover which is might be open by clicking the primary title
- menuItemPress is fired when a menu item is pressed
- if no menu items are defined - no arrow down is rendered next to the primary title

BREAKING CHANGE: titlePress event is removed and replaced by menuItems slot.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/290
