### PR TITLE
chore: display API Events since info

### DIFF
--- a/lib/documentation/templates/api-events-section.js
+++ b/lib/documentation/templates/api-events-section.js
@@ -13,7 +13,12 @@ module.exports = {
         {{#each events}}
           <div class="row {{checkEven @index}}">
             <div class="cell api-table-content-cell api-table-content-cell-bold">{{this.name}}</div>
-            <div class="cell api-table-content-cell api-table-content-cell-description">{{{this.description}}}</div>
+            <div class="cell api-table-content-cell api-table-content-cell-description">
+            {{{this.description}}}
+            {{#if this.since}}
+                <div class="api-table-content-cell-bold api-table-content-cell-since">since v{{{this.since}}}</div>
+            {{/if}}
+            </div>
           </div>
 
           {{#each this.parameters}}


### PR DESCRIPTION
<img width="1039" alt="Screenshot 2019-04-09 at 15 19 06" src="https://user-images.githubusercontent.com/15702139/55799771-d9812280-5ada-11e9-9c8a-2ddc07b1c72c.png">

