### PR TITLE
 fix(ui5-togglebutton): correct negative/positive stylings

### DIFF
--- a/packages/main/src/themes-next/ToggleButton.css
+++ b/packages/main/src/themes-next/ToggleButton.css
@@ -6,6 +6,10 @@ ui5-togglebutton {
 	display: inline-block;
 }
 
+.sapMBtn.sapMToggleBtnPressed {
+	text-shadow: none;
+}
+
 .sapMBtn.sapMToggleBtnPressed.sapMBtnNegative {
 	background-color: var(--sapUiButtonRejectActiveBackground);
 	border-color: var(--sapUiButtonRejectActiveBorderColor);
@@ -33,7 +37,6 @@ ui5-togglebutton {
 .sapMBtn.sapMToggleBtnPressed.sapMBtnDefault:not(:active):not(:hover),
 .sapMBtn.sapMToggleBtnPressed.sapMBtnEmphasized:not(:active):not(:hover),
 .sapMBtn.sapMToggleBtnPressed.sapMBtnTransparent:not(:active):not(:hover) {
-	text-shadow: none;
 	background-color: var(--sapUiToggleButtonPressedBackground);
 	border-color: var(--sapUiToggleButtonPressedBorderColor);
 	color: var(--sapUiToggleButtonPressedTextColor);

--- a/packages/main/src/themes-next/ToggleButton.css
+++ b/packages/main/src/themes-next/ToggleButton.css
@@ -30,7 +30,7 @@ ui5-togglebutton {
 	border-color: var(--sapUiButtonAcceptActiveBorderColor);
 }
 
-.sapMBtn.sapMToggleBtnPressed:not(:active):not(:hover),
+.sapMBtn.sapMToggleBtnPressed.sapMBtnDefault:not(:active):not(:hover),
 .sapMBtn.sapMToggleBtnPressed.sapMBtnEmphasized:not(:active):not(:hover),
 .sapMBtn.sapMToggleBtnPressed.sapMBtnTransparent:not(:active):not(:hover) {
 	text-shadow: none;


### PR DESCRIPTION
* remove the text shadow in pressed state
* correct the background colour for the negative and positive toggle buttons
* image of the issue (positive and negative button should be green/red):
<img width="534" alt="Screenshot 2019-04-12 at 15 39 28" src="https://user-images.githubusercontent.com/15702139/56037923-3c6ff500-5d39-11e9-9a1c-35f09749c617.png">
