### PR TITLE
fix(ui5-togglebutton): correct default btn hover bg and text color

### DIFF
--- a/packages/main/src/themes-next/ToggleButton.css
+++ b/packages/main/src/themes-next/ToggleButton.css
@@ -7,6 +7,7 @@ ui5-togglebutton {
 }
 
 .sapMBtn.sapMToggleBtnPressed {
+	color: var(--sapUiToggleButtonPressedTextColor);
 	text-shadow: none;
 }
 
@@ -39,7 +40,6 @@ ui5-togglebutton {
 .sapMBtn.sapMToggleBtnPressed.sapMBtnTransparent:not(:active):not(:hover) {
 	background-color: var(--sapUiToggleButtonPressedBackground);
 	border-color: var(--sapUiToggleButtonPressedBorderColor);
-	color: var(--sapUiToggleButtonPressedTextColor);
 }
 
 .sapMBtn.sapMToggleBtnPressed:not(.sapMBtnNegative):not(.sapMBtnPositive):focus,
@@ -54,7 +54,7 @@ ui5-togglebutton {
 	border-color: var(--sapUiContentContrastFocusColor);
 }
 
-.sapMBtn.sapMToggleBtnPressed:active
+.sapMBtn.sapMToggleBtnPressed:active,
 .sapMBtn.sapMToggleBtnPressed:hover,
 .sapMBtn.sapMToggleBtnPressed.sapMBtnEmphasized:active,
 .sapMBtn.sapMToggleBtnPressed.sapMBtnEmphasized:hover,


### PR DESCRIPTION
* The hover colour and the text colour of the default toggle button in pressed state used to be wrong
