### PR TITLE
docs: fix settings background on mobile

### DIFF
--- a/packages/playground/webapp/css/style.css
+++ b/packages/playground/webapp/css/style.css
@@ -275,7 +275,7 @@ html.sap-desktop .sapContrast .sapMLnk:focus:not(.sapMLnkDsbl) {
 
 
 /* Change Select default styles */
-.switch-container .select-width.sapMSlt.sapMSltDefault.sapMSltHoverable.sapMSltMinWidth.sapMSltWithArrow {
+.switch-container .select-width.sapMSlt.sapMSltDefault.sapMSltMinWidth.sapMSltWithArrow {
 	background-color: #000;
 }
 


### PR DESCRIPTION
* Issue: The sapMSltHoverable class is not present on mobile, thus the background of the select controls remains white and as the text colour is also white - they can`t be distinguished.
* Solution: remove this class from the selector
<img width="869" alt="Screenshot 2019-04-17 at 21 26 32" src="https://user-images.githubusercontent.com/15702139/56311945-cebc3280-6157-11e9-99c8-12dd67c9a59b.png">
