### PR TITLE
chore: rewrite imports with file extensions

### DIFF
--- a/packages/base/.eslintrc.js
+++ b/packages/base/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
 	},
 	"rules": {
 		"comma-dangle": [2, "always-multiline"], // difference from openui5
+		"import/extensions": ["error", "ignorePackages"], // override for UI5 WebComponents
 		"no-cond-assign": 2,
 		"no-console": 2,
 		"no-constant-condition": 2,

--- a/packages/base/src/Bootstrap.js
+++ b/packages/base/src/Bootstrap.js
@@ -1,10 +1,10 @@
-import whenDOMReady from "./util/whenDOMReady";
-import EventEnrichment from "./events/EventEnrichment";
-import { insertIconFontFace } from "./IconFonts";
-import DOMEventHandler from "./DOMEventHandler";
-import { initConfiguration } from "./Configuration";
-import { applyTheme } from "./Theming";
-import whenPolyfillLoaded from "./compatibility/whenPolyfillLoaded";
+import whenDOMReady from "./util/whenDOMReady.js";
+import EventEnrichment from "./events/EventEnrichment.js";
+import { insertIconFontFace } from "./IconFonts.js";
+import DOMEventHandler from "./DOMEventHandler.js";
+import { initConfiguration } from "./Configuration.js";
+import { applyTheme } from "./Theming.js";
+import whenPolyfillLoaded from "./compatibility/whenPolyfillLoaded.js";
 
 EventEnrichment.run();
 

--- a/packages/base/src/CLDR.js
+++ b/packages/base/src/CLDR.js
@@ -73,8 +73,8 @@ import zh_HK from "@ui5/webcomponents-core/dist/sap/ui/core/cldr/zh_HK.json";
 import zh_SG from "@ui5/webcomponents-core/dist/sap/ui/core/cldr/zh_SG.json";
 import zh_TW from "@ui5/webcomponents-core/dist/sap/ui/core/cldr/zh_TW.json";
 
-import { registerModuleContent } from "./ResourceLoaderOverrides";
-import { fetchTextOnce } from "./util/FetchHelper";
+import { registerModuleContent } from "./ResourceLoaderOverrides.js";
+import { fetchTextOnce } from "./util/FetchHelper.js";
 
 const cldrData = {
 	ar,

--- a/packages/base/src/CSS.js
+++ b/packages/base/src/CSS.js
@@ -1,5 +1,5 @@
-import { getTheme } from "./Configuration";
-import { getEffectiveStyle } from "./Theming";
+import { getTheme } from "./Configuration.js";
+import { getEffectiveStyle } from "./Theming.js";
 
 const styleMap = new Map();
 

--- a/packages/base/src/Configuration.js
+++ b/packages/base/src/Configuration.js
@@ -1,5 +1,5 @@
-import CalendarType from "@ui5/webcomponents-core/dist/sap/ui/core/CalendarType";
-import getDesigntimePropertyAsArray from "./util/getDesigntimePropertyAsArray";
+import CalendarType from "@ui5/webcomponents-core/dist/sap/ui/core/CalendarType.js";
+import getDesigntimePropertyAsArray from "./util/getDesigntimePropertyAsArray.js";
 
 const CONFIGURATION = {
 	theme: "sap_fiori_3",

--- a/packages/base/src/ControlRenderer.js
+++ b/packages/base/src/ControlRenderer.js
@@ -1,4 +1,4 @@
-import LitRenderer from "./renderer/LitRenderer";
+import LitRenderer from "./renderer/LitRenderer.js";
 
 const RendererImpl = LitRenderer;
 

--- a/packages/base/src/DOMEventHandler.js
+++ b/packages/base/src/DOMEventHandler.js
@@ -1,6 +1,6 @@
-import ControlEvents from "./events/ControlEvents";
-import getOriginalEventTarget from "./events/getOriginalEventTarget";
-import WebComponent from "./WebComponent";
+import ControlEvents from "./events/ControlEvents.js";
+import getOriginalEventTarget from "./events/getOriginalEventTarget.js";
+import WebComponent from "./WebComponent.js";
 
 const handleEvent = function handleEvent(event) {
 	// Get the DOM node where the original event occurred

--- a/packages/base/src/FocusHelper.js
+++ b/packages/base/src/FocusHelper.js
@@ -1,4 +1,4 @@
-import WebComponent from "./WebComponent";
+import WebComponent from "./WebComponent.js";
 
 const rFocusable = /^(?:input|select|textarea|button)$/i,
 	rClickable = /^(?:a|area)$/i;

--- a/packages/base/src/FormatSettings.js
+++ b/packages/base/src/FormatSettings.js
@@ -1,5 +1,5 @@
-import Locale from "./Locale";
-import { getLocale } from "./LocaleProvider";
+import Locale from "./Locale.js";
+import { getLocale } from "./LocaleProvider.js";
 
 const mSettings = {};
 

--- a/packages/base/src/IconPool.js
+++ b/packages/base/src/IconPool.js
@@ -1,4 +1,4 @@
-import URI from "@ui5/webcomponents-core/dist/sap/ui/thirdparty/URI";
+import URI from "@ui5/webcomponents-core/dist/sap/ui/thirdparty/URI.js";
 /* eslint-disable */
 
 const SAP_ICON_FONT_FAMILY = 'SAP-icons';

--- a/packages/base/src/Locale.js
+++ b/packages/base/src/Locale.js
@@ -1,4 +1,4 @@
-import getDesigntimePropertyAsArray from "./util/getDesigntimePropertyAsArray";
+import getDesigntimePropertyAsArray from "./util/getDesigntimePropertyAsArray.js";
 
 const rLocale = /^((?:[A-Z]{2,3}(?:-[A-Z]{3}){0,3})|[A-Z]{4}|[A-Z]{5,8})(?:-([A-Z]{4}))?(?:-([A-Z]{2}|[0-9]{3}))?((?:-[0-9A-Z]{5,8}|-[0-9][0-9A-Z]{3})*)((?:-[0-9A-WYZ](?:-[0-9A-Z]{2,8})+)*)(?:-(X(?:-[0-9A-Z]{1,8})+))?$/i;
 

--- a/packages/base/src/LocaleProvider.js
+++ b/packages/base/src/LocaleProvider.js
@@ -1,6 +1,6 @@
-import Locale from "./Locale";
-import detectNavigatorLanguage from "./util/detectNavigatorLanguage";
-import { getLanguage as getConfigLanguage } from "./Configuration";
+import Locale from "./Locale.js";
+import detectNavigatorLanguage from "./util/detectNavigatorLanguage.js";
+import { getLanguage as getConfigLanguage } from "./Configuration.js";
 
 const convertToLocaleOrNull = lang => {
 	try {

--- a/packages/base/src/RenderScheduler.js
+++ b/packages/base/src/RenderScheduler.js
@@ -1,4 +1,4 @@
-import RenderQueue from "./RenderQueue";
+import RenderQueue from "./RenderQueue.js";
 
 const MAX_RERENDER_COUNT = 10;
 

--- a/packages/base/src/ResourceBundle.js
+++ b/packages/base/src/ResourceBundle.js
@@ -1,8 +1,8 @@
-import "./shims/jquery-shim";
-import ResourceBundle from "@ui5/webcomponents-core/dist/sap/base/i18n/ResourceBundle";
-import { getLanguage } from "./LocaleProvider";
-import { registerModuleContent } from "./ResourceLoaderOverrides";
-import { fetchJsonOnce } from "./util/FetchHelper";
+import "./shims/jquery-shim.js";
+import ResourceBundle from "@ui5/webcomponents-core/dist/sap/base/i18n/ResourceBundle.js";
+import { getLanguage } from "./LocaleProvider.js";
+import { registerModuleContent } from "./ResourceLoaderOverrides.js";
+import { fetchJsonOnce } from "./util/FetchHelper.js";
 
 const bundleURLs = new Map();
 const singletonPromises = new Map();

--- a/packages/base/src/State.js
+++ b/packages/base/src/State.js
@@ -1,4 +1,4 @@
-import Function from "./types/Function";
+import Function from "./types/Function.js";
 
 class State {
 	constructor(control) {

--- a/packages/base/src/Theming.js
+++ b/packages/base/src/Theming.js
@@ -1,8 +1,8 @@
-import { getTheme, _setTheme } from "./Configuration";
-import { getStyles } from "./theming/ThemeBundle";
-import { getCustomCSS } from "./theming/CustomStyle";
-import { getThemeProperties } from "./theming/ThemeProperties";
-import { injectThemeProperties } from "./theming/StyleInjection";
+import { getTheme, _setTheme } from "./Configuration.js";
+import { getStyles } from "./theming/ThemeBundle.js";
+import { getCustomCSS } from "./theming/CustomStyle.js";
+import { getThemeProperties } from "./theming/ThemeProperties.js";
+import { injectThemeProperties } from "./theming/StyleInjection.js";
 
 const themeChangeCallbacks = [];
 

--- a/packages/base/src/WebComponent.js
+++ b/packages/base/src/WebComponent.js
@@ -1,14 +1,14 @@
-import { getWCNoConflict } from "./Configuration";
-import DOMObserver from "./compatibility/DOMObserver";
-import ShadowDOM from "./compatibility/ShadowDOM";
-import WebComponentMetadata from "./WebComponentMetadata";
-import Integer from "./types/Integer";
-import ControlRenderer from "./ControlRenderer";
-import RenderScheduler from "./RenderScheduler";
-import TemplateContext from "./TemplateContext";
-import State from "./State";
-import { createStyle } from "./CSS";
-import { attachThemeChange } from "./Theming";
+import { getWCNoConflict } from "./Configuration.js";
+import DOMObserver from "./compatibility/DOMObserver.js";
+import ShadowDOM from "./compatibility/ShadowDOM.js";
+import WebComponentMetadata from "./WebComponentMetadata.js";
+import Integer from "./types/Integer.js";
+import ControlRenderer from "./ControlRenderer.js";
+import RenderScheduler from "./RenderScheduler.js";
+import TemplateContext from "./TemplateContext.js";
+import State from "./State.js";
+import { createStyle } from "./CSS.js";
+import { attachThemeChange } from "./Theming.js";
 
 const metadata = {
 	properties: {

--- a/packages/base/src/WebComponentMetadata.js
+++ b/packages/base/src/WebComponentMetadata.js
@@ -1,5 +1,5 @@
-import DataType from "./types/DataType";
-import Function from "./types/Function";
+import DataType from "./types/DataType.js";
+import Function from "./types/Function.js";
 
 class WebComponentMetadata {
 	constructor(metadata) {

--- a/packages/base/src/animations/animate.js
+++ b/packages/base/src/animations/animate.js
@@ -1,5 +1,5 @@
-import AnimationQueue from "./AnimationQueue";
-import animationConfig from "./config";
+import AnimationQueue from "./AnimationQueue.js";
+import animationConfig from "./config.js";
 
 export default ({
 	beforeStart = animationConfig.identity,

--- a/packages/base/src/animations/scroll.js
+++ b/packages/base/src/animations/scroll.js
@@ -1,5 +1,5 @@
-import animate from "./animate";
-import animationConfig from "./config";
+import animate from "./animate.js";
+import animationConfig from "./config.js";
 
 export default ({
 	element = animationConfig.element,

--- a/packages/base/src/animations/slideDown.js
+++ b/packages/base/src/animations/slideDown.js
@@ -1,5 +1,5 @@
-import animationConfig from "./config";
-import animate from "./animate";
+import animationConfig from "./config.js";
+import animate from "./animate.js";
 
 export default ({
 	element = animationConfig.element,

--- a/packages/base/src/animations/slideUp.js
+++ b/packages/base/src/animations/slideUp.js
@@ -1,5 +1,5 @@
-import animationConfig from "./config";
-import animate from "./animate";
+import animationConfig from "./config.js";
+import animate from "./animate.js";
 
 export default ({
 	element = animationConfig.element,

--- a/packages/base/src/browsersupport/Edge.js
+++ b/packages/base/src/browsersupport/Edge.js
@@ -3,4 +3,4 @@ import "url-search-params-polyfill";
 
 
 // "pseudo mutation observer" fix for nodeValue
-import "../compatibility/patchNodeValue";
+import "../compatibility/patchNodeValue.js";

--- a/packages/base/src/browsersupport/IE11.js
+++ b/packages/base/src/browsersupport/IE11.js
@@ -1,36 +1,36 @@
 // String
-import "@ui5/webcomponents-core/dist/sap/ui/thirdparty/es6-string-methods";
+import "@ui5/webcomponents-core/dist/sap/ui/thirdparty/es6-string-methods.js";
 
 // Object
-import "../thirdparty/Object.entries";
+import "../thirdparty/Object.entries.js";
 
 // Array
-import "../thirdparty/Array.prototype.fill";
-import "../thirdparty/Array.prototype.includes";
+import "../thirdparty/Array.prototype.fill.js";
+import "../thirdparty/Array.prototype.includes.js";
 
 // Number
-import "../thirdparty/Number.isInteger";
-import "../thirdparty/Number.isNaN";
-import "../thirdparty/Number.parseInt";
+import "../thirdparty/Number.isInteger.js";
+import "../thirdparty/Number.isNaN.js";
+import "../thirdparty/Number.parseInt.js";
 
 // Element
-import "../thirdparty/Element.prototype.matches";
-import "../thirdparty/Element.prototype.closest";
+import "../thirdparty/Element.prototype.matches.js";
+import "../thirdparty/Element.prototype.closest.js";
 
 // WeakSet
-import "../thirdparty/WeakSet";
+import "../thirdparty/WeakSet.js";
 
 // fetch
-import "../thirdparty/fetch";
+import "../thirdparty/fetch.js";
 
 // async - await
 import "regenerator-runtime/runtime";
 
 // CSS Custom Properties polyfill
-import { cssVars, resetCssVars } from "../thirdparty/css-vars-ponyfill";
+import { cssVars, resetCssVars } from "../thirdparty/css-vars-ponyfill.js";
 
 // Plus all polyfills needed for Edge are also needed for IE11
-import "./Edge";
+import "./Edge.js";
 
 window.CSSVarsPonyfill = {
 	cssVars,

--- a/packages/base/src/compatibility/ShadowDOM.js
+++ b/packages/base/src/compatibility/ShadowDOM.js
@@ -1,14 +1,14 @@
-import { getTheme, getCompactSize } from "../Configuration";
-import getEffectiveRTL from "../util/getEffectiveRTL";
+import { getTheme, getCompactSize } from "../Configuration.js";
+import getEffectiveRTL from "../util/getEffectiveRTL.js";
 
-import { injectWebComponentStyle } from "../theming/StyleInjection";
-import { registerStyle } from "../theming/ThemeBundle";
+import { injectWebComponentStyle } from "../theming/StyleInjection.js";
+import { registerStyle } from "../theming/ThemeBundle.js";
 
-import setupBrowser from "../util/setupBrowser";
-import setupOS from "../util/setupOS";
-import setupSystem from "../util/setupSystem";
-import { getEffectiveStyle } from "../Theming";
-import { createStyle } from "../CSS";
+import setupBrowser from "../util/setupBrowser.js";
+import setupOS from "../util/setupOS.js";
+import setupSystem from "../util/setupSystem.js";
+import { getEffectiveStyle } from "../Theming.js";
+import { createStyle } from "../CSS.js";
 
 // shadow DOM templates per tag
 const shadowDOMTemplates = new Map();

--- a/packages/base/src/dates/CalendarDate.js
+++ b/packages/base/src/dates/CalendarDate.js
@@ -1,4 +1,4 @@
-import UniversalDate from "@ui5/webcomponents-core/dist/sap/ui/core/date/UniversalDate";
+import UniversalDate from "@ui5/webcomponents-core/dist/sap/ui/core/date/UniversalDate.js";
 
 class CalendarDate {
 	constructor() {

--- a/packages/base/src/dates/CalendarDatesRegistry.js
+++ b/packages/base/src/dates/CalendarDatesRegistry.js
@@ -1,5 +1,5 @@
-import Gregorian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian";
-import CalendarType from "@ui5/webcomponents-core/dist/sap/ui/core/CalendarType";
+import Gregorian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian.js";
+import CalendarType from "@ui5/webcomponents-core/dist/sap/ui/core/CalendarType.js";
 
 const registry = new Map();
 registry.set(CalendarType.Gregorian, Gregorian);

--- a/packages/base/src/dates/CalendarType.js
+++ b/packages/base/src/dates/CalendarType.js
@@ -1,4 +1,4 @@
-import DataType from "../types/DataType";
+import DataType from "../types/DataType.js";
 
 /**
  * Different calendar types.

--- a/packages/base/src/dates/CalendarUtils.js
+++ b/packages/base/src/dates/CalendarUtils.js
@@ -1,6 +1,6 @@
-import UniversalDate from "@ui5/webcomponents-core/dist/sap/ui/core/date/UniversalDate";
-import Locale from "@ui5/webcomponents-core/dist/sap/ui/core/Locale";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
+import UniversalDate from "@ui5/webcomponents-core/dist/sap/ui/core/date/UniversalDate.js";
+import Locale from "@ui5/webcomponents-core/dist/sap/ui/core/Locale.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
 
 const calculateWeekNumber = (oDate, iYear, oLocale, oLocaleData) => {
 	let iWeekNum = 0;

--- a/packages/base/src/delegate/ItemNavigation.js
+++ b/packages/base/src/delegate/ItemNavigation.js
@@ -5,10 +5,10 @@ import {
 	isRight,
 	isHome,
 	isEnd,
-} from "../events/PseudoEvents";
+} from "../events/PseudoEvents.js";
 
-import EventProvider from "../EventProvider";
-import WebComponent from "../WebComponent";
+import EventProvider from "../EventProvider.js";
+import WebComponent from "../WebComponent.js";
 
 // navigatable items must have id and tabindex
 class ItemNavigation extends EventProvider {

--- a/packages/base/src/delegate/ResizeHandler.js
+++ b/packages/base/src/delegate/ResizeHandler.js
@@ -1,6 +1,6 @@
-import WebComponent from "../WebComponent";
-import NativeResize from "./NativeResize";
-import CustomResize from "./CustomResize";
+import WebComponent from "../WebComponent.js";
+import NativeResize from "./NativeResize.js";
+import CustomResize from "./CustomResize.js";
 
 class ResizeHandler {
 	static initialize() {

--- a/packages/base/src/delegate/ScrollEnablement.js
+++ b/packages/base/src/delegate/ScrollEnablement.js
@@ -1,5 +1,5 @@
-import EventProvider from "../EventProvider";
-import scroll from "../animations/scroll";
+import EventProvider from "../EventProvider.js";
+import scroll from "../animations/scroll.js";
 
 const scrollEventName = "scroll";
 

--- a/packages/base/src/events/PseudoEvents.js
+++ b/packages/base/src/events/PseudoEvents.js
@@ -1,4 +1,4 @@
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
 
 const isEnter = event => (event.key ? event.key === "Enter" : event.keyCode === KeyCodes.ENTER) && !hasModifierKeys(event);
 

--- a/packages/base/src/shims/Core-shim.js
+++ b/packages/base/src/shims/Core-shim.js
@@ -1,6 +1,6 @@
-import { inject as injectCore } from "@ui5/webcomponents-core/dist/sap/ui/core/Core";
-import * as Configuration from "../Configuration";
-import * as FormatSettings from "../FormatSettings";
+import { inject as injectCore } from "@ui5/webcomponents-core/dist/sap/ui/core/Core.js";
+import * as Configuration from "../Configuration.js";
+import * as FormatSettings from "../FormatSettings.js";
 
 /**
  * Shim for the OpenUI5 core

--- a/packages/base/src/shims/jquery-shim.js
+++ b/packages/base/src/shims/jquery-shim.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import { inject as injectJQuery } from "@ui5/webcomponents-core/dist/sap/ui/thirdparty/jquery";
-import isPlainObject from "@ui5/webcomponents-core/dist/sap/base/util/isPlainObject";
+import { inject as injectJQuery } from "@ui5/webcomponents-core/dist/sap/ui/thirdparty/jquery.js";
+import isPlainObject from "@ui5/webcomponents-core/dist/sap/base/util/isPlainObject.js";
 
 var jQuery = {
 	extend: function() {

--- a/packages/base/src/theming/StyleInjection.js
+++ b/packages/base/src/theming/StyleInjection.js
@@ -1,4 +1,4 @@
-import createStyleInHead from "../util/createStyleInHead";
+import createStyleInHead from "../util/createStyleInHead.js";
 
 const injectedForTags = [];
 let ponyfillTimer;

--- a/packages/base/src/theming/ThemeProperties.js
+++ b/packages/base/src/theming/ThemeProperties.js
@@ -1,4 +1,4 @@
-import { fetchTextOnce } from "../util/FetchHelper";
+import { fetchTextOnce } from "../util/FetchHelper.js";
 
 const themeURLs = new Map();
 const propertiesStyles = new Map();

--- a/packages/base/src/types/CSSSize.js
+++ b/packages/base/src/types/CSSSize.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 class CSSSize extends DataType {
 	static isValid(value) {

--- a/packages/base/src/types/Function.js
+++ b/packages/base/src/types/Function.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 class Function extends DataType {
 	static isValid(value) {

--- a/packages/base/src/types/Integer.js
+++ b/packages/base/src/types/Integer.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 class Integer extends DataType {
 	static isValid(value) {

--- a/packages/base/src/types/PopupState.js
+++ b/packages/base/src/types/PopupState.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 const PopupStates = {
 	/**

--- a/packages/base/src/types/URI.js
+++ b/packages/base/src/types/URI.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 class URI extends DataType {
 	static isValid(value) {

--- a/packages/base/src/types/ValueState.js
+++ b/packages/base/src/types/ValueState.js
@@ -1,4 +1,4 @@
-import DataType from "./DataType";
+import DataType from "./DataType.js";
 
 /**
  * Different states.

--- a/packages/base/src/util/getEffectiveRTL.js
+++ b/packages/base/src/util/getEffectiveRTL.js
@@ -1,6 +1,6 @@
-import { getRTL, getLanguage } from "../Configuration";
-import getDesigntimePropertyAsArray from "./getDesigntimePropertyAsArray";
-import detectNavigatorLanguage from "./detectNavigatorLanguage";
+import { getRTL, getLanguage } from "../Configuration.js";
+import getDesigntimePropertyAsArray from "./getDesigntimePropertyAsArray.js";
+import detectNavigatorLanguage from "./detectNavigatorLanguage.js";
 
 const M_ISO639_OLD_TO_NEW = {
 	"iw": "he",

--- a/packages/base/src/util/setupBrowser.js
+++ b/packages/base/src/util/setupBrowser.js
@@ -1,4 +1,4 @@
-import { getBrowser } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { getBrowser } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 const setupBrowser = node => {
 	const b = getBrowser();

--- a/packages/base/src/util/setupOS.js
+++ b/packages/base/src/util/setupOS.js
@@ -1,4 +1,4 @@
-import { getOS } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { getOS } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 const setupOS = node => {
 	let osCSS = null;

--- a/packages/base/src/util/setupSystem.js
+++ b/packages/base/src/util/setupSystem.js
@@ -1,4 +1,4 @@
-import { getSystem } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { getSystem } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 const setupSystem = node => {
 	const system = getSystem();

--- a/packages/core/lib/esm-abs-to-rel/index.js
+++ b/packages/core/lib/esm-abs-to-rel/index.js
@@ -29,7 +29,7 @@ const convertImports = (srcPath) => {
 			if (!relativePath.startsWith(".")) {
 				relativePath = "./" + relativePath;
 			}
-			let relativeImport = relativePath + "/" + importeeFile;
+			let relativeImport = `${relativePath}/${importeeFile}.js`;
 			// console.log(importee + " --> " + relativeImport);
 			node.source.value = relativeImport;
 			changed = true;

--- a/packages/main/.eslintrc.js
+++ b/packages/main/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
 		// "consistent-return": 1, // removed for UI5 WebComponents
 		"curly": [2, "all"],
 		// "default-case": 1, // removed for UI5 WebComponents
+		"import/extensions": ["error", "ignorePackages"], // override for UI5 WebComponents
 		"no-alert": 2,
 		"no-caller": 2,
 		"no-div-regex": 2,

--- a/packages/main/bundle.es5.js
+++ b/packages/main/bundle.es5.js
@@ -1,9 +1,9 @@
 // ES5 bundle targets IE11 only
-import "@ui5/webcomponents-base/src/browsersupport/IE11";
+import "@ui5/webcomponents-base/src/browsersupport/IE11.js";
 
-import * as configuration from "@ui5/webcomponents-base/src/Configuration";
-import * as Theming from "@ui5/webcomponents-base/src/Theming";
-import "./bundle.esm";
+import * as configuration from "@ui5/webcomponents-base/src/Configuration.js";
+import * as Theming from "@ui5/webcomponents-base/src/Theming.js";
+import "./bundle.esm.js";
 
 export {
 	configuration,

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -1,64 +1,64 @@
 // ESM bundle targets Edge + browsers with native support
-import "@ui5/webcomponents-base/src/browsersupport/Edge";
+import "@ui5/webcomponents-base/src/browsersupport/Edge.js";
 
-import "@ui5/webcomponents-base/src/shims/jquery-shim";
-import "./dist/ThemePropertiesProvider";
+import "@ui5/webcomponents-base/src/shims/jquery-shim.js";
+import "./dist/ThemePropertiesProvider.js";
 
-import Gregorian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian";
-import Buddhist from "@ui5/webcomponents-core/dist/sap/ui/core/date/Buddhist";
-import Islamic from "@ui5/webcomponents-core/dist/sap/ui/core/date/Islamic";
-import Japanese from "@ui5/webcomponents-core/dist/sap/ui/core/date/Japanese";
-import Persian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Persian";
+import Gregorian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian.js";
+import Buddhist from "@ui5/webcomponents-core/dist/sap/ui/core/date/Buddhist.js";
+import Islamic from "@ui5/webcomponents-core/dist/sap/ui/core/date/Islamic.js";
+import Japanese from "@ui5/webcomponents-core/dist/sap/ui/core/date/Japanese.js";
+import Persian from "@ui5/webcomponents-core/dist/sap/ui/core/date/Persian.js";
 
-import Button from "./dist/Button";
-import CheckBox from "./dist/CheckBox";
-import Card from "./dist/Card";
-import Calendar from "./dist/Calendar";
-import CalendarHeader from "./dist/CalendarHeader";
-import DatePicker from "./dist/DatePicker";
-import Dialog from "./dist/Dialog";
-import Icon from "./dist/Icon";
-import Input from "./dist/Input";
-import InputSuggestions from "./dist/InputSuggestions";
-import Label from "./dist/Label";
-import Link from "./dist/Link";
-import DayPicker from "./dist/DayPicker";
-import Popover from "./dist/Popover";
-import Panel from "./dist/Panel";
-import RadioButton from "./dist/RadioButton";
-import Select from "./dist/Select";
-import ShellBar from "./dist/ShellBar";
-import ShellBarItem from "./dist/ShellBarItem";
-import Switch from "./dist/Switch";
-import MessageStrip from "./dist/MessageStrip";
-import TabContainer from "./dist/TabContainer";
-import Tab from "./dist/Tab";
-import TabSeparator from "./dist/TabSeparator";
-import Table from "./dist/Table";
-import TableColumn from "./dist/TableColumn";
-import TableRow from "./dist/TableRow";
-import TableCell from "./dist/TableCell";
-import TextArea from "./dist/TextArea";
-import Timeline from "./dist/Timeline";
-import TimelineItem from "./dist/TimelineItem";
-import Title from "./dist/Title";
-import ToggleButton from "./dist/ToggleButton";
+import Button from "./dist/Button.js";
+import CheckBox from "./dist/CheckBox.js";
+import Card from "./dist/Card.js";
+import Calendar from "./dist/Calendar.js";
+import CalendarHeader from "./dist/CalendarHeader.js";
+import DatePicker from "./dist/DatePicker.js";
+import Dialog from "./dist/Dialog.js";
+import Icon from "./dist/Icon.js";
+import Input from "./dist/Input.js";
+import InputSuggestions from "./dist/InputSuggestions.js";
+import Label from "./dist/Label.js";
+import Link from "./dist/Link.js";
+import DayPicker from "./dist/DayPicker.js";
+import Popover from "./dist/Popover.js";
+import Panel from "./dist/Panel.js";
+import RadioButton from "./dist/RadioButton.js";
+import Select from "./dist/Select.js";
+import ShellBar from "./dist/ShellBar.js";
+import ShellBarItem from "./dist/ShellBarItem.js";
+import Switch from "./dist/Switch.js";
+import MessageStrip from "./dist/MessageStrip.js";
+import TabContainer from "./dist/TabContainer.js";
+import Tab from "./dist/Tab.js";
+import TabSeparator from "./dist/TabSeparator.js";
+import Table from "./dist/Table.js";
+import TableColumn from "./dist/TableColumn.js";
+import TableRow from "./dist/TableRow.js";
+import TableCell from "./dist/TableCell.js";
+import TextArea from "./dist/TextArea.js";
+import Timeline from "./dist/Timeline.js";
+import TimelineItem from "./dist/TimelineItem.js";
+import Title from "./dist/Title.js";
+import ToggleButton from "./dist/ToggleButton.js";
 
-import List from "./dist/List";
-import StandardListItem from "./dist/StandardListItem";
-import CustomListItem from "./dist/CustomListItem";
-import GroupHeaderListItem from "./dist/GroupHeaderListItem";
+import List from "./dist/List.js";
+import StandardListItem from "./dist/StandardListItem.js";
+import CustomListItem from "./dist/CustomListItem.js";
+import GroupHeaderListItem from "./dist/GroupHeaderListItem.js";
 
 // used in test pages
-import RenderScheduler from "@ui5/webcomponents-base/src/RenderScheduler";
+import RenderScheduler from "@ui5/webcomponents-base/src/RenderScheduler.js";
 window.RenderScheduler = RenderScheduler;
-import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 window.isIE = isIE; // attached to the window object for testing purposes
 
 
 // Note: keep in sync with rollup.config value for IIFE
-import * as configuration from "@ui5/webcomponents-base/src/Configuration";
-import * as Theming from "@ui5/webcomponents-base/src/Theming";
+import * as configuration from "@ui5/webcomponents-base/src/Configuration.js";
+import * as Theming from "@ui5/webcomponents-base/src/Theming.js";
 window["sap-ui-webcomponents-main-bundle"] = {
 	configuration,
 	Theming,

--- a/packages/main/lib/hbs2ui5/RenderTemplates/LitRenderer.js
+++ b/packages/main/lib/hbs2ui5/RenderTemplates/LitRenderer.js
@@ -1,8 +1,8 @@
 const buildRenderer = (controlName, litTemplate) => {
 	return `
 /* eslint no-unused-vars: 0 */	
-import ifTruthy from '@ui5/webcomponents-base/src/renderer/ifTruthy';
-import { html, svg, repeat } from '@ui5/webcomponents-base/src/renderer/LitRenderer';
+import ifTruthy from '@ui5/webcomponents-base/src/renderer/ifTruthy.js';
+import { html, svg, repeat } from '@ui5/webcomponents-base/src/renderer/LitRenderer.js';
 const ${controlName}LitRenderer = {};
 ${litTemplate}
 ${controlName}LitRenderer.render = renderMe;

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -1,16 +1,16 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
-import ButtonTemplateContext from "./ButtonTemplateContext";
-import ButtonType from "./types/ButtonType";
-import ButtonRenderer from "./build/compiled/ButtonRenderer.lit";
-import Icon from "./Icon";
+import ButtonTemplateContext from "./ButtonTemplateContext.js";
+import ButtonType from "./types/ButtonType.js";
+import ButtonRenderer from "./build/compiled/ButtonRenderer.lit.js";
+import Icon from "./Icon.js";
 
 // Styles
-import buttonCss from "./themes/Button.css";
+import buttonCss from "./themes/Button.css.js";
 
 addCustomCSS("ui5-button", "sap_fiori_3", buttonCss);
 addCustomCSS("ui5-button", "sap_belize", buttonCss);

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -1,29 +1,29 @@
-import "@ui5/webcomponents-base/src/shims/jquery-shim";
-import "@ui5/webcomponents-base/src/shims/Core-shim";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration";
-import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings";
-import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate";
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import CalendarTemplateContext from "./CalendarTemplateContext";
-import CalendarHeader from "./CalendarHeader";
-import DayPicker from "./DayPicker";
-import MonthPicker from "./MonthPicker";
-import YearPicker from "./YearPicker";
-import CalendarRenderer from "./build/compiled/CalendarRenderer.lit";
+import "@ui5/webcomponents-base/src/shims/jquery-shim.js";
+import "@ui5/webcomponents-base/src/shims/Core-shim.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration.js";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings.js";
+import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
+import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import CalendarTemplateContext from "./CalendarTemplateContext.js";
+import CalendarHeader from "./CalendarHeader.js";
+import DayPicker from "./DayPicker.js";
+import MonthPicker from "./MonthPicker.js";
+import YearPicker from "./YearPicker.js";
+import CalendarRenderer from "./build/compiled/CalendarRenderer.lit.js";
 
 // default calendar for bundling
-import "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian";
+import "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian.js";
 
 // Styles
-import calendarCSS from "./themes/Calendar.css";
+import calendarCSS from "./themes/Calendar.css.js";
 
 addCustomCSS("ui5-calendar", "sap_fiori_3", calendarCSS);
 addCustomCSS("ui5-calendar", "sap_belize_hcb", calendarCSS);

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -1,14 +1,14 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import CalendarHeaderTemplateContext from "./CalendarHeaderTemplateContext";
-import Button from "./Button";
-import ButtonType from "./types/ButtonType";
-import CalendarHeaderRenderer from "./build/compiled/CalendarHeaderRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import CalendarHeaderTemplateContext from "./CalendarHeaderTemplateContext.js";
+import Button from "./Button.js";
+import ButtonType from "./types/ButtonType.js";
+import CalendarHeaderRenderer from "./build/compiled/CalendarHeaderRenderer.lit.js";
 
 // Styles
-import styles from "./themes/CalendarHeader.css";
+import styles from "./themes/CalendarHeader.css.js";
 
 addCustomCSS("ui5-calendar-header", "sap_belize", styles);
 addCustomCSS("ui5-calendar-header", "sap_belize_hcb", styles);

--- a/packages/main/src/CalendarTemplateContext.js
+++ b/packages/main/src/CalendarTemplateContext.js
@@ -1,4 +1,4 @@
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 
 class CalendarTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -1,15 +1,15 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { isIconURI } from "@ui5/webcomponents-base/src/IconPool";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import CardRenderer from "./build/compiled/CardRenderer.lit";
-import Icon from "./Icon";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { isIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import CardRenderer from "./build/compiled/CardRenderer.lit.js";
+import Icon from "./Icon.js";
 
 // Styles
-import cardCss from "./themes/Card.css";
+import cardCss from "./themes/Card.css.js";
 
 addCustomCSS("ui5-card", "sap_fiori_3", cardCss);
 addCustomCSS("ui5-card", "sap_belize", cardCss);

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -1,15 +1,15 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import ValueState from "@ui5/webcomponents-base/src/types/ValueState";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
-import CheckBoxRenderer from "./build/compiled/CheckBoxRenderer.lit";
-import CheckBoxTemplateContext from "./CheckBoxTemplateContext";
-import Label from "./Label";
+import CheckBoxRenderer from "./build/compiled/CheckBoxRenderer.lit.js";
+import CheckBoxTemplateContext from "./CheckBoxTemplateContext.js";
+import Label from "./Label.js";
 
 // Styles
-import checkboxCss from "./themes/CheckBox.css";
+import checkboxCss from "./themes/CheckBox.css.js";
 
 addCustomCSS("ui5-checkbox", "sap_fiori_3", checkboxCss);
 addCustomCSS("ui5-checkbox", "sap_belize", checkboxCss);

--- a/packages/main/src/CheckBoxTemplateContext.js
+++ b/packages/main/src/CheckBoxTemplateContext.js
@@ -1,4 +1,4 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 class CheckBoxTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/CustomListItem.js
+++ b/packages/main/src/CustomListItem.js
@@ -1,11 +1,11 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import ListItem from "./ListItem";
-import CustomListItemTemplateContext from "./CustomListItemTemplateContext";
-import CustomListItemRenderer from "./build/compiled/CustomListItemRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import ListItem from "./ListItem.js";
+import CustomListItemTemplateContext from "./CustomListItemTemplateContext.js";
+import CustomListItemRenderer from "./build/compiled/CustomListItemRenderer.lit.js";
 
 // Styles
-import columnListItemCss from "./themes/CustomListItem.css";
+import columnListItemCss from "./themes/CustomListItem.css.js";
 
 addCustomCSS("ui5-li-custom", "sap_fiori_3", columnListItemCss);
 addCustomCSS("ui5-li-custom", "sap_belize", columnListItemCss);

--- a/packages/main/src/CustomListItemTemplateContext.js
+++ b/packages/main/src/CustomListItemTemplateContext.js
@@ -1,4 +1,4 @@
-import ListItemTemplateContext from "./ListItemTemplateContext";
+import ListItemTemplateContext from "./ListItemTemplateContext.js";
 
 class CustomListItemTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -1,33 +1,33 @@
-import "@ui5/webcomponents-base/src/shims/jquery-shim";
-import "@ui5/webcomponents-base/src/shims/Core-shim";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import { getIconURI } from "@ui5/webcomponents-base/src/IconPool";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
-import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate";
-import ValueState from "@ui5/webcomponents-base/src/types/ValueState";
-import DatePickerTemplateContext from "./DatePickerTemplateContext";
-import Icon from "./Icon";
-import Popover from "./Popover";
-import Calendar from "./Calendar";
-import PopoverPlacementType from "./types/PopoverPlacementType";
-import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign";
-import Input from "./Input";
-import InputType from "./types/InputType";
-import DatePickerRenderer from "./build/compiled/DatePickerRenderer.lit";
+import "@ui5/webcomponents-base/src/shims/jquery-shim.js";
+import "@ui5/webcomponents-base/src/shims/Core-shim.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import { getIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
+import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat.js";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
+import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
+import DatePickerTemplateContext from "./DatePickerTemplateContext.js";
+import Icon from "./Icon.js";
+import Popover from "./Popover.js";
+import Calendar from "./Calendar.js";
+import PopoverPlacementType from "./types/PopoverPlacementType.js";
+import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
+import Input from "./Input.js";
+import InputType from "./types/InputType.js";
+import DatePickerRenderer from "./build/compiled/DatePickerRenderer.lit.js";
 
 // default calendar for bundling
-import "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian";
+import "@ui5/webcomponents-core/dist/sap/ui/core/date/Gregorian.js";
 
 // Styles
-import datePickerCss from "./themes/DatePicker.css";
+import datePickerCss from "./themes/DatePicker.css.js";
 
 addCustomCSS("ui5-datepicker", "sap_fiori_3", datePickerCss);
 addCustomCSS("ui5-datepicker", "sap_belize", datePickerCss);

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -1,21 +1,21 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration";
-import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate";
-import { calculateWeekNumber } from "@ui5/webcomponents-base/src/dates/CalendarUtils";
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import DayPickerTemplateContext from "./DayPickerTemplateContext";
-import DayPickerRenderer from "./build/compiled/DayPickerRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration.js";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
+import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import { calculateWeekNumber } from "@ui5/webcomponents-base/src/dates/CalendarUtils.js";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import DayPickerTemplateContext from "./DayPickerTemplateContext.js";
+import DayPickerRenderer from "./build/compiled/DayPickerRenderer.lit.js";
 
 // Styles
-import dayPickerCSS from "./themes/DayPicker.css";
+import dayPickerCSS from "./themes/DayPicker.css.js";
 
 addCustomCSS("ui5-daypicker", "sap_fiori_3", dayPickerCSS);
 addCustomCSS("ui5-daypicker", "sap_belize", dayPickerCSS);

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -1,13 +1,13 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
-import DialogTemplateContext from "./DialogTemplateContext";
-import Popup from "./Popup";
+import DialogTemplateContext from "./DialogTemplateContext.js";
+import Popup from "./Popup.js";
 // Template
-import DialogRenderer from "./build/compiled/DialogRenderer.lit";
+import DialogRenderer from "./build/compiled/DialogRenderer.lit.js";
 
 // Styles
-import dialogCss from "./themes/Dialog.css";
+import dialogCss from "./themes/Dialog.css.js";
 
 addCustomCSS("ui5-dialog", "sap_fiori_3", dialogCss);
 addCustomCSS("ui5-dialog", "sap_belize", dialogCss);

--- a/packages/main/src/DialogTemplateContext.js
+++ b/packages/main/src/DialogTemplateContext.js
@@ -1,4 +1,4 @@
-import { isPhone } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isPhone } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 class DialogTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -1,14 +1,14 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import ListItemBase from "./ListItemBase";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import ListItemBase from "./ListItemBase.js";
 
 // Template
-import GroupHeaderListItemRenderer from "./build/compiled/GroupHeaderListItemRenderer.lit";
-import GroupHeaderListItemTemplateContext from "./GroupHeaderListItemTemplateContext";
+import GroupHeaderListItemRenderer from "./build/compiled/GroupHeaderListItemRenderer.lit.js";
+import GroupHeaderListItemTemplateContext from "./GroupHeaderListItemTemplateContext.js";
 
 // Styles
-import listItemBaseCss from "./themes/ListItemBase.css";
-import groupheaderListItemCss from "./themes/GroupHeaderListItem.css";
+import listItemBaseCss from "./themes/ListItemBase.css.js";
+import groupheaderListItemCss from "./themes/GroupHeaderListItem.css.js";
 
 addCustomCSS("ui5-li-groupheader", "sap_fiori_3", listItemBaseCss);
 addCustomCSS("ui5-li-groupheader", "sap_fiori_3", groupheaderListItemCss);

--- a/packages/main/src/GroupHeaderListItemTemplateContext.js
+++ b/packages/main/src/GroupHeaderListItemTemplateContext.js
@@ -1,4 +1,4 @@
-import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext";
+import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext.js";
 
 class GroupHeaderListItemTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -1,13 +1,13 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import IconTemplateContext from "./IconTemplateContext";
-import IconRenderer from "./build/compiled/IconRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import IconTemplateContext from "./IconTemplateContext.js";
+import IconRenderer from "./build/compiled/IconRenderer.lit.js";
 
 // Styles
-import iconCss from "./themes/Icon.css";
+import iconCss from "./themes/Icon.css.js";
 
 addCustomCSS("ui5-icon", "sap_fiori_3", iconCss);
 addCustomCSS("ui5-icon", "sap_belize", iconCss);

--- a/packages/main/src/IconTemplateContext.js
+++ b/packages/main/src/IconTemplateContext.js
@@ -1,5 +1,5 @@
-import { getIconInfo } from "@ui5/webcomponents-base/src/IconPool";
-import { getRTL } from "@ui5/webcomponents-base/src/Configuration";
+import { getIconInfo } from "@ui5/webcomponents-base/src/IconPool.js";
+import { getRTL } from "@ui5/webcomponents-base/src/Configuration.js";
 
 const dir = getRTL() ? "rtl" : "ltr";
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -1,23 +1,23 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device";
-import ValueState from "@ui5/webcomponents-base/src/types/ValueState";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
+import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 import {
 	isUp,
 	isDown,
 	isSpace,
 	isEnter,
-} from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import Icon from "./Icon";
-import InputType from "./types/InputType";
+} from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import Icon from "./Icon.js";
+import InputType from "./types/InputType.js";
 // Template
-import InputRenderer from "./build/compiled/InputRenderer.lit";
-import InputTemplateContext from "./InputTemplateContext";
+import InputRenderer from "./build/compiled/InputRenderer.lit.js";
+import InputTemplateContext from "./InputTemplateContext.js";
 
 // Styles
-import styles from "./themes/Input.css";
-import shellbarInput from "./themes/ShellBarInput.css";
+import styles from "./themes/Input.css.js";
+import shellbarInput from "./themes/ShellBarInput.css.js";
 
 addCustomCSS("ui5-input", "sap_fiori_3", styles);
 addCustomCSS("ui5-input", "sap_belize", styles);

--- a/packages/main/src/InputSuggestions.js
+++ b/packages/main/src/InputSuggestions.js
@@ -1,5 +1,5 @@
-import Input from "./Input";
-import Suggestions from "./Suggestions";
+import Input from "./Input.js";
+import Suggestions from "./Suggestions.js";
 
 class InputSuggestions {}
 Input.getSuggestions = () => Suggestions;

--- a/packages/main/src/InputTemplateContext.js
+++ b/packages/main/src/InputTemplateContext.js
@@ -1,4 +1,4 @@
-import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isIE } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 class InputTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -1,13 +1,13 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
 // Template
-import LabelRenderer from "./build/compiled/LabelRenderer.lit";
-import LabelTemplateContext from "./LabelTemplateContext";
+import LabelRenderer from "./build/compiled/LabelRenderer.lit.js";
+import LabelTemplateContext from "./LabelTemplateContext.js";
 
 // Styles
-import labelCss from "./themes/Label.css";
+import labelCss from "./themes/Label.css.js";
 
 addCustomCSS("ui5-label", "sap_fiori_3", labelCss);
 addCustomCSS("ui5-label", "sap_belize", labelCss);

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -1,16 +1,16 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import LinkType from "./types/LinkType";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import LinkType from "./types/LinkType.js";
 
 // Template
-import LinkRederer from "./build/compiled/LinkRenderer.lit";
-import LinkTemplateContext from "./LinkTemplateContext";
+import LinkRederer from "./build/compiled/LinkRenderer.lit.js";
+import LinkTemplateContext from "./LinkTemplateContext.js";
 
 // Styles
-import linkCss from "./themes/Link.css";
+import linkCss from "./themes/Link.css.js";
 
 addCustomCSS("ui5-link", "sap_fiori_3", linkCss);
 addCustomCSS("ui5-link", "sap_belize", linkCss);

--- a/packages/main/src/LinkTemplateContext.js
+++ b/packages/main/src/LinkTemplateContext.js
@@ -1,4 +1,4 @@
-import LinkType from "./types/LinkType";
+import LinkType from "./types/LinkType.js";
 
 class LinkTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -1,21 +1,21 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
-import { isTabNext } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import ListItemBase from "./ListItemBase";
-import ListMode from "./types/ListMode";
-import BackgroundDesign from "./types/BackgroundDesign";
-import ListSeparators from "./types/ListSeparators";
-import ListItemType from "./types/ListItemType";
+import { isTabNext } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import ListItemBase from "./ListItemBase.js";
+import ListMode from "./types/ListMode.js";
+import BackgroundDesign from "./types/BackgroundDesign.js";
+import ListSeparators from "./types/ListSeparators.js";
+import ListItemType from "./types/ListItemType.js";
 // Template
-import ListRenderer from "./build/compiled/ListRenderer.lit";
-import ListTemplateContext from "./ListTemplateContext";
+import ListRenderer from "./build/compiled/ListRenderer.lit.js";
+import ListTemplateContext from "./ListTemplateContext.js";
 
 // Styles
-import listCss from "./themes/List.css";
+import listCss from "./themes/List.css.js";
 
 addCustomCSS("ui5-list", "sap_fiori_3", listCss);
 addCustomCSS("ui5-list", "sap_belize", listCss);

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -1,11 +1,11 @@
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import ListItemType from "./types/ListItemType";
-import ListMode from "./types/ListMode";
-import ListItemBase from "./ListItemBase";
-import "./RadioButton";
-import "./CheckBox";
-import "./Button";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import ListItemType from "./types/ListItemType.js";
+import ListMode from "./types/ListMode.js";
+import ListItemBase from "./ListItemBase.js";
+import "./RadioButton.js";
+import "./CheckBox.js";
+import "./Button.js";
 
 /**
  * @public

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -1,7 +1,7 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper";
-import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper.js";
+import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext.js";
 
 /**
  * @public

--- a/packages/main/src/ListItemBaseTemplateContext.js
+++ b/packages/main/src/ListItemBaseTemplateContext.js
@@ -1,4 +1,4 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 class ListItemBaseTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/ListItemTemplateContext.js
+++ b/packages/main/src/ListItemTemplateContext.js
@@ -1,7 +1,7 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
-import ListMode from "./types/ListMode";
-import ListItemType from "./types/ListItemType";
-import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
+import ListMode from "./types/ListMode.js";
+import ListItemType from "./types/ListItemType.js";
+import ListItemBaseTemplateContext from "./ListItemBaseTemplateContext.js";
 
 class ListItemTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/ListTemplateContext.js
+++ b/packages/main/src/ListTemplateContext.js
@@ -1,4 +1,4 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
 
 class ListTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -1,14 +1,14 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import MessageStripTemplateContext from "./MessageStripTemplateContext";
-import MessageStripType from "./types/MessageStripType";
-import MessageStripRenderer from "./build/compiled/MessageStripRenderer.lit";
-import Icon from "./Icon";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import MessageStripTemplateContext from "./MessageStripTemplateContext.js";
+import MessageStripType from "./types/MessageStripType.js";
+import MessageStripRenderer from "./build/compiled/MessageStripRenderer.lit.js";
+import Icon from "./Icon.js";
 
 // Styles
-import messageStripCss from "./themes/MessageStrip.css";
+import messageStripCss from "./themes/MessageStrip.css.js";
 
 addCustomCSS("ui5-messagestrip", "sap_fiori_3", messageStripCss);
 addCustomCSS("ui5-messagestrip", "sap_belize", messageStripCss);

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -1,20 +1,20 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration";
-import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
-import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import MonthPickerTemplateContext from "./MonthPickerTemplateContext";
-import MonthPickerRenderer from "./build/compiled/MonthPickerRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration.js";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
+import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import MonthPickerTemplateContext from "./MonthPickerTemplateContext.js";
+import MonthPickerRenderer from "./build/compiled/MonthPickerRenderer.lit.js";
 
 // Styles
-import styles from "./themes/MonthPicker.css";
+import styles from "./themes/MonthPicker.css.js";
 
 addCustomCSS("ui5-month-picker", "sap_fiori_3", styles);
 addCustomCSS("ui5-month-picker", "sap_belize", styles);

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -1,18 +1,18 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { getIconURI } from "@ui5/webcomponents-base/src/IconPool";
-import slideDown from "@ui5/webcomponents-base/src/animations/slideDown";
-import slideUp from "@ui5/webcomponents-base/src/animations/slideUp";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import PanelTemplateContext from "./PanelTemplateContext";
-import BackgroundDesign from "./types/BackgroundDesign";
-import PanelAccessibleRole from "./types/PanelAccessibleRole";
-import PanelRenderer from "./build/compiled/PanelRenderer.lit";
-import { fetchResourceBundle, getResourceBundle } from "./ResourceBundleProvider";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { getIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
+import slideDown from "@ui5/webcomponents-base/src/animations/slideDown.js";
+import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import PanelTemplateContext from "./PanelTemplateContext.js";
+import BackgroundDesign from "./types/BackgroundDesign.js";
+import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
+import PanelRenderer from "./build/compiled/PanelRenderer.lit.js";
+import { fetchResourceBundle, getResourceBundle } from "./ResourceBundleProvider.js";
 
 // Styles
-import panelCss from "./themes/Panel.css";
+import panelCss from "./themes/Panel.css.js";
 
 addCustomCSS("ui5-panel", "sap_fiori_3", panelCss);
 addCustomCSS("ui5-panel", "sap_belize", panelCss);

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -1,20 +1,20 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import RenderScheduler from "@ui5/webcomponents-base/src/RenderScheduler";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper";
-import PopoverTemplateContext from "./PopoverTemplateContext";
-import PopoverPlacementType from "./types/PopoverPlacementType";
-import PopoverVerticalAlign from "./types/PopoverVerticalAlign";
-import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign";
-import Popup from "./Popup";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import RenderScheduler from "@ui5/webcomponents-base/src/RenderScheduler.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper.js";
+import PopoverTemplateContext from "./PopoverTemplateContext.js";
+import PopoverPlacementType from "./types/PopoverPlacementType.js";
+import PopoverVerticalAlign from "./types/PopoverVerticalAlign.js";
+import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
+import Popup from "./Popup.js";
 
 
 // Template
-import PopoverRenderer from "./build/compiled/PopoverRenderer.lit";
+import PopoverRenderer from "./build/compiled/PopoverRenderer.lit.js";
 
 // Styles
-import popoverCss from "./themes/Popover.css";
+import popoverCss from "./themes/Popover.css.js";
 
 addCustomCSS("ui5-popover", "sap_fiori_3", popoverCss);
 addCustomCSS("ui5-popover", "sap_belize", popoverCss);

--- a/packages/main/src/PopoverTemplateContext.js
+++ b/packages/main/src/PopoverTemplateContext.js
@@ -1,4 +1,4 @@
-import PopoverPlacementType from "./types/PopoverPlacementType";
+import PopoverPlacementType from "./types/PopoverPlacementType.js";
 
 class PopoverTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -1,11 +1,11 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { isEscape } from "@ui5/webcomponents-base/src/events/PseudoEvents";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import FocusHelper from "@ui5/webcomponents-base/src/FocusHelper.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { isEscape } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 
 // Styles
-import styles from "./themes/Popup.css";
+import styles from "./themes/Popup.css.js";
 
 addCustomCSS("ui5-dialog", "sap_fiori_3", styles);
 addCustomCSS("ui5-dialog", "sap_belize", styles);

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -1,8 +1,8 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import ValueState from "@ui5/webcomponents-base/src/types/ValueState";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
 import {
 	isSpace,
 	isEnter,
@@ -10,14 +10,14 @@ import {
 	isLeft,
 	isUp,
 	isRight,
-} from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import RadioButtonGroup from "./RadioButtonGroup";
+} from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import RadioButtonGroup from "./RadioButtonGroup.js";
 // Template
-import RadioButtonRenderer from "./build/compiled/RadioButtonRenderer.lit";
-import RadioButtonTemplateContext from "./RadioButtonTemplateContext";
+import RadioButtonRenderer from "./build/compiled/RadioButtonRenderer.lit.js";
+import RadioButtonTemplateContext from "./RadioButtonTemplateContext.js";
 
 // Styles
-import radioButtonCss from "./themes/RadioButton.css";
+import radioButtonCss from "./themes/RadioButton.css.js";
 
 addCustomCSS("ui5-radiobutton", "sap_fiori_3", radioButtonCss);
 addCustomCSS("ui5-radiobutton", "sap_belize", radioButtonCss);

--- a/packages/main/src/RadioButtonTemplateContext.js
+++ b/packages/main/src/RadioButtonTemplateContext.js
@@ -1,5 +1,5 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
-import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
+import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 
 const SVGConfig = {
 	"compact": {

--- a/packages/main/src/ResourceBundleProvider.js
+++ b/packages/main/src/ResourceBundleProvider.js
@@ -1,4 +1,4 @@
-import { fetchResourceBundle, registerMessageBundles, getResourceBundle } from "@ui5/webcomponents-base/src/ResourceBundle";
+import { fetchResourceBundle, registerMessageBundles, getResourceBundle } from "@ui5/webcomponents-base/src/ResourceBundle.js";
 
 import ar from "./i18n/messagebundle_ar.json";
 import bg from "./i18n/messagebundle_bg.json";

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -1,23 +1,23 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
 import {
 	isSpace,
 	isUp,
 	isDown,
 	isEnter,
-} from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import ValueState from "@ui5/webcomponents-base/src/types/ValueState";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import Suggestions from "./Suggestions";
+} from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import Suggestions from "./Suggestions.js";
 
 // Template
-import SelectRenderer from "./build/compiled/SelectRenderer.lit";
-import SelectTemplateContext from "./SelectTemplateContext";
+import SelectRenderer from "./build/compiled/SelectRenderer.lit.js";
+import SelectTemplateContext from "./SelectTemplateContext.js";
 
 // Styles
-import selectCss from "./themes/Select.css";
+import selectCss from "./themes/Select.css.js";
 
 addCustomCSS("ui5-select", "sap_fiori_3", selectCss);
 addCustomCSS("ui5-select", "sap_belize", selectCss);

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -1,23 +1,23 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { getRTL } from "@ui5/webcomponents-base/src/Configuration";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import { isSpace, isEscape } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import StandardListItem from "./StandardListItem";
-import List from "./List";
-import Icon from "./Icon";
-import Popover from "./Popover";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { getRTL } from "@ui5/webcomponents-base/src/Configuration.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import { isSpace, isEscape } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import StandardListItem from "./StandardListItem.js";
+import List from "./List.js";
+import Icon from "./Icon.js";
+import Popover from "./Popover.js";
 
 // Template
-import ShellBarRenderer from "./build/compiled/ShellBarRenderer.lit";
-import ShellBarTemplateContext from "./ShellBarTemplateContext";
+import ShellBarRenderer from "./build/compiled/ShellBarRenderer.lit.js";
+import ShellBarTemplateContext from "./ShellBarTemplateContext.js";
 
 // Styles
-import styles from "./themes/ShellBar.css";
+import styles from "./themes/ShellBar.css.js";
 
 addCustomCSS("ui5-shellbar", "sap_belize", styles);
 addCustomCSS("ui5-shellbar", "sap_belize_hcb", styles);

--- a/packages/main/src/ShellBarItem.js
+++ b/packages/main/src/ShellBarItem.js
@@ -1,9 +1,9 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import URI from "@ui5/webcomponents-base/src/types/URI";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
 
 // Template
-import ShellBarItemRenderer from "./build/compiled/ShellBarItemRenderer.lit";
+import ShellBarItemRenderer from "./build/compiled/ShellBarItemRenderer.lit.js";
 
 /**
  * @public

--- a/packages/main/src/ShellBarTemplateContext.js
+++ b/packages/main/src/ShellBarTemplateContext.js
@@ -1,4 +1,4 @@
-import { getRTL } from "@ui5/webcomponents-base/src/Configuration";
+import { getRTL } from "@ui5/webcomponents-base/src/Configuration.js";
 
 class ShellBarTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -1,14 +1,14 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import ListItem from "./ListItem";
-import Icon from "./Icon";
-import StandardListItemTemplateContext from "./StandardListItemTemplateContext";
-import StandardListItemRenderer from "./build/compiled/StandardListItemRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import ListItem from "./ListItem.js";
+import Icon from "./Icon.js";
+import StandardListItemTemplateContext from "./StandardListItemTemplateContext.js";
+import StandardListItemRenderer from "./build/compiled/StandardListItemRenderer.lit.js";
 
 // Styles
-import listItemCss from "./themes/ListItem.css";
-import listItemBaseCss from "./themes/ListItemBase.css";
+import listItemCss from "./themes/ListItem.css.js";
+import listItemBaseCss from "./themes/ListItemBase.css.js";
 
 addCustomCSS("ui5-li", "sap_fiori_3", listItemCss);
 addCustomCSS("ui5-li", "sap_fiori_3", listItemBaseCss);

--- a/packages/main/src/StandardListItemTemplateContext.js
+++ b/packages/main/src/StandardListItemTemplateContext.js
@@ -1,4 +1,4 @@
-import ListItemTemplateContext from "./ListItemTemplateContext";
+import ListItemTemplateContext from "./ListItemTemplateContext.js";
 
 class StandardListItemTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Suggestions.js
+++ b/packages/main/src/Suggestions.js
@@ -1,8 +1,8 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import List from "./List";
-import Popover from "./Popover";
-import StandardListItem from "./StandardListItem"; // ensure <ui5-li> is loaded
-import CustomListItem from "./CustomListItem"; // ensure <ui5-li-custom> is loaded
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import List from "./List.js";
+import Popover from "./Popover.js";
+import StandardListItem from "./StandardListItem.js"; // ensure <ui5-li> is loaded
+import CustomListItem from "./CustomListItem.js"; // ensure <ui5-li-custom> is loaded
 
 (function noTreeShaked() {
 	`${StandardListItem}${CustomListItem}`; //eslint-disable-line

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -1,15 +1,15 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import KeyCodes from "@ui5/webcomponents-core/dist/sap/ui/events/KeyCodes.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
 
 // Template
-import SwitchRenderer from "./build/compiled/SwitchRenderer.lit";
-import SwitchTemplateContext from "./SwitchTemplateContext";
-import SwitchType from "./types/SwitchType";
+import SwitchRenderer from "./build/compiled/SwitchRenderer.lit.js";
+import SwitchTemplateContext from "./SwitchTemplateContext.js";
+import SwitchType from "./types/SwitchType.js";
 
 // Styles
-import switchCss from "./themes/Switch.css";
+import switchCss from "./themes/Switch.css.js";
 
 addCustomCSS("ui5-switch", "sap_fiori_3", switchCss);
 addCustomCSS("ui5-switch", "sap_belize", switchCss);

--- a/packages/main/src/SwitchTemplateContext.js
+++ b/packages/main/src/SwitchTemplateContext.js
@@ -1,5 +1,5 @@
-import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device";
-import SwitchType from "./types/SwitchType";
+import { isDesktop } from "@ui5/webcomponents-core/dist/sap/ui/Device.js";
+import SwitchType from "./types/SwitchType.js";
 
 class SwitchTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -1,11 +1,11 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import TabBase from "./TabBase";
-import TabTemplateContext from "./TabTemplateContext";
-import IconColor from "./types/IconColor";
-import Icon from "./Icon";
-import TabRenderer from "./build/compiled/TabRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import TabBase from "./TabBase.js";
+import TabTemplateContext from "./TabTemplateContext.js";
+import IconColor from "./types/IconColor.js";
+import Icon from "./Icon.js";
+import TabRenderer from "./build/compiled/TabRenderer.lit.js";
 
 /**
  * @public

--- a/packages/main/src/TabBase.js
+++ b/packages/main/src/TabBase.js
@@ -1,4 +1,4 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
 
 /**
  * @public

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -1,21 +1,21 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler";
-import ScrollEnablement from "@ui5/webcomponents-base/src/delegate/ScrollEnablement";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import TabContainerTemplateContext from "./TabContainerTemplateContext";
-import TabContainerRenderer from "./build/compiled/TabContainerRenderer.lit";
-import Button from "./Button";
-import CustomListItem from "./CustomListItem";
-import Icon from "./Icon";
-import List from "./List";
-import Popover from "./Popover";
-import TabBase from "./TabBase";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler.js";
+import ScrollEnablement from "@ui5/webcomponents-base/src/delegate/ScrollEnablement.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import TabContainerTemplateContext from "./TabContainerTemplateContext.js";
+import TabContainerRenderer from "./build/compiled/TabContainerRenderer.lit.js";
+import Button from "./Button.js";
+import CustomListItem from "./CustomListItem.js";
+import Icon from "./Icon.js";
+import List from "./List.js";
+import Popover from "./Popover.js";
+import TabBase from "./TabBase.js";
 
 // Styles
-import buttonCss from "./themes/TabContainer.css";
+import buttonCss from "./themes/TabContainer.css.js";
 
 addCustomCSS("ui5-tabcontainer", "sap_fiori_3", buttonCss);
 addCustomCSS("ui5-tabcontainer", "sap_belize", buttonCss);

--- a/packages/main/src/TabContainerTemplateContext.js
+++ b/packages/main/src/TabContainerTemplateContext.js
@@ -1,4 +1,4 @@
-import IconColor from "./types/IconColor";
+import IconColor from "./types/IconColor.js";
 
 class TabContainerTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/TabSeparator.js
+++ b/packages/main/src/TabSeparator.js
@@ -1,7 +1,7 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import TabSeparatorTemplateContext from "./TabSeparatorTemplateContext";
-import TabBase from "./TabBase";
-import TabSeparatorRenderer from "./build/compiled/TabSeparatorRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import TabSeparatorTemplateContext from "./TabSeparatorTemplateContext.js";
+import TabBase from "./TabBase.js";
+import TabSeparatorRenderer from "./build/compiled/TabSeparatorRenderer.lit.js";
 
 /**
  * @public

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -1,14 +1,14 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TableColumn from "./TableColumn";
-import TableRow from "./TableRow";
-import TableRenderer from "./build/compiled/TableRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import ResizeHandler from "@ui5/webcomponents-base/src/delegate/ResizeHandler.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TableColumn from "./TableColumn.js";
+import TableRow from "./TableRow.js";
+import TableRenderer from "./build/compiled/TableRenderer.lit.js";
 
 // Styles
-import styles from "./themes/Table.css";
+import styles from "./themes/Table.css.js";
 
 addCustomCSS("ui5-table", "sap_fiori_3", styles);
 addCustomCSS("ui5-table", "sap_belize", styles);

--- a/packages/main/src/TableCell.js
+++ b/packages/main/src/TableCell.js
@@ -1,10 +1,10 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TableCellRenderer from "./build/compiled/TableCellRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TableCellRenderer from "./build/compiled/TableCellRenderer.lit.js";
 
 // Styles
-import styles from "./themes/TableCell.css";
+import styles from "./themes/TableCell.css.js";
 
 addCustomCSS("ui5-table-cell", "sap_fiori_3", styles);
 addCustomCSS("ui5-table-cell", "sap_belize", styles);

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -1,12 +1,12 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import CSSSize from "@ui5/webcomponents-base/src/types/CSSSize";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TableColumnRenderer from "./build/compiled/TableColumnRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import CSSSize from "@ui5/webcomponents-base/src/types/CSSSize.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TableColumnRenderer from "./build/compiled/TableColumnRenderer.lit.js";
 
 // Styles
-import styles from "./themes/TableColumn.css";
+import styles from "./themes/TableColumn.css.js";
 
 addCustomCSS("ui5-table-column", "sap_fiori_3", styles);
 addCustomCSS("ui5-table-column", "sap_belize", styles);

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -1,11 +1,11 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TableCell from "./TableCell";
-import TableRowRenderer from "./build/compiled/TableRowRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TableCell from "./TableCell.js";
+import TableRowRenderer from "./build/compiled/TableRowRenderer.lit.js";
 
 // Styles
-import styles from "./themes/TableRow.css";
+import styles from "./themes/TableRow.css.js";
 
 addCustomCSS("ui5-table-row", "sap_fiori_3", styles);
 addCustomCSS("ui5-table-row", "sap_belize", styles);

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -1,14 +1,14 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import CSSSize from "@ui5/webcomponents-base/src/types/CSSSize";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TextAreaTemplateContext from "./TextAreaTemplateContext";
-import TextAreaRenderer from "./build/compiled/TextAreaRenderer.lit";
-import { fetchResourceBundle, getResourceBundle } from "./ResourceBundleProvider";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import CSSSize from "@ui5/webcomponents-base/src/types/CSSSize.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TextAreaTemplateContext from "./TextAreaTemplateContext.js";
+import TextAreaRenderer from "./build/compiled/TextAreaRenderer.lit.js";
+import { fetchResourceBundle, getResourceBundle } from "./ResourceBundleProvider.js";
 
 // Styles
-import styles from "./themes/TextArea.css";
+import styles from "./themes/TextArea.css.js";
 
 addCustomCSS("ui5-textarea", "sap_belize", styles);
 addCustomCSS("ui5-textarea", "sap_belize_hcb", styles);

--- a/packages/main/src/ThemePropertiesProvider.js
+++ b/packages/main/src/ThemePropertiesProvider.js
@@ -1,8 +1,8 @@
-import { registerThemeProperties } from "@ui5/webcomponents-base/src/theming/ThemeProperties";
+import { registerThemeProperties } from "@ui5/webcomponents-base/src/theming/ThemeProperties.js";
 
-import belizeThemeProperties from "./themes/sap_belize/parameters-bundle.css";
-import belizeHcbThemeProperties from "./themes/sap_belize_hcb/parameters-bundle.css";
-import fiori3ThemeProperties from "./themes/sap_fiori_3/parameters-bundle.css";
+import belizeThemeProperties from "./themes/sap_belize/parameters-bundle.css.js";
+import belizeHcbThemeProperties from "./themes/sap_belize_hcb/parameters-bundle.css.js";
+import fiori3ThemeProperties from "./themes/sap_fiori_3/parameters-bundle.css.js";
 
 registerThemeProperties("@ui5/webcomponents", "sap_belize", belizeThemeProperties);
 registerThemeProperties("@ui5/webcomponents", "sap_belize_hcb", belizeHcbThemeProperties);

--- a/packages/main/src/Timeline.js
+++ b/packages/main/src/Timeline.js
@@ -1,13 +1,13 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import TimelineTemplateContext from "./TimelineTemplateContext";
-import TimelineItem from "./TimelineItem";
-import TimelineRenderer from "./build/compiled/TimelineRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import TimelineTemplateContext from "./TimelineTemplateContext.js";
+import TimelineItem from "./TimelineItem.js";
+import TimelineRenderer from "./build/compiled/TimelineRenderer.lit.js";
 
 // Styles
-import styles from "./themes/Timeline.css";
+import styles from "./themes/Timeline.css.js";
 
 addCustomCSS("ui5-timeline", "sap_belize", styles);
 addCustomCSS("ui5-timeline", "sap_belize_hcb", styles);

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -1,17 +1,17 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import URI from "@ui5/webcomponents-base/src/types/URI";
-import Function from "@ui5/webcomponents-base/src/types/Function";
-import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import Icon from "./Icon";
-import Link from "./Link";
-import TimelineItemTemplateContext from "./TimelineItemTemplateContext";
-import TimelineItemRenderer from "./build/compiled/TimelineItemRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import URI from "@ui5/webcomponents-base/src/types/URI.js";
+import Function from "@ui5/webcomponents-base/src/types/Function.js";
+import { fetchCldrData } from "@ui5/webcomponents-base/src/CLDR.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import Icon from "./Icon.js";
+import Link from "./Link.js";
+import TimelineItemTemplateContext from "./TimelineItemTemplateContext.js";
+import TimelineItemRenderer from "./build/compiled/TimelineItemRenderer.lit.js";
 
 // Styles
-import styles from "./themes/TimelineItem.css";
+import styles from "./themes/TimelineItem.css.js";
 
 addCustomCSS("ui5-timeline-item", "sap_belize", styles);
 addCustomCSS("ui5-timeline-item", "sap_belize_hcb", styles);

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -1,12 +1,12 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import TitleLevel from "./types/TitleLevel";
-import TitleRenderer from "./build/compiled/TitleRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import TitleLevel from "./types/TitleLevel.js";
+import TitleRenderer from "./build/compiled/TitleRenderer.lit.js";
 
 // Styles
 // Styles
-import titleCss from "./themes/Title.css";
+import titleCss from "./themes/Title.css.js";
 
 addCustomCSS("ui5-title", "sap_fiori_3", titleCss);
 addCustomCSS("ui5-title", "sap_belize", titleCss);

--- a/packages/main/src/ToggleButton.js
+++ b/packages/main/src/ToggleButton.js
@@ -1,12 +1,12 @@
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import Button from "./Button";
-import ToggleButtonTemplateContext from "./ToggleButtonTemplateContext";
-import ToggleButtonRenderer from "./build/compiled/ToggleButtonRenderer.lit";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import Button from "./Button.js";
+import ToggleButtonTemplateContext from "./ToggleButtonTemplateContext.js";
+import ToggleButtonRenderer from "./build/compiled/ToggleButtonRenderer.lit.js";
 
 // Styles
-import btnCss from "./themes/Button.css";
-import toggleBtnCss from "./themes/ToggleButton.css";
+import btnCss from "./themes/Button.css.js";
+import toggleBtnCss from "./themes/ToggleButton.css.js";
 
 addCustomCSS("ui5-togglebutton", "sap_fiori_3", btnCss);
 addCustomCSS("ui5-togglebutton", "sap_belize", btnCss);

--- a/packages/main/src/ToggleButtonTemplateContext.js
+++ b/packages/main/src/ToggleButtonTemplateContext.js
@@ -1,4 +1,4 @@
-import ButtonTemplateContext from "./ButtonTemplateContext";
+import ButtonTemplateContext from "./ButtonTemplateContext.js";
 
 class ToggleButtonTemplateContext {
 	static calculate(state) {

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -1,21 +1,21 @@
-import WebComponent from "@ui5/webcomponents-base/src/WebComponent";
-import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap";
-import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData";
-import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration";
-import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings";
-import { isEnter, isSpace } from "@ui5/webcomponents-base/src/events/PseudoEvents";
-import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation";
-import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider";
-import Integer from "@ui5/webcomponents-base/src/types/Integer";
-import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat";
-import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType";
-import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate";
-import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle";
-import YearPickerTemplateContext from "./YearPickerTemplateContext";
-import YearPickerRenderer from "./build/compiled/YearPickerRenderer.lit";
+import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
+import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
+import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
+import { getCalendarType } from "@ui5/webcomponents-base/src/Configuration.js";
+import { getFormatLocale } from "@ui5/webcomponents-base/src/FormatSettings.js";
+import { isEnter, isSpace } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
+import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
+import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat.js";
+import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
+import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import { addCustomCSS } from "@ui5/webcomponents-base/src/theming/CustomStyle.js";
+import YearPickerTemplateContext from "./YearPickerTemplateContext.js";
+import YearPickerRenderer from "./build/compiled/YearPickerRenderer.lit.js";
 
 // Styles
-import styles from "./themes/YearPicker.css";
+import styles from "./themes/YearPicker.css.js";
 
 addCustomCSS("ui5-yearpicker", "sap_fiori_3", styles);
 addCustomCSS("ui5-yearpicker", "sap_belize", styles);

--- a/packages/main/src/types/BackgroundDesign.js
+++ b/packages/main/src/types/BackgroundDesign.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const BackgroundDesigns = {
 	Solid: "Solid",

--- a/packages/main/src/types/ButtonType.js
+++ b/packages/main/src/types/ButtonType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of Button.

--- a/packages/main/src/types/IconColor.js
+++ b/packages/main/src/types/IconColor.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const IconColors = {
 	/**

--- a/packages/main/src/types/InputType.js
+++ b/packages/main/src/types/InputType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const InputTypes = {
 	Text: "Text",

--- a/packages/main/src/types/LinkType.js
+++ b/packages/main/src/types/LinkType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of Button.

--- a/packages/main/src/types/ListItemType.js
+++ b/packages/main/src/types/ListItemType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of ListItem.

--- a/packages/main/src/types/ListMode.js
+++ b/packages/main/src/types/ListMode.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const ListModes = {
 	/**

--- a/packages/main/src/types/ListSeparators.js
+++ b/packages/main/src/types/ListSeparators.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const ListSeparatorsTypes = {
 	/**

--- a/packages/main/src/types/MessageStripType.js
+++ b/packages/main/src/types/MessageStripType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of MessageStrip.

--- a/packages/main/src/types/MessageType.js
+++ b/packages/main/src/types/MessageType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of Message.

--- a/packages/main/src/types/PanelAccessibleRole.js
+++ b/packages/main/src/types/PanelAccessibleRole.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const PanelAccessibleRoles = {
 

--- a/packages/main/src/types/PopoverHorizontalAlign.js
+++ b/packages/main/src/types/PopoverHorizontalAlign.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const PopoverHorizontalAligns = {
 	Center: "Center",

--- a/packages/main/src/types/PopoverPlacementType.js
+++ b/packages/main/src/types/PopoverPlacementType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const PopoverPlacementTypes = {
 	/**

--- a/packages/main/src/types/PopoverVerticalAlign.js
+++ b/packages/main/src/types/PopoverVerticalAlign.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const PopoverVerticalAligns = {
 	Center: "Center",

--- a/packages/main/src/types/SwitchType.js
+++ b/packages/main/src/types/SwitchType.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 /**
  * Different types of Switch.

--- a/packages/main/src/types/TitleLevel.js
+++ b/packages/main/src/types/TitleLevel.js
@@ -1,4 +1,4 @@
-import DataType from "@ui5/webcomponents-base/src/types/DataType";
+import DataType from "@ui5/webcomponents-base/src/types/DataType.js";
 
 const TitleLevels = {
 	H1: "H1",


### PR DESCRIPTION
Rewrite all imports across all packages (core, base and main) with file extensions
and force writing them this way by adding an eslint rule.
Example:
import WebComponent from "@ui5/webcomponents-base/src/WebComponent.js";
import ButtonRenderer from "./build/compiled/ButtonRenderer.lit.js";
import buttonCss from "./themes/Button.css.js";
* Packages are ignored: import { render } from "lit-html";
* The eslint rule is: "import/extensions": ["error", "ignorePackages"]
