### PR TITLE
feat: provide named exports for some base modules

### DIFF
--- a/packages/base/Theming.js
+++ b/packages/base/Theming.js
@@ -1,4 +1,3 @@
 import { setTheme, addCustomCSS } from "./src/Theming.js";
 
-export default {};
 export { setTheme, addCustomCSS };

--- a/packages/base/Theming.js
+++ b/packages/base/Theming.js
@@ -1,0 +1,4 @@
+import { setTheme, addCustomCSS } from "./src/Theming.js";
+
+export default {};
+export { setTheme, addCustomCSS };

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,0 +1,4 @@
+import UI5Element from "./src/UI5Element.js";
+
+export default UI5Element;
+export { UI5Element };

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -4,6 +4,7 @@
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
+  "module": "index.js",
   "keywords": [
     "openui5",
     "sapui5",

--- a/packages/base/src/Theming.js
+++ b/packages/base/src/Theming.js
@@ -1,5 +1,5 @@
 import { getTheme, _setTheme } from "./Configuration.js";
-import { getCustomCSS } from "./theming/CustomStyle.js";
+import { addCustomCSS, getCustomCSS } from "./theming/CustomStyle.js";
 import { getThemeProperties } from "./theming/ThemeProperties.js";
 import { injectThemeProperties } from "./theming/StyleInjection.js";
 
@@ -58,4 +58,5 @@ export {
 	applyTheme,
 	setTheme,
 	getEffectiveStyle,
+	addCustomCSS,
 };

--- a/packages/base/src/theming/ThemeProperties.js
+++ b/packages/base/src/theming/ThemeProperties.js
@@ -26,6 +26,10 @@ const getThemeProperties = async (packageName, themeName) => {
 
 const fetchThemeProperties = async (packageName, themeName) => {
 	const url = themeURLs.get(`${packageName}_${themeName}`);
+
+	if (!url) {
+		throw new Error(`You have to import @ui5/webcomponents/dist/ThemePropertiesProvider module to use theme switching`);
+	}
 	return fetchTextOnce(url);
 };
 

--- a/packages/main/src/ThemePropertiesProvider.js
+++ b/packages/main/src/ThemePropertiesProvider.js
@@ -2,8 +2,6 @@ import { registerThemeProperties } from "@ui5/webcomponents-base/src/theming/The
 
 import belizeThemeProperties from "./themes/sap_belize/parameters-bundle.css.js";
 import belizeHcbThemeProperties from "./themes/sap_belize_hcb/parameters-bundle.css.js";
-import fiori3ThemeProperties from "./themes/sap_fiori_3/parameters-bundle.css.js";
 
 registerThemeProperties("@ui5/webcomponents", "sap_belize", belizeThemeProperties);
 registerThemeProperties("@ui5/webcomponents", "sap_belize_hcb", belizeHcbThemeProperties);
-registerThemeProperties("@ui5/webcomponents", "sap_fiori_3", fiori3ThemeProperties);


### PR DESCRIPTION
- UI5Element is now default export of webcomponents-base
- Theming features exported in "@ui5/webcomponents-base/Theming"