### PR TITLE
refactor(ui5-radiobutton): improve group handling

### DIFF
--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -11,7 +11,7 @@
 			<circle class="sapMRbSvgOuter" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rOuter}}" stroke-width="2" fill="none" />
 			<circle class="sapMRbSvgInner" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rInner}}" stroke-width="10" />
 		</svg>
- 		<input type='radio' ?checked="{{ctr.selected}}" ?readonly="{{ctr.readOnly}}" ?disabled="{{ctr.readOnly}}" name="{{ctr.group}}" data-sap-no-tab-ref/>
+ 		<input type='radio' ?checked="{{ctr.selected}}" ?readonly="{{ctr.readOnly}}" ?disabled="{{ctr.readOnly}}" name="{{ctr.name}}" data-sap-no-tab-ref/>
 	</div>
 
 	{{#if ctr._label.text}}

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -157,6 +157,7 @@ class RadioButton extends UI5Element {
 	constructor() {
 		super();
 		this._label = {};
+		this.firstRendering = true;
 	}
 
 	onBeforeRendering() {
@@ -172,22 +173,28 @@ class RadioButton extends UI5Element {
 	syncGroup() {
 		const oldGroup = this._group;
 		const currentGroup = this.group;
+		const selected = this.selected
+		const previouslySelected = this._selected;
 
-		if (currentGroup === oldGroup) {
-			return;
+		if (currentGroup !== oldGroup) {
+			if (oldGroup) {
+				// remove the control from the previous group
+				RadioButtonGroup.removeFromGroup(this, oldGroup);
+			}
+			
+			if (currentGroup) {
+				// add the control to the existing group
+				RadioButtonGroup.addToGroup(this, currentGroup);
+			}
 		}
 
-		if (oldGroup) {
-			// remove the control from the previous group
-			RadioButtonGroup.removeFromGroup(this, oldGroup);
-		}
-
-		if (currentGroup) {
-			// add the control to the existing group
-			RadioButtonGroup.addToGroup(this, currentGroup);
+		if (currentGroup && selected && !previouslySelected && !this.firstRendering) {
+			RadioButtonGroup.selectItem(this, currentGroup);
 		}
 
 		this._group = this.group;
+		this._selected = selected;
+		this.firstRendering = false;
 	}
 
 	onclick() {
@@ -244,6 +251,8 @@ class RadioButton extends UI5Element {
 		if (!this.canToggle()) {
 			return this;
 		}
+
+		this._selected = !this.selected;
 
 		if (!this.group) {
 			this.selected = !this.selected;

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -133,7 +133,7 @@ const metadata = {
  * <code>select</code> event is fired.
  * When a <code>ui5-radiobutton</code> that is within a group is selected, the one
  * that was previously selected gets automatically deselected. You can group radio buttons by using the <code>name</code> property.
- * 
+ *
  *
  * <h3>ES6 Module Import</h3>
  *
@@ -192,7 +192,7 @@ class RadioButton extends UI5Element {
 
 		if (currentGroup) {
 			RadioButtonGroup.enforceSingleSelection(this, currentGroup);
-		}	
+		}
 
 		this._name = this.name;
 	}

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -188,9 +188,7 @@ class RadioButton extends UI5Element {
 				// add the control to the existing group
 				RadioButtonGroup.addToGroup(this, currentGroup);
 			}
-		}
-
-		if (currentGroup) {
+		} else if (currentGroup) {
 			RadioButtonGroup.enforceSingleSelection(this, currentGroup);
 		}
 

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -92,12 +92,17 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the group to which the <code>ui5-radiobutton</code> belongs.
+		 * Defines the name of the <code>ui5-radiobutton</code> and
+		 * radio buttons with the same <code>name</code> will form a radio button group.
+		 * <br/><b>Note:</b>
+		 * The selection can be changed with <code>ARROW_UP/DOWN</code> and <code>ARROW_LEFT/RIGHT</code> keys between radios in same group.
+		 * <br/><b>Note:</b>
+		 * Only one radio button can be selected per group.
 		 *
 		 * @type {string}
 		 * @public
 		 */
-		group: {
+		name: {
 			defaultValue: "",
 			type: String,
 		},
@@ -127,8 +132,8 @@ const metadata = {
  * When a <code>ui5-radiobutton</code> is selected by the user, the
  * <code>select</code> event is fired.
  * When a <code>ui5-radiobutton</code> that is within a group is selected, the one
- * that was previously selected gets
- * automatically deselected.
+ * that was previously selected gets automatically deselected. You can group radio buttons by using the <code>name</code> property.
+ * 
  *
  * <h3>ES6 Module Import</h3>
  *
@@ -157,7 +162,6 @@ class RadioButton extends UI5Element {
 	constructor() {
 		super();
 		this._label = {};
-		this.firstRendering = true;
 	}
 
 	onBeforeRendering() {
@@ -171,10 +175,8 @@ class RadioButton extends UI5Element {
 	}
 
 	syncGroup() {
-		const oldGroup = this._group;
-		const currentGroup = this.group;
-		const selected = this.selected;
-		const previouslySelected = this._selected;
+		const oldGroup = this._name;
+		const currentGroup = this.name;
 
 		if (currentGroup !== oldGroup) {
 			if (oldGroup) {
@@ -188,13 +190,11 @@ class RadioButton extends UI5Element {
 			}
 		}
 
-		if (currentGroup && selected && !previouslySelected && !this.firstRendering) {
-			RadioButtonGroup.selectItem(this, currentGroup);
-		}
+		if (currentGroup) {
+			RadioButtonGroup.enforceSingleSelection(this, currentGroup);
+		}	
 
-		this._group = this.group;
-		this._selected = selected;
-		this.firstRendering = false;
+		this._name = this.name;
 	}
 
 	onclick() {
@@ -202,7 +202,7 @@ class RadioButton extends UI5Element {
 	}
 
 	_handleDown(event) {
-		const currentGroup = this.group;
+		const currentGroup = this.name;
 
 		if (!currentGroup) {
 			return;
@@ -213,7 +213,7 @@ class RadioButton extends UI5Element {
 	}
 
 	_handleUp(event) {
-		const currentGroup = this.group;
+		const currentGroup = this.name;
 
 		if (!currentGroup) {
 			return;
@@ -252,15 +252,13 @@ class RadioButton extends UI5Element {
 			return this;
 		}
 
-		this._selected = !this.selected;
-
-		if (!this.group) {
+		if (!this.name) {
 			this.selected = !this.selected;
 			this.fireEvent("select");
 			return this;
 		}
 
-		RadioButtonGroup.selectItem(this, this.group);
+		RadioButtonGroup.selectItem(this, this.name);
 		return this;
 	}
 

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -173,7 +173,7 @@ class RadioButton extends UI5Element {
 	syncGroup() {
 		const oldGroup = this._group;
 		const currentGroup = this.group;
-		const selected = this.selected
+		const selected = this.selected;
 		const previouslySelected = this._selected;
 
 		if (currentGroup !== oldGroup) {
@@ -181,7 +181,7 @@ class RadioButton extends UI5Element {
 				// remove the control from the previous group
 				RadioButtonGroup.removeFromGroup(this, oldGroup);
 			}
-			
+
 			if (currentGroup) {
 				// add the control to the existing group
 				RadioButtonGroup.addToGroup(this, currentGroup);

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -92,8 +92,8 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the name of the <code>ui5-radiobutton</code> and
-		 * radio buttons with the same <code>name</code> will form a radio button group.
+		 * Defines the name of the <code>ui5-radiobutton</code>.
+		 * Radio buttons with the same <code>name</code> will form a radio button group.
 		 * <br/><b>Note:</b>
 		 * The selection can be changed with <code>ARROW_UP/DOWN</code> and <code>ARROW_LEFT/RIGHT</code> keys between radios in same group.
 		 * <br/><b>Note:</b>

--- a/packages/main/src/RadioButtonGroup.js
+++ b/packages/main/src/RadioButtonGroup.js
@@ -28,7 +28,7 @@ class RadioButtonGroup {
 
 		const group = this.getGroup(groupName);
 		const selectedRadio = this.selectedRadios.get(group);
-	
+
 		// Remove the radioBtn from the given group
 		group.forEach((_radioBtn, idx, arr) => {
 			if (radioBtn._id === _radioBtn._id) {
@@ -87,13 +87,11 @@ class RadioButtonGroup {
 	}
 
 	static updateSelectionInGroup(radioBtnToSelect, groupName) {
-		const group = this.getGroup(groupName);
 		const selectedRadio = this.selectedRadios.get(groupName);
 
 		this._deselectRadio(selectedRadio);
 		this._selectRadio(radioBtnToSelect);
 		this.selectedRadios.set(groupName, radioBtnToSelect);
-		console.log(groupName + "dasdada" + this.selectedRadios.entries());
 	}
 
 	static get groups() {

--- a/packages/main/src/RadioButtonGroup.js
+++ b/packages/main/src/RadioButtonGroup.js
@@ -7,6 +7,10 @@ class RadioButtonGroup {
 		return this.groups.get(groupName);
 	}
 
+	static getSelectedRadioFromGroup(groupName) {
+		return this.selectedRadios.get(groupName);
+	}
+
 	static removeGroup(groupName) {
 		this.selectedRadios.delete(groupName);
 		return this.groups.delete(groupName);
@@ -14,7 +18,7 @@ class RadioButtonGroup {
 
 	static addToGroup(radioBtn, groupName) {
 		if (this.hasGroup(groupName)) {
-			this._enforceSingleSelection(groupName, radioBtn);
+			this.enforceSingleSelection(radioBtn, groupName);
 			this.getGroup(groupName).push(radioBtn);
 		} else {
 			this.createGroup(radioBtn, groupName);
@@ -27,9 +31,9 @@ class RadioButtonGroup {
 		}
 
 		const group = this.getGroup(groupName);
-		const selectedRadio = this.selectedRadios.get(group);
+		const selectedRadio = this.getSelectedRadioFromGroup(groupName);
 
-		// Remove the radioBtn from the given group
+		// Remove the radio button from the given group
 		group.forEach((_radioBtn, idx, arr) => {
 			if (radioBtn._id === _radioBtn._id) {
 				return arr.splice(idx, 1);
@@ -37,7 +41,7 @@ class RadioButtonGroup {
 		});
 
 		if (selectedRadio === radioBtn) {
-			this.selectedRadios.set(group, null);
+			this.selectedRadios.set(groupName, null);
 		}
 
 		// Remove the group if it is empty
@@ -87,37 +91,26 @@ class RadioButtonGroup {
 	}
 
 	static updateSelectionInGroup(radioBtnToSelect, groupName) {
-		const selectedRadio = this.selectedRadios.get(groupName);
+		const selectedRadio = this.getSelectedRadioFromGroup(groupName);
 
 		this._deselectRadio(selectedRadio);
 		this._selectRadio(radioBtnToSelect);
 		this.selectedRadios.set(groupName, radioBtnToSelect);
 	}
 
-	static get groups() {
-		if (!this._groups) {
-			this._groups = new Map();
-		}
-		return this._groups;
-	}
-
-	static get selectedRadios() {
-		if (!this._selectedRadios) {
-			this._selectedRadios = new Map();
-		}
-		return this._selectedRadios;
-	}
-
 	static _deselectRadio(radioBtn) {
-		radioBtn.selected = false;
-		// radioBtn.fireEvent("select"); to be discussed
+		if (radioBtn) {
+			radioBtn.selected = false;
+		}
 	}
 
 	static _selectRadio(radioBtn) {
-		radioBtn.focus();
-		radioBtn.selected = true;
-		radioBtn._selected = true;
-		radioBtn.fireEvent("select");
+		if (radioBtn) {
+			radioBtn.focus();
+			radioBtn.selected = true;
+			radioBtn._selected = true;
+			radioBtn.fireEvent("select");
+		}
 	}
 
 	static _nextSelectable(pos, group) {
@@ -158,19 +151,37 @@ class RadioButtonGroup {
 		return previousRadioToSelect;
 	}
 
-	static _enforceSingleSelection(group, radioBtn) {
-		if (!radioBtn.selected) {
-			return;
-		}
-
-		const selectedRadio = this.selectedRadios.get(group);
+	static enforceSingleSelection(radioBtn, groupName) {
+		const selectedRadio = this.getSelectedRadioFromGroup(groupName);
 
 		if (!selectedRadio) {
 			return;
 		}
 
-		this._deselectRadio(selectedRadio);
-		this.selectedRadios.set(group, radioBtn);
+		if (radioBtn.selected) {
+			if(radioBtn !== selectedRadio) {
+				this._deselectRadio(selectedRadio);
+				this.selectedRadios.set(groupName, radioBtn);
+			}
+		} else {
+			if (radioBtn === selectedRadio) {
+				this.selectedRadios.set(groupName, null);
+			}
+		}
+	}
+
+	static get groups() {
+		if (!this._groups) {
+			this._groups = new Map();
+		}
+		return this._groups;
+	}
+
+	static get selectedRadios() {
+		if (!this._selectedRadios) {
+			this._selectedRadios = new Map();
+		}
+		return this._selectedRadios;
 	}
 }
 

--- a/packages/main/src/RadioButtonGroup.js
+++ b/packages/main/src/RadioButtonGroup.js
@@ -159,14 +159,12 @@ class RadioButtonGroup {
 		}
 
 		if (radioBtn.selected) {
-			if(radioBtn !== selectedRadio) {
+			if (radioBtn !== selectedRadio) {
 				this._deselectRadio(selectedRadio);
 				this.selectedRadios.set(groupName, radioBtn);
 			}
-		} else {
-			if (radioBtn === selectedRadio) {
-				this.selectedRadios.set(groupName, null);
-			}
+		} else if (radioBtn === selectedRadio) {
+			this.selectedRadios.set(groupName, null);
 		}
 	}
 

--- a/packages/main/src/RadioButtonTemplateContext.js
+++ b/packages/main/src/RadioButtonTemplateContext.js
@@ -25,7 +25,7 @@ class RadioButtonTemplateContext {
 			context = {
 				ctr: state,
 				readOnly: state.disabled || state.readOnly,
-				tabIndex: state.disabled || (!state.selected && state.group) ? "-1" : "0",
+				tabIndex: state.disabled || (!state.selected && state.name) ? "-1" : "0",
 				circle: compact ? SVGConfig.compact : SVGConfig.default,
 				classes: { main: mainClasses, inner: innerClasses },
 				styles: {

--- a/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
@@ -34,26 +34,27 @@
 
 	<section class="radio-section">
 		<ui5-title>ui5-radiobutton in group</ui5-title>
-		<ui5-radiobutton id="groupRb1" group="a" selected text="Option A long long should shrink long long text text text text text text text text"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb2" group="a" disabled text="Option C"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb3" group="a" text="Option D"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb1" name="a" selected text="Option A long long should shrink long long text text text text text text text text"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb2" name="a" disabled text="Option C"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb3" name="a" text="Option D"></ui5-radiobutton>
 	</section>
 
 	<section class="radio-section">
 		<ui5-title>ui5-radiobutton in group</ui5-title>
-		<ui5-radiobutton id="groupRb4" group="b" selected text="Option A long long should shrink long long text text text text text text text text"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb5" group="b" disabled text="Option C"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb6" group="b" text="Option D"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb4" name="b" selected text="Option A long long should shrink long long text text text text text text text text"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb5" name="b" disabled text="Option C"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb6" name="b" text="Option D"></ui5-radiobutton>
 	</section>
 
 	<div id="radioGroup" class="radio-section">
 		<ui5-title>Group of states</ui5-title>
 		<ui5-label id="lblRadioGroup"></ui5-label>
 		<ui5-label id="lblEventCounter"></ui5-label>
-		<ui5-radiobutton id="groupRb7" text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb8" text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb9"text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
-		<ui5-radiobutton id="groupRb10" text="Default" value-state="None" selected group="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb7" text="None selected" value-state="None" selected name="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb8" text="Warning" value-state="Warning" name="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb9"text="Error" value-state="Error" name="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb10" text="Default selected" value-state="None" selected name="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb11" text="Other group selected" value-state="None" selected name="GroupBB"></ui5-radiobutton>
 	</div>
 
 	<section>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
@@ -46,6 +46,16 @@
 		<ui5-radiobutton id="groupRb6" group="b" text="Option D"></ui5-radiobutton>
 	</section>
 
+	<div id="radioGroup" class="radio-section">
+		<ui5-title>Group of states</ui5-title>
+		<ui5-label id="lblRadioGroup"></ui5-label>
+		<ui5-label id="lblEventCounter"></ui5-label>
+		<ui5-radiobutton id="groupRb7" text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb8" text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb9"text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
+		<ui5-radiobutton id="groupRb10" text="Default" value-state="None" selected group="GroupB"></ui5-radiobutton>
+	</div>
+
 	<section>
 		<ui5-title>ui5-radiobutton states</ui5-title></p>
 		<ui5-radiobutton id="myRb6" selected text="Default"></ui5-radiobutton>
@@ -69,6 +79,7 @@
 
 	<script>
 		var counter = 0;
+		var groupEventCounter = 0;
 
 		[window["rb1"], window["rb2"], window["rb3"], window["rb4"]].forEach(function(radio) {
 			radio.addEventListener("select", function(event) {
@@ -76,6 +87,12 @@
 				window["field"].value = counter;
 			});
 		})
+
+		radioGroup.addEventListener("select", function(e) {
+			var radio = e.target;
+			lblRadioGroup.innerHTML = radio.text;
+			lblEventCounter.innerHTML = ++groupEventCounter;
+		});
 </script>
 </body>
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/RadioButton.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/RadioButton.qunit.js
@@ -56,7 +56,7 @@ TestHelper.ready(function () {
 			assert.notOk(radiobutton.querySelector("ui5-label"), "the default text is empty and ui5-label is not rendered.");
 		});
 
-		QUnit.test("The 'group' is not set by default", function (assert) {
+		QUnit.test("The 'name' is not set by default", function (assert) {
 			var radiobutton = this.getRadioButtonRoot();
 
 			assert.notOk(radiobutton.querySelector("input").getAttribute("name"), "there is no name attribute");
@@ -157,27 +157,27 @@ TestHelper.ready(function () {
 			});
 		});
 
-		QUnit.test("changing the 'group' is reflected in the DOM", function (assert) {
+		QUnit.test("changing the 'name' is reflected in the DOM", function (assert) {
 			assert.expect(1);
 
 			var done = assert.async(),
-				expectedGroup = "test",
+				expectedName = "test",
 				radiobutton = this.getRadioButtonRoot();
 
-			this.radiobutton.setAttribute("group", expectedGroup);
+			this.radiobutton.setAttribute("name", expectedName);
 
 			RenderScheduler.whenFinished().then(function () {
-				assert.equal(radiobutton.querySelector("input").getAttribute("name"), expectedGroup,  "the name is set to " + expectedGroup);
+				assert.equal(radiobutton.querySelector("input").getAttribute("name"), expectedName,  "the name is set to " + expectedName);
 				done();
 			});
 		});
 	});
 
-	QUnit.module("Group", function (hooks) {
+	QUnit.module("Name", function (hooks) {
 		hooks.beforeEach(function () {
-			var html = '<ui5-radiobutton id="myRb11" group="a" text="first" selected></ui5-radiobutton>'
-			+ '<ui5-radiobutton id="myRb12" group="a" text="second"></ui5-radiobutton>'
-			+ '<ui5-radiobutton id="myRb13" group="a" text="third"></ui5-radiobutton>';
+			var html = '<ui5-radiobutton id="myRb11" name="a" text="first" selected></ui5-radiobutton>'
+			+ '<ui5-radiobutton id="myRb12" name="a" text="second"></ui5-radiobutton>'
+			+ '<ui5-radiobutton id="myRb13" name="a" text="third"></ui5-radiobutton>';
 
 			fixture.innerHTML = html;
 

--- a/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
@@ -40,18 +40,18 @@
 	<section>
 		<h3>Basic RadioButton Types</h3>
 		<div class="snippet">
-			<ui5-radiobutton text="Option A" selected group="GroupA"></ui5-radiobutton>
-			<ui5-radiobutton text="Option B" value-state="None" group="GroupA"></ui5-radiobutton>
-			<ui5-radiobutton text="Option C" value-state="Warning" group="GroupA"></ui5-radiobutton>
-			<ui5-radiobutton text="Option D" value-state="Error" group="GroupA"></ui5-radiobutton>
-			<ui5-radiobutton text="Option E" disabled group="GroupA"></ui5-radiobutton>
+			<ui5-radiobutton text="Option A" selected name="GroupA"></ui5-radiobutton>
+			<ui5-radiobutton text="Option B" value-state="None" name="GroupA"></ui5-radiobutton>
+			<ui5-radiobutton text="Option C" value-state="Warning" name="GroupA"></ui5-radiobutton>
+			<ui5-radiobutton text="Option D" value-state="Error" name="GroupA"></ui5-radiobutton>
+			<ui5-radiobutton text="Option E" disabled name="GroupA"></ui5-radiobutton>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-radiobutton text="Option A" selected group="GroupA"></ui5-radiobutton>
-<ui5-radiobutton text="Option B" value-state="None" group="GroupA"></ui5-radiobutton>
-<ui5-radiobutton text="Option C" value-state="Warning" group="GroupA"></ui5-radiobutton>
-<ui5-radiobutton text="Option D" value-state="Error" group="GroupA"></ui5-radiobutton>
-<ui5-radiobutton text="Option E" disabled group="GroupA"></ui5-radiobutton>
+<ui5-radiobutton text="Option A" selected name="GroupA"></ui5-radiobutton>
+<ui5-radiobutton text="Option B" value-state="None" name="GroupA"></ui5-radiobutton>
+<ui5-radiobutton text="Option C" value-state="Warning" name="GroupA"></ui5-radiobutton>
+<ui5-radiobutton text="Option D" value-state="Error" name="GroupA"></ui5-radiobutton>
+<ui5-radiobutton text="Option E" disabled name="GroupA"></ui5-radiobutton>
 		</xmp></pre>
 	</section>
 
@@ -60,41 +60,38 @@
 			<div id="radioGroup" class="radio-button-group">
 				<ui5-title>Group of states</ui5-title>
 				<ui5-label id="lblRadioGroup">Selected radio: None</ui5-label>
-				<ui5-radiobutton text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
-				<ui5-radiobutton text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
-				<ui5-radiobutton text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
+				<ui5-radiobutton text="None" value-state="None" selected name="GroupB"></ui5-radiobutton>
+				<ui5-radiobutton text="Warning" value-state="Warning" name="GroupB"></ui5-radiobutton>
+				<ui5-radiobutton text="Error" value-state="Error" name="GroupB"></ui5-radiobutton>
 			</div>
 			<div id="radioGroup2" class="radio-button-group">
 				<ui5-title>Group of options</ui5-title>
 				<ui5-label id="lblRadioGroup2">Selected radio: Option A</ui5-label>
-				<ui5-radiobutton text="Option A" selected group="GroupC"></ui5-radiobutton>
-				<ui5-radiobutton text="Option B" value-state="None" group="GroupC"></ui5-radiobutton>
-				<ui5-radiobutton text="Option C" value-state="None" group="GroupC"></ui5-radiobutton>
+				<ui5-radiobutton text="Option A" selected name="GroupC"></ui5-radiobutton>
+				<ui5-radiobutton text="Option B" value-state="None" name="GroupC"></ui5-radiobutton>
+				<ui5-radiobutton text="Option C" value-state="None" name="GroupC"></ui5-radiobutton>
 			</div>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
 <script>
-const prefix = "Selected radio: ";
-
 radioGroup.addEventListener("select", function(e) {
-	var radio = e.target;
-	lblRadioGroup.innerHTML = prefix + (radio.selected && radio.text);
+	lblRadioGroup.innerHTML = e.target.text;
 });
 </script>
 
 <div id="radioGroup" class="radio-button-group">
 	<ui5-title>Group of states</ui5-title>
 	<ui5-label id="lblRadioGroup">Selected radio: None</ui5-label>
-	<ui5-radiobutton text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
-	<ui5-radiobutton text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
-	<ui5-radiobutton text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
+	<ui5-radiobutton text="None" value-state="None" selected name="GroupB"></ui5-radiobutton>
+	<ui5-radiobutton text="Warning" value-state="Warning" name="GroupB"></ui5-radiobutton>
+	<ui5-radiobutton text="Error" value-state="Error" name="GroupB"></ui5-radiobutton>
 </div>
 <div id="radioGroup2" class="radio-button-group">
 	<ui5-title>Group of options</ui5-title>
 	<ui5-label id="lblRadioGroup2">Selected radio: Option A</ui5-label>
-	<ui5-radiobutton text="Option A" selected group="GroupC"></ui5-radiobutton>
-	<ui5-radiobutton text="Option B" value-state="None" group="GroupC"></ui5-radiobutton>
-	<ui5-radiobutton text="Option C" value-state="None" group="GroupC"></ui5-radiobutton>
+	<ui5-radiobutton text="Option A" selected name="GroupC"></ui5-radiobutton>
+	<ui5-radiobutton text="Option B" value-state="None" name="GroupC"></ui5-radiobutton>
+	<ui5-radiobutton text="Option C" value-state="None" name="GroupC"></ui5-radiobutton>
 </div>
 		</xmp></pre>
 	</section>
@@ -104,16 +101,12 @@ radioGroup.addEventListener("select", function(e) {
 	</script>
 
 	<script>
-		var prefix = "Selected radio: ";
-
 		radioGroup.addEventListener("select", function(e) {
-			var radio = e.target;
-			lblRadioGroup.innerHTML = prefix + (radio.selected && radio.text);
+			lblRadioGroup.innerHTML = e.target.text;
 		});
 
 		radioGroup2.addEventListener("select", function(e) {
-			var radio = e.target;
-			lblRadioGroup2.innerHTML = prefix + (radio.selected && radio.text);
+			lblRadioGroup2.innerHTML = e.target.text;
 		});
 	</script>
 

--- a/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/RadioButton.sample.html
@@ -55,30 +55,43 @@
 		</xmp></pre>
 	</section>
 
-	<h3>Grouped RadioButton (navigate with UP and DOWN arrow keys)</h3>
+	<h3>RadioButton in group - navigate via [UP/Right] and [DOWN/Left] arrow keys</h3>
 		<div class="snippet" style="display: flex; flex-wrap: wrap; justify-content: space-around;">
-			<div class="radio-button-group">
-				<ui5-title>First Group</ui5-title>
+			<div id="radioGroup" class="radio-button-group">
+				<ui5-title>Group of states</ui5-title>
+				<ui5-label id="lblRadioGroup">Selected radio: None</ui5-label>
 				<ui5-radiobutton text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
 				<ui5-radiobutton text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
 				<ui5-radiobutton text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
 			</div>
-			<div class="radio-button-group">
-				<ui5-title>Second Group</ui5-title>
+			<div id="radioGroup2" class="radio-button-group">
+				<ui5-title>Group of options</ui5-title>
+				<ui5-label id="lblRadioGroup2">Selected radio: Option A</ui5-label>
 				<ui5-radiobutton text="Option A" selected group="GroupC"></ui5-radiobutton>
 				<ui5-radiobutton text="Option B" value-state="None" group="GroupC"></ui5-radiobutton>
 				<ui5-radiobutton text="Option C" value-state="None" group="GroupC"></ui5-radiobutton>
 			</div>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
-<div class="radio-button-group">
-	<ui5-title>First Group</ui5-title>
+<script>
+const prefix = "Selected radio: ";
+
+radioGroup.addEventListener("select", function(e) {
+	var radio = e.target;
+	lblRadioGroup.innerHTML = prefix + (radio.selected && radio.text);
+});
+</script>
+
+<div id="radioGroup" class="radio-button-group">
+	<ui5-title>Group of states</ui5-title>
+	<ui5-label id="lblRadioGroup">Selected radio: None</ui5-label>
 	<ui5-radiobutton text="None" value-state="None" selected group="GroupB"></ui5-radiobutton>
 	<ui5-radiobutton text="Warning" value-state="Warning" group="GroupB"></ui5-radiobutton>
 	<ui5-radiobutton text="Error" value-state="Error" group="GroupB"></ui5-radiobutton>
 </div>
-<div class="radio-button-group">
-	<ui5-title>Second Group</ui5-title>
+<div id="radioGroup2" class="radio-button-group">
+	<ui5-title>Group of options</ui5-title>
+	<ui5-label id="lblRadioGroup2">Selected radio: Option A</ui5-label>
 	<ui5-radiobutton text="Option A" selected group="GroupC"></ui5-radiobutton>
 	<ui5-radiobutton text="Option B" value-state="None" group="GroupC"></ui5-radiobutton>
 	<ui5-radiobutton text="Option C" value-state="None" group="GroupC"></ui5-radiobutton>
@@ -88,6 +101,20 @@
 
 	<script>
 		window.prettyPrint();
+	</script>
+
+	<script>
+		var prefix = "Selected radio: ";
+
+		radioGroup.addEventListener("select", function(e) {
+			var radio = e.target;
+			lblRadioGroup.innerHTML = prefix + (radio.selected && radio.text);
+		});
+
+		radioGroup2.addEventListener("select", function(e) {
+			var radio = e.target;
+			lblRadioGroup2.innerHTML = prefix + (radio.selected && radio.text);
+		});
 	</script>
 
 	<script defer src="../../../../../../www/samples/settings.js"></script>

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -4,8 +4,8 @@ describe("RadioButton general interaction", () => {
 	browser.url("http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/RadioButton.html");
 
 	it("tests select event", () => {
-		const radioButton = browser.findElementDeep("#rb1");
-		const field = browser.findElementDeep("#field");
+		const radioButton = browser.$("#rb1");
+		const field = browser.$("#field");
 
 		radioButton.click();
 		assert.strictEqual(field.getProperty("value"), "1", "Select event should be fired 1 time.");
@@ -15,9 +15,9 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests select event upon ENTER", () => {
-		const radioButton1 = browser.findElementDeep("#rb1");
-		const radioButton2 = browser.findElementDeep("#rb2");
-		const field = browser.findElementDeep("#field");
+		const radioButton1 = browser.$("#rb1");
+		const radioButton2 = browser.$("#rb2");
+		const field = browser.$("#field");
 
 		radioButton1.click();
 		radioButton1.keys("Tab");
@@ -30,9 +30,9 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests select event upon SPACE", () => {
-		const radioButton1 = browser.findElementDeep("#rb2");
-		const radioButton2 = browser.findElementDeep("#rb3");
-		const field = browser.findElementDeep("#field");
+		const radioButton1 = browser.$("#rb2");
+		const radioButton2 = browser.$("#rb3");
+		const field = browser.$("#field");
 
 		radioButton1.click();
 		radioButton1.keys("Tab");
@@ -45,8 +45,8 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests change event not fired, when disabled", () => {
-		const radioButton = browser.findElementDeep("#rb4");
-		const field = browser.findElementDeep("#field");
+		const radioButton = browser.$("#rb4");
+		const field = browser.$("#field");
 
 		radioButton.click();
 		radioButton.keys("Space");
@@ -56,9 +56,9 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests radio buttons selection within group with AROW-RIGHT key", () => {
-		const field = browser.findElementDeep("#field");
-		const radioButtonPreviouslySelected = browser.findElementDeep("#groupRb1");
-		const radioButtonToBeSelected = browser.findElementDeep("#groupRb3");
+		const field = browser.$("#field");
+		const radioButtonPreviouslySelected = browser.$("#groupRb1");
+		const radioButtonToBeSelected = browser.$("#groupRb3");
 
 		field.click();
 		field.keys("Tab");
@@ -72,8 +72,8 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests radio buttons selection within group with AROW-LEFT key", () => {
-		const radioButtonPreviouslySelected = browser.findElementDeep("#groupRb4");
-		const radioButtonToBeSelected = browser.findElementDeep("#groupRb6");
+		const radioButtonPreviouslySelected = browser.$("#groupRb4");
+		const radioButtonToBeSelected = browser.$("#groupRb6");
 
 		radioButtonPreviouslySelected.keys("ArrowLeft");
 
@@ -82,12 +82,35 @@ describe("RadioButton general interaction", () => {
 	});
 
 	it("tests radio buttons selection within group by clicking", () => {
-		const radioButtonPreviouslySelected = browser.findElementDeep("#groupRb6");
-		const radioButtonToBeSelected = browser.findElementDeep("#groupRb4");
+		const radioButtonPreviouslySelected = browser.$("#groupRb6");
+		const radioButtonToBeSelected = browser.$("#groupRb4");
 
 		radioButtonToBeSelected.click();
 
 		assert.ok(!radioButtonPreviouslySelected.getProperty("selected"), "Previously selected item has been de-selected.");
 		assert.ok(radioButtonToBeSelected.getProperty("selected"), "Pressing ArrowRight selects the next (not disabled) radio in the group.");
 	});
+	
+	it("tests single selection within group, even if multiple radios are set as selected", () => {
+		// radio with property selected=true, but not selected
+		const radioButtonNotSelected = browser.findElementDeep("#groupRb7 >>> .sapMRb");
+
+		// radio with property selected=true and actually selected as subsequent
+		const radioButtonActuallySelected = browser.findElementDeep("#groupRb10 >>> .sapMRb");
+
+		assert.ok(!radioButtonNotSelected.hasClass("sapMRbSel"), "The radio is not selected as following one selected");
+		assert.ok(radioButtonActuallySelected.hasClass("sapMRbSel"), 'The correct radio is selected');
+	});
+
+	it("tests select event from radio buttons within group", () => {
+		const radioButtonToBeSelected = browser.$("#groupRb7");
+		const lblEventCounter = browser.$("#lblEventCounter");
+		const lblSelectedRadio = browser.$("#lblRadioGroup");
+
+		radioButtonToBeSelected.click();
+
+		assert.equal(lblEventCounter.getHTML(false), "1", 'The select event is fired once');
+		assert.equal(lblSelectedRadio.getHTML(false), radioButtonToBeSelected.getProperty("text"), "The correct radio is selected");
+	});
+
 });


### PR DESCRIPTION
* Added new property "name", which replaces the property "group" (removed with this change)
* When selection changes within the group by user interaction - single "select" event is being fired and
the newly selected radio button is the event target.
* if more than one radio buttons within a group is set as selected, the last one is effectively selected.
* if  a ui5-radiobutton is added to a new group, the single selection rule would be applied.
* if the selected state is programatically changed, the single selection rule is applied and no event is fired.

BREAKING CHANGE: the property "group" is replaced by the "name" property.