### PR TITLE
wip: add test setup for single component import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ temp
 target
 dist
 build
+single_import
 
 # Ignore default target directory for the npm package 'ui5-codecompletion'
 .ui5

--- a/packages/main/button.bundle.js
+++ b/packages/main/button.bundle.js
@@ -1,0 +1,2 @@
+import "./component.bundle.js";
+import Button from "./dist/Button.js";

--- a/packages/main/component.bundle.js
+++ b/packages/main/component.bundle.js
@@ -1,0 +1,3 @@
+import "regenerator-runtime/runtime";
+import RenderScheduler from "@ui5/webcomponents-base/src/RenderScheduler.js";
+window.RenderScheduler = RenderScheduler;

--- a/packages/main/datepicker.bundle.js
+++ b/packages/main/datepicker.bundle.js
@@ -1,0 +1,2 @@
+import "./component.bundle.js";
+import DatePicker from "./dist/DatePicker";

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -140,6 +140,7 @@
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-terser": "^4.0.3",
+    "rollup-plugin-generate-html-template": "^1.1.3",
     "rollup-plugin-url": "^2.2.0",
     "rollup-plugin-visualizer": "^0.9.2",
     "serve": "^10.1.1",

--- a/packages/main/rollup.component.config.js
+++ b/packages/main/rollup.component.config.js
@@ -1,0 +1,48 @@
+import babel from "rollup-plugin-babel";
+import resolve from "rollup-plugin-node-resolve";
+import url from "rollup-plugin-url";
+import { terser } from "rollup-plugin-terser";
+import htmlTemplate from 'rollup-plugin-generate-html-template';
+
+const DEPLOY_PUBLIC_PATH = process.env.DEPLOY_PUBLIC_PATH || "";
+const INPUT_FILES = ["button.bundle.js", "textarea.bundle.js", "datepicker.bundle.js"];
+
+const getConfig = (inputFile) => {
+	const component = inputFile.split(".")[0];
+	return {
+		input: inputFile,
+		output: {
+			file: `test/single_import/${component}/${inputFile}`,
+			format: "iife",
+			name: "sap-ui-webcomponents-main-bundle",
+			extend: "true",
+		},
+		plugins: [
+			resolve(),
+			url({
+				limit: 0,
+				include: [
+					/.*cldr\/.*\.json/,
+					/.*i18n\/.*\.json/,
+					/.*sap.ui.core.*\/SAP-icons.*/,
+				],
+				emitFiles: true,
+				fileName: "[name].[hash][extname]",
+				publicPath: DEPLOY_PUBLIC_PATH + "/resources/sap/ui/webcomponents/main/",
+			}),
+			htmlTemplate({
+				template: `./test/sap/ui/webcomponents/main/pages/template.html`,
+				target: `single_import/${component}/${component}.html`,
+			}),
+			babel({
+				presets: ["@babel/preset-env"],
+				exclude: "node_modules/**",
+			}),
+			terser(),
+		]
+	}
+};
+
+const config = INPUT_FILES.map(getConfig);
+
+export default config

--- a/packages/main/test/sap/ui/webcomponents/main/pages/template.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<title>Single Import Template</title>
+	<script>
+		delete Document.prototype.adoptedStyleSheets
+	</script>
+</head>
+
+<body>
+	<ui5-button id="button1">Primary button</ui5-button>
+	<ui5-textarea id="textArea1" max-length="10"></ui5-textarea>
+	<ui5-datepicker id="datePicker1"></ui5-datepicker>
+</body>
+</html>

--- a/packages/main/test/specs/Component.spec.js
+++ b/packages/main/test/specs/Component.spec.js
@@ -1,0 +1,29 @@
+const assert = require("assert");
+
+// describe("button general interaction", () => {
+// 	browser.url("http://localhost:8080/test-resources/single_import/button/button.html");
+
+// 	it("component is rendered", () => {
+// 		const button = browser.findElementDeep("#button1 >>> .sapMBtn");
+// 		assert.ok(button, "Component rendered and its shadow DOM is created");
+// 	});
+// });
+
+// describe("datepicker general interaction", () => {
+// 	browser.url("http://localhost:8080/test-resources/single_import/datepicker/datepicker.html");
+
+// 	it("component is rendered", () => {
+// 		const datePicker = browser.findElementDeep("#datePicker1 >>> .sapMDP");
+// 		assert.ok(datePicker, "Component rendered and its shadow DOM is created");
+// 	});
+// });
+
+describe("textarea general interaction", () => {
+	browser.url("http://localhost:8080/test-resources/single_import/textarea/textarea.html");
+
+	it("component is rendered", () => {
+
+		const textArea = browser.findElementDeep("#textArea1 >>> .sapWCTextArea");
+		assert.ok(textArea, "Component rendered and its shadow DOM is created");
+	});
+});

--- a/packages/main/textarea.bundle.js
+++ b/packages/main/textarea.bundle.js
@@ -1,0 +1,2 @@
+import "./component.bundle.js";
+import TextArea from "./dist/TextArea";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8173,6 +8173,11 @@ rollup-plugin-filesize@^6.0.1:
     gzip-size "^5.0.0"
     terser "^3.10.0"
 
+rollup-plugin-generate-html-template@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-generate-html-template/-/rollup-plugin-generate-html-template-1.1.3.tgz#78b147beb3d197898cbc9f8ebbacf29e60474ca1"
+  integrity sha512-RhYt/rkxYeQdNKRHU+0diJ2auq/w0WA85BFXrHlv/k2M8dPNqycHtRfMcSGo43Cl9aL8Y6WywnyewqV9PieMEQ==
+
 rollup-plugin-less@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-less/-/rollup-plugin-less-1.1.2.tgz#c4bffacc24928b7f657a7a06e09930a3e2ebdfad"


### PR DESCRIPTION
* In general, the idea is to have a setup for testing the single component import scenario as usually different kinds of issues remain hidden, because we often work and test with the full bundle.
* New rollup config file is introduced(rollup.component.config.js), that is able to create html files by given template and these html files to include a script tag, pointing to the rollup built output file.
* Currently, running "rollup -c rollup.component.config.js" will create the following files under the test/single_import/{component} folder:
** button.html (with <script src="button.bundle.js"></script> )
**  button.bundle.js
** textarea.html (with <script src="textarea.bundle.js"></script> )
** textarea.bundle.js
** datepicker.html (with <script src="datepicker.bundle.js"></script> )
** datepicker.bundle.js
* Then we can run tests over those html files, as shown in Component.spec.js