### PR TITLE
refactor(ui5-panel): remove backgroundDesign property

### DIFF
--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -5,7 +5,6 @@ import slideDown from "@ui5/webcomponents-base/src/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 import PanelTemplateContext from "./PanelTemplateContext.js";
-import BackgroundDesign from "./types/BackgroundDesign.js";
 import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
 import PanelRenderer from "./build/compiled/PanelRenderer.lit.js";
 import { fetchResourceBundle, getResourceBundle } from "./ResourceBundleProvider.js";

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -88,18 +88,6 @@ const metadata = {
 		},
 
 		/**
-		 * Determines the background color of the <code>ui5-panel</code>.
-		 * Available options are <code>Solid</code> and <code>Transparent</code>.
-		 *
-		 * @type {BackgroundDesign}
-		 * @public
-		 */
-		backgroundDesign: {
-			type: BackgroundDesign,
-			defaultValue: BackgroundDesign.Solid,
-		},
-
-		/**
 		 * Sets the accessible aria role of the <code>ui5-panel</code>.
 		 * Depending on the usage, you can change the role from the default <code>Form</code>
 		 * to <code>Region</code> or <code>Complementary</code>.

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -12,6 +12,7 @@ ui5-panel {
 	overflow: hidden;
 	box-sizing: border-box;
 	position: relative;
+	background-color: var(--_ui5_panel_background_color);
 }
 
 .sapMPanel > header {
@@ -32,7 +33,6 @@ ui5-panel {
 	transition: transform 0.4s ease-out;
 	cursor: pointer;
 	position: relative;
-
 }
 
 .sapMPanel > header ui5-icon.sapMPanelIcon.sapMPanelIconExpanded {
@@ -77,6 +77,7 @@ ui5-panel {
 	box-sizing: border-box;
 	overflow: auto;
 	white-space: normal;
+	border-bottom: 1px solid var(--_ui5_panel_bottom_border_color);
 }
 
 .sapMPanelContent:focus {
@@ -86,6 +87,7 @@ ui5-panel {
 .sapMPanelWrappingDiv,
 .sapMPanelWrappingDivTb {
 	position: relative;
+	background-color: var(--_ui5_panel_background_color);
 }
 
 .sapMPanelWrappingDiv {
@@ -127,24 +129,12 @@ ui5-panel {
 	margin-left: 0;
 }
 
-.sapMPanelBGSolid {
-	background-color: var(--sapUiGroupContentBackground);
-}
-
-.sapMPanelBGTransparent {
-	background-color: transparent;
-}
-
 /* if Panel is not expandable, we do wish header to come with own border */
 .sapMPanel > .sapMPanelHdr,
 /* notice: sapMPanelWrappingDiv is available if Panel is expandable */
 .sapMPanelWrappingDiv,
 /* do not want border if expanded and if only header text */
 .sapMPanelWrappingDivTb {
-	border-bottom: 1px solid var(--sapUiGroupTitleBorderColor);
-}
-
-.sapMPanelContent:not(.sapMPanelBGTransparent) {
 	border-bottom: 1px solid var(--sapUiGroupTitleBorderColor);
 }
 

--- a/packages/main/src/themes/base/Panel-parameters.css
+++ b/packages/main/src/themes/base/Panel-parameters.css
@@ -1,3 +1,5 @@
 :root {
 	--_ui5_panel_focus_border: 1px dotted var(--sapUiContentFocusColor);
+	--_ui5_panel_background_color: var(--sapUiGroupContentBackground);
+	--_ui5_panel_bottom_border_color: var(--sapUiGroupTitleBorderColor);
 }

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/Panel.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/Panel.qunit.js
@@ -49,14 +49,6 @@ TestHelper.ready(function () {
 			assert.equal(panel.querySelector(".sapMPanelContent").style.display, "block", "the content div is shown");
 		});
 
-		QUnit.test("The default 'backgroundDesign' is 'Solid'", function (assert) {
-			var panel = this.getPanelRoot(),
-				panelContent = panel.querySelector(".sapMPanelContent"),
-				expectedClass = "sapMPanelBGSolid";
-
-			assert.ok(panelContent.classList.contains(expectedClass), "the content div has ." + expectedClass);
-		});
-
 		QUnit.test("The default 'accessibleRole' is 'Form'", function (assert) {
 			var panel = this.getPanelRoot(),
 				expectedRole = "form";
@@ -105,23 +97,6 @@ TestHelper.ready(function () {
 
 			RenderScheduler.whenFinished().then(function () {
 				assert.equal(panel.querySelector(".sapMPanelContent").style.display, "none", "the content div is hidden");
-
-				done();
-			});
-		});
-
-		QUnit.test("changing the 'backgroundDesign' is reflected in the DOM", function (assert) {
-			assert.expect(1);
-
-			var done = assert.async(),
-				panel = this.getPanelRoot(),
-				panelContent = panel.querySelector(".sapMPanelContent"),
-				expectedClass = "sapMPanelBGSolid";
-
-			this.panel.setAttribute("background-design", "Solid");
-
-			RenderScheduler.whenFinished().then(function () {
-				assert.ok(panelContent.classList.contains(expectedClass), "the content div has ." + expectedClass);
 
 				done();
 			});


### PR DESCRIPTION
* remove "backgroundDesign" property
* introduce css vars: --_ui5_panel_background_color and --_ui5_panel_bottom_border_color to replace the property

BREAKING CHANGE: the "backgroundDesign" property has been removed, use the corresponding 
CSS variables to alter the panel background.