### PR TITLE
fix(ui5-messagestrip): remove height 100% on element tag

### DIFF
--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -1,13 +1,11 @@
 :host(ui5-messagestrip) {
 	display: inline-block;
 	width: 100%;
-	height: 100%;
 }
 
 ui5-messagestrip {
 	display: inline-block;
 	width: 100%;
-	height: 100%;
 }
 
 span[data-sap-ui-wc-root] {


### PR DESCRIPTION
* Issue: the message strip used to take full parent height, although it might contain only few words.
* Solution: remove the height 100% on element tag, as it can be altered any time by the consumers.
* FIXES: https://github.com/SAP/ui5-webcomponents/issues/375
