### PR TITLE
fix: fix API build for composite components 

### DIFF
--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -65,7 +65,7 @@ const mergeParentAPI = entry => {
 	return entry;
 }
 
-const appendAddionalEntriesAPI = entry => {
+const appendAdditionalEntriesAPI = entry => {
 	if (entry.appenddocs) {
 		const additionalEntries = entry.appenddocs.split(" ");
 		entry.additionalDocs = [];
@@ -124,7 +124,7 @@ const generateComponentAPI = entry => {
 	entry = mergeParentAPI(entry);
 
 	// (2) append additional API for children
-	entry = appendAddionalEntriesAPI(entry);
+	entry = appendAdditionalEntriesAPI(entry);
 
 	// (3) generate sample page
 	generateSamplePage(entry);

--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -34,7 +34,6 @@ Handlebars.registerHelper('toKebabCase', function (str) {
 	return kebab !== str ? kebab : "";
 });
 
-
 Handlebars.registerHelper('checkEven', function (iIndex) {
 	return (iIndex % 2 === 0) ? "api-table-roll-even" : "api-table-roll-odd";
 });
@@ -46,28 +45,41 @@ Handlebars.registerPartial('methods', methodsTemplate);
 
 mkdirp(`dist/test-resources/sap/ui/webcomponents/main/api`);
 
-entries.forEach((entry, index) => {
+let entriesAPI = [];
 
-	const parentName = entry.extends;
-	let parent = getComponentByName(parentName) || {};
+const mergeParentAPI = entry => {
+	if (entriesAPI.indexOf(entry.basename) !== -1) {
+		return entry;
+	}
 
-	parent = { ...{ properties: [], events: [], slots: [] }, ...parent };
+	let parent = getComponentByName(entry.extends) || {};
+	parent = { ...{ properties: [], events: [], slots: [], cssVariables: [] }, ...parent };
 
 	// extend component documentation
 	entry.properties = [...(entry.properties || []), ...(parent.properties || [])];
 	entry.events = [...(entry.events || []), ...(parent.events || [])];
 	entry.slots = [...(entry.slots || []), ...(parent.slots || [])];
+	entry.cssVariables = [...(entry.cssVariables || []), ...(parent.cssVariables || [])];
 
+	return entry;
+}
+
+const appendAddionalChildAPI = entry => {
 	if (entry.appenddocs) {
 		const additionalEntries = entry.appenddocs.split(" ");
-
 		entry.additionalDocs = [];
 
 		additionalEntries.forEach(entryName => {
-			entry.additionalDocs.push(getComponentByName(entryName));
+			let additionalEntry = getComponentByName(entryName);
+			additionalEntry = mergeParentAPI(additionalEntry);
+			entry.additionalDocs.push(additionalEntry);
 		});
 	}
 
+	return entry;
+}
+
+const generateSamplePage = entry => {
 	let content = "";
 
 	try {
@@ -105,5 +117,21 @@ entries.forEach((entry, index) => {
 			// console.log(err);
 		});
 	}
+}
 
-});
+const generateComponentAPI = entry => {
+	entriesAPI.push(entry.basename);
+
+	// (1) merge parent API
+	entry = mergeParentAPI(entry);
+
+	// (2) append additional API for children
+	entry = appendAddionalChildAPI(entry);
+
+	// (3) generate sample page
+	generateSamplePage(entry);
+
+	entriesAPI = [];
+}
+
+entries.forEach(generateComponentAPI);

--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -65,7 +65,7 @@ const mergeParentAPI = entry => {
 	return entry;
 }
 
-const appendAddionalChildAPI = entry => {
+const appendAddionalEntriesAPI = entry => {
 	if (entry.appenddocs) {
 		const additionalEntries = entry.appenddocs.split(" ");
 		entry.additionalDocs = [];
@@ -124,7 +124,7 @@ const generateComponentAPI = entry => {
 	entry = mergeParentAPI(entry);
 
 	// (2) append additional API for children
-	entry = appendAddionalChildAPI(entry);
+	entry = appendAddionalEntriesAPI(entry);
 
 	// (3) generate sample page
 	generateSamplePage(entry);

--- a/lib/documentation/index.js
+++ b/lib/documentation/index.js
@@ -53,13 +53,14 @@ const mergeParentAPI = entry => {
 	}
 
 	let parent = getComponentByName(entry.extends) || {};
-	parent = { ...{ properties: [], events: [], slots: [], cssVariables: [] }, ...parent };
+	parent = { ...{ properties: [], events: [], slots: [] }, ...parent };
 
 	// extend component documentation
 	entry.properties = [...(entry.properties || []), ...(parent.properties || [])];
 	entry.events = [...(entry.events || []), ...(parent.events || [])];
 	entry.slots = [...(entry.slots || []), ...(parent.slots || [])];
-	entry.cssVariables = [...(entry.cssVariables || []), ...(parent.cssVariables || [])];
+
+	entriesAPI.push(entry.basename);
 
 	return entry;
 }
@@ -85,7 +86,6 @@ const generateSamplePage = entry => {
 	try {
 		content = fs.readFileSync(`dist/test-resources/sap/ui/webcomponents/main/samples/${capitalize(entry.basename)}.sample.html`, 'utf8');
 	} catch (err) { }
-
 
 	if (content) {
 		const fnRedirect = `
@@ -120,8 +120,6 @@ const generateSamplePage = entry => {
 }
 
 const generateComponentAPI = entry => {
-	entriesAPI.push(entry.basename);
-
 	// (1) merge parent API
 	entry = mergeParentAPI(entry);
 
@@ -130,8 +128,7 @@ const generateComponentAPI = entry => {
 
 	// (3) generate sample page
 	generateSamplePage(entry);
-
-	entriesAPI = [];
 }
 
 entries.forEach(generateComponentAPI);
+entriesAPI = [];


### PR DESCRIPTION
FIXES: https://github.com/SAP/ui5-webcomponents/issues/390
* Background: some of the components do not have separate sample page, but they are appended to others sample page. The API of those components is part (in most cases) of parent components API, that use them as composite components.
* Issue: the API of the composite/child components misses base properties.
* Root cause: the API generation of the parent component is done before the API generation of the composite/child components.
* Solution: calculate the API of those composite components before their addition to parents` component API.
Before (StandardListItem "selected"  and "type" properties are missing)
<img width="1373" alt="Screenshot 2019-05-15 at 10 49 38" src="https://user-images.githubusercontent.com/15702139/57757934-39cd3a80-76ff-11e9-9566-db1c4fc38ddd.png">
After (StandardListItem "selected"  and "type" properties are in place)
<img width="1320" alt="Screenshot 2019-05-15 at 10 49 22" src="https://user-images.githubusercontent.com/15702139/57757927-346ff000-76ff-11e9-9b38-8bcdd36636b8.png">
