### PR TITLE
 refactor(ui5-datepicker): rename event 'liveChange' to 'input'

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -158,14 +158,14 @@ const metadata = {
 		 * @public
 		*/
 		change: {},
+
 		/**
-		 * Fired when the value of the <code>ui5-datepicker</code> is changed,
-		 * for example at each keypress.
+		 * Fired when the value of the <code>ui5-datepicker</code> is changed at each key stroke.
 		 *
 		 * @event
 		 * @public
 		*/
-		liveChange: {},
+		input: {},
 	},
 };
 
@@ -353,7 +353,7 @@ class DatePicker extends UI5Element {
 		const isValid = this.isValid(nextValue);
 
 		this.value = nextValue;
-		this.fireEvent("liveChange", { value: nextValue, valid: isValid });
+		this.fireEvent("input", { value: nextValue, valid: isValid });
 	}
 
 	/**

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
@@ -36,7 +36,7 @@
 			title='Delivery Date!'>
 		</ui5-datepicker>
 		<ui5-label id="lblChange">change: N/A</ui5-label><br/>
-		<ui5-label id="lblLiveChange">liveChange: N/A</ui5-label><br/>
+		<ui5-label id="lblLiveChange">input: N/A</ui5-label><br/>
 
 		<h3>format-pattern - 'short', value - 'tomorrow'</h3>
 		<ui5-datepicker id='dp6'
@@ -96,12 +96,12 @@
 			console.log('change: ', e.detail);
 			labelChange.innerHTML = 'change: ' + JSON.stringify(e.detail);
 		});
-		dp.addEventListener('ui5-liveChange', function(e) {
-			console.log('liveChange: ', e.detail);
-			labelLiveChange.innerHTML = 'liveChange: ' + JSON.stringify(e.detail);
+		dp.addEventListener('input', function(e) {
+			console.log('input: ', e.detail);
+			labelLiveChange.innerHTML = 'input: ' + JSON.stringify(e.detail);
 		});
 
-		$('#ui5-datepicker--startDate').on('liveChange change', (function(e) {
+		$('#ui5-datepicker--startDate').on('input change', (function(e) {
 			var dp = $('#ui5-datepicker--startDate')[0];
 			dp.setAttribute('value-state', e.detail.valid ? 'None' : 'Error');
 			$('#startDate').val($('#ui5-datepicker--startDate').val());

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker.html
@@ -96,12 +96,12 @@
 			console.log('change: ', e.detail);
 			labelChange.innerHTML = 'change: ' + JSON.stringify(e.detail);
 		});
-		dp.addEventListener('input', function(e) {
+		dp.addEventListener('ui5-input', function(e) {
 			console.log('input: ', e.detail);
 			labelLiveChange.innerHTML = 'input: ' + JSON.stringify(e.detail);
 		});
 
-		$('#ui5-datepicker--startDate').on('input change', (function(e) {
+		$('#ui5-datepicker--startDate').on('ui5-input change', (function(e) {
 			var dp = $('#ui5-datepicker--startDate')[0];
 			dp.setAttribute('value-state', e.detail.valid ? 'None' : 'Error');
 			$('#startDate').val($('#ui5-datepicker--startDate').val());

--- a/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_fg.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/DatePicker_fg.html
@@ -60,9 +60,9 @@
 </head>
 <body>
 	<div class="header">
-			<ui5-radiobutton id="sap_fiori_3" group="theme" text="Fiori 3" selected></ui5-radiobutton>
-			<ui5-radiobutton id="sap_belize_hcb" group="theme" text="HCB_Custom"></ui5-radiobutton>
-			<ui5-radiobutton id="sap_belize" group="theme" text="Belize"></ui5-radiobutton>
+			<ui5-radiobutton id="sap_fiori_3" name="theme" text="Fiori 3" selected></ui5-radiobutton>
+			<ui5-radiobutton id="sap_belize_hcb" name="theme" text="HCB_Custom"></ui5-radiobutton>
+			<ui5-radiobutton id="sap_belize" name="theme" text="Belize"></ui5-radiobutton>
 	</div>
 
 	<div class="content">
@@ -86,7 +86,7 @@
 		$(function () {
 			var pickers = $('ui5-datepicker');
 
-			pickers.on('liveChange change', (function(e) {
+			pickers.on('input change', (function(e) {
 				this.setAttribute('value-state', e.detail.valid ? 'None' : 'Error');
 				$('#startDate').val($(this).val());
 				$('#startDate').trigger('change');
@@ -144,11 +144,11 @@
 
 			// theme change sample
 			var Theming = window["sap-ui-webcomponents-main-bundle"].Theming;
-            Theming.addCustomCSS('ui5-input', 'sap_belize_hcb', inputCSS);
-            Theming.addCustomCSS('ui5-icon', 'sap_belize_hcb', iconCSS);
+            Theming.addCustomCSS('ui5-input', inputCSS);
+            Theming.addCustomCSS('ui5-icon', iconCSS);
 
-			$('ui5-radiobutton[group="theme"]').on("select", function (event) {
-				if (event.detail.selected) {
+			$('ui5-radiobutton[name="theme"]').on("select", function (event) {
+				if (event.target.selected) {
 					var theme = event.target.id;
 					if (theme === "sap_belize_hcb") {
 						// only for the radio buttons sample page

--- a/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/DatePicker.sample.html
@@ -57,7 +57,7 @@
 		dp.setAttribute('value-state', e.detail.valid ? 'None' : 'Error');
 		console.log('change: ', e.detail);
 	});
-	dp.addEventListener('liveChange', (e) => console.log('liveChange: ', e.detail));
+	dp.addEventListener('input', (e) => console.log('input: ', e.detail));
 </script>
 	</xmp></pre>
 	</section>
@@ -178,7 +178,7 @@
 			dp.setAttribute('value-state', e.detail.valid? 'None' : 'Error');
 			console.log('change: ', e.detail);
 		});
-		dp.addEventListener('liveChange', function(e) {console.log('liveChange: ', e.detail)});
+		dp.addEventListener('input', function(e) {console.log('input: ', e.detail)});
 	</script>
 
 	<script defer src="../../../../../../www/samples/settings.js"></script>


### PR DESCRIPTION
Rename the 'liveChange' event  to 'input' in order to have consistency with the ui5-input,
which already fires 'input' event.
FIXES: https://github.com/SAP/ui5-webcomponents/issues/365

BREAKING CHANGE: 'liveChange' event  has been renamed to 'input'.