### PR TITLE
fix(ui5-panel): add missing dependency for ui5-icon

### DIFF
--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -1,10 +1,10 @@
 import UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
 import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
 import { getIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
-import Icon from "./Icon.js";
 import slideDown from "@ui5/webcomponents-base/src/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import Icon from "./Icon.js";
 import PanelTemplateContext from "./PanelTemplateContext.js";
 import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
 import PanelRenderer from "./build/compiled/PanelRenderer.lit.js";

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -1,6 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
 import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
 import { getIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
+import "./Icon.js";
 import slideDown from "@ui5/webcomponents-base/src/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -1,7 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
 import Bootstrap from "@ui5/webcomponents-base/src/Bootstrap.js";
 import { getIconURI } from "@ui5/webcomponents-base/src/IconPool.js";
-import "./Icon.js";
+import Icon from "./Icon.js";
 import slideDown from "@ui5/webcomponents-base/src/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
@@ -276,7 +276,10 @@ class Panel extends UI5Element {
 	}
 
 	static async define(...params) {
-		await fetchResourceBundle("@ui5/webcomponents");
+		await Promise.all([
+			fetchResourceBundle("@ui5/webcomponents"),
+			Icon.define(),
+		]);
 
 		super.define(...params);
 	}


### PR DESCRIPTION
When importing the `ui5-panel` by itself, it would not be able to load the `ui5-icon` that it makes use of.

### Example:
Rendering the panel with
```html
<ui5-panel width="100%" accesible-role="Complementary"></ui5-panel>
```

Without the fix:
<img width="1384" alt="Screen Shot 2019-05-17 at 20 27 14" src="https://user-images.githubusercontent.com/2848323/57961131-50cc8200-78e3-11e9-857d-5fd29f5909e5.png">

With this fix, it works as expected:
<img width="1385" alt="Screen Shot 2019-05-17 at 20 29 58" src="https://user-images.githubusercontent.com/2848323/57961166-84a7a780-78e3-11e9-8362-738b0f3f1b5c.png">

Also, I did not find how to test this implementation.