### PR TITLE
chore: remove boolean props defaultValue from metadata

### DIFF
--- a/packages/base/src/State.js
+++ b/packages/base/src/State.js
@@ -144,7 +144,6 @@ class State {
 				if (propDefaultValue !== undefined) {
 					console.warn("The 'defaultValue' metadata key is ignored for all booleans properties, they would be initialized with 'false' by default"); // eslint-disable-line
 				}
-
 			} else if (props[propName].multiple) {
 				defaultState[propName] = [];
 			} else if (props[propName].type === Object) {

--- a/packages/base/src/State.js
+++ b/packages/base/src/State.js
@@ -31,7 +31,7 @@ class State {
 						return this._data[prop];
 					}
 
-					if (propData.type === "boolean" || propData.type === Boolean) {
+					if (propData.type === Boolean) {
 						return false;
 					} else if (propData.multiple) { // eslint-disable-line
 						return [];

--- a/packages/base/src/State.js
+++ b/packages/base/src/State.js
@@ -135,14 +135,22 @@ class State {
 		// Initialize properties
 		const props = MetadataClass.getProperties();
 		for (const propName in props) { // eslint-disable-line
-			if (props[propName].type === "boolean") {
+
+			const propDefaultValue = props[propName].defaultValue;
+
+			if (props[propName].type === Boolean) {
 				defaultState[propName] = false;
+
+				if (propDefaultValue !== undefined) {
+					console.warn("The 'defaultValue' metadata key is ignored for all booleans properties, they would be initialized with 'false' by default"); // eslint-disable-line
+				}
+
 			} else if (props[propName].multiple) {
 				defaultState[propName] = [];
 			} else if (props[propName].type === Object) {
 				defaultState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : {};
 			} else {
-				defaultState[propName] = props[propName].defaultValue;
+				defaultState[propName] = propDefaultValue;
 			}
 		}
 

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -31,7 +31,6 @@ const metadata = {
 		 */
 		disabled: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -46,7 +45,6 @@ const metadata = {
 		 */
 		readOnly: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -62,7 +60,6 @@ const metadata = {
 		 */
 		checked: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -102,7 +99,6 @@ const metadata = {
 		 */
 		wrap: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -136,7 +136,6 @@ const metadata = {
 		},
 
 		_isPickerOpen: {
-			defaultValue: false,
 			type: Boolean,
 		},
 

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -30,7 +30,10 @@ const metadata = {
 		 * @defaultvalue "Information"
 		 * @public
 		 */
-		type: { type: MessageStripType, defaultValue: MessageStripType.Information },
+		type: {
+			type: MessageStripType,
+			defaultValue: MessageStripType.Information
+		},
 
 		/**
 		 * Defines the icon to be displayed as graphical element within the <code>ui5-messagestrip</code>.
@@ -47,7 +50,10 @@ const metadata = {
 		 * @defaultvalue ""
 		 * @public
 		 */
-		icon: { type: URI, defaultValue: null },
+		icon: {
+			type: URI,
+			defaultValue: null
+		},
 
 		/**
 		 * Defines whether the MessageStrip renders icon in the beginning.
@@ -56,7 +62,9 @@ const metadata = {
 		 * @defaultvalue false
 		 * @public
 		 */
-		hideIcon: { type: Boolean, defaultValue: false },
+		hideIcon: {
+			type: Boolean,
+		},
 
 		/**
 		 * Defines whether the MessageStrip renders close icon.
@@ -65,9 +73,13 @@ const metadata = {
 		 * @defaultvalue false
 		 * @public
 		 */
-		hideCloseButton: { type: Boolean, defaultValue: false },
+		hideCloseButton: {
+			type: Boolean,
+		},
 
-		_closeButton: { type: Object },
+		_closeButton: {
+			type: Object
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.MessageStrip.prototype */ {
 

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -32,7 +32,7 @@ const metadata = {
 		 */
 		type: {
 			type: MessageStripType,
-			defaultValue: MessageStripType.Information
+			defaultValue: MessageStripType.Information,
 		},
 
 		/**
@@ -52,7 +52,7 @@ const metadata = {
 		 */
 		icon: {
 			type: URI,
-			defaultValue: null
+			defaultValue: null,
 		},
 
 		/**
@@ -78,7 +78,7 @@ const metadata = {
 		},
 
 		_closeButton: {
-			type: Object
+			type: Object,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.MessageStrip.prototype */ {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -59,7 +59,6 @@ const metadata = {
 		 */
 		disabled: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -82,12 +81,10 @@ const metadata = {
 
 		_opened: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		_focused: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		_fnClickSelectBox: {

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -81,11 +81,10 @@ const metadata = {
 
 		_first: {
 			type: Boolean,
-			defaultValue: false,
 		},
+
 		_last: {
 			type: Boolean,
-			defaultValue: false,
 		},
 	},
 };

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -114,7 +114,6 @@ const metadata = {
 		 */
 		showExceededText: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -127,7 +126,6 @@ const metadata = {
 		 */
 		growing: {
 			type: Boolean,
-			defaultValue: false,
 		},
 
 		/**
@@ -180,7 +178,6 @@ const metadata = {
 		},
 		_focussed: {
 			type: Boolean,
-			defaultValue: false,
 		},
 		_listeners: {
 			type: Object,


### PR DESCRIPTION
Remove boolean props defaultValue from metadata, as all boolean props are and must be "false" by default.