### PR TITLE
fix: do not use assignedElements

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -579,7 +579,7 @@ class UI5Element extends HTMLElement {
 			if (curr.tagName.toUpperCase() !== "SLOT") {
 				return acc.concat([curr]);
 			}
-			return acc.concat(curr.assignedElements({ flatten: true }));
+			return acc.concat(curr.assignedNodes({ flatten: true }).filter(item => item instanceof HTMLElement));
 		};
 
 		return this[slotName].reduce(reducer, []);

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -97,7 +97,7 @@ const validateSingleSlot = (value, propData) => {
 		const isSlot = isTag && el.tagName.toUpperCase() === "SLOT";
 
 		if (isSlot) {
-			return el.assignedElements({ flatten: true });
+			return el.assignedNodes({ flatten: true }).filter(item => item instanceof HTMLElement);
 		}
 
 		return [el];


### PR DESCRIPTION
IE does not support assignedElements, therefore assignedNodes should be used instead.
This causes issues for Input with suggestions and Select.

Seems to be a known bug with the polyfill for IE:
https://github.com/webcomponents/webcomponentsjs/issues/1079
