### PR TITLE
 fix(ui5-title): render correct h{n} tag based on the "level" property

### DIFF
--- a/packages/main/src/Title.hbs
+++ b/packages/main/src/Title.hbs
@@ -1,9 +1,71 @@
-<h2
-	{{> controlData}}
-	class="{{classes.main}}"
-	style="{{styles.main}}"
-	role="heading">
-	<span id="{{ctr._id}}-inner">
-		<slot></slot>
-	</span>
-</h2>
+{{#if h1}}
+		<h1
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h1>
+{{/if}}
+		
+{{#if h2}}
+		<h2
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h2>
+{{/if}}
+
+{{#if h3}}
+		<h3
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h3>
+{{/if}}
+
+{{#if h4}}
+		<h4
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h4>
+{{/if}}
+
+{{#if h5}}
+		<h5
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h5>
+{{/if}}
+
+{{#if h6}}
+		<h6
+			{{> controlData}}
+			class="{{classes.main}}"
+			style="{{styles.main}}"
+			role="heading">
+			<span id="{{ctr._id}}-inner">
+				<slot></slot>
+			</span>
+		</h6>
+{{/if}}

--- a/packages/main/src/Title.hbs
+++ b/packages/main/src/Title.hbs
@@ -4,9 +4,7 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h1>
 {{/if}}
 		
@@ -16,9 +14,7 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h2>
 {{/if}}
 
@@ -28,9 +24,7 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h3>
 {{/if}}
 
@@ -40,9 +34,7 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h4>
 {{/if}}
 
@@ -52,9 +44,7 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h5>
 {{/if}}
 
@@ -64,8 +54,12 @@
 			class="{{classes.main}}"
 			style="{{styles.main}}"
 			role="heading">
-			<span id="{{ctr._id}}-inner">
-				<slot></slot>
-			</span>
+				{{> titleInner}}
 		</h6>
 {{/if}}
+
+{{#*inline "titleInner"}}
+	<span id="{{ctr._id}}-inner">
+		<slot></slot>
+	</span>
+{{/inline}}

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -92,12 +92,7 @@ class Title extends UI5Element {
 
 	static calculateTemplateContext(state) {
 		const context = {
-			h1: state.level === TitleLevel.H1,
-			h2: state.level === TitleLevel.H2 || state.level === TitleLevel.Auto,
-			h3: state.level === TitleLevel.H3,
-			h4: state.level === TitleLevel.H4,
-			h5: state.level === TitleLevel.H5,
-			h6: state.level === TitleLevel.H6,
+			[`${state.level.toLowerCase()}`]: true,
 			ctr: state,
 			classes: {
 				main: {

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -92,7 +92,12 @@ class Title extends UI5Element {
 
 	static calculateTemplateContext(state) {
 		const context = {
-			tag: (state.level === TitleLevel.Auto ? "div" : state.level).toLowerCase(),
+			h1: state.level === TitleLevel.H1,
+			h2: state.level === TitleLevel.H2 || state.level === TitleLevel.Auto,
+			h3: state.level === TitleLevel.H3,
+			h4: state.level === TitleLevel.H4,
+			h5: state.level === TitleLevel.H5,
+			h6: state.level === TitleLevel.H6,
 			ctr: state,
 			classes: {
 				main: {

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -1,16 +1,14 @@
 :host(ui5-title) {
-	display: inline-block;
+	display: block;
 	max-width: 100%;
 	color: var(--sapUiGroupTitleTextColor);
-	vertical-align: bottom;
 }
 
 ui5-title {
-	display: inline-block;
+	display: block;
 	overflow: hidden;
 	color: var(--sapUiGroupTitleTextColor);
 	max-width: 100%;
-	vertical-align: bottom;
 }
 
 .sapMTitle {

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<title>Title test page</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<script src="../../../../../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../../../../../resources/sap/ui/webcomponents/main/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js"></script>
+
+	<style>
+	</style>
+</head>
+
+<body>
+	<section>
+		<ui5-title id="titleH1" level="H1">Title level 1</ui5-title>
+		<ui5-title>Title level Auto (2)</ui5-title>
+		<ui5-title level="H2">Title level 2</ui5-title>
+		<ui5-title level="H3">Title level 3</ui5-title>
+		<ui5-title level="H4">Title level 4</ui5-title>
+		<ui5-title level="H5">Title level 5</ui5-title>
+		<ui5-title level="H6">Title level 6</ui5-title>
+	</section>
+</body>
+</html>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
@@ -21,11 +21,12 @@
 	<section>
 		<ui5-title id="titleH1" level="H1">Title level 1</ui5-title>
 		<ui5-title>Title level Auto (2)</ui5-title>
-		<ui5-title level="H2">Title level 2</ui5-title>
-		<ui5-title level="H3">Title level 3</ui5-title>
-		<ui5-title level="H4">Title level 4</ui5-title>
-		<ui5-title level="H5">Title level 5</ui5-title>
-		<ui5-title level="H6">Title level 6</ui5-title>
+		<ui5-title id="titleH2" level="H2">Title level 2</ui5-title>
+		<ui5-title id="titleH3" level="H3">Title level 3</ui5-title>
+		<ui5-title id="titleH4" level="H4">Title level 4</ui5-title>
+		<ui5-title id="titleH5" level="H5">Title level 5</ui5-title>
+		<ui5-title id="titleH6" level="H6">Title level 6</ui5-title>
+		<ui5-title  level="H2">Very long long long text of title title with level two</ui5-title>
 	</section>
 </body>
 </html>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Title.html
@@ -26,7 +26,7 @@
 		<ui5-title id="titleH4" level="H4">Title level 4</ui5-title>
 		<ui5-title id="titleH5" level="H5">Title level 5</ui5-title>
 		<ui5-title id="titleH6" level="H6">Title level 6</ui5-title>
-		<ui5-title  level="H2">Very long long long text of title title with level two</ui5-title>
+		<ui5-title level="H2">Very long long long text of title title with level two</ui5-title>
 	</section>
 </body>
 </html>

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -3,10 +3,19 @@ const assert = require('assert');
 describe("Rendering", () => {
 	browser.url('http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/Title.html');
 	
-	it("shadow DOM rendered", () => {
-		const title = browser.findElementDeep("#titleH1 >>> .sapMTitle");
-		const titleH1Tag = browser.findElementDeep("#titleH1 >>> .sapMTitle >>> h1");
-		assert.ok(title, "Title Shadow DOM is rendered");
+	it("h{n} tags rendered correctly", () => {
+		const titleH1Tag = browser.findElementDeep("#titleH1 >>> h1.sapMTitle");
+		const titleH2Tag = browser.findElementDeep("#titleH2 >>> h2.sapMTitle");
+		const titleH3Tag = browser.findElementDeep("#titleH3 >>> h3.sapMTitle");
+		const titleH4Tag = browser.findElementDeep("#titleH4 >>> h4.sapMTitle");
+		const titleH5Tag = browser.findElementDeep("#titleH5 >>> h5.sapMTitle");
+		const titleH6Tag = browser.findElementDeep("#titleH6 >>> h6.sapMTitle");
+
 		assert.ok(titleH1Tag, "h1 tag is rendered for level='H1'");
+		assert.ok(titleH2Tag, "h2 tag is rendered for level='H1'");
+		assert.ok(titleH3Tag, "h3 tag is rendered for level='H1'");
+		assert.ok(titleH4Tag, "h4 tag is rendered for level='H1'");
+		assert.ok(titleH5Tag, "h5 tag is rendered for level='H1'");
+		assert.ok(titleH6Tag, "h6 tag is rendered for level='H1'");
 	});
 });

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -1,1 +1,12 @@
 const assert = require('assert');
+
+describe("Rendering", () => {
+	browser.url('http://localhost:8080/test-resources/sap/ui/webcomponents/main/pages/Title.html');
+	
+	it("shadow DOM rendered", () => {
+		const title = browser.findElementDeep("#titleH1 >>> .sapMTitle");
+		const titleH1Tag = browser.findElementDeep("#titleH1 >>> .sapMTitle >>> h1");
+		assert.ok(title, "Title Shadow DOM is rendered");
+		assert.ok(titleH1Tag, "h1 tag is rendered for level='H1'");
+	});
+});

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -12,10 +12,10 @@ describe("Rendering", () => {
 		const titleH6Tag = browser.findElementDeep("#titleH6 >>> h6.sapMTitle");
 
 		assert.ok(titleH1Tag, "h1 tag is rendered for level='H1'");
-		assert.ok(titleH2Tag, "h2 tag is rendered for level='H1'");
-		assert.ok(titleH3Tag, "h3 tag is rendered for level='H1'");
-		assert.ok(titleH4Tag, "h4 tag is rendered for level='H1'");
-		assert.ok(titleH5Tag, "h5 tag is rendered for level='H1'");
-		assert.ok(titleH6Tag, "h6 tag is rendered for level='H1'");
+		assert.ok(titleH2Tag, "h2 tag is rendered for level='H2'");
+		assert.ok(titleH3Tag, "h3 tag is rendered for level='H3'");
+		assert.ok(titleH4Tag, "h4 tag is rendered for level='H4'");
+		assert.ok(titleH5Tag, "h5 tag is rendered for level='H5'");
+		assert.ok(titleH6Tag, "h6 tag is rendered for level='H6'");
 	});
 });


### PR DESCRIPTION
* render correct h{n} tag in the component Shadow DOM, based on the "level" property
* make the ui5-title a block element to match the native title behavior
* FIXES: https://github.com/SAP/ui5-webcomponents/issues/434