### PR TITLE
 docs: improve ui5-switch sample and jsdoc

### DIFF
--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -52,7 +52,7 @@ const metadata = {
 		 * Defines the text of the <code>ui5-switch</code> when switched on.
 		 *
 		 * <br><br>
-		 * <b>Note:</b> We recommend using short texts (up to 3 letters, because larger texts might be cut off.
+		 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
 		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
@@ -65,7 +65,7 @@ const metadata = {
 		 * Defines the text of the <code>ui5-switch</code> when switched off.
 		 *
 		 * <br><br>
-		 * <b>Note:</b> We recommend using short texts (up to 3 letters, because larger texts might be cut off.
+		 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
 		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
@@ -108,6 +108,13 @@ const metadata = {
  *
  * <h3 class="comment-api-title">Overview</h3>
  * The <code>ui5-switch</code> component is used for changing between binary states.
+ * </br>
+ * The component can display texts, that will be switched, based on the component state, via the <code>textOn</code> and <code>textOff</code> properties,
+ * but texts longer than 3 letters will be cuttted off.
+ * </br>
+ * However, users are able to customize the width of <code>ui5-switch</code> with pure CSS (&lt;ui5-switch style="width: 200px">), and set widths, depending on the texts they would use.
+ * </br>
+ * Note: the component would not automatically stretch to fit the whole text width.
  *
  * <h3>ES6 Module Import</h3>
  *

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -54,7 +54,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
 		 * @type {string}
-		 * @defaultvalue: ""
+		 * @defaultvalue ""
 		 * @public
 		 */
 		textOn: {
@@ -67,7 +67,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
 		 * @type {string}
-		 * @defaultvalue: ""
+		 * @defaultvalue ""
 		 * @public
 		 */
 		textOff: {

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -116,6 +116,9 @@ const metadata = {
  * </br>
  * Note: the component would not automatically stretch to fit the whole text width.
  *
+ * <h3>Keyboard Handling</h3>
+ * The state can be changed by pressing the Space and Enter keys.
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Switch";</code>

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Switch.sample.html
@@ -84,20 +84,6 @@
 		</xmp></pre>
 	</section>
 
-	<!-- Custom Switch -->
-	<section>
-		<h3>Custom Switch</h3>
-		<div class="snippet">
-			<ui5-switch style="width: 100px; min-width: 100px;" text-on="Enabled" text-off="Disabled" checked></ui5-switch>
-			<ui5-switch style="width: 100px; min-width: 100px;" text-on="Accept" text-off="Reject"></ui5-switch>
-		</div>
-		<pre class="prettyprint lang-html"><xmp>
-<ui5-switch style="width: 100px; min-width: 100px;" text-on="Enabled" text-off="Disabled"></ui5-switch>
-<ui5-switch style="width: 100px; min-width: 100px;" text-on="Accept" text-off="Reject"></ui5-switch>
-
-		</xmp></pre>
-	</section>
-
 	<script>
 		window.prettyPrint();
 	</script>


### PR DESCRIPTION
* Improve the overview section with more info about the text, that the ui5-switch can display.
* Remove the custom switch example as it is not Fiori 3 from one hand and from other the switch does not stretch to fit the whole text automatically, so better not advertise long texts in the documentation. However, the info about customising the ui5-switch is added to the overview section.