### PR TITLE
 fix(ui5-radiobutton): fix touch area size

### DIFF
--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -3,12 +3,12 @@
 	style="{{styles.main}}"
 	role="radio"
 	aria-checked="{{ctr.selected}}"
-	?aria-readonly="{{readonly}}"
+	aria-readonly="{{readonly}}"
 	tabindex="{{tabIndex}}">
 
 	<div class='{{classes.inner}}'>
 		<svg class="sapMRbSvg" focusable="false">
-			<circle class="sapMRbSvgOuter" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rOuter}}" stroke-width="2" fill="none" />
+			<circle class="sapMRbSvgOuter" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rOuter}}" stroke-width="{{strokeWidth}}" fill="none" />
 			<circle class="sapMRbSvgInner" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rInner}}" stroke-width="10" />
 		</svg>
  		<input type='radio' ?checked="{{ctr.selected}}" ?readonly="{{ctr.readonly}}" ?disabled="{{ctr.readonly}}" name="{{ctr.name}}" data-sap-no-tab-ref/>

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -103,7 +103,7 @@ const metadata = {
 		 * The selection can be changed with <code>ARROW_UP/DOWN</code> and <code>ARROW_LEFT/RIGHT</code> keys between radios in same group.
 		 * <br/><b>Note:</b>
 		 * Only one radio button can be selected per group.
-		 *
+		 * <br/>
 		 * <b>Important:</b> For the <code>name</code> property to have effect when submitting forms, you must add the following import to your project:
 		 * <code>import InputElementsFormSupport from "@ui5/webcomponents/dist/InputElementsFormSupport";</code>
 		 *
@@ -123,7 +123,7 @@ const metadata = {
 		 * Defines the form value of the <code>ui5-radiobutton</code>.
 		 * When a form with a radio button group is submitted, the group's value
 		 * will be the value of the currently selected radio button.
-		 *
+		 * <br/>
 		 * <b>Important:</b> For the <code>value</code> property to have effect, you must add the following import to your project:
 		 * <code>import InputElementsFormSupport from "@ui5/webcomponents/dist/InputElementsFormSupport";</code>
 		 *
@@ -161,7 +161,17 @@ const metadata = {
  * <code>select</code> event is fired.
  * When a <code>ui5-radiobutton</code> that is within a group is selected, the one
  * that was previously selected gets automatically deselected. You can group radio buttons by using the <code>name</code> property.
+ * <br/>
+ * Note: if <code>ui5-radiobutton</code> is not part of a group, it can be selected once, but can not be deselected back.
  *
+ * <h3>Keyboard Handling</h3>
+ *
+ * Once the <code>ui5-radiobutton</code> is on focus, it might be selected by pressing the Space and Enter keys.
+ * <br/>
+ * The Arrow Down/Arrow Up and Arrow Left/Arrow Right keys can be used to change selection between next/previous radio buttons in one group,
+ * while TAB and SHIFT + TAB can be used to enter or leave the radio button group.
+ * <br/>
+ * Note: On entering radio button group, the focus goes to the currently selected radio button.
  *
  * <h3>ES6 Module Import</h3>
  *

--- a/packages/main/src/RadioButtonTemplateContext.js
+++ b/packages/main/src/RadioButtonTemplateContext.js
@@ -3,22 +3,24 @@ import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 
 const SVGConfig = {
 	"compact": {
-		x: 8,
-		y: 8,
-		rInner: 3.5,
-		rOuter: 7,
+		x: 16,
+		y: 16,
+		rInner: 3,
+		rOuter: 8,
 	},
 	"default": {
-		x: 24,
-		y: 24,
+		x: 22,
+		y: 22,
 		rInner: 5,
-		rOuter: 10,
+		rOuter: 11,
 	},
 };
+
 
 class RadioButtonTemplateContext {
 	static calculate(state) {
 		const compact = getCompactSize();
+		const circle = compact ? SVGConfig.compact : SVGConfig.default;
 
 		const mainClasses = RadioButtonTemplateContext.getMainClasses(state),
 			innerClasses = RadioButtonTemplateContext.getInnerClasses(state),
@@ -26,7 +28,8 @@ class RadioButtonTemplateContext {
 				ctr: state,
 				readonly: state.disabled || state.readonly,
 				tabIndex: state.disabled || (!state.selected && state.name) ? "-1" : "0",
-				circle: compact ? SVGConfig.compact : SVGConfig.default,
+				circle,
+				strokeWidth: state.valueState === "None" ? "1" : "2",
 				classes: { main: mainClasses, inner: innerClasses },
 				styles: {
 					main: {},

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -12,10 +12,6 @@ ui5-radiobutton {
 	display: inline-block;
 }
 
-span[data-sap-ui-wc-root] {
-	display: inline-block;
-}
-
 .sapMRb {
 	position: relative;
 	display: flex;
@@ -39,10 +35,10 @@ span[data-sap-ui-wc-root] {
 	content: "";
 	display: block;
 	position: absolute;
-	top: .625rem;
-	bottom: .625rem;
-	left: .625rem;
-	right: .625rem;
+	top: 0.5rem;
+	bottom: 0.5rem;
+	left: 0.5rem;
+	right: 0.5rem;
 	pointer-events: none;
 	border: var(--_ui5_radiobutton_border_width) dotted var(--sapUiContentFocusColor);
 }
@@ -88,8 +84,8 @@ span[data-sap-ui-wc-root] {
 
 /* Inner */
 .sapMRb .sapMRbInner {
-	width: 3rem;
-	height: 3rem;
+	width: 2.75rem;
+	height: 2.75rem;
 	font-size: 1rem; /* override font size of the message dialog */
 	pointer-events: none;
 	vertical-align: top;
@@ -114,11 +110,11 @@ span[data-sap-ui-wc-root] {
 
 /* Label */
 .sapMRb ui5-label.labelInRadioButton {
-	width: calc(100% - 3rem);
+	width: calc(100% - 2.75rem);
 	padding-right: 1px;
 	vertical-align: top;
-	height: 3rem;
-	line-height: 3rem;
+	height: 2.75rem;
+	line-height: 2.75rem;
 	cursor: default;
 	max-width: 100%;
 	text-overflow: ellipsis;
@@ -128,8 +124,8 @@ span[data-sap-ui-wc-root] {
 
 /* SVG */
 .sapMRbSvg {
-	height: 3rem;
-	width: 3rem;
+	height: 2.75rem;
+	width: 2.75rem;
 	pointer-events: none;
 }
 
@@ -166,9 +162,9 @@ span[data-sap-ui-wc-root] {
 }
 
 .sapUiSizeCompact .sapMRb .sapMRbInner .sapMRbSvg {
-	height: 1rem;
-	width: 1rem;
-	line-height: 1rem;
+	height: 2rem;
+	width: 2rem;
+	line-height: 2rem;
 }
 
 .sapUiSizeCompact .sapMRb ui5-label.labelInRadioButton {
@@ -180,7 +176,7 @@ span[data-sap-ui-wc-root] {
 /* RTL */
 span[dir="rtl"] .sapMRb.sapMRbHasLabel:focus:before {
 	left: 0;
-	right: 0.625rem;
+	right: 0.5rem;
 }
 
 /* RTL in Compact */

--- a/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/RadioButton.html
@@ -15,6 +15,8 @@
 	<script nomodule src="../../../../../../resources/sap/ui/webcomponents/main/bundle.es5.js">
 	</script>
 
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+
 	<style>
 		.radio-section {
 			display: flex;
@@ -25,7 +27,7 @@
 
 <body>
 	<h1>ui5-radiobutton</h1>
-	<ui5-radiobutton id="rb1" text="Option A"></ui5-radiobutton>
+	<ui5-radiobutton id="rb1"></ui5-radiobutton>
 	<ui5-radiobutton id="rb2" text="Option B"></ui5-radiobutton>
 	<ui5-radiobutton id="rb3" text="Option C"></ui5-radiobutton>
 	<ui5-radiobutton id="rb4" disabled text="Option D"></ui5-radiobutton>


### PR DESCRIPTION
* correct touch area size and outer circle radius, according to the latest Fiori 3 spec
* correct outer circle width, based on the valueState
* declare aria-readonly as standard attribute (not boolean) as JAWS does not announce readonly,
if just aria-readonly is present, but it is fine if aria-readonly="true"
* add keyboard handling section
* FIXES: https://github.com/SAP/ui5-webcomponents/issues/443