### PR TITLE
fix(ui5-tabcontainer): remove typo from component template

### DIFF
--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -94,7 +94,7 @@
 							{{/if}}
 						</div>
 					</ui5-li-custom>
-				{{/unless}}s
+				{{/unless}}
 			{{/each}}
 		</ui5-list>
 	</ui5-popover>


### PR DESCRIPTION
Removed typo, the letter 's', from the template, that previously was repeated with each list item in the <ui5-tabcontainer> overflow menu.
<img width="600" alt="Screenshot 2019-05-25 at 17 27 05" src="https://user-images.githubusercontent.com/15702139/58370720-5abd3900-7f12-11e9-9ca6-5fb477afacd8.png">
