### PR TITLE
 fix(ui5-togglebutton): fix text vertical alignment in IE

### DIFF
--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -6,6 +6,18 @@ ui5-togglebutton:not([hidden]) {
 	display: inline-block;
 }
 
+:host(ui5-togglebutton) .sapMBtn::before {
+	content: ''; /* this is a hack for a bug in IE https:/* github.com/philipwalton/flexbugs/issues/231 */
+	min-height: inherit;
+	font-size: 0;
+}
+
+ui5-togglebutton .sapMBtn::before {
+	content: '';
+	min-height: inherit;
+	font-size: 0;
+}
+
 .sapMBtn.sapMToggleBtnPressed {
 	color: var(--sapUiToggleButtonPressedTextColor);
 	text-shadow: none;

--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -6,13 +6,7 @@ ui5-togglebutton:not([hidden]) {
 	display: inline-block;
 }
 
-:host(ui5-togglebutton) .sapMBtn::before {
-	content: ''; /* this is a hack for a bug in IE https:/* github.com/philipwalton/flexbugs/issues/231 */
-	min-height: inherit;
-	font-size: 0;
-}
-
-ui5-togglebutton .sapMBtn::before {
+ui5-togglebutton .sapMBtn::before { /* this is a hack for a bug in IE https:/* github.com/philipwalton/flexbugs/issues/231 */
 	content: '';
 	min-height: inherit;
 	font-size: 0;


### PR DESCRIPTION
The fix is already done for ui5-button, but was not done for the ui5-togglebutton.