### PR TITLE
fix(ui5-button): fix focus outline color of Emphasized button

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -206,16 +206,13 @@ ui5-button span[data-sap-ui-wc-root] .sapMBtn::before {
 	text-shadow: none;
 }
 
+.sapMBtn.sapMBtnEmphasized:focus::after,
 .sapMBtn.sapMBtnEmphasized.sapMBtnActive:focus::after {
 	border-color: var(--sapUiContentContrastFocusColor);
 }
 
 .sapMBtn.sapMBtnEmphasized:focus {
 	border-color: var(--_ui5_button_emphasized_focused_border_color);
-}
-
-.sapMBtn.sapMBtnEmphasized:focus::after {
-	border-color: var(--_ui5_button_positive_border_focus_hover_color);
 }
 
 .sapMBtn.sapMBtnTransparent {


### PR DESCRIPTION
Correct the focus outline color of button with type="Emphasized", based on visual designer feedback
to fulfil contrast ratio requirements.
before
<img width="95" alt="Screenshot 2019-06-03 at 9 37 39" src="https://user-images.githubusercontent.com/15702139/58781320-477e2d80-85e4-11e9-9d5a-9cd43f8ef3eb.png">
after
<img width="94" alt="Screenshot 2019-06-03 at 9 44 10" src="https://user-images.githubusercontent.com/15702139/58781324-48af5a80-85e4-11e9-8370-7cdc65209074.png">

