### PR TITLE
refactor(ui5-label): allow color and font-* customization

### DIFF
--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -2,6 +2,9 @@
 	display: inline-block;
 	max-width: 100%;
 	cursor: text;
+	color: var(--sapUiContentLabelColor);
+	font-family: var(--sapUiFontFamily);
+	font-size: var(--sapMFontMediumSize);
 }
 
 :host(ui5-label) span[data-sap-ui-wc-root] {
@@ -12,6 +15,9 @@ ui5-label:not([hidden]) {
 	display: inline-block;
 	max-width: 100%;
 	overflow: hidden;
+	color: var(--sapUiContentLabelColor);
+	font-family: var(--sapUiFontFamily);
+	font-size: var(--sapMFontMediumSize);
 	cursor: text;
 }
 
@@ -22,9 +28,6 @@ ui5-label span[data-sap-ui-wc-root] {
 .sapMLabel {
 	display: inline-block;
 	width: 100%;
-	color: var(--sapUiContentLabelColor);
-	font-family: var(--sapUiFontFamily);
-	font-size: var(--sapMFontMediumSize);
 	font-weight: normal;
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -2,12 +2,16 @@
 	display: block;
 	max-width: 100%;
 	color: var(--sapUiGroupTitleTextColor);
+	font-family: var(--sapUiFontHeaderFamily);
+	text-shadow: var(--sapUiShadowText);
 }
 
 ui5-title:not([hidden]) {
 	display: block;
 	overflow: hidden;
 	color: var(--sapUiGroupTitleTextColor);
+	font-family: var(--sapUiFontHeaderFamily);
+	text-shadow: var(--sapUiShadowText);
 	max-width: 100%;
 }
 
@@ -15,8 +19,6 @@ ui5-title:not([hidden]) {
 	display: inline-block;
 	position: relative;
 	font-weight: var(--sapUiFontHeaderWeight);
-	font-family: var(--sapUiFontHeaderFamily);
-	text-shadow: var(--sapUiShadowText);
 	box-sizing: border-box;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
The css props font-* and color of ui5-label can be changed by setting them the tag.
And, same goes for the ui5-title, except for the font-size as the "h" tags` font-size would overwrite the styles on the tag level.