### PR TITLE
feat(base): implement late validation

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -217,7 +217,7 @@ class UI5Element extends HTMLElement {
 	}
 
 	static get observedAttributes() {
-		const observedProps = this.getMetadata().getObservedProps();
+		const observedProps = this.getMetadata().getPublicPropsList();
 		return observedProps.map(camelToKebabCase);
 	}
 
@@ -268,8 +268,8 @@ class UI5Element extends HTMLElement {
 	}
 
 	_upgradeAllProperties() {
-		const observedProps = this.constructor.getMetadata().getObservedProps();
-		observedProps.forEach(this._upgradeProperty.bind(this));
+		const allProps = this.constructor.getMetadata().getPropsList();
+		allProps.forEach(this._upgradeProperty.bind(this));
 	}
 
 	static define() {

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -103,14 +103,12 @@ const validateSingleSlot = (value, slotData) => {
 			const isHTMLElement = el instanceof HTMLElement;
 			const tagName = isHTMLElement && el.tagName.toLowerCase();
 			const isCustomElement = isHTMLElement && tagName.includes("-");
-			if (isCustomElement && slotData.lateValidation) {
+			if (isCustomElement) {
 				window.customElements.whenDefined(tagName).then(() => {
 					if (!(el instanceof propertyType)) {
 						throw new Error(`${el} is not of type ${propertyType}`);
 					}
 				});
-			} else {
-				throw new Error(`${el} is not of type ${propertyType}`);
 			}
 		}
 	});

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -50,7 +50,7 @@ const metadata = {
 		items: {
 			type: ListItemBase,
 			multiple: true,
-			lateValidation: true
+			lateValidation: true,
 		},
 	},
 	properties: /** @lends  sap.ui.webcomponents.main.List.prototype */ {

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -50,7 +50,6 @@ const metadata = {
 		items: {
 			type: ListItemBase,
 			multiple: true,
-			lateValidation: true,
 		},
 	},
 	properties: /** @lends  sap.ui.webcomponents.main.List.prototype */ {

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -9,9 +9,6 @@ import ListItemBase from "./ListItemBase.js";
 import ListMode from "./types/ListMode.js";
 import ListSeparators from "./types/ListSeparators.js";
 import ListItemType from "./types/ListItemType.js";
-import StandardListItem from "./StandardListItem.js";
-import CustomListItem from "./CustomListItem.js";
-import GroupHeaderListItem from "./GroupHeaderListItem.js";
 // Template
 import ListRenderer from "./build/compiled/ListRenderer.lit.js";
 
@@ -53,6 +50,7 @@ const metadata = {
 		items: {
 			type: ListItemBase,
 			multiple: true,
+			lateValidation: true
 		},
 	},
 	properties: /** @lends  sap.ui.webcomponents.main.List.prototype */ {
@@ -588,16 +586,6 @@ class List extends UI5Element {
 				sapMLIBFocusable: isDesktop(),
 			},
 		};
-	}
-
-	static async define(...params) {
-		await Promise.all([
-			StandardListItem.define(),
-			CustomListItem.define(),
-			GroupHeaderListItem.define(),
-		]);
-
-		super.define(...params);
 	}
 }
 


### PR DESCRIPTION
Late validation allows to delay the validation of slot content until custom elements have been defined.

Note: only enable late validation on web components that don't depend on their children being defined. This may include setting properties/attributes, but not calling methods or instance checking. 

To support this change, UI5Element now upgrades all properties (including private) so that when a parent web component sets private properties to children, these will be upgraded as well eventually.

To enable the feature for a slot, use "lateValidation: true"