### PR TITLE
fix: access DOM in connectedCallback instead of constructor

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -57,12 +57,6 @@ class UI5Element extends HTMLElement {
 	}
 
 	async _initializeShadowRoot() {
-		const isCompact = getCompactSize();
-
-		if (isCompact) {
-			this.setAttribute("data-ui5-compact-size", "");
-		}
-
 		if (this.constructor.getMetadata().getNoShadowDOM()) {
 			return Promise.resolve();
 		}
@@ -82,6 +76,11 @@ class UI5Element extends HTMLElement {
 	}
 
 	async connectedCallback() {
+		const isCompact = getCompactSize();
+		if (isCompact) {
+			this.setAttribute("data-ui5-compact-size", "");
+		}
+
 		if (this.constructor.getMetadata().getNoShadowDOM()) {
 			return;
 		}


### PR DESCRIPTION
When a custom element is created via "document.createElement", the browser throws an exception when compactSize=true, because DOM is accessed in the constructor, rather than in connectedCallback