### PR TITLE
fix: fix broken translations

### DIFF
--- a/packages/base/src/ResourceBundle.js
+++ b/packages/base/src/ResourceBundle.js
@@ -1,4 +1,5 @@
 import "./shims/jquery-shim.js";
+import "./shims/Core-shim.js";
 import ResourceBundle from "@ui5/webcomponents-core/dist/sap/base/i18n/ResourceBundle.js";
 import formatMessage from "@ui5/webcomponents-core/dist/sap/base/strings/formatMessage.js";
 import { getLanguage } from "./LocaleProvider.js";


### PR DESCRIPTION
when a locale other than english is selected, the missing core-shim.js
import was causing the wrong locale to be used by the
core/ResourceBundle
now with adding the Core-shim.js import, all resource bundles
will have the correct locale at run time
