### PR TITLE
chore: add css params in json format

### DIFF
--- a/packages/main/config/postcss.bundles/postcss.config.js
+++ b/packages/main/config/postcss.bundles/postcss.config.js
@@ -1,6 +1,7 @@
 const postcssImport = require('postcss-import');
 const combineSelectors = require('postcss-combine-duplicated-selectors');
 const postcssCSStoESM = require('../../lib/postcss-css-to-esm/index.js');
+const postcssCSStoJSON = require('../../lib/postcss-css-to-json/index.js');
 const postcssDerivedColors = require('../../lib/postcss-process-derived-colors/index');
 const cssnano = require('cssnano');
 const postcssAddFallback = require('../../lib/postcss-add-fallback/index.js');
@@ -19,5 +20,6 @@ module.exports = {
             },
         ]}, ),
         postcssCSStoESM(),
+        postcssCSStoJSON(),
     ]
 };

--- a/packages/main/lib/postcss-css-to-json/index.js
+++ b/packages/main/lib/postcss-css-to-json/index.js
@@ -1,0 +1,20 @@
+const postcss = require('postcss');
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+module.exports = postcss.plugin('add css to JSON transform plugin', function (opts) {
+	opts = opts || {};
+
+	return function (root) {
+		const css = root.toString();
+		const targetFile = root.source.input.from.replace("/src/", "/dist/").replace("\\src\\", "\\dist\\");
+
+		mkdirp.sync(path.dirname(targetFile));
+
+		const filePath = `${targetFile}.json`;
+
+		fs.writeFileSync(filePath, JSON.stringify({_: css}));
+
+	}
+});


### PR DESCRIPTION
this will be used to enable using JSON imports for theming parameters
now there is either an inline .js import
or a .css import which bundlers might try to inject in the head