### PR TITLE
refactor(ui5-badge): set default color scheme

### DIFF
--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -113,8 +113,6 @@ class Badge extends UI5Element {
 		} else {
 			this.removeAttribute("__has-icon");
 		}
-
-		this.setAttribute("color-scheme", this.colorScheme);
 	}
 
 	get hasText() {

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -23,7 +23,7 @@ const metadata = {
 		/**
 		 * Defines the color scheme of the <code>ui5-badge</code>.
 		 * There are 10 predefined schemes. Each scheme applies different values for the <code>background-color> and <code>border-color</code>.
-		 * To use one you can set a number from <code>"1"</code> to <code>"10"</code>.
+		 * To use one you can set a number from <code>"1"</code> to <code>"10"</code>. The <code>colorScheme</code> <code>"1"</code> will be set by default.
 		 * <br><br>
 		 * <b>Note:</b> color schemes have no visual representation in High Contrast Black (sap_belize_hcb) theme.
 		 * @type {string}
@@ -32,6 +32,7 @@ const metadata = {
 		 */
 		colorScheme: {
 			type: String,
+			defaultValue: "1",
 		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.Badge.prototype */ {
@@ -112,6 +113,8 @@ class Badge extends UI5Element {
 		} else {
 			this.removeAttribute("__has-icon");
 		}
+
+		this.setAttribute("color-scheme", this.colorScheme);
 	}
 
 	get hasText() {

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -5,8 +5,8 @@
 	max-width: 100%;
 	padding: 0 0.625rem;
 	color: var(--sapUiBaseText);
-	background: var(--sapUiGroupContentBackground);
-	border: solid 1px var(--sapUiGroupContentBorderColor);
+	background: var(--ui5-badge-bg-color-scheme-1);
+	border: solid 1px var(--ui5-badge-border-color-scheme-1);
 	border-radius: 1.125rem;
 	box-sizing: border-box;
 	font-size: var(--sapMFontSmallSize);
@@ -114,8 +114,8 @@ ui5-badge:not([hidden]) {
 	max-width: 100%;
 	padding: 0 0.625rem;
 	color: var(--sapUiBaseText);
-	background: var(--sapUiGroupContentBackground);
-	border: solid 1px var(--sapUiGroupContentBorderColor); 
+	background: var(--ui5-badge-bg-color-scheme-1);
+	border: solid 1px var(--ui5-badge-border-color-scheme-1);
 	border-radius: 1.125rem;
 	box-sizing: border-box;
 	font-size: var(--sapMFontSmallSize);

--- a/packages/main/src/themes/base/Badge-parameters.css
+++ b/packages/main/src/themes/base/Badge-parameters.css
@@ -17,6 +17,6 @@
 	--ui5-badge-border-color-scheme-8: var(--sapUiAccent8);
 	--ui5-badge-bg-color-scheme-9: var(--sapUiAccent9Lighten37);
 	--ui5-badge-border-color-scheme-9: var(--sapUiAccent9);
-	--ui5-badge-bg-color-scheme-10: var(--sapUiAccent10Lighten37);
+	--ui5-badge-bg-color-scheme-10: var(--sapUiAccent10Lighten49);
 	--ui5-badge-border-color-scheme-10: var(--sapUiAccent10);
 }

--- a/packages/main/src/themes/base/component-derived-colors.js
+++ b/packages/main/src/themes/base/component-derived-colors.js
@@ -41,7 +41,7 @@ const derivationsFactory = ({ darken, lighten, contrast, fade, saturate, desatur
 		"--sapUiAccent7Lighten64": () => lighten("--sapUiAccent7", 64),
 		"--sapUiAccent8Lighten61": () => lighten("--sapUiAccent8", 61),
 		"--sapUiAccent9Lighten37": () => lighten("--sapUiAccent9", 37),
-		"--sapUiAccent10Lighten37": () => lighten("--sapUiAccent10", 37),
+		"--sapUiAccent10Lighten49": () => lighten("--sapUiAccent10", 49),
 	};
 
 	return derivations;


### PR DESCRIPTION
In addition, the appearance of color-scheme="10" is changed according to the Fiori 3 design,
as it used to result in wrong grey background color.
Before
<img width="201" alt="Screenshot 2019-06-15 at 8 51 58" src="https://user-images.githubusercontent.com/15702139/59547695-9795b200-8f4b-11e9-8a4e-8dc335a91412.png">
After
<img width="186" alt="Screenshot 2019-06-15 at 8 54 02" src="https://user-images.githubusercontent.com/15702139/59547696-9e242980-8f4b-11e9-991d-1835cbdc6ae5.png">

