### PR TITLE
refactor(ui5-button): remove aria-disabled

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -2,7 +2,6 @@
 		type="button"
 		class="{{classes.main}}"
 		?disabled="{{disabled}}"
-		aria-disabled="{{ariaDisabled}}"
 		data-sap-focus-ref
 		{{> ariaPressed}}
 		dir="{{rtl}}"

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -270,10 +270,6 @@ class Button extends UI5Element {
 		};
 	}
 
-	get ariaDisabled() {
-		return this.disabled ? "true" : undefined;
-	}
-
 	get rtl() {
 		return getEffectiveRTL() ? "rtl" : undefined;
 	}


### PR DESCRIPTION
As the button has a disabled attribute the aria-disabled attribute is not needed.
