### PR TITLE
refactor: remove focusout and focusin calling by convention

### DIFF
--- a/packages/base/src/events/ManagedEvents.js
+++ b/packages/base/src/events/ManagedEvents.js
@@ -4,8 +4,6 @@ ManagedEvents.events = [
 	"click",
 	"dblclick",
 	"contextmenu",
-	"focusin",
-	"focusout",
 	"keydown",
 	"keypress",
 	"keyup",

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -5,6 +5,7 @@
 		data-sap-focus-ref
 		{{> ariaPressed}}
 		dir="{{rtl}}"
+		@focusout={{onfocusout}}
 	>
 		{{#if icon}}
 			<ui5-icon

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -16,7 +16,7 @@ import buttonCss from "./themes/Button.css.js";
  * @public
  */
 const metadata = {
-	tag: "ui5-button",
+	tag: "ui5-button", 
 	properties: /** @lends sap.ui.webcomponents.main.Button.prototype */ {
 
 		/**
@@ -193,12 +193,6 @@ class Button extends UI5Element {
 				this._active = false;
 			}
 		};
-
-		this._deactivateByKey = (event) => {
-			if (isSpace(event) && this._active) {
-				this._active = false;
-			}
-		}
 	}
 
 	onBeforeRendering() {
@@ -210,12 +204,10 @@ class Button extends UI5Element {
 
 	onEnterDOM() {
 		document.addEventListener("mouseup", this._deactivate);
-		document.addEventListener("keyup", this._deactivateByKey);
 	}
 
 	onExitDOM() {
 		document.removeEventListener("mouseup", this._deactivate);
-		document.removeEventListener("keyup", this._deactivateByKey);
 	}
 
 	onclick(event) {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -16,7 +16,7 @@ import buttonCss from "./themes/Button.css.js";
  * @public
  */
 const metadata = {
-	tag: "ui5-button", 
+	tag: "ui5-button",
 	properties: /** @lends sap.ui.webcomponents.main.Button.prototype */ {
 
 		/**

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -193,6 +193,12 @@ class Button extends UI5Element {
 				this._active = false;
 			}
 		};
+
+		this._deactivateByKey = (event) => {
+			if (isSpace(event) && this._active) {
+				this._active = false;
+			}
+		}
 	}
 
 	onBeforeRendering() {
@@ -204,10 +210,12 @@ class Button extends UI5Element {
 
 	onEnterDOM() {
 		document.addEventListener("mouseup", this._deactivate);
+		document.addEventListener("keyup", this._deactivateByKey);
 	}
 
 	onExitDOM() {
 		document.removeEventListener("mouseup", this._deactivate);
+		document.removeEventListener("keyup", this._deactivateByKey);
 	}
 
 	onclick(event) {

--- a/packages/main/src/GroupHeaderListItem.hbs
+++ b/packages/main/src/GroupHeaderListItem.hbs
@@ -1,6 +1,9 @@
 <li
 	tabindex="{{_tabIndex}}"
-	class="{{classes.main}}">
+	class="{{classes.main}}"
+	@focusin="{{onfocusin}}"
+	@focusout="{{onfocusout}}"
+>
 		<div id="{{_id}}-content" class="{{classes.inner}}">
 				<span class="{{classes.span}}"><slot></slot></span>
 		</div>

--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -2,6 +2,8 @@
 	class="{{classes.main}}"
 	style="width: 100%;"
 	?aria-invalid="{{ariaInvalid}}"
+	@focusin="{{onfocusin}}"
+	@focusout="{{onfocusout}}"
 >
 <div id="{{_id}}-wrapper"
 	class="{{classes.wrapper}}"

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -316,8 +316,6 @@ class Input extends UI5Element {
 		// all user interactions
 		this.ACTION_ENTER = "enter";
 		this.ACTION_USER_INPUT = "input";
-
-		this._whenShadowRootReady().then(this.attachFocusHandlers.bind(this));
 	}
 
 	onBeforeRendering() {
@@ -410,12 +408,6 @@ class Input extends UI5Element {
 		if (this.Suggestions) {
 			this.Suggestions.updateSelectedItemPosition(null);
 		}
-	}
-
-	/* Private Methods */
-	attachFocusHandlers() {
-		this.shadowRoot.addEventListener("focusout", this.onfocusout.bind(this));
-		this.shadowRoot.addEventListener("focusin", this.onfocusin.bind(this));
 	}
 
 	enableSuggestions() {

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -1,5 +1,6 @@
 <div
 	class="{{classes.main}}"
+	@focusin="{{onfocusin}}"
 >
 	<!-- header -->
 	{{#if header}}

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -2,6 +2,8 @@
 	tabindex="{{_tabIndex}}"
 	class="{{classes.main}}"
 	dir="{{rtl}}"
+	@focusin="{{onfocusin}}"
+	@focusout="{{onfocusout}}"
 >
 		{{#if placeSelectionElementBefore}}
 			{{> selectionElement}}

--- a/packages/main/src/Popover.hbs
+++ b/packages/main/src/Popover.hbs
@@ -1,4 +1,4 @@
-<span class="{{classes.frame}}">
+<span class="{{classes.frame}}" @focusin="{{onfocusin}}">
 	<span id="{{_id}}-firstfe" tabindex="0" @focusin={{focusHelper.forwardToLast}}></span>	
 	<div style="{{styles.main}}" role="dialog" aria-labelledby="{{headerId}}" tabindex="-1" class="{{classes.main}}">
 			{{> header}}

--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -2,6 +2,7 @@
 	class="{{classes.main}}"
 	style="{{styles.main}}"
 	tabindex="{{_tabIndex}}"
+	@focusin="{{onfocusin}}"
 >
 	{{#each visibleCells}}
 		<div class="{{../classes.cellWrapper}}">

--- a/packages/main/src/TextArea.hbs
+++ b/packages/main/src/TextArea.hbs
@@ -2,6 +2,8 @@
 	class="{{classes.main}}"
 	style="{{styles.main}}"
 	?aria-invalid="{{ariaInvalid}}"
+	@focusin="{{onfocusin}}"
+	@focusout="{{onfocusout}}"
 >
 
 	{{#if growing}}


### PR DESCRIPTION
- if a keydown is on the button but keyup is not, the button used to stay active