### PR TITLE
refactor: remove ui5target

### DIFF
--- a/packages/base/src/DOMEventHandler.js
+++ b/packages/base/src/DOMEventHandler.js
@@ -1,9 +1,9 @@
 import ManagedEvents from "./events/ManagedEvents.js";
-import getOriginalEventTarget from "./events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "./events/getShadowDOMTarget.js";
 
 const handleEvent = function handleEvent(event) {
 	// Get the DOM node where the original event occurred
-	let target = getOriginalEventTarget(event);
+	let target = getShadowDOMTarget(event);
 
 	// Traverse the DOM
 	let shouldPropagate = true;

--- a/packages/base/src/DOMEventHandler.js
+++ b/packages/base/src/DOMEventHandler.js
@@ -4,7 +4,6 @@ import getOriginalEventTarget from "./events/getOriginalEventTarget.js";
 const handleEvent = function handleEvent(event) {
 	// Get the DOM node where the original event occurred
 	let target = getOriginalEventTarget(event);
-	event.ui5target = target;
 
 	// Traverse the DOM
 	let shouldPropagate = true;

--- a/packages/base/src/events/getShadowDOMTarget.js
+++ b/packages/base/src/events/getShadowDOMTarget.js
@@ -1,4 +1,4 @@
-const getOriginalEventTarget = function getOriginalEventTarget(event) {
+const getShadowDOMTarget = event => {
 	// Default - composedPath should be used (also covered by polyfill)
 	if (typeof event.composedPath === "function") {
 		const composedPath = event.composedPath();
@@ -11,4 +11,4 @@ const getOriginalEventTarget = function getOriginalEventTarget(event) {
 	return event.target;
 };
 
-export default getOriginalEventTarget;
+export default getShadowDOMTarget;

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -1,6 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/src/renderer/LitRenderer.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "@ui5/webcomponents-base/src/events/getShadowDOMTarget.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 import getEffectiveRTL from "@ui5/webcomponents-base/src/util/getEffectiveRTL.js";
@@ -97,11 +97,11 @@ class CalendarHeader extends UI5Element {
 
 	onclick(event) {
 		const composedPath = event.composedPath();
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 
 		for (let index = 0; index < composedPath.length; index++) {
 			const sAttributeValue = composedPath[index].getAttribute && composedPath[index].getAttribute("data-sap-cal-head-button");
-			const showPickerButton = originalTarget.getAttribute("data-sap-show-picker");
+			const showPickerButton = eventTarget.getAttribute("data-sap-show-picker");
 
 			if (showPickerButton) {
 				this[`_show${showPickerButton}Picker`]();
@@ -116,9 +116,9 @@ class CalendarHeader extends UI5Element {
 	}
 
 	onkeydown(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		if (isSpace(event) || isEnter(event)) {
-			const showPickerButton = originalTarget.getAttribute("data-sap-show-picker");
+			const showPickerButton = eventTarget.getAttribute("data-sap-show-picker");
 
 			if (showPickerButton) {
 				this[`_show${showPickerButton}Picker`]();

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -1,5 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/src/renderer/LitRenderer.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 import getEffectiveRTL from "@ui5/webcomponents-base/src/util/getEffectiveRTL.js";
@@ -96,10 +97,11 @@ class CalendarHeader extends UI5Element {
 
 	onclick(event) {
 		const composedPath = event.composedPath();
+		const originalTarget = getOriginalEventTarget(event);
 
 		for (let index = 0; index < composedPath.length; index++) {
 			const sAttributeValue = composedPath[index].getAttribute && composedPath[index].getAttribute("data-sap-cal-head-button");
-			const showPickerButton = event.ui5target.getAttribute("data-sap-show-picker");
+			const showPickerButton = originalTarget.getAttribute("data-sap-show-picker");
 
 			if (showPickerButton) {
 				this[`_show${showPickerButton}Picker`]();
@@ -114,8 +116,9 @@ class CalendarHeader extends UI5Element {
 	}
 
 	onkeydown(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		if (isSpace(event) || isEnter(event)) {
-			const showPickerButton = event.ui5target.getAttribute("data-sap-show-picker");
+			const showPickerButton = originalTarget.getAttribute("data-sap-show-picker");
 
 			if (showPickerButton) {
 				this[`_show${showPickerButton}Picker`]();

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -13,6 +13,7 @@ import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
 import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
 import { isShow } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import Icon from "./Icon.js";
 import Popover from "./Popover.js";
 import Calendar from "./Calendar.js";
@@ -317,10 +318,11 @@ class DatePicker extends UI5Element {
 	}
 
 	onclick(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		const icon = this.shadowRoot.querySelector("ui5-icon");
-		const isIconTab = (event.ui5target === icon);
+		const isIconTab = (originalTarget === icon);
 
-		if (icon && (isIconTab || event.ui5target.contains(icon.getDomRef()))) {
+		if (icon && (isIconTab || originalTarget.contains(icon.getDomRef()))) {
 			this.togglePicker();
 		}
 	}

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -13,7 +13,7 @@ import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
 import ValueState from "@ui5/webcomponents-base/src/types/ValueState.js";
 import { isShow } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "@ui5/webcomponents-base/src/events/getShadowDOMTarget.js";
 import Icon from "./Icon.js";
 import Popover from "./Popover.js";
 import Calendar from "./Calendar.js";
@@ -318,11 +318,11 @@ class DatePicker extends UI5Element {
 	}
 
 	onclick(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		const icon = this.shadowRoot.querySelector("ui5-icon");
-		const isIconTab = (originalTarget === icon);
+		const isIconTab = (eventTarget === icon);
 
-		if (icon && (isIconTab || originalTarget.contains(icon.getDomRef()))) {
+		if (icon && (isIconTab || eventTarget.contains(icon.getDomRef()))) {
 			this.togglePicker();
 		}
 	}

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -9,6 +9,7 @@ import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
 import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
 import { calculateWeekNumber } from "@ui5/webcomponents-base/src/dates/CalendarUtils.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import DayPickerTemplate from "./build/compiled/DayPickerTemplate.lit.js";
 
@@ -252,7 +253,7 @@ class DayPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		const target = event.ui5target;
+		const target = getOriginalEventTarget(event);
 
 		if (target.className.indexOf("sapWCDayPickerItem") === -1) {
 			return;
@@ -290,17 +291,19 @@ class DayPicker extends UI5Element {
 	}
 
 	_handleEnter(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		event.preventDefault();
-		if (event.ui5target.className.indexOf("sapWCDayPickerItem") > -1) {
-			const targetDate = parseInt(event.ui5target.getAttribute("data-sap-timestamp"));
+		if (originalTarget.className.indexOf("sapWCDayPickerItem") > -1) {
+			const targetDate = parseInt(originalTarget.getAttribute("data-sap-timestamp"));
 			this._modifySelectionAndNotifySubscribers(targetDate, event.ctrlKey);
 		}
 	}
 
 	_handleSpace(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		event.preventDefault();
-		if (event.ui5target.className.indexOf("sapWCDayPickerItem") > -1) {
-			const targetDate = parseInt(event.ui5target.getAttribute("data-sap-timestamp"));
+		if (originalTarget.className.indexOf("sapWCDayPickerItem") > -1) {
+			const targetDate = parseInt(originalTarget.getAttribute("data-sap-timestamp"));
 			this._modifySelectionAndNotifySubscribers(targetDate, event.ctrlKey);
 		}
 	}

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -9,7 +9,7 @@ import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
 import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
 import { calculateWeekNumber } from "@ui5/webcomponents-base/src/dates/CalendarUtils.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "@ui5/webcomponents-base/src/events/getShadowDOMTarget.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import DayPickerTemplate from "./build/compiled/DayPickerTemplate.lit.js";
 
@@ -253,7 +253,7 @@ class DayPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		const target = getOriginalEventTarget(event);
+		const target = getShadowDOMTarget(event);
 
 		if (target.className.indexOf("sapWCDayPickerItem") === -1) {
 			return;
@@ -291,19 +291,19 @@ class DayPicker extends UI5Element {
 	}
 
 	_handleEnter(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		event.preventDefault();
-		if (originalTarget.className.indexOf("sapWCDayPickerItem") > -1) {
-			const targetDate = parseInt(originalTarget.getAttribute("data-sap-timestamp"));
+		if (eventTarget.className.indexOf("sapWCDayPickerItem") > -1) {
+			const targetDate = parseInt(eventTarget.getAttribute("data-sap-timestamp"));
 			this._modifySelectionAndNotifySubscribers(targetDate, event.ctrlKey);
 		}
 	}
 
 	_handleSpace(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		event.preventDefault();
-		if (originalTarget.className.indexOf("sapWCDayPickerItem") > -1) {
-			const targetDate = parseInt(originalTarget.getAttribute("data-sap-timestamp"));
+		if (eventTarget.className.indexOf("sapWCDayPickerItem") > -1) {
+			const targetDate = parseInt(eventTarget.getAttribute("data-sap-timestamp"));
 			this._modifySelectionAndNotifySubscribers(targetDate, event.ctrlKey);
 		}
 	}

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -253,6 +253,11 @@ class DayPicker extends UI5Element {
 
 	onclick(event) {
 		const target = event.ui5target;
+
+		if (target.className.indexOf("sapWCDayPickerItem") === -1) {
+			return;
+		}
+
 		const dayPressed = this._isDayPressed(target);
 
 		if (dayPressed) {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -9,7 +9,7 @@ import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
 import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "@ui5/webcomponents-base/src/events/getShadowDOMTarget.js";
 import MonthPickerTemplate from "./build/compiled/MonthPickerTemplate.lit.js";
 
 // Styles
@@ -162,9 +162,9 @@ class MonthPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		const originalTarget = getOriginalEventTarget(event);
-		if (originalTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDOM(originalTarget);
+		const eventTarget = getShadowDOMTarget(event);
+		if (eventTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDOM(eventTarget);
 			this.timestamp = timestamp;
 			this._itemNav.current = this._month;
 			this.fireEvent("selectedMonthChange", { timestamp });
@@ -178,10 +178,10 @@ class MonthPicker extends UI5Element {
 	}
 
 	_activateMonth(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		event.preventDefault();
-		if (originalTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDOM(originalTarget);
+		if (eventTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDOM(eventTarget);
 			this.timestamp = timestamp;
 			this.fireEvent("selectedMonthChange", { timestamp });
 		}

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -9,6 +9,7 @@ import LocaleData from "@ui5/webcomponents-core/dist/sap/ui/core/LocaleData.js";
 import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import MonthPickerTemplate from "./build/compiled/MonthPickerTemplate.lit.js";
 
 // Styles
@@ -161,8 +162,9 @@ class MonthPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		if (event.ui5target.className.indexOf("sapWCMonthPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDOM(event.ui5target);
+		const originalTarget = getOriginalEventTarget(event);
+		if (originalTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDOM(originalTarget);
 			this.timestamp = timestamp;
 			this._itemNav.current = this._month;
 			this.fireEvent("selectedMonthChange", { timestamp });
@@ -176,9 +178,10 @@ class MonthPicker extends UI5Element {
 	}
 
 	_activateMonth(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		event.preventDefault();
-		if (event.ui5target.className.indexOf("sapWCMonthPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDOM(event.ui5target);
+		if (originalTarget.className.indexOf("sapWCMonthPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDOM(originalTarget);
 			this.timestamp = timestamp;
 			this.fireEvent("selectedMonthChange", { timestamp });
 		}

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -7,7 +7,13 @@
 	{{#if fixed}}
 		{{> header}}
 	{{else}}
-		<header @click="{{_header.press}}" @keydown="{{onHeaderKeyDown}}" @keyup="{{onHeaderKeyUp}}" class="{{classes.header}}" tabindex="{{headerTabIndex}}">
+		<header 
+				@click="{{_header.press}}" 
+				@keydown="{{onHeaderKeyDown}}" 
+				@keyup="{{onHeaderKeyUp}}" 
+				class="{{classes.header}}" 
+				tabindex="{{headerTabIndex}}"
+		>
 			<ui5-icon
 				class="{{classes.icon}}"
 				src="{{_icon.src}}"
@@ -23,7 +29,7 @@
 
 	<!-- content area -->
 	<div class="{{classes.content}}" tabindex="-1" style="{{styles.content}}">
-        <slot></slot>
+		<slot></slot>
 	</div>
 </div>
 

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -1,13 +1,13 @@
 <div
-		data-sap-ui-fastnavgroup="true"
-		class="{{classes.main}}"
-		role="{{accRole}}"
+	data-sap-ui-fastnavgroup="true"
+	class="{{classes.main}}"
+	role="{{accRole}}"
 >
 	<!-- header: either header or h1 with header text -->
 	{{#if fixed}}
 		{{> header}}
 	{{else}}
-		<header 
+		<header
             @click="{{_header.press}}"
             @keydown="{{onHeaderKeyDown}}"
             @keyup="{{onHeaderKeyUp}}"

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -7,7 +7,7 @@
 	{{#if fixed}}
 		{{> header}}
 	{{else}}
-		<header @click="{{_header.press}}" class="{{classes.header}}" tabindex="{{headerTabIndex}}">
+		<header @click="{{_header.press}}" @keydown="{{onHeaderKeyDown}}" @keyup="{{onHeaderKeyUp}}" class="{{classes.header}}" tabindex="{{headerTabIndex}}">
 			<ui5-icon
 				class="{{classes.icon}}"
 				src="{{_icon.src}}"

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -8,11 +8,11 @@
 		{{> header}}
 	{{else}}
 		<header 
-				@click="{{_header.press}}" 
-				@keydown="{{onHeaderKeyDown}}" 
-				@keyup="{{onHeaderKeyUp}}" 
-				class="{{classes.header}}" 
-				tabindex="{{headerTabIndex}}"
+            @click="{{_header.press}}"
+            @keydown="{{onHeaderKeyDown}}"
+            @keyup="{{onHeaderKeyUp}}"
+            class="{{classes.header}}"
+            tabindex="{{headerTabIndex}}"
 		>
 			<ui5-icon
 				class="{{classes.icon}}"

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -220,6 +220,10 @@ class Panel extends UI5Element {
 	}
 
 	onHeaderKeyDown(event) {
+		if (!this._headerOnTarget(event.target)) {
+			return;
+		}
+
 		if (isEnter(event)) {
 			this._toggleOpen();
 		}
@@ -230,6 +234,10 @@ class Panel extends UI5Element {
 	}
 
 	onHeaderKeyUp(event) {
+		if (!this._headerOnTarget(event.target)) {
+			return;
+		}
+
 		if (isSpace(event)) {
 			this._toggleOpen();
 		}
@@ -263,6 +271,10 @@ class Panel extends UI5Element {
 			this._contentExpanded = !this.collapsed;
 			this.fireEvent("toggle");
 		});
+	}
+
+	_headerOnTarget(target) {
+		return target.classList.contains("sapMPanelWrappingDiv");
 	}
 
 	get expanded() {

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -6,7 +6,6 @@ import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 import { fetchResourceBundle, getResourceBundle } from "@ui5/webcomponents-base/src/ResourceBundle.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import Icon from "./Icon.js";
 import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
 import PanelTemplate from "./build/compiled/PanelTemplate.lit.js";
@@ -220,24 +219,18 @@ class Panel extends UI5Element {
 		this._icon.press = !toggleWithInternalHeader ? this._toggle : this._noOp;
 	}
 
-	onkeydown(event) {
-		const originalTarget = getOriginalEventTarget(event);
-		const headerUsed = this._headerOnTarget(originalTarget);
-
-		if (isEnter(event) && headerUsed) {
+	onHeaderKeyDown(event) {
+		if (isEnter(event)) {
 			this._toggleOpen();
 		}
 
-		if (isSpace(event) && headerUsed) {
+		if (isSpace(event)) {
 			event.preventDefault();
 		}
 	}
 
-	onkeyup(event) {
-		const originalTarget = getOriginalEventTarget(event);
-		const headerUsed = this._headerOnTarget(originalTarget);
-
-		if (isSpace(event) && headerUsed) {
+	onHeaderKeyUp(event) {
+		if (isSpace(event)) {
 			this._toggleOpen();
 		}
 	}
@@ -270,10 +263,6 @@ class Panel extends UI5Element {
 			this._contentExpanded = !this.collapsed;
 			this.fireEvent("toggle");
 		});
-	}
-
-	_headerOnTarget(target) {
-		return target.classList.contains("sapMPanelWrappingDiv");
 	}
 
 	get expanded() {

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -6,6 +6,7 @@ import slideUp from "@ui5/webcomponents-base/src/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/src/events/PseudoEvents.js";
 import { getCompactSize } from "@ui5/webcomponents-base/src/Configuration.js";
 import { fetchResourceBundle, getResourceBundle } from "@ui5/webcomponents-base/src/ResourceBundle.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import Icon from "./Icon.js";
 import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
 import PanelTemplate from "./build/compiled/PanelTemplate.lit.js";
@@ -220,7 +221,8 @@ class Panel extends UI5Element {
 	}
 
 	onkeydown(event) {
-		const headerUsed = this._headerOnTarget(event.ui5target);
+		const originalTarget = getOriginalEventTarget(event);
+		const headerUsed = this._headerOnTarget(originalTarget);
 
 		if (isEnter(event) && headerUsed) {
 			this._toggleOpen();
@@ -232,7 +234,8 @@ class Panel extends UI5Element {
 	}
 
 	onkeyup(event) {
-		const headerUsed = this._headerOnTarget(event.ui5target);
+		const originalTarget = getOriginalEventTarget(event);
+		const headerUsed = this._headerOnTarget(originalTarget);
 
 		if (isSpace(event) && headerUsed) {
 			this._toggleOpen();

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -7,6 +7,7 @@ import { isEnter, isSpace } from "@ui5/webcomponents-base/src/events/PseudoEvent
 import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
 import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
 import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
+import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
 import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
@@ -187,8 +188,9 @@ class YearPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		if (event.ui5target.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(event.ui5target);
+		const originalTarget = getOriginalEventTarget(event);
+		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(originalTarget);
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
 			this._itemNav.current = YearPicker._MIDDLE_ITEM_INDEX;
@@ -212,9 +214,10 @@ class YearPicker extends UI5Element {
 	}
 
 	_handleEnter(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		event.preventDefault();
-		if (event.ui5target.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(event.ui5target);
+		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(originalTarget);
 
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
@@ -224,9 +227,10 @@ class YearPicker extends UI5Element {
 	}
 
 	_handleSpace(event) {
+		const originalTarget = getOriginalEventTarget(event);
 		event.preventDefault();
-		if (event.ui5target.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(event.ui5target);
+		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(originalTarget);
 
 			this._selectedYear = CalendarDate.fromTimestamp(
 				timestamp * 1000,

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -7,7 +7,7 @@ import { isEnter, isSpace } from "@ui5/webcomponents-base/src/events/PseudoEvent
 import ItemNavigation from "@ui5/webcomponents-base/src/delegate/ItemNavigation.js";
 import { getLocale } from "@ui5/webcomponents-base/src/LocaleProvider.js";
 import Integer from "@ui5/webcomponents-base/src/types/Integer.js";
-import getOriginalEventTarget from "@ui5/webcomponents-base/src/events/getOriginalEventTarget.js";
+import getShadowDOMTarget from "@ui5/webcomponents-base/src/events/getShadowDOMTarget.js";
 import DateFormat from "@ui5/webcomponents-core/dist/sap/ui/core/format/DateFormat.js";
 import CalendarType from "@ui5/webcomponents-base/src/dates/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-base/src/dates/CalendarDate.js";
@@ -188,9 +188,9 @@ class YearPicker extends UI5Element {
 	}
 
 	onclick(event) {
-		const originalTarget = getOriginalEventTarget(event);
-		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(originalTarget);
+		const eventTarget = getShadowDOMTarget(event);
+		if (eventTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(eventTarget);
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
 			this._itemNav.current = YearPicker._MIDDLE_ITEM_INDEX;
@@ -214,10 +214,10 @@ class YearPicker extends UI5Element {
 	}
 
 	_handleEnter(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		event.preventDefault();
-		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(originalTarget);
+		if (eventTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(eventTarget);
 
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
@@ -227,10 +227,10 @@ class YearPicker extends UI5Element {
 	}
 
 	_handleSpace(event) {
-		const originalTarget = getOriginalEventTarget(event);
+		const eventTarget = getShadowDOMTarget(event);
 		event.preventDefault();
-		if (originalTarget.className.indexOf("sapWCYearPickerItem") > -1) {
-			const timestamp = this.getTimestampFromDom(originalTarget);
+		if (eventTarget.className.indexOf("sapWCYearPickerItem") > -1) {
+			const timestamp = this.getTimestampFromDom(eventTarget);
 
 			this._selectedYear = CalendarDate.fromTimestamp(
 				timestamp * 1000,

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/DayPicker.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/DayPicker.qunit.js
@@ -71,7 +71,7 @@ TestHelper.ready(function () {
 			RenderScheduler.whenFinished().then(function () {
 				var e = {
 					preventDefault: function() { },
-					target: getDaysDomRefs.call(this)[20] // getOriginalEventTarget will return this as a fallback
+					target: getDaysDomRefs.call(this)[20] // getShadowDOMTarget will return this as a fallback
 				};
 
 				this.month._handleEnter(e);
@@ -92,7 +92,7 @@ TestHelper.ready(function () {
 			RenderScheduler.whenFinished().then(function () {
 				var e = {
 					preventDefault: function() {},
-					target: getDaysDomRefs.call(this)[20] // getOriginalEventTarget will return this as a fallback
+					target: getDaysDomRefs.call(this)[20] // getShadowDOMTarget will return this as a fallback
 				};
 
 				this.month._handleSpace(e);

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/DayPicker.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/DayPicker.qunit.js
@@ -71,7 +71,7 @@ TestHelper.ready(function () {
 			RenderScheduler.whenFinished().then(function () {
 				var e = {
 					preventDefault: function() { },
-					ui5target: getDaysDomRefs.call(this)[20]
+					target: getDaysDomRefs.call(this)[20] // getOriginalEventTarget will return this as a fallback
 				};
 
 				this.month._handleEnter(e);
@@ -92,7 +92,7 @@ TestHelper.ready(function () {
 			RenderScheduler.whenFinished().then(function () {
 				var e = {
 					preventDefault: function() {},
-					ui5target: getDaysDomRefs.call(this)[20]
+					target: getDaysDomRefs.call(this)[20] // getOriginalEventTarget will return this as a fallback
 				};
 
 				this.month._handleSpace(e);


### PR DESCRIPTION
In addition, a bug is fixed with this change: clicking between the cells in the date picker no longer produces a JS error in the console.