### PR TITLE
docs: better explain slot usage

### DIFF
--- a/lib/documentation/templates/api-slots-section.js
+++ b/lib/documentation/templates/api-slots-section.js
@@ -1,15 +1,16 @@
 module.exports = {
   template: `
   {{#if slots}}
-    <h3 class="comment-api-title space-top" >Children</h3>
+    <h3 class="comment-api-title space-top" >Slots</h3>
 	<p class="small-space-top" >
-	  This Web Component accepts other HTML Elements as children. 
-	  Use the <code>slot</code> attribute to define the category of each child, if more than one category is accepted.
+	  This Element provides slot(s). This means it can display its child nodes.<br>
+	  Unless targeting the default slot, use the <code>slot</code> attribute to define the destination slot for each child.<br>
+	  Text, along with HTML Elements with no <code>slot</code> attribute, goes the the <code>default</code> slot.
 	</p>
 
     <div class="small-space-top api-table">
       <div class="head api-table-header-roll">
-        <div class="cell api-table-header-cell">Category</div>
+        <div class="cell api-table-header-cell">Slot</div>
         <div class="cell api-table-header-cell">Type</div>
         <div class="cell api-table-header-cell">Description</div>
       </div>


### PR DESCRIPTION
BREAKING CHANGE: the "data-ui5-slot" attribute is deprecated. Use "slot" instead.
All slots can accept multiple child nodes now. Several web components can now accept
text in addition to HTML elements. See the documentation for details about individual web components.

Previous changes: #590