### PR TITLE
refactor(ui5-shellbar-item): rename press event to itemClick

### DIFF
--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -680,7 +680,7 @@ class ShellBar extends UI5Element {
 				return item.shadowRoot.querySelector(`#${refItemId}`);
 			})[0];
 
-			const prevented = !shellbarItem.fireEvent("press", { targetRef: event.target }, true);
+			const prevented = !shellbarItem.fireEvent("itemClick", { targetRef: event.target }, true);
 
 			this._defaultItemPressPrevented = prevented;
 		}

--- a/packages/main/src/ShellBarItem.js
+++ b/packages/main/src/ShellBarItem.js
@@ -40,7 +40,7 @@ const metadata = {
 		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
-		press: {
+		itemClick: {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},

--- a/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/ShellBar.html
@@ -196,7 +196,7 @@
 		});
 
 		["disc", "call"].forEach(function(id) {
-			window[id].addEventListener("ui5-press", function(event) {
+			window[id].addEventListener("ui5-itemClick", function(event) {
 				event.preventDefault();
 				window["press-input"].value = event.target.id;
 				window["custom-item-popover"].openBy(event.detail.targetRef);


### PR DESCRIPTION
FIXES: https://github.com/SAP/ui5-webcomponents/issues/611

BREAKING CHANGE: ui5-shellbar-item press event is renamed to itemClick