### PR TITLE
fix: enable default icon size to be changed

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -1,13 +1,15 @@
-:host(ui5-icon:not([hidden])) {
+:host(:not([hidden])) {
 	display: inline-block;
 	outline: none;
 	color: var(--sapUiContentNonInteractiveIconColor);
+	font-size: var(--sapUiFontSize);
 }
 
 ui5-icon:not([hidden]) {
 	display: inline-block;
 	outline: none;
 	color: var(--sapUiContentNonInteractiveIconColor);
+	font-size: var(--sapUiFontSize);
 }
 
 .sapWCIcon {
@@ -25,7 +27,6 @@ ui5-icon:not([hidden]) {
 	content: attr(data-sap-ui-icon-content);
 	speak: none;
 	font-weight: normal;
-	font-size: var(--sapUiFontSize);
 	-webkit-font-smoothing: antialiased;
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
move the default font size to the host element so it can be styled externally