### PR TITLE
refactor: metadata noAttribute added

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -220,8 +220,8 @@ class UI5Element extends HTMLElement {
 	}
 
 	static get observedAttributes() {
-		const observedProps = this.getMetadata().getPublicPropsList();
-		return observedProps.map(camelToKebabCase);
+		const observedAttributes = this.getMetadata().getAttributesList();
+		return observedAttributes.map(camelToKebabCase);
 	}
 
 	attributeChangedCallback(name, oldValue, newValue) {
@@ -241,7 +241,7 @@ class UI5Element extends HTMLElement {
 	}
 
 	_updateAttribute(name, newValue) {
-		if (!UI5ElementMetadata.isPublicProperty(name)) {
+		if (!this.constructor.getMetadata().hasAttribute(name)) {
 			return;
 		}
 

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -55,11 +55,6 @@ class UI5ElementMetadata {
 const validateSingleProperty = (value, propData) => {
 	const propertyType = propData.type;
 
-	// Association handling
-	if (propData.association) {
-		return value;
-	}
-
 	if (propertyType === Boolean) {
 		return typeof value === "boolean" ? value : false;
 	}

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -10,12 +10,17 @@ class UI5ElementMetadata {
 		return this.metadata.tag;
 	}
 
+	hasAttribute(propName) {
+		const propData = this.getProperties()[propName];
+		return propData.type !== Object && !propData.noAttribute;
+	}
+
 	getPropsList() {
 		return Object.keys(this.getProperties());
 	}
 
-	getPublicPropsList() {
-		return this.getPropsList().filter(UI5ElementMetadata.isPublicProperty);
+	getAttributesList() {
+		return this.getPropsList().filter(this.hasAttribute, this);
 	}
 
 	getSlots() {
@@ -32,10 +37,6 @@ class UI5ElementMetadata {
 
 	getEvents() {
 		return this.metadata.events || {};
-	}
-
-	static isPublicProperty(prop) {
-		return prop.charAt(0) !== "_";
 	}
 
 	static validatePropertyValue(value, propData) {

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -76,9 +76,11 @@ const metadata = {
 		},
 		_calendarWidth: {
 			type: String,
+			noAttribute: true,
 		},
 		_calendarHeight: {
 			type: String,
+			noAttribute: true,
 		},
 		formatPattern: {
 			type: String,

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -85,6 +85,7 @@ const metadata = {
 
 		_headerActive: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Card.prototype */ {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -137,6 +137,7 @@ const metadata = {
 
 		_isPickerOpen: {
 			type: Boolean,
+			noAttribute: true,
 		},
 		_popover: {
 			type: Object,

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -69,6 +69,7 @@ const metadata = {
 		},
 		_hidden: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.DayPicker.prototype */ {

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -77,8 +77,6 @@ const metadata = {
  * providing valuable information to the user.
  * Usually it is placed next to a value holder, such as a text field.
  * It informs the user about what data is displayed or expected in the value holder.
- * The <code>ui5-label</code> is associated with its value holder by setting the
- * <code>labelFor</code> association.
  * <br><br>
  * The <code>ui5-label</code> appearance can be influenced by properties,
  * such as <code>required</code> and <code>wrap</code>.

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -90,6 +90,7 @@ const metadata = {
 
 		_rel: {
 			type: String,
+			noAttribute: true,
 		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.Link.prototype */ {

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -45,11 +45,13 @@ const metadata = {
 
 		_active: {
 			type: Boolean,
+			noAttribute: true,
 		},
 
 		_mode: {
 			type: ListMode,
 			defaultValue: ListMode.None,
+			noAttribute: true,
 		},
 	},
 	events: {

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -17,11 +17,13 @@ const metadata = {
 
 		_hideBorder: {
 			type: Boolean,
+			noAttribute: true,
 		},
 
 		_tabIndex: {
 			type: String,
 			defaultValue: "-1",
+			noAttribute: true,
 		},
 	},
 	events: {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -44,6 +44,7 @@ const metadata = {
 		},
 		_hidden: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.MonthPicker.prototype */ {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -121,8 +121,14 @@ const metadata = {
 			type: Boolean,
 		},
 
-		_filteredItems: { type: Object },
-		_iconPressed: { type: Boolean },
+		_filteredItems: {
+			type: Object
+		},
+
+		_iconPressed: {
+			type: Boolean,
+			noAttribute: true,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.MultiComboBox.prototype */ {
 		/**

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -122,7 +122,7 @@ const metadata = {
 		},
 
 		_filteredItems: {
-			type: Object
+			type: Object,
 		},
 
 		_iconPressed: {

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -108,9 +108,11 @@ const metadata = {
 		},
 		_contentExpanded: {
 			type: Boolean,
+			noAttribute: true,
 		},
 		_animationRunning: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -106,34 +106,42 @@ const metadata = {
 
 		_left: {
 			type: Integer,
+			noAttribute: true,
 		},
 		_top: {
 			type: Integer,
+			noAttribute: true,
 		},
 
 		_width: {
 			type: String,
+			noAttribute: true,
 		},
 		_height: {
 			type: String,
+			noAttribute: true,
 		},
 
 		_maxContentHeight: {
 			type: Integer,
+			noAttribute: true,
 		},
 
 		_arrowTranslateX: {
 			type: Integer,
 			defaultValue: 0,
+			noAttribute: true,
 		},
 
 		_arrowTranslateY: {
 			type: Integer,
 			defaultValue: 0,
+			noAttribute: true,
 		},
 		_actualPlacementType: {
 			type: PopoverPlacementType,
 			defaultValue: PopoverPlacementType.Right,
+			noAttribute: true,
 		},
 		_focusElementsHandlers: {
 			type: Object,

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -55,7 +55,6 @@ const metadata = {
 		 */
 		initialFocus: {
 			type: String,
-			association: true,
 		},
 
 		/**

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -80,9 +80,11 @@ const metadata = {
 
 		_zIndex: {
 			type: Integer,
+			noAttribute: true,
 		},
 		_hideBlockLayer: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.Popup.prototype */ {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -98,6 +98,7 @@ const metadata = {
 
 		_text: {
 			type: String,
+			noAttribute: true,
 		},
 
 		/**

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -109,6 +109,7 @@ const metadata = {
 
 		_breakpointSize: {
 			type: String,
+			noAttribute: true,
 		},
 
 		_itemsInfo: {
@@ -122,6 +123,7 @@ const metadata = {
 
 		_showBlockLayer: {
 			type: Boolean,
+			noAttribute: true,
 		},
 		_searchField: {
 			type: Object,

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -101,6 +101,7 @@ const metadata = {
 		_tabIndex: {
 			type: String,
 			defaultValue: "-1",
+			noAttribute: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Tab.prototype */ {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -90,14 +90,17 @@ const metadata = {
 
 		_scrollable: {
 			type: Boolean,
+			noAttribute: true,
 		},
 
 		_scrollableBack: {
 			type: Boolean,
+			noAttribute: true,
 		},
 
 		_scrollableForward: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.TabContainer.prototype */ {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -85,7 +85,6 @@ const metadata = {
 
 		_selectedTab: {
 			type: TabBase,
-			association: true,
 		},
 
 		_scrollable: {

--- a/packages/main/src/TableCell.js
+++ b/packages/main/src/TableCell.js
@@ -26,12 +26,15 @@ const metadata = {
 
 		_firstInRow: {
 			type: Boolean,
+			noAttribute: true,
 		},
 		_lastInRow: {
 			type: Boolean,
+			noAttribute: true,
 		},
 		_hasBorder: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.TableCell.prototype */ {

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -184,6 +184,7 @@ const metadata = {
 		_height: {
 			type: CSSSize,
 			defaultValue: null,
+			noAttribute: true,
 		},
 
 		_mirrorText: {
@@ -193,6 +194,7 @@ const metadata = {
 		},
 		_maxHeight: {
 			type: String,
+			noAttribute: true,
 		},
 		_listeners: {
 			type: Object,

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -88,6 +88,7 @@ const metadata = {
 		_tabIndex: {
 			type: String,
 			defaultValue: "-1",
+			noAttribute: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.TimelineItem.prototype */ {

--- a/packages/main/src/Token.js
+++ b/packages/main/src/Token.js
@@ -55,7 +55,7 @@ const metadata = {
 		 */
 		readonly: { type: Boolean },
 
-		_tabIndex: { type: String, defaultValue: "-1" },
+		_tabIndex: { type: String, defaultValue: "-1", noAttribute: true },
 	},
 
 	events: /** @lends sap.ui.webcomponents.main.Token.prototype */ {

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -26,7 +26,7 @@ const metadata = {
 		showMore: { type: Boolean },
 		disabled: { type: Boolean },
 
-		_nMoreText: { type: String },
+		_nMoreText: { type: String, noAttribute: true },
 		_hiddenTokens: { type: Object, multiple: true },
 	},
 	events: /** @lends sap.ui.webcomponents.main.Tokenizer.prototype */ {

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -41,6 +41,7 @@ const metadata = {
 		},
 		_selectedYear: {
 			type: Integer,
+			noAttribute: true,
 		},
 		_yearIntervals: {
 			type: Object,
@@ -48,6 +49,7 @@ const metadata = {
 		},
 		_hidden: {
 			type: Boolean,
+			noAttribute: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.YearPicker.prototype */ {

--- a/packages/main/test/sap/ui/webcomponents/main/pages/notepad/notepad.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/notepad/notepad.html
@@ -44,7 +44,8 @@
                     },
                     _timesGreeted: {
 				    	type: Integer,
-                        defaultValue: 0
+                        defaultValue: 0,
+                        noAttribute: true,
                     }
                 },
 				slots: {


### PR DESCRIPTION
- new metadata entity added: "noAttribute"
- properties that have "noAttribute: true" or are of type "Object" won't have attributes
- all other properties will have attributes (no magic detection if their names start with _ or not)
- metadata "association" entity is removed

After this change it will be possible to have properties starting with underscore that also have attribute equivalents. Until now if you wanted to make a private property also have an attribute, you had to rename it not to start with underscore.
