### PR TITLE
fix: icon no longer flickers on IE

### DIFF
--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -2,6 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getIconData } from "@ui5/webcomponents-base/dist/SVGIconRegistry.js";
+import createStyleInHead from "@ui5/webcomponents-base/dist/util/createStyleInHead.js";
 import { fetchResourceBundle, getResourceBundle } from "@ui5/webcomponents-base/dist/ResourceBundle.js";
 import IconTemplate from "./generated/templates/IconTemplate.lit.js";
 
@@ -111,9 +112,20 @@ class Icon extends UI5Element {
 	}
 
 	static async define(...params) {
+		this.createGlobalStyle();
 		await fetchResourceBundle("@ui5/webcomponents");
 
 		super.define(...params);
+	}
+
+	static createGlobalStyle() {
+		if (!window.ShadyDOM) {
+			return;
+		}
+		const styleElement = document.head.querySelector(`style[data-ui5-icon-global]`);
+		if (!styleElement) {
+			createStyleInHead(`ui5-icon:not([data-ui5-defined]) { display: none !important; }`, { "data-ui5-icon-global": "" });
+		}
 	}
 
 	_normalizeIconURI(iconURI) {
@@ -147,6 +159,13 @@ class Icon extends UI5Element {
 
 	get dir() {
 		return getRTL() ? "rtl" : "ltr";
+	}
+
+	onEnterDOM() {
+		if (!window.ShadyDOM) {
+			return;
+		}
+		this.setAttribute("data-ui5-defined", "");
 	}
 }
 

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Simple.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Simple.html
@@ -30,6 +30,7 @@
 <body>
 
     <ui5-button>ivan</ui5-button>
+    <ui5-icon src="sap-icon://add"></ui5-icon>
 
 </body>
 </html>


### PR DESCRIPTION
For IE CSS enters the head tag with setTimeout, because we schedule the CSS Vars ponyfill rather than run it immediately when CSS is available. The reason for this scheduling is that we need all CSS styles processed at once, otherwise it's too slow. We can't run the ponyfill for styles one by one due to the way it works (if you run it for just one style, the output will be for only this style, regardless of others processed earlier).

This is an icon-only solution until we have a framework-wide solution, because for icon the flicker is the worst, due to SVG scaling on IE. We create a global style in the head at define time and use it to hide the icon until it has entered the DOM.

