### PR TITLE
fix(ui5-switch): don`t mirror checkmark icon in RTL

### DIFF
--- a/packages/main/src/Switch.hbs
+++ b/packages/main/src/Switch.hbs
@@ -12,7 +12,7 @@
 			<div class="ui5-switch-slider">
 				{{#if graphical}}
 					<span class="ui5-switch-text ui5-switch-text--on">
-						<ui5-icon src="sap-icon://accept" class="ui5-switch-icon-on"></ui5-icon>
+						<ui5-icon src="sap-icon://accept" dir="ltr" class="ui5-switch-icon-on"></ui5-icon>
 					</span>
 					<span class="ui5-switch-text ui5-switch-text--off">
 						<ui5-icon src="sap-icon://decline" class="ui5-switch-icon-off"></ui5-icon>


### PR DESCRIPTION
before (in RTL):
<img width="98" alt="Screenshot 2019-08-22 at 16 00 24" src="https://user-images.githubusercontent.com/15702139/63568096-d6b03700-c57c-11e9-8172-ccd0633f7f5f.png">

after  (in RTL):
<img width="89" alt="Screenshot 2019-08-23 at 8 06 22" src="https://user-images.githubusercontent.com/15702139/63568160-ee87bb00-c57c-11e9-8859-af518b58c432.png">
