### PR TITLE
wip: i18n usage proposal

### DIFF
--- a/packages/base/src/AssetRegistry.js
+++ b/packages/base/src/AssetRegistry.js
@@ -1,9 +1,9 @@
-import { registerI18nBundle } from "./asset-registries/i18n.js";
+import { setI18nBundle } from "./asset-registries/i18n.js";
 import { registerCldr } from "./asset-registries/LocaleData.js";
 import { registerThemeProperties } from "./asset-registries/Themes.js";
 
 export {
 	registerCldr,
 	registerThemeProperties,
-	registerI18nBundle,
+	setI18nBundle,
 };

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -8,6 +8,7 @@ import RenderScheduler from "./RenderScheduler.js";
 import { getConstructableStyle, createHeadStyle, getShadowRootStyle } from "./CSS.js";
 import { attachThemeChange } from "./Theming.js";
 import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
+import { getI18nProvider } from "./i18nBundle";
 import isValidPropertyName from "./util/isValidPropertyName.js";
 
 const metadata = {
@@ -277,7 +278,14 @@ class UI5Element extends HTMLElement {
 
 	static async define() {
 		await boot();
-		const tag = this.getMetadata().getTag();
+
+		const md = this.getMetadata();
+		const tag = md.getTag();
+		const i18nPackage = md.getI18nPackage();
+
+		if (i18nPackage) {
+			this.getI18nText = (await getI18nProvider(i18nPackage)).getText;
+		}
 
 		const definedLocally = DefinitionsSet.has(tag);
 		const definedGlobally = customElements.get(tag);

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -35,6 +35,10 @@ class UI5ElementMetadata {
 		return this.metadata.properties || {};
 	}
 
+	getI18nPackage() {
+		return this.metadata.i18n;
+	}
+
 	static validatePropertyValue(value, propData) {
 		const isMultiple = propData.multiple;
 		if (isMultiple) {

--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -27,15 +27,26 @@ const getI18nBundleData = packageName => {
  * @param {Object} bundle an object with string locales as keys and the URLs of where the corresponding locale can be fetched from, f.e {"en": "path/en.json", ...}
  * @public
  */
-const registerI18nBundle = (packageName, bundle) => {
+const setI18nBundle = (packageName, bundle) => {
 	bundleURLs.set(packageName, bundle);
+};
+
+const getI18nBundle = async packageName => {
+	let data = getI18nBundleData(packageName);
+	if (data) {
+		return data;
+	}
+
+	data = await fetchI18nBundle(packageName);
+	setI18nBundleData(packageName, data);
+	return data;
 };
 
 /**
  * This method preforms the asyncronous task of fething the actual text resources. It will fetch
  * each text resource over the network once (even for multiple calls to the same method).
  * It should be fully finished before the i18nBundle class is created in the webcomponents.
- * This method uses the bundle URLs that are populated by the <code>registerI18nBundle</code> method.
+ * This method uses the bundle URLs that are populated by the <code>setI18nBundle</code> method.
  * To simplify the usage, the synchronization of both methods happens internally for the same <code>bundleId</code>
  * @param {packageName} packageName the node project package id
  * @public
@@ -59,17 +70,14 @@ const fetchI18nBundle = async packageName => {
 	const bundleURL = bundlesForPackage[localeId];
 
 	if (typeof bundleURL === "object") { // inlined from build
-		setI18nBundleData(packageName, bundleURL);
 		return bundleURL;
 	}
 
-	const data = await fetchJsonOnce(bundleURL);
-	setI18nBundleData(packageName, data);
+	return fetchJsonOnce(bundleURL);
 };
 
 export {
-	fetchI18nBundle,
-	registerI18nBundle,
-	setI18nBundleData,
-	getI18nBundleData,
+	fetchI18nBundle, // kept not to break unrefcatored components
+	setI18nBundle,
+	getI18nBundle,
 };

--- a/packages/base/src/i18nBundle.js
+++ b/packages/base/src/i18nBundle.js
@@ -1,32 +1,30 @@
-import { fetchI18nBundle, getI18nBundleData } from "./asset-registries/i18n.js";
-import formatMessage from "./util/formatMessage";
+import { fetchI18nBundle, getI18nBundle } from "./asset-registries/i18n.js";
+import formatI18nText from "./util/formatI18nText";
 
 const I18nBundleInstances = new Map();
 
 class I18nBundle {
-	constructor(packageName) {
-		this.packageName = packageName;
+	constructor() {
+		this.data = null;
 	}
 
 	getText(textObj, ...params) {
-		const bundle = getI18nBundleData(this.packageName);
-
-		if (!bundle || !bundle[textObj.key]) {
-			return formatMessage(textObj.defaultText, params); // Fallback to "en"
+		if (!this.data || !this.data[textObj.key]) {
+			return formatI18nText(textObj.defaultText, params);
 		}
 
-		return formatMessage(bundle[textObj.key], params);
+		return formatI18nText(this.data[textObj.key], params);
 	}
 }
 
-const getI18nBundle = packageName => {
-	if (I18nBundleInstances.has(packageName)) {
-		return I18nBundleInstances.get(packageName);
+const getI18nProvider = async packageName => {
+	if (!I18nBundleInstances.has(packageName)) {
+		const i18nBunle = new I18nBundle();
+		i18nBunle.data = await getI18nBundle(packageName);
+		I18nBundleInstances.set(packageName, i18nBunle);
 	}
 
-	const i18nBunle = new I18nBundle(packageName);
-	I18nBundleInstances.set(packageName, i18nBunle);
-	return i18nBunle;
+	return I18nBundleInstances.get(packageName);
 };
 
-export { fetchI18nBundle, getI18nBundle };
+export { fetchI18nBundle, getI18nBundle, getI18nProvider };

--- a/packages/base/src/util/formatI18nText.js
+++ b/packages/base/src/util/formatI18nText.js
@@ -1,6 +1,6 @@
 const messageFormatRegEX = /('')|'([^']+(?:''[^']*)*)(?:'|$)|\{([0-9]+(?:\s*,[^{}]*)?)\}|[{}]/g;
 
-const formatMessage = (text, values) => {
+const formatI18nText = (text, values) => {
 	values = values || [];
 
 	return text.replace(messageFormatRegEX, ($0, $1, $2, $3, offset) => {
@@ -20,4 +20,4 @@ const formatMessage = (text, values) => {
 	});
 };
 
-export default formatMessage;
+export default formatI18nText;

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 
 // Template
@@ -16,6 +15,7 @@ import badgeCss from "./generated/themes/Badge.css.js";
  */
 const metadata = {
 	tag: "ui5-badge",
+	i18n: "@ui5/webcomponents",
 	properties: /** @lends sap.ui.webcomponents.main.Badge.prototype */  {
 
 		/**
@@ -87,12 +87,6 @@ const metadata = {
  * @public
  */
 class Badge extends UI5Element {
-	constructor() {
-		super();
-
-		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
-	}
-
 	static get metadata() {
 		return metadata;
 	}
@@ -107,12 +101,6 @@ class Badge extends UI5Element {
 
 	static get styles() {
 		return badgeCss;
-	}
-
-	static async define(...params) {
-		await fetchI18nBundle("@ui5/webcomponents");
-
-		super.define(...params);
 	}
 
 	onBeforeRendering() {
@@ -136,7 +124,7 @@ class Badge extends UI5Element {
 	}
 
 	get badgeDescription() {
-		return this.i18nBundle.getText(BADGE_DESCRIPTION);
+		return Badge.getI18nText(BADGE_DESCRIPTION);
 	}
 }
 

--- a/packages/main/src/json-imports/i18n.js
+++ b/packages/main/src/json-imports/i18n.js
@@ -1,4 +1,4 @@
-import { registerI18nBundle } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";
+import { setI18nBundle } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";
 
 import ar from "../assets/i18n/messagebundle_ar.json";
 import bg from "../assets/i18n/messagebundle_bg.json";
@@ -92,4 +92,4 @@ Suggested pattern: "assets\\\/.*\\\.json"`);
 }
 /* eslint-enable */
 
-registerI18nBundle("@ui5/webcomponents", bundleMap);
+setI18nBundle("@ui5/webcomponents", bundleMap);


### PR DESCRIPTION
- new `getI18nBundle` method within `asset-registries/i18n`, which internally performs `fetchI18nBundle`.
- new metadata entry `i18n:"@ui5/webcomponents"` to declare component would need translation.
- UI5Element preloads translations if the above metadata entry is used.
- Magic: UI5Element creates method on the component constructor - `constructor.getI18nText`.

Look at the `Badge.js` to see the difference in the usage of i18n bundle.
How this approach would look like if a component needs translations from more than 1 bundle?