### PR TITLE
refactor(ui5-input): stop importing StandardListItem and CustomListItem

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -55,6 +55,10 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> The suggestion would be displayed only if the <code>showSuggestions</code>
 		 * property is set to <code>true</code>.
+		 * <br><br>
+		 * <b>Note:</b> The &lt;ui5-li> and  &lt;ui5-li-custom> are recommended to be used as suggestion items.
+		 * <br>
+		 * In order to use them, you need to import either <code>"@ui5/webcomponents/dist/StandardListItem"</code>, or  <code>"@ui5/webcomponents/dist/CustomListItem"</code> module.
 		 *
 		 * @type {HTMLElement[]}
 		 * @slot
@@ -191,7 +195,9 @@ const metadata = {
 
 		/**
 		 * Defines whether the <code>ui5-input</code> should show suggestions, if such are present.
-		 *
+		 * <br><br>
+		 * <b>Note:</b>
+		 * Don`t forget to import the <code>InputSuggestions</code> module from "@ui5/webcomponents/dist/features/InputSuggestions.js" to enable this functionality.
 		 * @type {Boolean}
 		 * @defaultvalue false
 		 * @public

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -2,12 +2,6 @@ import { registerFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.j
 
 import List from "../List.js";
 import Popover from "../Popover.js";
-import StandardListItem from "../StandardListItem.js"; // ensure <ui5-li> is loaded
-import CustomListItem from "../CustomListItem.js"; // ensure <ui5-li-custom> is loaded
-
-(function noTreeShaked() {
-	`${StandardListItem}${CustomListItem}`; //eslint-disable-line
-}());
 
 /**
  * A class to manage the <code>Input</code suggestion items.

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
@@ -72,7 +72,7 @@
 	<section>
 		<h3>Input With Suggestions (Note: the usage depends on the framework you are using)</h3>
 		<div class="snippet">
-			<ui5-input id="suggestions-input" class="samples-padding samples-responsive-padding-bottom input-width" placeholder="Start typing country name" show-suggestions>
+			<ui5-input id="suggestions-input" class="samples-responsive-padding-bottom input-width" placeholder="Start typing country name" show-suggestions>
 			</ui5-input>
 
 			<script>


### PR DESCRIPTION
The ui5-input with suggestions used to import both StandardListItem and CustomListItem,
but It`s better to let this to the consumer. The consumer can decide to import the one or the other (or both) or not use them at all, although usage of other items will not work as expected.
* Remove StandardListItem and CustomListItem imports.
* Update API doc, recommending to use StandardListItem or CustomListItem items.
* Fix unrelated sample issue - the placeholder of the input below has been misaligned due to obsolete styling.

before:
<img width="342" alt="Screenshot 2019-09-02 at 13 49 21" src="https://user-images.githubusercontent.com/15702139/64110846-db01fe80-cd8b-11e9-9c9f-760cf4c29597.png">

after:
<img width="348" alt="Screenshot 2019-09-02 at 13 49 16" src="https://user-images.githubusercontent.com/15702139/64110872-ea814780-cd8b-11e9-8d85-da97cd517b83.png">

BREAKING CHANGE: `ui5-input` with suggestions no longer loads `ui5-li `and `ui5-li-custom` items, you need to explicitly import them.
