### PR TITLE
chore(ui5-textarea): remove unused private property

### DIFF
--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import CSSSize from "@ui5/webcomponents-base/dist/types/CSSSize.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
@@ -179,12 +178,6 @@ const metadata = {
 		 */
 		exceeding: {
 			type: Boolean,
-		},
-
-		_height: {
-			type: CSSSize,
-			defaultValue: null,
-			noAttribute: true,
 		},
 
 		_mirrorText: {


### PR DESCRIPTION
The "_height" private property is removed as it is not used. This way we are one step closer to remove the "CSSSize" type.