### PR TITLE
fix: DOMEventHandler does not crash in edge cases

### DIFF
--- a/packages/base/src/DOMEventHandler.js
+++ b/packages/base/src/DOMEventHandler.js
@@ -42,7 +42,7 @@ const dispatchEvent = function dispatchEvent(element, event) {
 const getParentDOMNode = function getParentDOMNode(node) {
 	const parentNode = node.parentNode;
 
-	if (parentNode && parentNode.host) {
+	if (parentNode && (parentNode instanceof window.ShadowRoot) && parentNode.host) {
 		return parentNode.host;
 	}
 


### PR DESCRIPTION
When a form element contains an input with name equal to "host", the form itself gets a "host" property, making the DOMEventHandler.js loop infinitely. The new check makes sure host is accessed only from shadow roots.