### PR TITLE
refactor: provide better CSS encapsulation for IE

### DIFF
--- a/packages/base/src/CSS.js
+++ b/packages/base/src/CSS.js
@@ -3,7 +3,8 @@ import { getTheme } from "./config/Theme.js";
 import { injectWebComponentStyle } from "./theming/StyleInjection.js";
 import adaptCSSForIE from "./util/CSSTransformUtils.js";
 
-const styleMap = new Map();
+const constructableStyleMap = new Map();
+const IEStyleSet = new Set();
 
 /**
  * Creates the needed CSS for a web component class in the head tag
@@ -12,9 +13,14 @@ const styleMap = new Map();
  */
 const createHeadStyle = ElementClass => {
 	const tag = ElementClass.getMetadata().getTag();
+	if (IEStyleSet.has(tag)) {
+		return;
+	}
+
 	let cssContent = getEffectiveStyle(ElementClass);
 	cssContent = adaptCSSForIE(cssContent, tag);
 	injectWebComponentStyle(tag, cssContent);
+	IEStyleSet.add(tag);
 };
 
 /**
@@ -28,14 +34,14 @@ const getConstructableStyle = ElementClass => {
 	const styleContent = getEffectiveStyle(ElementClass);
 	const theme = getTheme();
 	const key = theme + tagName;
-	if (styleMap.has(key)) {
-		return styleMap.get(key);
+	if (constructableStyleMap.has(key)) {
+		return constructableStyleMap.get(key);
 	}
 
 	const style = new CSSStyleSheet();
 	style.replaceSync(styleContent);
 
-	styleMap.set(key, style);
+	constructableStyleMap.set(key, style);
 	return style;
 };
 

--- a/packages/base/src/CSS.js
+++ b/packages/base/src/CSS.js
@@ -1,7 +1,7 @@
 import { getEffectiveStyle } from "./Theming.js";
 import { getTheme } from "./config/Theme.js";
 import { injectWebComponentStyle } from "./theming/StyleInjection.js";
-import replaceSelectors from "./util/CSSTransformUtils.js";
+import adaptCSSForIE from "./util/CSSTransformUtils.js";
 
 const styleMap = new Map();
 
@@ -53,13 +53,6 @@ const getShadowRootStyle = ElementClass => {
 	const styleContent = getEffectiveStyle(ElementClass);
 	return styleContent;
 };
-
-const adaptCSSForIE = (css, tag) => {
-	css = replaceSelectors(css, ":host", tag);
-	css = replaceSelectors(css, "::slotted", ``);
-	return css;
-};
-
 
 // eslint-disable-next-line
 export { createHeadStyle, getConstructableStyle, getShadowRootStyle};

--- a/packages/base/src/theming/StyleInjection.js
+++ b/packages/base/src/theming/StyleInjection.js
@@ -1,6 +1,5 @@
 import createStyleInHead from "../util/createStyleInHead.js";
 
-const injectedForTags = [];
 let ponyfillTimer;
 
 const ponyfillNeeded = () => !!window.CSSVarsPonyfill;
@@ -48,14 +47,10 @@ const injectThemeProperties = cssText => {
  */
 const injectWebComponentStyle = (tagName, cssText) => {
 	// Edge and IE
-	if (injectedForTags.indexOf(tagName) !== -1) {
-		return;
-	}
 	createStyleInHead(cssText, {
 		"data-ui5-element-styles": tagName,
 		"disabled": "disabled",
 	});
-	injectedForTags.push(tagName);
 
 	// When injecting component styles, more might come in the same tick, so run the ponyfill async (to avoid double work)
 	if (ponyfillNeeded()) {

--- a/packages/base/src/util/CSSTransformUtils.js
+++ b/packages/base/src/util/CSSTransformUtils.js
@@ -45,7 +45,7 @@ const replaceSelectors = (str, selector, replacement) => {
 };
 
 const adaptLinePart = (line, tag) => {
-	line = replaceSelectors(line, "::slotted", tag); // first remove all ::slotted() occurrences
+	line = replaceSelectors(line, "::slotted", ``); // first remove all ::slotted() occurrences
 
 	// Host selector - replace it
 	if (line.startsWith(":host")) {
@@ -53,7 +53,13 @@ const adaptLinePart = (line, tag) => {
 	}
 
 	// IE specific selector (directly written with the tag) - keep it
-	if (line.startsWith(tag)) {
+	// Note: a space must be matched after the tag, otherwise f.e. for ui5-timeline, selectors such as ui5-timeline-item won't be adapted
+	if (line.startsWith(`${tag} `)) {
+		return line;
+	}
+
+	// Leave out @keyframes and keyframe values (0%, 100%, etc...)
+	if (line.match(/^[@0-9]/)) {
 		return line;
 	}
 

--- a/packages/base/src/util/CSSTransformUtils.js
+++ b/packages/base/src/util/CSSTransformUtils.js
@@ -44,4 +44,39 @@ const replaceSelectors = (str, selector, replacement) => {
 	return str;
 };
 
-export default replaceSelectors;
+const adaptLinePart = (line, tag) => {
+	line = replaceSelectors(line, "::slotted", tag); // first remove all ::slotted() occurrences
+
+	// Host selector - replace it
+	if (line.startsWith(":host")) {
+		return replaceSelector(line, ":host", 0, tag);
+	}
+
+	// IE specific selector (directly written with the tag) - keep it
+	if (line.startsWith(tag)) {
+		return line;
+	}
+
+	// No host and no tag in the beginning of the selector - prepend the tag
+	return `${tag} ${line}`;
+};
+
+const adaptCSSForIE = (str, tag) => {
+	str = str.replace(/([{}])/g, `$1\n`);
+	let result = ``;
+	const lines = str.split(`\n`);
+	lines.forEach(line => {
+		const mustProcess = line.match(/{$/); // Only work on lines that end on {, otherwise just append to result
+		if (mustProcess) {
+			const lineParts = line.split(",");
+			const processedLineParts = lineParts.map(linePart => {
+				return adaptLinePart(linePart, tag);
+			});
+			line = processedLineParts.join(",");
+		}
+		result = `${result}${line}`;
+	});
+	return result;
+};
+
+export default adaptCSSForIE;

--- a/packages/base/src/util/CSSTransformUtils.js
+++ b/packages/base/src/util/CSSTransformUtils.js
@@ -53,8 +53,7 @@ const adaptLinePart = (line, tag) => {
 	}
 
 	// IE specific selector (directly written with the tag) - keep it
-	// Note: a space must be matched after the tag, otherwise f.e. for ui5-timeline, selectors such as ui5-timeline-item won't be adapted
-	if (line.startsWith(`${tag} `)) {
+	if (line.match(new RegExp(`^${tag}[^a-zA-Z0-9-]`))) {
 		return line;
 	}
 
@@ -68,6 +67,7 @@ const adaptLinePart = (line, tag) => {
 };
 
 const adaptCSSForIE = (str, tag) => {
+	str = str.replace(/\n/g, ` `);
 	str = str.replace(/([{}])/g, `$1\n`);
 	let result = ``;
 	const lines = str.split(`\n`);

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -20,7 +20,7 @@
 	padding: 0 0.3125em;
 }
 
-:host ::slotted(ui5-icon) {
+::slotted(ui5-icon) {
 	width: 0.75em;
 	height: 0.75em;
 	flex-shrink: 0;

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -116,7 +116,7 @@
 	border: 0;
 }
 
-:host bdi {
+bdi {
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -170,7 +170,7 @@
 	width: var(--sap_wc_input_compact_min_width);
 }
 
-:host ::slotted(ui5-icon) {
+::slotted(ui5-icon) {
 	padding: var(--_ui5_input_icon_padding);
 }
 

--- a/packages/main/src/themes/ShellBar.css
+++ b/packages/main/src/themes/ShellBar.css
@@ -35,7 +35,7 @@
 }
 
 /* IE does not apply all selectors if separated by comma and 1 is invalid; TODOs - Keep that in sync and recheck after Shady CSS */
-:host ::slotted(ui5-icon) {
+::slotted(ui5-icon) {
 	height: 2.25rem;
 	padding: 0;
 	margin-left: 0.5rem;
@@ -363,19 +363,19 @@
 	height: 2.25rem;
 }
 
-:host ::slotted(ui5-input) {
+::slotted(ui5-input) {
 	background-color: var(--sapUiShellColor);
 	border: 1px solid var(--sapUiShellBorderColorLighten30);
 	color: var(--sapUiShellTextColor);
 	height: 100%;
 }
 
-:host ::slotted(ui5-input:hover) {
+::slotted(ui5-input:hover) {
 	background: var(--sapUiShellHoverBackground);
 	border: 1px solid var(--sapUiShellBorderColorLighten30);
 }
 
-:host ::slotted(ui5-input[focused]) {
+::slotted(ui5-input[focused]) {
 	outline: 1px dotted var(--sapUiContentContrastFocusColor);
 }
 
@@ -423,7 +423,7 @@
 	margin-right: 0;
 }
 
-:host ::slotted(ui5-icon) {
+::slotted(ui5-icon) {
 	width: .75rem;
 	height: .75rem;
 	margin-right: 0.5rem;
@@ -434,16 +434,16 @@
 	box-sizing: content-box;
 }
 
-:host ::slotted(ui5-icon:hover) {
+::slotted(ui5-icon:hover) {
 	background: var(--sapUiShellHoverBackground);
 }
 
-:host ::slotted(ui5-icon:active) {
+::slotted(ui5-icon:active) {
 	background: var(--sapUiShellActiveBackground);
 	color: var(--sapUiShellActiveTextColor);
 }
 
-:host ::slotted(ui5-icon:focus)::after {
+::slotted(ui5-icon:focus)::after {
 	content: "";
 	position: absolute;
 	width: calc(100% - 0.375rem);

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -3,7 +3,7 @@
 	width: 100%;
 }
 
-:host table {
+table {
 	width: 100%;
 	border-spacing: 0;
 	border-collapse: collapse;
@@ -16,7 +16,7 @@
 	font-size: var(--sapMFontMediumSize);
 }
 
-:host tr {
+tr {
 	height: 3rem;
 }
 

--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -2,7 +2,7 @@
 	display: contents;
 }
 
-:host td {
+td {
 	padding: 0.25rem;
 	vertical-align: middle;
 }

--- a/packages/main/src/themes/TableColumn.css
+++ b/packages/main/src/themes/TableColumn.css
@@ -7,7 +7,7 @@
 	box-sizing: border-box;
 }
 
-:host th {
+th {
 	background: var(--sapUiListHeaderBackground);
 	border-bottom: 1px solid var(--sapUiListBorderColor);
 	border: none;


### PR DESCRIPTION
- automatically add the tag before each selector that doesn't have it
- replace :host
- replace ::slotted

- revert all CSS selectors that had :host added artificially due to the previous algorithm