### PR TITLE
fix(ui5-input): use translated text

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -619,7 +619,7 @@ class Input extends UI5Element {
 	}
 
 	get suggestionsText() {
-		return INPUT_SUGGESTIONS.defaultText;
+		return this.i18nBundle.getText(INPUT_SUGGESTIONS);
 	}
 
 	static async define(...params) {


### PR DESCRIPTION
"Suggestions available" is now correctly translated.
