### PR TITLE
fix(ui5-messagestrip): correct text color in HCB

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -109,8 +109,6 @@ const metadata = {
 		/**
 		 * Defines a short hint, intended to aid the user with data entry when the
 		 * <code>ui5-datepicker</code> has no value.
-		 * <br><br>
-		 * <b>Note:</b> The placeholder is not supported in IE. If the placeholder is provided, it won`t be displayed in IE.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -91,8 +91,6 @@ const metadata = {
 		/**
 		 * Defines a short hint intended to aid the user with data entry when the
 		 * <code>ui5-input</code> has no value.
-		 * <br><br>
-		 * <b>Note:</b> The placeholder is not supported in IE. If the placeholder is provided, it won`t be displayed in IE.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -183,15 +183,6 @@ class MessageStrip extends UI5Element {
 		super.define(...params);
 	}
 
-	static typeClassesMappings() {
-		return {
-			"Information": "ui5-messagestrip--info",
-			"Positive": "ui5-messagestrip--positive",
-			"Negative": "ui5-messagestrip--negative",
-			"Warning": "ui5-messagestrip--warning",
-		};
-	}
-
 	static iconMappings() {
 		return {
 			"Information": "sap-icon://message-information",
@@ -219,17 +210,12 @@ class MessageStrip extends UI5Element {
 				"ui5-messagestrip-root": true,
 				"ui5-messagestrip-icon--hidden": this.noIcon,
 				"ui5-messagestrip-close-icon--hidden": this.noCloseButton,
-				[this.typeClasses]: true,
 			},
 		};
 	}
 
 	get messageStripIcon() {
 		return this.icon || MessageStrip.iconMappings()[this.type];
-	}
-
-	get typeClasses() {
-		return MessageStrip.typeClassesMappings()[this.type];
 	}
 }
 

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -59,8 +59,6 @@ const metadata = {
 		/**
 		 * Defines a short hint intended to aid the user with data entry when the
 		 * <code>ui5-multi-combobox</code> has no value.
-		 * <br><br>
-		 * <b>Note:</b> The placeholder is not supported in IE. If the placeholder is provided, it won`t be displayed in IE.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -17,6 +17,7 @@ ui5-messagestrip:not([hidden]) {
 	border-radius: var(--_ui5_messagestrip_border_radius);
 	padding: var(--_ui5_messagestrip_padding);
 	border-width: var(--_ui5_messagestrip_border_width);
+	color: var(--sapUiBaseText);
 	border-style: solid;
 	box-sizing: border-box;
 	padding: 0.4375rem 2rem 0.4375rem 2.5rem;
@@ -52,7 +53,6 @@ ui5-messagestrip:not([hidden]) {
 .ui5-messagestrip--info {
 	background-color: var(--sapUiNeutralBG);
 	border-color: var(--sapUiNeutralBorder);
-	color: var(--sapUiBaseText);
 }
 
 .ui5-messagestrip--info .ui5-messagestrip-icon {

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -14,11 +14,12 @@ ui5-messagestrip:not([hidden]) {
 	width: 100%;
 	height: 100%;
 	display: flex;
-	border-radius: var(--_ui5_messagestrip_border_radius);
+	background-color: var(--sapUiNeutralBG);
 	padding: var(--_ui5_messagestrip_padding);
+	border-radius: var(--_ui5_messagestrip_border_radius);
 	border-width: var(--_ui5_messagestrip_border_width);
-	color: var(--sapUiBaseText);
 	border-style: solid;
+	border-color: var(--sapUiNeutralBorder);
 	box-sizing: border-box;
 	padding: 0.4375rem 2rem 0.4375rem 2.5rem;
 	position: relative;
@@ -29,6 +30,7 @@ ui5-messagestrip:not([hidden]) {
 	top: var(--_ui5_messagestrip_icon_top);
 	left: 0.75rem;
 	box-sizing: border-box;
+	color: var(--sapUiNeutralElement);
 }
 
 .ui5-messagestrip-root .ui5-messagestrip-text {
@@ -50,39 +52,30 @@ ui5-messagestrip:not([hidden]) {
 	font-size: var(--sapMFontMediumSize);
 }
 
-.ui5-messagestrip--info {
-	background-color: var(--sapUiNeutralBG);
-	border-color: var(--sapUiNeutralBorder);
-}
-
-.ui5-messagestrip--info .ui5-messagestrip-icon {
-	color: var(--sapUiNeutralElement);
-}
-
-.ui5-messagestrip--positive {
+:host(ui5-messagestrip[type="Positive"]) .ui5-messagestrip-root {
 	background-color: var(--sapUiSuccessBG);
 	border-color: var(--sapUiSuccessBorder);
 }
 
-.ui5-messagestrip--positive .ui5-messagestrip-icon {
+:host(ui5-messagestrip[type="Positive"]) .ui5-messagestrip-icon {
 	color: var(--sapUiPositiveElement);
 }
 
-.ui5-messagestrip--negative {
+:host(ui5-messagestrip[type="Negative"]) .ui5-messagestrip-root {
 	background-color: var(--sapUiErrorBG);
 	border-color: var(--sapUiErrorBorder);
 }
 
-.ui5-messagestrip--negative .ui5-messagestrip-icon {
+:host(ui5-messagestrip[type="Negative"]) .ui5-messagestrip-icon {
 	color: var(--sapUiNegativeElement);
 }
 
-.ui5-messagestrip--warning {
+:host(ui5-messagestrip[type="Warning"]) .ui5-messagestrip-root {
 	background-color: var(--sapUiWarningBG);
 	border-color: var(--sapUiWarningBorder);
 }
 
-.ui5-messagestrip--warning .ui5-messagestrip-icon {
+:host(ui5-messagestrip[type="Warning"]) .ui5-messagestrip-icon {
 	color: var(--sapUiCriticalElement);
 }
 


### PR DESCRIPTION
-  Fix the text color for Warning, Success and Negative states, which used to remain black in HCB
- Make use of attributes instead of CSS Classes
- Update Input, MultiComboBox, DatePicker API about the support of placeholder