### PR TITLE
fix(ui5-button): fix Transparent button border in Fiori 3 & HCB

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -219,7 +219,7 @@ bdi {
 	background-color: var(--sapUiButtonLiteBackground);
 	color: var(--sapUiButtonLiteTextColor);
 	text-shadow: var(--_ui5_button_text_shadow);
-	border-color: var(--_ui5_button_tansparent_border_color);
+	border-color: var(--_ui5_button_transparent_border_color);
 }
 
 :host([design="Transparent"]):hover {

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -217,10 +217,9 @@ bdi {
 
 :host([design="Transparent"]) {
 	background-color: var(--sapUiButtonLiteBackground);
-	border-color: var(--sapUiButtonLiteBorderColor);
 	color: var(--sapUiButtonLiteTextColor);
 	text-shadow: var(--_ui5_button_text_shadow);
-	border-color: transparent;
+	border-color: var(--_ui5_button_tansparent_border_color);
 }
 
 :host([design="Transparent"]):hover {
@@ -234,7 +233,7 @@ bdi {
 }
 
 :host([design="Transparent"]:not([active]):hover) {
-	border-color: transparent;
+	border-color: var(--_ui5_button_transparent_hover_border_color);
 }
 
 /* IE Specific CSS */

--- a/packages/main/src/themes/base/Button-parameters.css
+++ b/packages/main/src/themes/base/Button-parameters.css
@@ -17,7 +17,7 @@
 	--_ui5_button_focus_width: 1px;
 	--_ui5_button_focus_color: var(--sapUiContentFocusColor);
 
-	--_ui5_button_tansparent_border_color: transparent;
+	--_ui5_button_transparent_border_color: transparent;
 	--_ui5_button_transparent_hover_border_color: var(--sapUiButtonBorderColor);
 	--_ui5_button_active_border_color: var(--sapUiButtonActiveBorderColor);
 	--_ui5_button_positive_border_color: var(--sapUiButtonAcceptBorderColor);

--- a/packages/main/src/themes/base/Button-parameters.css
+++ b/packages/main/src/themes/base/Button-parameters.css
@@ -17,7 +17,8 @@
 	--_ui5_button_focus_width: 1px;
 	--_ui5_button_focus_color: var(--sapUiContentFocusColor);
 
-
+	--_ui5_button_tansparent_border_color: transparent;
+	--_ui5_button_transparent_hover_border_color: var(--sapUiButtonBorderColor);
 	--_ui5_button_active_border_color: var(--sapUiButtonActiveBorderColor);
 	--_ui5_button_positive_border_color: var(--sapUiButtonAcceptBorderColor);
 	--_ui5_button_positive_border_hover_color: var(--sapUiButtonAcceptHoverBorderColor);

--- a/packages/main/src/themes/sap_belize/Button-parameters.css
+++ b/packages/main/src/themes/sap_belize/Button-parameters.css
@@ -1,1 +1,5 @@
 @import "../base/Button-parameters.css";
+
+:root {
+	--_ui5_button_transparent_hover_border_color: transparent;
+}

--- a/packages/main/src/themes/sap_belize_hcb/Button-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Button-parameters.css
@@ -9,7 +9,7 @@
 	--_ui5_button_positive_focus_border_color: transparent;
 	--_ui5_button_negative_focus_border_color: transparent;
 	--_ui5_button_negative_active_border_color: transparent;
-	--_ui5_button_tansparent_border_color: var(--sapUiButtonBorderColor);
+	--_ui5_button_transparent_border_color: var(--sapUiButtonBorderColor);
 	--_ui5_button_focus_width: 1px;
 	--_ui5_button_focus_color: var(--sapUiContentFocusColor);
 	--_ui5_button_focussed_border_color: transparent;

--- a/packages/main/src/themes/sap_belize_hcb/Button-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Button-parameters.css
@@ -9,6 +9,7 @@
 	--_ui5_button_positive_focus_border_color: transparent;
 	--_ui5_button_negative_focus_border_color: transparent;
 	--_ui5_button_negative_active_border_color: transparent;
+	--_ui5_button_tansparent_border_color: var(--sapUiButtonBorderColor);
 	--_ui5_button_focus_width: 1px;
 	--_ui5_button_focus_color: var(--sapUiContentFocusColor);
 	--_ui5_button_focussed_border_color: transparent;


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/788
Two corrections:
- Border provided for Transparent button upon hover in Fiori 3:
<img width="180" alt="Screenshot 2019-09-24 at 16 58 53" src="https://user-images.githubusercontent.com/15702139/65518308-c75e3980-deec-11e9-8ecc-fe47d8c9cb44.png">

- In HCB there should be always a border even for Transparent button (hovered or not):
<img width="186" alt="Screenshot 2019-09-24 at 16 58 16" src="https://user-images.githubusercontent.com/15702139/65518477-08564e00-deed-11e9-8d25-abe240d983aa.png">
<img width="187" alt="Screenshot 2019-09-24 at 16 59 13" src="https://user-images.githubusercontent.com/15702139/65518481-0a201180-deed-11e9-92c8-8e83a25f7b16.png">

Note:
- However, in Belize there is no border on hover for Transparent button and this is kept as it is currently:
<img width="189" alt="Screenshot 2019-09-24 at 17 04 52" src="https://user-images.githubusercontent.com/15702139/65518777-8581c300-deed-11e9-9599-e08f48385f35.png">

