### PR TITLE
chore: update contact info

### DIFF
--- a/packages/playground/webapp/index.html
+++ b/packages/playground/webapp/index.html
@@ -176,7 +176,8 @@
                         <h2>Contact Us</h2>
                         <div class="links">
                             <a href="https://github.com/SAP/ui5-webcomponents/issues/new" target="_blank">Report Issue</a>
-                            <a href="mailto:openui5@sap.com">Contact Us</a>
+                            <a href="https://openui5.slack.com/" target="_blank">Technical Questions</a>
+                            <a href="mailto:openui5@sap.com?subject=[UI5 Web Components]">Product Questions</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The purpose of this change is to make it clearer that the email should be used for high level product-related questions, and technical questions should be asked in slack. Also, a subject is pre-populated so that it can be distinguished from OpenUI5.