### PR TITLE
refactor(ui5-panel): align toggle button visual design

### DIFF
--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -38,15 +38,10 @@
 }
 
 .ui5-panel-header-button {
-	cursor: pointer;
-	color: var(--sapUiContentIconColor);
-	border: none;
-	background: none;
 	min-width: 2rem;
 	width: 2rem;
 	height: 2rem;
 	transition: transform 0.4s ease-out;
-	border: 1px solid transparent;
 }
 
 .ui5-panel-header-button-icon {
@@ -54,28 +49,8 @@
 	color: inherit;
 }
 
-.ui5-panel-header-button[focused] {
-	outline-style: var(--_ui5_panel_header_button_outline_style);
-	outline-offset: -.25rem;
-}
-
-.ui5-panel-header-button:hover {
-	background: var(--_ui5_panel_header_button_hover_background_color);
-	border: 1px solid var(--_ui5_panel_header_button_hover_border_color);
-}
-
-.ui5-panel-header-button[active] {
-	background: var(--_ui5_panel_header_button_active_background_color);
-	border: 1px solid var(--_ui5_panel_header_button_active_border_color);
-	outline-color: var(--sapUiContentFocusColor);
-}
-
 :host(:not([_has-header])) .ui5-panel-header-button {
 	pointer-events: none;
-}
-
-:host(:not([_has-header])) .ui5-panel-header-button:focus {
-	outline: none;
 }
 
 :host(:not([_has-header]):not([fixed])) {
@@ -109,10 +84,4 @@
 	align-items: center;
 	width: var(--_ui5_panel_button_root_width);
 	margin-right: .25rem;
-}
-
-/* IE specific CSS */
-
-ui5-panel .ui5-panel-header-button[focused] {
-	outline: none;
 }

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -62,13 +62,12 @@
 .ui5-panel-header-button:hover {
 	background: var(--_ui5_panel_header_button_hover_background_color);
 	border: 1px solid var(--_ui5_panel_header_button_hover_border_color);
-	color: var(--_ui5_panel_header_button_hover_color);
 }
 
 .ui5-panel-header-button[active] {
 	background: var(--_ui5_panel_header_button_active_background_color);
 	border: 1px solid var(--_ui5_panel_header_button_active_border_color);
-	color: var(--_ui5_panel_header_button_active_color);
+	outline-color: var(--sapUiContentFocusColor);
 }
 
 :host(:not([_has-header])) .ui5-panel-header-button {

--- a/packages/main/src/themes/base/Panel-parameters.css
+++ b/packages/main/src/themes/base/Panel-parameters.css
@@ -2,9 +2,9 @@
 	--_ui5_panel_focus_border: 1px dotted var(--sapUiContentFocusColor);
 	--_ui5_panel_header_height: 3rem;
 	--_ui5_panel_header_title_size: var(--sapMFontHeader4Size);
-	--_ui5_panel_header_button_outline_style: dashed;
-	--_ui5_panel_header_button_hover_background_color: white;
-	--_ui5_panel_header_button_active_background_color: white;
+	--_ui5_panel_header_button_outline_style: dotted;
+	--_ui5_panel_header_button_hover_background_color: transparent;
+	--_ui5_panel_header_button_active_background_color: transparent;
 	--_ui5_panel_header_button_hover_color: var(--sapUiContentIconColor);
 	--_ui5_panel_header_button_active_color: var(--sapUiContentIconColor);
 	--_ui5_panel_header_button_hover_border_color: transparent;

--- a/packages/main/src/themes/base/Panel-parameters.css
+++ b/packages/main/src/themes/base/Panel-parameters.css
@@ -2,12 +2,5 @@
 	--_ui5_panel_focus_border: 1px dotted var(--sapUiContentFocusColor);
 	--_ui5_panel_header_height: 3rem;
 	--_ui5_panel_header_title_size: var(--sapMFontHeader4Size);
-	--_ui5_panel_header_button_outline_style: dotted;
-	--_ui5_panel_header_button_hover_background_color: transparent;
-	--_ui5_panel_header_button_active_background_color: transparent;
-	--_ui5_panel_header_button_hover_color: var(--sapUiContentIconColor);
-	--_ui5_panel_header_button_active_color: var(--sapUiContentIconColor);
-	--_ui5_panel_header_button_hover_border_color: transparent;
-	--_ui5_panel_header_button_active_border_color: transparent;
 	--_ui5_panel_button_root_width: 3rem;
 }

--- a/packages/main/src/themes/sap_belize_hcb/Panel-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Panel-parameters.css
@@ -2,5 +2,4 @@
 
 :root {
 	--_ui5_panel_focus_border: 0.125rem dotted var(--sapUiContentFocusColor);
-	--_ui5_panel_header_button_outline_style: dashed;
 }

--- a/packages/main/src/themes/sap_belize_hcb/Panel-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Panel-parameters.css
@@ -2,6 +2,5 @@
 
 :root {
 	--_ui5_panel_focus_border: 0.125rem dotted var(--sapUiContentFocusColor);
-	--_ui5_panel_header_button_active_background_color: transparent;
-	--_ui5_panel_header_button_hover_background_color: transparent;
+	--_ui5_panel_header_button_outline_style: dashed;
 }

--- a/packages/main/src/themes/sap_fiori_3/Panel-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/Panel-parameters.css
@@ -3,7 +3,5 @@
 :root {
 	--_ui5_panel_header_height: 2.75rem;
 	--_ui5_panel_header_title_size: var(--sapMFontHeader5Size);
-	--_ui5_panel_header_button_hover_color: var(--sapUiButtonLiteTextColor);
-	--_ui5_panel_header_button_active_color: var(--sapUiButtonActiveTextColor);
 	--_ui5_panel_button_root_width: 2.75rem;
 }

--- a/packages/main/src/themes/sap_fiori_3/Panel-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/Panel-parameters.css
@@ -3,12 +3,7 @@
 :root {
 	--_ui5_panel_header_height: 2.75rem;
 	--_ui5_panel_header_title_size: var(--sapMFontHeader5Size);
-	--_ui5_panel_header_button_outline_style: dotted;
-	--_ui5_panel_header_button_hover_background_color: var(--sapUiButtonLiteHoverBackground);
-	--_ui5_panel_header_button_active_background_color: var(--sapUiButtonLiteActiveBackground);;
 	--_ui5_panel_header_button_hover_color: var(--sapUiButtonLiteTextColor);
 	--_ui5_panel_header_button_active_color: var(--sapUiButtonActiveTextColor);
-	--_ui5_panel_header_button_hover_border_color: var(--sapUiButtonHoverBorderColor);;
-	--_ui5_panel_header_button_active_border_color: var(--sapUiButtonLiteActiveBorderColor);;
 	--_ui5_panel_button_root_width: 2.75rem;
 }


### PR DESCRIPTION
The latest design suggests that the ui5-panel's expand/collapse button should be the same as a Transparent ui5-button. We used to have significant amount of additional css, that is no longer needed as we use Transparent ui5-button already. All the css (other than sizing) and css properties  are removed.
Note: The following design is for Fiori 3 (quartz), but we will apply it for Fiori 2 (belize) as well.

