### PR TITLE
feat(ui5-list): added new param for selectionChange event

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -292,7 +292,7 @@ class List extends UI5Element {
 		this._selectionRequested = true;
 
 		if (this[`handle${this.mode}`]) {
-			selectionChange = this[`handle${this.mode}`](event.detail.item, event.selected);
+			selectionChange = this[`handle${this.mode}`](event.detail.item, event.detail.selected);
 		}
 
 		if (selectionChange) {
@@ -456,8 +456,8 @@ class List extends UI5Element {
 				detail: {
 					item: pressedItem,
 					selectionComponentPressed: false,
+					selected: !pressedItem.selected,
 				},
-				selected: !pressedItem.selected,
 			});
 		}
 

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -167,12 +167,15 @@ const metadata = {
 		 * @event
 		 * @param {Array} selectedItems an array of the selected items.
 		 * @param {Array} previouslySelectedItems an array of the previously selected items.
+		 * @param {Boolean} selectionComponentPressed a boolean indicating if the user used the selection components
+		 * in SingleSelection(ui5-radiobutton) and MultiSelection(ui5-checkbox) modes to change the selection.
 		 * @public
 		 */
 		selectionChange: {
 			detail: {
 				selectedItems: { type: Array },
 				previouslySelectedItems: { type: Array },
+				selectionComponentPressed: { type: Boolean },
 			},
 		},
 	},
@@ -293,7 +296,11 @@ class List extends UI5Element {
 		}
 
 		if (selectionChange) {
-			this.fireEvent("selectionChange", { selectedItems: this.getSelectedItems(), previouslySelectedItems });
+			this.fireEvent("selectionChange", {
+				selectedItems: this.getSelectedItems(),
+				previouslySelectedItems,
+				selectionComponentPressed: event.detail.selectionComponentPressed,
+			});
 		}
 	}
 
@@ -448,6 +455,7 @@ class List extends UI5Element {
 			this.onSelectionRequested({
 				detail: {
 					item: pressedItem,
+					selectionComponentPressed: false,
 				},
 				selected: !pressedItem.selected,
 			});

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -34,7 +34,7 @@
 				id="{{_id}}-singleSelectionElement"
 				class="ui5-li-singlesel-radiobtn"
 				?selected="{{selected}}"
-				@click="{{onSelectionComponentPress}}">
+				@click="{{onSingleSelectionComponentPress}}">
 		</ui5-radiobutton>
 	{{/if}}
 
@@ -43,7 +43,7 @@
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"
-				@click="{{onSelectionComponentPress}}">
+				@click="{{onMultiSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}
 
@@ -53,7 +53,7 @@
 				id="{{_id}}-deleteSelectionElement"
 				design="Transparent"
 				icon="sap-icon://decline"
-				@ui5-press="{{_onDelete}}"
+				@ui5-press="{{onDelete}}"
 			></ui5-button>
 		</div>
 	{{/if}}

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -33,7 +33,8 @@
 		<ui5-radiobutton
 				id="{{_id}}-singleSelectionElement"
 				class="ui5-li-singlesel-radiobtn"
-				?selected="{{selected}}">
+				?selected="{{selected}}"
+				@click="{{onSelectionComponentPress}}">
 		</ui5-radiobutton>
 	{{/if}}
 
@@ -41,7 +42,8 @@
 		<ui5-checkbox
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
-				?checked="{{selected}}">
+				?checked="{{selected}}"
+				@click="{{onSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}
 

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -186,8 +186,12 @@ class ListItem extends ListItemBase {
 	 * Called when selection components in Single (ui5-radiobutton)
 	 * and Multi (ui5-checkbox) selection modes are used.
 	 */
-	onSelectionComponentPress(event) {
-		this.fireEvent("_selectionRequested", { item: this, selected: event.target.selected, selectionComponentPressed: true });
+	onMultiSelectionComponentPress(event) {
+		this.fireEvent("_selectionRequested", { item: this, selected: !event.target.checked, selectionComponentPressed: true });
+	}
+
+	onSingleSelectionComponentPress(event) {
+		this.fireEvent("_selectionRequested", { item: this, selected: !event.target.selected, selectionComponentPressed: true });
 	}
 
 	activate() {
@@ -196,8 +200,8 @@ class ListItem extends ListItemBase {
 		}
 	}
 
-	_onDelete(event) {
-		this.fireEvent("_selectionRequested", { item: this, selected: event.selected });
+	onDelete(event) {
+		this.fireEvent("_selectionRequested", { item: this, selectionComponentPressed: false });
 	}
 
 	fireItemPress() {

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -182,6 +182,14 @@ class ListItem extends ListItemBase {
 		this.fireItemPress();
 	}
 
+	/*
+	 * Called when selection components in Single (ui5-radiobutton)
+	 * and Multi (ui5-checkbox) selection modes are used.
+	 */
+	onSelectionComponentPress(event) {
+		this.fireEvent("_selectionRequested", { item: this, selected: event.target.selected, selectionComponentPressed: true });
+	}
+
 	activate() {
 		if (this.type === ListItemType.Active) {
 			this.active = true;

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
@@ -47,6 +47,7 @@
 		<ui5-li>Option #2</ui5-li>
 		<ui5-li>Option #3</ui5-li>
 	</ui5-list>
+
 	<ui5-input id="fieldMultiSelResult"></ui5-input>
 
 	<script>

--- a/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/List_test_page.html
@@ -42,6 +42,13 @@
 		<ui5-li image="./img/HT-2002.jpg"  description="2GB RAM, Intel i7 4.5 GHz">DVD set</ui5-li>
 	</ui5-list>
 
+	<ui5-list id="listMultiSel" mode="MultiSelect">
+		<ui5-li id="option1">Option #1</ui5-li>
+		<ui5-li>Option #2</ui5-li>
+		<ui5-li>Option #3</ui5-li>
+	</ui5-list>
+	<ui5-input id="fieldMultiSelResult"></ui5-input>
+
 	<script>
 		'use strict';
 
@@ -67,6 +74,10 @@
 
 		listEvents.addEventListener("ui5-selectionChange", function(event) {
 			selectionChangeResultPreviousItemsParameter.value = event.detail.previouslySelectedItems[0].id;
+		})
+
+		listMultiSel.addEventListener("ui5-selectionChange", function(event) {
+			fieldMultiSelResult.value = event.detail.selectionComponentPressed;
 		})
 	</script>
 </body>

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -28,6 +28,15 @@ describe("Date Picker Tests", () => {
 		assert.strictEqual(secondItem.getProperty("id"), selectionChangeResultPreviousItemsParameter.getProperty("value"));
 	});
 
+	it("selectionChange using selection component", () => {
+		const fieldResult = $("#fieldMultiSelResult");
+		const firstItemSelectionComponent = $("#listMultiSel #option1").shadow$(".ui5-li-multisel-cb");
+
+		firstItemSelectionComponent.click();
+
+		assert.strictEqual(fieldResult.getProperty("value"), "true");
+	});
+
 	it("header text", () => {
 		list.id = "#list1";
 


### PR DESCRIPTION
`selectionComponentPressed` param will be provided along with the `selectionChange` event
to indicate if a selection component is used in SingleSelect (ui5-radiobutton) and MultiSelect (ui5-checkbox) modes to change the selection.