### PR TITLE
fix(ui5-link): fix link hover effect

### DIFF
--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -16,8 +16,8 @@
 	pointer-events: none;
 }
 
-:host([design="Subtle"]):not([disabled]) .ui5-link-root:hover,
-:host([design="Subtle"]):not([disabled]) .ui5-link-root:hover {
+:host(:not([disabled])) .ui5-link-root:hover,
+:host(:not([disabled])) .ui5-link-root:hover {
 	text-decoration: underline;
 	color: var(--sapUiLinkHover);
 }

--- a/packages/main/test/sap/ui/webcomponents/main/pages/Link.html
+++ b/packages/main/test/sap/ui/webcomponents/main/pages/Link.html
@@ -36,6 +36,13 @@
 </head>
 
 <body>
+	<div class="group">
+		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank">Standard Link</ui5-link>
+		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" design="Subtle">Subtle link</ui5-link>
+		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" disabled>Disabled</ui5-link>
+		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" design="Emphasized">Emphasized</ui5-link>
+	</div>
+
 	<section class="group">
 		<h2>cross-origin</h2>
 		<ui5-link href="https://www.google.com" target="_blank" id="link">link</ui5-link><span>native span</span>


### PR DESCRIPTION
Due to previous CSS refactoring we lost the hover effect on the ui5-links, now it is fixed.