### PR TITLE
fix(ui5-tabcontainer): fix selected tab text color in HCB

### DIFF
--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -59,7 +59,7 @@
 }
 
 .ui5-tc__headerItem--selected.ui5-tc__headerItem--textOnly {
-	color: var(--sapUiSelected);
+	color: var(--_ui5_tc_headeritem_text_selected_color);
 }
 
 .ui5-tc__headerItem--selected.ui5-tc__headerItem--textOnly .ui5-tc__headerItemContent::after,

--- a/packages/main/src/themes/base/TabContainer-parameters.css
+++ b/packages/main/src/themes/base/TabContainer-parameters.css
@@ -4,6 +4,7 @@
 
 	/* Header Item */
 	--_ui5_tc_headerItem_color: var(--sapUiGroupTitleTextColor);
+	--_ui5_tc_headeritem_text_selected_color: var(--sapUiSelected); 
 	--_ui5_tc_headerItem_positive_selected_border_color: var(--sapUiPositive);
 	--_ui5_tc_headerItem_negative_selected_border_color: var(--sapUiNegative);
 	--_ui5_tc_headerItem_critical_selected_border_color: var(--sapUiCritical);

--- a/packages/main/src/themes/sap_belize_hcb/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/TabContainer-parameters.css
@@ -15,6 +15,7 @@
 	--_ui5_tc_headerItemIcon_color: var(--sapUiObjectHeaderBorderColor);
 	--_ui5_tc_headerItemIcon_selected_background: var(--sapUiSelected);
 	--_ui5_tc_headerItemIcon_selected_color: var(--sapUiContentIconColor);
+	--_ui5_tc_headeritem_text_selected_color: var(--sapUiObjectHeaderBorderColor);
 	--_ui5_tc_headerItemIcon_positive_selected_background: var(--sapUiSelected);
 	--_ui5_tc_headerItemIcon_negative_selected_background: var(--sapUiSelected);
 	--_ui5_tc_headerItemIcon_critical_selected_background: var(--sapUiSelected);


### PR DESCRIPTION
Fix tab selected text color and ensure proper contrast  ration in HCB.

before:
<img width="542" alt="Screenshot 2019-09-30 at 15 55 15" src="https://user-images.githubusercontent.com/15702139/65880725-eb14fa00-e39a-11e9-99c7-aceefbf81b5d.png">
after:
<img width="551" alt="Screenshot 2019-09-30 at 15 54 30" src="https://user-images.githubusercontent.com/15702139/65880732-ee0fea80-e39a-11e9-8b33-716837718383.png">
