### PR TITLE
fix: hide week number in Islamic, Buddhist Japanese calendars

### DIFF
--- a/packages/main/src/DayPicker.hbs
+++ b/packages/main/src/DayPicker.hbs
@@ -1,13 +1,13 @@
 <div class="ui5-dp-root" style="{{styles.wrapper}}">
 
 	{{#if showWeekNumbers}}
-	<div class="ui5-dp-weeknumber-container">
-		{{#each _weekNumbers}}
-			<div class="ui5-dp-weekname-container">
-				<span class="ui5-dp-weekname">{{this}}</span>
-			</div>
-		{{/each}}
-	</div>
+		<div class="ui5-dp-weeknumber-container">
+			{{#each _weekNumbers}}
+				<div class="ui5-dp-weekname-container">
+					<span class="ui5-dp-weekname">{{this}}</span>
+				</div>
+			{{/each}}
+		</div>
 	{{/if}}
 
 	<div id="{{_id}}-content" class="ui5-dp-content">

--- a/packages/main/src/DayPicker.hbs
+++ b/packages/main/src/DayPicker.hbs
@@ -1,5 +1,6 @@
 <div class="ui5-dp-root" style="{{styles.wrapper}}">
 
+	{{#if showWeekNumbers}}
 	<div class="ui5-dp-weeknumber-container">
 		{{#each _weekNumbers}}
 			<div class="ui5-dp-weekname-container">
@@ -7,6 +8,7 @@
 			</div>
 		{{/each}}
 	</div>
+	{{/if}}
 
 	<div id="{{_id}}-content" class="ui5-dp-content">
 		<div role="row" class="ui5-dp-days-names-container">

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -300,7 +300,7 @@ class DayPicker extends UI5Element {
 		}
 	}
 
-	get showWeekNumbers () {
+	get showWeekNumbers() {
 		return this.primaryCalendarType === CalendarType.Gregorian;
 	}
 

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -300,6 +300,10 @@ class DayPicker extends UI5Element {
 		}
 	}
 
+	get showWeekNumbers () {
+		return this.primaryCalendarType === CalendarType.Gregorian;
+	}
+
 	get _timestamp() {
 		return this.timestamp !== undefined ? this.timestamp : Math.floor(new Date().getTime() / 1000);
 	}

--- a/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
+++ b/packages/main/test/sap/ui/webcomponents/main/samples/Input.sample.html
@@ -214,7 +214,7 @@
 
 	<script>
 		var searchCriteria = "PASTA";
-		searchIcon.addEventListener("press", function(){
+		searchIcon.addEventListener("click", function(){
 			alert("Look for: " + searchCriteria);
 		});
 		searchInput.addEventListener("input", function(e){


### PR DESCRIPTION
The week number does not make sense for Islamic, Buddhist Japanese calendars and show it only for Gregorian calendar.