### PR TITLE
refactor(ui5-panel): remove ui5-icon from hbs template

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -20,15 +20,9 @@
 				aria-expanded="{{expanded}}"
 				?non-focusable="{{nonFocusableButton}}"
 				@click="{{_toggleButtonClick}}"
-			>
-
-				<ui5-icon
-					src="sap-icon://navigation-right-arrow"
-					class="ui5-panel-header-button-icon"
-					accessible-name="{{toggleIconTitle}}"
-				>
-				</ui5-icon>
-			</ui5-button>
+				icon="sap-icon://navigation-right-arrow"
+				title="{{toggleButtonTitle}}"
+			></ui5-button>
 		</div>
 
 		{{#if _hasHeader}}

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -4,7 +4,7 @@ import slideDown from "@ui5/webcomponents-base/dist/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/dist/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/events/PseudoEvents.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import Icon from "./Icon.js";
+import Button from "./Button.js";
 import "./icons/navigation-right-arrow.js";
 import PanelAccessibleRole from "./types/PanelAccessibleRole.js";
 import PanelTemplate from "./generated/templates/PanelTemplate.lit.js";
@@ -294,7 +294,7 @@ class Panel extends UI5Element {
 		return target.classList.contains("sapMPanelWrappingDiv");
 	}
 
-	get toggleIconTitle() {
+	get toggleButtonTitle() {
 		return this.i18nBundle.getText(PANEL_ICON);
 	}
 
@@ -333,7 +333,7 @@ class Panel extends UI5Element {
 	static async define(...params) {
 		await Promise.all([
 			fetchI18nBundle("@ui5/webcomponents"),
-			Icon.define(),
+			Button.define(),
 		]);
 
 		super.define(...params);

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -74,6 +74,7 @@
 .ui5-button-root .ui5-button-icon {
 	font-size: var(--_ui5_button_base_icon_only_font_size);
 	height: 0;
+	min-width: 1rem;
 	top: -.5rem;
 	position: relative;
 	color: inherit;

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -74,7 +74,6 @@
 .ui5-button-root .ui5-button-icon {
 	font-size: var(--_ui5_button_base_icon_only_font_size);
 	height: 0;
-	min-width: 1rem;
 	top: -.5rem;
 	position: relative;
 	color: inherit;

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -38,9 +38,6 @@
 }
 
 .ui5-panel-header-button {
-	min-width: 2rem;
-	width: 2rem;
-	height: 2rem;
 	transition: transform 0.4s ease-out;
 }
 

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -44,11 +44,6 @@
 	transition: transform 0.4s ease-out;
 }
 
-.ui5-panel-header-button-icon {
-	pointer-events: none;
-	color: inherit;
-}
-
 :host(:not([_has-header])) .ui5-panel-header-button {
 	pointer-events: none;
 }
@@ -82,6 +77,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	flex-shrink: 0;
 	width: var(--_ui5_panel_button_root_width);
 	margin-right: .25rem;
 }

--- a/packages/main/test/sap/ui/webcomponents/main/qunit/Panel.qunit.js
+++ b/packages/main/test/sap/ui/webcomponents/main/qunit/Panel.qunit.js
@@ -40,7 +40,7 @@ TestHelper.ready(function () {
 			var panel = this.getPanelRoot();
 
 			assert.ok(panel.querySelector(".ui5-panel-header-content"), "header wrapping div exists");
-			assert.ok(panel.querySelector("ui5-icon"), "expandable icon exists");
+			assert.ok(panel.querySelector("ui5-button"), "expandable icon exists");
 		});
 
 		QUnit.test("The default 'accessibleRole' is 'Form'", function (assert) {


### PR DESCRIPTION
- refactor `ui5-panel` toggle button as following:  remove the `ui5-icon` inside `ui5-button` form the template as it is not needed as we can use `ui5-button` with `icon` property. 
- the `flex-shrink: 0` is needed in order to make the toggle button not move to left and right when the user shrinks or expands the screen
```css
.ui5-panel-header-button-root {flex-shrink: 0}
```


