### PR TITLE
fix(ui5-busyindicator): remove incorrect CSS transformation in IE

### DIFF
--- a/packages/base/src/util/CSSTransformUtils.js
+++ b/packages/base/src/util/CSSTransformUtils.js
@@ -53,13 +53,14 @@ const adaptLinePart = (line, tag) => {
 		return replaceSelector(line, ":host", 0, tag);
 	}
 
-	// IE specific selector (directly written with the tag) - keep it
-	if (line.match(new RegExp(`^${tag}[^a-zA-Z0-9-]`))) {
+	// Leave out @keyframes and keyframe values (0%, 100%, etc...)
+	// csso shortens '100%' -> 'to', make sure to leave it untouched
+	if (line.match(/^[@0-9]/) || line === "to" || line === "to{") {
 		return line;
 	}
 
-	// Leave out @keyframes and keyframe values (0%, 100%, etc...)
-	if (line.match(/^[@0-9]/)) {
+	// IE specific selector (directly written with the tag) - keep it
+	if (line.match(new RegExp(`^${tag}[^a-zA-Z0-9-]`))) {
 		return line;
 	}
 


### PR DESCRIPTION
keyframes gets optimised by csso
'100%' --> 'to' which doesn't match the
runtime CSS transformation rules
and incorrectly prepends the tag name,
making the CSS invalid and braking on IE
