### PR TITLE
fix: update version to 1.0.0-rc3 in playground

### DIFF
--- a/packages/playground/webapp/index.html
+++ b/packages/playground/webapp/index.html
@@ -35,7 +35,7 @@
                                     Github Project &rsaquo;</a>
                                 <iframe src="https://ghbtns.com/github-btn.html?user=sap&repo=ui5-webcomponents&type=star&count=true&size=small" frameborder="0" scrolling="0" width="90px" height="20px"></iframe>
                             </div>
-                            <div class="curr-version">Current version 1.0.0-rc.2</div>
+                            <div class="curr-version">Current version 1.0.0-rc.3</div>
                         </div>
                 </div>
             </header>

--- a/packages/playground/webapp/view/Main.view.xml
+++ b/packages/playground/webapp/view/Main.view.xml
@@ -18,7 +18,7 @@
 
 				<ToolbarSpacer></ToolbarSpacer>
 
-				<Label class="version-label" text="v1.0.0-rc.2">
+				<Label class="version-label" text="v1.0.0-rc.3">
 					<layoutData>
 						<OverflowToolbarLayoutData priority="NeverOverflow" />
 					</layoutData>
@@ -78,7 +78,7 @@
 				</FlexBox>
 
 				<HBox width="100%" justifyContent="SpaceBetween" alignItems="Center">
-					<Label class="version-label-in-settings" text="v1.0.0-rc.2" />
+					<Label class="version-label-in-settings" text="v1.0.0-rc.3" />
 					<HBox class="settings-buttons-wrapper" width="100%" justifyContent="End">
 						<Button type="Transparent" text="Close" press="closeSettingsMenu" class="margin-end custom-button-height" />
 						<Button text="Apply" press="applyChangeSettings" class="custom-button-height" />


### PR DESCRIPTION
Hi there, this is my first "test contribution". I hope I did everything right. cla-assistant.io is not working right now...

This PR just just updates the version number you see in the playground in some places.
