### PR TITLE
Fix: whenPolyfillLoaded

### DIFF
--- a/packages/base/src/compatibility/whenPolyfillLoaded.js
+++ b/packages/base/src/compatibility/whenPolyfillLoaded.js
@@ -6,7 +6,9 @@ const whenPolyfillLoaded = () => {
 	}
 
 	polyfillLoadedPromise = new Promise(resolve => {
-		if (window.WebComponents && window.WebComponents.waitFor) {
+		if (window.WebComponents
+			&& !window.WebComponents.ready
+			&& window.WebComponents.waitFor) {
 			// the polyfill loader is present
 			window.WebComponents.waitFor(() => {
 				// the polyfills are loaded, safe to execute code depending on their APIs


### PR DESCRIPTION
Check that polyfill are not already loaded and that we are not waiting on an event that has already been emitted.