### PR TITLE
refactor: remove deepEqual from metadata

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -675,18 +675,11 @@ class UI5Element extends HTMLElement {
 					}
 				},
 				set(value) {
-					let isDifferent = false;
 					value = this.constructor.getMetadata().constructor.validatePropertyValue(value, propData);
 
 					const oldState = this._state[prop];
 
-					if (propData.deepEqual) {
-						isDifferent = JSON.stringify(oldState) !== JSON.stringify(value);
-					} else {
-						isDifferent = oldState !== value;
-					}
-
-					if (isDifferent) {
+					if (oldState !== value) {
 						this._state[prop] = value;
 						this._invalidate(prop, value);
 						this._propertyChange(prop, value);

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -59,7 +59,6 @@ const metadata = {
 		selectedDates: {
 			type: Integer,
 			multiple: true,
-			deepEqual: true,
 		},
 
 		_header: {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -145,7 +145,6 @@ const metadata = {
 		},
 		_calendar: {
 			type: Object,
-			deepEqual: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.DatePicker.prototype */ {

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -50,7 +50,6 @@ const metadata = {
 		selectedDates: {
 			type: Integer,
 			multiple: true,
-			deepEqual: true,
 		},
 
 		_weeks: {

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -125,7 +125,6 @@ const metadata = {
 
 		_itemsInfo: {
 			type: Object,
-			deepEqual: true,
 		},
 
 		_actionList: {
@@ -341,7 +340,7 @@ class ShellBar extends UI5Element {
 
 		this._itemsInfo = [];
 		this._isInitialRendering = true;
-		this._focussedItem = null;
+		this._focusedItem = null;
 
 		// marks if preventDefault() is called in item's press handler
 		this._defaultItemPressPrevented = false;
@@ -376,12 +375,7 @@ class ShellBar extends UI5Element {
 			const items = that._itemsInfo.filter(info => {
 				const isVisible = info.classes.indexOf("ui5-shellbar-hidden-button") === -1;
 				const isSet = info.classes.indexOf("ui5-shellbar-invisible-button") === -1;
-
-				if (isVisible && isSet) {
-					return true;
-				}
-
-				return false;
+				return isVisible && isSet;
 			}).sort((item1, item2) => {
 				if (item1.domOrder < item2.domOrder) {
 					return -1;
@@ -417,7 +411,7 @@ class ShellBar extends UI5Element {
 				return clone;
 			});
 
-			that._itemsInfo = newItems;
+			that._updateItemsInfo(newItems);
 		};
 
 		this._delegates.push(this._itemNav);
@@ -471,8 +465,8 @@ class ShellBar extends UI5Element {
 	onAfterRendering() {
 		this._overflowActions();
 
-		if (this._focussedItem) {
-			this._focussedItem._tabIndex = "0";
+		if (this._focusedItem) {
+			this._focusedItem._tabIndex = "0";
 		}
 	}
 
@@ -506,7 +500,7 @@ class ShellBar extends UI5Element {
 	_handleSizeS() {
 		const hasIcons = this.showNotifications || this.showProductSwitch || this.searchField.length || this.items.length;
 
-		this._itemsInfo = this._getAllItems(hasIcons).map(info => {
+		const newItems = this._getAllItems(hasIcons).map(info => {
 			const isOverflowIcon = info.classes.indexOf("ui5-shellbar-overflow-button") !== -1;
 			const isImageIcon = info.classes.indexOf("ui5-shellbar-image-button") !== -1;
 			const shouldStayOnScreen = isOverflowIcon || (isImageIcon && this.profile);
@@ -516,6 +510,8 @@ class ShellBar extends UI5Element {
 				style: `order: ${shouldStayOnScreen ? 1 : -1}`,
 			});
 		});
+
+		this._updateItemsInfo(newItems);
 	}
 
 	_handleActionsOverflow() {
@@ -570,12 +566,12 @@ class ShellBar extends UI5Element {
 			}
 		}
 
-		this._focussedItem = this._findInitiallyFocussedItem(focusableItems);
+		this._focusedItem = this._findInitiallyFocusedItem(focusableItems);
 
 		return itemsByPriority;
 	}
 
-	_findInitiallyFocussedItem(items) {
+	_findInitiallyFocusedItem(items) {
 		items.sort((item1, item2) => {
 			const order1 = parseInt(item1.style.split("order: ")[1]);
 			const order2 = parseInt(item2.style.split("order: ")[1]);
@@ -607,8 +603,8 @@ class ShellBar extends UI5Element {
 			return this._handleSizeS();
 		}
 
-		const items = this._handleActionsOverflow();
-		this._itemsInfo = items;
+		const newItems = this._handleActionsOverflow();
+		this._updateItemsInfo(newItems);
 	}
 
 	_toggleActionPopover() {
@@ -806,6 +802,13 @@ class ShellBar extends UI5Element {
 			},
 		];
 		return items;
+	}
+
+	_updateItemsInfo(newItems) {
+		const isDifferent = JSON.stringify(this._itemsInfo) !== JSON.stringify(newItems);
+		if (isDifferent) {
+			this._itemsInfo = newItems;
+		}
 	}
 
 	get classes() {

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -29,7 +29,6 @@ const metadata = {
 		_columnsInfo: {
 			type: Object,
 			multiple: true,
-			deepEqual: true,
 		},
 		_tabIndex: {
 			type: String,


### PR DESCRIPTION
- invalidation again happens only on reference change for objects
- if some web component needs to minimize invalidation, equality checks must be done internally