### PR TITLE
fix: order slots in state as in Light DOM

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -197,9 +197,9 @@ class UI5Element extends HTMLElement {
 			const propertyName = slotData.propertyName || slotName;
 
 			if (slottedChildrenMap.has(propertyName)) {
-				slottedChildrenMap.get(propertyName).push({child, idx});
+				slottedChildrenMap.get(propertyName).push({ child, idx });
 			} else {
-				slottedChildrenMap.set(propertyName, [{child, idx}]);
+				slottedChildrenMap.set(propertyName, [{ child, idx }]);
 			}
 		});
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -196,14 +196,14 @@ class UI5Element extends HTMLElement {
 				this._attachChildPropertyUpdated(child, slotData);
 			}
 
-			slottedChildren.push({child, idx});
+			slottedChildren.push({ child, idx });
 		});
 
 		await Promise.all(allChildrenUpgraded);
 
 		// Distribute the child in the _state object, keeping the Light DOM order,
 		// not the order elements are defined.
-		this._state[propertyName] = slottedChildren.sort((a, b) => (a.idx > b.idx) ? 1 : -1).map(_ => _.child);
+		this._state[propertyName] = slottedChildren.sort((a, b) => a.idx - b.idx).map(_ => _.child);
 		slottedChildren = null;
 
 		this._invalidate();


### PR DESCRIPTION
FIXES: https://github.com/SAP/ui5-webcomponents/issues/873

Order slotted children in components state properly, keeping their order in the Light DOM, not the order the children are defined.