### PR TITLE
chore(ui5-input): clear warnings when name property is set

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -72,6 +72,16 @@ const metadata = {
 		_beginContent: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used for native <code>input</code> HTML element to enable form sumbit,
+		 * when <code>name</code> property is set. 
+		 * @type {HTMLElement[]}
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 	properties: /** @lends  sap.ui.webcomponents.main.Input.prototype */  {
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -75,7 +75,7 @@ const metadata = {
 
 		/**
 		 * The slot is used for native <code>input</code> HTML element to enable form sumbit,
-		 * when <code>name</code> property is set. 
+		 * when <code>name</code> property is set.
 		 * @type {HTMLElement[]}
 		 * @private
 		 */


### PR DESCRIPTION
**Issue** 
When you use ui5-input and set the name property, warnings are thrown.

**Steps**
1. Go to https://sap.github.io/ui5-webcomponents/master/test-resources/sap/ui/webcomponents/main/pages/Input.html
2.  Observe the warnings in the console: "Unknown slotName: formSupport, ignoring <input type=​"hidden" data-ui5-form-support slot=​"formSupport" name=​"my-input-email" value>​ Valid values are: icon, default, _beginContent

**Root cause**
We create a native input to enable form support and insert it with slot="formSupport", but the UI5 Element slot validation throws these warnings when a slot, unknown to component's metadata, is about to be slotted.

**Solution**
It`s strange to have warnings, as there is nothing wrong with the usage, "name" property has been given and the "FormSupport" feature is imported, so adding a private slot "formSupport" seems fine.