### PR TITLE
chore(ui5-input): remove obsolete _beginContent slot

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -4,10 +4,6 @@
 	@focusout="{{onfocusout}}"
 >
 	<div class="ui5-input-content">
-		{{#if _beginContent.length}}
-			<slot name="_beginContent"></slot>
-		{{/if}}
-
 		<input id="{{_id}}-inner"
 			class="ui5-input-inner"
 			type="{{inputType}}"

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -69,10 +69,6 @@ const metadata = {
 			type: HTMLElement,
 		},
 
-		_beginContent: {
-			type: HTMLElement,
-		},
-
 		/**
 		 * The slot is used for native <code>input</code> HTML element to enable form sumbit,
 		 * when <code>name</code> property is set.


### PR DESCRIPTION
The _beginContent slot used  to serve the MultiComboBox, but since the component started using a native input element  instead of ui5-input, the slot is not used anymore.