### PR TITLE
refactor: item navigation simplification

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -418,12 +418,18 @@ class UI5Element extends HTMLElement {
 	}
 
 	_render() {
-		// Call the onBeforeRendering hook
+		// suppress invalidation to prevent state changes scheduling another rendering
+		this._suppressInvalidation = true;
+
 		if (typeof this.onBeforeRendering === "function") {
-			this._suppressInvalidation = true;
 			this.onBeforeRendering();
-			delete this._suppressInvalidation;
 		}
+
+		// Intended for framework usage only. Currently ItemNavigation updates tab indexes after the component has updated its state but before the template is rendered
+		this.dispatchEvent(new CustomEvent("_componentStateFinalized"));
+
+		// resume normal invalidation handling
+		delete this._suppressInvalidation;
 
 		// Update the shadow root with the render result
 		// console.log(this.getDomRef() ? "RE-RENDER" : "FIRST RENDER", this);

--- a/packages/base/src/delegate/ItemNavigation.js
+++ b/packages/base/src/delegate/ItemNavigation.js
@@ -21,9 +21,12 @@ class ItemNavigation extends EventProvider {
 
 		this.rootWebComponent = rootWebComponent;
 		this.rootWebComponent.addEventListener("keydown", this.onkeydown.bind(this));
+		this.rootWebComponent.addEventListener("_componentStateFinalized", () => {
+			this._init();
+		});
 	}
 
-	init() {
+	_init() {
 		this._getItems().forEach((item, idx) => {
 			item._tabIndex = (idx === this.currentIndex) ? "0" : "-1";
 		});
@@ -141,9 +144,8 @@ class ItemNavigation extends EventProvider {
 			items[i]._tabIndex = (i === this.currentIndex ? "0" : "-1");
 		}
 
-		if (this._setItems) {
-			this._setItems(items);
-		}
+
+		this.rootWebComponent._invalidate();
 	}
 
 	focusCurrent() {
@@ -192,10 +194,6 @@ class ItemNavigation extends EventProvider {
 		}
 
 		return this.rootWebComponent.getDomRef().querySelector(`#${currentItem.id}`);
-	}
-
-	set setItemsCallback(fn) {
-		this._setItems = fn;
 	}
 
 	set getItemsCallback(fn) {

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -220,8 +220,6 @@ class DayPicker extends UI5Element {
 			this._itemNav.current = todayIndex;
 		}
 
-		this._itemNav.init();
-
 		const aDayNamesWide = this._oLocaleData.getDays("wide", this._primaryCalendarType);
 		const aDayNamesAbbreviated = this._oLocaleData.getDays("abbreviated", this._primaryCalendarType);
 		const aUltraShortNames = aDayNamesAbbreviated.map(n => n);

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -257,7 +257,6 @@ class List extends UI5Element {
 
 	onBeforeRendering() {
 		this.prepareListItems();
-		this._itemNavigation.init();
 	}
 
 	initItemNavigation() {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -133,8 +133,6 @@ class MonthPicker extends UI5Element {
 		}
 
 		this._quarters = quarters;
-
-		this._itemNav.init();
 	}
 
 	onAfterRendering() {

--- a/packages/main/src/ShellBar.js
+++ b/packages/main/src/ShellBar.js
@@ -447,11 +447,6 @@ class ShellBar extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		const size = this._handleBarBreakpoints();
-		if (size !== "S") {
-			this._itemNav.init();
-		}
-
 		this._hiddenIcons = this._itemsInfo.filter(info => {
 			const isHidden = (info.classes.indexOf("ui5-shellbar-hidden-button") !== -1);
 			const isSet = info.classes.indexOf("ui5-shellbar-invisible-button") === -1;

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -194,8 +194,6 @@ class TabContainer extends UI5Element {
 		}
 
 		this.calculateRenderItems();
-
-		this._itemNavigation.init();
 	}
 
 	calculateRenderItems() {

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -177,8 +177,6 @@ class Table extends UI5Element {
 	onBeforeRendering() {
 		const columnSettings = this.getColumnPropagationSettings();
 
-		this._itemNavigation.init();
-
 		this.rows.forEach(row => {
 			row._columnsInfo = columnSettings;
 			row.removeEventListener("ui5-_focused", this.fnOnRowFocused);

--- a/packages/main/src/Timeline.js
+++ b/packages/main/src/Timeline.js
@@ -71,10 +71,6 @@ class Timeline extends UI5Element {
 		this.initItemNavigation();
 	}
 
-	onBeforeRendering() {
-		this._itemNavigation.init();
-	}
-
 	initItemNavigation() {
 		this._itemNavigation = new ItemNavigation(this);
 		this._itemNavigation.getItemsCallback = () => this.items;

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -112,7 +112,6 @@ class Tokenizer extends UI5Element {
 		setTimeout(() => {
 			// wait for the layouting and update the text
 			this._nMoreText = this.i18nBundle.getText(MULTIINPUT_SHOW_MORE_TOKENS, [this.overflownTokens.length]);
-			this._itemNav.init();
 		}, 0);
 	}
 

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -101,9 +101,6 @@ class YearPicker extends UI5Element {
 		this._itemNav.getItemsCallback = function getItemsCallback() {
 			return [].concat(...this._yearIntervals);
 		}.bind(this);
-		this._itemNav.setItemsCallback = function setItemsCallback(items) {
-			this._yearIntervals = items;
-		}.bind(this);
 
 		this._itemNav.attachEvent(
 			ItemNavigation.BORDER_REACH,
@@ -160,8 +157,6 @@ class YearPicker extends UI5Element {
 		}
 
 		this._yearIntervals = intervals;
-
-		this._itemNav.init();
 	}
 
 	onAfterRendering() {


### PR DESCRIPTION
- ItemNavigation invalidates the component when it
changes the tabIndex, this is simpler than the removed setItemsCallback
- UI5Element fires a private event after onBeforeRendering, but before the
actual rendering so the item navigation
can automatically apply tab indexes
in case the component changed the state and wipted the tab indexes
- adapt all components to new behaviour