### PR TITLE
chore: use passive touch listeners

### DIFF
--- a/packages/base/src/delegate/ScrollEnablement.js
+++ b/packages/base/src/delegate/ScrollEnablement.js
@@ -6,8 +6,8 @@ const scrollEventName = "scroll";
 class ScrollEnablement extends EventProvider {
 	constructor(containerComponent) {
 		super();
-		containerComponent.addEventListener("touchstart", this.ontouchstart.bind(this));
-		containerComponent.addEventListener("touchmove", this.ontouchmove.bind(this));
+		containerComponent.addEventListener("touchstart", this.ontouchstart.bind(this), { passive: true });
+		containerComponent.addEventListener("touchmove", this.ontouchmove.bind(this), { passive: true });
 	}
 
 	set scrollContainer(container) {


### PR DESCRIPTION
- since the ScrollEnablement does not use preventDefault, it is ok
to switch to passive event listeneres
for the touch events (and get rid of
the console warnings)