### PR TITLE
refactor(ui5-button): subscribe event handlers within HBS template

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -9,6 +9,9 @@
 		@focusin={{_onfocusin}}
 		@click={{_onclick}}
 		@mousedown={{_onmousedown}}
+		@mouseup={{_onmouseup}}
+		@keydown={{_onkeydown}}
+		@keyup={{_onkeyup}}
 		tabindex={{tabIndexValue}}
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -164,7 +164,6 @@ const metadata = {
 		 */
 		click: {},
 	},
-	_eventHandlersByConvention: true,
 };
 
 /**
@@ -261,17 +260,17 @@ class Button extends UI5Element {
 		this.active = true;
 	}
 
-	onmouseup(event) {
+	_onmouseup(event) {
 		event.isMarked = "button";
 	}
 
-	onkeydown(event) {
+	_onkeydown(event) {
 		if (isSpace(event) || isEnter(event)) {
 			this.active = true;
 		}
 	}
 
-	onkeyup(event) {
+	_onkeyup(event) {
 		if (isSpace(event) || isEnter(event)) {
 			this.active = false;
 		}


### PR DESCRIPTION
The button should not override on* handlers and instead use internal functions and subscribe the event handlers within HBS template.

Part of https://github.com/SAP/ui5-webcomponents/issues/834
