### PR TITLE
chore: map dist to src for VSCode navigation

### DIFF
--- a/packages/main/jsconfig.json
+++ b/packages/main/jsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "target": "es2017",
+      "allowSyntheticDefaultImports": false,
+      "baseUrl": "./",
+      "paths": {
+        "@ui5/webcomponents-base/dist/*": ["../base/src/*"]
+      }
+    },
+    "exclude": ["node_modules", "dist"]
+  }


### PR DESCRIPTION
VS code reads the jsconfig.json file and the paths mapping.

This enables CMD-click on a module in `@ui5/webcomponents-base/dist/` to navigate to the `src` folder of the monorepo instead of the `dist` folder where any edits would be lost.