### PR TITLE
chore: improve test stability

### DIFF
--- a/packages/main/test/pages/DatePicker_test_page.html
+++ b/packages/main/test/pages/DatePicker_test_page.html
@@ -15,6 +15,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 </head>
 <body>
+	<ui5-datepicker id="dp12"></ui5-datepicker>
 	<ui5-datepicker id="dp"></ui5-datepicker>
 	<ui5-datepicker id="dp1" value="11/11/11"></ui5-datepicker>
 	<ui5-datepicker id="dp2" format-pattern="yyyy, dd/MM"></ui5-datepicker>
@@ -29,7 +30,6 @@
 	<ui5-datepicker id="dp9" value="today"></ui5-datepicker>
 	<ui5-datepicker id="dp10" disabled></ui5-datepicker>
 	<ui5-datepicker id="dp11"></ui5-datepicker>
-	<ui5-datepicker id="dp12"></ui5-datepicker>
 	<ui5-datepicker id="dp13"></ui5-datepicker>
 
 	<label id='lbl'>0</label>


### PR DESCRIPTION
all the failing tests are when an interaction in the popover of the datepicker occurs.

since those interactions are on the last date picker towards the end of the document,
try moving it to the beginning so
we hopfully don't get the element not interactible errors
