### PR TITLE
fix: spacebar works for HTML elements inside a ui5-table

### DIFF
--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -2,7 +2,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
-import { isSpace } from "@ui5/webcomponents-base/dist/events/PseudoEvents.js";
 import TableTemplate from "./generated/templates/TableTemplate.lit.js";
 
 // Styles
@@ -202,12 +201,6 @@ class Table extends UI5Element {
 
 	onRowFocused(event) {
 		this._itemNavigation.update(event.target);
-	}
-
-	_onkeydown(event) {
-		if (isSpace(event)) {
-			event.preventDefault();
-		}
 	}
 
 	_onColumnHeaderClick(event) {


### PR DESCRIPTION
We prevented spacebar inside a table in order to suppress the default scrolling behavior. However, the side effects of this are too detrimental - buttons inside the table don't activate on space and inputs inside the table don't accept space. Therefore, it's better to let the developer manually prevent scrolling, if necessary.