### PR TITLE
fix(ui5-tabcontainer): fix overflow item default semantic color

### DIFF
--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -233,14 +233,9 @@
 }
 
 .ui5-tc__overflowItem ui5-icon {
-	color: var(--sapUiNeutralText);
-}
-
-.ui5-tc__overflowItem--positive ui5-icon, 
-.ui5-tc__overflowItem--negative ui5-icon,
-.ui5-tc__overflowItem--critical ui5-icon {
 	color: currentColor;
 }
+
 
 .ui5-tc__content {
 	background-color: var(--sapUiGroupContentBackground);

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -83,9 +83,13 @@
 					</ui5-tab>
 					<ui5-tab icon="sap-icon://menu" text="Monitors" selected semantic-color="Critical" additional-text="45">
 					</ui5-tab>
-				<ui5-tab icon="sap-icon://menu2" text="Keyboards"  semantic-color="Negative" additional-text="15">
-				</ui5-tab>
-				<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  semantic-color="Negative" additional-text="40">
+					<ui5-tab icon="sap-icon://menu2" text="Keyboards"  semantic-color="Negative" additional-text="15">
+					</ui5-tab>
+					<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  semantic-color="Negative" additional-text="40">
+					</ui5-tab>
+					<ui5-tab icon="sap-icon://menu2" text="Neutral" semantic-color="Neutral" additional-text="40">
+					</ui5-tab>
+					<ui5-tab icon="sap-icon://menu2" text="Default" additional-text="40">
 					</ui5-tab>
 				</ui5-tabcontainer>
 			</div>


### PR DESCRIPTION
![ezgif com-resize](https://user-images.githubusercontent.com/15702139/69729835-ab1a8b00-112f-11ea-8a22-39fc7b9ceb93.gif)

This is a follow up of Follow up of: #988 where overflow items appearance in negative, positive and critical states have been fixed. However, I missed the default semantic appearance.
Now the default semantic appearance of the overflow item text and icon in active state also looks correct.
