### PR TITLE
chore: fix checkbox wrapping degradation caused by #965

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -141,7 +141,6 @@ https://github.com/philipwalton/flexbugs/issues/231
 	cursor: default;
 	text-overflow: ellipsis;
 	overflow: hidden;
-	white-space: nowrap;
 	pointer-events: none;
 	user-select: none;
 	-ms-user-select: none;

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -11,10 +11,6 @@
 	cursor: text;
 }
 
-:host([wrap]) .ui5-label-root {
-	white-space: normal;
-}
-
 :host(:not([wrap])) .ui5-label-root {
 	font-weight: inherit;
 	display: inline-block;
@@ -56,4 +52,3 @@
 	vertical-align: middle;
 	line-height: 0;
 }
-

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -1,6 +1,7 @@
 :host(:not([hidden])) {
 	display: inline-flex;
 }
+
 :host {
 	max-width: 100%;
 	color: var(--sapUiContentLabelColor);
@@ -8,7 +9,12 @@
 	font-size: var(--sapMFontMediumSize);
 	font-weight: normal;
 	cursor: text;
-}	
+}
+
+:host([wrap]) .ui5-label-root {
+	white-space: normal;
+}
+
 :host(:not([wrap])) .ui5-label-root {
 	font-weight: inherit;
 	display: inline-block;
@@ -16,6 +22,7 @@
 	cursor: inherit;
 	overflow: hidden;
 }
+
 :host(:not([wrap])) .ui5-label-text-wrapper {
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -27,15 +34,19 @@
 :host(:not([wrap])[required][show-colon]) .ui5-label-text-wrapper {
 	max-width: calc(100%-0.725rem);
 }
+
 :host(:not([wrap])[required]) .ui5-label-text-wrapper {
 	max-width: calc(100%-0.475rem);
 }
+
 :host(:not([wrap])[show-colon]) .ui5-label-text-wrapper {
 	max-width: calc(100%-0.3rem);
 }
+
 :host([show-colon]) .ui5-label-required-colon:before {
 	content: ":";
 }
+
 :host([required]) .ui5-label-required-colon:after {
 	content:"*";
 	color: var(--sapUiFieldRequiredColor);


### PR DESCRIPTION
The pull request fixes degradation, caused by a recent style changes in the ui5-label #965,
causing ui5-checkbox label stop wrapping.