### PR TITLE
fix(ui5-datepicker): it is now possible to set an empty placeholder

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -636,7 +636,7 @@ class UI5Element extends HTMLElement {
 			} else if (propType === Object) {
 				defaultState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : {};
 			} else if (propType === String) {
-				defaultState[propName] = propDefaultValue || "";
+				defaultState[propName] = propDefaultValue !== undefined ? propDefaultValue : "";
 			} else {
 				defaultState[propName] = propDefaultValue;
 			}

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -636,7 +636,7 @@ class UI5Element extends HTMLElement {
 			} else if (propType === Object) {
 				defaultState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : {};
 			} else if (propType === String) {
-				defaultState[propName] = propDefaultValue !== undefined ? propDefaultValue : "";
+				defaultState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : "";
 			} else {
 				defaultState[propName] = propDefaultValue;
 			}
@@ -678,7 +678,7 @@ class UI5Element extends HTMLElement {
 					if (propData.type === Boolean) {
 						return false;
 					} else if (propData.type === String) {  // eslint-disable-line
-						return propDefaultValue || "";
+						return propDefaultValue;
 					} else if (propData.multiple) { // eslint-disable-line
 						return [];
 					} else {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -118,7 +118,7 @@ const metadata = {
 		 */
 		placeholder: {
 			type: String,
-			defaultValue: null,
+			defaultValue: undefined,
 		},
 
 		/**
@@ -392,7 +392,7 @@ class DatePicker extends UI5Element {
 	}
 
 	get _placeholder() {
-		return this.placeholder === null ? this._displayFormat : this.placeholder;
+		return this.placeholder !== undefined ? this.placeholder : this._displayFormat;
 	}
 
 	getFormat() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -118,6 +118,7 @@ const metadata = {
 		 */
 		placeholder: {
 			type: String,
+			defaultValue: null,
 		},
 
 		/**
@@ -391,7 +392,7 @@ class DatePicker extends UI5Element {
 	}
 
 	get _placeholder() {
-		return this.placeholder || this._displayFormat;
+		return this.placeholder === null ? this._displayFormat : this.placeholder;
 	}
 
 	getFormat() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -112,8 +112,10 @@ const metadata = {
 		 * <code>ui5-datepicker</code> has no value.
 		 *
 		 * <b>Note:</b> When no placeholder is set, the format pattern is displayed as a placeholder.
+		 * Passing an empty string as the value of this property will make the <code>ui5-datepicker</code> appear empty - without placeholder or format pattern.
+		 *
 		 * @type {string}
-		 * @defaultvalue ""
+		 * @defaultvalue undefined
 		 * @public
 		 */
 		placeholder: {

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -78,6 +78,9 @@
 
 		<h3>japanese calendar type</h3>
 		<ui5-datepicker primary-calendar-type='Japanese'></ui5-datepicker>
+
+        <h3>explicitly set empty placeholder</h3>
+        <ui5-datepicker placeholder=""></ui5-datepicker>
 	</div>
 	<script>
 		var dp = document.getElementById('dp5');


### PR DESCRIPTION
- It is now possible to explicitly set `undefined` as default value for `String`, and it will not be overridden by `""`
- Datepicker.js sets the default value for `placeholder` to `undefined`