### PR TITLE
fix(ui5-checkbox): fix truncation in compactSize

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -148,6 +148,13 @@ https://github.com/philipwalton/flexbugs/issues/231
 }
 
 /* Compact */
+:host([text][data-ui5-compact-size]) .ui5-checkbox-root {
+	padding-right: 0;
+}
+:host([text][data-ui5-compact-size]) .ui5-checkbox-root:focus::before {
+	right: 0;
+}
+
 :host([wrap][text][data-ui5-compact-size]) .ui5-checkbox-root {
 	min-height: auto;
 	padding-top: var(--_ui5_checkbox_wrapped_focus_padding);
@@ -186,7 +193,6 @@ https://github.com/philipwalton/flexbugs/issues/231
 
 :host([data-ui5-compact-size]) .ui5-checkbox-root .ui5-checkbox-label {
 	margin-left: var(--_ui5_checkbox_compact_wrapper_padding);
-	width: calc(100% - .8125rem - var(--_ui5_checkbox_compact_inner_size));
 }
 
 :host([data-ui5-compact-size]) .ui5-checkbox-icon {

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-	<ui5-checkbox id="cb1"></ui5-checkbox>
+	<ui5-checkbox id="cb1" text="Long long long text"></ui5-checkbox>
 	<ui5-checkbox id="cbError" value-state="Error"></ui5-checkbox>
 	<ui5-checkbox id="cb2" disabled></ui5-checkbox>
 	<ui5-checkbox id="truncatingCb" text="Long long long text that should truncate at some point" style="width: 300px"></ui5-checkbox>


### PR DESCRIPTION
Although there is enough space, the checkbox used to truncate,
now this is fixed.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/996

Before
<img width="579" alt="Screenshot 2019-11-28 at 15 39 00" src="https://user-images.githubusercontent.com/15702139/69810836-7113bc80-11f5-11ea-96ab-f67d087cc71a.png">

After
<img width="517" alt="Screenshot 2019-11-28 at 15 18 21" src="https://user-images.githubusercontent.com/15702139/69810665-17ab8d80-11f5-11ea-875f-343d107ccd46.png">

