### PR TITLE
docs(ui5-shellbar): display component properties

### DIFF
--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -27,7 +27,7 @@ import styles from "./generated/themes/ShellBar.css.js";
  */
 const metadata = {
 	tag: "ui5-shellbar",
-	properties: /** @lends  sap.ui.webcomponents.fiori.ShellBar.prototype */ {
+	properties: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 
 		/**
 		 * Defines the <code>logo</code> source URI.
@@ -145,7 +145,7 @@ const metadata = {
 		},
 	},
 
-	slots: /** @lends  sap.ui.webcomponents.main.ShellBar.prototype */ {
+	slots: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 		/**
 		 * Defines the <code>ui5-shellbar</code> aditional items.
 		 * <br><br>
@@ -200,7 +200,7 @@ const metadata = {
 			type: HTMLElement,
 		},
 	},
-	events: /** @lends sap.ui.webcomponents.main.ShellBar.prototype */ {
+	events: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 		/**
 		 *
 		 * Fired, when the notification icon is activated.
@@ -299,7 +299,7 @@ const metadata = {
  *
  * @constructor
  * @author SAP SE
- * @alias sap.ui.webcomponents.main.ShellBar
+ * @alias sap.ui.webcomponents.fiori.ShellBar
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-shellbar
  * @appenddocs ShellBarItem

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -30,7 +30,7 @@ const metadata = {
 		},
 	},
 
-	events: /** @lends sap.ui.webcomponents.main.ShellBarItem.prototype */ {
+	events: /** @lends sap.ui.webcomponents.fiori.ShellBarItem.prototype */ {
 		/**
 		 * Fired, when the item is pressed.
 		 *
@@ -55,7 +55,7 @@ const metadata = {
  * <code>import "@ui5/webcomponents-fiori/dist/ShellBarItem";</code>
  * @constructor
  * @author SAP SE
- * @alias sap.ui.webcomponents.main.ShellBarItem
+ * @alias sap.ui.webcomponents.fiori.ShellBarItem
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-shellbar-item
  * @public


### PR DESCRIPTION
Display `ui5-shellbar` and `ui5-shellbar-item` properties as part of the API.
Root cause: mixing the @ lends marks (sap.ui.webcomponents.main and sap.ui.webcomponents.fiori) causes missing of API data.