### PR TITLE
chore(ui5-checkbox): fix the wrapping functionality unit test

### DIFF
--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -13,7 +13,7 @@
 	<script>delete Document.prototype.adoptedStyleSheets;</script>
 
 	<style>
-		ui5-checkbox {
+		ui5-checkbox:not(.ui5-cb-testing-wrap) {
 			border: 1px solid red;
 		}
 	</style>
@@ -24,8 +24,7 @@
 	<ui5-checkbox id="cbError" value-state="Error"></ui5-checkbox>
 	<ui5-checkbox id="cb2" disabled></ui5-checkbox>
 	<ui5-checkbox id="truncatingCb" text="Long long long text that should truncate at some point" style="width: 300px"></ui5-checkbox>
-	<ui5-checkbox id="wrappingCb" text="Longest ever text written in English that have to truncate immediately because it is so long of course!" style="width: 300px"></ui5-checkbox>
-
+	<ui5-checkbox id="wrappingCb" wrap class="ui5-cb-testing-wrap" text="Longest ever text written in English that have to truncate immediately because it is so long of course!" style="width: 300px"></ui5-checkbox>
 	<ui5-input id="field"></ui5-input>
 
 	<ui5-checkbox></ui5-checkbox>

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require("chai").assert;
 
 describe("CheckBox general interaction", () => {
 	browser.url("http://localhost:8080/test-resources/pages/CheckBox.html");


### PR DESCRIPTION
The test that verifies if the wrapping of the component is working is now actually tests that correctly.
- The checkbox under test used to not have "wrap" set and 
- In addition, it has 2px border (set by inline styles in the test page) so its height is bigger than our threshold (44px) with 2px, and even when it stops wrapping - the test would pass.