### PR TITLE
chore: add livereload

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -7,6 +7,7 @@ const url = require("rollup-plugin-url");
 const { terser } = require("rollup-plugin-terser");
 const notify = require('rollup-plugin-notify');
 const filesize = require('rollup-plugin-filesize');
+const livereload = require('rollup-plugin-livereload');
 
 const getConfig = (options) => {
 
@@ -40,11 +41,13 @@ const getConfig = (options) => {
 		const plugins = [];
 		let publicPath = DEPLOY_PUBLIC_PATH || "/resources/";
 
-		plugins.push(filesize({
-			render : function (options, bundle, { minSize, gzipSize, brotliSize, bundleSize }){
-				return gzipSize;
-			}
-		}));
+		if (!process.env.DEV) {
+			plugins.push(filesize({
+				render : function (options, bundle, { minSize, gzipSize, brotliSize, bundleSize }){
+					return gzipSize;
+				}
+			}));
+		}
 
 		plugins.push(ui5DevImportCheckerPlugin());
 
@@ -74,8 +77,17 @@ const getConfig = (options) => {
 		}
 
 		if (process.env.DEV) {
-			plugins.push(notify({
-				success: true
+			plugins.push(notify());
+		}
+
+		const es6DevMain = process.env.DEV && !transpile && options.name === "@ui5/webcomponents";
+		if (es6DevMain) {
+			plugins.push(livereload({
+				watch: [
+					"dist/resources/bundle.esm.js",
+					"dist/**/*.html",
+					"dist/**/*.json",
+				]
 			}));
 		}
 
@@ -138,6 +150,8 @@ const getConfig = (options) => {
 		mkdirp.sync(DIST);
 		mkdirp.sync(DIST_PLAYGROUND);
 	}
+
+	console.log({config});
 
 	return config;
 };

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -151,8 +151,6 @@ const getConfig = (options) => {
 		mkdirp.sync(DIST_PLAYGROUND);
 	}
 
-	console.log({config});
-
 	return config;
 };
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,7 @@
     "sapui5",
     "ui5"
   ],
-  "scripts": {
-  },
+  "scripts": {},
   "bin": {
     "wc-dev": "bin/dev.js",
     "wc-create-ui5-element": "bin/create-ui5-element.js"
@@ -66,6 +65,7 @@
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-less": "^1.1.2",
+    "rollup-plugin-livereload": "^1.0.4",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-notify": "^1.1.0",
     "rollup-plugin-string": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,7 +1972,7 @@ chokidar@3.0.2:
   optionalDependencies:
     fsevents "^2.0.6"
 
-chokidar@^2.0.0, chokidar@^2.1.8:
+chokidar@^2.0.0, chokidar@^2.1.5, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -5670,6 +5670,15 @@ lit-html@^1.0.0:
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.1.2.tgz#2e3560a7075210243649c888ad738eaf0daa8374"
   integrity sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA==
 
+"livereload@0.8.0 || ^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/livereload/-/livereload-0.8.2.tgz#0ebb756cd5150bc956e33110b884bc2d7d87b723"
+  integrity sha512-8wCvhiCL4cGVoT3U5xoe+UjpiiVZLrlOvr6dbhb1VlyC5QarhrlyRRt4z7EMGO4KSgXj+tKF/dr284F28/wI+g==
+  dependencies:
+    chokidar "^2.1.5"
+    opts ">= 1.2.0"
+    ws "^6.2.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -6665,6 +6674,11 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+"opts@>= 1.2.0":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/opts/-/opts-1.2.7.tgz#4de4721d592c96901dae623a438c988e9ea7779f"
+  integrity sha512-hwZhzGGG/GQ7igxAVFOEun2N4fWul31qE9nfBdCnZGQCB5+L7tN9xZ+94B4aUpLOJx/of3zZs5XsuubayQYQjA==
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -8255,6 +8269,13 @@ rollup-plugin-less@^1.1.2:
     mkdirp "^0.5.1"
     rollup "^0.34.7"
     rollup-pluginutils "^1.5.1"
+
+rollup-plugin-livereload@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-livereload/-/rollup-plugin-livereload-1.0.4.tgz#480919211c699db85a532dabe9aa29035578f9c1"
+  integrity sha512-nbnSP8Mj2mmLZkrf080z3PrdacmpAW6UkmgM+BWClcJ8MSsruPONGTwirhZaNNHjUYvkJ+iF5/pSk4g0KV2uVQ==
+  dependencies:
+    livereload "0.8.0 || ^0.8.2"
 
 rollup-plugin-node-resolve@^4.0.0:
   version "4.2.4"
@@ -10063,7 +10084,7 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.1.0:
+ws@^6.1.0, ws@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==


### PR DESCRIPTION
- enabled only for `main`
- notifications switched to errors only
- filesize plugin moved to prod build only (bundle in less than 1s now)
