### PR TITLE
fix(ui5-tabcontainer): fix tab content overflow and height calculation

### DIFF
--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -1,5 +1,5 @@
 <div
-	class="ui5-tc-root"
+	class="{{classes.root}}"
 	dir="{{rtl}}"
 >
 	<div class="{{classes.header}}" id="{{_id}}-header">

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -100,6 +100,11 @@ const metadata = {
 			type: Boolean,
 			noAttribute: true,
 		},
+		_textOnly: {
+			type: Boolean,
+			noAttribute: true,
+		},
+
 	},
 	events: /** @lends  sap.ui.webcomponents.main.TabContainer.prototype */ {
 		/**
@@ -182,12 +187,13 @@ class TabContainer extends UI5Element {
 
 	onBeforeRendering() {
 		const hasSelected = this.items.some(item => item.selected);
+		this._textOnly = this.items.every(item => !item.icon);
+
 		this.items.forEach(item => {
 			item._getTabContainerHeaderItemCallback = _ => {
 				return this.getDomRef().querySelector(`#${item._id}`);
 			};
 		});
-
 		if (this.items.length && !hasSelected) {
 			this.items[0].selected = true;
 		}
@@ -351,6 +357,10 @@ class TabContainer extends UI5Element {
 
 	get classes() {
 		return {
+			root: {
+				"ui5-tc-root" : true,
+				"ui5-tc--textOnly": this._textOnly,
+			},
 			header: {
 				"ui5-tc__header": true,
 				"ui5-tc__header--scrollable": this._scrollable,

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -358,7 +358,7 @@ class TabContainer extends UI5Element {
 	get classes() {
 		return {
 			root: {
-				"ui5-tc-root" : true,
+				"ui5-tc-root": true,
 				"ui5-tc--textOnly": this._textOnly,
 			},
 			header: {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -16,11 +16,17 @@
 }
 
 .ui5-tc__header {
+	display: flex;
+	align-items: center;
+	height: var(--_ui5_tc_header_height);
 	background-color: var(--sapUiObjectHeaderBackground);
 	border-bottom: var(--_ui5_tc_header_border_bottom);
 	box-shadow: var(--_ui5_tc_header_box_shadow);
-	display: flex;
-	align-items: center;
+	box-sizing: border-box;
+}
+
+.ui5-tc-root.ui5-tc--textOnly .ui5-tc__header {
+	height: var(--_ui5_tc_header_height_text_only);
 }
 
 .ui-tc__headerScrollContainer {
@@ -236,13 +242,17 @@
 	color: currentColor;
 }
 
+.ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {
+	height: calc(100% - var(--_ui5_tc_header_height_text_only)); /* the header height (text only tabs) */
+}
 
 .ui5-tc__content {
+	position: relative;
+	height: calc(100% - var(--_ui5_tc_header_height)); /* the header height (tabs with icons and text) */
+	padding: 1rem;
 	background-color: var(--sapUiGroupContentBackground);
 	border-bottom: var(--_ui5_tc_content_border_bottom);
-	padding: 1rem;
-	position: relative;
-	height: 100%;
+	box-sizing: border-box;
 }
 
 .ui5-tc__content--collapsed {
@@ -410,4 +420,20 @@
 
 :host([data-ui5-compact-size]) .ui5-tc__headerItem--withIcon  .ui5-tc__headerItemAdditionalText + .ui5-tc__headerItemText {
 	margin-top: 0.3125rem;
+}
+
+:host([data-ui5-compact-size]) .ui5-tc-root.ui5-tc--textOnly .ui5-tc__header {
+	height: var(--_ui5_tc_header_height_text_only_compact);
+}
+
+:host([data-ui5-compact-size]) .ui5-tc__header {
+	height: var(--_ui5_tc_header_height_compact);
+}
+
+:host([data-ui5-compact-size]) .ui5-tc__content {
+	height: calc(100% - var(--_ui5_tc_header_height_compact)); /* the header height (tabs with icons and text) */
+}
+
+:host([data-ui5-compact-size]) .ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {
+	height: calc(100% - var(--_ui5_tc_header_height_text_only_compact)); /* the header height (tabs text only) */
 }

--- a/packages/main/src/themes/base/TabContainer-parameters.css
+++ b/packages/main/src/themes/base/TabContainer-parameters.css
@@ -1,4 +1,9 @@
 :root {
+	/* Header */
+	--_ui5_tc_header_height: 4.6875rem;
+	--_ui5_tc_header_height_compact: 3.6875rem;
+	--_ui5_tc_header_height_text_only: 3rem;
+	--_ui5_tc_header_height_text_only_compact: 2rem;
 	--_ui5_tc_header_box_shadow: inset 0 -0.25rem 0 -0.125rem var(--sapUiObjectHeaderBorderColor);
 	--_ui5_tc_header_border_bottom: 0.125rem solid var(--sapUiObjectHeaderBackground);
 

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -89,6 +89,55 @@
 				</ui5-tabcontainer>
 			</div>
 
+			<div class="sample" style="height: 200px">
+				<ui5-tabcontainer fixed showOverflow style="height: 100%;" id="tc-scrollable-child">
+					<ui5-tab text="Tab 1" selected id="scrollable-tab">
+						<ui5-button>Toggle style</ui5-button>
+
+
+						<!-- Simple use case -->
+						<!-- <div style="background: red; height: 100%; width: 100%"></div> -->
+
+						<!-- Complex use case -->
+						<ui5-table>
+							<ui5-table-column slot="columns">Source</ui5-table-column>
+							<ui5-table-column slot="columns">Method</ui5-table-column>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+
+							<ui5-table-row>
+								<ui5-table-cell>Cell 1</ui5-table-cell>
+								<ui5-table-cell>Cell 2</ui5-table-cell>
+							</ui5-table-row>
+						</ui5-table>
+					</ui5-tab>
+
+				</ui5-tabcontainer>
+			</div>
+<br />
 			<div class="sample">
 				<h4>Icon and Text</h4>
 
@@ -175,54 +224,6 @@
 				</ui5-tabcontainer>
 			</div>
 
-			<div class="sample" style="height: 300px">
-				<ui5-tabcontainer fixed showOverflow style="height: 100%;" id="tc-scrollable-child">
-					<ui5-tab text="Tab 1" selected id="scrollable-tab">
-						<ui5-button>Toggle style</ui5-button>
-
-
-						<!-- Simple use case -->
-						<!-- <div style="background: red; height: 100%; width: 100%"></div> -->
-
-						<!-- Complex use case -->
-						<ui5-table>
-							<ui5-table-column slot="columns">Source</ui5-table-column>
-							<ui5-table-column slot="columns">Method</ui5-table-column>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-						</ui5-table>
-					</ui5-tab>
-
-				</ui5-tabcontainer>
-			</div>
 		</div>
 		<div class="result">
 			<h2>Result</h2>

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -46,15 +46,6 @@
 			text-shadow: 0 0 0.125rem #ffffff;
 			font-family: "72", Arial, Helvetica, sans-serif;
 		}
-
-		.main {
-			display: flex;
-		}
-
-		.samples {
-			flex-grow: 4;
-			max-width: 80%;
-		}
 	</style>
 </head>
 
@@ -64,171 +55,231 @@
 		<h1 class="header-title">ui5-tabcontainer</h1>
 	</header>
 
-	<section class="main">
-		<div class="samples">
-			<h2>Tab Container</h2>
-			<div class="sample">
-				<h4>Filter</h4>
+	<section>
+		<h2>Tab Container</h2>
+		<ui5-tabcontainer id="tabContainer1" fixed collapsed show-overflow="true">
+			<ui5-tab text="Products" additional-text="125">
+			</ui5-tab>
+			<ui5-tab-separator></ui5-tab-separator>
+			<ui5-tab icon="sap-icon://menu2" text="Laptops" semantic-color="Positive" additional-text="25">
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu" text="Monitors" selected semantic-color="Critical" additional-text="45">
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2" text="Keyboards"  semantic-color="Negative" additional-text="15">
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  semantic-color="Negative" additional-text="40">
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2" text="Neutral" semantic-color="Neutral" additional-text="40">
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2" text="Default" additional-text="40">
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-				<ui5-tabcontainer id="tabContainer1" fixed collapsed show-overflow="true">
-					<ui5-tab text="Products" additional-text="125">
-					</ui5-tab>
-					<ui5-tab-separator></ui5-tab-separator>
-					<ui5-tab icon="sap-icon://menu2" text="Laptops" semantic-color="Positive" additional-text="25">
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu" text="Monitors" selected semantic-color="Critical" additional-text="45">
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2" text="Keyboards"  semantic-color="Negative" additional-text="15">
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  semantic-color="Negative" additional-text="40">
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2" text="Neutral" semantic-color="Neutral" additional-text="40">
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2" text="Default" additional-text="40">
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
+	<section>
+		<h2>Icon only</h2>
+		<ui5-tabcontainer show-overflow="true" id="tabContainerIconOnly">
+			<ui5-tab icon="sap-icon://card" selected>
+				<ui5-button>Button 11</ui5-button>
+				<ui5-button>Button 12</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-			<div class="sample" style="height: 200px">
-				<ui5-tabcontainer fixed showOverflow style="height: 100%;" id="tc-scrollable-child">
-					<ui5-tab text="Tab 1" selected id="scrollable-tab">
-						<ui5-button>Toggle style</ui5-button>
+	<section>
+		<h2>Text only</h2>
+		<ui5-tabcontainer show-overflow="true" id="tabContainerTextOnly">
+			<ui5-tab text="Products ID" selected>
+				<ui5-button>Button 11</ui5-button>
+				<ui5-button>Button 12</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Avaialability">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Date of Expire">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Date of Delivery">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Date of Manifacture">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Value">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Price">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Net profit">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Company name">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Warehouse Location">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Address">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Country">
+				<ui5-button>Button 4</ui5-button>
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
+	<section style="height: 300px">
+		<ui5-tabcontainer fixed showOverflow style="height: 100%;" id="tc-scrollable-child">
+			<ui5-tab text="Tab 1" selected id="scrollable-tab">
+				<ui5-button>Toggle style</ui5-button>
 
-						<!-- Simple use case -->
-						<!-- <div style="background: red; height: 100%; width: 100%"></div> -->
+				<ui5-table>
+					<ui5-table-column slot="columns">Source</ui5-table-column>
+					<ui5-table-column slot="columns">Method</ui5-table-column>
 
-						<!-- Complex use case -->
-						<ui5-table>
-							<ui5-table-column slot="columns">Source</ui5-table-column>
-							<ui5-table-column slot="columns">Method</ui5-table-column>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
+					<ui5-table-row>
+						<ui5-table-cell>Cell 1</ui5-table-cell>
+						<ui5-table-cell>Cell 2</ui5-table-cell>
+					</ui5-table-row>
+				</ui5-table>
+			</ui5-tab>
 
-							<ui5-table-row>
-								<ui5-table-cell>Cell 1</ui5-table-cell>
-								<ui5-table-cell>Cell 2</ui5-table-cell>
-							</ui5-table-row>
-						</ui5-table>
-					</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-				</ui5-tabcontainer>
-			</div>
-<br />
-			<div class="sample">
-				<h4>Icon and Text</h4>
+	<section>
+		<h2>Icon and Text</h2>
 
-				<ui5-tabcontainer show-overflow="true">
-					<ui5-tab icon="sap-icon://card" text="Tab 1" additional-text="123" selected>
-						<ui5-button>Button 11</ui5-button>
-						<ui5-button>Button 12</ui5-button>
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2" text="Tab 2" additional-text="444">
-						<ui5-button>Button 2</ui5-button>
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://employee" text="Tab 3" additional-text="123">
-						<ui5-button>Button 3</ui5-button>
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
+		<ui5-tabcontainer show-overflow="true">
+			<ui5-tab icon="sap-icon://card" text="Tab 1" additional-text="123" selected>
+				<div style="height: 300px">
+					<h4>Content with set height: 300px</h4>
+					<ui5-button>Button 11</ui5-button>
+					<ui5-button>Button 12</ui5-button>
+				</div>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://menu2" text="Tab 2" additional-text="444">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab icon="sap-icon://employee" text="Tab 3" additional-text="123">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-			<div class="sample">
-				<h4>Icon only</h4>
+	<section>
+		<h2>Text and additional text</h2>
 
-				<ui5-tabcontainer show-overflow="true" id="tabContainerIconOnly">
-					<ui5-tab icon="sap-icon://card" selected>
-						<ui5-button>Button 11</ui5-button>
-						<ui5-button>Button 12</ui5-button>
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://menu2">
-						<ui5-button>Button 2</ui5-button>
-					</ui5-tab>
-					<ui5-tab icon="sap-icon://employee">
-						<ui5-button>Button 3</ui5-button>
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
+		<ui5-tabcontainer show-overflow="true">
+			<ui5-tab text="Tab 1" additional-text="additional" selected>
+				<ui5-button>Button 11</ui5-button>
+				<ui5-button>Button 12</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Tab 2" additional-text="additional">
+				<ui5-button>Button 2</ui5-button>
+			</ui5-tab>
+			<ui5-tab text="Tab 3" additional-text="additional">
+				<ui5-button>Button 3</ui5-button>
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-			<div class="sample">
-				<h4>Text only</h4>
+	<section>
+		<h2>Tabs with input elements</h2>
 
-				<ui5-tabcontainer show-overflow="true" id="tabContainerTextOnly">
-					<ui5-tab text="Tab 1" selected>
-						<ui5-button>Button 11</ui5-button>
-						<ui5-button>Button 12</ui5-button>
-					</ui5-tab>
-					<ui5-tab text="Tab 2">
-						<ui5-button>Button 2</ui5-button>
-					</ui5-tab>
-					<ui5-tab text="Tab 3">
-						<ui5-button>Button 3</ui5-button>
-					</ui5-tab>
-					<ui5-tab text="Tab 4">
-						<ui5-button>Button 4</ui5-button>
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
+		<ui5-tabcontainer show-overflow="true">
+			<ui5-tab text="Tab 1" selected>
+				<p>ui5-input</p>
+				<ui5-input></ui5-input>
+			</ui5-tab>
+			<ui5-tab text="Tab 2">
+				<p>browser input</p>
+				<input type="text">
+			</ui5-tab>
+		</ui5-tabcontainer>
+	</section>
 
-			<div class="sample">
-				<h4>Text and additional text</h4>
-
-				<ui5-tabcontainer show-overflow="true">
-					<ui5-tab text="Tab 1" additional-text="additional" selected>
-						<ui5-button>Button 11</ui5-button>
-						<ui5-button>Button 12</ui5-button>
-					</ui5-tab>
-					<ui5-tab text="Tab 2" additional-text="additional">
-						<ui5-button>Button 2</ui5-button>
-					</ui5-tab>
-					<ui5-tab text="Tab 3" additional-text="additional">
-						<ui5-button>Button 3</ui5-button>
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
-
-			<div class="sample">
-				<h4>Tabs with input elements</h4>
-
-				<ui5-tabcontainer show-overflow="true">
-					<ui5-tab text="Tab 1" selected>
-						<p>ui5-input</p>
-						<ui5-input></ui5-input>
-					</ui5-tab>
-					<ui5-tab text="Tab 2">
-						<p>browser input</p>
-						<input type="text">
-					</ui5-tab>
-				</ui5-tabcontainer>
-			</div>
-
-		</div>
-		<div class="result">
-			<h2>Result</h2>
-			<span id="result"></span>
-		</div>
+	<section class="result">
+		<h2>Result</h2>
+		<span id="result"></span>
 	</section>
 
 	<script>

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -86,6 +86,6 @@ describe("TabContainer general interaction", () => {
 		});
 	
 		assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
-		assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
+		// assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
 	});
 });

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -14,55 +14,49 @@ describe("TabContainer general interaction", () => {
 		assert.strictEqual(result.getText(), SELECTED_TAB_TEXT, "Item text is retrieved correctly.");
 	});
 
-	// it("scroll works on iconsOnly TabContainer", () => {
-	// 	browser.setWindowSize(520, 1080);
+	it("scroll works on iconsOnly TabContainer", () => {
+		browser.setWindowSize(520, 1080);
+		browser.pause(2000);
 
-	// 	browser.pause(1000);
+		const arrowLeft = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowLeft");
+		const arrowRight = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowRight");
 
-	// 	const arrowLeft = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowLeft");
-	// 	const arrowRight = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowRight");
+		assert.ok(!arrowLeft.isDisplayed(), "'Left Arrow' should be initially hidden");
+		assert.ok(arrowRight.isDisplayed(), "'Right Arrow' should be initially shown");
 
-	// 	assert.ok(!arrowLeft.isDisplayed(), "'Left Arrow' should be initially hidden");
-	// 	assert.ok(arrowRight.isDisplayed(), "'Right Arrow' should be initially shown");
+		arrowRight.click();
+		browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		// arrowRight.click();
-		// browser.pause(300); // TODO: wait for animation finish. Remove when solved on framework level
+		assert.ok(arrowLeft.isDisplayed(), "'Left Arrow' should be visible after 'Right arrow' click");
 
-		// arrowLeft.click();
-		// browser.pause(300); // TODO: wait for animation finish. Remove when solved on framework level
+		arrowLeft.click();
+		browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		// assert.ok(!arrowLeft.shadow$("svg").isDisplayed(), "'Left Arrow' should be hidden after 'Left Arrow' click");
-		// assert.ok(arrowRight.shadow$("svg").isDisplayed(), "'Right Arrow' should be shown after 'Left Arrow' click");
-	// });
+		assert.ok(!arrowLeft.isDisplayed(), "'Left Arrow' should be hidden after 'Left arrow' click");
+		assert.ok(arrowRight.isDisplayed(), "'Right Arrow' should be visible  after 'Left arrow' click");
+	});
 
-	// it("scroll works on textOnly TabContainer", () => {
-	// 	browser.setWindowSize(310, 1080);
-	// 	browser.$("#tabContainerTextOnly").scrollIntoView();
+	it("scroll works on textOnly TabContainer", () => {
+		browser.setWindowSize(520, 1080);
+		browser.pause(2000);
 
-	// 	let arrowLeft = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowLeft");
-	// 	let arrowRight = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowRight");
+		let arrowLeft = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowLeft");
+		let arrowRight = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowRight");
 
-	// 	assert.ok(!arrowLeft.shadow$("svg").isDisplayed(), "'Left Arrow' should be initially hidden");
-	// 	assert.ok(arrowRight.shadow$("svg").isDisplayed(), "'Right Arrow' should be initially shown");
+		assert.ok(!arrowLeft.shadow$("svg").isDisplayed(), "'Left Arrow' should be initially hidden");
+		assert.ok(arrowRight.shadow$("svg").isDisplayed(), "'Right Arrow' should be initially shown");
 
-	// 	arrowRight.click();
-	// 	browser.pause(300); // TODO: wait for animation finish. Remove when solved on framework level
+		arrowRight.click();
+		browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-	// 	arrowLeft = browser.$("#tabContainerIconOnly").shadow$("ui5-icon.ui5-tc__headerArrowLeft");
-	// 	arrowRight = browser.$("#tabContainerIconOnly").shadow$("ui5-icon.ui5-tc__headerArrowRight");
+		assert.ok(arrowLeft.isDisplayed(), "'Left Arrow' should be visible after 'Right arrow' click");
 
-	// 	assert.ok(arrowLeft.shadow$("svg").isDisplayed(), "'Left Arrow' should be shown after 'Right Arrow' click");
-	// 	assert.ok(!arrowRight.shadow$("svg").isDisplayed(), "'Right Arrow' should be hidden after 'Right Arrow' click");
+		arrowLeft.click();
+		browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-	// 	arrowLeft.click();
-	// 	browser.pause(300); // TODO: wait for animation finish. Remove when solved on framework level
-
-	// 	arrowLeft = browser.$("#tabContainerIconOnly").shadow$("ui5-icon.ui5-tc__headerArrowLeft");
-	// 	arrowRight = browser.$("#tabContainerIconOnly").shadow$("ui5-icon.ui5-tc__headerArrowRight");
-
-	// 	assert.ok(!arrowLeft.isDisplayed(), "'Left Arrow' should be hidden after 'Left Arrow' click");
-	// 	assert.ok(arrowRight.isDisplayed(), "'Right Arrow' should be shown after 'Left Arrow' click");
-	// });
+		assert.ok(!arrowLeft.isDisplayed(), "'Left Arrow' should be hidden after 'Left arrow' click");
+		assert.ok(arrowRight.isDisplayed(), "'Right Arrow' should be visible  after 'Left arrow' click");
+	});
 
 
 	it("tests if content is scrollable when tabcontainer takes limited height by its parent", () => {
@@ -86,6 +80,6 @@ describe("TabContainer general interaction", () => {
 		});
 	
 		assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
-		// assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
+		assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
 	});
 });

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require("chai").assert;
 
 describe("TabContainer general interaction", () => {
 	browser.url("http://localhost:8080/test-resources/pages/TabContainer.html");
@@ -65,27 +65,27 @@ describe("TabContainer general interaction", () => {
 	// });
 
 
-	// it("tests if content is scrollable when tabcontainer takes limited height by its parent", () => {
-	// 	const { tcHeight, tcScrollHeight } = browser.execute(() => {
-	// 		const scrollableContent = document.getElementById("tc-scrollable-child");
-	//
-	// 		return {
-	// 			tcHeight: scrollableContent.offsetHeight,
-	// 			tcScrollHeight: scrollableContent.scrollHeight,
-	// 		}
-	// 	});
-	//
-	//
-	// 	const { tabHeight, tabScrollHeight } = browser.execute(() => {
-	// 		const scrollableContent = document.getElementById("scrollable-tab").shadowRoot.querySelector("div");
-	//
-	// 		return {
-	// 			tabHeight: scrollableContent.offsetHeight,
-	// 			tabScrollHeight: scrollableContent.scrollHeight,
-	// 		}
-	// 	});
-	//
-	// 	assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
-	// 	assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
-	// });
+	it("tests if content is scrollable when tabcontainer takes limited height by its parent", () => {
+		const { tcHeight, tcScrollHeight } = browser.execute(() => {
+			const scrollableContent = document.getElementById("tc-scrollable-child");
+	
+			return {
+				tcHeight: scrollableContent.offsetHeight,
+				tcScrollHeight: scrollableContent.scrollHeight,
+			}
+		});
+	
+	
+		const { tabHeight, tabScrollHeight } = browser.execute(() => {
+			const scrollableContent = document.getElementById("scrollable-tab").shadowRoot.querySelector("div");
+	
+			return {
+				tabHeight: scrollableContent.offsetHeight,
+				tabScrollHeight: scrollableContent.scrollHeight,
+			}
+		});
+	
+		assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
+		assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
+	});
 });


### PR DESCRIPTION
The tab container content part used to have height: 100% and did not take into account the header (the tab strip). 
Now the tab strip have determined heights in cozy and compact and the content is calculated accordingly calc(100% - headerHeight) and the test are green again.