### PR TITLE
chore(css-vars-verify): ignore HCB specific variables

### DIFF
--- a/packages/theme-base/lib/verify-vars/index.js
+++ b/packages/theme-base/lib/verify-vars/index.js
@@ -65,7 +65,7 @@ for (let i = 0; i < varArrays.length; i++) {
 		if (i !== j) {
 			const missing = varArrays[i].filter(v => !varArrays[j].includes(v));
 			missing.forEach(v => {
-				if (!missingVars.includes(v)) {
+				if (!missingVars.includes(v) && !v.startsWith("sapHC")) {
 					missingVars.push(v);
 				}
 			})


### PR DESCRIPTION
The sapHC_* are High Contrast Black specific and should not be log as missing in the rest of the themes.
