### PR TITLE
fix(ui5-label): fix truncation when show-colon is set

### DIFF
--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -28,15 +28,15 @@
 }
 
 :host(:not([wrap])[required][show-colon]) .ui5-label-text-wrapper {
-	max-width: calc(100%-0.725rem);
+	max-width: calc(100% - 0.725rem);
 }
 
 :host(:not([wrap])[required]) .ui5-label-text-wrapper {
-	max-width: calc(100%-0.475rem);
+	max-width: calc(100% - 0.475rem);
 }
 
 :host(:not([wrap])[show-colon]) .ui5-label-text-wrapper {
-	max-width: calc(100%-0.3rem);
+	max-width: calc(100% - 0.2rem);
 }
 
 :host([show-colon]) .ui5-label-required-colon:before {

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -16,6 +16,8 @@
 		}
 	</script>
 
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
@@ -37,6 +39,21 @@
 	<section class="group">
 		<h2>Basic labels</h2>
 		<ui5-label id="basic-label">Basic Label</ui5-label>
+		<ui5-label show-colon id="basic-label2">Basic Label</ui5-label>
+		<ui5-label required id="basic-label2">Basic Label</ui5-label>
+		<ui5-label show-colon required id="basic-label3">Basic Label</ui5-label>
+
+		<h2>Basic long labels</h2>
+		<ui5-label id="basic-label4">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label show-colon id="basic-label5">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label required id="basic-label6">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label show-colon required id="basic-label6">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+
+		<h2>Basic long labels  with predefined width</h2>
+		<ui5-label style="width: 100px" id="basic-label7">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label style="width: 100px" show-colon id="basic-label8">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label style="width: 100px" required id="basic-label8">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
+		<ui5-label style="width: 100px" show-colon required id="basic-label9">Start The quick brown fox jumps over the lazy sheep End</ui5-label>
 	</section>
 	<section class="group">
 		<h2>Required labels</h2>

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -74,6 +74,10 @@
 
 	</section>
 
+	<h2>Test show-colon not forcing truncation</h2>
+	<ui5-label id="showColon-false">Basic Label</ui5-label>
+	<ui5-label show-colon id="showColon-true">Basic Label</ui5-label>
+
 	<section class="group">
 		<h2>label + input</h2>
 		<div style="display: flex; align-items: center">

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -27,6 +27,18 @@ describe("General API", () => {
 		assert.strictEqual(requiredLabelContent, '"*"', "after's content should be *");
 	});
 
+	it("tests show-colon does not force truncation", () => {
+		const labelWithNoColon = browser.$("#showColon-false").shadow$(".ui5-label-text-wrapper");
+		const labelWithShowColon = browser.$("#showColon-true").shadow$(".ui5-label-text-wrapper");
+
+		const labelWithNoColonSize = labelWithNoColon.getSize();
+		const labelWithShowColonSize = labelWithShowColon.getSize();
+
+		// Comparing ui5-label(s) "Basic Label" and "Basic Label:", but just the "Basic Label" part,
+		// that should be equal if no trunctation and not equal if truncated.
+		assert.strictEqual(labelWithNoColonSize.width, labelWithShowColonSize.width, "Both texts are equal in width");
+	});
+
 	it("should wrap the text of the label", () => {
 		const wrappingLabel = browser.$("#wrapping-label");
 		const truncatingLabel = browser.$("#truncated-label");


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/1077

The allocated width for the ":" used to be bigger than the ":" itself causing the ui5-label always to truncate, when show-colon is set to "true".

<img width="856" alt="Screenshot 2019-12-18 at 14 37 30" src="https://user-images.githubusercontent.com/15702139/71088405-ff50e200-21a6-11ea-9c5b-eb3e2ab6f4a4.png">


<img width="531" alt="Screenshot 2019-12-18 at 14 37 38" src="https://user-images.githubusercontent.com/15702139/71088420-0a0b7700-21a7-11ea-9feb-6e7d1813e5c4.png">
