### PR TITLE
feature(framework): allow setting compactSize dynamically

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -118,7 +118,7 @@ To do so, please import the desired functionality from the respective `"@ui5/web
 ```js
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { getNoConflict, setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
+import { getCompactSize, setCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";

--- a/docs/Public Module Imports.md
+++ b/docs/Public Module Imports.md
@@ -278,7 +278,7 @@ In order to to be able to use Buddhist, Islamic, Japanese or Persian calendar wi
 ```js
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { getNoConflict, setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
+import { getCompactSize, setCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";

--- a/packages/base/src/ContentDensity.js
+++ b/packages/base/src/ContentDensity.js
@@ -1,0 +1,20 @@
+const contentDensityChangeCallbacks = [];
+
+const attachContentDensityChange = callback => {
+	if (contentDensityChangeCallbacks.indexOf(callback) === -1) {
+		contentDensityChangeCallbacks.push(callback);
+	}
+};
+
+const _applyContentDensity = contentDensity => {
+	_executeContentDensityChangeCallbacks(contentDensity);
+};
+
+const _executeContentDensityChangeCallbacks = contentDensity => {
+	contentDensityChangeCallbacks.forEach(callback => callback(contentDensity));
+};
+
+export {
+	attachContentDensityChange,
+	_applyContentDensity,
+};

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -7,6 +7,7 @@ import Integer from "./types/Integer.js";
 import RenderScheduler from "./RenderScheduler.js";
 import { getConstructableStyle, createHeadStyle, getShadowRootStyle } from "./CSS.js";
 import { attachThemeChange } from "./Theming.js";
+import { attachContentDensityChange } from "./ContentDensity.js";
 import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
 import isValidPropertyName from "./util/isValidPropertyName.js";
 
@@ -28,6 +29,7 @@ class UI5Element extends HTMLElement {
 		this._initializeShadowRoot();
 
 		attachThemeChange(this.onThemeChanged.bind(this));
+		attachContentDensityChange(this.onContentDensityChanged.bind(this));
 
 		let deferredResolve;
 		this._domRefReadyPromise = new Promise(resolve => {
@@ -49,6 +51,19 @@ class UI5Element extends HTMLElement {
 		} else {
 			const oldStyle = this.shadowRoot.querySelector("style");
 			oldStyle.textContent = newStyle.textContent;
+		}
+	}
+
+	onContentDensityChanged() {
+		this._syncContentDensity();
+	}
+
+	_syncContentDensity() {
+		const isCompact = getCompactSize();
+		if (isCompact) {
+			this.setAttribute("data-ui5-compact-size", "");
+		} else {
+			this.removeAttribute("data-ui5-compact-size");
 		}
 	}
 
@@ -76,10 +91,7 @@ class UI5Element extends HTMLElement {
 	}
 
 	async connectedCallback() {
-		const isCompact = getCompactSize();
-		if (isCompact) {
-			this.setAttribute("data-ui5-compact-size", "");
-		}
+		this._syncContentDensity();
 
 		if (!this.constructor.needsShadowDOM()) {
 			return;

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -56,6 +56,9 @@ class UI5Element extends HTMLElement {
 
 	onContentDensityChanged() {
 		this._syncContentDensity();
+		if (this.constructor.getMetadata().getInvalidateOnContentDensityChange()) {
+			this._invalidate();
+		}
 	}
 
 	_syncContentDensity() {

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -39,6 +39,10 @@ class UI5ElementMetadata {
 		return this.metadata.events || {};
 	}
 
+	getInvalidateOnContentDensityChange() {
+		return !!this.metadata.invalidateOnContentDensityChange;
+	}
+
 	static validatePropertyValue(value, propData) {
 		const isMultiple = propData.multiple;
 		if (isMultiple) {

--- a/packages/base/src/config/CompactSize.js
+++ b/packages/base/src/config/CompactSize.js
@@ -1,9 +1,23 @@
 import { getCompactSize as getConfiguredCompactSize } from "../InitialConfiguration.js";
+import { _applyContentDensity } from "../ContentDensity.js";
 
-const compactSize = getConfiguredCompactSize();
+let compactSize = getConfiguredCompactSize();
 
 const getCompactSize = () => {
 	return compactSize;
 };
 
-export { getCompactSize }; // eslint-disable-line
+const setCompactSize = newCompactSize => {
+	if (compactSize === newCompactSize) {
+		return;
+	}
+
+	compactSize = newCompactSize;
+
+	_applyContentDensity(compactSize ? "compact" : "cozy");
+};
+
+export {
+	getCompactSize,
+	setCompactSize,
+};

--- a/packages/main/bundle.es5.js
+++ b/packages/main/bundle.es5.js
@@ -6,7 +6,7 @@ import "./bundle.esm.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
+import { getCompactSize, setCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getRegisteredNames as getIconNames } from  "@ui5/webcomponents-base/dist/SVGIconRegistry.js"
 const configuration = {
@@ -15,6 +15,7 @@ const configuration = {
 	setTheme,
 	setNoConflict,
 	getCompactSize,
+	setCompactSize,
 	getRTL,
 };
 export {

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -67,7 +67,7 @@ window.isIE = isIE; // attached to the window object for testing purposes
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
+import { getCompactSize, setCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getRegisteredNames as getIconNames } from  "@ui5/webcomponents-base/dist/SVGIconRegistry.js"
 window["sap-ui-webcomponents-bundle"] = {
@@ -77,6 +77,7 @@ window["sap-ui-webcomponents-bundle"] = {
 		setTheme,
 		setNoConflict,
 		getCompactSize,
+		setCompactSize,
 		getRTL,
 	},
 	getIconNames,

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -164,6 +164,7 @@ const metadata = {
 		 */
 		select: {},
 	},
+	invalidateOnContentDensityChange: true,
 };
 
 const SVGConfig = {


### PR DESCRIPTION
- The term `contentDensity` is used instead of `compactSize` for new files and vars (to be compatible with the upcoming rework of `compactSize`)
- All UI5 Elements subscribe to content density change and modify their host accordingly
- A new module `ContentDensity.js`, similar to `Theming.js` added to allow to subscribe/execute
- Only `ui5-radiobutton` currently uses `compactSize` outside of pure CSS, therefore it needs to be rerendered, thus the new metadata `invalidateOnContentDensityChange`. This is needed as components cannot call `_invalidate()` themselves, it's private to `UI5Element.js`