### PR TITLE
refactor(ui5-li): switch focus styling via state

### DIFF
--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -172,7 +172,8 @@ class ListItem extends ListItemBase {
 		this.deactivate();
 	}
 
-	_onfocusout(event) {
+	_onfocusout() {
+		super._onfocusout();
 		this.deactivate();
 	}
 

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -25,6 +25,14 @@ const metadata = {
 			defaultValue: "-1",
 			noAttribute: true,
 		},
+
+		/**
+		 * Indicates if the element is on focus
+		 * @private
+		 */
+		focused: {
+			type: Boolean,
+		},
 	},
 	events: {
 		_focused: {},
@@ -53,7 +61,12 @@ class ListItemBase extends UI5Element {
 	}
 
 	_onfocusin(event) {
+		this.focused = true;
 		this.fireEvent("_focused", event);
+	}
+
+	_onfocusout(_event) {
+		this.focused = false;
 	}
 
 	_onkeydown(event) {

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -30,12 +30,22 @@
 	box-sizing: border-box;
 }
 
-.ui5-li-root.ui5-li--focusable:focus {
+:host([focused]) .ui5-li-root.ui5-li--focusable {
 	outline: none;
 }
 
-.ui5-li-root.ui5-li--focusable:focus:after,
-.ui5-li-root.ui5-li--focusable .ui5-li-content:focus:after {
+:host([focused]) .ui5-li-root.ui5-li--focusable:after {
+	content: "";
+	border: var(--_ui5_listitembase_focus_width) dotted var(--sapContent_FocusColor);
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	pointer-events: none;
+}
+
+:host([focused]) .ui5-li-content:focus:after {
 	content: "";
 	border: var(--_ui5_listitembase_focus_width) dotted var(--sapContent_FocusColor);
 	position: absolute;


### PR DESCRIPTION
Add private property "focused" to apply the focus styling, even when the component is not on focus. This will allow the implementation of complex UX requirements related to the Combobox and MiltiCombobox, where the actual focus remains in the input field, but the visual focus outline moves between the items.