### PR TITLE
fix: Merge metadata properly

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -1,3 +1,5 @@
+import merge from "@ui5/webcomponents-utils/dist/sap/base/util/merge.js";
+
 import boot from "./boot.js";
 import { skipOriginalEvent } from "./config/NoConflict.js";
 import { getCompactSize } from "./config/CompactSize.js";
@@ -335,33 +337,20 @@ class UI5Element extends HTMLElement {
 	}
 
 	static getMetadata() {
-		let klass = this; // eslint-disable-line
-
-		if (klass.hasOwnProperty("_metadata")) { // eslint-disable-line
-			return klass._metadata;
+		if (this.hasOwnProperty("_metadata")) { // eslint-disable-line
+			return this._metadata;
 		}
 
-		const metadatas = [Object.assign(klass.metadata, {})];
+		const metadataObjects = [this.metadata];
+		let klass = this; // eslint-disable-line
 		while (klass !== UI5Element) {
 			klass = Object.getPrototypeOf(klass);
-			metadatas.push(klass.metadata);
+			metadataObjects.unshift(klass.metadata);
 		}
+		const mergedMetadata = merge({}, ...metadataObjects);
 
-		const result = metadatas[0];
-
-		result.properties = this._mergeMetadataEntry(metadatas, "properties"); // merge properties
-		result.slots = this._mergeMetadataEntry(metadatas, "slots"); // merge slots
-		result.events = this._mergeMetadataEntry(metadatas, "events"); // merge events
-
-		this._metadata = new UI5ElementMetadata(result);
+		this._metadata = new UI5ElementMetadata(mergedMetadata);
 		return this._metadata;
-	}
-
-	static _mergeMetadataEntry(metadatas, prop) {
-		return metadatas.reverse().reduce((result, current) => { // eslint-disable-line
-			Object.assign(result, current[prop] || {});
-			return result;
-		}, {});
 	}
 
 	_attachChildPropertyUpdated(child, propData) {

--- a/packages/utils/used-modules.txt
+++ b/packages/utils/used-modules.txt
@@ -5,6 +5,7 @@ sap/base/util/LoaderExtensions.js
 sap/base/util/ObjectPath.js
 sap/base/util/array/uniqueSort.js
 sap/base/util/deepEqual.js
+sap/base/util/merge.js
 sap/base/util/isPlainObject.js
 sap/base/util/now.js
 sap/ui/base/Interface.js


### PR DESCRIPTION
- The `metadata` objects were not merged correctly due to calling `Array.prototype.reverse` several times in a row, while not considering it changes the original object, thus when merging slots, it was done in the opposite direction
- The merge was not deep so you couldn't just override a setting for a property or slot for example
- Additionally the variable `klass` was used only when necessary for clarity (when looping over prototypes), for the rest `this` is more intuitive

This changes uses the deep merge `merge.js` from the `utils` project.

closes: https://github.com/SAP/ui5-webcomponents/issues/454

