### PR TITLE
refactor: improve auto-generated IDs

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -598,7 +598,7 @@ class UI5Element extends HTMLElement {
 	 * @private
 	 */
 	static _nextID() {
-		const className = "el";
+		const className = kebabToCamelCase(this.getMetadata().getTag());
 		const lastNumber = IDMap.get(className);
 		const nextNumber = lastNumber !== undefined ? lastNumber + 1 : 1;
 		IDMap.set(className, nextNumber);

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -111,7 +111,7 @@ class MonthPicker extends UI5Element {
 
 			const month = {
 				timestamp: timestamp.toString(),
-				id: `${this._state._id}-m${i}`,
+				id: `${this._id}-m${i}`,
 				name: this._oLocaleData.getMonths("wide", this._primaryCalendarType)[i],
 				classes: "ui5-mp-item",
 			};

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -140,7 +140,7 @@ class YearPicker extends UI5Element {
 
 			const year = {
 				timestamp: timestamp.toString(),
-				id: `${this._state._id}-y${timestamp}`,
+				id: `${this._id}-y${timestamp}`,
 				year: oYearFormat.format(oCalDate.toLocalJSDate()),
 				classes: "ui5-yp-item",
 			};


### PR DESCRIPTION
- `_nextID` now generates better IDs based on the class name (rather than a hard-coded prefix), which makes the Map used useful (before it could have been an integer instead).
- Wrongly generated IDs were fixed (`_state` is private to `UI5Element.js` and should not be used outside)