### PR TITLE
refactor: simplify theming management

### DIFF
--- a/packages/base/src/CSS.js
+++ b/packages/base/src/CSS.js
@@ -1,5 +1,4 @@
 import { getEffectiveStyle } from "./Theming.js";
-import { getTheme } from "./config/Theme.js";
 import { injectWebComponentStyle } from "./theming/StyleInjection.js";
 import adaptCSSForIE from "./util/CSSTransformUtils.js";
 
@@ -32,33 +31,16 @@ const createHeadStyle = ElementClass => {
 const getConstructableStyle = ElementClass => {
 	const tagName = ElementClass.getMetadata().getTag();
 	const styleContent = getEffectiveStyle(ElementClass);
-	const theme = getTheme();
-	const key = theme + tagName;
-	if (constructableStyleMap.has(key)) {
-		return constructableStyleMap.get(key);
+	if (constructableStyleMap.has(tagName)) {
+		return constructableStyleMap.get(tagName);
 	}
 
 	const style = new CSSStyleSheet();
 	style.replaceSync(styleContent);
 
-	constructableStyleMap.set(key, style);
+	constructableStyleMap.set(tagName, style);
 	return style;
 };
 
-/**
- * Returns the CSS to be injected inside a web component shadow root, or undefined if not needed
- * Note: FF, Safari
- * @param ElementClass
- * @returns {string}
- */
-const getShadowRootStyle = ElementClass => {
-	if (document.adoptedStyleSheets || window.ShadyDOM) {
-		return;
-	}
-
-	const styleContent = getEffectiveStyle(ElementClass);
-	return styleContent;
-};
-
 // eslint-disable-next-line
-export { createHeadStyle, getConstructableStyle, getShadowRootStyle};
+export { createHeadStyle, getConstructableStyle };

--- a/packages/base/src/CSS.js
+++ b/packages/base/src/CSS.js
@@ -42,5 +42,7 @@ const getConstructableStyle = ElementClass => {
 	return style;
 };
 
-// eslint-disable-next-line
-export { createHeadStyle, getConstructableStyle };
+export {
+	createHeadStyle,
+	getConstructableStyle,
+};

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -8,7 +8,7 @@ import UI5ElementMetadata from "./UI5ElementMetadata.js";
 import Integer from "./types/Integer.js";
 import RenderScheduler from "./RenderScheduler.js";
 import { getConstructableStyle, createHeadStyle } from "./CSS.js";
-import { attachThemeChange, getEffectiveStyle } from "./Theming.js";
+import { getEffectiveStyle } from "./Theming.js";
 import { attachContentDensityChange } from "./ContentDensity.js";
 import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
 import isValidPropertyName from "./util/isValidPropertyName.js";
@@ -40,7 +40,6 @@ class UI5Element extends HTMLElement {
 		this._upgradeAllProperties();
 		this._initializeShadowRoot();
 
-		attachThemeChange(this._onThemeChanged.bind(this));
 		attachContentDensityChange(this._onContentDensityChanged.bind(this));
 
 		let deferredResolve;
@@ -51,11 +50,6 @@ class UI5Element extends HTMLElement {
 
 		this._monitoredChildProps = new Map();
 	}
-
-	/**
-	 * @private
-	 */
-	_onThemeChanged() {}
 
 	/**
 	 * @private

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -7,8 +7,8 @@ import DOMObserver from "./compatibility/DOMObserver.js";
 import UI5ElementMetadata from "./UI5ElementMetadata.js";
 import Integer from "./types/Integer.js";
 import RenderScheduler from "./RenderScheduler.js";
-import { getConstructableStyle, createHeadStyle, getShadowRootStyle } from "./CSS.js";
-import { attachThemeChange } from "./Theming.js";
+import { getConstructableStyle, createHeadStyle } from "./CSS.js";
+import { attachThemeChange, getEffectiveStyle } from "./Theming.js";
 import { attachContentDensityChange } from "./ContentDensity.js";
 import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
 import isValidPropertyName from "./util/isValidPropertyName.js";
@@ -55,19 +55,7 @@ class UI5Element extends HTMLElement {
 	/**
 	 * @private
 	 */
-	_onThemeChanged() {
-		if (window.ShadyDOM || !this.constructor._needsShadowDOM()) {
-			// polyfill theme handling is in head styles directly
-			return;
-		}
-		const newStyle = getConstructableStyle(this.constructor);
-		if (document.adoptedStyleSheets) {
-			this.shadowRoot.adoptedStyleSheets = [newStyle];
-		} else {
-			const oldStyle = this.shadowRoot.querySelector("style");
-			oldStyle.textContent = newStyle.textContent;
-		}
-	}
+	_onThemeChanged() {}
 
 	/**
 	 * @private
@@ -488,9 +476,12 @@ class UI5Element extends HTMLElement {
 	 * @private
 	 */
 	_updateShadowRoot() {
+		let styleToPrepend;
 		const renderResult = this.constructor.template(this);
-		// For browsers that do not support constructable style sheets (and not using the polyfill)
-		const styleToPrepend = getShadowRootStyle(this.constructor);
+
+		if (!document.adoptedStyleSheets && !window.ShadyDOM) {
+			styleToPrepend = getEffectiveStyle(this.constructor);
+		}
 		this.constructor.render(renderResult, this.shadowRoot, styleToPrepend, { eventContext: this });
 	}
 


### PR DESCRIPTION
- Component-specific CSS is no longer dependent on the theme, therefore nothing happens on theme change
- Constructable stylesheets no longer need the theme as part of the key - currently exactly the same constructable style is created 4 times (once for each theme) unnecessarily
- Directly use `getEffectiveStyle` in `UI5Element.js` and move the logic when to use it there as well, in order to make it consistent with the Chrome and IE/Edge checks (which are also in `UI5Element.js`). Therefore `getShadowRootStyle` becomes unnecessary.