### PR TITLE
refactor(ui5-icon): remove src property

### DIFF
--- a/packages/base/src/asset-registries/Themes.js
+++ b/packages/base/src/asset-registries/Themes.js
@@ -39,7 +39,7 @@ const fetchThemeProperties = async (packageName, themeName) => {
 	const url = themeURLs.get(`${packageName}_${themeName}`);
 
 	if (!url) {
-		throw new Error(`You have to import @ui5/webcomponents/dist/json-imports/Themes module to use theme switching`);
+		throw new Error(`You have to import the ${packageName}/dist/Assets.js module to switch to additional themes`);
 	}
 	return fetchJsonOnce(url);
 };

--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -32,20 +32,20 @@ const registerI18nBundle = (packageName, bundle) => {
 };
 
 /**
- * This method preforms the asyncronous task of fething the actual text resources. It will fetch
+ * This method preforms the asynchronous task of fetching the actual text resources. It will fetch
  * each text resource over the network once (even for multiple calls to the same method).
  * It should be fully finished before the i18nBundle class is created in the webcomponents.
  * This method uses the bundle URLs that are populated by the <code>registerI18nBundle</code> method.
  * To simplify the usage, the synchronization of both methods happens internally for the same <code>bundleId</code>
- * @param {packageName} packageName the node project package id
+ * @param {packageName} packageName the NPM package name
  * @public
  */
 const fetchI18nBundle = async packageName => {
 	const bundlesForPackage = bundleURLs.get(packageName);
 
 	if (!bundlesForPackage) {
-		console.warn(`Message bundle assets are not configured. Falling back to english texts.`, /* eslint-disable-line */
-		` You need to import @ui5/webcomponents/dist/json-imports/i18n.js with a build tool that supports JSON imports.`); /* eslint-disable-line */
+		console.warn(`Message bundle assets are not configured. Falling back to English texts.`, /* eslint-disable-line */
+		` You need to import ${packageName}/dist/Assets.js with a build tool that supports JSON imports.`); /* eslint-disable-line */
 		return;
 	}
 

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -15,26 +15,6 @@ import iconCss from "./generated/themes/Icon.css.js";
 const metadata = {
 	tag: "ui5-icon",
 	properties: /** @lends sap.ui.webcomponents.main.Icon.prototype */ {
-
-		/**
-		 * Defines the source URI of the <code>ui5-icon</code>.
-		 * <br><br>
-		 * To browse all available icons, see the
-		 * <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
-		 * <br><br>
-		 * Example:
-		 * <br>
-		 * <code>src='sap-icon://add'</code>, <code>src='sap-icon://delete'</code>, <code>src='sap-icon://employee'</code>.
-		 *<b> NOTE: This property is about to be removed in the next version! Please use the <code>name</code> property instead.</b>
-		 *
-		 * @type {string}
-		 * @public
-		 * @deprecated
-		*/
-		src: {
-			type: String,
-		},
-
 		/**
 		 * Defines the unique identifier (icon name) of each <code>ui5-icon</code>.
 		 * <br><br>
@@ -169,19 +149,18 @@ class Icon extends UI5Element {
 	}
 
 	async onBeforeRendering() {
-		const name = this.name || this.src;
-		if (this.src) {
+		const name = this.name;
+		if (!name) {
 			/* eslint-disable-next-line */
-			console.warn(`The src property is about to be depricated in the next version of UI5 Web Components. Please use the name property!`);
+			return console.warn("Icon name property is required", this);
 		}
-
 		let iconData = getIconDataSync(name);
 		if (!iconData) {
 			try {
 				iconData = await getIconData(name);
 			} catch (e) {
 				/* eslint-disable-next-line */
-				return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents/dist/icons/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/json-imports/Icons.js".`);
+				return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents/dist/icons/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/Assets.js".`);
 			}
 		}
 		this.pathData = iconData.pathData;


### PR DESCRIPTION
- remove the `src` property in favor of `name` (it used to be deprecated)
- fix the `console.warn` messages to suggest the new asset imports (not just for icons, but for other assets as well)

BREAKING CHANGE: The `src` property is replaced with `name` and no longer requires the `sap-icon://` protocol. For example: `<ui5-icon src="sap-icon://add">` becomes `<ui5-icon name="add">`