### PR TITLE
chore: improve UI5Element detection

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -163,9 +163,10 @@ class UI5Element extends HTMLElement {
 	}
 
 	/**
+	 * Note: this method is also manually called by "compatibility/patchNodeValue.js"
 	 * @private
 	 */
-	async _processChildren(mutations) {
+	async _processChildren() {
 		const hasSlots = this.constructor.getMetadata().hasSlots();
 		if (hasSlots) {
 			await this._updateSlots();

--- a/packages/base/src/compatibility/patchNodeValue.js
+++ b/packages/base/src/compatibility/patchNodeValue.js
@@ -12,7 +12,7 @@ const patchNodeValue = () => {
 
 			// Call manually the mutation observer callback
 			const parentElement = this.parentNode;
-			if (parentElement instanceof Element && typeof parentElement._processChildren === "function") {
+			if (parentElement instanceof HTMLElement && parentElement.isUI5Element) {
 				parentElement._processChildren();
 			}
 		},

--- a/packages/base/test/specs/UI5ElementInvalidation.js
+++ b/packages/base/test/specs/UI5ElementInvalidation.js
@@ -166,6 +166,60 @@ describe("Invalidation works", () => {
 		assert.strictEqual(res, true, "Invalidated");
 	});
 
+	it("Tests that modifying textContent invalidates", () => {
+
+		const res = browser.executeAsync( async (done) => {
+
+			const el = document.getElementById("gen");
+			el.textContent = "test";
+			await window.RenderScheduler.whenFinished();
+
+			// Number of invalidations may vary with children/slots count, so just check for invalidation
+			let invalidated = false;
+
+			const original = el._invalidate;
+			el._invalidate = () => {
+				original.apply(el, arguments);
+				invalidated = true;
+			};
+
+			el.textContent = "test2";
+
+			await window.RenderScheduler.whenFinished();
+
+			return done(invalidated);
+		});
+
+		assert.strictEqual(res, true, "Invalidated");
+	});
+
+	it("Tests that modifying nodeValue invalidates", () => {
+
+		const res = browser.executeAsync( async (done) => {
+
+			const el = document.getElementById("gen");
+			el.textContent = "test";
+			await window.RenderScheduler.whenFinished();
+
+			// Number of invalidations may vary with children/slots count, so just check for invalidation
+			let invalidated = false;
+
+			const original = el._invalidate;
+			el._invalidate = () => {
+				original.apply(el, arguments);
+				invalidated = true;
+			};
+
+			el.childNodes[0].nodeValue = "test2";
+
+			await window.RenderScheduler.whenFinished();
+
+			return done(invalidated);
+		});
+
+		assert.strictEqual(res, true, "Invalidated");
+	});
+
 	it("Tests that multiple invalidations result in a single rendering", () => {
 
 		const res = browser.executeAsync( async (done) => {


### PR DESCRIPTION
- The IE patch that overcomes the limitation of the fake Mutation Observer now uses the official duck-typing check for UI5Element. Additionally it was documented that `_processChildren` is called from the outside and should not be renamed.
- Added 2 tests checking for invalidation upon text change inside a web component with a slot of type `Node`