### PR TITLE
chore: fix unstable test

### DIFF
--- a/packages/main/test/pageobjects/DayPickerTestPage.js
+++ b/packages/main/test/pageobjects/DayPickerTestPage.js
@@ -7,12 +7,12 @@ class DayPickerTestHelper {
 		return browser.executeAsync(async (id, done) => {
 			await window.RenderScheduler.whenFinished();
 
-			document.getElementById(id).shadowRoot.querySelector("ui5-popover") // ui5-popover
+			const el = document.getElementById(id).shadowRoot.querySelector("ui5-popover") // ui5-popover
 				.shadowRoot.querySelector("slot").assignedNodes()[0] // ui5-calendar
 				.shadowRoot.querySelector("ui5-daypicker") // ui5-daypicker
 				.shadowRoot.querySelector(".ui5-dp-root");
 
-			return done();
+			return done(el);
 		}, this._sut);
 	}
 

--- a/packages/main/test/pageobjects/DayPickerTestPage.js
+++ b/packages/main/test/pageobjects/DayPickerTestPage.js
@@ -3,25 +3,31 @@ class DayPickerTestHelper {
 		this._sut = id;
 	}
 
-	get getDayPickerRoot() {
-		return browser.execute((id) => {
-			return document.getElementById(id).shadowRoot.querySelector("ui5-popover") // ui5-popover
+	get dayPickerRoot() {
+		return browser.executeAsync(async (id, done) => {
+			await window.RenderScheduler.whenFinished();
+
+			document.getElementById(id).shadowRoot.querySelector("ui5-popover") // ui5-popover
 				.shadowRoot.querySelector("slot").assignedNodes()[0] // ui5-calendar
 				.shadowRoot.querySelector("ui5-daypicker") // ui5-daypicker
 				.shadowRoot.querySelector(".ui5-dp-root");
+
+			return done();
 		}, this._sut);
 	}
 
 	get currentDate() {
-		return browser.execute((id) => {
+		return browser.executeAsync(async (id, done) => {
+			await window.RenderScheduler.whenFinished();
+
 			const timestamp = document.getElementById(id).shadowRoot.querySelector("ui5-popover") // ui5-popover
 			.shadowRoot.querySelector("slot").assignedNodes()[0] // ui5-calendar
 			.shadowRoot.querySelector("ui5-daypicker") // ui5-daypicker
 			.timestamp;
 
-			return new Date(timestamp*1000).getDate(); //parse the unix timestamp 
+			return done(new Date(timestamp*1000).getDate()); //parse the unix timestamp
 		}, this._sut);
 	}
-};
+}
 
 module.exports = new DayPickerTestHelper();

--- a/packages/main/test/specs/DayPicker.spec.js
+++ b/packages/main/test/specs/DayPicker.spec.js
@@ -12,7 +12,7 @@ describe("Day Picker Tests", () => {
 
 	it("Day Picker Renders", () => {
 		daypicker.id = "daypicker";
-		const DayPicker = daypicker.getDayPickerRoot;
+		const DayPicker = daypicker.dayPickerRoot;
 
 		assert.ok(DayPicker, "Day Picker is rendered");
 	});


### PR DESCRIPTION
- This test sometimes fails, because it does not use the framework methods that synchronize with the `RenderScheduler`, but rather directly executes low-level code with `browser.execute`. Therefore the fix is to use `browser.executeAsync` and wait for the rendering to be complete manually.
- Additionally fixed the wrongly named getter