### PR TITLE
chore: update npmignore files

### DIFF
--- a/packages/theme-base/.npmignore
+++ b/packages/theme-base/.npmignore
@@ -2,7 +2,6 @@
 dist/api.json
 dist/resources
 dist/test-resources
-lib/
 node_modules/
 src/
 test/

--- a/packages/tools/.npmignore
+++ b/packages/tools/.npmignore
@@ -9,6 +9,5 @@ bundle.*.js
 .eslintrc.js
 .eslintignore
 main.*js
-serve.json
 wdio.conf.js
 !core

--- a/packages/tools/.npmignore
+++ b/packages/tools/.npmignore
@@ -2,7 +2,6 @@
 dist/api.json
 dist/resources
 dist/test-resources
-lib/
 node_modules/
 src/
 test/
@@ -10,7 +9,6 @@ bundle.*.js
 .eslintrc.js
 .eslintignore
 main.*js
-rollup*
 serve.json
 wdio.conf.js
 !core


### PR DESCRIPTION
The tools package "lib" folder and rollup.js are not being published in npm (they are simply ignored),
but they are needed for other repos using our tooling to build and develop UI5 Web Components.