### PR TITLE
refactor(ui5-radiobutton): set compact via CSS

### DIFF
--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -14,8 +14,8 @@
 
 	<div class='ui5-radio-inner {{classes.inner}}'>
 		<svg class="ui5-radio-svg" focusable="false" aria-hidden="true">
-			<circle class="ui5-radio-svg-outer" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rOuter}}" stroke-width="{{strokeWidth}}" fill="none" />
-			<circle class="ui5-radio-svg-inner" cx="{{circle.x}}" cy="{{circle.y}}" r="{{circle.rInner}}" stroke-width="10" />
+			<circle class="ui5-radio-svg-outer" r="50%" />
+			<circle class="ui5-radio-svg-inner" r="5" />
 		</svg>
  		<input type='radio' ?checked="{{selected}}" ?readonly="{{readonly}}" ?disabled="{{disabled}}" name="{{name}}" data-sap-no-tab-ref/>
 	</div>

--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -14,8 +14,8 @@
 
 	<div class='ui5-radio-inner {{classes.inner}}'>
 		<svg class="ui5-radio-svg" focusable="false" aria-hidden="true">
-			<circle class="ui5-radio-svg-outer" r="50%" />
-			<circle class="ui5-radio-svg-inner" r="5" />
+			<circle class="ui5-radio-svg-outer" cx="50%" cy="50%" r="50%" />
+			<circle class="ui5-radio-svg-inner" cx="50%" cy="50%" r="22%" />
 		</svg>
  		<input type='radio' ?checked="{{selected}}" ?readonly="{{readonly}}" ?disabled="{{disabled}}" name="{{name}}" data-sap-no-tab-ref/>
 	</div>

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -1,5 +1,4 @@
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
-import { getCompactSize } from "@ui5/webcomponents-base/dist/config/CompactSize.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
@@ -165,21 +164,6 @@ const metadata = {
 		select: {},
 	},
 	invalidateOnContentDensityChange: true,
-};
-
-const SVGConfig = {
-	"compact": {
-		x: 16,
-		y: 16,
-		rInner: 3,
-		rOuter: 8,
-	},
-	"default": {
-		x: 22,
-		y: 22,
-		rInner: 5,
-		rOuter: 11,
-	},
 };
 
 /**
@@ -402,10 +386,6 @@ class RadioButton extends UI5Element {
 
 	get strokeWidth() {
 		return this.valueState === "None" ? "1" : "2";
-	}
-
-	get circle() {
-		return getCompactSize() ? SVGConfig.compact : SVGConfig.default;
 	}
 
 	get rtl() {

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -5,6 +5,7 @@
 }
 
 :host {
+	min-width: var(--_ui5_radiobutton_min_width);
 	max-width: 100%;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -120,9 +121,13 @@
 }
 
 .ui5-radio-inner input {
-	margin: 0; /* FF puts margin */
+	-webkit-appearance: none;
 	visibility: hidden;
 	width: 0;
+	left: 0;
+	position: absolute;
+	font-size: inherit;
+	margin: 0; /* FF puts margin */
 }
 
 /* Label */
@@ -170,10 +175,14 @@ ui5-label.ui5-radio-label {
 .ui5-radio-svg-outer,
 .ui5-radio-svg-inner {
 	flex-shrink: 0;
-	transform: translate(0.6875rem, 0.6875rem);
+	transform: var(--_ui5_radiobutton_svg_transform);
 }
 
 /* Compact size */
+:host([data-ui5-compact-size]) {
+	min-width: var(--_ui5_radiobutton_min_width_compact);
+}
+
 :host([data-ui5-compact-size]) .ui5-radio-root {
 	height : 2rem;
 }
@@ -188,11 +197,11 @@ ui5-label.ui5-radio-label {
 }
 
 :host([data-ui5-compact-size]) .ui5-radio-svg-outer {
-	transform: translate(0.5rem, 0.5rem);
+	transform: var(--_ui5_radiobutton_svg_outer_transform_compact);
 }
 
 :host([data-ui5-compact-size]) .ui5-radio-svg-inner {
-	transform: translate(0.5rem, 0.5rem) scale(0.6);
+	transform: var(--_ui5_radiobutton_svg_inner_transform_compact);
 }
 
 :host([data-ui5-compact-size][wrap][text]) ui5-label.ui5-radio-label {

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -62,22 +62,27 @@
 	fill: var(--sapField_ReadOnly_Background);
 	stroke: var(--sapField_ReadOnly_BorderColor);
 }
+/* State */
+:host([value-state="Error"]) .ui5-radio-svg-outer,
+:host([value-state="Warning"]) .ui5-radio-svg-outer {
+	stroke-width: 2;
+}
 
 /* Error state */
-:host([value-state="Error"][selected]) .ui5-radio-root .ui5-radio-svg-inner {
+:host([value-state="Error"][selected]) .ui5-radio-svg-inner {
 	fill: var(--_ui5_radiobutton_selected_error_fill);
 }
-:host([value-state="Error"]) .ui5-radio-root .ui5-radio-svg-outer,
+:host([value-state="Error"]) .ui5-radio-svg-outer,
 :host([value-state="Error"]) .ui5-radio-root:hover .ui5-radio-inner.ui5-radio-inner--hoverable:hover .ui5-radio-svg-outer {
 	stroke: var(--sapField_InvalidColor);
 	fill: var(--sapField_InvalidBackground);
 }
 
 /* Warning state */
-:host([value-state="Warning"][selected]) .ui5-radio-root .ui5-radio-svg-inner {
+:host([value-state="Warning"][selected]) .ui5-radio-svg-inner {
 	fill: var(--_ui5_radiobutton_selected_warning_fill);
 }
-:host([value-state="Warning"]) .ui5-radio-root .ui5-radio-svg-outer,
+:host([value-state="Warning"]) .ui5-radio-svg-outer,
 :host([value-state="Warning"]) .ui5-radio-root:hover .ui5-radio-inner.ui5-radio-inner--hoverable:hover .ui5-radio-svg-outer {
 	stroke: var(--sapField_WarningColor);
 	fill: var(--sapField_WarningBackground);
@@ -99,12 +104,15 @@
 
 /* Inner */
 .ui5-radio-inner {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
 	width: 2.75rem;
 	height: 2.75rem;
 	font-size: 1rem; /* override font size of the message dialog */
 	pointer-events: none;
 	vertical-align: top;
-	display: inline-block;
 }
 
 .ui5-radio-inner:focus {
@@ -143,18 +151,26 @@ ui5-label.ui5-radio-label {
 
 /* SVG */
 .ui5-radio-svg {
-	height: 2.75rem;
-	width: 2.75rem;
+	height: 1.375rem;
+	width: 1.375rem;
+	overflow: visible;
 	pointer-events: none;
 }
 
-.ui5-radio-svg .ui5-radio-svg-outer {
+.ui5-radio-svg-outer {
 	fill: var(--sapField_Background);
 	stroke: currentColor;
+	stroke-width: 1;
 }
 
-.ui5-radio-svg .ui5-radio-svg-inner {
+.ui5-radio-svg-inner {
 	fill: none;
+}
+
+.ui5-radio-svg-outer,
+.ui5-radio-svg-inner {
+	flex-shrink: 0;
+	transform: translate(0.6875rem, 0.6875rem);
 }
 
 /* Compact size */
@@ -164,6 +180,19 @@ ui5-label.ui5-radio-label {
 
 :host([data-ui5-compact-size][wrap][text]) .ui5-radio-root {
 	height: auto;
+}
+
+:host([data-ui5-compact-size]) .ui5-radio-svg {
+	height: 1rem;
+	width: 1rem;
+}
+
+:host([data-ui5-compact-size]) .ui5-radio-svg-outer {
+	transform: translate(0.5rem, 0.5rem);
+}
+
+:host([data-ui5-compact-size]) .ui5-radio-svg-inner {
+	transform: translate(0.5rem, 0.5rem) scale(0.6);
 }
 
 :host([data-ui5-compact-size][wrap][text]) ui5-label.ui5-radio-label {
@@ -188,11 +217,6 @@ ui5-label.ui5-radio-label {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-}
-
-:host([data-ui5-compact-size]) .ui5-radio-root .ui5-radio-inner .ui5-radio-svg {
-	height: 2rem;
-	width: 2rem;
 }
 
 :host([data-ui5-compact-size]) .ui5-radio-root ui5-label.ui5-radio-label {

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -175,7 +175,6 @@ ui5-label.ui5-radio-label {
 .ui5-radio-svg-outer,
 .ui5-radio-svg-inner {
 	flex-shrink: 0;
-	transform: var(--_ui5_radiobutton_svg_transform);
 }
 
 /* Compact size */
@@ -194,14 +193,6 @@ ui5-label.ui5-radio-label {
 :host([data-ui5-compact-size]) .ui5-radio-svg {
 	height: 1rem;
 	width: 1rem;
-}
-
-:host([data-ui5-compact-size]) .ui5-radio-svg-outer {
-	transform: var(--_ui5_radiobutton_svg_outer_transform_compact);
-}
-
-:host([data-ui5-compact-size]) .ui5-radio-svg-inner {
-	transform: var(--_ui5_radiobutton_svg_inner_transform_compact);
 }
 
 :host([data-ui5-compact-size][wrap][text]) ui5-label.ui5-radio-label {

--- a/packages/main/src/themes/base/RadioButton-parameters.css
+++ b/packages/main/src/themes/base/RadioButton-parameters.css
@@ -1,11 +1,6 @@
 :root {
 	--_ui5_radiobutton_min_width: 2.75rem;
 	--_ui5_radiobutton_min_width_compact: 2rem;
-
-	--_ui5_radiobutton_svg_transform: translate(0.6875rem, 0.6875rem);
-	--_ui5_radiobutton_svg_inner_transform_compact: translate(0.5rem, 0.5rem) scale(0.6);
-	--_ui5_radiobutton_svg_outer_transform_compact: translate(0.5rem, 0.5rem);
-
 	--_ui5_radiobutton_hover_fill: var(--sapField_Hover_Background);
 	--_ui5_radiobutton_border_width: 1px;
 	--_ui5_radiobutton_selected_fill: var(--sapSelectedColor);

--- a/packages/main/src/themes/base/RadioButton-parameters.css
+++ b/packages/main/src/themes/base/RadioButton-parameters.css
@@ -1,4 +1,11 @@
 :root {
+	--_ui5_radiobutton_min_width: 2.75rem;
+	--_ui5_radiobutton_min_width_compact: 2rem;
+
+	--_ui5_radiobutton_svg_transform: translate(0.6875rem, 0.6875rem);
+	--_ui5_radiobutton_svg_inner_transform_compact: translate(0.5rem, 0.5rem) scale(0.6);
+	--_ui5_radiobutton_svg_outer_transform_compact: translate(0.5rem, 0.5rem);
+
 	--_ui5_radiobutton_hover_fill: var(--sapField_Hover_Background);
 	--_ui5_radiobutton_border_width: 1px;
 	--_ui5_radiobutton_selected_fill: var(--sapSelectedColor);


### PR DESCRIPTION
Reuse same SVG mark up for both "compact and "cozy" content densities and apply corresponding differences in size via CSS only and remove all current JS calculations.