### PR TITLE
fix(Icon): Update warning to show correct path

### DIFF
--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -160,7 +160,7 @@ class Icon extends UI5Element {
 				iconData = await getIconData(name);
 			} catch (e) {
 				/* eslint-disable-next-line */
-				return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents/dist/icons/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/Assets.js".`);
+				return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents-icons/dist/icons/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/Assets.js".`);
 			}
 		}
 		this.pathData = iconData.pathData;


### PR DESCRIPTION
The warning was pointing to `@ui5/webcomponents` instead of `@ui5/webcomponents-icons`

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
