### PR TITLE
fix(ui5-li): correct focus color when active

### DIFF
--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -56,7 +56,7 @@
 	pointer-events: none;
 }
 
-:host([active][focused]) .ui5-li-content:focus:after {
+:host([active][focused]) .ui5-li-root.ui5-li--focusable:after {
 	border-color: var(--sapContent_ContrastFocusColor);
 }
 

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -56,6 +56,10 @@
 	pointer-events: none;
 }
 
+:host([active][focused]) .ui5-li-content:focus:after {
+	border-color: var(--sapContent_ContrastFocusColor);
+}
+
 .ui5-li-content {
 	max-width: 100%;
 	min-height: 1px; /* IE specific: fixes vertical centering with flex  */


### PR DESCRIPTION
When pressed down the list item focus color should be changed to fulfil the constrast ratio with the background in active state.
