### PR TITLE
feature(ui5-textarea): allow users to modify textarea background

### DIFF
--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -5,6 +5,7 @@
 :host {
 	width: 100%;
 	color: var(--sapField_TextColor);
+	background-color: var(--sapField_Background);
 	font-size: var(--sapFontMediumSize);
 	font-family: var(--sapFontFamily);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
@@ -57,7 +58,6 @@
 	-moz-appearance: textfield;
 	overflow: auto;
 	resize: none;
-    background-color: var(--sapField_Background);
     border: 1px solid var(--sapField_BorderColor);
     border-radius: inherit;
 }


### PR DESCRIPTION
Users can now override the color, but not the background. So move the CSS rule to the host.