### PR TITLE
fix(ui5-avatar): remove background color when there is no image

### DIFF
--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -81,11 +81,11 @@
 	width: 3rem;
 }
 
-:host(:not([img-src])) {
+:host(:not([img])) {
 	background-color: var(--sapAccentColor6);
 }
 
-:host(:not([img-src])) .ui5-avatar-icon {
+:host(:not([img])) .ui5-avatar-icon {
 	color: var(--sapContent_ImagePlaceholderForegroundColor);
 }
 


### PR DESCRIPTION
The CSS rule was left over when "img-src" was renamed to "image" and due to that all transparent images became blue.