### PR TITLE
refactor(ui5-checkbox, ui5-radiobutton): propagate tabindex

### DIFF
--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -300,7 +300,8 @@ class CheckBox extends UI5Element {
 	}
 
 	get tabIndex() {
-		return this.disabled ? undefined : "0";
+		const tabindex = this.getAttribute("tabindex");
+		return this.disabled ? undefined : tabindex || "0";
 	}
 
 	get rtl() {

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -36,6 +36,7 @@
 {{#*inline "selectionElement"}}
 	{{#if modeSingleSelect}}
 		<ui5-radiobutton
+				tabindex="-1"
 				id="{{_id}}-singleSelectionElement"
 				class="ui5-li-singlesel-radiobtn"
 				?selected="{{selected}}"
@@ -45,6 +46,7 @@
 
 	{{#if modeMultiSelect}}
 		<ui5-checkbox
+				tabindex="-1"
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -380,7 +380,17 @@ class RadioButton extends UI5Element {
 	}
 
 	get tabIndex() {
-		return this.disabled || (!this.selected && this.name) ? "-1" : "0";
+		const tabindex = this.getAttribute("tabindex");
+
+		if (this.disabled) {
+			return "-1";
+		}
+
+		if (this.name) {
+			return this.selected ? "0" : "-1";
+		}
+
+		return tabindex || "0";
 	}
 
 	get strokeWidth() {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -132,6 +132,7 @@
 .ui5-li-multisel-cb,
 .ui5-li-singlesel-radiobtn {
 	flex-shrink: 0;
+	pointer-events: none;
 }
 
 :host() ui5-checkbox.ui5-li-singlesel-radiobtn {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -132,7 +132,6 @@
 .ui5-li-multisel-cb,
 .ui5-li-singlesel-radiobtn {
 	flex-shrink: 0;
-	pointer-events: none;
 }
 
 :host() ui5-checkbox.ui5-li-singlesel-radiobtn {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -34,17 +34,6 @@ describe("List Tests", () => {
 		assert.strictEqual(secondItem.getProperty("id"), selectionChangeResultPreviousItemsParameter.getProperty("value"));
 	});
 
-	it("selectionChange using selection component", () => {
-		const fieldResult = $("#fieldMultiSelResult");
-		const firstItem = $("#listMultiSel #option1");
-		const firstItemSelectionComponent = $("#listMultiSel #option1").shadow$(".ui5-li-multisel-cb");
-
-		firstItemSelectionComponent.click();
-
-		assert.ok(firstItem.getProperty("selected"), "item is selected");
-		assert.strictEqual(fieldResult.getProperty("value"), "true");
-	});
-
 	it("No data text is shown", () => {
 		const noDataText = browser.$("#no-data-list").shadow$(".ui5-list-nodata-text");
 


### PR DESCRIPTION
- checkbox,  radio: consider the "tabindex" set on the host and propagate it into the shadow DOM.
- list item: set "tabindex='-1'" to the selection components as there is no need of a tab stop
