### PR TITLE
fix(ui5-input): border-color on hover

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -122,7 +122,7 @@
 	background: var(--sapField_ReadOnly_Background);
 }
 
-:host(:not([value-state]:not([readonly])):hover) {
+:host(:not([readonly]):hover) {
 	background-color: var(--sapField_Hover_Background);
 	border: 1px solid var(--sapField_Hover_BorderColor);
 }

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -122,7 +122,7 @@
 	background: var(--sapField_ReadOnly_Background);
 }
 
-:host(:not([readonly]):hover) {
+:host(:not([value-state]):not([readonly]):hover) {
 	background-color: var(--sapField_Hover_Background);
 	border: 1px solid var(--sapField_Hover_BorderColor);
 }


### PR DESCRIPTION
due to css syntax typo (combining :not selectors), the hover effect used not apply.