### PR TITLE
fix(ui5-table-row): fix 1st and "nodata" rows visual

### DIFF
--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -38,6 +38,8 @@ tr {
 	box-sizing: border-box;
 	color: var(--sapTextColor);
 	min-height: 3rem;
+	background-color: var(--sapList_Background);
+	border-top: 1px solid var(--sapList_BorderColor);
 }
 
 :host([_no-data-displayed]) {

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -2,7 +2,7 @@
 	display: contents;
 }
 
-:host(:not(:first-of-type)) .ui5-table-row-root {
+.ui5-table-row-root {
 	background-color: var(--sapList_Background);
 	border-top: 1px solid var(--sapList_BorderColor);
 }


### PR DESCRIPTION
Before (the 1st row and the "nodata" rows have been greyish)
<img width="751" alt="Screenshot 2020-01-27 at 5 23 13 PM" src="https://user-images.githubusercontent.com/15702139/73187425-0cf47280-412a-11ea-8db3-94bd92fdd30e.png">
<img width="753" alt="Screenshot 2020-01-27 at 5 23 20 PM" src="https://user-images.githubusercontent.com/15702139/73187514-2dbcc800-412a-11ea-9e0f-c0bf7ebeaee5.png">


After
<img width="752" alt="Screenshot 2020-01-27 at 5 22 40 PM" src="https://user-images.githubusercontent.com/15702139/73187525-31e8e580-412a-11ea-99ab-92b2761196b3.png">
<img width="751" alt="Screenshot 2020-01-27 at 5 22 47 PM" src="https://user-images.githubusercontent.com/15702139/73187528-33b2a900-412a-11ea-8378-81b33118b29b.png">

