### PR TITLE
refactor(ui5-list): clicking inactive items doesn't change selection

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -445,10 +445,8 @@ class List extends UI5Element {
 	onItemPress(event) {
 		const pressedItem = event.detail.item;
 
-		if (pressedItem.type === ListItemType.Active) {
-			this.fireEvent("itemPress", { item: pressedItem });
-			this.fireEvent("itemClick", { item: pressedItem });
-		}
+		this.fireEvent("itemPress", { item: pressedItem });
+		this.fireEvent("itemClick", { item: pressedItem });
 
 		if (!this._selectionRequested && this.mode !== ListMode.Delete) {
 			this._selectionRequested = true;

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -6,7 +6,6 @@ import { isTabNext } from "@ui5/webcomponents-base/dist/events/PseudoEvents.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
 import ListMode from "./types/ListMode.js";
 import ListSeparators from "./types/ListSeparators.js";
-import ListItemType from "./types/ListItemType.js";
 
 // Template
 import ListTemplate from "./generated/templates/ListTemplate.lit.js";

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -38,6 +38,7 @@
 {{#*inline "selectionElement"}}
 	{{#if modeSingleSelect}}
 		<ui5-radiobutton
+				?disabled="{{isInactive}}"
 				tabindex="-1"
 				id="{{_id}}-singleSelectionElement"
 				class="ui5-li-singlesel-radiobtn"
@@ -48,6 +49,7 @@
 
 	{{#if modeMultiSelect}}
 		<ui5-checkbox
+				?disabled="{{isInactive}}"
 				tabindex="-1"
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -195,10 +195,18 @@ class ListItem extends ListItemBase {
 	 * and Multi (ui5-checkbox) selection modes are used.
 	 */
 	onMultiSelectionComponentPress(event) {
+		if (this.isInactive) {
+			return;
+		}
+
 		this.fireEvent("_selectionRequested", { item: this, selected: event.target.checked, selectionComponentPressed: true });
 	}
 
 	onSingleSelectionComponentPress(event) {
+		if (this.isInactive) {
+			return;
+		}
+
 		this.fireEvent("_selectionRequested", { item: this, selected: !event.target.selected, selectionComponentPressed: true });
 	}
 
@@ -213,7 +221,15 @@ class ListItem extends ListItemBase {
 	}
 
 	fireItemPress(event) {
+		if (this.isInactive) {
+			return;
+		}
+
 		this.fireEvent("_press", { item: this, selected: this.selected, key: event.key });
+	}
+
+	get isInactive() {
+		return this.type === ListItemType.Inactive;
 	}
 
 	get placeSelectionElementBefore() {

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -7,6 +7,7 @@
 :host {
 	overflow: hidden;
 	max-width: 100%;
+	outline: none;
 }
 
 /* disabled */

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -62,6 +62,20 @@
 
 	<br/><br/>
 
+	<ui5-list id="inactiveMultiSelect" header-text="API: ListItem type='Inactive'" mode="MultiSelect">
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
+
+	<ui5-list id="inactiveSingleSelect" header-text="API: ListItem type='Inactive'" mode="SingleSelectBegin">
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
+
 	<ui5-list id="myList" mode="SingleSelect" header-text="API: mode='SingleSelect'">
 		<ui5-li id="country1" >Argentina</ui5-li>
 		<ui5-li id="country2" >Bulgaria</ui5-li>

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -87,6 +87,18 @@
 
 	</ui5-list>
 
+	<ui5-list id="inactiveMultiSelect" header-text="API: ListItem type='Inactive'" mode="MultiSelect">
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
+
+	<ui5-list id="inactiveSingleSelect" header-text="API: ListItem type='Inactive'" mode="SingleSelectBegin">
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+	</ui5-list>
+
 	<script>
 		'use strict';
 

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -24,7 +24,6 @@ describe("List Tests", () => {
 	});
 
 	it("selectionChange events provides previousSelection item", () => {
-		const list = $("#listEvents");
 		const selectionChangeResultPreviousItemsParameter = $("#selectionChangeResultPreviousItemsParameter");
 		const firstItem = $("#listEvents #country1");
 		const secondItem = $("#listEvents #country2");
@@ -67,6 +66,30 @@ describe("List Tests", () => {
 		});
 		
 		assert.strictEqual(listItemsLength, 3, "List items are rendered");
+	});
+
+	it("Clicking on inactive items does not change single selection", () => {
+		list.id = "#inactiveSingleSelect";
+		const firstItem = list.getItem(0);
+		const secondItem = list.getItem(1);
+
+		firstItem.click();
+		secondItem.click();
+
+		assert.ok(!firstItem.getAttribute("selected"), "The first item is not selected");
+		assert.ok(!secondItem.getAttribute("selected"), "The second item is notselected");
+	});
+
+	it("Clicking on inactive items does not change multi selection", () => {
+		list.id = "#inactiveMultiSelect";
+		const firstItem = list.getItem(0);
+		const secondItem = list.getItem(1);
+
+		firstItem.click();
+		secondItem.click();
+
+		assert.ok(!firstItem.getAttribute("selected"), "The first item is not selected");
+		assert.ok(!secondItem.getAttribute("selected"), "The second item is notselected");
 	});
 
 	it("mode: none. clicking item does not select it", () => {


### PR DESCRIPTION
Previously, clicking on list items with type="Inactive" in a List used to change selection in "SingleSelect" and "MultiSelect" modes. 
Now,  clicking on inactive items would not take effect. To change the selection you have to use list items with type="Active".

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1171