### PR TITLE
fix(ui5-shellbar): fire logoClick on small size

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -16,7 +16,7 @@
 		{{#if showArrowDown}}
 			<button tabindex="0" class="{{classes.button}}" @click="{{_header.press}}">
 				{{#if interactiveLogo}}
-					<img class="ui5-shellbar-logo" src="{{logo}}" />
+					<img class="ui5-shellbar-logo" src="{{logo}}" @click="{{_logoPress}}" />
 				{{/if}}
 
 				{{#if primaryTitle}}

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -81,6 +81,7 @@
 ></ui5-shellbar>
 
 <ui5-shellbar
+        id="shellbarWithLogoClick"
         class="shellbar-example"
         logo="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg"
         primary-title="SAP Labs Bulgaria"
@@ -158,9 +159,8 @@
     </ui5-list>
 </ui5-popover>
 
-<ui5-input id="press-input" style="margin-top: 2rem; width: 240px;">
-
-</ui5-input>
+<ui5-input id="press-input" style="margin-top: 2rem;"></ui5-input>
+<ui5-input id="press-input2" style="margin-top: 2rem;"></ui5-input>
 
 <script>
 	shellbar.addEventListener("ui5-profileClick", function(event) {
@@ -178,6 +178,10 @@
 
 	shellbar.addEventListener("ui5-logoClick", function(event) {
 		window["press-input"].value = "Logo"
+	});
+
+	shellbarWithLogoClick.addEventListener("ui5-logoClick", function(event) {
+		window["press-input2"].value = shellbarWithLogoClick.primaryTitle.replace(/\s/g, "");
 	});
 
 	shellbar.addEventListener("ui5-coPilotClick", function(event) {

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -228,7 +228,7 @@ describe("Component Behavior", () => {
 				assert.strictEqual(input.getValue(), "Product Switch", "Input value is set by click event of Product Switch icon");
 			});
 
-			it("tests logoPress event", () => {
+			it("tests logoClick event", () => {
 				const logo = browser.$("#shellbar").shadow$(".ui5-shellbar-logo");
 				const input = browser.$("#press-input");
 
@@ -281,6 +281,15 @@ describe("Component Behavior", () => {
 		describe("Small screen", () => {
 			before(() => {
 				browser.setWindowSize(510, 1080);
+			});
+
+			it("tests logoClick event", () => {
+				const logo = browser.$("#shellbarWithLogoClick").shadow$(".ui5-shellbar-logo");
+				const title = "SAPLabsBulgaria";
+				const input = browser.$("#press-input2");
+
+				logo.click();
+				assert.strictEqual(input.getValue(), title, "Input value is set by click event of Logo");
 			});
 
 			it("tests opening of menu", () => {


### PR DESCRIPTION
On small sizes, the img tag, that represents the user logo is rendered in different place in the template, but the click handler was not attached and therefore on small sizes the logoClick event is not fired.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1188#