### PR TITLE
chore: add export to icons to fix CodeSandbox

### DIFF
--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -12,7 +12,9 @@ const template = (name, pathData) => `import { registerIcon } from "@ui5/webcomp
 const name = "${name}";
 const pathData = "${pathData}";
 
-registerIcon(name, { pathData });`;
+registerIcon(name, { pathData });
+
+export default { pathData };`;
 
 const accTemplate = (name, pathData, accData) => `import { registerIcon } from "@ui5/webcomponents-base/dist/SVGIconRegistry.js";
 import { ${accData.key} } from "../generated/i18n/i18n-defaults.js";
@@ -21,7 +23,9 @@ const name = "${name}";
 const pathData = "${pathData}";
 const accData = ${accData.key};
 
-registerIcon(name, { pathData, accData });`;
+registerIcon(name, { pathData, accData });
+
+export default { pathData, accData };`;
 
 
 const createIcons = (file) => {


### PR DESCRIPTION
Just a shot in the dark.
The only difference I found between the Button (working in CodeSandbox) and the Switch, MessageStrip and DatePicker (which does not), is that the last import icons.