### PR TITLE
refactor(ui5-responsive-popover): keep Popover defaults

### DIFF
--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -1,6 +1,8 @@
 <ui5-responsive-popover
 	no-arrow
 	_disable-initial-focus
+	placement-type="Bottom"
+	horizontal-align="Left"
 	@ui5-afterOpen={{_afterOpenPopover}}
 	@ui5-afterClose={{_afterClosePopover}}
 >

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -1,5 +1,6 @@
 <ui5-responsive-popover
 	no-arrow
+	content-only-on-desktop
 	_disable-initial-focus
 	placement-type="Bottom"
 	horizontal-align="Left"

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -1,5 +1,6 @@
 <ui5-responsive-popover
 	id="{{_id}}-responsive-popover"
+	content-only-on-desktop
 	allow-target-overlap="{{_respPopoverConfig.allowTargetOverlap}}"
 	stay-open-on-scroll="{{_respPopoverConfig.stayOpenOnScroll}}"
 	placement-type="Bottom"

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -2,6 +2,8 @@
 	id="{{_id}}-responsive-popover"
 	allow-target-overlap="{{_respPopoverConfig.allowTargetOverlap}}"
 	stay-open-on-scroll="{{_respPopoverConfig.stayOpenOnScroll}}"
+	placement-type="Bottom"
+	horizontal-align="Left"
 	no-arrow
 	with-padding
 	no-stretch

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -2,6 +2,8 @@
 	<ui5-responsive-popover
 		no-arrow
 		_disable-initial-focus
+		placement-type="Bottom"
+		horizontal-align="Left"
 		@ui5-afterOpen={{_afterOpenPopover}}
 		@ui5-afterClose={{_afterClosePopover}}
 	>

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -1,5 +1,6 @@
 {{#if showSuggestions}}
 	<ui5-responsive-popover
+		content-only-on-desktop
 		no-arrow
 		_disable-initial-focus
 		placement-type="Bottom"

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -1,5 +1,7 @@
 {{!-- Selected items popover --}}
-<ui5-responsive-popover 
+<ui5-responsive-popover
+	placement-type="Bottom"
+	horizontal-align="Left"
 	class="ui5-multi-combobox-selected-items-responsive-popover"
 	no-arrow
 	_disable-initial-focus
@@ -64,6 +66,8 @@
 
 {{!-- All items popover --}}
 <ui5-responsive-popover
+	placement-type="Bottom"
+	horizontal-align="Left"
 	class="ui5-multi-combobox-all-items-responsive-popover"
 	no-arrow
 	_disable-initial-focus

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -5,6 +5,7 @@
 	class="ui5-multi-combobox-selected-items-responsive-popover"
 	no-arrow
 	_disable-initial-focus
+	content-only-on-desktop
 	@ui5-afterClose={{_afterClosePopover}}
 >
 	<div slot="header" class="ui5-responsive-popover-header">
@@ -71,6 +72,7 @@
 	class="ui5-multi-combobox-all-items-responsive-popover"
 	no-arrow
 	_disable-initial-focus
+	content-only-on-desktop
 	@ui5-selectionChange={{_listSelectionChange}}
 	@ui5-afterClose={{_toggleIcon}}
 	@ui5-afterOpen={{_toggleIcon}}

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -1,7 +1,6 @@
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import ResponsivePopoverTemplate from "./generated/templates/ResponsivePopoverTemplate.lit.js";
-import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 import Popover from "./Popover.js";
 import Dialog from "./Dialog.js";
 

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -33,7 +33,7 @@ const metadata = {
 
 		/**
 		 * Defines if only the content would be displayed (without header and footer) in the popover on Desktop.
-		 * By default bothe the header and footer would be displayed.
+		 * By default both the header and footer would be displayed.
 		 * @protected
 		 */
 		contentOnlyOnDesktop: {

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -30,6 +30,15 @@ const metadata = {
 		withPadding: {
 			type: Boolean,
 		},
+
+		/**
+		 * Defines if only the content would be displayed (without header and footer) in the popover on Desktop.
+		 * By default bothe the header and footer would be displayed.
+		 * @protected
+		 */
+		contentOnlyOnDesktop: {
+			type: Boolean,
+		},
 	},
 };
 
@@ -130,11 +139,11 @@ class ResponsivePopover extends Popover {
 	}
 
 	get _displayHeader() {
-		return this._isPhone;
+		return this._isPhone || !this.contentOnlyOnDesktop;
 	}
 
 	get _displayFooter() {
-		return this._isPhone;
+		return this._isPhone || !this.contentOnlyOnDesktop;
 	}
 }
 

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -69,12 +69,6 @@ class ResponsivePopover extends Popover {
 		super.define(...params);
 	}
 
-	constructor() {
-		super();
-		this.placementType = "Bottom";
-		this.horizontalAlign = PopoverHorizontalAlign.Left;
-	}
-
 	/**
 	 * @public
 	 */

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -2,6 +2,8 @@
 	<ui5-responsive-popover
 		no-arrow
 		_disable-initial-focus
+		placement-type="Bottom"
+		horizontal-align="Left"
 		@ui5-afterOpen="{{_applyFocusAfterOpen}}"
 		@ui5-beforeOpen="{{_beforeOpen}}"
 		@ui5-afterClose="{{_afterClose}}"

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -2,6 +2,7 @@
 	<ui5-responsive-popover
 		no-arrow
 		_disable-initial-focus
+		content-only-on-desktop
 		placement-type="Bottom"
 		horizontal-align="Left"
 		@ui5-afterOpen="{{_applyFocusAfterOpen}}"

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -1,6 +1,7 @@
 <ui5-responsive-popover
 	id="{{_id}}-overflowMenu"
 	horizontal-align="Right"
+	placement-type="Bottom"
 	with-padding
 	no-arrow
 >

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -2,6 +2,7 @@
 	id="{{_id}}-overflowMenu"
 	horizontal-align="Right"
 	placement-type="Bottom"
+	content-only-on-desktop
 	with-padding
 	no-arrow
 >

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -72,8 +72,6 @@
 		</div>
 	</ui5-responsive-popover>
 
-	<br />
-	<input id="field" />
 	<script>
 		btnOpen.addEventListener("click", function(event) {
 			respPopover.open(btnOpen);

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html style="height: 100%">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>ResponsivePopover</title>
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+	<style>
+	
+	.popover-footer,
+	.popover-header {
+		margin: 0.25rem 0.25rem;
+	}
+	
+	.popover-content {
+		padding: 1rem;
+	}
+	</style>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+	<ui5-button id="btnOpen" design="Positive">Open me</ui5-button> <br/>
+	<ui5-button id="btnOpen2" design="Negative">Open me</ui5-button> <br/>
+	<ui5-button id="btnOpen3" design="Negative">Header/Footer hidden on Desktop</ui5-button>
+
+	<!-- with header and footer slots -->
+	<ui5-responsive-popover id="respPopover">
+		<div id="respPopoverHeader" slot="header">
+			<ui5-title>Hello World</ui5-title>
+		</div>
+
+		<div class="popover-content">
+			<ui5-label for="emailInput" required>Email: </ui5-label>
+			<ui5-input id="emailInput" class="samples-margin-top" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
+		</div>
+
+		<div slot="footer" class="popover-footer">
+			<ui5-button id="btnClose" design="Emphasized">Subscribe</ui5-button>
+		</div>
+	</ui5-responsive-popover>
+
+	<!-- with header-text and footer slot-->
+	<ui5-responsive-popover id="respPopover2" header-text="Newsletter subscription">
+		<div class="popover-content">
+			<ui5-label for="emailInput" required>Email: </ui5-label>
+			<ui5-input id="emailInput" class="samples-margin-top" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
+		</div>
+
+		<div slot="footer" class="popover-footer">
+			<ui5-label>You are already subscribed.</ui5-label>
+			<ui5-button id="btnClose2">Cancel</ui5-button>
+		</div>
+	</ui5-responsive-popover>
+
+	<ui5-responsive-popover id="respPopover3" content-only-on-desktop>
+		<div id="respPopoverHeader3" slot="header">
+			<ui5-title>Hello World</ui5-title>
+		</div>
+
+		<div class="popover-content">
+			<ui5-label for="emailInput" required>Email: </ui5-label>
+			<ui5-input id="emailInput" class="samples-margin-top" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
+		</div>
+
+		<div slot="footer" class="popover-footer">
+			<ui5-button id="btnClose3" design="Emphasized">Subscribe</ui5-button>
+		</div>
+	</ui5-responsive-popover>
+
+	<br />
+	<input id="field" />
+	<script>
+		btnOpen.addEventListener("click", function(event) {
+			respPopover.open(btnOpen);
+		});
+		btnClose.addEventListener("click", function(event) {
+			respPopover.close();
+		});
+
+		btnOpen2.addEventListener("click", function(event) {
+			respPopover2.open(btnOpen2);
+		});
+		btnClose2.addEventListener("click", function(event) {
+			respPopover2.close();
+		});
+
+		btnOpen3.addEventListener("click", function(event) {
+			respPopover3.open(btnOpen3);
+		});
+		btnClose3.addEventListener("click", function(event) {
+			respPopover3.close();
+		});
+	</script>
+</body>
+</html>

--- a/packages/main/test/specs/ResponsivePopover.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.spec.js
@@ -5,7 +5,7 @@ describe("ResponsivePopover general interaction", () => {
 
 	it("header and footer are displayed by default", () => {
 		const btnOpenPopover = $("#btnOpen");
-		const field = $("#field");
+		const btnClosePopover = $("#btnClose");
 
 		btnOpenPopover.click();
 		
@@ -15,13 +15,12 @@ describe("ResponsivePopover general interaction", () => {
 		assert.ok(popover.isDisplayedInViewport(), "ResponsivePopover is opened.");
 		assert.ok(header.isExisting(), "Header is displayed.");
 
-		field.click();
+		btnClosePopover.click();
 		assert.ok(!popover.isDisplayedInViewport(), "ResponsivePopover is closed.");
 	});
 
 	it("header and footer are hidden on desktop", () => {
 		const btnOpenPopover = $("#btnOpen3");
-		const field = $("#field");
 
 		btnOpenPopover.click();
 
@@ -30,8 +29,5 @@ describe("ResponsivePopover general interaction", () => {
 
 		assert.ok(popover.isDisplayedInViewport(), "ResponsivePopover is opened.");
 		assert.ok(!header.isExisting(), "Header is not displayed.");
-
-		field.click();
-		assert.ok(!popover.isDisplayedInViewport(), "ResponsivePopover remains opened.");
 	});
 });

--- a/packages/main/test/specs/ResponsivePopover.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.spec.js
@@ -1,0 +1,37 @@
+const assert = require("chai").assert;
+
+describe("ResponsivePopover general interaction", () => {
+	browser.url("http://localhost:8080/test-resources/pages/ResponsivePopover.html");
+
+	it("header and footer are displayed by default", () => {
+		const btnOpenPopover = $("#btnOpen");
+		const field = $("#field");
+
+		btnOpenPopover.click();
+		
+		const popover = browser.$("#respPopover");
+		const header = popover.shadow$(".ui5-popover-header-root");
+
+		assert.ok(popover.isDisplayedInViewport(), "ResponsivePopover is opened.");
+		assert.ok(header.isExisting(), "Header is displayed.");
+
+		field.click();
+		assert.ok(!popover.isDisplayedInViewport(), "ResponsivePopover is closed.");
+	});
+
+	it("header and footer are hidden on desktop", () => {
+		const btnOpenPopover = $("#btnOpen3");
+		const field = $("#field");
+
+		btnOpenPopover.click();
+
+		const popover = browser.$("#respPopover3");
+		const header = popover.shadow$(".ui5-popover-header-root");
+
+		assert.ok(popover.isDisplayedInViewport(), "ResponsivePopover is opened.");
+		assert.ok(!header.isExisting(), "Header is not displayed.");
+
+		field.click();
+		assert.ok(!popover.isDisplayedInViewport(), "ResponsivePopover remains opened.");
+	});
+});


### PR DESCRIPTION
The `horizontalAlign` and `placementType` properties in the Popover have defaults `Center` and `Right`, but the ResponsivePopover (which extends the Popover) overwrites these defaults in its constructor (for the purposes of other components - Select, Input, ComboBox, DatePicker) to `Left` and `Bottom`.

Also, until know the "header" and the "footer" slots was not displayed on desktop.
As a result, the API reference displays the defaults, inherited from the Popover, but in reality they are implicitly overwritten or not working as expected.

Now the slots are displayed by default, unless the new protected API is not used - contentOnlyOnDesktop (for the purposes of other components - Select, Input, ComboBox, DatePicker)
And we keep the defaults, inherited from the Popover and set the needed values in the components' templates.