### PR TITLE
POC: lazy static area initialization

### DIFF
--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -9,6 +9,7 @@ import { getStaticAreaInstance, removeStaticArea } from "./StaticArea.js";
 class StaticAreaItem {
 	constructor(_ui5ElementContext) {
 		this.ui5ElementContext = _ui5ElementContext;
+		this._rendered = false;
 	}
 
 	/**
@@ -18,6 +19,12 @@ class StaticAreaItem {
 		const renderResult = this.ui5ElementContext.constructor.staticAreaTemplate(this.ui5ElementContext),
 			stylesToAdd = this.ui5ElementContext.constructor.staticAreaStyles || false;
 
+		this._ensureInstance();
+		this.ui5ElementContext.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
+		this._rendered = true;
+	}
+
+	_ensureInstance() {
 		if (!this.staticAreaItemDomRef) {
 			// Initial rendering of fragment
 
@@ -27,8 +34,6 @@ class StaticAreaItem {
 
 			getStaticAreaInstance().appendChild(this.staticAreaItemDomRef);
 		}
-
-		this.ui5ElementContext.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
 	}
 
 	/**
@@ -69,6 +74,9 @@ class StaticAreaItem {
 	 * Returns reference to the DOM element where the current fragment is added.
 	 */
 	getDomRef() {
+		if (!this._rendered) {
+			this._updateFragment();
+		}
 		return this.staticAreaItemDomRef.shadowRoot;
 	}
 }

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -12,6 +12,22 @@ class StaticAreaItem {
 		this._rendered = false;
 	}
 
+	isRendered() {
+		return this._rendered;
+	}
+
+	get _lazyStaticAreaItemDomRef() {
+		if (!this.staticAreaItemDomRef) {
+			this.staticAreaItemDomRef = document.createElement("ui5-static-area-item");
+			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
+			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
+
+			getStaticAreaInstance().appendChild(this.staticAreaItemDomRef);
+		}
+
+		return this.staticAreaItemDomRef;
+	}
+
 	/**
 	 * @protected
 	 */
@@ -19,21 +35,8 @@ class StaticAreaItem {
 		const renderResult = this.ui5ElementContext.constructor.staticAreaTemplate(this.ui5ElementContext),
 			stylesToAdd = this.ui5ElementContext.constructor.staticAreaStyles || false;
 
-		this._ensureInstance();
-		this.ui5ElementContext.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
+		this.ui5ElementContext.constructor.render(renderResult, this._lazyStaticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
 		this._rendered = true;
-	}
-
-	_ensureInstance() {
-		if (!this.staticAreaItemDomRef) {
-			// Initial rendering of fragment
-
-			this.staticAreaItemDomRef = document.createElement("ui5-static-area-item");
-			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
-			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
-
-			getStaticAreaInstance().appendChild(this.staticAreaItemDomRef);
-		}
 	}
 
 	/**
@@ -45,6 +48,7 @@ class StaticAreaItem {
 		staticArea.removeChild(this.staticAreaItemDomRef);
 
 		this.staticAreaItemDomRef = null;
+		this._rendered = false;
 
 		// remove static area
 		if (staticArea.childElementCount < 1) {
@@ -56,16 +60,10 @@ class StaticAreaItem {
 	 * @protected
 	 */
 	_updateContentDensity(isCompact) {
-		if (!this.staticAreaItemDomRef) {
-			return;
-		}
-
 		if (isCompact) {
-			this.staticAreaItemDomRef.classList.add("sapUiSizeCompact");
-			this.staticAreaItemDomRef.classList.add("ui5-content-density-compact");
+			this._lazyStaticAreaItemDomRef.classList.add("ui5-content-density-compact");
 		} else {
-			this.staticAreaItemDomRef.classList.remove("sapUiSizeCompact");
-			this.staticAreaItemDomRef.classList.remove("ui5-content-density-compact");
+			this._lazyStaticAreaItemDomRef.classList.remove("ui5-content-density-compact");
 		}
 	}
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -102,7 +102,7 @@ class UI5Element extends HTMLElement {
 		}
 
 		// Render Fragment if neccessary
-		if (this.constructor._needsStaticArea()) {
+		if (this._shouldUpdateFragment()) {
 			this.staticAreaItem._updateFragment(this);
 		}
 	}
@@ -449,7 +449,7 @@ class UI5Element extends HTMLElement {
 		delete this._invalidated;
 		this._updateShadowRoot();
 
-		if (this.constructor._needsStaticArea()) {
+		if (this._shouldUpdateFragment()) {
 			this.staticAreaItem._updateFragment(this);
 		}
 
@@ -589,6 +589,18 @@ class UI5Element extends HTMLElement {
 		};
 
 		return this[slotName].reduce(reducer, []);
+	}
+
+	_shouldUpdateFragment() {
+		return this.constructor._needsStaticArea() && this._staticAreaInUse;
+	}
+
+	startUsingStaticArea() {
+		this._staticAreaInUse = true;
+	}
+
+	stopUsingStaticArea() {
+		this._staticAreaInUse = false;
 	}
 
 	get isCompact() {

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -100,11 +100,6 @@ class UI5Element extends HTMLElement {
 				this.onEnterDOM();
 			}
 		}
-
-		// Render Fragment if neccessary
-		if (this._shouldUpdateFragment()) {
-			this.staticAreaItem._updateFragment(this);
-		}
 	}
 
 	/**
@@ -592,15 +587,7 @@ class UI5Element extends HTMLElement {
 	}
 
 	_shouldUpdateFragment() {
-		return this.constructor._needsStaticArea() && this._staticAreaInUse;
-	}
-
-	startUsingStaticArea() {
-		this._staticAreaInUse = true;
-	}
-
-	stopUsingStaticArea() {
-		this._staticAreaInUse = false;
+		return this.constructor._needsStaticArea() && this.staticAreaItem.isRendered();
 	}
 
 	get isCompact() {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -388,13 +388,11 @@ class Select extends UI5Element {
 	}
 
 	_beforeOpen() {
-		this.startUsingStaticArea();
 		this._selectedIndexBeforeOpen = this._selectedIndex;
 		this._lastSelectedOption = this.options[this._selectedIndex];
 	}
 
 	_afterClose() {
-		this.stopUsingStaticArea();
 		this._toggleIcon();
 
 		if (this._escapePressed) {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -388,11 +388,13 @@ class Select extends UI5Element {
 	}
 
 	_beforeOpen() {
+		this.startUsingStaticArea();
 		this._selectedIndexBeforeOpen = this._selectedIndex;
 		this._lastSelectedOption = this.options[this._selectedIndex];
 	}
 
 	_afterClose() {
+		this.stopUsingStaticArea();
 		this._toggleIcon();
 
 		if (this._escapePressed) {


### PR DESCRIPTION
We should discuss this 

Objectives:
 - do not create the static area item until the last possible moment (usually first user interaction with the control, such as ui5-select click to open the menu)
 - do not update the shadow root fragment while the popup is closed