### PR TITLE
refactor(ui5-carousel): improve animation

### DIFF
--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -246,7 +246,7 @@ class Carousel extends UI5Element {
 	get styles() {
 		return {
 			content: {
-				"left": `-${this.selectedIndex * 100}%`,
+				transform: `translateX(-${this.selectedIndex * 100}%)`,
 			},
 		};
 	}

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -49,7 +49,7 @@
     flex-direction: row;
     flex-wrap: nowrap;
     background: var(--sapBackgroundColor);
-    transition: left .5s cubic-bezier(.46, 0, .44, 1);
+    transition: transform 0.5s cubic-bezier(.46, 0, .44, 1);
 }
 
 .ui5-carousel-content.ui5-carousel-content-no-animation {

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -49,7 +49,8 @@
     flex-direction: row;
     flex-wrap: nowrap;
     background: var(--sapBackgroundColor);
-    transition: transform 0.5s cubic-bezier(.46, 0, .44, 1);
+	transition: transform 0.5s cubic-bezier(.46, 0, .44, 1);
+	will-change: transform;
 }
 
 .ui5-carousel-content.ui5-carousel-content-no-animation {


### PR DESCRIPTION
It is recommended and better for the performance to use transform: translate instead of transitioning the "left"