### PR TITLE
chore(ui5-switch): optimize animation

### DIFF
--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -25,6 +25,7 @@
 	height: 100%;
 	overflow: hidden;
 	pointer-events: none;
+	will-change: transform;
 }
 
 .ui5-switch-track {


### PR DESCRIPTION
When there is a lot of content on the page, the switch animation may cause the browser to repaint everything. This creates a new context for the switch animated area only.