### PR TITLE
chore(ui5-table): do not invalidate all rows unnecessarily

### DIFF
--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -205,9 +205,14 @@ class Table extends UI5Element {
 
 	onBeforeRendering() {
 		const columnSettings = this.getColumnPropagationSettings();
+		const columnSettingsString = JSON.stringify(columnSettings);
 
 		this.rows.forEach(row => {
-			row._columnsInfo = columnSettings;
+			if (row._columnsInfoString !== columnSettingsString) {
+				row._columnsInfo = columnSettings;
+				row._columnsInfoString = JSON.stringify(row._columnsInfo);
+			}
+
 			row.removeEventListener("ui5-_focused", this.fnOnRowFocused);
 			row.addEventListener("ui5-_focused", this.fnOnRowFocused);
 


### PR DESCRIPTION
Ever since we removed the `deepEqual` metadata property, components are expected to handle object invalidation manually (to suppress invalidation if the object content did not change). This way the rows are not invalidated unnecessarily any more.