### PR TITLE
chore: use the LocaleData.js _get() method

### DIFF
--- a/packages/base/src/features/OpenUI5Support.js
+++ b/packages/base/src/features/OpenUI5Support.js
@@ -47,7 +47,7 @@ const getLocaleDataObject = () => {
 
 	const config = core.getConfiguration();
 	const LocaleData = sap.ui.require("sap/ui/core/LocaleData");
-	return LocaleData.getInstance(config.getLocale()).mData;
+	return LocaleData.getInstance(config.getLocale())._get();
 };
 
 const listenForThemeChange = () => {


### PR DESCRIPTION
We used to directly access the private `mData` property, but it's safer in the long run to use a `ui5-restricted` method instead.