### PR TITLE
feature(framework): add managedSlots metadata entity

### DIFF
--- a/docs/dev/Metadata.md
+++ b/docs/dev/Metadata.md
@@ -130,3 +130,32 @@ Notes:
  -----|-------------
  Node | Accepts both Text nodes and HTML Elements
  HTMLElement | Accepts HTML Elements only
+
+## Managed slots
+
+Determines whether the framework should manage the slots of this UI5 Web Component. 
+
+This setting is useful for UI5 Web Components that dont' just slot children, but additionally base their own 
+rendering on the presence/absence/type of children.
+
+```json
+{
+	"managedSlots": true
+}
+```
+
+When `managedSlots` is set to `true`:
+ - The framework will invalidate this UI5 Web Component, whenever its children are added/removed/changed.
+ - If any of this UI5 Web Component's children are custom elements, the framework will await until they are all
+ defined and upgraded, before rendering the component for the first time.
+ - The framework will create properties for each slot on this UI5 Web Component's instances for easier access
+ to the slotted children. For example, if there area `header`, `content` and `footer` slots, there will be
+ respectively `header`, `content` and `footer` properties of type `Array` holding the slotted children for each slot.
+ *Note:* You can use the `propertyName` metadata entity, described above, to modify these. 
+ 
+ In essence, set this to `true` if the UI5 Web Component you're developing should be aware of its children
+ for the purposes of its own state management and rendering (contrary to just displaying them).
+ 
+ An example of a component that would benefit from `managedSlots` is a Tab Container that monitors its children (Tabs)
+ in order to display a link on its Tab Strip for each Tab child. Therefore it would need to be invalidated whenever
+ Tabs are added/removed, in order to update its own state and visualization.

--- a/docs/dev/Metadata.md
+++ b/docs/dev/Metadata.md
@@ -149,7 +149,7 @@ When `managedSlots` is set to `true`:
  - If any of this UI5 Web Component's children are custom elements, the framework will await until they are all
  defined and upgraded, before rendering the component for the first time.
  - The framework will create properties for each slot on this UI5 Web Component's instances for easier access
- to the slotted children. For example, if there area `header`, `content` and `footer` slots, there will be
+ to the slotted children. For example, if there are `header`, `content` and `footer` slots, there will be
  respectively `header`, `content` and `footer` properties of type `Array` holding the slotted children for each slot.
  *Note:* You can use the `propertyName` metadata entity, described above, to modify these. 
  

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -86,6 +86,14 @@ class UI5ElementMetadata {
 	}
 
 	/**
+	 * Determines whether this UI5 Element needs to invalidate if children are added/removed/changed
+	 * @public
+	 */
+	slotsAreManaged() {
+		return !!this.metadata.managedSlots;
+	}
+
+	/**
 	 * Returns an object with key-value pairs of properties and their metadata definitions
 	 * @public
 	 */

--- a/packages/base/test/elements/Generic.js
+++ b/packages/base/test/elements/Generic.js
@@ -26,6 +26,7 @@ const metadata = {
 			defaultValue: "Hello",
 		}
 	},
+	managedSlots: true,
 	slots: {
 		default: {
 			type: Node,

--- a/packages/base/test/elements/Parent.js
+++ b/packages/base/test/elements/Parent.js
@@ -3,6 +3,7 @@ import litRender, { html } from "../../renderer/LitRenderer.js";
 
 const metadata = {
 	tag: "ui5-test-parent",
+	managedSlots: true,
 	slots: {
 		default: {
 			type: Node,

--- a/packages/fiori/src/ProductSwitch.js
+++ b/packages/fiori/src/ProductSwitch.js
@@ -22,6 +22,7 @@ const metadata = {
 			type: Integer,
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.ProductSwitch.prototype */ {
 		/**
 		 * Defines the items of the <code>ui5-product-switch</code>.

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -140,7 +140,7 @@ const metadata = {
 			defaultValue: [],
 		},
 	},
-
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 		/**
 		 * Defines the <code>ui5-shellbar</code> aditional items.

--- a/packages/fiori/test/pages/Components.html
+++ b/packages/fiori/test/pages/Components.html
@@ -9,7 +9,7 @@
 
     <script data-ui5-config type="application/json">
         {
-            "rtl": false,
+            "rtl": false
         }
     </script>
 
@@ -21,7 +21,7 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 
-    <ui5-shellbar id="shellbar2" hidden><ui5-icon name="nav-back" slot="icon"></ui5-icon></ui5-shellbar>
+    <ui5-shellbar id="shellbar2" hidden></ui5-shellbar>
 
 </body>
 </html>

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -33,6 +33,7 @@ const metadata = {
 			defaultValue: "1",
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Badge.prototype */ {
 		/**
 		 * Defines the text of the <code>ui5-badge</code>.

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -22,6 +22,7 @@ import cardCss from "./generated/themes/Card.css.js";
  */
 const metadata = {
 	tag: "ui5-card",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Card.prototype */ {
 
 		/**

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -83,6 +83,7 @@ const metadata = {
 			defaultValue: CarouselArrowsPlacement.Content,
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
 		/**
 		 * Defines the content of the <code>ui5-carousel</code>.

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -165,6 +165,7 @@ const metadata = {
 			type: Object,
 		},
 	},
+	managedSlots: true,
 	slots: {
 		/**
 		 * Defines the <code>ui5-combobox</code> items.

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -115,6 +115,7 @@ const metadata = {
 			defaultValue: ValueState.None,
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.FileUploader.prototype */ {
 		/**
 		 * By default the <code>ui5-file-uploader</code> contains a single input field. With this slot you can pass any content that you wish to add. See the samples for more information

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -34,6 +34,7 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
  */
 const metadata = {
 	tag: "ui5-input",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Input.prototype */ {
 
 		/**

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -22,6 +22,7 @@ const INFINITE_SCROLL_DEBOUNCE_RATE = 250; // ms
  */
 const metadata = {
 	tag: "ui5-list",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.List.prototype */ {
 
 		/**

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -60,6 +60,7 @@ const metadata = {
 			type: Boolean,
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.MessageStrip.prototype */ {
 		/**
 		 * Defines the text of the <code>ui5-messagestrip</code>.

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -38,6 +38,7 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
  */
 const metadata = {
 	tag: "ui5-multi-combobox",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.MultiComboBox.prototype */ {
 		/**
 		 * Defines the <code>ui5-multi-combobox</code> items.

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -21,6 +21,7 @@ import panelCss from "./generated/themes/Panel.css.js";
  */
 const metadata = {
 	tag: "ui5-panel",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Panel.prototype */ {
 
 		/**

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -164,6 +164,7 @@ const metadata = {
 			type: Boolean,
 		},
 	},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Popover.prototype */ {
 		/**
 		 * Defines the content of the Web Component.

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -13,6 +13,7 @@ import { getNextZIndex } from "./popup-utils/PopupUtils.js";
  * @public
  */
 const metadata = {
+	managedSlots: true,
 	slots: /** @lends  sap.ui.webcomponents.main.Popup.prototype */ {
 
 		/**

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -15,6 +15,7 @@ import SegmentedButtonCss from "./generated/themes/SegmentedButton.css.js";
 const metadata = {
 	tag: "ui5-segmentedbutton",
 	properties: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */  {},
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */ {
 
 		/**

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -35,6 +35,7 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
  */
 const metadata = {
 	tag: "ui5-select",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Select.prototype */ {
 
 		/**

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -34,6 +34,7 @@ const SCROLL_STEP = 128;
  */
 const metadata = {
 	tag: "ui5-tabcontainer",
+	managedSlots: true,
 	slots: /** @lends  sap.ui.webcomponents.main.TabContainer.prototype */ {
 		/**
 		 * Defines the tabs.

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -13,6 +13,7 @@ import styles from "./generated/themes/Table.css.js";
  */
 const metadata = {
 	tag: "ui5-table",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Table.prototype */ {
 
 		/**

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -10,6 +10,7 @@ import styles from "./generated/themes/TableRow.css.js";
  */
 const metadata = {
 	tag: "ui5-table-row",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.TableRow.prototype */ {
 		/**
 		 * Defines the cells of the <code>ui5-table-row</code>.

--- a/packages/main/src/Timeline.js
+++ b/packages/main/src/Timeline.js
@@ -11,6 +11,7 @@ import styles from "./generated/themes/Timeline.css.js";
  */
 const metadata = {
 	tag: "ui5-timeline",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Timeline.prototype */ {
 		/**
 		 * Determines the content of the <code>ui5-timeline</code>.

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -14,6 +14,7 @@ import styles from "./generated/themes/Tokenizer.css.js";
  */
 const metadata = {
 	tag: "ui5-tokenizer",
+	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.Tokenizer.prototype */ {
 		"default": {
 			propertyName: "tokens",


### PR DESCRIPTION
Most components that slot children don't base their own rendering on the presence/absence/state of their children, so it's unnecessary to have them wait for their children on first rendering, invalidate on children change, etc... Therefore slot support is off by default for all components. Components that really use their children should set `managedSlots` to `true` in their metadata.

BREAKING CHANGE: If your components need to access their children, you should set `managedSlots: true` in metadata. Otherwise slot accessors (such as `this.items`, `this.content`, etc...) will no longer work.
