### PR TITLE
chore(framework): check for individual slots

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -443,6 +443,8 @@ class UI5Element extends HTMLElement {
 	 * @protected
 	 */
 	_render() {
+		const hasIndividualSlots = this.constructor.getMetadata().hasIndividualSlots();
+
 		// suppress invalidation to prevent state changes scheduling another rendering
 		this._suppressInvalidation = true;
 
@@ -468,7 +470,9 @@ class UI5Element extends HTMLElement {
 		}
 
 		// Safari requires that children get the slot attribute only after the slot tags have been rendered in the shadow DOM
-		this._assignIndividualSlotsToChildren();
+		if (hasIndividualSlots) {
+			this._assignIndividualSlotsToChildren();
+		}
 
 		// Call the onAfterRendering hook
 		if (typeof this.onAfterRendering === "function") {

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -90,9 +90,7 @@ class UI5ElementMetadata {
 	 * @public
 	 */
 	hasIndividualSlots() {
-		return this.slotsAreManaged() && Object.entries(this.getSlots()).some(pair => {
-			return pair[1].individualSlots;
-		});
+		return this.slotsAreManaged() && Object.entries(this.getSlots()).some(([_slotName, slotData]) => slotData.individualSlots);
 	}
 
 	/**

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -86,6 +86,16 @@ class UI5ElementMetadata {
 	}
 
 	/**
+	 * Determines whether this UI5 Element supports any slots with "individualSlots: true"
+	 * @public
+	 */
+	hasIndividualSlots() {
+		return this.slotsAreManaged() && Object.entries(this.getSlots()).some(pair => {
+			return pair[1].individualSlots;
+		});
+	}
+
+	/**
 	 * Determines whether this UI5 Element needs to invalidate if children are added/removed/changed
 	 * @public
 	 */


### PR DESCRIPTION
This is a performance optimization, because checking the metadata is much cheaper than iterating through all DOM children, and for most components this is unnecessary.

Note: Object.entries is used because Object.values does not exist in IE.