### PR TITLE
refactor(framework): call _render directly

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -105,7 +105,7 @@ class UI5Element extends HTMLElement {
 				await this._processChildren();
 			}
 
-			await RenderScheduler.renderImmediately(this);
+			this._render();
 			this._domRefReadyPromise._deferredResolve();
 			if (typeof this.onEnterDOM === "function") {
 				this.onEnterDOM();


### PR DESCRIPTION
 - Do not run the whole RenderManager cycle, but just render the component directly