### PR TITLE
fix(ui5-button): fix icon shrinking

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -66,6 +66,7 @@
 	top: -.5rem;
 	position: relative;
 	color: inherit;
+	flex-shrink: 0;
 }
 
 :host([icon-end]) .ui5-button-root {


### PR DESCRIPTION
Setting smaller width to ui5-button makes its icon shrinking:
<img width="90" alt="Screenshot 2020-02-28 at 9 04 58 AM" src="https://user-images.githubusercontent.com/15702139/75518396-77d6e900-5a09-11ea-9136-63bbf46253e0.png">

Setting flex-shrink: 0, preserves the icon size.
<img width="89" alt="Screenshot 2020-02-28 at 9 06 07 AM" src="https://user-images.githubusercontent.com/15702139/75518439-9341f400-5a09-11ea-911d-e6e77f3a8cd0.png">
