### PR TITLE
chore(ui5-switch): add shadow parts

### DIFF
--- a/packages/main/src/Switch.hbs
+++ b/packages/main/src/Switch.hbs
@@ -11,7 +11,7 @@
 	dir="{{rtl}}"
 >
 	<div class="ui5-switch-inner">
-		<div class="ui5-switch-track">
+		<div class="ui5-switch-track" part="slider">
 			<div class="ui5-switch-slider">
 				{{#if graphical}}
 					<span class="ui5-switch-text ui5-switch-text--on">
@@ -21,11 +21,11 @@
 						<ui5-icon name="decline" class="ui5-switch-icon-off"></ui5-icon>
 					</span>
 				{{else}}
-					<span class="ui5-switch-text ui5-switch-text--on">{{_textOn}}</span>
-					<span class="ui5-switch-text ui5-switch-text--off">{{_textOff}}</span>
+					<span class="ui5-switch-text ui5-switch-text--on" part="text-on">{{_textOn}}</span>
+					<span class="ui5-switch-text ui5-switch-text--off" part="text-off">{{_textOff}}</span>
 				{{/if}}
 
-				<span class="ui5-switch-handle"></span>
+				<span class="ui5-switch-handle" part="handle"></span>
 			</div>
 		</div>
 	</div>

--- a/packages/main/test/pages/Switch.html
+++ b/packages/main/test/pages/Switch.html
@@ -17,6 +17,42 @@
 	ui5-switch {
 		margin: 8px;
 	}
+
+    #styled1::part(slider) {
+        height: 1.75rem;
+        background: orange;
+        border-color: green;
+    }
+    #styled1::part(text-on) {
+        color: blue;
+        font-weight: bold;
+    }
+    #styled1::part(text-off) {
+        color: magenta;
+        font-weight: bold;
+    }
+    #styled1::part(handle) {
+        background: orange;
+        border-color: green;
+    }
+
+    .styled2::part(slider) {
+        height: 0.75rem;
+        background: purple;
+        border-color: white;
+    }
+    .styled2::part(text-on) {
+        font-size: .5rem;
+        color: white;
+    }
+    .styled2::part(text-off) {
+        font-size: .5rem;
+        color: white;
+    }
+    .styled2::part(handle) {
+        background: purple;
+        border-color: white;
+    }
 </style>
 <body style="background-color: var(--sapBackgroundColor);">
 	<h3>Default Switch</h3>
@@ -58,6 +94,12 @@
 		<ui5-switch text-on="Enabled" text-off="disabled" style="width: 200px; height: 100px;"></ui5-switch>
 		<ui5-switch checked  text-on="Allowed" text-off="Prohibitted" style="width: 200px; height: 200px;"></ui5-switch>
 	</div>
+
+    <h3>Switch styled with shadow parts</h3>
+    <div style="display: flex">
+        <ui5-switch id="styled1" text-on="On" text-off="Off"></ui5-switch>
+        <ui5-switch class="styled2" checked text-on="Yes" text-off="No"></ui5-switch>
+    </div>
 
 	<ui5-input id="field"></ui5-input>
 </body>


### PR DESCRIPTION
This change is experimental. It adds 4 shadow parts to `ui5-switch`
- `slider` (on the -track div, note: it's not on the -slider div)
- `text-on` (text on span)
- `text-off` (text off span)
- `handle` (on the -handle div)

Two samples were added in the test page.