### PR TITLE
chore(ui5-button): button part exposed

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -16,7 +16,7 @@
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"
 		title="{{accInfo.title}}"
-        part="button"
+		part="button"
 	>
 		{{#if icon}}
 			<ui5-icon

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -16,6 +16,7 @@
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"
 		title="{{accInfo.title}}"
+        part="button"
 	>
 		{{#if icon}}
 			<ui5-icon

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -13,6 +13,18 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
+    <style>
+        .long-button {
+            width: 1000px;
+        }
+        .long-button-begin::part(button) {
+            justify-content: flex-start;
+        }
+        .long-button-end::part(button) {
+            justify-content: flex-end;
+        }
+    </style>
+
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
@@ -149,8 +161,14 @@
 	<ui5-togglebutton design="Emphasized" icon="employee">Emphasized</ui5-togglebutton>
 	<ui5-togglebutton disabled design="Emphasized" icon="employee">Emphasized</ui5-togglebutton>
 
+    <br/>
+    <br/>
+    <ui5-button class="long-button long-button-begin" icon="download">Download</ui5-button>
+    <ui5-button class="long-button" icon="download">Download</ui5-button>
+    <ui5-button class="long-button long-button-end" icon="download">Download</ui5-button>
 
-	<script>
+
+    <script>
 		var clickCounter = document.querySelector("#click-counter");
 		var button = document.querySelector("#button1");
 		var disabledButton = document.querySelector("#button-disabled");


### PR DESCRIPTION
Sometimes it makes sense to have a button, much wider than its text, and be able to align the text and icon.