### PR TITLE
chore: Remove api.json from .npmignore files

### DIFF
--- a/packages/fiori/.npmignore
+++ b/packages/fiori/.npmignore
@@ -1,5 +1,4 @@
 *.css
-dist/api.json
 dist/resources
 dist/test-resources
 lib/

--- a/packages/icons/.npmignore
+++ b/packages/icons/.npmignore
@@ -1,5 +1,4 @@
 *.css
-dist/api.json
 dist/resources
 dist/test-resources
 lib/

--- a/packages/main/.npmignore
+++ b/packages/main/.npmignore
@@ -1,5 +1,4 @@
 *.css
-dist/api.json
 dist/resources
 dist/test-resources
 lib/

--- a/packages/theme-base/.npmignore
+++ b/packages/theme-base/.npmignore
@@ -1,5 +1,4 @@
 *.css
-dist/api.json
 dist/resources
 dist/test-resources
 node_modules/


### PR DESCRIPTION
This PR removes the generated api.json from the `.npmignore` files. With the help of that file, the UI5 Web Components for React can more easily generate the wrapper components.
