### PR TITLE
chore(framework): improve Mutation Observer performance

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -151,9 +151,11 @@ class UI5Element extends HTMLElement {
 		if (!shouldObserveChildren) {
 			return;
 		}
+
+		const canSlotText = this.constructor.getMetadata().canSlotText();
 		const mutationObserverOptions = {
 			childList: true,
-			subtree: false,
+			subtree: canSlotText,
 			characterData: true,
 		};
 		DOMObserver.observeDOMNode(this, this._processChildren.bind(this), mutationObserverOptions);
@@ -253,7 +255,7 @@ class UI5Element extends HTMLElement {
 		slottedChildrenMap.forEach((children, slot) => {
 			this._state[slot] = children.sort((a, b) => a.idx - b.idx).map(_ => _.child);
 		});
-		this._invalidate();
+		this._invalidate("slots");
 	}
 
 	/**

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -153,7 +153,7 @@ class UI5Element extends HTMLElement {
 		}
 		const mutationObserverOptions = {
 			childList: true,
-			subtree: true,
+			subtree: false,
 			characterData: true,
 		};
 		DOMObserver.observeDOMNode(this, this._processChildren.bind(this), mutationObserverOptions);

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -184,7 +184,7 @@ class UI5Element extends HTMLElement {
 	 */
 	async _updateSlots() {
 		const slotsMap = this.constructor.getMetadata().getSlots();
-		const canSlotText = slotsMap.default && slotsMap.default.type === Node;
+		const canSlotText = this.constructor.getMetadata().canSlotText();
 		const domChildren = Array.from(canSlotText ? this.childNodes : this.children);
 
 		// Init the _state object based on the supported slots

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -77,6 +77,11 @@ class UI5ElementMetadata {
 		return this.metadata.slots || {};
 	}
 
+	canSlotText() {
+		const defaultSlot = this.getSlots().default;
+		return defaultSlot && defaultSlot.type === "Node";
+	}
+
 	/**
 	 * Determines whether this UI5 Element supports any slots
 	 * @public

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -77,6 +77,10 @@ class UI5ElementMetadata {
 		return this.metadata.slots || {};
 	}
 
+	/**
+	 * Determines whether this UI5 Element has a default slot of type Node, therefore can slot text
+	 * @returns {boolean}
+	 */
 	canSlotText() {
 		const defaultSlot = this.getSlots().default;
 		return defaultSlot && defaultSlot.type === Node;

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -79,7 +79,7 @@ class UI5ElementMetadata {
 
 	canSlotText() {
 		const defaultSlot = this.getSlots().default;
-		return defaultSlot && defaultSlot.type === "Node";
+		return defaultSlot && defaultSlot.type === Node;
 	}
 
 	/**

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -46,7 +46,7 @@ const metadata = {
 		 * @public
 		 */
 		"default": {
-			type: Node,
+			type: HTMLElement,
 		},
 	},
 	properties: /** @lends sap.ui.webcomponents.main.Panel.prototype */ {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -173,7 +173,7 @@ const metadata = {
 		 * @public
 		 */
 		"default": {
-			type: Node,
+			type: HTMLElement,
 		},
 
 		/**

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -23,7 +23,7 @@ const metadata = {
 		 * @public
 		 */
 		"default": {
-			type: Node,
+			type: HTMLElement,
 		},
 
 		/**

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -77,9 +77,10 @@
 		</div>
 
 		<!-- Content -->
-        This is my panel <!-- fafa --> <br>
+		This is my panel <!-- fafa --> <br>
 		<ui5-title id="p1-content1">Lorem ipsum!</ui5-title>
 		<ui5-label id="p1-content2" wrap>
+			<span>
 			Lorem ipsum dolor sit amet, tamquam invidunt cu sed, unum regione mel ea, quo ea alia novum. Ne qui illud zril
 			nostrum, vel ea sint dicant postea. Vel ne facete tritani, neglegentur concludaturque sed te. His animal dolorum ut.
 			Aeterno appareat ei mei, cu sed elit scripserit, an quodsi oportere accusamus quo. Pri ea probo corpora rationibus,
@@ -96,6 +97,7 @@
 			sensibus duo.
 			Vis cu commodo definiebas, postea dissentias ne vim. Modo homero eos ad. Ut vix equidem temporibus. At duo audire
 			volumus, id volumus rationibus vim. Sit ne diam volumus. Augue labitur mel cu, an eam omnis causae hendrerit.
+			</span>
 		</ui5-label>
 
 	</ui5-panel>
@@ -108,6 +110,7 @@
 		<!-- Content -->
 		<ui5-title>Lorem ipsum!</ui5-title>
 		<ui5-label wrap>
+			<span>
 			Lorem ipsum dolor sit amet, tamquam invidunt cu sed, unum regione mel ea, quo ea alia novum. Ne qui illud zril
 			nostrum, vel ea sint dicant postea. Vel ne facete tritani, neglegentur concludaturque sed te. His animal dolorum ut.
 			Aeterno appareat ei mei, cu sed elit scripserit, an quodsi oportere accusamus quo. Pri ea probo corpora rationibus,
@@ -124,6 +127,7 @@
 			sensibus duo.
 			Vis cu commodo definiebas, postea dissentias ne vim. Modo homero eos ad. Ut vix equidem temporibus. At duo audire
 			volumus, id volumus rationibus vim. Sit ne diam volumus. Augue labitur mel cu, an eam omnis causae hendrerit.
+			</span>
 		</ui5-label>
 
 	</ui5-panel>


### PR DESCRIPTION
Background: the Mutation Observer needs `subtree` only for the purpose of detecting changes to text nodes. `childList` will trigger the Mutation Observer if new text nodes are added/removed, but it will not if an existing text node is changed by `nodeValue` assignment. Therefore `subtree` is required to efficiently track whenever the text inside a component changed. This is relevant if a component for example renders differently based on the presence of text or the length of the text.

It is safe to remove `subtree` for all components that do not slot text, as they either don't care about changes to their children (but do care about new children are added/removed), or they use `listenFor`.

In addition to the change, some often used containers' default slots were changed to `HTMLElement` rather than `Node`, which makes it possible to not monitor all their DOM trees.

BREAKING CHANGE:
`ui5-panel`, `ui5-popover` and `ui5-dialog` can no longer slot text. If you need this functionality, wrap the text in a `span` or `div` element.