### PR TITLE
fix(ui5-input): fix exceptions thrown when KH used

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -436,13 +436,13 @@ class Input extends UI5Element {
 
 	/* Event handling */
 	_handleUp(event) {
-		if (this.Suggestions) {
+		if (this.Suggestions && this.Suggestions.isOpened()) {
 			this.Suggestions.onUp(event);
 		}
 	}
 
 	_handleDown(event) {
-		if (this.Suggestions) {
+		if (this.Suggestions && this.Suggestions.isOpened()) {
 			this.Suggestions.onDown(event);
 		}
 	}

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -36,7 +36,7 @@
 		<ui5-list separators="Inner">
 			{{#each suggestionsTexts}}
 				<ui5-li
-					?icon="{{this.icon}}"
+					icon="{{this.icon}}"
 					@ui5-_itemPress="{{ fnOnSuggestionItemPress }}" 
 				>{{ this.text }}</ui5-li>
 			{{/each}}

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -247,7 +247,7 @@ class Suggestions {
 
 	_getScrollContainer() {
 		if (!this._scrollContainer) {
-			this._scrollContainer = this._respPopover.getDomRef().shadowRoot.querySelector(".ui5-popover-content");
+			this._scrollContainer = this._respPopover.getDomRef().querySelector(".ui5-popover-content");
 		}
 
 		return this._scrollContainer;

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -175,6 +175,7 @@ describe("Input general interaction", () => {
 		assert.strictEqual(suggestionsInput.getValue(), "Cozy", "First item has been selected");
 		assert.strictEqual(inputResult.getValue(), "1", "suggestionItemSelected event called once");
 
+		suggestionsInput.keys("c"); // to open the suggestions pop up once again 
 		suggestionsInput.keys("ArrowUp");
 
 		assert.strictEqual(suggestionsInput.getValue(), "Condensed", "First item has been selected");


### PR DESCRIPTION
Fix exceptions thrown when keyboard handling is used. When the input has suggestions, moving up/down throws exception in few cases: always when the suggestions popup is closed and always when it is opened and tries to bring an item into view

- fix: the ScrollContainer (that moves the item into view) used to throw exceptions
- fix: handle UP/DOWN when the suggestions are opened, otherwise we prevent the default behaviour - bringing the cursor to the start/end of the input text
- fix: the icons of the items are not displayed
