### PR TITLE
fix(ui5-busyindicator): display animated dots as size=Large by default

### DIFF
--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -48,12 +48,17 @@
 	align-items: center;
 	position: relative;
 	background-color: inherit;
+	min-width: 8rem;
+	min-height: 3rem;
 }
 
 .ui5-busyindicator-circle {
 	display: inline-block;
 	background-color: currentColor;
 	border-radius: 50%;
+	width: 1rem;
+	height: 1rem;
+	margin: 0 .75rem;
 }
 
 .ui5-busyindicator-circle::before {

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -23,6 +23,12 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
+	<ui5-title>Default (Large) ui5-busyindicator</ui5-title>
+	<ui5-busyindicator active></ui5-busyindicator>
+	<br/>
+	<br/>
+
+	<ui5-title>Medium ui5-busyindicator</ui5-title>
 	<ui5-busyindicator size="Medium" active id="indicator1"></ui5-busyindicator>
 
 	<br/>


### PR DESCRIPTION
Currently if the user does not set the "size" property, the indicator (animated dots) will not not be displayed, but should be displayed as "size=Large", which is the default value of the "size" property.

Now the following markup works and displays the animated dots as expected:
```html
<ui5-busyindicator active></ui5-busyindicator>
```
