### PR TITLE
refactor(ui5-input): improve group suggestion item handling

### DIFF
--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -59,6 +59,10 @@ class GroupHeaderListItem extends ListItemBase {
 	static get styles() {
 		return [ListItemBase.styles, groupheaderListItemCss];
 	}
+
+	get group() {
+		return true;
+	}
 }
 
 GroupHeaderListItem.define();

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -569,7 +569,7 @@ class Input extends UI5Element {
 
 	previewSuggestion(item) {
 		this.valueBeforeItemSelection = this.value;
-		this.value = item.textContent;
+		this.value = item.group ? "" : item.textContent;
 	}
 
 	fireEventByAction(action) {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -552,6 +552,10 @@ class Input extends UI5Element {
 	}
 
 	selectSuggestion(item, keyboardUsed) {
+		if (item.group) {
+			return;
+		}
+
 		const itemText = item.text || item.textContent; // keep textContent for compatibility
 		const fireInput = keyboardUsed
 			? this.valueBeforeItemSelection !== itemText : this.value !== itemText;

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -18,16 +18,6 @@ const metadata = {
 	properties: /** @lends  sap.ui.webcomponents.main.ListItem.prototype */ {
 
 		/**
-		 * Defines the selected state of the <code>ListItem</code>.
-		 * @type {boolean}
-		 * @defaultvalue false
-		 * @public
-		 */
-		selected: {
-			type: Boolean,
-		},
-
-		/**
 		 * Defines the visual indication and behavior of the list items.
 		 * Available options are <code>Active</code> (by default), <code>Inactive</code> and <code>Detail</code>.
 		 * <br><br>

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -13,6 +13,16 @@ const metadata = {
 	properties: /** @lends  sap.ui.webcomponents.main.ListItemBase.prototype */  {
 
 		/**
+		 * Defines the selected state of the <code>ListItem</code>.
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 */
+		selected: {
+			type: Boolean,
+		},
+
+		/**
 		* Defines if the list item should display its bottom border.
 		* @private
 		*/

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -1,5 +1,4 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import StandardListItem from "./StandardListItem.js";
 import GroupHeaderListItem from "./GroupHeaderListItem.js";
@@ -92,9 +91,11 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the item to be displayed as a group item. When set, the other properties,
-		 * such as <code>image</code>, <code>icon</code>, <code>description</code>, etc. will be omitted.
-		 * Only the <code>text</code> will be displayed.
+		 * Defines the item to be displayed as a group item. 
+		 * <br>
+		 * <b>Note:</b>
+		 * When set, the other properties, such as <code>image</code>, <code>icon</code>, <code>description</code>, etc. will be omitted
+		 * and only the <code>text</code> will be displayed.
 		 * @type {string}
 		 * @public
 		 */
@@ -121,10 +122,6 @@ const metadata = {
 class SuggestionItem extends UI5Element {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -1,4 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import StandardListItem from "./StandardListItem.js";
 import GroupHeaderListItem from "./GroupHeaderListItem.js";
@@ -91,7 +92,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the item to be displayed as a group item. 
+		 * Defines the item to be displayed as a group item.
 		 * <br>
 		 * <b>Note:</b>
 		 * When set, the other properties, such as <code>image</code>, <code>icon</code>, <code>description</code>, etc. will be omitted

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -261,7 +261,7 @@ class Suggestions {
 	}
 
 	_getItems() {
-		return [].slice.call(this.responsivePopover.querySelectorAll("ui5-li"));
+		return [].slice.call(this.responsivePopover.querySelectorAll("ui5-li, ui5-li-groupheader"));
 	}
 
 	_getComponent() {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -3,11 +3,6 @@
 	cursor: pointer;
 }
 
-/* selected */
-:host([selected]) {
-	background: var(--sapList_SelectionBackgroundColor);
-}
-
 /* selected and hovered */
 :host([selected][actionable]:not([active]):hover) {
 	background : var(--sapList_Hover_SelectionBackground);

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -8,6 +8,11 @@
 	box-sizing: border-box;
 }
 
+/* selected */
+:host([selected]) {
+	background: var(--sapList_SelectionBackgroundColor);
+}
+
 :host([has-border]) {
 	border-bottom: var(--ui5-listitem-border-bottom);
 }

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -39,7 +39,7 @@
 		</ui5-input>
 	</div>
 
-	<h3> Input with suggestions: ui5-suggestion-item</h3>
+	<h3> Input suggestions with ui5-suggestion-item</h3>
 	<ui5-input show-suggestions style="width: 100%">
 		<ui5-suggestion-item text="Cozy"></ui5-suggestion-item>
 		<ui5-suggestion-item text="Compact"></ui5-suggestion-item>
@@ -50,8 +50,7 @@
 	</ui5-input>
 	<br/>
 	<br/>
-	<br/>
-	<ui5-title>suggestion with ui5-li</ui5-title>
+	<h3>Input suggestions with ui5-li</h3>
 	<ui5-input id="myInput2" show-suggestions style="width: 100%">
 		<ui5-li>Cozy</ui5-li>
 		<ui5-li>Compact</ui5-li>
@@ -59,6 +58,18 @@
 		<ui5-li>Cozy</ui5-li>
 		<ui5-li>Compact</ui5-li>
 		<ui5-li>Condensed</ui5-li>
+	</ui5-input>
+	<br/>
+	<br/>
+	<h3>Input suggestions with grouping</h3>
+	<ui5-input id="myInputGrouping"show-suggestions style="width: 100%">
+		<ui5-suggestion-item group text="Content Density"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Compact"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Condensed"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Cozy"></ui5-suggestion-item>
+		<ui5-suggestion-item group text="Themes"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Quartz"></ui5-suggestion-item>
+		<ui5-suggestion-item text="HCB"></ui5-suggestion-item>
 	</ui5-input>
 
 	<h3> Input disabled</h3>
@@ -86,6 +97,9 @@
 	</ui5-input>
 	<h3> 'change' event result</h3>
 	<ui5-input id="inputResult"></ui5-input>
+
+	<h3> 'suggestionItemSelect' event result on group item</h3>
+	<ui5-input id="inputResultGrouping"></ui5-input>
 
 	<h3> Test 'input' event</h3>
 	<ui5-input id="input2" value-state="Error" placeholder="Error state ...">
@@ -177,15 +191,19 @@
 		var sap_database_entries = [{ key: "A", text: "A" }, { key: "Afg", text: "Afghanistan" }, { key: "Arg", text: "Argentina" }, { key: "Alb", text: "Albania" }, { key: "Arm", text: "Armenia" }, { key: "Alg", text: "Algeria" }, { key: "And", text: "Andorra" }, { key: "Ang", text: "Angola" }, { key: "Ast", text: "Austria" }, { key: "Aus", text: "Australia" }, { key: "Aze", text: "Azerbaijan" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "B", text: "B" }, { key: "Bel", text: "Belarus" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }, { key: "C", text: "C" }, { key: "Ch", text: "China" }, { key: "Cub", text: "Cuba" }, { key: "Chil", text: "Chili" }, { key: "L", text: "L" }, { key: "Lat", text: "Latvia" }, { key: "Lit", text: "Litva" }, { key: "P", text: "P" }, { key: "Prt", text: "Portugal" }, { key: "S", text: "S" }, { key: "Sen", text: "Senegal" }, { key: "Ser", text: "Serbia" }, { key: "Sey", text: "Seychelles" }, { key: "Sierra", text: "Sierra Leone" }, { key: "Sgp", text: "Singapore" }, { key: "Sint", text: "Sint Maarten" }, { key: "Slv", text: "Slovakia" }, { key: "Slo", text: "Slovenia" }];
 
 		var input = document.getElementById('myInput');
+		var inputGrouping = document.getElementById('myInputGrouping');
 		var myInput2 = document.getElementById('myInput2');
 		var input1 = document.getElementById('input1');
 		var input2 = document.getElementById('input2');
 		var inputResult = document.getElementById('inputResult');
+		var inputResultGrouping = document.getElementById('inputResultGrouping');
 		var inputLiveChangeResult = document.getElementById('inputLiveChangeResult');
 		var label = document.getElementById('myLabel');
 		var labelChange = document.getElementById('myLabelChange');
 		var labelLiveChange = document.getElementById('myLabelLiveChange');
 		var labelSubmit = document.getElementById('myLabelSubmit');
+
+		var suggestionSelectedCounterWithGrouping = 0;
 
 		var suggest = function (event) {
 			var input = event.target;
@@ -225,6 +243,12 @@
 			label.innerHTML = "Event [suggestionSelectEvent] :: " + item.id;
 			suggestionSelectedCounter += 1;
 			inputResult.value = suggestionSelectedCounter;
+		});
+
+		inputGrouping.addEventListener("ui5-suggestionItemSelect", function (event) {
+			var item = event.detail.item;
+			suggestionSelectedCounterWithGrouping += 1;
+			inputResultGrouping.value = suggestionSelectedCounterWithGrouping;
 		});
 
 		input.addEventListener("ui5-change", function (event) {

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -185,6 +185,18 @@ describe("Input general interaction", () => {
 		assert.strictEqual(inputResult.getValue(), "1", "suggestionItemSelect is fired once");
 	});
 
+	it("handles group suggestion item via keyboard", () => {
+		const suggestionsInput = $("#myInputGrouping").shadow$("input");
+		const inputResult = $("#inputResultGrouping").shadow$("input");
+
+		suggestionsInput.click();
+		suggestionsInput.keys("ArrowDown");
+		suggestionsInput.keys("Enter");
+
+		assert.strictEqual(suggestionsInput.getValue(), "", "Group item is not selected");
+		assert.strictEqual(inputResult.getValue(), "", "suggestionItemSelected event is not called");
+	});
+
 	it("Input's maxlength property is set correctly", () => {
 		const input5 = $("#input-tel");
 		const inputShadowRef = $("#input-tel").shadow$("input");


### PR DESCRIPTION
Couple of improvements in handling a group item within the suggestion popover:
- When navigating via the keyboard over a group item, the text in the input field should be cleared
- However, the group item should also have the selection visual, when reached via the keyboard, but it can not be selected neither with the keyboard, nor with a click