### PR TITLE
fix(framework): Provide a workaround for Firefox 74 shadow root bug

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -105,6 +105,10 @@ class UI5Element extends HTMLElement {
 				await this._processChildren();
 			}
 
+			if (!this.shadowRoot) { // Workaround for Firefox74 bug
+				await Promise.resolve();
+			}
+
 			await RenderScheduler.renderImmediately(this);
 			this._domRefReadyPromise._deferredResolve();
 			if (typeof this.onEnterDOM === "function") {


### PR DESCRIPTION
Firefox 74 seems to have a bug regarding shadow root creation. Even though `attachShadow` is called in the constructor, `this.shadowRoot` is still `null` in `connectedCallback`. If you try to create it again there, it fails, as it was already created, it's just not available yet. Therefore with `managedSlots: true` it works, as there is async work going on, and the `shadowRoot` is ready when rendering. 

The fix is to await a microtask, if there is no shadow root in `connectedCallback` and `needsShadowRoot` is equal to `true`.