### PR TITLE
fix(ui5-datepicker): fix hover bg-color when readonly

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -127,7 +127,7 @@
 	border: 1px solid var(--sapField_Hover_BorderColor);
 }
 
-:host([value-state="None"]:hover) {
+:host([value-state="None"]:not([readonly]):hover) {
 	background-color: var(--sapField_Hover_Background);
 	border: 1px solid var(--sapField_Hover_BorderColor);
 }


### PR DESCRIPTION
The hover state used to be wrong, when the date picker is readonly.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1354