### PR TITLE
fix(ui5-tabcontainer): fix sizes on compact

### DIFF
--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -49,6 +49,7 @@
 				icon="slim-arrow-down"
 				type="Transparent"
 				title="{{overflowMenuTitle}}"
+				design="Transparent"
 			></ui5-button>
 		{{/if}}
 	</div>

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -182,7 +182,7 @@
 /*** TextOnly Tab styles ***/
 .ui5-tc__headerItem--textOnly {
 	font-size: var(--sapFontMediumSize);
-	height: var(--_ui5_tc_item_text);
+	height: var(--_ui5_tc_item_text_text_only);
 	display: flex;
 	align-items: center;
 	line-height: var(--_ui5_tc_item_text_line_height);

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -44,6 +44,7 @@
 	--_ui5_switch_rtl_transform: translateX(1.875rem) translateX(-100%);
 	--_ui5_switch_text_right: calc(-100% + 1.9125rem);
 	--_ui5_tc_item_text: 3rem;
+	--_ui5_tc_item_text_text_only: 3rem;
 	--_ui5_tc_item_text_line_height: normal;
 	--_ui5_tc_item_icon_size: 1.5rem;
 	--_ui5_tc_item_add_text_margin_top: 0.625rem;
@@ -156,7 +157,6 @@
 	--_ui5_tc_item_text_line_height: 1.325rem;
 	--_ui5_tc_item_icon_size: 1rem;
 	--_ui5_tc_item_add_text_margin_top: 0.3125rem;
-	--_ui5_tc_header_height_text_only: var(--_ui5_tc_header_height_text_only_compact);
 	--_ui5_tc_header_height: var(--_ui5_tc_header_height_compact);
 
 	/* Radio Button */


### PR DESCRIPTION
- size of text-only and text-only + count should be the same in cozy and compact
- overflow button is transparent by design

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1358