### PR TITLE
fix(ui5-carousel): add missing icon imports

### DIFF
--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -20,6 +20,9 @@ import {
 } from "./generated/i18n/i18n-defaults.js";
 import CarouselArrowsPlacement from "./types/CarouselArrowsPlacement.js";
 import CarouselTemplate from "./generated/templates/CarouselTemplate.lit.js";
+import "@ui5/webcomponents-icons/dist/icons/slim-arrow-left.js";
+import "@ui5/webcomponents-icons/dist/icons/slim-arrow-right.js";
+
 import Button from "./Button.js";
 
 // Styles


### PR DESCRIPTION
These icons are used in Carousel.hbs