### PR TITLE
chore(tools): Remove the unnecessary Assets.js import

### DIFF
--- a/packages/tools/lib/init-package/resources/src/Assets.js
+++ b/packages/tools/lib/init-package/resources/src/Assets.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents-localization/dist/Assets.js"; // CLDR
 import "@ui5/webcomponents-theme-base/dist/Assets.js"; // Theming
 
 // own INIT_PACKAGE_VAR_NAME package assets


### PR DESCRIPTION
The `localization` package is not a dependency of the demo project, but its `Assets.js` is imported, breaking the build. Instead of making it a dependency, just remove the import. CLDR assets are not needed by the demo project.