### PR TITLE
docs(ui5-busyindicator): use 'Medium' as default size

### DIFF
--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -36,7 +36,7 @@ const metadata = {
 		 * <b>Note:</b> Available options are "Small", "Medium", and "Large".
 		 *
 		 * @type {BusyIndicatorSize}
-		 * @defaultvalue "Large"
+		 * @defaultvalue "Medium"
 		 * @public
 		 */
 		size: { type: BusyIndicatorSize, defaultValue: BusyIndicatorSize.Medium },


### PR DESCRIPTION
**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
