### PR TITLE
docs: use enum type instead of string

### DIFF
--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -71,7 +71,7 @@ const metadata = {
 		 * <li><code>Circle</code></li>
 		 * <li><code>Square</code></li>
 		 * <ul>
-		 * @type {string}
+		 * @type {AvatarShape}
 		 * @defaultvalue "Circle"
 		 * @public
 		 */
@@ -108,7 +108,7 @@ const metadata = {
 		 * <li><code>Cover</code></li>
 		 * <li><code>Contain</code></li>
 		 * <ul>
-		 * @type {String}
+		 * @type {AvatarFitType}
 		 * @defaultvalue "Cover"
 		 * @public
 		 */
@@ -134,7 +134,7 @@ const metadata = {
 		 * <li><code>Accent10</code></li>
 		 * <li><code>Placeholder</code></li>
 		 * <ul>
-		 * @type {String}
+		 * @type {AvatarBackgroundColor}
 		 * @defaultvalue "Accent6"
 		 * @public
 		 */

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -91,7 +91,7 @@ const metadata = {
 		 * <li><code>L</code></li>
 		 * <li><code>XL</code></li>
 		 * <ul>
-		 * @type {string}
+		 * @type {AvatarSize}
 		 * @defaultvalue "S"
 		 * @public
 		 */

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -41,7 +41,7 @@ const metadata = {
 		 * Defines the calendar type used for display.
 		 * If not defined, the calendar type of the global configuration is used.
 		 * Available options are: "Gregorian", "Islamic", "Japanese", "Buddhist" and "Persian".
-		 * @type {string}
+		 * @type {CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -82,7 +82,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Available options are <code>Warning</code>, <code>Error</code>, and <code>None</code> (default).
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -102,7 +102,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -61,7 +61,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -119,7 +119,7 @@ const metadata = {
 		 * <li><code>Persian</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {CalendarType}
 		 * @defaultvalue "Gregorian"
 		 * @public
 		 */

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -47,7 +47,7 @@ const metadata = {
 		/**
 		 * Sets a calendar type used for display.
 		 * If not set, the calendar type of the global configuration is used.
-		 * @type {string}
+		 * @type {CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -118,7 +118,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -170,7 +170,7 @@ const metadata = {
 		 * that use different soft keyboard layouts depending on the given input type.</li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {InputType}
 		 * @defaultvalue "Text"
 		 * @public
 		 */
@@ -204,7 +204,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -67,7 +67,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Avaialble options are <code>Default</code>, <code>Subtle</code>, and <code>Emphasized</code>.
 		 *
-		 * @type {string}
+		 * @type {LinkDesign}
 		 * @defaultvalue "Default"
 		 * @public
 		 */

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -96,7 +96,7 @@ const metadata = {
 		 * <b>Note:</b> Avalaible options are <code>None</code>, <code>SingleSelect</code>,
 		 * <code>MultiSelect</code>, and <code>Delete</code>.
 		 *
-		 * @type {string}
+		 * @type {ListMode}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -127,7 +127,7 @@ const metadata = {
 		 * item doesn't have a bottom separator.</li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ListSeparators}
 		 * @defaultvalue "All"
 		 * @public
 		 */

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -24,7 +24,7 @@ const metadata = {
 		 * <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press and hover,
 		 * while with type <code>Inactive</code> and <code>Detail</code> - will not.
 		 *
-		 * @type {string}
+		 * @type {ListItemType}
 		 * @defaultvalue "Active"
 		 * @public
 		*/

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -86,7 +86,7 @@ const metadata = {
 		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 *
 		 * @type {HTMLElement}
-		 * @defaultvalue ""
+         * @slot
 		 * @public
 		 */
 		"icon": {

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -85,7 +85,7 @@ const metadata = {
 		 *
 		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 *
-		 * @type {string}
+		 * @type {HTMLElement}
 		 * @defaultvalue ""
 		 * @public
 		 */

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -32,7 +32,7 @@ const metadata = {
 		/**
 		 * Sets a calendar type used for display.
 		 * If not set, the calendar type of the global configuration is used.
-		 * @type {string}
+		 * @type {CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -125,7 +125,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -95,7 +95,7 @@ const metadata = {
 		 * <li><code>Warning</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -106,7 +106,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -75,7 +75,7 @@ const metadata = {
 		 * Defines the state of the <code>info</code>.
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code> and <code>"Erorr"</code>.
-		 * @type {string}
+		 * @type {ValueState}
 		 * @public
 		 * @since 0.13.0
 		 */

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -76,6 +76,7 @@ const metadata = {
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code> and <code>"Erorr"</code>.
 		 * @type {ValueState}
+         * @defaultvalue "None"
 		 * @public
 		 * @since 0.13.0
 		 */

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -84,6 +84,7 @@ const metadata = {
 		 * <br><br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code> and <code>"Erorr"</code>.
 		 * @type {ValueState}
+         * @defaultvalue "None"
 		 * @public
 		 */
 		infoState: {
@@ -98,6 +99,7 @@ const metadata = {
 		 * When set, the other properties, such as <code>image</code>, <code>icon</code>, <code>description</code>, etc. will be omitted
 		 * and only the <code>text</code> will be displayed.
 		 * @type {boolean}
+         * @defaultvalue false
 		 * @public
 		 */
 		group: {

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -97,7 +97,7 @@ const metadata = {
 		 * <b>Note:</b>
 		 * When set, the other properties, such as <code>image</code>, <code>icon</code>, <code>description</code>, etc. will be omitted
 		 * and only the <code>text</code> will be displayed.
-		 * @type {string}
+		 * @type {boolean}
 		 * @public
 		 */
 		group: {

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -83,7 +83,7 @@ const metadata = {
 		 * Defines the state of the <code>info</code>.
 		 * <br><br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code> and <code>"Erorr"</code>.
-		 * @type {string}
+		 * @type {ValueState}
 		 * @public
 		 */
 		infoState: {

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -84,7 +84,7 @@ const metadata = {
 		 *
 		 * <br><br>
 		 * <b>Note:</b> The color value depends on the current theme.
-		 * @type {string}
+		 * @type {SemanticColor}
 		 * @defaultvalue "Default"
 		 * @public
 		 */

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -105,7 +105,7 @@ const metadata = {
 		 * <li><code>Inline</code></li>
 		 * <ul>
 		 *
-		 * @type {String}
+		 * @type {TabLayout}
 		 * @defaultvalue "Standard"
 		 * @public
 		 */

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -100,7 +100,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -45,7 +45,7 @@ const metadata = {
 		 * Defines the name of the item.
 		 *
 		 * @type {string}
-		 * @defaultvalue false
+		 * @defaultvalue ""
 		 * @public
 		 */
 		itemName: {

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -30,7 +30,7 @@ const metadata = {
 		 * Defines the <code>ui5-title</code> level.
 		 * Available options are: <code>"H6"</code> to <code>"H1"</code>.
 		 *
-		 * @type {string}
+		 * @type {TitleLevel}
 		 * @defaultvalue "H2"
 		 * @public
 		*/

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -51,7 +51,7 @@ const metadata = {
 		 * <li><code>BottomEnd</code></li>
 		 * </ul>
 		 *
-		 * @type {string}
+		 * @type {ToastPlacement}
 		 * @defaultvalue "BottomCenter"
 		 * @public
 		 */

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -32,7 +32,7 @@ const metadata = {
 		/**
 		 * Sets a calendar type used for display.
 		 * If not set, the calendar type of the global configuration is used.
-		 * @type {string}
+		 * @type {CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {


### PR DESCRIPTION
In several places, `string` was used as `@type` annotation for the documentation. This PR is replacing those string annotations with the corresponding enums.