### PR TITLE
chore: handle missing vars within ThermeDesigner

### DIFF
--- a/packages/fiori/src/themes/ProductSwitch.css
+++ b/packages/fiori/src/themes/ProductSwitch.css
@@ -1,6 +1,6 @@
 :host {
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-product-switch-root {

--- a/packages/fiori/src/themes/ProductSwitchItem.css
+++ b/packages/fiori/src/themes/ProductSwitchItem.css
@@ -12,7 +12,7 @@
 }
 
 :host([active]) {
-	background:var(--sapList_HighlightColor);
+	background:var(--sapList_Hover_Background);
 }
 
 :host([active]) .ui5-product-switch-item-root .ui5-product-switch-item-icon,
@@ -128,7 +128,7 @@
 	}
 
 	.ui5-product-switch-item-root .ui5-product-switch-item-text-content .ui5-product-switch-item-subtitle {
-		font-size: var(--sapFontMediumSize);
+		font-size: var(--sapFontSize);
 		padding-top: .75rem;
 	}
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -11,7 +11,7 @@
 	background: var(--sapShellColor);
 	height: 2.75rem;
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-weight: normal;
 	box-sizing: border-box;
 }

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -8,7 +8,7 @@
 	min-width: var(--_ui5_button_base_min_width);
 	height: var(--_ui5_button_base_height);
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	text-shadow: var(--_ui5_button_text_shadow);
 	border-radius: var(--_ui5_button_border_radius);
 	border-width: 0.0625rem;

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -25,7 +25,7 @@
 	overflow: hidden;
 	white-space: nowrap;
 	padding: 0;
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-calheader-arrowbtn.ui5-calheader-arrowbtn-disabled:hover,

--- a/packages/main/src/themes/Card.css
+++ b/packages/main/src/themes/Card.css
@@ -108,7 +108,7 @@
 
 .ui5-card-header .ui5-card-header-text .ui5-card-subheading {
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-weight: normal;
 	color: var(--sapTile_TextColor);
 	margin-top: .5rem;

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -61,7 +61,7 @@
 	position: relative;
 	color: var(--sapTextColor);
 	background: var(--sapLegend_WorkingBackground);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	border: var(--_ui5_daypicker_item_border);
 }
 

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -9,7 +9,7 @@
 	min-width: var(--_ui5_input_width);
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -6,7 +6,7 @@
 	max-width: 100%;
 	color: var(--sapContent_LabelColor);
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-weight: normal;
 	cursor: text;
 }

--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -8,7 +8,7 @@
 	max-width: 100%;
 	color: var(--sapLinkColor);
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	cursor: pointer;
 }
 

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -52,7 +52,7 @@
 	height: 2rem;
 	box-sizing: border-box;
 	-webkit-text-size-adjust: none;	/* To improve readability Mobile Safari automatically increases the size of small text so let's disable this */
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	line-height: 2rem;
 	background-color: var(--sapList_FooterBackground);
@@ -76,7 +76,7 @@
 	border-bottom: 1px solid var(--sapList_BorderColor);
 	padding: 0 1rem !important;
 	height: var(--_ui5_list_no_data_height);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-list-nodata-text {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -11,7 +11,7 @@
 /* selected and active */
 :host([active][actionable]),
 :host([selected][active][actionable]) {
-	background: var(--sapList_HighlightColor);
+	background: var(--sapList_Active_Background);
 }
 
 /* hovered */
@@ -81,7 +81,7 @@
 
 .ui5-li-desc {
 	color: var(--sapContent_LabelColor);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-li-info {

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -41,7 +41,7 @@
 
 .ui5-messagestrip-text {
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-messagestrip--info {

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -12,7 +12,7 @@
 	display: flex;
 	flex-direction: column;
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;
 }

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -3,7 +3,7 @@
 	flex: 1;
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -181,6 +181,11 @@
 	transform	: var(--_ui5_switch_slide_transform);
 }
 
+.ui5-switch-root.ui5-switch--checked .ui5-switch-text--on,
+.ui5-switch-root.ui5-switch--checked .ui5-switch-text--off {
+	color: var(--sapButton_Track_Selected_TextColor);
+}
+
 /* switch semantic off */
 .ui5-switch-root.ui5-switch--semantic .ui5-switch-track,
 .ui5-switch-root.ui5-switch--semantic .ui5-switch-handle {
@@ -242,8 +247,8 @@
 
  /* switch on hover, when switched on */
 .ui5-switch-desktop.ui5-switch-root.ui5-switch--checked:not(.ui5-switch--disabled):hover .ui5-switch-handle {
-	background: var(--sapToggleButton_Pressed_HoverBackground);
-	border-color: var(--sapToggleButton_Pressed_HoverBorderColor);
+	background: var(--sapButton_Selected_Hover_Background);
+	border-color: var(--sapButton_Hover_BorderColor);
 }
 
 /* semantic switch on hover, when switched off */

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -181,7 +181,7 @@
 
 /*** TextOnly Tab styles ***/
 .ui5-tc__headerItem--textOnly {
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	height: var(--_ui5_tc_item_text_text_only);
 	display: flex;
 	align-items: center;

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -13,7 +13,7 @@ table {
 	color: var(--sapTextColor);
 	height: 3rem;
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-table-header-row:focus {

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -20,5 +20,5 @@
 .ui5-table-row-popin-title {
 	color: var(--sapContent_LabelColor);
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -5,7 +5,7 @@
 :host {
 	width: 100%;
 	color: var(--sapField_TextColor);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	border-color: var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
@@ -84,7 +84,7 @@
 	width: 100%;
 	word-break: break-all;
 	padding: 0.5625rem 0.6875rem;
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	white-space: pre-wrap;
 	box-sizing: border-box;

--- a/packages/main/src/themes/TimelineItem.css
+++ b/packages/main/src/themes/TimelineItem.css
@@ -127,7 +127,7 @@
 	color: var(--sapTextColor);
 	font-family: var(--sapFontFamily);
 	font-weight: 400;
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 .ui5-tli-title span {

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -1,7 +1,7 @@
 :host {
 	font-family: var(--sapFontFamily);
 	color: var(--sapTextColor);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 :host([open]) .ui5-toast-root {

--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -51,7 +51,7 @@
 
 :host([pressed][active]),
 :host([pressed]:hover) {
-	background: var(--sapToggleButton_Pressed_HoverBackground);
+	background: var(--sapButton_Selected_Hover_Background);
 }
 
 /* IE Specific CSS, duplicate it for ToggleButton */

--- a/packages/main/src/themes/Token.css
+++ b/packages/main/src/themes/Token.css
@@ -26,8 +26,8 @@
 }
 
 :host([selected]:not([readonly]):hover) {
-	background: var(--sapToggleButton_Pressed_HoverBackground);
-	border: 1px solid var(--sapToggleButton_Pressed_HoverBorderColor);
+	background: var(--sapButton_Selected_Hover_Background);
+	border: 1px solid var(--sapButton_Selected_Hover_BorderColor);
 }
 
 :host([readonly]) {
@@ -52,7 +52,7 @@
 	padding-top: 0.25rem;
 	padding-bottom: 0.25rem;
 	box-sizing: border-box;
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	user-select: none;
 }

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -54,7 +54,7 @@
 	margin-left: .25rem;
 	cursor: pointer;
 	white-space: nowrap;
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 }
 
 :host([expanded]) .ui5-tokenizer--content {

--- a/packages/main/src/themes/YearPicker.css
+++ b/packages/main/src/themes/YearPicker.css
@@ -12,7 +12,7 @@
 	display: flex;
 	flex-direction: column;
 	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontMediumSize);
+	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;
 }

--- a/packages/main/src/themes/base/WheelSlider-parameters.css
+++ b/packages/main/src/themes/base/WheelSlider-parameters.css
@@ -1,5 +1,5 @@
 :root{
-	--_ui5_wheelslider_item_text_size: var(--sapFontMediumSize);
+	--_ui5_wheelslider_item_text_size: var(--sapFontSize);
 	--_ui5_wheelslider_label_text_size: var(--sapFontSmallSize);
 	--_ui5_wheelslider_selection_frame_margin_top: calc(var(--_ui5_wheelslider_item_height) * 2);
 	--_ui5_wheelslider_mobile_selection_frame_margin_top: calc(var(--_ui5_wheelslider_item_height) * 4);

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -105,7 +105,7 @@
 	/* List */
 	--_ui5_list_no_data_height: 2rem;
 	--_ui5_list_item_cb_margin_right: .5rem;
-	--_ui5_list_item_title_size: var(--sapFontMediumSize);
+	--_ui5_list_item_title_size: var(--sapFontSize);
 	--_ui5_list_item_img_size: 1.75rem;
 	--_ui5_list_item_img_margin: 0.55rem 0.75rem 0.5rem 0rem;
 	--_ui5_list_item_base_height: 2rem;

--- a/packages/theme-base/src/themes/sap_belize/base-parameters-vars.less
+++ b/packages/theme-base/src/themes/sap_belize/base-parameters-vars.less
@@ -32,13 +32,11 @@
   --sapShellColor: @sapShellColor;
   --sapShell_BorderColor: @sapShell_BorderColor;
   --sapShell_InteractiveTextColor: @sapShell_InteractiveTextColor;
-  --sapBackgroundColorDefault: @sapBackgroundColorDefault;
   --sapBackgroundColor: @sapBackgroundColor;
   --sapFontFamily: @sapFontFamily;
   --sapContent_GridSize: @sapContent_GridSize;
-  --sapFontSize: @sapFontSize; /*  0.75em; */
+  --sapFontSize: @sapFontSize;
   --sapFontSmallSize: @sapFontSmallSize;
-  --sapFontMediumSize: @sapFontMediumSize;
   --sapFontLargeSize: @sapFontLargeSize;
   --sapTextColor: @sapTextColor;
   --sapLinkColor: @sapLinkColor;
@@ -86,8 +84,6 @@
   --sapElement_Height: @sapElement_Height;
   --sapElement_BorderWidth: @sapElement_BorderWidth;
   --sapContent_LineHeight: @sapContent_LineHeight;
-  --sapContent_ElementHeight: @sapContent_ElementHeight;
-  --sapContent_ElementHeight_PX: @sapContent_ElementHeight_PX;
   --sapContent_IconHeight: @sapContent_IconHeight;
   --sapContent_ContrastTextColor: @sapContent_ContrastTextColor;
   --sapContent_ContrastIconColor: @sapContent_ContrastIconColor;
@@ -115,6 +111,7 @@
   --sapButton_Selected_Background: @sapButton_Selected_Background;
   --sapButton_Selected_BorderColor: @sapButton_Selected_BorderColor;
   --sapButton_Selected_TextColor: @sapButton_Selected_TextColor;
+  --sapButton_Selected_Hover_Background: @sapButton_Selected_Hover_Background;
   --sapButton_Emphasized_Background: @sapButton_Emphasized_Background;
   --sapButton_Emphasized_BorderColor: @sapButton_Emphasized_BorderColor;
   --sapButton_Emphasized_Hover_BorderColor: @sapButton_Emphasized_Hover_BorderColor;
@@ -154,6 +151,7 @@
   --sapButton_Selected_Hover_BorderColor: @sapButton_Selected_Hover_BorderColor;
   --sapButton_Track_Background: @sapButton_Track_Background;
   --sapButton_Track_Selected_Background: @sapButton_Track_Selected_Background;
+  --sapButton_Track_Selected_TextColor: @sapButton_Track_Selected_TextColor;
   --sapTile_SeparatorColor: @sapTile_SeparatorColor;
   --sapButton_TokenBackground: @sapButton_TokenBackground;
   --sapButton_TokenBorderColor: @sapButton_TokenBorderColor;
@@ -196,7 +194,6 @@
   --sapList_GroupHeaderTextColor: @sapList_GroupHeaderTextColor;
   --sapList_Hover_Background: @sapList_Hover_Background;
   --sapList_Hover_SelectionBackground: @sapList_Hover_SelectionBackground;
-  --sapList_HighlightColor: @sapList_HighlightColor;
   --sapList_Background: @sapList_Background;
   --sapList_Active_TextColor: @sapList_Active_TextColor;
   --sapList_TableGroupHeaderTextColor: @sapList_TableGroupHeaderTextColor;
@@ -274,7 +271,6 @@
 
   --sapShell_TextColor: @sapShell_TextColor;
   --sapShell_Background: @sapShell_Background;
-  --sapShell_BackgroundPatternColor: @sapShell_BackgroundPatternColor;
   --sapShell_Hover_Background: @sapShell_Hover_Background;
   --sapShell_Active_Background: @sapShell_Active_Background;
   --sapShell_Active_TextColor: @sapShell_Active_TextColor;
@@ -298,6 +294,4 @@
   --sapInfobar_Background: @sapInfobar_Background;
   --sapToolbar_SeparatorColor: @sapToolbar_SeparatorColor;
   --sapHighlightTextColor: @sapHighlightTextColor;
-  --sapToggleButton_Pressed_HoverBackground: @sapToggleButton_Pressed_HoverBackground;
-  --sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBorderColor;
 }

--- a/packages/theme-base/src/themes/sap_belize/base-parameters.less
+++ b/packages/theme-base/src/themes/sap_belize/base-parameters.less
@@ -28,13 +28,11 @@
 @sapBaseColor: @sapPrimary3;
 @sapShellColor: transparent;
 @sapShell_BorderColor: transparent;
-@sapBackgroundColorDefault: @sapPrimary5;
 @sapBackgroundColor: @sapPrimary5;
 @sapFontFamily: "72", "72full", Arial, Helvetica, sans-serif;
 @sapContent_GridSize: 1rem;
-@sapFontSize: ~"calc(0.875 * @{sapContent_GridSize})"; /*  0.75em; */
+@sapFontSize: .875rem;
 @sapFontSmallSize: calc(0.75 * @sapContent_GridSize);
-@sapFontMediumSize: calc(0.875 * @sapContent_GridSize);
 @sapFontLargeSize: calc(1 * @sapContent_GridSize);
 @sapTextColor: @sapPrimary7;
 @sapLinkColor: #0070b1;
@@ -84,8 +82,6 @@
 @sapElement_Height: ~"calc(2.5 * @{sapContent_GridSize})";
 @sapElement_BorderWidth: ~"calc(0.0625 * @{sapContent_GridSize})";
 @sapContent_LineHeight: 1.4;
-@sapContent_ElementHeight: 1.37em;
-@sapContent_ElementHeight_PX: 22px;
 @sapContent_IconHeight: @sapContent_GridSize;
 @sapContent_ContrastTextColor: #fff;
 @sapContent_ContrastIconColor: @sapContent_ContrastTextColor;
@@ -120,15 +116,16 @@
 
 @sapButton_Background: darken(@sapPrimary4, 3);
 @sapButton_BorderColor: darken(@sapButton_Background, 30);
+@sapButton_Selected_Hover_Background: #427bac;
 @sapButton_BorderWidth: @sapElement_BorderWidth;
 @sapButton_TextColor: contrast(@sapButton_Background, darken(@sapHighlightColor, 10), @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_IconColor: @sapButton_TextColor;
 @sapButton_Active_TextColor: contrast(@sapActiveColor, @sapButton_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Active_Background: @sapActiveColor;
 @sapButton_Active_BorderColor: @sapButton_Active_Background;
-@sapButton_Selected_Background: darken(@sapSelectedColor, 10);
-@sapButton_Selected_BorderColor: darken(@sapButton_Selected_Background, 5);
-@sapButton_Selected_TextColor: contrast(@sapButton_Selected_Background, @sapButton_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
+@sapButton_Selected_Background: #346187;
+@sapButton_Selected_BorderColor: #2d5475;
+@sapButton_Selected_TextColor: #fff;
 @sapButton_Hover_BorderColor: @sapButton_BorderColor;
 @sapButton_Hover_TextColor: contrast(@sapButton_Hover_Background, darken(@sapHighlightColor, 10), @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Hover_Background: darken(@sapButton_Background, 5);
@@ -161,6 +158,7 @@
 @sapButton_Lite_Hover_Background: fade(darken(@sapButton_Hover_Background, 22), 50);
 @sapButton_Selected_Hover_BorderColor: #427bac;
 @sapButton_Track_Background: #fff;
+@sapButton_Track_Selected_TextColor: #fff;
 @sapButton_Track_Selected_Background: #346187;
 @sapTile_SeparatorColor: #ccc;
 @sapButton_TokenBackground: #f7f7f7;
@@ -204,9 +202,9 @@
 @sapList_Background: @sapPrimary4;
 @sapList_BorderColor: darken(@sapList_Background, 10.15);
 @sapList_HeaderBorderColor: @sapList_BorderColor;
-@sapList_Active_Background: @sapList_HighlightColor;
+@sapList_Active_Background: #427cac;
+@sapList_Active_TextColor: #fff;
 @sapList_BorderWidth: @sapElement_BorderWidth;
-@sapList_HighlightColor: @sapHighlightColor;
 @sapList_GroupHeaderBackground: @sapList_Background;
 @sapList_GroupHeaderBorderColor: darken(@sapList_BorderColor, 10);
 @sapList_TableGroupHeaderBorderColor: @sapList_GroupHeaderBorderColor;
@@ -216,7 +214,6 @@
 @sapList_Hover_Background: #f0f0f0;
 @sapList_Hover_SelectionBackground: contrast(@sapList_SelectionBackgroundColor, darken(@sapList_SelectionBackgroundColor, 3), lighten(@sapList_SelectionBackgroundColor, 3));
 @sapList_HeaderTextColor: contrast(@sapList_HeaderBackground, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-@sapList_Active_TextColor: contrast(@sapList_HighlightColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_TableGroupHeaderBackground: darken(@sapList_Background, 5);
 @sapList_TableGroupHeaderTextColor: contrast(@sapList_TableGroupHeaderBackground, @sapContent_MarkerTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_SelectionBackgroundColor: lighten(desaturate(@sapSelectedColor, 2), 47);
@@ -270,7 +267,6 @@
 
 @sapShell_TextColor: darken(@sapBrandColor, 10);
 @sapShell_Background: darken(desaturate(@sapBaseColor, 6), 11);
-@sapShell_BackgroundPatternColor: fade(@sapPrimary4, 8);
 @sapShell_InteractiveTextColor: @sapShell_TextColor;
 @sapShell_Hover_Background: darken(@sapBrandColor, 10);
 @sapShell_Active_Background: @sapActiveColor;
@@ -294,6 +290,3 @@
 @sapInfobar_Background: darken(@sapAccentColor7, 5);
 @sapToolbar_SeparatorColor: fade(@sapPrimary1, 20);
 @sapHighlightTextColor: contrast(@sapHighlightColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-
-@sapToggleButton_Pressed_HoverBackground: lighten(@sapButton_Selected_Background, 10);
-@sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBackground;

--- a/packages/theme-base/src/themes/sap_belize_hcb/base-parameters-vars.less
+++ b/packages/theme-base/src/themes/sap_belize_hcb/base-parameters-vars.less
@@ -5,13 +5,11 @@
 	--sapHighlightColor: @sapHighlightColor;
 	--sapBaseColor: @sapBaseColor;
 	--sapShellColor: @sapShellColor;
-	--sapBackgroundColorDefault: @sapBackgroundColorDefault;
 	--sapBackgroundColor: @sapBackgroundColor;
 	--sapContent_GridSize: @sapContent_GridSize;
 	--sapFontFamily: @sapFontFamily;
 	--sapFontSize: @sapFontSize;
 	--sapFontSmallSize: @sapFontSmallSize;
-	--sapFontMediumSize: @sapFontMediumSize;
 	--sapFontLargeSize: @sapFontLargeSize;
 	--sapTextColor: @sapTextColor;
 	--sapLinkColor: @sapLinkColor;
@@ -100,8 +98,6 @@
 	--sapElement_Height: @sapElement_Height;
 	--sapElement_BorderWidth: @sapElement_BorderWidth;
 	--sapContent_LineHeight: @sapContent_LineHeight;
-	--sapContent_ElementHeight: @sapContent_ElementHeight;
-	--sapContent_ElementHeight_PX: @sapContent_ElementHeight_PX;
 	--sapContent_IconHeight: @sapContent_IconHeight;
 	--sapContent_IconColor: @sapContent_IconColor;
 	--sapContent_ContrastIconColor: @sapContent_ContrastIconColor;
@@ -135,7 +131,6 @@
   --sapContent_Shadow3: @sapContent_Shadow3;
 
 	--sapShell_Background: @sapShell_Background;
-	--sapShell_BackgroundPatternColor: @sapShell_BackgroundPatternColor;
 	--sapShell_BorderColor: @sapShell_BorderColor;
 	--sapShell_TextColor: @sapShell_TextColor;
 	--sapShell_InteractiveTextColor: @sapShell_InteractiveTextColor;
@@ -151,6 +146,7 @@
 	--sapButton_Selected_Background: @sapButton_Selected_Background;
 	--sapButton_Selected_BorderColor: @sapButton_Selected_BorderColor;
 	--sapButton_Selected_TextColor: @sapButton_Selected_TextColor;
+	--sapButton_Selected_Hover_Background: @sapButton_Selected_Hover_Background;
 	--sapButton_Hover_Background: @sapButton_Hover_Background;
 	--sapButton_Hover_BorderColor: @sapButton_Hover_BorderColor;
 	--sapButton_Active_TextColor: @sapButton_Active_TextColor;
@@ -185,7 +181,7 @@
 	--sapButton_Selected_Hover_BorderColor: @sapButton_Selected_Hover_BorderColor;
 	--sapButton_Track_Background: @sapButton_Track_Background;
 	--sapButton_Track_Selected_Background: @sapButton_Track_Selected_Background;
-
+	--sapButton_Track_Selected_TextColor: @sapButton_Track_Selected_TextColor;
 	--sapField_Background: @sapField_Background;
 	--sapField_BorderColor: @sapField_BorderColor;
 	--sapField_TextColor: @sapField_TextColor;
@@ -228,7 +224,6 @@
 	--sapList_Active_Background: @sapList_Active_Background;
 	--sapList_BorderColor: @sapList_BorderColor;
 	--sapList_BorderWidth: @sapList_BorderWidth;
-	--sapList_HighlightColor: @sapList_HighlightColor;
 	--sapList_SelectionBackgroundColor: @sapList_SelectionBackgroundColor;
 	--sapList_Background: @sapList_Background;
 	--sapList_Hover_Background: @sapList_Hover_Background;
@@ -302,8 +297,4 @@
 	--sapButton_TextColor: @sapButton_TextColor;
 	--sapButton_Emphasized_TextColor: @sapButton_Emphasized_TextColor;
 	--sapContent_ForegroundTextColor: @sapContent_ForegroundTextColor;
-
-	// custom added params as no base ("sap" prefix) params equivalent exist
-	--sapToggleButton_Pressed_HoverBackground: @sapToggleButton_Pressed_HoverBackground;
-	--sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBorderColor;
 }

--- a/packages/theme-base/src/themes/sap_belize_hcb/base-parameters.less
+++ b/packages/theme-base/src/themes/sap_belize_hcb/base-parameters.less
@@ -2,13 +2,11 @@
 @sapHighlightColor: @sapBrandColor;
 @sapBaseColor: @sapHC_StandardBackground;
 @sapShellColor: @sapHC_StandardBackground;
-@sapBackgroundColorDefault: @sapHC_StandardBackground;
 @sapBackgroundColor: @sapHC_StandardBackground;
 @sapFontFamily: "72", "72full", Arial, Helvetica, sans-serif;
 @sapContent_GridSize: 1rem;
-@sapFontSize: calc(0.875 * @sapContent_GridSize);
+@sapFontSize: .875rem;
 @sapFontSmallSize: calc(0.75 * @sapContent_GridSize);
-@sapFontMediumSize: calc(0.875 * @sapContent_GridSize);
 @sapFontLargeSize: calc(1 * @sapContent_GridSize);
 @sapTextColor: @sapHC_StandardForeground;
 @sapLinkColor: @sapHC_StandardForeground;
@@ -16,8 +14,6 @@
 @sapCompanyLogo: none;
 @sapBackgroundImage: none;
 @sapBackgroundImageOpacity: 1.0;
-
-
 @sapHC_StandardBackground: #000000;
 @sapHC_HighlightBackground: #7A5100;
 @sapHC_HighlightAltBackground: #0F5D94;
@@ -98,8 +94,6 @@
 @sapElement_Height: calc(2.5 * @sapContent_GridSize);
 @sapElement_BorderWidth: calc(0.0625 * @sapContent_GridSize);
 @sapContent_LineHeight: 1.4;
-@sapContent_ElementHeight: 1.37em;
-@sapContent_ElementHeight_PX: 22px;
 @sapContent_IconHeight: @sapContent_GridSize;
 @sapContent_IconColor: @sapHC_StandardForeground;
 @sapContent_ContrastIconColor: @sapContent_IconColor;
@@ -132,7 +126,6 @@
 @sapContent_Selected_TextColor: #fff;
 
 @sapShell_Background: @sapBackgroundColor;
-@sapShell_BackgroundPatternColor: @sapBackgroundColor;
 @sapShell_BorderColor: @sapHC_StandardForeground;
 @sapShell_TextColor: @sapTextColor;
 @sapShell_InteractiveTextColor: @sapShell_TextColor;
@@ -148,6 +141,7 @@
 @sapButton_IconColor: @sapButton_TextColor;
 @sapButton_Selected_Background: @sapSelectedColor;
 @sapButton_Selected_BorderColor: @sapButton_BorderColor;
+@sapButton_Selected_Hover_Background: #7a5100;
 @sapButton_Selected_TextColor: contrast(@sapButton_Selected_Background, @sapButton_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Hover_Background: @sapHighlightColor;
 @sapButton_Hover_BorderColor: @sapButton_BorderColor;
@@ -185,7 +179,7 @@
 @sapButton_Selected_Hover_BorderColor: #ffffff;
 @sapButton_Track_Background: #000000;
 @sapButton_Track_Selected_Background: #0F5D94;
-
+@sapButton_Track_Selected_TextColor: #fff;
 
 @sapField_Background: @sapBackgroundColor;
 @sapField_BorderColor: @sapHC_StandardForeground;
@@ -226,7 +220,6 @@
 @sapList_HeaderBorderColor: @sapHC_StandardForeground;
 @sapList_BorderColor: @sapHC_ReducedAltForeground;
 @sapList_BorderWidth: @sapElement_BorderWidth;
-@sapList_HighlightColor: @sapHighlightColor;
 @sapList_SelectionBackgroundColor: @sapSelectedColor;
 @sapList_Background: @sapBackgroundColor;
 @sapList_HeaderTextColor: contrast(@sapList_HeaderBackground, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
@@ -234,8 +227,8 @@
 @sapList_TextColor: contrast(@sapList_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_Hover_Background: #7a5100;
 @sapList_Hover_SelectionBackground: @sapList_Hover_Background;
-@sapList_Active_TextColor: contrast(@sapList_HighlightColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-@sapList_Active_Background: @sapList_HighlightColor;
+@sapList_Active_TextColor: #fff;
+@sapList_Active_Background: #7a5100;
 @sapList_GroupHeaderTextColor: @sapList_TextColor;
 @sapList_GroupHeaderBackground: @sapHC_ReducedBackground;
 @sapList_GroupHeaderBorderColor: @sapHC_StandardForeground;
@@ -301,7 +294,3 @@
 @sapPageFooter_TextColor: contrast(@sapPageFooter_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapGroup_TitleTextColor: contrast(@sapBackgroundColor, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapContent_ForegroundTextColor: contrast(@sapContent_ForegroundColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-
-// custom added params as no base ("sap" prefix) params equivalent exist
-@sapToggleButton_Pressed_HoverBackground: @sapButton_Hover_Background;
-@sapToggleButton_Pressed_HoverBorderColor: @sapButton_Hover_BorderColor;

--- a/packages/theme-base/src/themes/sap_belize_hcw/base-parameters-vars.less
+++ b/packages/theme-base/src/themes/sap_belize_hcw/base-parameters-vars.less
@@ -5,13 +5,11 @@
   --sapHighlightColor: @sapHighlightColor;
   --sapBaseColor: @sapBaseColor;
   --sapShellColor: @sapShellColor;
-  --sapBackgroundColorDefault: @sapBackgroundColorDefault;
   --sapBackgroundColor: @sapBackgroundColor;
   --sapContent_GridSize: @sapContent_GridSize;
   --sapFontFamily: @sapFontFamily;
   --sapFontSize: @sapFontSize;
   --sapFontSmallSize: @sapFontSmallSize;
-  --sapFontMediumSize: @sapFontMediumSize;
   --sapFontLargeSize: @sapFontLargeSize;
   --sapTextColor: @sapTextColor;
   --sapLinkColor: @sapLinkColor;
@@ -100,8 +98,6 @@
   --sapElement_Height: @sapElement_Height;
   --sapElement_BorderWidth: @sapElement_BorderWidth;
   --sapContent_LineHeight: @sapContent_LineHeight;
-  --sapContent_ElementHeight: @sapContent_ElementHeight;
-  --sapContent_ElementHeight_PX: @sapContent_ElementHeight_PX;
   --sapContent_IconHeight: @sapContent_IconHeight;
   --sapContent_IconColor: @sapContent_IconColor;
   --sapContent_Selected_Background: @sapContent_Selected_Background;
@@ -136,7 +132,6 @@
   --sapContent_Shadow3: @sapContent_Shadow3;
 
   --sapShell_Background: @sapShell_Background;
-  --sapShell_BackgroundPatternColor: @sapShell_BackgroundPatternColor;
   --sapShell_BorderColor: @sapShell_BorderColor;
   --sapShell_TextColor: @sapShell_TextColor;
   --sapShell_InteractiveTextColor: @sapShell_InteractiveTextColor;
@@ -152,6 +147,7 @@
   --sapButton_Selected_Background: @sapButton_Selected_Background;
   --sapButton_Selected_BorderColor: @sapButton_Selected_BorderColor;
   --sapButton_Selected_TextColor: @sapButton_Selected_TextColor;
+  --sapButton_Selected_Hover_Background: @sapButton_Selected_Hover_Background;
   --sapButton_Hover_Background: @sapButton_Hover_Background;
   --sapButton_Hover_BorderColor: @sapButton_Hover_BorderColor;
   --sapButton_Active_TextColor: @sapButton_Active_TextColor;
@@ -186,7 +182,7 @@
   --sapButton_Selected_Hover_BorderColor: @sapButton_Selected_Hover_BorderColor;
   --sapButton_Track_Background: @sapButton_Track_Background;
   --sapButton_Track_Selected_Background: @sapButton_Track_Selected_Background;
-
+  --sapButton_Track_Selected_TextColor: @sapButton_Track_Selected_TextColor;
   --sapField_Background: @sapField_Background;
   --sapField_BorderColor: @sapField_BorderColor;
   --sapField_TextColor: @sapField_TextColor;
@@ -229,7 +225,6 @@
   --sapList_Active_Background: @sapList_Active_Background;
   --sapList_BorderColor: @sapList_BorderColor;
   --sapList_BorderWidth: @sapList_BorderWidth;
-  --sapList_HighlightColor: @sapList_HighlightColor;
   --sapList_SelectionBackgroundColor: @sapList_SelectionBackgroundColor;
   --sapList_Background: @sapList_Background;
   --sapList_Hover_Background: @sapList_Hover_Background;
@@ -303,8 +298,4 @@
   --sapButton_TextColor: @sapButton_TextColor;
   --sapButton_Emphasized_TextColor: @sapButton_Emphasized_TextColor;
   --sapContent_ForegroundTextColor: @sapContent_ForegroundTextColor;
-
-  // custom added params as no base ("sap" prefix) params equivalent exist
-  --sapToggleButton_Pressed_HoverBackground: @sapToggleButton_Pressed_HoverBackground;
-  --sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBorderColor;
 }

--- a/packages/theme-base/src/themes/sap_belize_hcw/base-parameters.less
+++ b/packages/theme-base/src/themes/sap_belize_hcw/base-parameters.less
@@ -2,13 +2,11 @@
 @sapHighlightColor: @sapBrandColor;
 @sapBaseColor: @sapHC_StandardBackground;
 @sapShellColor: @sapHC_StandardBackground;
-@sapBackgroundColorDefault: @sapHC_StandardBackground;
 @sapBackgroundColor: @sapHC_StandardBackground;
 @sapFontFamily: "72", "72full", Arial, Helvetica, sans-serif;
 @sapContent_GridSize: 1rem;
-@sapFontSize: calc(0.875 * @sapContent_GridSize);
+@sapFontSize: .875rem;
 @sapFontSmallSize: calc(0.75 * @sapContent_GridSize);
-@sapFontMediumSize: calc(0.875 * @sapContent_GridSize);
 @sapFontLargeSize: calc(1 * @sapContent_GridSize);
 @sapTextColor: @sapHC_StandardForeground;
 @sapLinkColor: @sapHC_StandardForeground;
@@ -17,16 +15,13 @@
 @sapBackgroundImage: none;
 @sapBackgroundImageOpacity: 1.0;
 
-
 @sapHC_StandardBackground: #ffffff;
 @sapHC_HighlightBackground: #ec8b46;
 @sapHC_HighlightAltBackground: #8fb5ff;
-
 @sapHC_ReducedAltBackground: #4d4d4d;
 @sapHC_StandardForeground: #000000;
 @sapHC_EnhancedForeground: #006500;
 @sapHC_ReducedForeground: #888888;
-
 @sapHC_ReducedAltForeground: #585858;
 @sapHC_ReducedBackground: #b3b3b3;
 
@@ -100,8 +95,6 @@
 @sapElement_Height: calc(2.5 * @sapContent_GridSize);
 @sapElement_BorderWidth: calc(0.0625 * @sapContent_GridSize);
 @sapContent_LineHeight: 1.4;
-@sapContent_ElementHeight: 1.37em;
-@sapContent_ElementHeight_PX: 22px;
 @sapContent_IconHeight: @sapContent_GridSize;
 @sapContent_IconColor: @sapHC_StandardForeground;
 @sapContent_ContrastIconColor: @sapContent_IconColor;
@@ -134,7 +127,6 @@
 @sapContent_Selected_TextColor: #000;
 
 @sapShell_Background: @sapBackgroundColor;
-@sapShell_BackgroundPatternColor: @sapBackgroundColor;
 @sapShell_BorderColor: @sapHC_StandardForeground;
 @sapShell_TextColor: @sapTextColor;
 @sapShell_InteractiveTextColor: @sapShell_TextColor;
@@ -145,6 +137,7 @@
 
 @sapButton_Background: @sapBackgroundColor;
 @sapButton_BorderWidth: @sapElement_BorderWidth;
+@sapButton_Selected_Hover_Background: #ec8b46;
 @sapButton_BorderColor: @sapHC_StandardForeground;
 @sapButton_TextColor: contrast(@sapButton_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_IconColor: @sapButton_TextColor;
@@ -187,7 +180,7 @@
 @sapButton_Selected_Hover_BorderColor: #000000;
 @sapButton_Track_Background: #ffffff;
 @sapButton_Track_Selected_Background: #8FB5FF;
-
+@sapButton_Track_Selected_TextColor: #000;
 @sapField_Background: @sapBackgroundColor;
 @sapField_BorderColor: @sapHC_StandardForeground;
 @sapField_TextColor: @sapTextColor;
@@ -227,7 +220,6 @@
 @sapList_HeaderBorderColor: @sapHC_StandardForeground;
 @sapList_BorderColor: @sapHC_ReducedAltForeground;
 @sapList_BorderWidth: @sapElement_BorderWidth;
-@sapList_HighlightColor: @sapHighlightColor;
 @sapList_SelectionBackgroundColor: @sapSelectedColor;
 @sapList_Background: @sapBackgroundColor;
 @sapList_HeaderTextColor: contrast(@sapList_HeaderBackground, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
@@ -235,8 +227,8 @@
 @sapList_TextColor: contrast(@sapList_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_Hover_Background: #ec8b46;
 @sapList_Hover_SelectionBackground: @sapList_Hover_Background;
-@sapList_Active_TextColor: contrast(@sapList_HighlightColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-@sapList_Active_Background: @sapList_HighlightColor;
+@sapList_Active_Background: #ec8b46;
+@sapList_Active_TextColor: #000;
 @sapList_GroupHeaderTextColor: @sapList_TextColor;
 @sapList_GroupHeaderBackground: @sapHC_ReducedBackground;
 @sapList_GroupHeaderBorderColor: @sapHC_StandardForeground;
@@ -301,8 +293,4 @@
 @sapPageFooter_TextColor: contrast(@sapPageFooter_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapGroup_TitleTextColor: contrast(@sapBackgroundColor, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapContent_ForegroundTextColor: contrast(@sapContent_ForegroundColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-
-// custom added params as no base ("sap" prefix) params equivalent exist
-@sapToggleButton_Pressed_HoverBackground: @sapButton_Hover_Background;
-@sapToggleButton_Pressed_HoverBorderColor: @sapButton_Hover_BorderColor;
 

--- a/packages/theme-base/src/themes/sap_fiori_3/base-parameters-vars.less
+++ b/packages/theme-base/src/themes/sap_fiori_3/base-parameters-vars.less
@@ -15,7 +15,6 @@
   --sapFontFamily: @sapFontFamily;
   --sapFontSize: @sapFontSize;
   --sapFontSmallSize: @sapFontSmallSize;
-  --sapFontMediumSize: @sapFontMediumSize;
   --sapFontLargeSize: @sapFontLargeSize;
   --sapTextColor: @sapTextColor;
   --sapLinkColor: @sapLinkColor;
@@ -81,8 +80,6 @@
   --sapElement_BorderWidth: @sapElement_BorderWidth;
 
   --sapContent_LineHeight: @sapContent_LineHeight;
-  --sapContent_ElementHeight: @sapContent_ElementHeight;
-  --sapContent_ElementHeight_PX: @sapContent_ElementHeight_PX;
   --sapContent_IconHeight: @sapContent_IconHeight;
   --sapContent_IconColor: @sapContent_IconColor;
   --sapContent_Selected_Background: @sapContent_Selected_Background;
@@ -144,7 +141,6 @@
   --sapList_Active_Background: @sapList_Active_Background;
   --sapList_HeaderBorderColor: @sapList_HeaderBorderColor;
   --sapList_BorderWidth: @sapList_BorderWidth;
-  --sapList_HighlightColor: @sapList_HighlightColor;
   --sapList_Background: @sapList_Background;
   --sapList_GroupHeaderBackground: @sapList_Background;
   --sapList_Hover_Background: @sapList_Hover_Background;
@@ -163,7 +159,6 @@
   --sapButton_TokenBackground: @sapButton_TokenBackground;
   --sapButton_TokenBorderColor: @sapButton_TokenBorderColor;
   --sapHighlightColor: @sapHighlightColor;
-  --sapBackgroundColorDefault: @sapBackgroundColorDefault;
   --sapBackgroundColor: @sapBackgroundColor;
   --sapErrorBackground: @sapErrorBackground;
   --sapWarningBackground: @sapWarningBackground;
@@ -178,7 +173,6 @@
   --sapContent_ForegroundTextColor: @sapContent_ForegroundTextColor;
 
   --sapShell_Background: @sapShell_Background;
-  --sapShell_BackgroundPatternColor: @sapShell_BackgroundPatternColor;
   --sapShell_BorderColor: @sapShell_BorderColor;
   --sapShell_InteractiveTextColor: @sapShell_InteractiveTextColor;
   --sapShell_TextColor: @sapShell_TextColor;
@@ -194,6 +188,7 @@
   --sapButton_Selected_Background: @sapButton_Selected_Background;
   --sapButton_Selected_BorderColor: @sapButton_Selected_BorderColor;
   --sapButton_Selected_TextColor: @sapButton_Selected_TextColor;
+  --sapButton_Selected_Hover_Background: @sapButton_Selected_Hover_Background;
   --sapButton_Hover_BorderColor: @sapButton_Hover_BorderColor;
   --sapButton_Hover_Background: @sapButton_Hover_Background;
   --sapButton_Hover_TextColor: @sapButton_Hover_TextColor;
@@ -232,7 +227,7 @@
   --sapButton_Selected_Hover_BorderColor: @sapButton_Selected_Hover_BorderColor;
   --sapButton_Track_Background: @sapButton_Track_Background;
   --sapButton_Track_Selected_Background: @sapButton_Track_Selected_Background;
-
+  --sapButton_Track_Selected_TextColor: @sapButton_Track_Selected_TextColor;
   --sapField_PlaceholderTextColor: @sapField_PlaceholderTextColor;
   --sapField_ReadOnly_Background: @sapField_ReadOnly_Background;
   --sapField_RequiredColor: @sapField_RequiredColor;
@@ -295,7 +290,4 @@
   --sapTile_TextColor: @sapTile_TextColor;
   --sapTile_IconColor: @sapTile_IconColor;
   --sapToolbar_SeparatorColor: @sapToolbar_SeparatorColor;
-
-  --sapToggleButton_Pressed_HoverBackground: @sapToggleButton_Pressed_HoverBackground;
-  --sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBorderColor;
 }

--- a/packages/theme-base/src/themes/sap_fiori_3/base-parameters.less
+++ b/packages/theme-base/src/themes/sap_fiori_3/base-parameters.less
@@ -10,9 +10,8 @@
 @sapContent_BadgeBackground: @sapAccentColor2;
 
 @sapFontFamily: "72", "72full", Arial, Helvetica, sans-serif;
-@sapFontSize: calc(0.875 * @sapContent_GridSize);
+@sapFontSize: .875rem;
 @sapFontSmallSize: calc(0.75 * @sapContent_GridSize);
-@sapFontMediumSize: calc(0.875 * @sapContent_GridSize);
 @sapFontLargeSize: calc(1 * @sapContent_GridSize);
 @sapTextColor: @sapPrimary6;
 @sapLinkColor: @sapPrimary2;
@@ -78,8 +77,6 @@
 @sapElement_BorderWidth: calc(0.0625 * @sapContent_GridSize);
 
 @sapContent_LineHeight: 1.4;
-@sapContent_ElementHeight: 1.37em;
-@sapContent_ElementHeight_PX: 22px;
 @sapContent_IconHeight: @sapContent_GridSize;
 @sapContent_IconColor: @sapHighlightColor;
 @sapContent_ContrastIconColor: @sapContent_ContrastTextColor;
@@ -140,10 +137,9 @@
 @sapToolbar_Background: transparent;
 @sapInfobar_Background: @sapAccentColor7;
 
-@sapList_Active_Background:  @sapHighlightColor;
+@sapList_Active_Background: #0854a0;
 @sapList_HeaderBorderColor: @sapList_BorderColor;
 @sapList_BorderWidth: @sapElement_BorderWidth;
-@sapList_HighlightColor: @sapHighlightColor;
 @sapList_Background: @sapBaseColor;
 @sapList_GroupHeaderBackground: @sapList_Background;
 @sapList_GroupHeaderTextColor: @sapList_TextColor;
@@ -164,7 +160,6 @@
 @sapButton_TokenBorderColor: #c2c2c2;
 
 @sapHighlightColor: darken(@sapBrandColor, 10);
-@sapBackgroundColorDefault: darken(@sapPrimary3, 3);
 @sapBackgroundColor: darken(@sapPrimary3, 3);
 @sapErrorBackground: lighten(@sapErrorColor, 59.5);
 @sapWarningBackground: lighten(@sapWarningColor, 49);
@@ -179,7 +174,6 @@
 @sapShell_Active_Background: darken(@sapShellColor, 10);
 @sapShell_Active_TextColor: contrast(@sapShell_Active_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapShell_Background: @sapPrimary4;
-@sapShell_BackgroundPatternColor: transparent;
 @sapShell_BorderColor: @sapShellColor;
 @sapShell_InteractiveTextColor: #d1e8ff;
 @sapShell_InteractiveBorderColor: #7996b4;
@@ -188,6 +182,7 @@
 @sapButton_TextColor: contrast(@sapButton_Background, @sapHighlightColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Selected_Background: @sapSelectedColor;
 @sapButton_Selected_BorderColor: @sapSelectedColor;
+@sapButton_Selected_Hover_Background: #095caf;
 @sapButton_Selected_TextColor: contrast(@sapButton_Selected_Background, @sapButton_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Active_BorderColor: @sapActiveColor;
 @sapButton_Active_Background: @sapActiveColor;
@@ -228,7 +223,7 @@
 @sapButton_Selected_Hover_BorderColor: #095caf;
 @sapButton_Track_Background: #ededed;
 @sapButton_Track_Selected_Background: #ebf5fe;
-
+@sapButton_Track_Selected_TextColor: #32363a;
 @sapField_PlaceholderTextColor: lighten(@sapContent_LabelColor, 4);
 @sapField_ReadOnly_Background: fade(darken(@sapField_Background, 5), 50);
 @sapField_RequiredColor: darken(@sapAccentColor2, 2);
@@ -244,7 +239,7 @@
 @sapList_SelectionBackgroundColor: lighten(desaturate(@sapSelectedColor, 24), 61);
 @sapList_HeaderBackground: darken(@sapList_Background, 5);
 @sapList_Hover_SelectionBackground: contrast(@sapList_SelectionBackgroundColor, darken(@sapList_SelectionBackgroundColor, 3), lighten(@sapList_SelectionBackgroundColor, 3));
-@sapList_Active_TextColor: contrast(@sapList_Active_Background, @sapList_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
+@sapList_Active_TextColor: #fff;
 @sapList_TableGroupHeaderBackground: darken(@sapList_Background, 6.1);
 @sapList_TableGroupHeaderBorderColor: darken(@sapList_BorderColor, 4.9);
 @sapList_TableGroupHeaderTextColor: contrast(@sapList_TableGroupHeaderBackground, @sapList_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
@@ -292,7 +287,3 @@
 @sapTile_TextColor: contrast(@sapTile_Background, @sapContent_LabelColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapTile_IconColor: contrast(@sapTile_Background, lighten(@sapShellColor ,20), @sapContent_ContrastIconColor, @sapContent_ContrastTextThreshold);
 @sapToolbar_SeparatorColor: darken(@sapBaseColor, 15);
-
-
-@sapToggleButton_Pressed_HoverBackground: lighten(@sapSelectedColor, 3);
-@sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBackground;

--- a/packages/theme-base/src/themes/sap_fiori_3_dark/base-parameters-vars.less
+++ b/packages/theme-base/src/themes/sap_fiori_3_dark/base-parameters-vars.less
@@ -14,7 +14,6 @@
   --sapFontFamily: @sapFontFamily;
   --sapFontSize: @sapFontSize;
   --sapFontSmallSize: @sapFontSmallSize;
-  --sapFontMediumSize: @sapFontMediumSize;
   --sapFontLargeSize: @sapFontLargeSize;
   --sapTextColor: @sapTextColor;
   --sapLinkColor: @sapLinkColor;
@@ -81,8 +80,6 @@
   --sapElement_BorderWidth: @sapElement_BorderWidth;
 
   --sapContent_LineHeight: @sapContent_LineHeight;
-  --sapContent_ElementHeight: @sapContent_ElementHeight;
-  --sapContent_ElementHeight_PX: @sapContent_ElementHeight_PX;
   --sapContent_IconHeight: @sapContent_IconHeight;
   --sapContent_IconColor: @sapContent_IconColor;
   --sapContent_ContrastIconColor: @sapContent_ContrastIconColor;
@@ -101,7 +98,6 @@
   --sapContent_ForegroundBorderColor: @sapContent_ForegroundBorderColor;
 
   --sapShell_Background: @sapShell_Background;
-  --sapShell_BackgroundPatternColor: @sapShell_BackgroundPatternColor;
   --sapShell_BorderColor: @sapShell_BorderColor;
   --sapShell_InteractiveTextColor: @sapShell_InteractiveTextColor;
   --sapShell_InteractiveBorderColor: @sapShell_InteractiveBorderColor;
@@ -109,6 +105,7 @@
   --sapButton_BorderColor: @sapButton_BorderColor;
   --sapButton_BorderWidth: @sapButton_BorderWidth;
   --sapButton_Background: @sapButton_Background;
+  --sapButton_Selected_Hover_Background: @sapButton_Selected_Hover_Background;
   --sapButton_TextColor: @sapButton_TextColor;
   --sapButton_IconColor: @sapButton_IconColor;
   --sapButton_Hover_BorderColor: @sapButton_Hover_BorderColor;
@@ -150,7 +147,7 @@
   --sapButton_Selected_Hover_BorderColor: @sapButton_Selected_Hover_BorderColor;
   --sapButton_Track_Background: @sapButton_Track_Background;
   --sapButton_Track_Selected_Background: @sapButton_Track_Selected_Background;
- 
+  --sapButton_Track_Selected_TextColor: @sapButton_Track_Selected_TextColor;
   --sapField_Background: @sapField_Background;
   --sapField_BorderColor: @sapField_BorderColor;
   --sapField_TextColor: @sapField_TextColor;
@@ -183,7 +180,6 @@
   --sapList_HeaderBorderColor: @sapList_HeaderBorderColor;
   --sapList_BorderWidth: @sapList_BorderWidth;
   --sapList_Active_Background: @sapList_Active_Background;
-  --sapList_HighlightColor: @sapList_HighlightColor;
   --sapList_Background: @sapList_Background;
   --sapList_GroupHeaderBackground: @sapList_GroupHeaderBackground;
   --sapList_GroupHeaderTextColor: @sapList_GroupHeaderTextColor;
@@ -201,7 +197,6 @@
   --sapTile_SeparatorColor: @sapTile_SeparatorColor;
   --sapButton_TokenBackground: @sapButton_TokenBackground;
   --sapButton_TokenBorderColor: @sapButton_TokenBorderColor;
-  --sapBackgroundColorDefault: @sapBackgroundColorDefault;
   --sapBackgroundColor: @sapBackgroundColor;
   --sapErrorBackground: @sapErrorBackground;
   --sapWarningBackground: @sapWarningBackground;
@@ -292,7 +287,4 @@
   --sapTile_TextColor: @sapTile_TextColor;
   --sapTile_IconColor: @sapTile_IconColor;
   --sapObjectHeader_BorderColor: @sapObjectHeader_BorderColor;
-
-  --sapToggleButton_Pressed_HoverBackground: @sapToggleButton_Pressed_HoverBackground;
-  --sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBorderColor;
 }

--- a/packages/theme-base/src/themes/sap_fiori_3_dark/base-parameters.less
+++ b/packages/theme-base/src/themes/sap_fiori_3_dark/base-parameters.less
@@ -9,9 +9,8 @@
 @sapContent_BadgeBackground: @sapAccentColor2;
 
 @sapFontFamily: "72", "72full", Arial, Helvetica, sans-serif;
-@sapFontSize: calc(0.875 * @sapContent_GridSize);
+@sapFontSize: .875rem;
 @sapFontSmallSize: calc(0.75 * @sapContent_GridSize);
-@sapFontMediumSize: calc(0.875 * @sapContent_GridSize);
 @sapFontLargeSize: calc(1 * @sapContent_GridSize);
 @sapTextColor: @sapPrimary6;
 @sapLinkColor: @sapPrimary2;
@@ -78,8 +77,6 @@
 @sapElement_BorderWidth: calc(0.0625 * @sapContent_GridSize);
 
 @sapContent_LineHeight: 1.4;
-@sapContent_ElementHeight: 1.37em;
-@sapContent_ElementHeight_PX: 22px;
 @sapContent_IconHeight: @sapContent_GridSize;
 @sapContent_IconColor: @sapHighlightColor;
 @sapContent_ContrastIconColor: @sapContent_ContrastTextColor;
@@ -111,7 +108,6 @@
 @sapContent_Selected_TextColor: #29313a;
 
 @sapShell_Background: @sapPrimary4;
-@sapShell_BackgroundPatternColor: transparent;
 @sapShell_BorderColor: @sapShellColor;
 @sapShell_InteractiveTextColor: #d1e8ff;
 
@@ -126,6 +122,7 @@
 @sapButton_TextColor: contrast(@sapButton_Background, @sapHighlightColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Selected_Background: @sapSelectedColor;
 @sapButton_Selected_BorderColor: @sapSelectedColor;
+@sapButton_Selected_Hover_Background: #83c1f5;
 @sapButton_Selected_TextColor: contrast(@sapButton_Selected_Background, @sapButton_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapButton_Hover_Background: darken(@sapHighlightColor, 60);
 @sapButton_Hover_TextColor: contrast(@sapButton_Hover_Background, @sapHighlightColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
@@ -160,7 +157,7 @@
 @sapButton_Selected_Hover_BorderColor: #83c1f5;
 @sapButton_Track_Background: #38434f;
 @sapButton_Track_Selected_Background: #062e4f;
-
+@sapButton_Track_Selected_TextColor: #fafafa;
 @sapField_Background: @sapBaseColor;
 @sapField_BorderColor: @sapPrimary5;
 @sapField_TextColor: @sapTextColor;
@@ -192,8 +189,8 @@
 
 @sapList_HeaderBorderColor: @sapList_BorderColor;
 @sapList_BorderWidth: @sapElement_BorderWidth;
-@sapList_Active_Background: @sapActiveColor;
-@sapList_HighlightColor: @sapHighlightColor;
+@sapList_Active_Background: #91c8f6;
+@sapList_Active_TextColor: #29313a;
 @sapList_Background: @sapBaseColor;
 @sapList_GroupHeaderBackground: @sapList_Background;
 @sapList_GroupHeaderTextColor: @sapList_TextColor;
@@ -239,11 +236,8 @@
 @sapTile_Background: @sapBaseColor;
 @sapTile_BorderColor: transparent;
 @sapTile_SeparatorColor: #424f5e;
-
 @sapButton_TokenBackground: #29313A;
 @sapButton_TokenBorderColor: #687d94;
-
-@sapBackgroundColorDefault: darken(@sapPrimary3, 6);
 @sapBackgroundColor: darken(@sapPrimary3, 6);
 @sapErrorBackground: darken(@sapNegativeColor, 65);
 @sapWarningBackground: darken(@sapCriticalColor, 60);
@@ -252,13 +246,11 @@
 @sapNeutralBackground: darken(@sapNeutralColor, 45);
 @sapInformativeTextColor: lighten(@sapInformativeColor, 10);
 @sapHighlightTextColor: contrast(@sapHighlightColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
-
 @sapShell_TextColor: contrast(@sapShellColor, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapShell_Hover_Background: darken(@sapShellColor, 7);
 @sapShell_Active_Background: darken(@sapShellColor, 10);
 @sapShell_Active_TextColor: contrast(@sapShell_Active_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapShell_InteractiveBorderColor: #7996b4;
-
 @sapField_PlaceholderTextColor: darken(@sapContent_LabelColor, 10);
 @sapField_ReadOnly_Background: fade(lighten(@sapField_Background, 8), 50);
 @sapField_ReadOnly_BorderColor: darken(@sapField_BorderColor, 20);
@@ -267,18 +259,15 @@
 @sapGroup_TitleTextColor: contrast(@sapBackgroundColor, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapGroup_ContentBorderColor: lighten(@sapGroup_ContentBackground, 10);
 @sapToolbar_SeparatorColor: lighten(@sapBaseColor, 15);
-
 @sapList_HeaderBackground: darken(@sapList_Background, 3);
 @sapList_HeaderTextColor: contrast(@sapList_HeaderBackground, @sapTitleColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_BorderColor: lighten(@sapList_Background, 8);
 @sapList_TextColor: contrast(@sapList_Background, @sapTextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_SelectionBackgroundColor: darken(desaturate(@sapSelectedColor, 55), 48);
-@sapList_Active_TextColor: contrast(@sapList_Active_Background, @sapList_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_TableGroupHeaderBackground: darken(@sapList_Background, 6.1);
 @sapList_TableGroupHeaderBorderColor: lighten(@sapList_BorderColor, 15);
 @sapList_TableGroupHeaderTextColor: contrast(@sapList_TableGroupHeaderBackground, @sapList_TextColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapList_FooterBackground: darken(@sapList_Background, 2);
-
 @sapScrollBar_FaceColor: lighten(@sapBaseColor, 15);
 @sapScrollBar_TrackColor: darken(@sapBaseColor, 4);
 @sapScrollBar_Hover_FaceColor: darken(@sapScrollBar_FaceColor, 3);
@@ -291,6 +280,3 @@
 @sapTile_TextColor: contrast(@sapTile_Background, @sapContent_LabelColor, @sapContent_ContrastTextColor, @sapContent_ContrastTextThreshold);
 @sapTile_IconColor: contrast(@sapTile_Background, lighten(@sapShellColor, 35), @sapContent_ContrastIconColor, @sapContent_ContrastTextThreshold);
 @sapObjectHeader_BorderColor: lighten(@sapObjectHeader_Background, 8);
-
-@sapToggleButton_Pressed_HoverBackground: darken(@sapSelectedColor, 3);
-@sapToggleButton_Pressed_HoverBorderColor: @sapToggleButton_Pressed_HoverBackground;


### PR DESCRIPTION

The following params are widely used in calculation of other base params and can be removed when we start using the theming-base-content:

- sapContent_GridSize
- sapPrimary1
- sapPrimary2
- sapPrimary3
- sapPrimary4
- sapPrimary5
- sapPrimary6
- sapPrimary7

The following params have no replacement yet:
- sapSubtleLinkColor (should be replaced by sapLink_SubtleColor, but the last is not available yet)

The following are tracked, removed and replaced:
- sapFontMediumSize
- sapList_HighlightColor
- sapToggleButton_Pressed_HoverBackground
- sapToggleButton_Pressed_HoverBorderColor

The following are removed as not used anywhere:
- sapContent_ElementHeight
- sapContent_ElementHeight_PX
- sapBackgroundColorDefault
- sapShell_BackgroundPatternColor