### PR TITLE
fix(ui5-carousel): Content now shrinks properly

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -5,12 +5,12 @@
 >
     <div class="ui5-carousel-overflow-hidden">
         <div class="{{classes.content}}" style="{{styles.content}}">
-            {{#each items}}
-                <div class="{{../classes.item}}">
+            {{#each pages}}
+                <div class="{{../classes.page}}">
                     {{#each this}}
-                        {{#if this.item}}
+                        <div class="ui5-carousel-item" style="width: {{this.width}}%">
                             <slot name="{{this.item._individualSlot}}" tabindex="{{this.tabIndex}}"></slot>
-                        {{/if}}
+                        </div>
                     {{/each}}
                 </div>
             {{/each}}
@@ -56,7 +56,7 @@
                             ></div>
                         {{/each}}
                     {{else}}
-                        <ui5-label>{{currenlySelectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{items.length}}</ui5-label>
+                        <ui5-label>{{currenlySelectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
                     {{/if}}
                 </div>
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -179,10 +179,6 @@ class Carousel extends UI5Element {
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 	}
 
-	onBeforeRendering() {
-		this.itemsPerPage = this.effectiveItemsPerPage;
-	}
-
 	onAfterRendering() {
 		this._scrollEnablement.scrollContainer = this.getDomRef();
 	}
@@ -214,7 +210,7 @@ class Carousel extends UI5Element {
 	navigateLeft() {
 		if (this.selectedIndex - 1 < 0) {
 			if (this.cycling) {
-				this.selectedIndex = this.items.length - 1;
+				this.selectedIndex = this.pages.length - 1;
 			}
 		} else {
 			--this.selectedIndex;
@@ -222,7 +218,7 @@ class Carousel extends UI5Element {
 	}
 
 	navigateRight() {
-		if (this.selectedIndex + 1 > this.items.length - 1) {
+		if (this.selectedIndex + 1 > this.pages.length - 1) {
 			if (this.cycling) {
 				this.selectedIndex = 0;
 			}
@@ -239,18 +235,26 @@ class Carousel extends UI5Element {
 	 * Assuming that all items have the same width
 	 * @private
 	 */
-	get items() {
+	get pages() {
 		const result = [],
-			innerArraysLength = Math.ceil(this.content.length / this.itemsPerPage);
+			pagesCount = Math.ceil(this.content.length / this.effectiveItemsPerPage);
 
-		for (let i = 0; i < innerArraysLength; i++) {
+		for (let pageIdx = 0; pageIdx < pagesCount; pageIdx++) {
 			result.push([]);
-			for (let j = 0; j < this.itemsPerPage; j++) {
-				result[i].push({
-					item: this.content[(i * this.itemsPerPage) + j],
-					tabIndex: i === this.selectedIndex ? "0" : "-1",
-				});
+			for (let itemIdx = 0; itemIdx < this.effectiveItemsPerPage; itemIdx++) {
+				const item = this.content[(pageIdx * this.effectiveItemsPerPage) + itemIdx];
+				if (item) {
+					result[pageIdx].push({
+						item,
+						tabIndex: pageIdx === this.selectedIndex ? "0" : "-1",
+					});
+				}
 			}
+			const itemsOnThisPage = result[pageIdx].length;
+			const itemWidth = Math.floor(100 / itemsOnThisPage);
+			result[pageIdx].forEach(item => {
+				item.width = itemWidth;
+			});
 		}
 
 		return result;
@@ -280,19 +284,19 @@ class Carousel extends UI5Element {
 				"ui5-carousel-navigation-wrapper": true,
 				"ui5-carousel-navigation-with-buttons": this.arrowsPlacement === CarouselArrowsPlacement.Navigation,
 			},
-			item: {
-				"ui5-carousel-item": true,
-				"ui5-carousel-item-multiple": this.itemsPerPage > 1,
+			page: {
+				"ui5-carousel-page": true,
+				"ui5-carousel-page-multiple": this.effectiveItemsPerPage > 1,
 			},
 		};
 	}
 
 	get isPageTypeDots() {
-		return this.items.length < Carousel.pageTypeLimit;
+		return this.pages.length < Carousel.pageTypeLimit;
 	}
 
 	get dots() {
-		return this.items.map((item, index) => {
+		return this.pages.map((item, index) => {
 			return {
 				active: index === this.selectedIndex,
 			};

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -23,8 +23,8 @@
 .ui5-carousel-overflow-hidden {
     width: 100%;
     height: inherit;
-    display: flex;
     position: relative;
+    display: flex;
     flex-direction: column;
     align-items: center;
     overflow: hidden;
@@ -43,7 +43,8 @@
 
 .ui5-carousel-content {
     width: 100%;
-    height: inherit;
+    height: 100%;
+    position: relative;
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -34,11 +34,12 @@
     width: 100%;
     padding: 0 .5rem;
     position: absolute;
-    top: 50%;
+    top: calc(50% - 2.5rem);
     display: flex;
     justify-content: space-between;
     box-sizing: border-box;
 }
+
 
 .ui5-carousel-content {
     width: 100%;

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -23,8 +23,8 @@
 .ui5-carousel-overflow-hidden {
     width: 100%;
     height: inherit;
-    position: relative;
     display: flex;
+    position: relative;
     flex-direction: column;
     align-items: center;
     overflow: hidden;
@@ -42,9 +42,7 @@
 
 .ui5-carousel-content {
     width: 100%;
-    height: 100%;
     height: inherit;
-    position: relative;
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
@@ -65,7 +63,7 @@
     height: calc(100% - 3.5rem);
 }
 
-.ui5-carousel-item {
+.ui5-carousel-page {
     width: 100%;
     padding: 0 3rem;
     flex: 0 0 auto;
@@ -75,8 +73,20 @@
     box-sizing: border-box;
 }
 
-.ui5-carousel-item-multiple {
+.ui5-carousel-page-multiple {
     justify-content: space-around;
+}
+
+.ui5-carousel-item {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 1.25rem;
+}
+
+.ui5-carousel-item:last-child {
+    margin-right: 0;
 }
 
 .ui5-carousel-navigation-button {

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -19,7 +19,144 @@
 		height: 25rem;
 		margin-bottom: 1rem;
 	}
+
+    .myCard {
+        height: 100%;
+    }
 </style>
+
+<ui5-carousel items-per-page="3">
+    <ui5-card
+            id="card"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="4 of 10"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+</ui5-carousel>
+
+
 <ui5-carousel id="carousel1" cycling="true">
 	<ui5-button>Button 1</ui5-button>
 	<ui5-button>Button 2</ui5-button>

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -49,7 +49,7 @@ describe("Carousel general interaction", () => {
 
 	it("ItemsPerPage property is working properly", () => {
 		const carousel = browser.$("#carousel4");
-		const pages = carousel.getProperty("items").length;
+		const pages = carousel.getProperty("pages").length;
 
 		assert.strictEqual(pages, 3, "There are only 3 pages.");
 	});


### PR DESCRIPTION
When the user shrinks the Carousel a lot, items overlap each other and items from other pages also appear from the sides and overlap the currently visible items. The goal of this change is to provide items fixed-size containers with pre-calculated widths and space these containers evenly.

Changes:
 - rename `items` to `pages` in the names of variables/CSS classes
 - introduce `items` - divs around the slots that have calculated width (100% / number of items per page),  `100% height` and margins, so that the content may not go out of its boundary and looks tidy even when you shrink the carousel.
 - do not modify the public API (`itemsPerPage`) in `onBeforeRendering` but use `effectiveItemsPerPage` everywhere instead
 - When to the side, navigation arrows used to be positioned at `50%` which does not account for their size, so they were not truly centered. Move them up.