### PR TITLE
refactor(ui5-input, ui5-textarea): enable "font-style" overstyling

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -11,6 +11,7 @@
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
+	font-style: normal;
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
@@ -51,7 +52,7 @@
 	background: transparent;
 	color: inherit;
 	border: none;
-	font-style: normal;
+	font-style: inherit;
 	-webkit-appearance: none;
 	-moz-appearance: textfield;
 	line-height: normal;

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -7,6 +7,7 @@
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
+	font-style: normal;
 	border-color: var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
 	box-sizing: border-box;
@@ -57,6 +58,7 @@
 	color: inherit;
 	font-size: inherit;
 	font-family: inherit;
+	font-style: inherit;
 	-webkit-appearance: none;
 	-moz-appearance: textfield;
 	overflow: auto;

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -7,7 +7,7 @@
 	--_ui5_input_error_font_weight: normal;
 	--_ui5_input_focus_border_width: 1px;
 	--_ui5_input_error_warning_border_style: solid;
-	--_ui5_input_error_warning_font_style: normal;
+	--_ui5_input_error_warning_font_style: inherit;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;
 	--_ui5_input_disabled_border_color: var(--sapField_BorderColor);


### PR DESCRIPTION
Enable users to change the font-style of the text in the input and textarea.
It's a recent requirement by the "MDK" project, that consume us.