### PR TITLE
fix(ui5-select): prevent scrolling on SPACE

### DIFF
--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -321,6 +321,10 @@ class Select extends UI5Element {
 			this._toggleRespPopover();
 		}
 
+		if (isSpace(event)) {
+			event.preventDefault();
+		}
+
 		if (!this._isPickerOpen) {
 			this._handleArrowNavigation(event, true);
 		}


### PR DESCRIPTION
When the parent container has scrollbar, pressing SPACE activates scrolling by default
and the Select have to prevent it.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1412