### PR TITLE
chore: fix TextArea  TAB/SHIFT+TAB  interaction

### DIFF
--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -372,6 +372,7 @@ class TextArea extends UI5Element {
 	}
 
 	onAfterRendering() {
+		console.log("onAfterRendering()", {el: this, open: this.openValueStateMsgPopover});
 		this.toggleValueStateMessage(this.openValueStateMsgPopover);
 		this._firstRendering = false;
 	}
@@ -391,6 +392,7 @@ class TextArea extends UI5Element {
 	_onfocusin() {
 		this.focused = true;
 		this._openValueStateMsgPopover = true;
+		console.log("_onfocusin()",this);
 	}
 
 	_onfocusout() {
@@ -447,7 +449,7 @@ class TextArea extends UI5Element {
 
 	async closePopover() {
 		this.popover = await this._getPopover();
-		this.popover && this.popover.close();
+		this.popover && this.popover.close(false, false, true);
 	}
 
 	async _getPopover() {

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -372,7 +372,6 @@ class TextArea extends UI5Element {
 	}
 
 	onAfterRendering() {
-		console.log("onAfterRendering()", {el: this, open: this.openValueStateMsgPopover});
 		this.toggleValueStateMessage(this.openValueStateMsgPopover);
 		this._firstRendering = false;
 	}
@@ -392,7 +391,6 @@ class TextArea extends UI5Element {
 	_onfocusin() {
 		this.focused = true;
 		this._openValueStateMsgPopover = true;
-		console.log("_onfocusin()",this);
 	}
 
 	_onfocusout() {


### PR DESCRIPTION
Problem: I found out that pressing TAB or SHIFT+TAB from a TextArea with valueStateMessage popover opened is not possible, due to the focus restoring mechanism of the popover, that brings the focus back to the TextArea.
Solution: use the 3rd param of Popover.prototype.close as follows: popover.close(false, false, true /*preventFocusRestore*/)