### PR TITLE
fix(ui5-upload-collection): ensure event.dataTransfer.types is array

### DIFF
--- a/packages/fiori/src/upload-utils/UploadCollectionBodyDnD.js
+++ b/packages/fiori/src/upload-utils/UploadCollectionBodyDnD.js
@@ -9,7 +9,7 @@ import EventProvider from "@ui5/webcomponents-base/dist/EventProvider.js";
 import UploadCollectionDnDOverlayMode from "../types/UploadCollectionDnDMode.js";
 
 const draggingFiles = event => {
-	return event.dataTransfer.types.includes("Files");
+	return Array.from(event.dataTransfer.types).includes("Files");
 };
 
 const eventProvider = new EventProvider();


### PR DESCRIPTION
In Internet Explorer event.dataTransfer.types is DOMStringList,
which doesn't implement the "includes" method.