### PR TITLE
feat(ui5-carousel): Allow different number of items per page based on component width

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -56,7 +56,7 @@
                             ></div>
                         {{/each}}
                     {{else}}
-                        <ui5-label>{{selectedPageIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
+                        <ui5-label>{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
                     {{/if}}
                 </div>
 

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -56,7 +56,7 @@
                             ></div>
                         {{/each}}
                     {{else}}
-                        <ui5-label>{{currenlySelectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
+                        <ui5-label>{{selectedPageIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
                     {{/if}}
                 </div>
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -12,6 +12,7 @@ import {
 	getI18nBundle,
 } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ScrollEnablement from "@ui5/webcomponents-base/dist/delegate/ScrollEnablement.js";
+import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
@@ -55,6 +56,21 @@ const metadata = {
 			defaultValue: 1,
 		},
 
+		itemsPerPageS: {
+			type: Integer,
+			defaultValue: undefined,
+		},
+
+		itemsPerPageM: {
+			type: Integer,
+			defaultValue: undefined,
+		},
+
+		itemsPerPageL: {
+			type: Integer,
+			defaultValue: undefined,
+		},
+
 		/**
 		 * If set to true the navigation is hidden.
 		 * @type {boolean}
@@ -95,6 +111,14 @@ const metadata = {
 		arrowsPlacement: {
 			type: CarouselArrowsPlacement,
 			defaultValue: CarouselArrowsPlacement.Content,
+		},
+
+		/**
+		 * Defines the carousel width in pixels
+		 * @private
+		 */
+		_width: {
+			type: Integer,
 		},
 	},
 	managedSlots: true,
@@ -177,10 +201,25 @@ class Carousel extends UI5Element {
 		});
 
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
+		this._onResizeBound = this._onResize.bind(this);
 	}
 
 	onAfterRendering() {
 		this._scrollEnablement.scrollContainer = this.getDomRef();
+	}
+
+	onEnterDOM() {
+		ResizeHandler.register(this, this._onResizeBound);
+	}
+
+	onExitDOM() {
+		ResizeHandler.deregister(this, this._onResizeBound);
+	}
+
+	_onResize() {
+		// const currentItem = (this.selectedIndex + 1) * this.effectiveItemsPerPage;
+		this._width = this.offsetWidth;
+		// this.selectedIndex = Math.ceil(currentItem / this.effectiveItemsPerPage);
 	}
 
 	_updateScrolling(event) {
@@ -261,7 +300,23 @@ class Carousel extends UI5Element {
 	}
 
 	get effectiveItemsPerPage() {
-		return isDesktop() ? this.itemsPerPage : 1;
+		if (!isDesktop()) {
+			return 1;
+		}
+
+		if (this.itemsPerPageS && this._width <= 640) {
+			return this.itemsPerPageS;
+		}
+
+		if (this.itemsPerPageM && this._width <= 1024) {
+			return this.itemsPerPageM;
+		}
+
+		if (this.itemsPerPageL) {
+			return this.itemsPerPageL;
+		}
+
+		return this.itemsPerPage;
 	}
 
 	get styles() {
@@ -316,7 +371,7 @@ class Carousel extends UI5Element {
 		return this.i18nBundle.getText(CAROUSEL_OF_TEXT);
 	}
 
-	get currenlySelectedIndexToShow() {
+	get currentlySelectedIndexToShow() {
 		return this.selectedIndex + 1;
 	}
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -234,6 +234,8 @@ class Carousel extends UI5Element {
 			return;
 		}
 
+		// Whenever the number of items per page changes, the selected index needs to be re-adjusted so that the items
+		// that were visible before, can be visible as much as possible afterwards.
 		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
 		this.selectedIndex = Math.round(this.selectedIndex * adjustment);
 	}

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -87,7 +87,7 @@ const metadata = {
 		 * @defaultvalue 0
 		 * @public
 		 */
-		selectedIndex: {
+		selectedPageIndex: {
 			type: Integer,
 			defaultValue: 0,
 		},
@@ -217,9 +217,18 @@ class Carousel extends UI5Element {
 	}
 
 	_onResize() {
-		// const currentItem = (this.selectedIndex + 1) * this.effectiveItemsPerPage;
+		const oldItemsPerPage = this.effectiveItemsPerPage;
+
+		// Change transitively effectiveItemsPerPage by modifying _width
 		this._width = this.offsetWidth;
-		// this.selectedIndex = Math.ceil(currentItem / this.effectiveItemsPerPage);
+
+		// Items per page did not change, therefore page index does not need to be re-adjusted
+		if (this.effectiveItemsPerPage === oldItemsPerPage) {
+			return;
+		}
+
+		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
+		this.selectedPageIndex = Math.floor(this.selectedPageIndex * adjustment);
 	}
 
 	_updateScrolling(event) {
@@ -247,22 +256,22 @@ class Carousel extends UI5Element {
 	}
 
 	navigateLeft() {
-		if (this.selectedIndex - 1 < 0) {
+		if (this.selectedPageIndex - 1 < 0) {
 			if (this.cycling) {
-				this.selectedIndex = this.pages.length - 1;
+				this.selectedPageIndex = this.pages.length - 1;
 			}
 		} else {
-			--this.selectedIndex;
+			--this.selectedPageIndex;
 		}
 	}
 
 	navigateRight() {
-		if (this.selectedIndex + 1 > this.pages.length - 1) {
+		if (this.selectedPageIndex + 1 > this.pages.length - 1) {
 			if (this.cycling) {
-				this.selectedIndex = 0;
+				this.selectedPageIndex = 0;
 			}
 		} else {
-			++this.selectedIndex;
+			++this.selectedPageIndex;
 		}
 	}
 
@@ -285,7 +294,7 @@ class Carousel extends UI5Element {
 				if (item) {
 					result[pageIdx].push({
 						item,
-						tabIndex: pageIdx === this.selectedIndex ? "0" : "-1",
+						tabIndex: pageIdx === this.selectedPageIndex ? "0" : "-1",
 					});
 				}
 			}
@@ -322,7 +331,7 @@ class Carousel extends UI5Element {
 	get styles() {
 		return {
 			content: {
-				transform: `translateX(-${this.selectedIndex * 100}%)`,
+				transform: `translateX(-${this.selectedPageIndex * 100}%)`,
 			},
 		};
 	}
@@ -353,7 +362,7 @@ class Carousel extends UI5Element {
 	get dots() {
 		return this.pages.map((item, index) => {
 			return {
-				active: index === this.selectedIndex,
+				active: index === this.selectedPageIndex,
 			};
 		});
 	}
@@ -371,8 +380,8 @@ class Carousel extends UI5Element {
 		return this.i18nBundle.getText(CAROUSEL_OF_TEXT);
 	}
 
-	get currentlySelectedIndexToShow() {
-		return this.selectedIndex + 1;
+	get selectedPageIndexToShow() {
+		return this.selectedPageIndex + 1;
 	}
 
 	get showNavigationArrows() {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -41,34 +41,41 @@ const metadata = {
 		 * @defaultvalue false
 		 * @public
 		 */
-		cycling: {
+		cyclic: {
 			type: Boolean,
 		},
 
 		/**
-		 * Sets the amount of items per page. If this property is set, on mobile devices it will always fallback to 1.
+		 * Sets the number of items per page on small size (up to 640px). One item per page shown by default.
 		 * @type {Integer}
 		 * @defaultvalue 1
 		 * @public
 		 */
-		itemsPerPage: {
+		itemsPerPageS: {
 			type: Integer,
 			defaultValue: 1,
 		},
 
-		itemsPerPageS: {
-			type: Integer,
-			defaultValue: undefined,
-		},
-
+		/**
+		 * Sets the number of items per page on medium size (from 640px to 1024px). One item per page shown by default.
+		 * @type {Integer}
+		 * @defaultvalue 1
+		 * @public
+		 */
 		itemsPerPageM: {
 			type: Integer,
-			defaultValue: undefined,
+			defaultValue: 1,
 		},
 
+		/**
+		 * Sets the number of items per page on large size (more than 1024px). One item per page shown by default.
+		 * @type {Integer}
+		 * @defaultvalue 1
+		 * @public
+		 */
 		itemsPerPageL: {
 			type: Integer,
-			defaultValue: undefined,
+			defaultValue: 1,
 		},
 
 		/**
@@ -228,7 +235,7 @@ class Carousel extends UI5Element {
 		}
 
 		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
-		this.selectedIndex = Math.floor(this.selectedIndex * adjustment);
+		this.selectedIndex = Math.round(this.selectedIndex * adjustment);
 	}
 
 	_updateScrolling(event) {
@@ -257,7 +264,7 @@ class Carousel extends UI5Element {
 
 	navigateLeft() {
 		if (this.selectedIndex - 1 < 0) {
-			if (this.cycling) {
+			if (this.cyclic) {
 				this.selectedIndex = this.pages.length - 1;
 			}
 		} else {
@@ -267,7 +274,7 @@ class Carousel extends UI5Element {
 
 	navigateRight() {
 		if (this.selectedIndex + 1 > this.pages.length - 1) {
-			if (this.cycling) {
+			if (this.cyclic) {
 				this.selectedIndex = 0;
 			}
 		} else {
@@ -309,23 +316,15 @@ class Carousel extends UI5Element {
 	}
 
 	get effectiveItemsPerPage() {
-		if (!isDesktop()) {
-			return 1;
-		}
-
-		if (this.itemsPerPageS && this._width <= 640) {
+		if (this._width <= 640) {
 			return this.itemsPerPageS;
 		}
 
-		if (this.itemsPerPageM && this._width <= 1024) {
+		if (this._width <= 1024) {
 			return this.itemsPerPageM;
 		}
 
-		if (this.itemsPerPageL) {
-			return this.itemsPerPageL;
-		}
-
-		return this.itemsPerPage;
+		return this.itemsPerPageL;
 	}
 
 	get styles() {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -87,7 +87,7 @@ const metadata = {
 		 * @defaultvalue 0
 		 * @public
 		 */
-		selectedPageIndex: {
+		selectedIndex: {
 			type: Integer,
 			defaultValue: 0,
 		},
@@ -228,7 +228,7 @@ class Carousel extends UI5Element {
 		}
 
 		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
-		this.selectedPageIndex = Math.floor(this.selectedPageIndex * adjustment);
+		this.selectedIndex = Math.floor(this.selectedIndex * adjustment);
 	}
 
 	_updateScrolling(event) {
@@ -256,22 +256,22 @@ class Carousel extends UI5Element {
 	}
 
 	navigateLeft() {
-		if (this.selectedPageIndex - 1 < 0) {
+		if (this.selectedIndex - 1 < 0) {
 			if (this.cycling) {
-				this.selectedPageIndex = this.pages.length - 1;
+				this.selectedIndex = this.pages.length - 1;
 			}
 		} else {
-			--this.selectedPageIndex;
+			--this.selectedIndex;
 		}
 	}
 
 	navigateRight() {
-		if (this.selectedPageIndex + 1 > this.pages.length - 1) {
+		if (this.selectedIndex + 1 > this.pages.length - 1) {
 			if (this.cycling) {
-				this.selectedPageIndex = 0;
+				this.selectedIndex = 0;
 			}
 		} else {
-			++this.selectedPageIndex;
+			++this.selectedIndex;
 		}
 	}
 
@@ -294,7 +294,7 @@ class Carousel extends UI5Element {
 				if (item) {
 					result[pageIdx].push({
 						item,
-						tabIndex: pageIdx === this.selectedPageIndex ? "0" : "-1",
+						tabIndex: pageIdx === this.selectedIndex ? "0" : "-1",
 					});
 				}
 			}
@@ -331,7 +331,7 @@ class Carousel extends UI5Element {
 	get styles() {
 		return {
 			content: {
-				transform: `translateX(-${this.selectedPageIndex * 100}%)`,
+				transform: `translateX(-${this.selectedIndex * 100}%)`,
 			},
 		};
 	}
@@ -362,7 +362,7 @@ class Carousel extends UI5Element {
 	get dots() {
 		return this.pages.map((item, index) => {
 			return {
-				active: index === this.selectedPageIndex,
+				active: index === this.selectedIndex,
 			};
 		});
 	}
@@ -380,8 +380,8 @@ class Carousel extends UI5Element {
 		return this.i18nBundle.getText(CAROUSEL_OF_TEXT);
 	}
 
-	get selectedPageIndexToShow() {
-		return this.selectedPageIndex + 1;
+	get selectedIndexToShow() {
+		return this.selectedIndex + 1;
 	}
 
 	get showNavigationArrows() {

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -25,7 +25,7 @@
     }
 </style>
 
-<ui5-carousel items-per-page="3">
+<ui5-carousel items-per-page-s="3" items-per-page-m="3" items-per-page-l="3">
     <ui5-card
             id="card"
             status="4 of 10"
@@ -157,7 +157,7 @@
 </ui5-carousel>
 
 
-<ui5-carousel items-per-page-s="1" items-per-page-m="3" items-per-page-l="4">
+<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
     <ui5-card
             id="card"
             status="Item 1"
@@ -348,7 +348,7 @@
 	</ui5-list>
 </ui5-carousel>
 
-<ui5-carousel id="carousel5" items-per-page="4">
+<ui5-carousel id="carousel5" items-per-page-m="4" items-per-page-l="4">
 	<ui5-button>Button 1</ui5-button>
 	<ui5-button>Button 2</ui5-button>
 	<ui5-button>Button 3</ui5-button>
@@ -362,7 +362,7 @@
 <ui5-title>Carousel with one page</ui5-title>
 <ui5-label>The arrows and dots are not displayed</ui5-label>
 
-<ui5-carousel id="carousel6" items-per-page="3">
+<ui5-carousel id="carousel6" items-per-page-m="3" items-per-page-l="4">
 	<ui5-button>Button 1</ui5-button>
 	<ui5-button>Button 2</ui5-button>
 	<ui5-button>Button 3</ui5-button>

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -157,6 +157,139 @@
 </ui5-carousel>
 
 
+<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
+    <ui5-card
+            id="card"
+            status="Item 1"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="Item 2"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="Item 3" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="Item 4"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="Item 5"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="Item 6" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="Item 7"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="Item 8"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="Item 9" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="Item 10"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="Item 11" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+</ui5-carousel>
+
+
+
 <ui5-carousel id="carousel1" cycling="true">
 	<ui5-button>Button 1</ui5-button>
 	<ui5-button>Button 2</ui5-button>

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -157,7 +157,7 @@
 </ui5-carousel>
 
 
-<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
+<ui5-carousel items-per-page-s="1" items-per-page-m="3" items-per-page-l="4">
     <ui5-card
             id="card"
             status="Item 1"
@@ -290,7 +290,7 @@
 
 
 
-<ui5-carousel id="carousel1" cycling="true">
+<ui5-carousel id="carousel1" cyclic="true">
 	<ui5-button>Button 1</ui5-button>
 	<ui5-button>Button 2</ui5-button>
 	<ui5-button>Button 3</ui5-button>


### PR DESCRIPTION
`ui5-carousel` is now size-aware:
 - uses a `ResizeHandler`
 - `itemsPerPage` replaced by `itemsPerPageS`, `itemsPerPageM` and `itemsPerPageL`. They all have default value of `1` so a plain `ui5-carousel` without any properties set will behave as before. The user can now increase the number of items for different screen sizes separately. Since the default value for `itemsPerPageS` is  `1`, no special logic is needed for phone any more.
 - `cycling` renamed to `cyclic` as this is the correct adjective

BREAKING CHANGE:
The `cycling` property was renamed to `cyclic`.
The `itemsPerPage` property was replaced by 3 new properties:  `itemsPerPageS`, `itemsPerPageM` and `itemsPerPageL`. To achieve exactly the same result as before, set `itemsPerPageM` and `itemsPerPageL` to whatever the value of `itemsPerPage` was, but it's recommended to set them independently for best user experience.