### PR TITLE
fix(ui5-popover): allow opening if opener is not fully visible

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -422,10 +422,10 @@ class Popover extends UI5Element {
 		const threshold = 32;
 
 		const limits = {
-			"Right": openerRect.top,
-			"Left": openerRect.top,
+			"Right": openerRect.right,
+			"Left": openerRect.left,
 			"Top": openerRect.top,
-			"Bottom": openerRect.top,
+			"Bottom": openerRect.bottom,
 		};
 
 		const closedPopupParent = getClosedPopupParent(this._opener);


### PR DESCRIPTION
Fixes #1421
![image](https://user-images.githubusercontent.com/16850339/78780864-f7ac8780-79a7-11ea-9581-bbb837eaa94f.png)

