### PR TITLE
feat(ui5-carousel): add navigate event

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -19,6 +19,7 @@
         {{#if arrows.content}}
             <div class="ui5-carousel-navigation-arrows">
                 <ui5-button
+                     arrow-back
                     class="ui5-carousel-navigation-button"
                     icon="slim-arrow-left"
                     tabindex="-1"
@@ -26,6 +27,7 @@
                     @keydown={{_onbuttonkeydown}}
                 ></ui5-button>
                 <ui5-button
+                    arrow-forward
                     class="ui5-carousel-navigation-button"
                     icon="slim-arrow-right"
                     tabindex="-1"
@@ -39,6 +41,7 @@
             <div class="{{classes.navigation}}">
                 {{#if arrows.navigation}}
                 <ui5-button
+                    arrow-back
                     class="ui5-carousel-navigation-button"
                     icon="slim-arrow-left"
                     tabindex="-1"
@@ -62,6 +65,7 @@
 
                 {{#if arrows.navigation}}
                     <ui5-button
+                        arrow-forward
                         class="ui5-carousel-navigation-button"
                         icon="slim-arrow-right"
                         tabindex="-1"

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -90,7 +90,11 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the index of the initially selected page.
+		 * Defines the index of the initially selected item.
+		 * <br><br>
+		 * <b>Note:</b>
+		 * When there are multiple items displayed,
+		 * the <code>selectedIndex</code> would define the first item within view.
 		 * @type {Integer}
 		 * @defaultvalue 0
 		 * @public
@@ -154,8 +158,9 @@ const metadata = {
 	events: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
 
 		/**
-		 * Fired when the user clicks on the navigation arrows
-		 * and changes the selected page.
+		 * Fired whenever the <code>selectedIndex</code> changes due to user interaction,
+		 * when the user clicks on the navigation arrows or while resizing,
+		 * based on the <code>items-per-page-l</code>, <code>items-per-page-m</code> and <code>items-per-page-s</code> properties.
 		 *
 		 * @event
 		 * @param {Integer} selectedIndex the current <code>selectedIndex</code>.

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -150,7 +150,7 @@ const metadata = {
 		 * @event
 		 * @param {Integer} selectedIndex the current <code>selectedIndex</code>.
 		 * @public
-		 * @sice 1.0.0-rc.7
+		 * @since 1.0.0-rc.7
 		 */
 		selectedPageChange: {
 			detail: {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -144,15 +144,13 @@ const metadata = {
 	},
 	events: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
 		/**
-		 * Fired when the currently <code>selectedIndex</code> changes due to user interaction.
-		 * <b>Note:</b> it changes when the user clicks on the navigation arrows, or upon screen resize.
-		 * As the user can define how many items to be displayed on different screen sizes,
-		 * the number of pages and the <code>selectedIndex</code> might change.
+		 * Fired when the currently selected page changes,
+		 * when the user clicks on the navigation arrows, or upon screen resize.
 		 *
 		 * @event
 		 * @public
 		 */
-		selectedIndexChange: {
+		selectedPageChange: {
 		},
 	},
 };
@@ -247,12 +245,7 @@ class Carousel extends UI5Element {
 		// Whenever the number of items per page changes, the selected index needs to be re-adjusted so that the items
 		// that were visible before, can be visible as much as possible afterwards.
 		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
-		const peviousSelectedIndex = this.selectedIndex;
 		this.selectedIndex = Math.round(this.selectedIndex * adjustment);
-
-		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
-		}
 	}
 
 	_updateScrolling(event) {
@@ -291,7 +284,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
+			this.fireEvent("selectedPageChange", { selectedIndex: this.selectedIndex });
 		}
 	}
 
@@ -307,7 +300,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
+			this.fireEvent("selectedPageChange", { selectedIndex: this.selectedIndex });
 		}
 	}
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -146,8 +146,8 @@ const metadata = {
 		/**
 		 * Fired when the currently <code>selectedIndex</code> changes due to user interaction.
 		 * <b>Note:</b> it changes when the user clicks on the navigation arrows, or upon screen resize.
-		 * s the user can define how many items to be displayed on different screen sizes, the <code>selectedIndex</code> might change on resize.
-		 *
+		 * As the user can define how many items to be displayed on different screen sizes,
+		 * the number of pages and the <code>selectedIndex</code> might change.
 		 *
 		 * @event
 		 * @public
@@ -251,7 +251,7 @@ class Carousel extends UI5Element {
 		this.selectedIndex = Math.round(this.selectedIndex * adjustment);
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
 		}
 	}
 
@@ -291,7 +291,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
 		}
 	}
 
@@ -307,7 +307,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex });
 		}
 	}
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -143,7 +143,17 @@ const metadata = {
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
-		//
+		/**
+		 * Fired when the currently <code>selectedIndex</code> changes due to user interaction.
+		 * <b>Note:</b> it changes when the user clicks on the navigation arrows, or upon screen resize.
+		 * s the user can define how many items to be displayed on different screen sizes, the <code>selectedIndex</code> might change on resize.
+		 *
+		 *
+		 * @event
+		 * @public
+		 */
+		selectedIndexChange: {
+		},
 	},
 };
 
@@ -237,7 +247,12 @@ class Carousel extends UI5Element {
 		// Whenever the number of items per page changes, the selected index needs to be re-adjusted so that the items
 		// that were visible before, can be visible as much as possible afterwards.
 		const adjustment = oldItemsPerPage / this.effectiveItemsPerPage;
+		const peviousSelectedIndex = this.selectedIndex;
 		this.selectedIndex = Math.round(this.selectedIndex * adjustment);
+
+		if (peviousSelectedIndex !== this.selectedIndex) {
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
+		}
 	}
 
 	_updateScrolling(event) {
@@ -265,6 +280,8 @@ class Carousel extends UI5Element {
 	}
 
 	navigateLeft() {
+		const peviousSelectedIndex = this.selectedIndex;
+
 		if (this.selectedIndex - 1 < 0) {
 			if (this.cyclic) {
 				this.selectedIndex = this.pages.length - 1;
@@ -272,15 +289,25 @@ class Carousel extends UI5Element {
 		} else {
 			--this.selectedIndex;
 		}
+
+		if (peviousSelectedIndex !== this.selectedIndex) {
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
+		}
 	}
 
 	navigateRight() {
+		const peviousSelectedIndex = this.selectedIndex;
+
 		if (this.selectedIndex + 1 > this.pages.length - 1) {
 			if (this.cyclic) {
 				this.selectedIndex = 0;
 			}
 		} else {
 			++this.selectedIndex;
+		}
+
+		if (peviousSelectedIndex !== this.selectedIndex) {
+			this.fireEvent("selectedIndexChange", { selectedIndex: this.selectedIndex }); 
 		}
 	}
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -145,7 +145,7 @@ const metadata = {
 	events: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
 		/**
 		 * Fired when the currently selected page changes,
-		 * when the user clicks on the navigation arrows, or upon screen resize.
+		 * when the user clicks on the navigation arrows.
 		 *
 		 * @event
 		 * @public

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -148,9 +148,14 @@ const metadata = {
 		 * when the user clicks on the navigation arrows.
 		 *
 		 * @event
+		 * @param {Integer} selectedIndex the current <code>selectedIndex</code>.
 		 * @public
+		 * @sice 1.0.0-rc.7
 		 */
 		selectedPageChange: {
+			detail: {
+				selectedIndex: { type: Integer },
+			},
 		},
 	},
 };

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -307,6 +307,8 @@ class Carousel extends UI5Element {
 	}
 
 	navigateLeft() {
+		this._resizing = false;
+
 		const peviousSelectedIndex = this.selectedIndex;
 
 		if (this.selectedIndex - 1 < 0) {
@@ -323,6 +325,8 @@ class Carousel extends UI5Element {
 	}
 
 	navigateRight() {
+		this._resizing = false;
+
 		const peviousSelectedIndex = this.selectedIndex;
 
 		if (this.selectedIndex + 1 > this.pagesCount - 1) {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -91,10 +91,6 @@ const metadata = {
 
 		/**
 		 * Defines the index of the initially selected item.
-		 * <br><br>
-		 * <b>Note:</b>
-		 * When there are multiple items displayed,
-		 * the <code>selectedIndex</code> would define the first item within view.
 		 * @type {Integer}
 		 * @defaultvalue 0
 		 * @public

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -143,16 +143,17 @@ const metadata = {
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Carousel.prototype */ {
+
 		/**
-		 * Fired when the currently selected page changes,
-		 * when the user clicks on the navigation arrows.
+		 * Fired when the user clicks on the navigation arrows
+		 * and changes the selected page.
 		 *
 		 * @event
 		 * @param {Integer} selectedIndex the current <code>selectedIndex</code>.
 		 * @public
 		 * @since 1.0.0-rc.7
 		 */
-		selectedPageChange: {
+		navigate: {
 			detail: {
 				selectedIndex: { type: Integer },
 			},
@@ -289,7 +290,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedPageChange", { selectedIndex: this.selectedIndex });
+			this.fireEvent("navigate", { selectedIndex: this.selectedIndex });
 		}
 	}
 
@@ -305,7 +306,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (peviousSelectedIndex !== this.selectedIndex) {
-			this.fireEvent("selectedPageChange", { selectedIndex: this.selectedIndex });
+			this.fireEvent("navigate", { selectedIndex: this.selectedIndex });
 		}
 	}
 

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -374,7 +374,7 @@
 
 <script>
 	var counter = 0;
-	carousel5.addEventListener("ui5-selectedPageChange", function(event){
+	carousel5.addEventListener("ui5-navigate", function(event){
 		result.value = event.detail.selectedIndex;
 		resultCounter.value = ++counter;
 	});

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -374,7 +374,7 @@
 
 <script>
 	var counter = 0;
-	carousel5.addEventListener("ui5-selectedIndexChange", function(event){
+	carousel5.addEventListener("ui5-selectedPageChange", function(event){
 		result.value = event.detail.selectedIndex;
 		resultCounter.value = ++counter;
 	});

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -358,6 +358,8 @@
 	<ui5-button>Button 7</ui5-button>
 	<ui5-button>Button 8</ui5-button>
 </ui5-carousel>
+<ui5-input id="result"></ui5-input>
+<ui5-input id="resultCounter"></ui5-input>
 
 <ui5-title>Carousel with one page</ui5-title>
 <ui5-label>The arrows and dots are not displayed</ui5-label>
@@ -369,4 +371,12 @@
 </ui5-carousel>
 
 </body>
+
+<script>
+	var counter = 0;
+	carousel5.addEventListener("ui5-selectedIndexChange", function(event){
+		result.value = event.detail.selectedIndex;
+		resultCounter.value = ++counter;
+	});
+</script>
 </html>

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -65,7 +65,7 @@ describe("Carousel general interaction", () => {
 		assert.strictEqual(pages, 1, "There are only 3 pages.");
 	});
 
-	it("Event selectedPageChange fired when pressing navigation arrows", () => {
+	it("Event navigate fired when pressing navigation arrows", () => {
 		const carousel = browser.$("#carousel5");
 		const selectedIndex = browser.$("#result");
 		const eventCounter = browser.$("#resultCounter");
@@ -74,18 +74,18 @@ describe("Carousel general interaction", () => {
 
 		navigationArrowForward.click(); // forward
 		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex is correct.");
-		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedPageChange is fired.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The navigate is fired.");
 		
 		navigationArrowForward.click(); // forward
 		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex remains the same as this is the last page.");
-		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedPageChange not fired as this is last page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The navigate not fired as this is last page.");
 		
 		navigationArrowsBack.click(); // back
 		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex is correct");
-		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedPageChange is fired.");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The navigate is fired.");
 
 		navigationArrowsBack.click(); // back
 		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex remains the same as this is the first page.");
-		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedPageChange is not fired as this is the first page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The navigate is not fired as this is the first page.");
 	});
 });

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -65,7 +65,7 @@ describe("Carousel general interaction", () => {
 		assert.strictEqual(pages, 1, "There are only 3 pages.");
 	});
 
-	it("Event selectedIndexChange fired when pressing navigation arrows", () => {
+	it("Event selectedPageChange fired when pressing navigation arrows", () => {
 		const carousel = browser.$("#carousel5");
 		const selectedIndex = browser.$("#result");
 		const eventCounter = browser.$("#resultCounter");
@@ -74,18 +74,18 @@ describe("Carousel general interaction", () => {
 
 		navigationArrowForward.click(); // forward
 		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex is correct.");
-		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedIndexChange is fired.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedPageChange is fired.");
 		
 		navigationArrowForward.click(); // forward
 		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex remains the same as this is the last page.");
-		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedIndexChange not fired as this is last page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedPageChange not fired as this is last page.");
 		
 		navigationArrowsBack.click(); // back
 		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex is correct");
-		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedIndexChange is fired.");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedPageChange is fired.");
 
 		navigationArrowsBack.click(); // back
 		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex remains the same as this is the first page.");
-		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedIndexChange is not fired as this is the first page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedPageChange is not fired as this is the first page.");
 	});
 });

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -64,4 +64,28 @@ describe("Carousel general interaction", () => {
 		assert.ok(!navigationArrows.isExisting(), "Navigation is rendered");
 		assert.strictEqual(pages, 1, "There are only 3 pages.");
 	});
+
+	it("Event selectedIndexChange fired when pressing navigation arrows", () => {
+		const carousel = browser.$("#carousel5");
+		const selectedIndex = browser.$("#result");
+		const eventCounter = browser.$("#resultCounter");
+		const navigationArrowForward = carousel.shadow$("ui5-button[arrow-forward]");
+		const navigationArrowsBack = carousel.shadow$("ui5-button[arrow-back]");
+
+		navigationArrowForward.click(); // forward
+		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex is correct.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedIndexChange is fired.");
+		
+		navigationArrowForward.click(); // forward
+		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex remains the same as this is the last page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "1", "The selectedIndexChange not fired as this is last page.");
+		
+		navigationArrowsBack.click(); // back
+		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex is correct");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedIndexChange is fired.");
+
+		navigationArrowsBack.click(); // back
+		assert.strictEqual(selectedIndex.getProperty("value"), "0", "The selectedIndex remains the same as this is the first page.");
+		assert.strictEqual(eventCounter.getProperty("value"), "2", "The selectedIndexChange is not fired as this is the first page.");
+	});
 });


### PR DESCRIPTION
The event is fired whenever the selectedIndex changes due to user interaction - when the user clicks on the navigation arrows or while resizing, based on the "items-per-page-s/m/l" properties.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1449