### PR TITLE
fix(ui5-shellbar): do not duplicate popover menu items

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -748,8 +748,20 @@ class UI5Element extends HTMLElement {
 				throw new Error(`"${prop}" is not a valid property name. Use a name that does not collide with DOM APIs`);
 			}
 
-			if (propData.type === "boolean" && propData.defaultValue) {
+			if (propData.type === Boolean && propData.defaultValue) {
 				throw new Error(`Cannot set a default value for property "${prop}". All booleans are false by default.`);
+			}
+
+			if (propData.type === Array) {
+				throw new Error(`Wrong type for property "${prop}". Properties cannot be of type Array - use "multiple: true" and set "type" to the single value type, such as "String", "Object", etc...`);
+			}
+
+			if (propData.type === Object && propData.defaultValue) {
+				throw new Error(`Cannot set a default value for property "${prop}". All properties of type "Object" are empty objects by default.`);
+			}
+
+			if (propData.multiple && propData.defaultValue) {
+				throw new Error(`Cannot set a default value for property "${prop}". All multiple properties are empty arrays by default.`);
 			}
 
 			Object.defineProperty(proto, prop, {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -138,8 +138,8 @@ const metadata = {
 		},
 
 		_menuPopoverItems: {
-			type: Array,
-			defaultValue: [],
+			type: String,
+			multiple: true,
 		},
 	},
 	managedSlots: true,


### PR DESCRIPTION
The `_menuPopoverItems` metadata property had a wrong type and a wrong default value. When the default value is an object, in this case `[]`, whenever there is a type mismatch, the default value is returned: `return propDefaultValue;` in `UI5Element.js`. However, if the default value is an object, it's passed by reference and when the components work with it (f.e. push items as is here), the `defaultValue` is updated every time. Thus items are duplicated again and again.

In addition, to prevent this from happening in the future, some more metadata checks are added:
 - `type` can no longer be `Array`
 - properties of `type` equal to `Object`, or with `multiple: true`, cannot have a default value at all. The default value can only be `{}` or `[]` respectively, and provided by the framework.

In addition, the check for `Boolean` properties was wrong, a leftover from the time when `Boolean` was denoted by a string `"boolean"`.