### PR TITLE
fix(ui5-datepicker): fix the value validation

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -423,7 +423,8 @@ class DatePicker extends UI5Element {
 
 	_handleInputChange() {
 		let nextValue = this._getInput().getInputValue();
-		const isValid = this.isValid(nextValue);
+		const emptyValue = nextValue === "";
+		const isValid = emptyValue || this.isValid(nextValue);
 		const isInValidRange = this.isInValidRange(this._getTimeStampFromString(nextValue));
 
 		if (isValid && isInValidRange) {
@@ -442,7 +443,8 @@ class DatePicker extends UI5Element {
 
 	_handleInputLiveChange() {
 		const nextValue = this._getInput().getInputValue();
-		const isValid = this.isValid(nextValue) && this.isInValidRange(this._getTimeStampFromString(nextValue));
+		const emptyValue = nextValue === "";
+		const isValid = emptyValue || (this.isValid(nextValue) && this.isInValidRange(this._getTimeStampFromString(nextValue)));
 
 		this.value = nextValue;
 		this.fireEvent("input", { value: nextValue, valid: isValid });
@@ -495,8 +497,12 @@ class DatePicker extends UI5Element {
 
 	// because the parser understands more than one format
 	// but we need values in one format
-	normalizeValue(sValue) {
-		return this.getFormat().format(this.getFormat().parse(sValue));
+	normalizeValue(value) {
+		if (value === "") {
+			return value;
+		}
+
+		return this.getFormat().format(this.getFormat().parse(value));
 	}
 
 	get validValue() {


### PR DESCRIPTION
**Background**
If there is value in the input field and the user removes that value,
the component sets "value-state=error" and fires "change" and "input" events with "valid: false" and this is not correct - empty input field should be a valid state.

**Note**: there is a method, called "isValid", but I did not add the check for empty value in that method by purpose, because it is used in a lot of places, where (if valid) the value is parsed or formatted  and would throw errors on empty string, and I would need to make more changes to handle that. So this "isValid" is more like is the value valid for the given format.