### PR TITLE
chore(ui5-dialog): Popover, Dialog and Toast have borders in Windows High Co…

### DIFF
--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -20,6 +20,12 @@
 	overflow: hidden;
 }
 
+@media screen and (-ms-high-contrast: active) {
+    .ui5-popover-root {
+        border: 1px solid var(--sapPageFooter_BorderColor);
+    }
+}
+
 :host([modal])::before {
 	content: "";
 	position: fixed;
@@ -29,7 +35,6 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	position: fixed;
 	outline: 0 none;
 	z-index: -1;
 }

--- a/packages/main/src/themes/Popup.css
+++ b/packages/main/src/themes/Popup.css
@@ -22,6 +22,12 @@
 	min-height: 2rem;
 }
 
+@media screen and (-ms-high-contrast: active) {
+    .ui5-popup-root {
+        border: 1px solid var(--sapPageFooter_BorderColor);
+    }
+}
+
 .ui5-popup-root .ui5-popup-header {
 	margin: 0;
 	color: var(--sapPageHeader_TextColor);

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -31,6 +31,12 @@
 	z-index: 999;
 }
 
+@media screen and (-ms-high-contrast: active) {
+    .ui5-toast-root {
+        border: 1px solid var(--sapPageFooter_BorderColor);
+    }
+}
+
 :host(:not([placement])) .ui5-toast-root {
 	bottom: var(--_ui5_toast_vertical_offset);
 	left: 50%;


### PR DESCRIPTION
Background: `Windows High Contrast Mode` is an accessibility mode that switches the whole operating system to High Contrast (https://support.microsoft.com/en-us/help/4026951/windows-10-turn-high-contrast-mode-on-or-off), Edge/IE11 included, by overriding CSS colors to artificially create contrast. *Note that this has nothing to do with UI5 themes - all UI5 themes look practically the same in Windows High Contrast mode*.

Our popups: `ui5-dialog`, `ui5-popover` and `ui5-toast` however lack borders in this mode, due to the fact that they use `box-shadow` rather than `border` and the High Contrast Mode seems to be unable to switch `box-shadow`.

This change adds border only when `-ms-high-contrast: active` is on. This is a vendor-specific media selector that is on whenever Windows is in High Contrast Mode.

closes: https://github.com/SAP/ui5-webcomponents/issues/1429

