### PR TITLE
fix(ui5-shellbar): enable items keyboard handling

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -1,7 +1,6 @@
 <div
 	class="{{classes.wrapper}}"
 	dir="{{rtl}}"
-	@keydown={{_onkeydown}}
 >
 	<div class="ui5-shellbar-overflow-container ui5-shellbar-overflow-container-left">
 
@@ -54,58 +53,54 @@
 		<div class="ui5-shellbar-overflow-container-right-child">
 
 			{{#if hasSearchField}}
-				<ui5-icon
+				<ui5-button
 					id="{{this._id}}-item-1"
 					class="{{classes.items.search}} ui5-shellbar-button ui5-shellbar-search-button"
-					name="sap-icon://search"
+					icon="sap-icon://search"
 					data-ui5-text="Search"
 					data-ui5-notification-count="{{notificationCount}}"
 					@click={{_handleSearchIconPress}}
-					tabindex="0"
-				></ui5-icon>
+				></ui5-button>
 			{{/if}}
 
 			{{#each customItemsInfo}}
-				<ui5-icon
+				<ui5-button
 					id="{{this.id}}"
 					style="{{this.style}}"
 					class="{{this.classes}}"
-					tabindex="0"
-					name="{{this.icon}}"
+					icon="{{this.icon}}"
 					data-count="{{this.count}}"
 					data-ui5-notification-count="{{../notificationCount}}"
 					data-ui5-external-action-item-id="{{this.refItemid}}"
 					@click={{this.press}}
-				></ui5-icon>
+				></ui5-button>
 			{{/each}}
 
 			{{#if showNotifications}}
-			<ui5-icon
+			<ui5-button
 				id="{{this._id}}-item-2"
 				style="{{styles.items.notification}}"
 				class="{{classes.items.notification}} ui5-shellbar-button ui5-shellbar-bell-button"
-				tabindex="0"
-				name="sap-icon://bell"
+				icon="sap-icon://bell"
 				data-ui5-text="Notifications"
 				data-ui5-notification-count="{{notificationCount}}"
 				@click={{_handleNotificationsPress}}
-			></ui5-icon>
+			></ui5-button>
 			{{/if}}
 
-			<ui5-icon
+			<ui5-button
 				id="{{this._id}}-item-5"
 				style="{{styles.items.overflow}}"
 				class="{{classes.items.overflow}} ui5-shellbar-button ui5-shellbar-overflow-button-shown ui5-shellbar-overflow-button"
-				name="sap-icon://overflow"
+				icon="sap-icon://overflow"
 				@click="{{_handleOverflowPress}}"
-				tabindex="0"
-			></ui5-icon>
+			></ui5-button>
 
 			{{#if hasProfile}}
 				<ui5-button
 					id="{{this._id}}-item-3"
 					@click={{_handleProfilePress}}
-					style="{{styles.items.profile}} width: 36px;"
+					style="{{styles.items.profile}}"
 					class="ui5-shellbar-button ui5-shellbar-image-button">
 						<slot
 							name="profile"
@@ -114,15 +109,14 @@
 			{{/if}}
 
 			{{#if showProductSwitch}}
-			<ui5-icon
+			<ui5-button
 				id="{{this._id}}-item-4"
 				style="{{styles.items.product}}"
 				class="{{classes.items.product}} ui5-shellbar-button ui5-shellbar-button-product-switch"
-				name="sap-icon://grid"
+				icon="sap-icon://grid"
 				data-ui5-text="Product Switch"
 				@click={{_handleProductSwitchPress}}
-				tabindex="0"
-			></ui5-icon>
+			></ui5-button>
 			{{/if}}
 		</div>
 	</div>

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -98,6 +98,7 @@
 
 			{{#if hasProfile}}
 				<ui5-button
+					profile-btn
 					id="{{this._id}}-item-3"
 					@click={{_handleProfilePress}}
 					style="{{styles.items.profile}}"

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -40,36 +40,6 @@
 		{{/if}}
 	</div>
 
-	<div class="ui5-shellbar-overflow-container ui5-shellbar-overflow-container-right">
-
-		<div class="ui5-shellbar-overflow-container-right-child">
-			{{#each _itemsInfo}}
-				{{#if this.icon}}
-					<ui5-icon
-						tabindex="{{this._tabIndex}}"
-						data-count="{{this.count}}"
-						data-ui5-notification-count="{{../notificationCount}}"
-						data-ui5-external-action-item-id="{{this.refItemid}}"
-						class="{{this.classes}}"
-						name="{{this.icon}}"
-						id="{{this.id}}"
-						style="{{this.style}}"
-						@click={{this.press}}>
-					</ui5-icon>
-				{{else}}
-					<slot
-						name="profile"
-						id="{{this.id}}"
-						style="{{this.style}}"
-						class="{{this.classes}}"
-						tabindex="{{this._tabIndex}}"
-						@click={{this.press}}
-					></slot>
-				{{/if}}
-			{{/each}}
-		</div>
-	</div>
-
 	<div id="{{_id}}-searchfield-wrapper"
 		class="ui5-shellbar-search-field"
 		style="{{styles.searchField}}"
@@ -77,6 +47,84 @@
 		{{#if searchField.length}}
 			<slot name="searchField"></slot>
 		{{/if}}
+	</div>
+
+	<div class="ui5-shellbar-overflow-container ui5-shellbar-overflow-container-right">
+
+		<div class="ui5-shellbar-overflow-container-right-child">
+
+			{{#if hasSearchField}}
+				<ui5-icon
+					id="{{this._id}}-item-1"
+					class="{{classes.items.search}} ui5-shellbar-button ui5-shellbar-search-button"
+					name="sap-icon://search"
+					data-ui5-text="Search"
+					data-ui5-notification-count="{{notificationCount}}"
+					@click={{_handleSearchIconPress}}
+					tabindex="0"
+				></ui5-icon>
+			{{/if}}
+
+			{{#each customItemsInfo}}
+				<ui5-icon
+					id="{{this.id}}"
+					style="{{this.style}}"
+					class="{{this.classes}}"
+					tabindex="0"
+					name="{{this.icon}}"
+					data-count="{{this.count}}"
+					data-ui5-notification-count="{{../notificationCount}}"
+					data-ui5-external-action-item-id="{{this.refItemid}}"
+					@click={{this.press}}
+				></ui5-icon>
+			{{/each}}
+
+			{{#if showNotifications}}
+			<ui5-icon
+				id="{{this._id}}-item-2"
+				style="{{styles.items.notification}}"
+				class="{{classes.items.notification}} ui5-shellbar-button ui5-shellbar-bell-button"
+				tabindex="0"
+				name="sap-icon://bell"
+				data-ui5-text="Notifications"
+				data-ui5-notification-count="{{notificationCount}}"
+				@click={{_handleNotificationsPress}}
+			></ui5-icon>
+			{{/if}}
+
+			<ui5-icon
+				id="{{this._id}}-item-5"
+				style="{{styles.items.overflow}}"
+				class="{{classes.items.overflow}} ui5-shellbar-button ui5-shellbar-overflow-button-shown ui5-shellbar-overflow-button"
+				name="sap-icon://overflow"
+				@click="{{_handleOverflowPress}}"
+				tabindex="0"
+			></ui5-icon>
+
+			{{#if hasProfile}}
+				<ui5-button
+					id="{{this._id}}-item-3"
+					@click={{_handleProfilePress}}
+					style="{{styles.items.profile}} width: 36px;"
+					class="ui5-shellbar-button ui5-shellbar-image-button">
+						<slot
+							name="profile"
+						></slot>
+				</ui5-button>
+			{{/if}}
+
+			{{#if showProductSwitch}}
+			<ui5-icon
+				id="{{this._id}}-item-4"
+				style="{{styles.items.product}}"
+				class="{{classes.items.product}} ui5-shellbar-button ui5-shellbar-button-product-switch"
+				name="sap-icon://grid"
+				data-ui5-text="Product Switch"
+				@click={{_handleProductSwitchPress}}
+				tabindex="0"
+			></ui5-icon>
+			{{/if}}
+		</div>
 	</div>
 </div>
 

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -13,7 +13,7 @@
 		{{/unless}}
 
 		{{#if showArrowDown}}
-			<button tabindex="0" class="{{classes.button}}" @click="{{_header.press}}">
+			<button tabindex="{{menuBtnTabindex}}" class="{{classes.button}}" @click="{{_header.press}}">
 				{{#if interactiveLogo}}
 					<img class="ui5-shellbar-logo" src="{{logo}}" @click="{{_logoPress}}" />
 				{{/if}}

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -33,7 +33,13 @@
 
 	<div class="ui5-shellbar-overflow-container ui5-shellbar-overflow-container-middle">
 		{{#if showCoPilot}}
-			{{> coPilot}}
+			<div class="ui5-shellbar-copilot-wrapper"
+				tabindex="0"
+				@keydown="{{_coPilotKeydown}}"
+				@keyup="{{_coPilotKeyup}}"
+				?active="{{coPilotActive}}">
+				{{> coPilot}}
+			</div>
 		{{else}}
 			<span class="ui5-shellbar-co-pilot-placeholder"></span>
 		{{/if}}
@@ -124,7 +130,7 @@
 </div>
 
 {{#*inline "coPilot"}}
-	<svg @click="{{_coPilotPress}}" width="44" height="44" viewBox="-150 -150 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ui5-shellbar-coPilot">
+	<svg @click="{{_coPilotPress}}" focusable="false" width="44" height="44" viewBox="-150 -150 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ui5-shellbar-coPilot">
 		<defs>
 			<linearGradient id="f" x1="0%" x2="100%" y1="100%" y2="0%"><stop offset="0%" stop-color="#c0d9f2" stop-opacity=".87"/><stop offset="80%" stop-color="#fff" stop-opacity=".87"/></linearGradient>
 			<linearGradient id="e" x1="0%" x2="100%" y1="100%" y2="0%"><stop offset="0%" stop-color="#b4d2ff" stop-opacity=".16"/><stop offset="80%" stop-color="#fff" stop-opacity=".16"/></linearGradient>

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -130,7 +130,7 @@
 </div>
 
 {{#*inline "coPilot"}}
-	<svg @click="{{_coPilotPress}}" focusable="false" width="44" height="44" viewBox="-150 -150 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ui5-shellbar-coPilot">
+	<svg @click="{{_coPilotClick}}" focusable="false" width="44" height="44" viewBox="-150 -150 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ui5-shellbar-coPilot">
 		<defs>
 			<linearGradient id="f" x1="0%" x2="100%" y1="100%" y2="0%"><stop offset="0%" stop-color="#c0d9f2" stop-opacity=".87"/><stop offset="80%" stop-color="#fff" stop-opacity=".87"/></linearGradient>
 			<linearGradient id="e" x1="0%" x2="100%" y1="100%" y2="0%"><stop offset="0%" stop-color="#b4d2ff" stop-opacity=".16"/><stop offset="80%" stop-color="#fff" stop-opacity=".16"/></linearGradient>

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -863,6 +863,10 @@ class ShellBar extends UI5Element {
 		return !!this.profile.length;
 	}
 
+	get menuBtnTabindex() {
+		return this.menuItems.length > 0 ? "0" : "-1";
+	}
+
 	static async onDefine() {
 		await Promise.all([
 			Button.define(),

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -420,10 +420,14 @@ class ShellBar extends UI5Element {
 		});
 	}
 
-	_coPilotPress(event) {
+	_fireCoPilotClick() {
 		this.fireEvent("coPilotClick", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
 		});
+	}
+
+	_coPilotClick() {
+		this._fireCoPilotClick();
 	}
 
 	_coPilotKeydown(event) {
@@ -431,20 +435,17 @@ class ShellBar extends UI5Element {
 			this.coPilotActive = true;
 			event.preventDefault();
 			return;
-		} 
+		}
 
 		if (isEnter(event)) {
 			this.coPilotActive = true;
-			this.fireEvent("coPilotClick", {
-				targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
-			});
+			this._fireCoPilotClick();
 		}
 	}
+
 	_coPilotKeyup(event) {
 		if (isSpace(event)) {
-			this.fireEvent("coPilotClick", {
-				targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
-			});
+			this._fireCoPilotClick();
 		}
 		this.coPilotActive = false;
 	}

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -381,12 +381,13 @@ class ShellBar extends UI5Element {
 		});
 
 		this._header = {
-			press: event => {
+			press: async () => {
 				this._updateClonedMenuItems();
 
 				if (this.menuItems.length) {
 					this.updateStaticAreaItemContentDensity();
-					this.menuPopover.openBy(this.shadowRoot.querySelector(".ui5-shellbar-menu-button"));
+					const menuPopover = await this._getMenuPopover();
+					menuPopover.openBy(this.shadowRoot.querySelector(".ui5-shellbar-menu-button"));
 				}
 			},
 		};
@@ -738,6 +739,11 @@ class ShellBar extends UI5Element {
 		const staticAreaItem = await this.getStaticAreaItemDomRef();
 		this.overflowPopover = staticAreaItem.querySelector(".ui5-shellbar-overflow-popover");
 		this.menuPopover = staticAreaItem.querySelector(".ui5-shellbar-menu-popover");
+	}
+
+	async _getMenuPopover() {
+		const staticAreaItem = await this.getStaticAreaItemDomRef();
+		return staticAreaItem.querySelector(".ui5-shellbar-menu-popover");
 	}
 
 	isIconHidden(name) {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -5,6 +5,7 @@ import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
+import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
@@ -116,6 +117,10 @@ const metadata = {
 		 * @private
 		 */
 		showSearchField: {
+			type: Boolean,
+		},
+
+		coPilotActive: {
 			type: Boolean,
 		},
 
@@ -419,6 +424,29 @@ class ShellBar extends UI5Element {
 		this.fireEvent("coPilotClick", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
 		});
+	}
+
+	_coPilotKeydown(event) {
+		if (isSpace(event)) {
+			this.coPilotActive = true;
+			event.preventDefault();
+			return;
+		} 
+
+		if (isEnter(event)) {
+			this.coPilotActive = true;
+			this.fireEvent("coPilotClick", {
+				targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
+			});
+		}
+	}
+	_coPilotKeyup(event) {
+		if (isSpace(event)) {
+			this.fireEvent("coPilotClick", {
+				targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
+			});
+		}
+		this.coPilotActive = false;
 	}
 
 	onBeforeRendering() {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -4,12 +4,11 @@ import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.j
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
-import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
-import Icon from "@ui5/webcomponents/dist/Icon.js";
+import Button from "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents-icons/dist/icons/search.js";
 import "@ui5/webcomponents-icons/dist/icons/bell.js";
 import "@ui5/webcomponents-icons/dist/icons/overflow.js";
@@ -541,12 +540,6 @@ class ShellBar extends UI5Element {
 		this.overflowPopover.openBy(overflowButton);
 	}
 
-	_onkeydown(event) {
-		if (isSpace(event)) {
-			event.preventDefault();
-		}
-	}
-
 	onEnterDOM() {
 		ResizeHandler.register(this, this._handleResize);
 	}
@@ -644,7 +637,6 @@ class ShellBar extends UI5Element {
 				style: `order: ${this.searchField.length ? 1 : -10}`,
 				id: `${this._id}-item-${1}`,
 				press: this._handleSearchIconPress.bind(this),
-				_tabIndex: "-1",
 			},
 			...this.items.map((item, index) => {
 				return {
@@ -659,7 +651,6 @@ class ShellBar extends UI5Element {
 					style: `order: ${2}`,
 					show: true,
 					press: this._handleCustomActionPress.bind(this),
-					_tabIndex: "0",
 					custom: true,
 				};
 			}),
@@ -673,7 +664,6 @@ class ShellBar extends UI5Element {
 				show: this.showNotifications,
 				domOrder: this.showNotifications ? (++domOrder) : -1,
 				press: this._handleNotificationsPress.bind(this),
-				_tabIndex: "-1",
 			},
 			{
 				icon: "overflow",
@@ -685,7 +675,6 @@ class ShellBar extends UI5Element {
 				domOrder: showOverflowButton ? (++domOrder) : -1,
 				id: `${this.id}-item-${5}`,
 				press: this._handleOverflowPress.bind(this),
-				_tabIndex: "-1",
 				show: true,
 			},
 			{
@@ -698,7 +687,6 @@ class ShellBar extends UI5Element {
 				domOrder: this.hasProfile ? (++domOrder) : -1,
 				show: this.hasProfile,
 				press: this._handleProfilePress.bind(this),
-				_tabIndex: "-1",
 			},
 			{
 				icon: "grid",
@@ -710,7 +698,6 @@ class ShellBar extends UI5Element {
 				show: this.showProductSwitch,
 				domOrder: this.showProductSwitch ? (++domOrder) : -1,
 				press: this._handleProductSwitchPress.bind(this),
-				_tabIndex: "-1",
 			},
 		];
 		return items;
@@ -843,7 +830,7 @@ class ShellBar extends UI5Element {
 
 	static async onDefine() {
 		await Promise.all([
-			Icon.define(),
+			Button.define(),
 			List.define(),
 			Popover.define(),
 			StandardListItem.define(),

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -201,6 +201,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-button {
 	min-width: 2.25rem;
+	width: 2.5rem;
 	font-size: 1rem;
 	padding: .625rem;
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -377,6 +377,33 @@ ui5-icon[data-count]::before {
 }
 
 
+.ui5-shellbar-copilot-wrapper {
+	position: relative;
+	outline: none;
+	box-sizing: border-box;
+}
+
+.ui5-shellbar-copilot-wrapper:hover {
+	background: var(--sapShell_Hover_Background);
+}
+
+.ui5-shellbar-copilot-wrapper:active,
+.ui5-shellbar-copilot-wrapper[active] {
+	background: var(--sapShell_Active_Background);
+}
+
+.ui5-shellbar-copilot-wrapper:focus::after {
+	content: "";
+	position: absolute;
+	width: 100%;
+	height: calc(100% - 0.75rem);
+	border: 1px dotted var(--sapContent_ContrastFocusColor);
+	pointer-events: none;
+	left: 0;
+	top: 0.25rem;
+	z-index: 1;
+}
+
 .ui5-shellbar-co-pilot-placeholder {
 	width: 2.75rem;
 	height: 2.75rem;

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -36,6 +36,7 @@
 }
 
 .ui5-shellbar-menu-button,
+.ui5-shellbar-button,
 ::slotted(ui5-button[slot="startButton"]) {
 	outline: none;
 }
@@ -49,7 +50,7 @@
 
 ::slotted(ui5-button[slot="startButton"][active]),
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:active,
-.ui5-shellbar-button:active,
+.ui5-shellbar-button[active],
 .ui5-shellbar-image-button:active {
 	background: var(--sapShell_Active_Background);
 	color: var(--sapShell_Active_TextColor);
@@ -57,7 +58,7 @@
 
 ::slotted(ui5-button[slot="startButton"][focused])::after,
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:focus::after,
-.ui5-shellbar-button:focus::after,
+.ui5-shellbar-button[focused]::after,
 .ui5-shellbar-image-button:focus::after {
 	content: "";
 	position: absolute;
@@ -80,6 +81,7 @@ slot[name="profile"] {
 	height: 2.25rem;
 	padding: .25rem;
 	background-color: transparent;
+	pointer-events: none;
 }
 
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive::-moz-focus-inner {
@@ -200,10 +202,7 @@ slot[name="profile"] {
 }
 
 .ui5-shellbar-button {
-	min-width: 2.25rem;
 	width: 2.5rem;
-	font-size: 1rem;
-	padding: .625rem;
 }
 
 .ui5-shellbar-image-buttonImage {
@@ -420,4 +419,8 @@ ui5-icon[data-count]::before {
 	margin-left: 0;
 	justify-content: center;
 	align-items: center;
+}
+
+::slotted(ui5-button[profile-btn]) {
+	width: auto;
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -24,8 +24,8 @@
 	padding: 0;
 	margin-left: 0.5rem;
 	border: none;
-	outline: none;
 	background: transparent;
+	outline-color:  var(--sapShell_TextColor);
 	color: var(--sapShell_TextColor);
 	box-sizing: border-box;
 	cursor: pointer;
@@ -33,6 +33,11 @@
 	position: relative;
 	font-size: 0.75rem;
 	font-weight: bold;
+}
+
+.ui5-shellbar-menu-button,
+::slotted(ui5-button[slot="startButton"]) {
+	outline: none;
 }
 
 ::slotted(ui5-button[slot="startButton"]:hover),

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -25,7 +25,7 @@
 	margin-left: 0.5rem;
 	border: none;
 	background: transparent;
-	outline-color:  var(--sapShell_TextColor);
+	outline-color: var(--sapShell_TextColor);
 	color: var(--sapShell_TextColor);
 	box-sizing: border-box;
 	cursor: pointer;

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -242,7 +242,7 @@ describe("Component Behavior", () => {
 			});
 
 			it("tests profilePress event", () => {
-				const profileIcon = browser.$("#shellbar").$("ui5-avatar");
+				const profileIcon = browser.$("#shellbar").shadow$("[profile-btn]");
 				const input = browser.$("#press-input");
 
 				profileIcon.click();
@@ -345,7 +345,7 @@ describe("Component Behavior", () => {
 			});
 
 			it("tests profilePress event", () => {
-				const profileIcon = browser.$("#shellbar").$("ui5-avatar");
+				const profileIcon = browser.$("#shellbar").shadow$("[profile-btn]");
 				const input = browser.$("#press-input");
 
 				profileIcon.click();

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -1,6 +1,27 @@
 
 const assert = require("chai").assert;
 
+const getOverflowPopover = id => {
+	const staticAreaItemClassName = browser.getStaticAreaItemClassName(`#${id}`);
+	return browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
+}
+
+const getOverflowChildProp = (id, pos, prop) => {
+	const popover = getOverflowPopover(id);
+
+	return browser.execute((popover, pos, prop) => {
+		return popover.querySelectorAll("ui5-li")[pos].getAttribute(prop);
+	}, popover, pos, prop);
+}
+
+const getCustomActionProp = (id, pos, prop) => {
+	const shellbar = browser.$(`#${id}`);
+
+	return browser.execute((shellbar, pos, prop) => {
+		return shellbar.shadowRoot.querySelectorAll(".ui5-shellbar-custom-item")[pos].getAttribute(prop);
+	}, shellbar, pos, prop);
+}
+
 describe("Component Behavior", () => {
 	browser.url("http://localhost:8081/test-resources/pages/ShellBar.html");
 
@@ -25,7 +46,7 @@ describe("Component Behavior", () => {
 			const primaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-menu-button-title");
 			const secondaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-secondary-title");
 			const searchIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
-			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:first-child");
+			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item");
 			const customActionIcon2 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:nth-child(2)");
 			const notificationsIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 			const profileIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-image-button");
@@ -62,7 +83,7 @@ describe("Component Behavior", () => {
 			const primaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-menu-button-title");
 			const secondaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-secondary-title");
 			const searchIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
-			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:first-child");
+			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item");
 			const customActionIcon2 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:nth-child(2)");
 			const notificationsIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 			const profileIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-image-button");
@@ -85,21 +106,20 @@ describe("Component Behavior", () => {
 			browser.setWindowSize(870, 1080);
 
 			const shellbar = browser.$("#shellbar");
-			const shellbarWrapper = browser.$("#shellbar").shadow$("div");
 			const overflowButton = browser.$("#shellbar").shadow$(".ui5-shellbar-overflow-button");
 			const backButton = browser.$("#shellbar ui5-button[slot='startButton'");
 			const primaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-menu-button-title");
 			const secondaryTitle = browser.$("#shellbar").shadow$(".ui5-shellbar-secondary-title");
 			const searchIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
-			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:first-child");
+			const customActionIcon1 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item");
 			const customActionIcon2 = browser.$("#shellbar").shadow$(".ui5-shellbar-custom-item:nth-child(2)");
 			const notificationsIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 			const profileIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-image-button");
 			const productSwitchIcon = browser.$("#shellbar").shadow$(".ui5-shellbar-button-product-switch");
-			const staticAreaItemClassName = browser.getStaticAreaItemClassName("#shellbar")
-			const overflowPopover = browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
-			const overflowPopoverItem1 = browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover ui5-li:first-child");
-			const overflowPopoverItem2 = browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover ui5-li:nth-child(2)");
+
+			const overflowPopover =  getOverflowPopover("shellbar");
+			const overflowPopoverItem1Icon = getOverflowChildProp("shellbar", 0, "icon");
+			const overflowPopoverItem2Icon = getOverflowChildProp("shellbar", 1, "icon");
 
 			overflowButton.click();
 
@@ -118,9 +138,8 @@ describe("Component Behavior", () => {
 			assert.strictEqual(productSwitchIcon.isDisplayed(), true, "Product switch should be visible");
 			assert.strictEqual(overflowPopover.isDisplayedInViewport(), true, "Overflow popover should be visible");
 			assert.strictEqual(listItemsCount, 2, "2 actions should overflow");
-			assert.strictEqual(overflowPopoverItem1.getProperty("icon"), customActionIcon1.getProperty("name"), "Popover items have same sources as corresponding icons");
-			assert.strictEqual(overflowPopoverItem2.getProperty("icon"), customActionIcon2.getProperty("name"), "Popover items have same sources as corresponding icons");
-
+			assert.strictEqual(overflowPopoverItem1Icon, getCustomActionProp("shellbar", 0, "name"), "Popover items have same sources as corresponding icons", overflowPopoverItem1Icon);
+			assert.strictEqual(overflowPopoverItem2Icon, getCustomActionProp("shellbar", 1, "name"), "Popover items have same sources as corresponding icons", overflowPopoverItem2Icon);
 		});
 
 		it("tests M Breakpoint and overflow 780px", () => {

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -28,9 +28,9 @@ describe("Component Behavior", () => {
 	describe("ui5-shellbar-item", () => {
 		it("tests count property", () => {
 			const shellbar = browser.$("#shellbarwithitems");
-			const icon = shellbar.shadow$("ui5-icon[data-count]");
+			const icon = shellbar.shadow$("ui5-button[data-count]");
 
-			assert.strictEqual(icon.getAttribute("data-count"), '42', "Count property propagates to ui5-icon");
+			assert.strictEqual(icon.getAttribute("data-count"), '42', "Count property propagates to ui5-button");
 		})
 	});
 
@@ -138,8 +138,8 @@ describe("Component Behavior", () => {
 			assert.strictEqual(productSwitchIcon.isDisplayed(), true, "Product switch should be visible");
 			assert.strictEqual(overflowPopover.isDisplayedInViewport(), true, "Overflow popover should be visible");
 			assert.strictEqual(listItemsCount, 2, "2 actions should overflow");
-			assert.strictEqual(overflowPopoverItem1Icon, getCustomActionProp("shellbar", 0, "name"), "Popover items have same sources as corresponding icons", overflowPopoverItem1Icon);
-			assert.strictEqual(overflowPopoverItem2Icon, getCustomActionProp("shellbar", 1, "name"), "Popover items have same sources as corresponding icons", overflowPopoverItem2Icon);
+			assert.strictEqual(overflowPopoverItem1Icon, getCustomActionProp("shellbar", 0, "icon"), "Popover items have same sources as corresponding icons", overflowPopoverItem1Icon);
+			assert.strictEqual(overflowPopoverItem2Icon, getCustomActionProp("shellbar", 1, "icon"), "Popover items have same sources as corresponding icons", overflowPopoverItem2Icon);
 		});
 
 		it("tests M Breakpoint and overflow 780px", () => {


### PR DESCRIPTION
**Fixes**
- Enable moving between all focusable items in she ShellBar with TAB and SHIFT + TAB
- all actions can be now triggered with SPACE or ENTER

**Background**
All ui5-icon elements now become ui5-button, the ui5-button has tabindex=0 and also can be triggered with SPACE and ENTER. To ensure the correct tab order, the layout of the items is changed in such way that their DOM order is the same as their display order.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15702139/79138807-cf64c480-7dbd-11ea-973e-c0ed24a583f3.gif)

Fixes: https://github.com/SAP/ui5-webcomponents/issues/860
