### PR TITLE
fix(ui5-dialog): improve accessibility

### DIFF
--- a/packages/main/src/Dialog.hbs
+++ b/packages/main/src/Dialog.hbs
@@ -1,9 +1,9 @@
 {{>include "./Popup.hbs"}}
 
-<div class="ui5-popup-frame" @focusin="{{_onfocusin}}">
+<span class="ui5-popup-frame" @focusin="{{_onfocusin}}">
 	<span id="{{_id}}-firstfe" tabindex="0"></span>
 	<div style="{{zindex}}" class="ui5-dialog-root-parent {{classes.dialogParent}}">
-		<div tabindex="-1" aria-labelledby="{{headerAriaLabelledBy}}" role="dialog" aria-modal="true" class="ui5-popup-root ui5-dialog-root {{classes.dialogParent}}">
+		<section tabindex="-1" aria-labelledby="{{headerAriaLabelledBy}}" role="dialog" aria-modal="true" class="ui5-popup-root ui5-dialog-root {{classes.dialogParent}}">
 			{{> header}}
 			<section class="ui5-dialog-section">
 				<div class="ui5-popup-content">
@@ -13,8 +13,8 @@
 				</div>
 			</section>
 			{{> footer}}
-		</div>
+		</section>
 	</div>
 	<span id="{{_id}}-lastfe" tabindex="0"></span>
 	<div tabindex="0" id="{{_id}}-blocklayer" style="{{blockLayer}}" class="{{classes.blockLayer}}"></div>
-</div>
+</span>

--- a/packages/main/src/Dialog.hbs
+++ b/packages/main/src/Dialog.hbs
@@ -1,6 +1,6 @@
 {{>include "./Popup.hbs"}}
 
-<span class="ui5-popup-frame" @focusin="{{_onfocusin}}">
+<div class="ui5-popup-frame" @focusin="{{_onfocusin}}">
 	<span id="{{_id}}-firstfe" tabindex="0"></span>
 	<div style="{{zindex}}" class="ui5-dialog-root-parent {{classes.dialogParent}}">
 		<div tabindex="-1" aria-labelledby="{{headerAriaLabelledBy}}" role="dialog" aria-modal="true" class="ui5-popup-root ui5-dialog-root {{classes.dialogParent}}">
@@ -17,4 +17,4 @@
 	</div>
 	<span id="{{_id}}-lastfe" tabindex="0"></span>
 	<div tabindex="0" id="{{_id}}-blocklayer" style="{{blockLayer}}" class="{{classes.blockLayer}}"></div>
-</span>
+</div>

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -6,7 +6,7 @@
 					<slot name="header"></slot>
 				</div>
 			{{else}}
-				<h2 id="{{_id}}-popup-heading" role="{{role}}" class="ui5-popup-header ui5-popup-headerText">{{headerText}}</h2>
+				<h2 id="{{_id}}-popup-heading" class="ui5-popup-header ui5-popup-headerText">{{headerText}}</h2>
 			{{/if}}
 		</header>
 	{{/if}}
@@ -15,7 +15,7 @@
 {{#*inline "footer"}}
 	{{#if hasFooter}}
 		<footer>
-			<div class="ui5-popup-footer">
+			<div class="ui5-popup-footer" role="toolbar">
 				<slot name="footer"></slot>
 			</div>
 		</footer>


### PR DESCRIPTION
The footer was missing its role="toolbar" attribute, the "h2" tag does not need a role="heading" and 
change "section" tag  to achieve proper acc landmark for the footer and the header.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1466