### PR TITLE
refactor(ui5-carousel): rework component behaviour

### DIFF
--- a/packages/base/src/delegate/ScrollEnablement.js
+++ b/packages/base/src/delegate/ScrollEnablement.js
@@ -107,7 +107,7 @@ class ScrollEnablement extends EventProvider {
 		const container = this._container;
 		const dragX = this.isPhone ? event.pageX : event.x;
 		const dragY = this.isPhone ? event.pageY : event.y;
-
+debugger;
 		container.scrollLeft += this._prevDragX - dragX;
 		container.scrollTop += this._prevDragY - dragY;
 

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -10,7 +10,7 @@
             {{#each pages}}
                 <div class="{{../classes.page}}">
                     {{#each this}}
-                        <div id="carousel-item-{{posinset}}"
+                        <div id="{{id}}"
                              class="ui5-carousel-item"
                              style="width: {{this.width}}%"
                              role="option"

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -58,7 +58,7 @@
                     {{#if isPageTypeDots}}
                         {{#each dots}}
                             <div
-                                role="image"
+                                role="img"
                                 aria-label="{{ariaLabel}}"
                                 ?active="{{active}}"
                                 class="ui5-carousel-navigation-dot"

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -5,20 +5,17 @@
     aria-activedescendant="{{ariaActiveDescendant}}"
     @keydown={{_onkeydown}}
 >
-    <div class="ui5-carousel-overflow-hidden">
+    <div class="ui5-carousel-viewport">
         <div class="{{classes.content}}" style="{{styles.content}}">
-            {{#each pages}}
-                <div class="{{../classes.page}}">
-                    {{#each this}}
-                        <div id="{{id}}"
-                             class="ui5-carousel-item"
-                             style="width: {{this.width}}%"
-                             role="option"
-                             aria-posinset="{{posinset}}"
-                             aria-setsize="{{setsize}}">
-                            <slot name="{{this.item._individualSlot}}" tabindex="{{this.tabIndex}}"></slot>
-                        </div>
-                    {{/each}}
+            {{#each items}}
+                <div id="{{id}}"
+                    class="ui5-carousel-item"
+                    style="width: {{this.width}}px; visibility: {{visible}}"
+                    role="option"
+                    aria-posinset="{{posinset}}"
+                    aria-setsize="{{setsize}}"
+                    >
+                    <slot name="{{this.item._individualSlot}}" tabindex="{{this.tabIndex}}"></slot>
                 </div>
             {{/each}}
         </div>
@@ -26,14 +23,14 @@
         {{#if arrows.content}}
             <div class="ui5-carousel-navigation-arrows">
                 <ui5-button
-                    class="ui5-carousel-navigation-button"
+                    class="ui5-carousel-navigation-button {{classes.navPrevButton}}"
                     icon="slim-arrow-left"
                     tabindex="-1"
                     @click={{navigateLeft}}
                     @keydown={{_onbuttonkeydown}}
                 ></ui5-button>
                 <ui5-button
-                    class="ui5-carousel-navigation-button"
+                    class="ui5-carousel-navigation-button {{classes.navNextButton}}"
                     icon="slim-arrow-right"
                     tabindex="-1"
                     @click={{navigateRight}}
@@ -46,7 +43,7 @@
             <div class="{{classes.navigation}}">
                 {{#if arrows.navigation}}
                 <ui5-button
-                    class="ui5-carousel-navigation-button"
+                    class="ui5-carousel-navigation-button {{classes.navPrevButton}}"
                     icon="slim-arrow-left"
                     tabindex="-1"
                     @click={{navigateLeft}}
@@ -65,13 +62,14 @@
                             ></div>
                         {{/each}}
                     {{else}}
-                        <ui5-label>{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pages.length}}</ui5-label>
+                        <ui5-label>{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pagesCount}}</ui5-label>
                     {{/if}}
                 </div>
 
                 {{#if arrows.navigation}}
                     <ui5-button
-                        class="ui5-carousel-navigation-button"
+                        class="ui5-carousel-navigation-button {{classes.navNextButton}}"
+                        style="visibility: "
                         icon="slim-arrow-right"
                         tabindex="-1"
                         @click={{navigateRight}}

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -1,6 +1,8 @@
 <section
     class="ui5-carousel-root"
     tabindex="0"
+    role="listbox"
+    aria-activedescendant="{{ariaActiveDescendant}}"
     @keydown={{_onkeydown}}
 >
     <div class="ui5-carousel-overflow-hidden">
@@ -8,7 +10,12 @@
             {{#each pages}}
                 <div class="{{../classes.page}}">
                     {{#each this}}
-                        <div class="ui5-carousel-item" style="width: {{this.width}}%">
+                        <div id="carousel-item-{{posinset}}"
+                             class="ui5-carousel-item"
+                             style="width: {{this.width}}%"
+                             role="option"
+                             aria-posinset="{{posinset}}"
+                             aria-setsize="{{setsize}}">
                             <slot name="{{this.item._individualSlot}}" tabindex="{{this.tabIndex}}"></slot>
                         </div>
                     {{/each}}
@@ -51,7 +58,9 @@
                     {{#if isPageTypeDots}}
                         {{#each dots}}
                             <div
-                                ?active="{{this.active}}"
+                                role="image"
+                                aria-label="{{ariaLabel}}"
+                                ?active="{{active}}"
                                 class="ui5-carousel-navigation-dot"
                             ></div>
                         {{/each}}

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -70,7 +70,6 @@
                 {{#if arrows.navigation}}
                     <ui5-button
                         class="ui5-carousel-navigation-button {{classes.navNextButton}}"
-                        style="visibility: "
                         icon="slim-arrow-right"
                         tabindex="-1"
                         @click={{navigateRight}}

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -14,7 +14,7 @@
                     role="option"
                     aria-posinset="{{posinset}}"
                     aria-setsize="{{setsize}}"
-                    >
+                >
                     <slot name="{{this.item._individualSlot}}" tabindex="{{this.tabIndex}}"></slot>
                 </div>
             {{/each}}

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -302,10 +302,12 @@ class Carousel extends UI5Element {
 			for (let itemIdx = 0; itemIdx < this.effectiveItemsPerPage; itemIdx++) {
 				const item = this.content[(pageIdx * this.effectiveItemsPerPage) + itemIdx];
 				if (item) {
+					const posinset = pageIdx * this.effectiveItemsPerPage + itemIdx + 1;
 					result[pageIdx].push({
+						id: `${this._id}-carousel-item-${posinset}`,
 						item,
 						tabIndex: pageIdx === this.selectedIndex ? "0" : "-1",
-						posinset: pageIdx * this.effectiveItemsPerPage + itemIdx + 1,
+						posinset,
 						setsize: this.content.length,
 					});
 				}
@@ -394,7 +396,7 @@ class Carousel extends UI5Element {
 	}
 
 	get ariaActiveDescendant() {
-		return this.content.length ? `carousel-item-${(this.selectedIndex * this.effectiveItemsPerPage) + 1}` : undefined;
+		return this.content.length ? `${this._id}-carousel-item-${(this.selectedIndex * this.effectiveItemsPerPage) + 1}` : undefined;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -218,6 +218,7 @@ class Carousel extends UI5Element {
 
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 		this._onResizeBound = this._onResize.bind(this);
+		this._resizing = false; // indicates if the carousel is in process of resizing
 	}
 
 	onBeforeRendering() {
@@ -226,6 +227,7 @@ class Carousel extends UI5Element {
 
 	onAfterRendering() {
 		this._scrollEnablement.scrollContainer = this.getDomRef();
+		this._resizing = false; // not invalidating
 	}
 
 	onEnterDOM() {
@@ -246,9 +248,11 @@ class Carousel extends UI5Element {
 	_onResize() {
 		const previousItemsPerPage = this.effectiveItemsPerPage;
 
+		// Set the resizing flag to suppress animation while resizing
+		this._resizing = true;
+
 		// Change transitively effectiveItemsPerPage by modifying _width
 		this._width = this.offsetWidth;
-
 		this._itemWidth = Math.floor(this._width / this.effectiveItemsPerPage);
 
 		// Items per page did not change or the current,
@@ -359,7 +363,7 @@ class Carousel extends UI5Element {
 			},
 			content: {
 				"ui5-carousel-content": true,
-				"ui5-carousel-content-no-animation": this.shouldAnimate,
+				"ui5-carousel-content-no-animation": this.supressAimation,
 				"ui5-carousel-content-has-navigation": this.showNavigationArrows,
 				"ui5-carousel-content-has-navigation-and-buttons": this.showNavigationArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation,
 			},
@@ -416,8 +420,8 @@ class Carousel extends UI5Element {
 		return this.cyclic || this.selectedIndex + 1 <= this.pagesCount - 1;
 	}
 
-	get shouldAnimate() {
-		return getAnimationMode() === AnimationMode.None;
+	get supressAimation() {
+		return this._resizing || getAnimationMode() === AnimationMode.None;
 	}
 
 	get selectedIndexToShow() {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -220,6 +220,10 @@ class Carousel extends UI5Element {
 		this._onResizeBound = this._onResize.bind(this);
 	}
 
+	onBeforeRendering() {
+		this.validateSelectedIndex();
+	}
+
 	onAfterRendering() {
 		this._scrollEnablement.scrollContainer = this.getDomRef();
 	}
@@ -232,9 +236,15 @@ class Carousel extends UI5Element {
 		ResizeHandler.deregister(this, this._onResizeBound);
 	}
 
+	validateSelectedIndex() {
+		if (!this.isIndexInRange(this.selectedIndex)) {
+			this.selectedIndex = 0;
+			console.warn(`The "selectedIndex" is out of range, changed to: ${0}`); // eslint-disable-line
+		}
+	}
+
 	_onResize() {
-		const oldItemsPerPage = this.effectiveItemsPerPage;
-		const oldPagesCount = this.pagesCount;
+		const previousItemsPerPage = this.effectiveItemsPerPage;
 
 		// Change transitively effectiveItemsPerPage by modifying _width
 		this._width = this.offsetWidth;
@@ -243,18 +253,13 @@ class Carousel extends UI5Element {
 
 		// Items per page did not change or the current,
 		// therefore page index does not need to be re-adjusted
-		if (this.effectiveItemsPerPage === oldItemsPerPage) {
+		if (this.effectiveItemsPerPage === previousItemsPerPage) {
 			return;
 		}
 
-		if (this.selectedIndex !== oldPagesCount - 1) {
-			return;
+		if (this.selectedIndex > this.pagesCount - 1) {
+			this.selectedIndex = this.pagesCount - 1;
 		}
-
-		// We need to adjust the index, when the last index was selected:
-		// (1) transition from more pages towards less pages (decrease with the difference of old and new page number)
-		// (2) transition from less pages towards more pages (increase with the difference of old and new page number)
-		this.selectedIndex = this.selectedIndex + this.pagesCount - oldPagesCount;
 	}
 
 	_updateScrolling(event) {
@@ -333,6 +338,10 @@ class Carousel extends UI5Element {
 
 	isItemInViewport(index) {
 		return index >= this.selectedIndex && index <= this.selectedIndex + this.effectiveItemsPerPage - 1;
+	}
+
+	isIndexInRange(index) {
+		return index >= 0 && index <= this.pagesCount - 1;
 	}
 
 	get styles() {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -18,6 +18,7 @@ import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import {
 	CAROUSEL_OF_TEXT,
+	CAROUSEL_DOT_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
 import CarouselArrowsPlacement from "./types/CarouselArrowsPlacement.js";
 import CarouselTemplate from "./generated/templates/CarouselTemplate.lit.js";
@@ -304,6 +305,8 @@ class Carousel extends UI5Element {
 					result[pageIdx].push({
 						item,
 						tabIndex: pageIdx === this.selectedIndex ? "0" : "-1",
+						posinset: pageIdx * this.effectiveItemsPerPage + itemIdx + 1,
+						setsize: this.content.length,
 					});
 				}
 			}
@@ -364,6 +367,7 @@ class Carousel extends UI5Element {
 		return this.pages.map((item, index) => {
 			return {
 				active: index === this.selectedIndex,
+				ariaLabel: this.i18nBundle.getText(CAROUSEL_DOT_TEXT, [index + 1], [this.pages.length]),
 			};
 		});
 	}
@@ -387,6 +391,10 @@ class Carousel extends UI5Element {
 
 	get showNavigationArrows() {
 		return !this.hideNavigation && this.pages.length > 1;
+	}
+
+	get ariaActiveDescendant() {
+		return this.content.length ? `carousel-item-${(this.selectedIndex * this.effectiveItemsPerPage) + 1}` : undefined;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -37,6 +37,9 @@ DATEPICKER_DATE_ACC_TEXT=Date
 # Carousel of text
 CAROUSEL_OF_TEXT=of
 
+#Carousel dots text
+CAROUSEL_DOT_TEXT=Item {0} of {1} displayed
+
 #XACT: DatePicker 'Open Picker' icon title
 DATEPICKER_OPEN_ICON_TITLE=Open Picker
 

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -20,37 +20,25 @@
     align-items: center;
 }
 
-.ui5-carousel-overflow-hidden {
+.ui5-carousel-viewport {
     width: 100%;
     height: inherit;
     position: relative;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     overflow: hidden;
 }
 
-.ui5-carousel-navigation-arrows {
-    width: 100%;
-    padding: 0 .5rem;
-    position: absolute;
-    top: calc(50% - 2.5rem);
-    display: flex;
-    justify-content: space-between;
-    box-sizing: border-box;
-}
-
-
 .ui5-carousel-content {
-    width: 100%;
     height: 100%;
     position: relative;
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     background: var(--sapBackgroundColor);
-	transition: transform 0.5s cubic-bezier(.46, 0, .44, 1);
-	will-change: transform;
+    transition: transform 0.5s cubic-bezier(.46, 0, .44, 1);
+    will-change: transform;
 }
 
 .ui5-carousel-content.ui5-carousel-content-no-animation {
@@ -65,39 +53,25 @@
     height: calc(100% - 3.5rem);
 }
 
-.ui5-carousel-page {
-    width: 100%;
-    padding: 0 3rem;
-    flex: 0 0 auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-}
-
-.ui5-carousel-page-multiple {
-    justify-content: space-around;
-}
-
 .ui5-carousel-item {
     height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-right: 1.25rem;
+    padding: 0 1rem;
+    box-sizing: border-box;
+    transition: visibility 0.5s linear;
+    will-change: visibility;
 }
 
-.ui5-carousel-item:last-child {
-    margin-right: 0;
-}
-
-.ui5-carousel-navigation-button {
-    width: var(--ui5_carousel_button_size);
-    height: var(--ui5_carousel_button_size);
-    border-radius: 50%;
-    box-shadow: var(--sapContent_Shadow1);
-    cursor: pointer;
-    outline-offset: .1rem;
+.ui5-carousel-navigation-arrows {
+    width: 100%;
+    padding: 0 1.5rem;
+    position: absolute;
+    top: calc(50% - 2.5rem);
+    display: flex;
+    justify-content: space-between;
+    box-sizing: border-box;
 }
 
 .ui5-carousel-navigation-wrapper {
@@ -113,6 +87,19 @@
 
 .ui5-carousel-navigation-wrapper.ui5-carousel-navigation-with-buttons {
     height: 3.5rem;
+}
+
+.ui5-carousel-navigation-button {
+    width: var(--ui5_carousel_button_size);
+    height: var(--ui5_carousel_button_size);
+    border-radius: 50%;
+    box-shadow: var(--sapContent_Shadow1);
+    cursor: pointer;
+    outline-offset: .1rem;
+}
+
+.ui5-carousel-navigation-button--hidden {
+    visibility: hidden;
 }
 
 .ui5-carousel-navigation {

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -77,6 +77,7 @@
     padding:0 1.5rem;
     position: absolute;
     top: calc(50% - 2.5rem);
+    left: 0;
     display: flex;
     justify-content: space-between;
     box-sizing: border-box;

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -28,7 +28,7 @@
 <ui5-carousel items-per-page-s="3" items-per-page-m="3" items-per-page-l="3">
     <ui5-card
             id="card"
-            status="4 of 10"
+            status="1 of 11"
             heading="Quick Links"
             subheading="quick links"
             header-interactive
@@ -44,7 +44,7 @@
 
     <ui5-card
             id="card2"
-            status="4 of 10"
+            status="2 of 11"
             heading="Quick Links"
             subheading="quick links"
             class="myCard">
@@ -55,7 +55,7 @@
         </ui5-list>
     </ui5-card>
 
-    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+    <ui5-card heading="Quick Links" status="3 of 11" subheading="quick links" class="myCard">
         <ui5-list id="myList3" separators="Inner">
             <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
             <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
@@ -64,7 +64,7 @@
 
     <ui5-card
             id="card"
-            status="4 of 10"
+            status="4 of 11"
             heading="Quick Links"
             subheading="quick links"
             header-interactive
@@ -80,7 +80,7 @@
 
     <ui5-card
             id="card2"
-            status="4 of 10"
+            status="5 of 11"
             heading="Quick Links"
             subheading="quick links"
             class="myCard">
@@ -91,7 +91,7 @@
         </ui5-list>
     </ui5-card>
 
-    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+    <ui5-card heading="Quick Links" status="6 of 11" subheading="quick links" class="myCard">
         <ui5-list id="myList3" separators="Inner">
             <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
             <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
@@ -100,7 +100,7 @@
 
     <ui5-card
             id="card"
-            status="4 of 10"
+            status="7 of 11"
             heading="Quick Links"
             subheading="quick links"
             header-interactive
@@ -116,7 +116,7 @@
 
     <ui5-card
             id="card2"
-            status="4 of 10"
+            status="8 of 11"
             heading="Quick Links"
             subheading="quick links"
             class="myCard">
@@ -127,7 +127,7 @@
         </ui5-list>
     </ui5-card>
 
-    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+    <ui5-card heading="Quick Links" status="9 of 11" subheading="quick links" class="myCard">
         <ui5-list id="myList3" separators="Inner">
             <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
             <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
@@ -136,7 +136,7 @@
 
     <ui5-card
             id="card2"
-            status="4 of 10"
+            status="10 of 11"
             heading="Quick Links"
             subheading="quick links"
             class="myCard">
@@ -147,7 +147,7 @@
         </ui5-list>
     </ui5-card>
 
-    <ui5-card heading="Quick Links" subheading="quick links" class="myCard">
+    <ui5-card heading="Quick Links" status="11 of 11" subheading="quick links" class="myCard">
         <ui5-list id="myList3" separators="Inner">
             <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
             <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
@@ -286,6 +286,109 @@
         </ui5-list>
     </ui5-card>
 
+</ui5-carousel>
+
+<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
+    <ui5-card
+            id="card"
+            status="1 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="2 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="3 of 8" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="4 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="5 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card heading="Quick Links" status="6 of 8" subheading="quick links" class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
+
+    <ui5-card
+            id="card"
+            status="7 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            header-interactive
+            class="myCard">
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+            <ui5-li icon="line-charts" >Marketing plans</ui5-li>
+        </ui5-list>
+
+        <ui5-input id="field" value="0"></ui5-input>
+    </ui5-card>
+
+    <ui5-card
+            id="card2"
+            status="8 of 8"
+            heading="Quick Links"
+            subheading="quick links"
+            class="myCard">
+        <ui5-icon name="group" slot="avatar"></ui5-icon>
+        <ui5-list id="myList3" separators="Inner">
+            <ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>
+            <ui5-li icon="opportunity" >Segmentation Models</ui5-li>
+        </ui5-list>
+    </ui5-card>
 </ui5-carousel>
 
 

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -471,5 +471,18 @@
 	<ui5-button>Button 3</ui5-button>
 </ui5-carousel>
 
+<ui5-title>Carousel with out of range index</ui5-title>
+<ui5-carousel id="carousel7" items-per-page-s="1" items-per-page-m="4" items-per-page-l="8" selected-index="15">
+	<ui5-button>Button 1</ui5-button>
+	<ui5-button>Button 2</ui5-button>
+	<ui5-button>Button 3</ui5-button>
+	<ui5-button>Button 4</ui5-button>
+	<ui5-button>Button 5</ui5-button>
+	<ui5-button>Button 6</ui5-button>
+	<ui5-button>Button 7</ui5-button>
+	<ui5-button>Button 8</ui5-button>
+	<ui5-button>Button 9</ui5-button>
+</ui5-carousel>
+
 </body>
 </html>

--- a/packages/main/test/samples/Carousel.sample.html
+++ b/packages/main/test/samples/Carousel.sample.html
@@ -31,7 +31,7 @@
 </style>
 
 <section>
-	<h3>Carousel With Images</h3>
+	<h3>Carousel With Single Item per Page</h3>
 
 	<div class="snippet">
 		<ui5-carousel>
@@ -42,25 +42,6 @@
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-carousel>
-	<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
-	<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
-	<img src="../../../assets/images/sample3.jpg" alt="Bulb">
-</ui5-carousel>
-	</xmp></pre>
-</section>
-
-<section>
-	<h3>Carousel With Arrow Placement, SelectedIndex and Cycling</h3>
-
-	<div class="snippet">
-		<ui5-carousel arrows-placement="Navigation" selected-index="2" cyclic>
-			<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
-			<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
-			<img src="../../../assets/images/sample3.jpg" alt="Bulb">
-		</ui5-carousel>
-	</div>
-	<pre class="prettyprint lang-html"><xmp>
-<ui5-carousel arrows-placement="Navigation" selected-index="2" cyclic>
 	<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
 	<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
 	<img src="../../../assets/images/sample3.jpg" alt="Bulb">
@@ -169,6 +150,25 @@
 				</ui5-list>
 			</div>
 		</ui5-card>
+</ui5-carousel>
+	</xmp></pre>
+</section>
+
+<section>
+	<h3>Carousel With Arrow Placement, SelectedIndex and Cyclic</h3>
+
+	<div class="snippet">
+		<ui5-carousel arrows-placement="Navigation" selected-index="2" cyclic>
+			<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
+			<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
+			<img src="../../../assets/images/sample3.jpg" alt="Bulb">
+		</ui5-carousel>
+	</div>
+	<pre class="prettyprint lang-html"><xmp>
+<ui5-carousel arrows-placement="Navigation" selected-index="2" cyclic>
+	<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
+	<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
+	<img src="../../../assets/images/sample3.jpg" alt="Bulb">
 </ui5-carousel>
 	</xmp></pre>
 </section>

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -57,8 +57,8 @@ describe("Carousel general interaction", () => {
 	it("Aria attributes are set", () => {
 		const carousel = browser.$("#carousel5");
 		const ITEMS = "8";
-		const ACTIVEDESCENDANT_PAGE_1 = "carousel-item-1";
-		const ACTIVEDESCENDANT_PAGE_2 = "carousel-item-5";
+		const ACTIVEDESCENDANT_PAGE_1 = `${carousel.getProperty("_id")}-carousel-item-1`;
+		const ACTIVEDESCENDANT_PAGE_2 = `${carousel.getProperty("_id")}-carousel-item-5`;
 
 		// check page indicators ARIA
 		const pageIndicatorDot1 = carousel.shadow$(".ui5-carousel-navigation-dot:first-child");

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -54,6 +54,35 @@ describe("Carousel general interaction", () => {
 		assert.strictEqual(pages, 3, "There are only 3 pages.");
 	});
 
+	it("Aria attributes are set", () => {
+		const carousel = browser.$("#carousel5");
+		const ITEMS = "8";
+		const ACTIVEDESCENDANT_PAGE_1 = "carousel-item-1";
+		const ACTIVEDESCENDANT_PAGE_2 = "carousel-item-5";
+
+		// check page indicators ARIA
+		const pageIndicatorDot1 = carousel.shadow$(".ui5-carousel-navigation-dot:first-child");
+		const pageIndicatorDot2 = carousel.shadow$(".ui5-carousel-navigation-dot:nth-child(2)");
+		assert.strictEqual(pageIndicatorDot1.getAttribute("aria-label"), "Item 1 of 2 displayed", "The aria-label of page indicator is correct.");
+		assert.strictEqual(pageIndicatorDot2.getAttribute("aria-label"), "Item 2 of 2 displayed", "The aria-label of page indicator is correct.");
+
+		// check random carousel items ARIA
+		const carouselItem3 = carousel.shadow$(".ui5-carousel-item:nth-child(3)");
+		const carouselItem4 = carousel.shadow$(".ui5-carousel-item:nth-child(4)");
+		assert.strictEqual(carouselItem3.getAttribute("aria-posinset"), "3", "The aria-posinset of carousel item is correct.");
+		assert.strictEqual(carouselItem3.getAttribute("aria-setsize"), ITEMS, "The aria-setsize of carousel item  is correct.");
+		assert.strictEqual(carouselItem4.getAttribute("aria-posinset"), "4", "The aria-posinset of carousel item is correct.");
+		assert.strictEqual(carouselItem4.getAttribute("aria-setsize"), ITEMS, "The aria-setsize of carousel item is correct.");
+
+		// check root tag ARIA
+		const carouselRoot = carousel.shadow$(".ui5-carousel-root");
+		assert.strictEqual(carouselRoot.getAttribute("aria-activedescendant"), ACTIVEDESCENDANT_PAGE_1, "The aria-activedescendant of carousel is correct.");
+
+		// check root tag ARIA after navigating to 2nd page
+		carousel.shadow$(".ui5-carousel-navigation-button:nth-child(2)").click();
+		assert.strictEqual(carouselRoot.getAttribute("aria-activedescendant"), ACTIVEDESCENDANT_PAGE_2, "The aria-activedescendant of carousel is correct.");
+	});
+
 	it("Arrows and Dots not displayed in case of single page", () => {
 		const carousel = browser.$("#carousel6");
 		const pages = carousel.getProperty("pages").length;

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -100,4 +100,14 @@ describe("Carousel general interaction", () => {
 		assert.ok(!navigationArrows.isExisting(), "Navigation arrows are not rendered");
 		assert.strictEqual(pages, 1, "There is only 1 page.");
 	});
+
+
+	it("Invalid selectedIndex normalized", () => {
+		const carousel = browser.$("#carousel7");
+		const selectedIndex = carousel.getProperty("selectedIndex");
+		const NORMALIZED_INDEX = 0;
+
+		assert.strictEqual(selectedIndex, NORMALIZED_INDEX,
+			"Although '15' is set, the actual selectedIndex is changed to 0.");
+	});
 });


### PR DESCRIPTION
- [ Refactor ] Previously entire page of items is being moved in and out of the view during navigation. Now, the items are moved in and out the visible area one by one, in other words all the items are shifted to the left and to the right by one.

- [ New Implementation ] Initial accessibility spec is implemented (as in openui5), but can be further improved as it does not handle the multiple items per page case the best way.

- [ Bug Fix ] Previously the navigation arrows were remaining displayed, although no previous or next item is available and pressing the arrows didn't perform any action. Now, the arrows remain hidden if no previous/next item is available to navigate towards.

- [ Bug Fix ] Previously the navigation arrows have been misplaced in IE, making the component not usable at all 
as the next arrow is out of the viewport ([reproduce in IE](https://sap.github.io/ui5-webcomponents/master/playground/main/pages/Carousel/)). Now the arrows are displayed correctly in IE too.

- [ Bug Fix ] Previously setting "selectedIndex" that is out of range brings the component to unacceptable/ broken state. Now, the "selectedIndex" is validated and changed to its default value when not valid.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1277