### PR TITLE
fix(ui5-messagestrip): fix component visual

### DIFF
--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -5,11 +5,11 @@
 	aria-labelledby="{{_id}}">
 
 	{{#unless noIcon}}
-        <div  class="ui5-messagestrip-icon">
+        <div class="ui5-messagestrip-icon-wrapper">
             {{#if iconProvided}}
                 <slot name="icon"></slot>
             {{else}}
-                <ui5-icon name="{{standardIconName}}"></ui5-icon>
+                <ui5-icon name="{{standardIconName}}" class="ui5-messagestrip-icon"></ui5-icon>
             {{/if}}
         </div>
 	{{/unless}}

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -18,7 +18,7 @@
 	position: relative;
 }
 
-.ui5-messagestrip-root .ui5-messagestrip-icon {
+.ui5-messagestrip-root .ui5-messagestrip-icon-wrapper {
 	position: absolute;
 	top: var(--_ui5_messagestrip_icon_top);
 	left: 0.75rem;
@@ -45,13 +45,13 @@
 }
 
 .ui5-messagestrip--info {
-	background-color: var(--sapNeutralBackground);
-	border-color: var(--sapNeutralColor);
+	background-color: var(--sapInformationBackground);
+	border-color: var(--sapInformationBorderColor);
 	color: var(--sapTextColor);
 }
 
 .ui5-messagestrip--info .ui5-messagestrip-icon {
-	color: var(--sapNeutralElementColor);
+	color: var(--sapInformativeElementColor);
 }
 
 .ui5-messagestrip--positive {


### PR DESCRIPTION
- fix type="Information" appearance, by setting the correct variables, previously the "neutral" semantic variables has been used
- fix the icons colours in all types, they used to remain grey (their default color), instead of being in the respective semantic color according to the component type

Before
<img width="539" alt="Screenshot 2020-04-20 at 1 11 50 PM" src="https://user-images.githubusercontent.com/15702139/79740629-ab970680-8308-11ea-8e05-754cc4f6c7b7.png">


After
<img width="539" alt="Screenshot 2020-04-20 at 1 11 40 PM" src="https://user-images.githubusercontent.com/15702139/79740638-afc32400-8308-11ea-825e-0eadab9b9df2.png">


FIXES: https://github.com/SAP/ui5-webcomponents/issues/1496