### PR TITLE
fix(ui5-busyindicator): fix component placement and appearance in IE

### DIFF
--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -11,6 +11,11 @@
 	opacity: 0.6;
 }
 
+/* IE sets opacity 0.6 to busy indicatore internal elements */
+:host([active]) ::slotted([class^="ui5-busyindicator-"]) {
+	opacity: 1;
+}
+
 :host([size="Small"]) .ui5-busyindicator-root {
 	min-width: 1.5em;
 	min-height: .5rem;
@@ -73,6 +78,11 @@
 	justify-content: center;
 	align-items: center;
 	background-color: inherit;
+	/* Fixes IE positioning */
+	left: 0;
+	right: 0;
+	top: 50%;
+	transform: translate(0, -50%);
 }
 
 .circle-animation-0 {

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -7,13 +7,12 @@
 	pointer-events: none;
 }
 
-:host([active]) ::slotted(*) {
+/**
+ * IE fix: using just the "*" all selector in IE,
+ * will set the opacity=0.6 to busy indicator internal elements
+ */
+:host([active]) ::slotted(:not([class^="ui5-busyindicator-"])) {
 	opacity: 0.6;
-}
-
-/* IE sets opacity 0.6 to busy indicatore internal elements */
-:host([active]) ::slotted([class^="ui5-busyindicator-"]) {
-	opacity: 1;
 }
 
 :host([size="Small"]) .ui5-busyindicator-root {


### PR DESCRIPTION
The opacity of 0.6 used to apply to the busy indicator inter elements in IE due to the absence of shadow DOM, also the position of the circles used to be wrong. Both the visual and the placement is now fixed.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1497

Now in IE:
<img width="346" alt="Screenshot 2020-04-21 at 1 58 37 PM" src="https://user-images.githubusercontent.com/15702139/79859138-39422700-83d9-11ea-8cbd-eccf8b4d38ba.png">

Previously in IE:
<img width="331" alt="Screenshot 2020-04-21 at 2 08 17 PM" src="https://user-images.githubusercontent.com/15702139/79859364-90e09280-83d9-11ea-913d-46c4509e19d4.png">

