### PR TITLE
fix(ui5-multi-combobox): fix initial focus on mobile

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -485,6 +485,15 @@ class MultiComboBox extends UI5Element {
 		}
 	}
 
+	_setInitialFocusInResponsivePopover() {
+		this._innerInput.focus();
+	}
+
+	_onAllItemsPopoverAfterOpen() {
+		this._setInitialFocusInResponsivePopover();
+		this._toggleIcon();
+	}
+
 	_getSelectedItems() {
 		// Angular 2 way data binding
 		this.selectedValues = this.items.filter(item => item.selected);

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -7,6 +7,7 @@
 	_disable-initial-focus
 	content-only-on-desktop
 	@ui5-afterClose={{_afterClosePopover}}
+	@ui5-afterOpen={{_setInitialFocusInResponsivePopover}}
 >
 	<div slot="header" class="ui5-responsive-popover-header">
 		<div class="row">
@@ -75,7 +76,7 @@
 	content-only-on-desktop
 	@ui5-selectionChange={{_listSelectionChange}}
 	@ui5-afterClose={{_toggleIcon}}
-	@ui5-afterOpen={{_toggleIcon}}
+	@ui5-afterOpen={{_onAllItemsPopoverAfterOpen}}
 >
 	<div slot="header" class="ui5-responsive-popover-header">
 		<div class="row">


### PR DESCRIPTION
Before this change, when opened the initial focus of the ```ui5-multi-combobox``` on mobile was still on the native input out of the dialog. This breaks the whole view as the input can be anywhere on the page. With this change the focus is now set on the input inside the dialog

It is implemented like this(and not using the initial-focus API of the popover), because on both Chrome and Safari the bug is still present.