### PR TITLE
chore(tools): enhance i18n json imports scripts

### DIFF
--- a/packages/theme-base/package-scripts.js
+++ b/packages/theme-base/package-scripts.js
@@ -26,7 +26,7 @@ module.exports = {
 				...buildThemesCommands
 			},
 			postcss: "postcss dist/**/parameters-bundle.css --config config/postcss.themes --base dist/ --dir dist/css/",
-			jsonImports: `node "${jsonImportsScript}"`,
+			jsonImports: `node "${jsonImportsScript}" dist/generated/json-imports`,
 		}
 	},
 };

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -28,8 +28,8 @@ const getScripts = (options) => {
 			},
 			jsonImports: {
 				default: "mkdirp dist/generated/json-imports && nps build.jsonImports.themes build.jsonImports.i18n",
-				themes: `node "${LIB}/generate-json-imports/themes.js"`,
-				i18n: `node "${LIB}/generate-json-imports/i18n.js"`,
+				themes: `node "${LIB}/generate-json-imports/themes.js" dist/generated/json-imports`,
+				i18n: `node "${LIB}/generate-json-imports/i18n.js" dist/generated/assets/i18n dist/generated/json-imports`,
 			},
 			bundle: "rollup --config config/rollup.config.js --environment ES5_BUILD",
 			samples: {

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -23,8 +23,8 @@ const getScripts = (options) => {
 			},
 			i18n: {
 				default: "nps build.i18n.defaultsjs build.i18n.json",
-				defaultsjs: `mkdirp dist/generated/i18n && node "${LIB}/i18n/defaults.js" src/i18n dist/generated/i18n`,
-				json: `mkdirp dist/generated/assets/i18n && node "${LIB}/i18n/toJSON.js" src/i18n dist/generated/assets/i18n`,
+				defaultsjs: `node "${LIB}/i18n/defaults.js" src/i18n dist/generated/i18n`,
+				json: `node "${LIB}/i18n/toJSON.js" src/i18n dist/generated/assets/i18n`,
 			},
 			jsonImports: {
 				default: "mkdirp dist/generated/json-imports && nps build.jsonImports.themes build.jsonImports.i18n",

--- a/packages/tools/lib/generate-json-imports/themes.js
+++ b/packages/tools/lib/generate-json-imports/themes.js
@@ -1,6 +1,9 @@
 const fs = require("fs");
+const path = require('path');
 const mkdirp = require("mkdirp");
 const assets = require("../../assets-meta.js");
+
+const outputFile = path.normalize(`${process.argv[2]}/Themes.js`);
 
 const optionalThemes = assets.themes.all.filter(theme => theme !== assets.themes.default);
 
@@ -26,5 +29,5 @@ Suggested pattern: "assets\\\\\\/.*\\\\\\.json"\`);
 ${registerLines};
 `;
 
-mkdirp.sync("dist/generated/json-imports/");
-fs.writeFileSync("dist/generated/json-imports/Themes.js", content);
+mkdirp.sync(path.dirname(outputFile));
+fs.writeFileSync(outputFile, content);

--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const PropertiesReader = require('properties-reader');
+const mkdirp = require("mkdirp");
 const assets = require('../../assets-meta.js');
 
 const defaultLanguage = assets.languages.default;
@@ -67,4 +68,5 @@ const writeI18nDefaultsFile = (file, content) => {
 	});
 };
 
+mkdirp.sync(path.dirname(outputFile));
 writeI18nDefaultsFile(outputFile, getOutputFileContent(properties, defaultLanguageProperties));

--- a/packages/tools/lib/i18n/toJSON.js
+++ b/packages/tools/lib/i18n/toJSON.js
@@ -12,6 +12,7 @@ const glob = require("glob");
 const PropertiesReader = require('properties-reader');
 const fs = require('fs');
 const assets = require('../../assets-meta.js');
+const mkdirp = require("mkdirp");
 
 const allLanguages = assets.languages.all;
 
@@ -32,6 +33,7 @@ const messagesJSONDist = path.normalize(`${process.argv[3]}`);
 	console.log(`[i18n]: "${filename}.json" has been generated!`);
 };
 
+mkdirp.sync(messagesJSONDist);
  glob(messagesBundles, {}, (err, files) => {
 	if (err) {
 		return console.log("No messagebundle files found!");


### PR DESCRIPTION
This PR adds `src` and `dest` parameters to the `generate-json-imports` scripts and generates the required parent folders for i18n assets during the script execution.