### PR TITLE
fix(build): escape quotes in translation texts

### DIFF
--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -32,7 +32,9 @@ catch (e) {}
  * };
  */
 const getTextInfo = (key, value, defaultLanguageValue) => {
-	const effectiveValue = defaultLanguageValue || value;
+	let effectiveValue = defaultLanguageValue || value;
+	effectiveValue.replace(/"/g, "\\\""); // escape double quotes in translations
+
 	return `const ${key} = {key: "${key}", defaultText: "${effectiveValue}"};`;
 };
 


### PR DESCRIPTION
**Background**
The Translation Delivery pull request fails and I found out that one of the new texts in messagebundle_en.properties has has quoted word  `Drop files to upload them or use the "Upload" button `.

**Issue:**
Later when building the i18n-defaults.js, the following fails:

```js
// effectiveValue  has double quotes itself and a word inside with double quotes in addition
return `const ${key} = {key: "${key}", defaultText: "${effectiveValue}"};`;
```

**Solution**: escaping those quotes.