### PR TITLE
chore: use the changed value

### DIFF
--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -34,7 +34,7 @@ catch (e) {}
  */
 const getTextInfo = (key, value, defaultLanguageValue) => {
 	let effectiveValue = defaultLanguageValue || value;
-	effectiveValue.replace(/"/g, "\\\""); // escape double quotes in translations
+	effectiveValue = effectiveValue.replace(/\"/g, "\\\""); // escape double quotes in translations
 
 	return `const ${key} = {key: "${key}", defaultText: "${effectiveValue}"};`;
 };


### PR DESCRIPTION
Sorry, technical mistake, the new value after the replace was never used, now it is correct.