### PR TITLE
feat(ui5-tabcontainer): content can be displayed above the tab strip

### DIFF
--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -2,6 +2,10 @@
 	class="{{classes.root}}"
 	dir="{{rtl}}"
 >
+	{{#if contentAbove}}
+		{{> contentArea}}
+	{{/if}}
+
 	<div class="{{classes.header}}" id="{{_id}}-header">
 		<ui5-icon @click="{{_onHeaderBackArrowClick}}" class="{{classes.headerBackArrow}}" name="slim-arrow-left" tabindex="-1" accessible-name="{{previousIconACCName}}" show-tooltip></ui5-icon>
 
@@ -46,7 +50,7 @@
 			<ui5-button
 				@click="{{_onOverflowButtonClick}}"
 				class="{{classes.overflowButton}}"
-				icon="slim-arrow-down"
+				icon="{{overflowMenuIcon}}"
 				type="Transparent"
 				title="{{overflowMenuTitle}}"
 				design="Transparent"
@@ -54,7 +58,13 @@
 		{{/if}}
 	</div>
 
-	<!-- content area -->
+	{{#unless contentAbove}}
+		{{> contentArea}}
+	{{/unless}}
+
+</div>
+
+{{#*inline "contentArea"}}
 	<div class="{{classes.content}}">
 		{{#each renderItems}}
 			{{#unless this.isSeparator}}
@@ -64,7 +74,7 @@
 			{{/unless}}
 		{{/each}}
 	</div>
-</div>
+{{/inline}}
 
 {{#*inline "standardTab"}}
 	{{#if this.item.icon}}

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -6,6 +6,7 @@ import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import "@ui5/webcomponents-icons/dist/icons/slim-arrow-up.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-down.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-left.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-right.js";
@@ -73,6 +74,19 @@ const metadata = {
 		 * @public
 		 */
 		collapsed: {
+			type: Boolean,
+		},
+
+		/**
+		 * When set to <code>true</code>, the tab content area is displayed above rather than below the tabs.
+		 * <br><br>
+		 * <b>Note:</b> Use this property only when the <code>ui5-tabcontainer</code> is at the bottom of the page.
+		 *
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 */
+		contentAbove: {
 			type: Boolean,
 		},
 
@@ -460,6 +474,10 @@ class TabContainer extends UI5Element {
 
 	get overflowMenuTitle() {
 		return this.i18nBundle.getText(TABCONTAINER_OVERFLOW_MENU_TITLE);
+	}
+
+	get overflowMenuIcon() {
+		return this.contentAbove ? "slim-arrow-up" : "slim-arrow-down";
 	}
 
 	get rtl() {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -25,6 +25,10 @@
 	box-sizing: border-box;
 }
 
+:host([content-above]) .ui5-tc__header {
+    border-top: var(--_ui5_tc_header_border_bottom);
+}
+
 .ui5-tc-root.ui5-tc--textOnly .ui5-tc__header {
 	height: var(--_ui5_tc_header_height_text_only);
 }
@@ -239,6 +243,10 @@
 	background-color: var(--sapGroup_ContentBackground);
 	border-bottom: var(--_ui5_tc_content_border_bottom);
 	box-sizing: border-box;
+}
+
+:host([content-above]) .ui5-tc__content {
+    border-top: var(--_ui5_tc_content_border_bottom);
 }
 
 .ui5-tc__content--collapsed {

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -54,7 +54,7 @@
 
 	<section>
 		<h2>Tab Container</h2>
-		<ui5-tabcontainer id="tabContainer1" fixed collapsed show-overflow="true">
+		<ui5-tabcontainer id="tabContainer1" fixed collapsed show-overflow>
 			<ui5-tab text="Products" additional-text="125">
 			</ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
@@ -64,7 +64,7 @@
 			</ui5-tab>
 			<ui5-tab icon="sap-icon://menu2" text="Keyboards" semantic-color="Negative" additional-text="15">
 			</ui5-tab>
-			<ui5-tab icon="sap-icon://menu2" disabled="true" text="Disabled"  semantic-color="Negative" additional-text="40">
+			<ui5-tab icon="sap-icon://menu2" disabled text="Disabled"  semantic-color="Negative" additional-text="40">
 			</ui5-tab>
 			<ui5-tab icon="sap-icon://menu2" text="Neutral" semantic-color="Neutral" additional-text="40">
 			</ui5-tab>
@@ -75,7 +75,7 @@
 
 	<section>
 		<h2>Icon only</h2>
-		<ui5-tabcontainer show-overflow="true" id="tabContainerIconOnly">
+		<ui5-tabcontainer show-overflow id="tabContainerIconOnly">
 			<ui5-tab icon="sap-icon://card" selected>
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -121,7 +121,7 @@
 
 	<section>
 		<h2>Text only</h2>
-		<ui5-tabcontainer show-overflow="true" id="tabContainerTextOnly">
+		<ui5-tabcontainer show-overflow id="tabContainerTextOnly">
 			<ui5-tab text="Products ID" selected>
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -225,7 +225,7 @@
 	<section>
 		<h2>Icon and Text</h2>
 
-		<ui5-tabcontainer show-overflow="true">
+		<ui5-tabcontainer show-overflow>
 			<ui5-tab icon="sap-icon://card" text="Tab 1" additional-text="123">
 				<div style="height: 300px">
 					<h4>Content with set height: 300px</h4>
@@ -245,7 +245,7 @@
 	<section>
 		<h2>Icon and Text with tabLayout="Inline"</h2>
 
-		<ui5-tabcontainer show-overflow="true" tab-layout="Inline">
+		<ui5-tabcontainer show-overflow tab-layout="Inline">
 			<ui5-tab icon="sap-icon://card" text="Tab 1" additional-text="123">
 				<div style="height: 300px">
 					<h4>Content with set height: 300px</h4>
@@ -265,7 +265,7 @@
 	<section>
 		<h2>Text and additional text</h2>
 
-		<ui5-tabcontainer show-overflow="true">
+		<ui5-tabcontainer show-overflow>
 			<ui5-tab text="Tab 1" additional-text="additional">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -282,7 +282,7 @@
 	<section>
 		<h2>Text and additional text with tabLayout="Inline"</h2>
 
-		<ui5-tabcontainer show-overflow="true" tab-layout="Inline">
+		<ui5-tabcontainer show-overflow tab-layout="Inline">
 			<ui5-tab text="Monitors" additional-text="10">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -299,7 +299,7 @@
 	<section>
 		<h2>Tabs with input elements</h2>
 
-		<ui5-tabcontainer show-overflow="true">
+		<ui5-tabcontainer show-overflow>
 			<ui5-tab text="Tab 1" selected>
 				<p>ui5-input</p>
 				<ui5-input></ui5-input>
@@ -320,7 +320,7 @@
 	<section class="ui5-content-density-compact">
 		<h3>TabContainer in Compact</h3>
 		<div>
-		<ui5-tabcontainer show-overflow="true">
+		<ui5-tabcontainer show-overflow>
 			<ui5-tab text="Products ID">
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
@@ -361,6 +361,53 @@
 		</ui5-tabcontainer>
 		</div>
 	</section>
+
+
+    <section>
+        <h2>Content above</h2>
+        <ui5-tabcontainer show-overflow content-above>
+            <ui5-tab icon="sap-icon://card" selected>
+                <ui5-button>Button 11</ui5-button>
+                <ui5-button>Button 12</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://menu2">
+                <ui5-button>Button 2</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://menu2">
+                <ui5-button>Button 2</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://menu2">
+                <ui5-button>Button 2</ui5-button>
+            </ui5-tab>
+            <ui5-tab icon="sap-icon://employee">
+                <ui5-button>Button 3</ui5-button>
+            </ui5-tab>
+        </ui5-tabcontainer>
+    </section>
 
 	<script>
 		document.getElementById("tabContainer1").addEventListener("ui5-tabSelect", function (event) {


### PR DESCRIPTION
The new `content-above` Boolean property lets the user position the content area above the tab strip. By doing so, the overflow menu arrow also changes direction to point upwards, rather than downwards.
