### PR TITLE
fix(framework): reliably re-render lists of DOM nodes

### DIFF
--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -25,7 +25,6 @@ describe("General interaction", () => {
 		const input = combo.shadow$("#ui5-combobox-input");
 		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#combo");
 		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = popover.$("ui5-list").$$("ui5-li");
 
 		input.click();
 		input.keys("b");
@@ -40,6 +39,7 @@ describe("General interaction", () => {
 
 		assert.strictEqual(selection, "ahrain", "ahrain should be selected");
 		assert.strictEqual(combo.getProperty("value"), "Bulgaria", "Value should be Bulgaria");
+		const listItems = popover.$("ui5-list").$$("ui5-li");
 		assert.ok(listItems[0].getProperty("selected"), "List Item should be selected");
 
 		lazy.click();

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -135,7 +135,7 @@ function visitEachBlock(block) {
 	var bParamAdded = false;
 	visitSubExpression.call(this, block);
 
-	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", undefined, (item, index) => ";
+	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", (item, index) => item._id || index, (item, index) => ";
 	this.paths.push(normalizePath.call(this, block.params[0].original));
 	this.blockPath = "item";
 


### PR DESCRIPTION
In the `lit-html` `repeat` directive, the key function is defined as follows:
`export type KeyFn<T> = (item: T, index: number) => unknown;`
It takes 2 arguments: `item` and `index` and the usage is as follows:
`newKeys[index] = keyFn ? keyFn(item, index) : index;`

We pass `undefined` to our `repeat` in `litVisitor` class. Therefore `lit-html` takes the `index` as key.
The purpose of this change is to pass the `_id`, which is unique to every UI5 Web Component, and the `index` as fallback, so that the algorithm works as before when there are no `_id`s (f.e. when we don't iterate on arrays of UI5 Web Components).

This will optimize the rerendering of lists of UI5 Web Comopnents and also prevent some bugs, such as the filtering of items in `ui5-multi-combobox`.

fixes: https://github.com/SAP/ui5-webcomponents/issues/1487