### PR TITLE
chore(ui5-datetime-picker): fix icon blinking on open

### DIFF
--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -235,8 +235,8 @@ class DateTimePicker extends DatePicker {
 	 * @public
 	 */
 	async openPicker(options) {
-		await this.setSlidersValue();
 		await super.openPicker(options);
+		await this.setSlidersValue();
 		this.expandHoursSlider();
 		this.storePreviousValue();
 	}


### PR DESCRIPTION
DateTimePicker's  icon background blinks on open (look at the video). 
Calling super.openPicker first resolves the issue as the pressed state of the icon is immediately set upon click, otherwise it is clicked, released and then the pressed state is set, causing that blinking.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15702139/80202712-b7e3d200-862e-11ea-9e1e-dedc48a6e4c4.gif)
