### PR TITLE
chore(ui5-tabcontainer): hide header in overflow dialog

### DIFF
--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -5,6 +5,7 @@
 	content-only-on-desktop
 	with-padding
 	no-arrow
+	_hide-header
 >
 	<ui5-list @ui5-itemPress="{{_onOverflowListItemSelect}}">
 		{{#each renderItems}}


### PR DESCRIPTION
The overflow list should not have a header with close button, when opened in phone as dialog