### PR TITLE
fix(framework): rendering is no longer delayed 

### DIFF
--- a/packages/base/src/CustomElementsRegistry.js
+++ b/packages/base/src/CustomElementsRegistry.js
@@ -1,0 +1,23 @@
+const DefinitionsSet = new Set();
+
+const registerTag = tag => {
+	DefinitionsSet.add(tag);
+};
+
+const isTagRegistered = tag => {
+	return DefinitionsSet.has(tag);
+};
+
+const getAllRegisteredTags = () => {
+	const arr = [];
+	DefinitionsSet.forEach(tag => {
+		arr.push(tag);
+	});
+	return arr;
+};
+
+export {
+	registerTag,
+	isTagRegistered,
+	getAllRegisteredTags,
+};

--- a/packages/base/src/RenderScheduler.js
+++ b/packages/base/src/RenderScheduler.js
@@ -119,16 +119,13 @@ class RenderScheduler {
 		return renderTaskPromise;
 	}
 
-	/**
-	 * return a promise that will be resolved once all ui5 webcomponents on the page have their shadow root ready
-	 */
-	static async whenShadowDOMReady() {
+	static whenAllCustomElementsAreDefined() {
 		const definedPromises = getAllRegisteredTags().map(tag => customElements.whenDefined(tag));
 		return Promise.all(definedPromises);
 	}
 
 	static async whenFinished() {
-		await RenderScheduler.whenShadowDOMReady();
+		await RenderScheduler.whenAllCustomElementsAreDefined();
 		await RenderScheduler.whenDOMUpdated();
 	}
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -3,6 +3,7 @@ import boot from "./boot.js";
 import UI5ElementMetadata from "./UI5ElementMetadata.js";
 import StaticAreaItem from "./StaticAreaItem.js";
 import RenderScheduler from "./RenderScheduler.js";
+import { registerTag, isTagRegistered } from "./CustomElementsRegistry.js";
 import DOMObserver from "./compatibility/DOMObserver.js";
 import { skipOriginalEvent } from "./config/NoConflict.js";
 import getConstructableStyle from "./theming/getConstructableStyle.js";
@@ -18,7 +19,6 @@ const metadata = {
 	},
 };
 
-const DefinitionsSet = new Set();
 let autoId = 0;
 
 const elementTimeouts = new Map();
@@ -858,14 +858,14 @@ class UI5Element extends HTMLElement {
 
 		const tag = this.getMetadata().getTag();
 
-		const definedLocally = DefinitionsSet.has(tag);
+		const definedLocally = isTagRegistered(tag);
 		const definedGlobally = customElements.get(tag);
 
 		if (definedGlobally && !definedLocally) {
 			console.warn(`Skipping definition of tag ${tag}, because it was already defined by another instance of ui5-webcomponents.`); // eslint-disable-line
 		} else if (!definedGlobally) {
 			this._generateAccessors();
-			DefinitionsSet.add(tag);
+			registerTag(tag);
 			window.customElements.define(tag, this);
 		}
 		return this;


### PR DESCRIPTION
- When there are not-imported UI5 Elements on the page, each rendering cycle is delayed by 5 seconds, making the whole page unresponsive. This is an extract from this pull request: https://github.com/SAP/ui5-webcomponents/pull/1308 :
- All elements are registered centrally (so not only `UI5Element.js` can access this information)
- `RenderScheduler.js` no longer guesses which elements are UI5 Elements, but reads this from the registry, and no longer waits for 5 seconds. If an element is imported, its awaited until it's defined.
- Additionally the `whenShadowDOMReady` function was renamed as its name was misleading.

As a result of this change, it's now possible to have UI5 Elements that don't start with `ui5-`.

closes: https://github.com/SAP/ui5-webcomponents/issues/1537