### PR TITLE
chore(ui5-textarea): add "part" to inner textarea

### DIFF
--- a/packages/main/src/TextArea.hbs
+++ b/packages/main/src/TextArea.hbs
@@ -32,7 +32,8 @@
 		@change="{{_onchange}}"
 		@keyup="{{_onkeyup}}"
 		@keydown="{{_onkeydown}}"
-		data-sap-focus-ref>
+		data-sap-focus-ref
+		part="textarea">
 	</textarea>
 
 	{{#if showExceededText}}

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -57,6 +57,10 @@
 		.fixed-height {
 			height: 160px;
 		}
+
+		.customTextArea::part(textarea) {
+			background: bisque;
+		}
 	</style>
 	</head>
 
@@ -171,6 +175,15 @@
 	</section>
 	<section class="group">
 		<ui5-input id="inputResult" class="fixed-width"></ui5-input>
+	</section>
+
+	<section class="group">
+		<ui5-textarea
+			class="customTextArea fixed-width fixed-height"
+			maxlength="20"
+			show-exceeded-text
+		>
+		</ui5-textarea>
 	</section>
 
 	<script>


### PR DESCRIPTION
The MDK colleagues requested a way to change the bg-color of the TextArea.
But, the TextArea has relatively complex structure and setting background on the "host" would affect the exceeded text under the native textarea. Introducing a "part" attribute will enable users to change inner textarea background.