### PR TITLE
refactor(ui5-icon): Overwrite WebView user agent stylesheet

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -20,9 +20,11 @@
 
 :host(:not([dir="ltr"])) .ui5-icon-root[dir=rtl] {
 	transform: scale(-1, -1);
+	transform-origin: center;
 }
 
 .ui5-icon-root {
 	display:flex;
 	transform: scale(1, -1);
+	transform-origin: center;
 }


### PR DESCRIPTION
WebView user agent stylesheet sets document as:
transform-origin: 0px 0px 0px
As a result all icons as displaced
This is to support usage of WebComponents on Android devices.
