### PR TITLE
fix(ui5-li): Do not announce active list item type

### DIFF
--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -267,6 +267,10 @@ class ListItem extends ListItemBase {
 		return this.type === ListItemType.Detail;
 	}
 
+	get typeActive() {
+		return this.type === ListItemType.Active;
+	}
+
 	get ariaSelected() {
 		if (this.modeMultiSelect) {
 			return this.selected;

--- a/packages/main/src/StandardListItem.hbs
+++ b/packages/main/src/StandardListItem.hbs
@@ -8,9 +8,9 @@
 		{{#if description}}
 			<span part="description" class="ui5-li-desc">{{description}}</span>
 		{{/if}}
-        {{#unless typeActive}}
-		    <span class="ui5-hidden-text">{{type}}</span>
-        {{/unless}}
+		{{#unless typeActive}}
+			<span class="ui5-hidden-text">{{type}}</span>
+		{{/unless}}
 	</div>
 	{{#if info}}
 		<span part="info" class="ui5-li-info">{{info}}</span>

--- a/packages/main/src/StandardListItem.hbs
+++ b/packages/main/src/StandardListItem.hbs
@@ -8,7 +8,9 @@
 		{{#if description}}
 			<span part="description" class="ui5-li-desc">{{description}}</span>
 		{{/if}}
-		<span class="ui5-hidden-text">{{type}}</span>
+        {{#unless typeActive}}
+		    <span class="ui5-hidden-text">{{type}}</span>
+        {{/unless}}
 	</div>
 	{{#if info}}
 		<span part="info" class="ui5-li-info">{{info}}</span>


### PR DESCRIPTION
Since most of the list items are of `type` `active` by default, it is redundant to have the screen reader repeat the word "Active" so many times. It's simpler to only read "Inactive" or "Detail" for the items of these two types.