### PR TITLE
fix(ui5-button): make buttons truncate

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -33,6 +33,9 @@
 	position: relative;
 	font-size: 0.75rem;
 	font-weight: bold;
+	white-space: initial;
+	overflow: initial;
+	text-overflow: initial;
 }
 
 .ui5-shellbar-menu-button,

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -17,6 +17,9 @@
 	border: 1px solid var(--sapButton_BorderColor);
 	color: var(--sapButton_TextColor);
 	box-sizing: border-box;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 :host([disabled]) {
@@ -86,6 +89,7 @@
 }
 
 .ui5-button-text {
+	max-width: 100%;
 	outline: none;
 	position: relative;
 	white-space: inherit;
@@ -93,8 +97,13 @@
 	text-overflow: inherit;
 }
 
-:host([has-icon]) .ui5-button-text {
+:host([has-icon]:not([icon-end])) .ui5-button-text {
+	max-width: calc(100% - 1rem);
 	margin-left: var(--_ui5_button_base_icon_margin);
+}
+
+:host([has-icon][icon-end]) .ui5-button-text {
+	margin-left: 0;
 }
 
 :host([disabled]) {

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -89,7 +89,6 @@
 }
 
 .ui5-button-text {
-	max-width: 100%;
 	outline: none;
 	position: relative;
 	white-space: inherit;

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -66,6 +66,9 @@
 	<ui5-button icon="employee" aria-label="Download book">Action Bar Button</ui5-button>
 	<ui5-button icon="download"></ui5-button>
 
+	<ui5-button icon="employee" aria-label="Download book" style="width: 6rem;">Action Bar Button</ui5-button>
+	<ui5-button icon="employee" icon-end aria-label="Download book" style="width: 6rem;">Action Bar Button</ui5-button>
+
 	<br />
 	<br />
 


### PR DESCRIPTION
The text of a button should truncate if it is longer than the button(if width is set). Before this change it was wrapping.

Related to: #1400