### PR TITLE
fix(hbs2ui5): enables 3 or more levels of inheritance with templates

### DIFF
--- a/packages/tools/lib/hbs2lit/src/compiler.js
+++ b/packages/tools/lib/hbs2lit/src/compiler.js
@@ -11,7 +11,7 @@ const removeWhiteSpaces = (source) => {
 const compileString = async (sInput, config) => {
 	let sPreprocessed = sInput;
 
-	sPreprocessed = await includesReplacer.replace(sPreprocessed, config);
+	sPreprocessed = includesReplacer.replace(sPreprocessed, config);
 	sPreprocessed = removeWhiteSpaces(sPreprocessed);
 
 	const ast = Handlebars.parse(sPreprocessed);

--- a/packages/tools/lib/hbs2lit/src/includesReplacer.js
+++ b/packages/tools/lib/hbs2lit/src/includesReplacer.js
@@ -1,23 +1,18 @@
 const path = require("path");
-const {promisify} = require("util");
 const nativeFs = require("fs");
 
 function replaceIncludes(hbs, config) {
 	const fs = config.fs || nativeFs;
-	const readFile = promisify(fs.readFile);
 	const inclRegex = /{{>\s*include\s*["']([a-zA-Z.\/]+)["']}}/g;
-
-	async function replacer(match, p1) {
-		const includeContent = await readFile(path.join(config.templatesPath, p1), "utf-8");
-		hbs = hbs.replace(match, includeContent);
-	}
-
 	let match;
-	const replacers = [];
-	while ((match = inclRegex.exec (hbs)) !== null) {
-		replacers.push(replacer(match[0], match[1]));
+
+	while((match = inclRegex.exec(hbs)) !== null) {
+		inclRegex.lastIndex = 0;
+		const includeContent = fs.readFileSync(path.join(config.templatesPath, match[1]), "utf-8");
+		hbs = hbs.replace(match[0], includeContent);
 	}
-	return Promise.all(replacers).then(() => hbs);
+
+	return hbs;
 }
 
 module.exports = {


### PR DESCRIPTION
- lookup for include statements in the hbs files used to be just
one level above the class.