### PR TITLE
refactor(ui5-input): add template hook

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -4,6 +4,8 @@
 	@focusout="{{_onfocusout}}"
 >
 	<div class="ui5-input-content">
+		{{> preContent}}
+
 		<input id="{{_id}}-inner"
 			class="ui5-input-inner"
 			type="{{inputType}}"
@@ -50,3 +52,6 @@
 
 	<slot name="formSupport"></slot>
 </div>
+
+
+{{#*inline "preContent"}}{{/inline}}


### PR DESCRIPTION
Adds a template hook to allow components,  extending the Input to add content, positioned right before the input field. The use case is an ui5-input, used as a search field that needs to show a "transitive search" info, the category that the users search in. For more info see the related issue.

Related to: https://github.com/SAP/ui5-webcomponents/issues/1588