### PR TITLE
chore: cleanup static class members

### DIFF
--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Priority from "@ui5/webcomponents/dist/types/Priority.js";
 import List from "@ui5/webcomponents/dist/List.js";
@@ -116,10 +115,6 @@ const metadata = {
 class NotificationListGroupItem extends NotificationListItemBase {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get styles() {

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { fetchI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
@@ -186,10 +185,6 @@ class NotificationListItem extends NotificationListItemBase {
 
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get styles() {

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -107,10 +106,6 @@ class NotificationListItemBase extends ListItemBase {
 
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get staticAreaTemplate() {

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ListItemType from "@ui5/webcomponents/dist/types/ListItemType.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
@@ -230,10 +229,6 @@ const metadata = {
 class UploadCollectionItem extends ListItem {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get styles() {

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -281,7 +281,7 @@ class ComboBox extends UI5Element {
 	}
 
 	static get staticAreaStyles() {
-		return [ComboBoxPopoverCss, ResponsivePopoverCommonCss];
+		return [ResponsivePopoverCommonCss, ComboBoxPopoverCss];
 	}
 
 	static get template() {

--- a/packages/main/src/CustomListItem.js
+++ b/packages/main/src/CustomListItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ListItem from "./ListItem.js";
 import CustomListItemTemplate from "./generated/templates/CustomListItemTemplate.lit.js";
 
@@ -44,10 +43,6 @@ const metadata = {
 class CustomListItem extends ListItem {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get template() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -314,7 +314,7 @@ class DatePicker extends UI5Element {
 	}
 
 	static get staticAreaStyles() {
-		return [datePickerPopoverCss, ResponsivePopoverCommonCss];
+		return [ResponsivePopoverCommonCss, datePickerPopoverCss];
 	}
 
 	constructor() {

--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -170,7 +170,7 @@ class DateTimePicker extends DatePicker {
 	}
 
 	static get staticAreaStyles() {
-		return [DateTimePickerPopoverCss, ...super.staticAreaStyles];
+		return [...super.staticAreaStyles, DateTimePickerPopoverCss];
 	}
 
 	static async onDefine() {

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ListItemBase from "./ListItemBase.js";
 
@@ -47,10 +46,6 @@ const metadata = {
  * @public
  */
 class GroupHeaderListItem extends ListItemBase {
-	static get render() {
-		return litRender;
-	}
-
 	static get template() {
 		return GroupHeaderListItemTemplate;
 	}

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -92,11 +92,11 @@ class ListItem extends ListItemBase {
 	}
 
 	static get styles() {
-		return [styles, ListItemBase.styles];
+		return [ListItemBase.styles, styles];
 	}
 
-	constructor(props) {
-		super(props);
+	constructor() {
+		super();
 
 		this.deactivateByKey = event => {
 			if (isEnter(event)) {

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -1,3 +1,4 @@
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { getTabbableElements } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
 import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
@@ -64,6 +65,10 @@ const metadata = {
 class ListItemBase extends UI5Element {
 	static get metadata() {
 		return metadata;
+	}
+
+	static get render() {
+		return litRender;
 	}
 
 	static get styles() {

--- a/packages/main/src/MultiComboBoxItem.js
+++ b/packages/main/src/MultiComboBoxItem.js
@@ -27,9 +27,6 @@ const metadata = {
  * @public
  */
 class MultiComboBoxItem extends ComboBoxItem {
-	/**
-	 * @public
-	 */
 	static get metadata() {
 		return metadata;
 	}

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import { getNextZIndex } from "./popup-utils/PopupUtils.js";
 import ResponsivePopoverTemplate from "./generated/templates/ResponsivePopoverTemplate.lit.js";
@@ -78,10 +77,6 @@ const metadata = {
 class ResponsivePopover extends Popover {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get styles() {

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import ListItem from "./ListItem.js";
 import Icon from "./Icon.js";
@@ -126,16 +125,8 @@ const metadata = {
  * @public
  */
 class StandardListItem extends ListItem {
-	static get render() {
-		return litRender;
-	}
-
 	static get template() {
 		return StandardListItemTemplate;
-	}
-
-	static get styles() {
-		return ListItem.styles;
 	}
 
 	static get metadata() {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -212,7 +212,7 @@ class TabContainer extends UI5Element {
 	}
 
 	static get staticAreaStyles() {
-		return [...staticAreaTabStyles, ResponsivePopoverCommonCss];
+		return [ResponsivePopoverCommonCss, ...staticAreaTabStyles];
 	}
 
 	static get render() {

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -273,7 +273,7 @@ class TimePicker extends UI5Element {
 	}
 
 	static get staticAreaStyles() {
-		return [TimePickerPopoverCss, ResponsivePopoverCommonCss];
+		return [ResponsivePopoverCommonCss, TimePickerPopoverCss];
 	}
 
 

--- a/packages/main/src/ToggleButton.js
+++ b/packages/main/src/ToggleButton.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Button from "./Button.js";
 import ToggleButtonTemplate from "./generated/templates/ToggleButtonTemplate.lit.js";
 
@@ -52,10 +51,6 @@ const metadata = {
 class ToggleButton extends Button {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get template() {

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -1,4 +1,3 @@
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isLeft, isRight } from "@ui5/webcomponents-base/dist/Keys.js";
 import ListItem from "./ListItem.js";
@@ -134,10 +133,6 @@ const metadata = {
  * @since 1.0.0-rc.8
  */
 class TreeListItem extends ListItem {
-	static get render() {
-		return litRender;
-	}
-
 	static get template() {
 		return TreeListItemTemplate;
 	}


### PR DESCRIPTION
Several changes:
 - In `static get styles()` and `static get staticAreaStyles()` the order of CSS files matters. The base class CSS/static area CSS should always come first so that the more specific child component CSS overrides it (and not the other way round). Some components currently load these in the wrong order, but as far as I could find out, there were not any duplicate selectors.
 - For components that extend other components (not `UI5Element.js`) it is unneeded to specify `static get render` as it was specified in the parent already.
 - If a component does not have its own CSS, it is not necessary to have `static get styles()` and return the CSS of its parent component, because this is already there on the inheritance chain.