### PR TITLE
fix(ui5-table-row): Do not show the colon when there is no popin text

### DIFF
--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -13,13 +13,15 @@
 			<slot name="{{this._individualSlot}}"></slot>
 		{{/each}}
 	{{/if}}
-</tr>	
+</tr>
 
 {{#if shouldPopin}}
 	{{#each popinCells}}
 		<tr class="ui5-table-popin-row" @ui5-_cellclick="{{_oncellclick}}">
 			<td colspan="{{../visibleCellsCount}}">
-				<span class="ui5-table-row-popin-title">{{this.popinText}}:</span>
+				{{#if this.popinText}}
+					<span class="ui5-table-row-popin-title">{{this.popinText}}:</span>
+				{{/if}}
 				<div>
 					<slot name="{{this.cell._individualSlot}}"></slot>
 				</div>


### PR DESCRIPTION
There are use cases when a column does not have a title at all, hence no popin text is set for it either. However, if this is the case, the colon symbol (`:`) always stays alone on a single line above the value.