### PR TITLE
feat(ui5-table): allow for custom styling

### DIFF
--- a/packages/main/src/TableCell.hbs
+++ b/packages/main/src/TableCell.hbs
@@ -1,3 +1,7 @@
-<td @click="{{_onclick}}" tabindex="-1">
+<td
+	@click="{{_onclick}}"
+	tabindex="-1"
+	part="cell"
+>
 	<slot></slot>
 </td>

--- a/packages/main/src/TableColumn.hbs
+++ b/packages/main/src/TableColumn.hbs
@@ -1,5 +1,6 @@
-<th scope="col">
-	<div class="ui5-table-column-root">
-		<slot></slot>
-	</div>
+<th
+	scope="col"
+	part="column"
+>
+	<slot></slot>
 </th>

--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -3,6 +3,7 @@
 	@focusin="{{_onfocusin}}"
 	@ui5-_cellclick="{{_oncellclick}}"
 	data-sap-focus-ref
+    class="ui5-table-row-root"
 	part="row"
 >
 	{{#if shouldPopin}}
@@ -18,7 +19,7 @@
 
 {{#if shouldPopin}}
 	{{#each popinCells}}
-		<tr class="ui5-table-popin-row" @ui5-_cellclick="{{_oncellclick}}">
+		<tr part="popin-row" class="ui5-table-popin-row" @ui5-_cellclick="{{_oncellclick}}">
 			<td colspan="{{../visibleCellsCount}}">
 				<span class="ui5-table-row-popin-title">{{this.popinText}}:</span>
 				<div>

--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -1,9 +1,10 @@
 <tr
-	class="ui5-table-row-root"
 	tabindex="{{_tabIndex}}"
 	@focusin="{{_onfocusin}}"
 	@ui5-_cellclick="{{_oncellclick}}"
-	data-sap-focus-ref>
+	data-sap-focus-ref
+	part="row"
+>
 	{{#if shouldPopin}}
 		{{#each visibleCells}}
 			<slot name="{{this._individualSlot}}"></slot>
@@ -13,7 +14,7 @@
 			<slot name="{{this._individualSlot}}"></slot>
 		{{/each}}
 	{{/if}}
-</tr>	
+</tr>
 
 {{#if shouldPopin}}
 	{{#each popinCells}}

--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -1,9 +1,9 @@
 <tr
+	class="ui5-table-row-root"
 	tabindex="{{_tabIndex}}"
 	@focusin="{{_onfocusin}}"
 	@ui5-_cellclick="{{_oncellclick}}"
 	data-sap-focus-ref
-    class="ui5-table-row-root"
 	part="row"
 >
 	{{#if shouldPopin}}

--- a/packages/main/src/themes/TableColumn.css
+++ b/packages/main/src/themes/TableColumn.css
@@ -4,15 +4,15 @@
 
 th {
 	background: var(--sapList_HeaderBackground);
-    border: none;
+	border: none;
 	border-bottom: 1px solid var(--sapList_BorderColor);
 	width: inherit;
 	font-weight: normal;
-    padding: 0.25rem;
-    box-sizing: border-box;
-    height: 3rem;
-    text-align: left;
-    vertical-align: middle;
+	padding: 0.25rem;
+	box-sizing: border-box;
+	height: 3rem;
+	text-align: left;
+	vertical-align: middle;
 }
 
 :host([first]) th {

--- a/packages/main/src/themes/TableColumn.css
+++ b/packages/main/src/themes/TableColumn.css
@@ -2,27 +2,20 @@
 	display: contents;
 }
 
-:host .ui5-table-column-root {
-	padding: 0.25rem;
-	box-sizing: border-box;
-}
-
 th {
 	background: var(--sapList_HeaderBackground);
+    border: none;
 	border-bottom: 1px solid var(--sapList_BorderColor);
-	border: none;
 	width: inherit;
 	font-weight: normal;
+    padding: 0.25rem;
+    box-sizing: border-box;
+    height: 3rem;
+    text-align: left;
+    vertical-align: middle;
 }
 
-.ui5-table-column-root {
-	display: flex;
-	height: 3rem;
-	justify-content: flex-start;
-	align-items: center;
-}
-
-:host([first]) .ui5-table-column-root {
+:host([first]) th {
 	padding-left: 1rem;
 }
 

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -2,12 +2,12 @@
 	display: contents;
 }
 
-.ui5-table-row-root {
+tr {
 	background-color: var(--sapList_Background);
 	border-top: 1px solid var(--sapList_BorderColor);
 }
 
-.ui5-table-row-root:focus {
+tr:focus {
 	outline: var(--ui5_table_row_outline_width) dotted var(--sapContent_FocusColor);
 	outline-offset: -0.125rem;
 }

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -2,12 +2,12 @@
 	display: contents;
 }
 
-tr {
+.ui5-table-row-root {
 	background-color: var(--sapList_Background);
 	border-top: 1px solid var(--sapList_BorderColor);
 }
 
-tr:focus {
+.ui5-table-row-root:focus {
 	outline: var(--ui5_table_row_outline_width) dotted var(--sapContent_FocusColor);
 	outline-offset: -0.125rem;
 }

--- a/packages/main/test/pages/TableCustomStyling.html
+++ b/packages/main/test/pages/TableCustomStyling.html
@@ -42,8 +42,9 @@
         height: 6rem;
     }
 
-    /* All columns */
+    /* All columns - center both vertically and horizontally */
     #tbl ui5-table-column::part(column) {
+        vertical-align: middle;
         text-align: center;
     }
 

--- a/packages/main/test/pages/TableCustomStyling.html
+++ b/packages/main/test/pages/TableCustomStyling.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>Web components Table</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<script data-ui5-config type="application/json">
+		{
+			"language": "EN"
+		}
+	</script>
+
+	<script>
+		delete Document.prototype.adoptedStyleSheets
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+</head>
+
+<style>
+	.demo-table {
+		width: 100%;
+	}
+
+	body,
+	html {
+		margin: 0;
+		height: 100%;
+	}
+
+    /* All rows - height */
+    #tbl ui5-table-row::part(row) {
+        height: 4rem;
+    }
+    /* One row - higher than the rest */
+    #tbl ui5-table-row#row3::part(row) {
+        height: 6rem;
+    }
+
+    /* All columns */
+    #tbl ui5-table-column::part(column) {
+        text-align: center;
+    }
+
+    /* All cells - center both vertically and horizontally */
+    #tbl ui5-table-cell::part(cell) {
+        vertical-align: middle;
+        text-align: center;
+    }
+
+    /* Title column & cells - left aligned */
+    #tbl ui5-table-cell.title-cell::part(cell),
+    #tbl ui5-table-column.title-column::part(column) {
+        text-align: left;
+    }
+
+    /* Price column & cells - right aligned with some padding */
+    #tbl ui5-table-cell.price-cell::part(cell),
+    #tbl ui5-table-column.price-column::part(column) {
+        text-align: right;
+        padding-right: 0.75rem;
+    }
+</style>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+	<ui5-table class="demo-table" id="tbl">
+		<!-- Columns -->
+		<ui5-table-column class="title-column" slot="columns">
+			<ui5-label>Product</ui5-label>
+		</ui5-table-column>
+
+		<ui5-table-column class="supplier-column" slot="columns" min-width="1024" popin-text="Supplier">
+			<ui5-label>Supplier</ui5-label>
+		</ui5-table-column>
+
+		<ui5-table-column class="dim-column" slot="columns" min-width="800" popin-text="Dimensions" demand-popin>
+			<div class="column-content">
+				<ui5-label>Dimensions</ui5-label>
+			</div>
+		</ui5-table-column>
+
+		<ui5-table-column class="weight-column" slot="columns" min-width="640" popin-text="Weight" demand-popin>
+			<ui5-label>Weight</ui5-label>
+		</ui5-table-column>
+
+		<ui5-table-column class="price-column" slot="columns">
+			<ui5-label>Price</ui5-label>
+		</ui5-table-column>
+
+
+		<ui5-table-row id="row1">
+			<ui5-table-cell class="title-cell">Notebook Basic 15</ui5-table-cell>
+			<ui5-table-cell>Very Best Screens</ui5-table-cell>
+			<ui5-table-cell>30 x 18 x 3 cm</ui5-table-cell>
+			<ui5-table-cell>4.2 KG</ui5-table-cell>
+			<ui5-table-cell class="price-cell">956 EUR</ui5-table-cell>
+		</ui5-table-row>
+
+        <ui5-table-row id="row2">
+            <ui5-table-cell class="title-cell">Notebook Basic 17</ui5-table-cell>
+            <ui5-table-cell>Very Best Screens</ui5-table-cell>
+            <ui5-table-cell>40 x 18 x 3 cm</ui5-table-cell>
+            <ui5-table-cell>4.6 KG</ui5-table-cell>
+            <ui5-table-cell class="price-cell">1956 EUR</ui5-table-cell>
+        </ui5-table-row>
+
+        <ui5-table-row id="row3">
+            <ui5-table-cell class="title-cell">Notebook Basic 19</ui5-table-cell>
+            <ui5-table-cell>Very Best Screens</ui5-table-cell>
+            <ui5-table-cell>50 x 18 x 3 cm</ui5-table-cell>
+            <ui5-table-cell>4.9 KG</ui5-table-cell>
+            <ui5-table-cell class="price-cell">2956 EUR</ui5-table-cell>
+        </ui5-table-row>
+
+	</ui5-table>
+
+</body>
+
+</html>


### PR DESCRIPTION
Currently the user has no control over **size** and **positioning** for `ui5-table-column`, `ui5-table-row` and `ui5-table-cell`.

This change exposes shadow parts that make it possible to control these settings. 
Additionally, the Table Column must be one element only in order for the positioning to work, so the nested `div` is removed.

*Important*: exposing these shadow parts to a large extend binds us to using `th`, `tr` and `td` as people will start setting CSS properties that work on their respective `display` modes, and wouldn't work on `div`, if we change it down the road.

closes: https://github.com/SAP/ui5-webcomponents/issues/1626