### PR TITLE
fix(ui5-popover): close popup when no opener

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -379,6 +379,13 @@ class Popover extends Popup {
 		return (limits[placement] < 0 || (limits[placement] + threshold > closedPopupParent.innerHeight)) || overflowsBottom || overflowsTop;
 	}
 
+	shouldCloseDueToNoOpener(openerRect) {
+		return openerRect.top === 0
+			&& openerRect.bottom === 0
+			&& openerRect.left === 0
+			&& openerRect.right === 0;
+	}
+
 	reposition() {
 		const popoverSize = this.popoverSize;
 		const openerRect = this._opener.getBoundingClientRect();
@@ -459,7 +466,7 @@ class Popover extends Popup {
 
 		const placementType = this.getActualPlacementType(targetRect, popoverSize);
 
-		this._preventRepositionAndClose = this.shouldCloseDueToOverflow(placementType, targetRect);
+		this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placementType, targetRect);
 
 		const isVertical = placementType === PopoverPlacementType.Top
 			|| placementType === PopoverPlacementType.Bottom;


### PR DESCRIPTION
The popover used to position itself according to 0, 0, 0 ,0 coordinates after the opener is being removed from the DOM. Now, it closes.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1571