### PR TITLE
refactor(ui5-input): define increment step for type="Number"

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -30,6 +30,7 @@
 			@click={{_click}}
 			data-sap-no-tab-ref
 			data-sap-focus-ref
+			step="{{step}}"
 		/>
 		{{#if icon.length}}
 			<div class="ui5-input-icon-root">

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -904,6 +904,10 @@ class Input extends UI5Element {
 		return this.i18nBundle.getText(INPUT_SUGGESTIONS);
 	}
 
+	get step() {
+		return this.type === InputType.Number ? "any" : undefined;
+	}
+
 	get _isPhone() {
 		return isPhone();
 	}

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -29,6 +29,7 @@ describe("Attributes propagation", () => {
 	it("Type attribute is propagated properly", () => {
 		const sExpectedType = "number";
 		assert.strictEqual(browser.$("#input-number").shadow$(".ui5-input-inner").getAttribute("type"), sExpectedType, "Type property was propagated");
+		assert.strictEqual(browser.$("#input-number").shadow$(".ui5-input-inner").getAttribute("step"), "any", "The step attr is set");
 	});
 
 	it("Value attribute is propagated properly", () => {


### PR DESCRIPTION
The Input with type="Number" now behaves as the sap.m.Input when it comes to incrementing/decrementing the value.
Previously it used to round the value to the next Integer (2.14 to 2 or 3), now it increments or decrements the value by 1 (2.14 to 1.14 or 3.14).

Related to: https://github.com/SAP/ui5-webcomponents/issues/1637