### PR TITLE
fix(framework): allow for empty theme files

### DIFF
--- a/packages/base/src/asset-registries/Themes.js
+++ b/packages/base/src/asset-registries/Themes.js
@@ -31,8 +31,8 @@ const registerThemeProperties = (packageName, themeName, style) => {
 	if (style._) {
 		// JSON object like ({"_": ":root"})
 		themeStyles.set(`${packageName}_${themeName}`, style._);
-	} else if (style.includes(":root")) {
-		// pure string
+	} else if (style.includes(":root") || style === "") {
+		// pure string, including empty string
 		themeStyles.set(`${packageName}_${themeName}`, style);
 	} else {
 		// url for fetching
@@ -44,7 +44,7 @@ const registerThemeProperties = (packageName, themeName, style) => {
 
 const getThemeProperties = async (packageName, themeName) => {
 	const style = themeStyles.get(`${packageName}_${themeName}`);
-	if (style) {
+	if (style !== undefined) { // it's valid for style to be an empty string
 		return style;
 	}
 


### PR DESCRIPTION
It is valid for a theme parameters file to be empty (no parameters for this theme). However, `Theming.js` did not account for this and in both registering and getting a theme.

closes: https://github.com/SAP/ui5-webcomponents/issues/1599