### PR TITLE
chore: remove pages from search results on the playground

### DIFF
--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -199,6 +199,9 @@ function initSearch() {
             searchResults.appendChild(resultsList);
   
             for (var i in results) {
+              if (store[results[i].ref].url.indexOf("pages") > -1) {
+                continue;
+              }
               var resultsListItem = document.createElement("li");
               var resultsLink = document.createElement("a");
               var resultsUrlDesc = document.createElement("span");


### PR DESCRIPTION
Currently on the playground if you search for textarea the top answer leads to: https://sap.github.io/ui5-webcomponents/playground/main/pages/TextArea/
which is usually not what users are looking for. Most of the people are looking for the textarea sample and docs: https://sap.github.io/ui5-webcomponents/playground/components/TextArea/

Now all the results from pages area excluded from the search results