### PR TITLE
chore(tools): blank files are no longer copied to dist

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -40,14 +40,14 @@ const getScripts = (options) => {
 		},
 		copy: {
 			default: "nps copy.src copy.test copy.webcomponents-polyfill",
-			src: "copy-and-watch \"src/**/*.js\" dist/",
-			test: "copy-and-watch \"test/**/*.*\" dist/test-resources",
-			"webcomponents-polyfill": `copy-and-watch "${polyfillPath}" dist/webcomponentsjs/`,
+			src: `node "${LIB}/copy-and-watch/index.js" "src/**/*.js" dist/`,
+			test: `node "${LIB}/copy-and-watch/index.js" "test/**/*.*" dist/test-resources`,
+			"webcomponents-polyfill": `node "${LIB}/copy-and-watch/index.js" "${polyfillPath}" dist/webcomponentsjs/`,
 		},
 		watch: {
 			default: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle" "nps watch.styles"',
-			src: 'nps "copy.src --watch --skip-initial-copy"',
-			test: 'nps "copy.test --watch --skip-initial-copy"',
+			src: 'nps "copy.src --watch --safe --skip-initial-copy"',
+			test: 'nps "copy.test --watch --safe --skip-initial-copy"',
 			bundle: "rollup --config config/rollup.config.js -w --environment ES5_BUILD,DEV",
 			styles: {
 				default: 'concurrently "nps watch.styles.themes" "nps watch.styles.components"',
@@ -61,7 +61,7 @@ const getScripts = (options) => {
 		start: "nps prepare dev",
 		serve: {
 			default: "nps serve.prepare serve.run",
-			prepare: `copy-and-watch "${serveConfig}" dist/`,
+			prepare: `node "${LIB}/copy-and-watch/index.js" "${serveConfig}" dist/`,
 			run: `serve --no-clipboard -l ${port} dist`,
 		},
 		test: {

--- a/packages/tools/icons-collection/nps.js
+++ b/packages/tools/icons-collection/nps.js
@@ -8,8 +8,8 @@ const getScripts = () => {
 		clean: "rimraf dist",
 		copy: {
 			default: "nps copy.json-imports copy.icon-collections",
-			"json-imports": 'copy-and-watch "src/**/*.js" dist/',
-			"icon-collections": 'copy-and-watch "src/icon-collections/**/*.json" dist/generated/assets/icon-collections/'
+			"json-imports": `node "${LIB}/copy-and-watch/index.js" "src/**/*.js" dist/`,
+			"icon-collections": `node "${LIB}/copy-and-watch/index.js" "src/icon-collections/**/*.json" dist/generated/assets/icon-collections/`
 		},
 		build: {
 			default: "nps clean copy build.i18n build.icons",

--- a/packages/tools/lib/copy-and-watch/index.js
+++ b/packages/tools/lib/copy-and-watch/index.js
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+const chokidar = require('chokidar');
+const glob = require('glob');
+const globParent = require('glob-parent');
+require('colors');
+
+/* CODE */
+
+const args = process.argv.slice(2);
+const options = {};
+
+['watch', 'clean', 'skip-initial-copy', 'safe'].forEach(key => {
+	const index = args.indexOf(`--${key}`);
+	if (index >= 0) {
+		options[key] = true;
+		args.splice(index, 1);
+	}
+});
+
+if (args.length < 2) {
+	console.error('Not enough arguments: copy-and-watch [options] <sources> <target>'.red);
+	process.exit(1);
+}
+
+if (options['skip-initial-copy'] && !options['watch']) {
+	console.error('--skip-initial-copy argument is meant to be used with --watch, otherwise no files will be copied'.red);
+	process.exit(1);
+}
+
+const target = args.pop();
+const sources = args;
+const parents = [...new Set(sources.map(globParent))];
+
+const findTarget = from => {
+	const parent = parents
+		.filter(p => from.indexOf(p) >= 0)
+		.sort()
+		.reverse()[0];
+	return path.join(target, path.relative(parent, from));
+};
+const createDirIfNotExist = to => {
+	'use strict';
+
+	const dirs = [];
+	let dir = path.dirname(to);
+
+	while (dir !== path.dirname(dir)) {
+		dirs.unshift(dir);
+		dir = path.dirname(dir);
+	}
+
+	dirs.forEach(dir => {
+		if (!fs.existsSync(dir)) {
+			fs.mkdirSync(dir);
+		}
+	});
+};
+const copy = from => {
+	const to = findTarget(from);
+	createDirIfNotExist(to);
+	const stats = fs.statSync(from);
+	if (stats.isDirectory()) {
+		return;
+	}
+	fs.writeFileSync(to, fs.readFileSync(from));
+	console.log('[COPY]'.yellow, from, 'to'.yellow, to);
+};
+const remove = from => {
+	const to = findTarget(from);
+	fs.unlinkSync(to);
+	console.log('[DELETE]'.yellow, to);
+};
+const rimraf = dir => {
+	if (fs.existsSync(dir)) {
+		fs.readdirSync(dir).forEach(entry => {
+			const entryPath = path.join(dir, entry);
+			if (fs.lstatSync(entryPath).isDirectory()) {
+				rimraf(entryPath);
+			} else {
+				fs.unlinkSync(entryPath);
+			}
+		});
+		fs.rmdirSync(dir);
+	}
+};
+
+// clean
+if (options.clean) {
+	rimraf(target);
+}
+
+// initial copy
+if (!options['skip-initial-copy']) {
+	sources.forEach(s => glob.sync(s).forEach(copy));
+}
+
+// watch
+if (options.watch) {
+	const chokidarOptions = {
+		ignoreInitial: true
+	};
+
+	if (options.safe) {
+		chokidarOptions.awaitWriteFinish = {
+			stabilityThreshold: 500,
+			pollInterval: 100
+		};
+	}
+
+	chokidar
+		.watch(sources, chokidarOptions)
+		.on('ready', () => sources.forEach(s => console.log('[WATCH]'.yellow, s)))
+		.on('add', copy)
+		.on('addDir', copy)
+		.on('change', copy)
+		.on('unlink', remove)
+		.on('unlinkDir', remove)
+		.on('error', e => console.log('[ERROR]'.red, e));
+}

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -39,7 +39,6 @@
     "clean-css": "^4.2.1",
     "command-line-args": "^5.1.1",
     "concurrently": "^5.0.0",
-    "copy-and-watch": "^0.1.4",
     "cross-env": "^5.2.0",
     "cssnano": "^4.1.10",
     "escodegen": "^1.11.0",


### PR DESCRIPTION
The problem: `copy-and-watch` internally uses `chokidar` to watch files, but provides no interface for setting `chokidar`'s options. One of these options is `awaitWriteFinish` which makes `chokidar` fire `add` and `change` events only when the file is no longer being written (as opposed to when the file starts being written). This ensures that `rollup` does not try to bundle files that are not completely copied to `dist/`.

The solution: fork `copy-and-watch` to our `lib/` in the `tools` package and add a `safe` option that forces `chokidar` to use `awaitWriteFinish`. We can revert to the original `copy-and-watch` if such a feature gets added sometime in the future.

fixes: https://github.com/SAP/ui5-webcomponents/issues/1634