### PR TITLE
fix(framework): component children that are slots now invalidate parent upon slotchange

### DIFF
--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -1,6 +1,7 @@
 import DataType from "./types/DataType.js";
 import isDescendantOf from "./util/isDescendantOf.js";
 import { camelToKebabCase } from "./util/StringHelper.js";
+import isSlot from "./util/isSlot.js";
 
 /**
  *
@@ -150,10 +151,7 @@ const validateSingleSlot = (value, slotData) => {
 	}
 
 	const getSlottedNodes = el => {
-		const isTag = el instanceof HTMLElement;
-		const isSlot = isTag && el.localName === "slot";
-
-		if (isSlot) {
+		if (isSlot(el)) {
 			return el.assignedNodes({ flatten: true }).filter(item => item instanceof HTMLElement);
 		}
 

--- a/packages/base/src/util/isSlot.js
+++ b/packages/base/src/util/isSlot.js
@@ -1,0 +1,3 @@
+const isSlot = el => el && el instanceof HTMLElement && el.localName === "slot";
+
+export default isSlot;

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -863,19 +863,7 @@ class Input extends UI5Element {
 	}
 
 	get valueStateMessageText() {
-		const valueStateMessage = [];
-
-		this.valueStateMessage.forEach(el => {
-			if (el.localName === "slot") {
-				el.assignedNodes({ flatten: true }).forEach(assignedNode => {
-					valueStateMessage.push(assignedNode.cloneNode(true));
-				});
-			} else {
-				valueStateMessage.push(el.cloneNode(true));
-			}
-		});
-
-		return valueStateMessage;
+		return this.getSlottedNodes("valueStateMessage").map(el => el.cloneNode(true));
 	}
 
 	get shouldDisplayOnlyValueStateMessage() {


### PR DESCRIPTION
There are composition scenarios where a component, say `ui5-upload-collection` creates a `ui5-list` in its shadow root and slots all its children to the list transitively by just rendering a `slot` in the list.

Example:
```html
<ui5-list
	mode="{{mode}}"
	@ui5-selectionChange="{{_onSelectionChange}}"
	@ui5-itemDelete="{{_onItemDelete}}"
>
	<slot></slot>
</ui5-list>
```

The problem with this is that the framework will only invalidate the `ui5-list` whenever its children are added/removed, but in this case the only child is the slot and it is completely static. Yet, when the user adds items to the `ui5-upload-collection`, they will be rendered transitively by the list, but the list will not be updated. Therefore some of the children may not be displayed properly.

The reported issue is that when you add items to the upload collection in "Delete" mode, the new items don't get a "Delete" button until the list is invalidated by something else.

Therefore, this change adds some extra capabilities for components with `managedSlots: true`. If they have `<slot>` children, these will have `slotchange` attached/detached automatically by the framework, and the parent component, in this example `ui5-list` will be invalidated whenever the `slotchange` event is fired, which is upon adding/removing elements to the slot.

In the future, this may be easily enhanced to work recursively by doing the same for slots inside slots, but for the time being this might not be necessary.

Additionally, a new `isSlot` utility is added to check if a Node is slot.
Additionally, `ui5-input` was changed to use the `getSlottedNodes` function, already provided by `UI5Element.js` instead of re-implementing it, to easily get the list of all slotted children in the `valueStateMessage` slot.

This change will affect several components: `ui5-upload-collection`, `ui5-tree`, `ui5-datepicker`, etc... mostly components that transitively slot content to the input or list.

fixes: https://github.com/SAP/ui5-webcomponents/issues/1647