### PR TITLE
fix(ui5-icon): Icon now has a correct role

### DIFF
--- a/packages/main/src/CalendarHeader.hbs
+++ b/packages/main/src/CalendarHeader.hbs
@@ -51,5 +51,5 @@
 			name="{{_btnNext.icon}}"
 		>
 		</ui5-icon>
-
+    </div>
 </div>

--- a/packages/main/src/Icon.hbs
+++ b/packages/main/src/Icon.hbs
@@ -3,7 +3,7 @@
 	tabindex="{{tabIndex}}"
 	dir="{{dir}}"
 	viewBox="0 0 512 512"
-	role="img"
+	role="{{role}}"
 	focusable="false"
 	preserveAspectRatio="xMidYMid meet"
 	aria-label="{{accessibleNameText}}"

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -198,6 +198,14 @@ class Icon extends UI5Element {
 		return this.interactive ? "0" : "-1";
 	}
 
+	get role() {
+		if (this.interactive) {
+			return "button";
+		}
+
+		return this.accessibleNameText ? "img" : "presentation";
+	}
+
 	static createGlobalStyle() {
 		if (!window.ShadyDOM) {
 			return;


### PR DESCRIPTION
Until now `ui5-icon` had a fixed `role` attribute - it was always `img`.

Now, according to the `accessibleName` and `interactive` properties, it may be `button`, `img` or `presentation`.

The default `role` of all icons is now `presentation`. The only way to change this is to set either `interactive` to `true` (so you get `role=button`) or to set `accessibleName`, in which case you get `img`.

In addition: a missing closing `</div>` was added.

closes: https://github.com/SAP/ui5-webcomponents/issues/1581