### PR TITLE
fix(ui5-duration-picker): fix defaultValue of maxValue

### DIFF
--- a/packages/main/src/DurationPicker.js
+++ b/packages/main/src/DurationPicker.js
@@ -72,11 +72,12 @@ const metadata = {
 		 * Defines a formatted maximal time that the user will be able to adjust.
 		 *
 		 * @type {string}
-		 * @defaultvalue "00:00:00"
+		 * @defaultvalue "23:59:59"
 		 * @public
 		 */
 		maxValue: {
 			type: String,
+			defaultValue: "23:59:59",
 		},
 
 		/**
@@ -179,7 +180,7 @@ const metadata = {
 		 *
 		 * @event
 		 * @public
-		*/
+		 */
 		change: {},
 	},
 };


### PR DESCRIPTION
This PR fixes the default value of `maxValue` as the duration-picker is currently restricted to a max duration of 23:59:59. 

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
