### PR TITLE
fix(ui5-textarea): fix text vertical alignment

### DIFF
--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -52,7 +52,7 @@
 	width: 100%;
 	height: 100%;
 	margin: 0;
-	padding: 0.5625rem 0.6875rem;
+	padding: var(--_ui5_textarea_padding);
 	line-height: 1.4;
 	box-sizing: border-box;
 	color: inherit;
@@ -72,6 +72,7 @@
 
 :host([growing]) .ui5-textarea-root {
 	position: relative;
+	min-height: var(--_ui5_input_height);
 }
 
 :host([growing]) .ui5-textarea-inner {
@@ -80,12 +81,16 @@
 	left: 0;
 }
 
+:host([growing][growing-max-lines="1"]) .ui5-textarea-inner {
+	line-height: normal;
+}
+
 .ui5-textarea-mirror {
 	line-height: 1.4;
 	visibility: hidden;
 	width: 100%;
 	word-break: break-all;
-	padding: 0.5625rem 0.6875rem;
+	padding: var(--_ui5_textarea_padding);
 	font-size: var(--sapFontSize);
 	font-family: var(--sapFontFamily);
 	white-space: pre-wrap;

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -39,6 +39,7 @@
 
 .ui5-textarea-root {
 	height: 100%;
+	min-height: var(--_ui5_input_height);
 	display: inline-flex;
 	vertical-align: top;
 	outline: none;
@@ -72,7 +73,6 @@
 
 :host([growing]) .ui5-textarea-root {
 	position: relative;
-	min-height: var(--_ui5_input_height);
 }
 
 :host([growing]) .ui5-textarea-inner {

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -81,10 +81,6 @@
 	left: 0;
 }
 
-:host([growing][growing-max-lines="1"]) .ui5-textarea-inner {
-	line-height: normal;
-}
-
 .ui5-textarea-mirror {
 	line-height: 1.4;
 	visibility: hidden;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -56,6 +56,9 @@
 	--_ui5_tc_item_icon_size: 1.5rem;
 	--_ui5_tc_item_add_text_margin_top: 0.625rem;
 
+	/* TextArea */
+	--_ui5_textarea_padding: 0.5625rem 0.6875rem;
+
 	/* Responsive Popover */
 	--_ui5-responnsive_popover_header_height: 2.75rem;
 
@@ -112,6 +115,9 @@
 	--_ui5_input_icon_min_width: var(--_ui5_input_compact_min_width);
 	--_ui5_input_icon_padding: .25rem .5rem;
 	--_ui5_input_value_state_icon_padding: .1875rem .5rem;
+
+	/* TextArea */
+	--_ui5_textarea_padding: .1875rem .5rem;
 
 	/* List */
 	--_ui5_list_no_data_height: 2rem;

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -179,6 +179,26 @@
 		</ui5-textarea>
 	</section>
 
+	<section class="group">
+		<ui5-title>Growing: growing-max-lines="1"</ui5-title>
+		<br>
+		<ui5-textarea growing growing-max-lines="1"></ui5-textarea>
+
+		<ui5-title>Growing: growing-max-lines="4"</ui5-title>
+		<br>
+		<ui5-textarea growing growing-max-lines="4"></ui5-textarea>
+	</section>
+
+	<section class="group sapUiSizeCompact">
+		<ui5-title>Growing: growing-max-lines="1" (compact)</ui5-title>
+		<br>
+		<ui5-textarea growing growing-max-lines="1"></ui5-textarea>
+
+		<ui5-title>Growing: growing-max-lines="4" (compact)</ui5-title>
+		<br>
+		<ui5-textarea growing growing-max-lines="4"></ui5-textarea>
+	</section>
+
 	<script>
 		var changeCounter = 0;
 		var inputCounter = 0;


### PR DESCRIPTION
Issue: when growing and growing-max-lines="1" are set the text in the input field is a little downwards and not vertically centred. Now it is fixed and the new metrics for padding and height are the ones the openui5 TextArea uses.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1661