### PR TITLE
fix(ui5-button): determine icon-only ignoring comment nodes

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -284,7 +284,7 @@ class Button extends UI5Element {
 			console.warn(`In order for the "submits" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line
 		}
 
-		this.iconOnly = !this.childNodes.length;
+		this.iconOnly = this.isIconOnly;
 		this.hasIcon = !!this.icon;
 	}
 
@@ -392,6 +392,10 @@ class Button extends UI5Element {
 		}
 
 		return this.nonFocusable ? "-1" : this._tabIndex;
+	}
+
+	get isIconOnly() {
+		return !Array.from(this.childNodes).filter(node => node.nodeType !== Node.COMMENT_NODE).length;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -284,7 +284,7 @@ class Button extends UI5Element {
 			console.warn(`In order for the "submits" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line
 		}
 
-		this.iconOnly = this.isIconOnly;
+		this.iconOnly = !this.textContent;
 		this.hasIcon = !!this.icon;
 	}
 
@@ -392,10 +392,6 @@ class Button extends UI5Element {
 		}
 
 		return this.nonFocusable ? "-1" : this._tabIndex;
-	}
-
-	get isIconOnly() {
-		return !Array.from(this.childNodes).filter(node => node.nodeType !== Node.COMMENT_NODE).length;
 	}
 
 	static async onDefine() {

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -29,6 +29,8 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
+
+	<ui5-button icon="home"><!----><!----></ui5-button>
 	<ui5-icon name="invalid_name"></ui5-icon>
 	<ui5-button design="Emphasized" icon="invalid_name">Press</ui5-button>
 


### PR DESCRIPTION
If we use the "ui5-button" internally in other component's template like this:

```html
<ui5-button icon="{{this.icon}}">{{this.text}}</ui5-button>
```

And, if any button happens not to have a text, we will get the following result in the DOM:

```html
<ui5-button icon="home"><!----><!----></ui5-button>
```

Then, in Button.js we used to set icon-only if there are no childNodes, but in this case there are child nodes, because the comments are child nodes. Some styles, that rely on having a text are applied and the button does not look right:

<img width="130" alt="Screenshot 2020-05-22 at 10 40 47 PM" src="https://user-images.githubusercontent.com/15702139/82704537-6dca2c80-9c7e-11ea-84b5-dd17b9f2bd0c.png">

Now the icon-only is set properly, checking against the textContent as it does not include comments and the same button looks like a standard one:
<img width="111" alt="Screenshot 2020-05-22 at 10 41 04 PM" src="https://user-images.githubusercontent.com/15702139/82704623-a23de880-9c7e-11ea-8512-6cce6198fd24.png">

Other possible way is to filter the child nodes by nodeType:
```js
this.iconOnly = !Array.from(this.childNodes)
                       .filter(node => node.nodeType !== Node.COMMENT_NODE).length;
```

