### PR TITLE
feat(ui5-tools): libraries can now control chromedriver version

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest",
     "array-uniq": "^2.0.0",
     "copy-and-watch": "^0.1.4",
     "eslint": "^5.13.0",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -31,6 +31,7 @@
     "@ui5/webcomponents-theme-base": "1.0.0-rc.7"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.0.0-rc.7"
+    "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -24,6 +24,7 @@
     "@ui5/webcomponents-base": "0.20.0"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.0.0-rc.7"
+    "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -25,6 +25,7 @@
     "@buxlabs/amd-to-es6": "^0.15.0",
     "@openui5/sap.ui.core": "1.76.0",
     "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest",
     "copy-and-watch": "^0.1.4",
     "escodegen": "^1.11.0",
     "esprima": "^4.0.1",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -31,6 +31,7 @@
     "@ui5/webcomponents-theme-base": "1.0.0-rc.7"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.0.0-rc.7"
+    "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest"
   }
 }

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.0.0-rc.7",
+    "chromedriver": "latest",
     "chokidar-cli": "^2.0.0",
     "copy-and-watch": "^0.1.4",
     "cssnano": "^4.1.10",

--- a/packages/tools/lib/init-package/index.js
+++ b/packages/tools/lib/init-package/index.js
@@ -109,6 +109,7 @@ const updatePackageFile = () => {
 
 	packageContent.devDependencies = packageContent.devDependencies || {};
 	packageContent.devDependencies["chromedriver"] = "latest";
+	packageContent.devDependencies["wdio-chromedriver-service"] = "latest";
 
 	fs.writeFileSync("package.json", beautify(packageContent, null, 2, 100));
 };

--- a/packages/tools/lib/init-package/index.js
+++ b/packages/tools/lib/init-package/index.js
@@ -107,6 +107,9 @@ const updatePackageFile = () => {
 	packageContent.dependencies["@ui5/webcomponents-theme-base"] = RC_VER;
 	packageContent.dependencies["@ui5/webcomponents-tools"] = RC_VER;
 
+	packageContent.devDependencies = packageContent.devDependencies || {};
+	packageContent.devDependencies["chromedriver"] = "latest";
+
 	fs.writeFileSync("package.json", beautify(packageContent, null, 2, 100));
 };
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -35,7 +35,6 @@
     "@webcomponents/webcomponentsjs": "^2.4.0",
     "chai": "^4.2.0",
     "chokidar-cli": "^2.0.0",
-    "chromedriver": "^83.0.0",
     "clean-css": "^4.2.1",
     "command-line-args": "^5.1.1",
     "concurrently": "^5.0.0",
@@ -73,6 +72,9 @@
     "rollup-plugin-visualizer": "^0.9.2",
     "serve": "^10.1.1",
     "wdio-chromedriver-service": "^6.0.2"
+  },
+  "peerDependencies": {
+    "chromedriver": "*"
   },
   "resolutions": {
     "rollup-plugin-livereload/livereload/chokidar": "^3.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,7 +1996,7 @@ chrome-launcher@^0.13.1:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chromedriver@^83.0.0:
+chromedriver@latest:
   version "83.0.0"
   resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-83.0.0.tgz#75d7d838e58014658c3990089464166fef951926"
   integrity sha512-AePp9ykma+z4aKPRqlbzvVlc22VsQ6+rgF+0aL3B5onHOncK18dWSkLrSSJMczP/mXILN9ohGsvpuTwoRSj6OQ==


### PR DESCRIPTION
Currently third-party libraries that use UI5 Web Components tools cannot control `chromedriver` version, which may be problematic whenever Google Chrome isn't automatically updated on their system. 

To solve this, we're moving `chromedriver` to a *peer dependency* rather than a *dev dependency* to `@ui5/webcomponents-tools`. All packages, internal or external, must now specify a suitable for them `chromedriver` version.

BREAKING CHANGE: If you are a UI5 Web Components third-party library author, you need to add a dev dependency to `chromedriver` in your project.
For example, if you had:
```json
  "devDependencies": {
    "@ui5/webcomponents-tools": "1.0.0-rc.7"
  }
```
you should change this to:
```json
  "devDependencies": {
    "@ui5/webcomponents-tools": "1.0.0-rc.7",
    "chromedriver": "latest"
  }
``` 
Feel free to choose a version that suits your specific use case best, or `latest` if in doubt.

closes: https://github.com/SAP/ui5-webcomponents/issues/1682