### PR TITLE
refactor(ui5-checkbox): enable aria-label forwarding

### DIFF
--- a/packages/main/src/CheckBox.hbs
+++ b/packages/main/src/CheckBox.hbs
@@ -4,6 +4,7 @@
 	aria-checked="{{checked}}"
 	aria-readonly="{{ariaReadonly}}"
 	aria-disabled="{{ariaDisabled}}"
+	aria-label="{{ariaLabel}}"
 	aria-labelledby="{{ariaLabelledBy}}"
 	aria-describedby="{{ariaDescribedBy}}"
 	tabindex="{{tabIndex}}"

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -124,6 +124,18 @@ const metadata = {
 			type: String,
 		},
 
+		/**
+		 * Determines the <code>aria-label</code>, set on the component root tag.
+		 * @type {string}
+		 * @defaultvalue undefined
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		ariaLabel: {
+			type: String,
+			defaultValue: undefined
+		},
+
 		_label: {
 			type: Object,
 		},

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -133,7 +133,7 @@ const metadata = {
 		 */
 		ariaLabel: {
 			type: String,
-			defaultValue: undefined
+			defaultValue: undefined,
 		},
 
 		_label: {

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -69,7 +69,7 @@
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"
-				aria-label="{{_accInfo.checkbox.ariaLabel}}"
+				aria-label="{{_accInfo.ariaLabel}}"
 				@click="{{onMultiSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -69,6 +69,7 @@
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"
+				aria-label="{{_accInfo.checkbox.ariaLabel}}"
 				@click="{{onMultiSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -8,12 +8,10 @@ import ListItemBase from "./ListItemBase.js";
 import "./RadioButton.js";
 import "./CheckBox.js";
 import "./Button.js";
-import { DELETE } from "./generated/i18n/i18n-defaults.js";
+import { DELETE, ARIA_LABEL_LIST_ITEM_CHECKBOX } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
 import styles from "./generated/themes/ListItem.css.js";
-
-import { ARIA_LABEL_LIST_ITEM_CHECKBOX } from "./generated/i18n/i18n-defaults.js";
 
 /**
  * @public

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -288,9 +288,7 @@ class ListItem extends ListItemBase {
 			role: "option",
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
-			checkbox: {
-				ariaLabel: this.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
-			},
+			ariaLabel: this.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
 		};
 	}
 

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -13,6 +13,8 @@ import { DELETE } from "./generated/i18n/i18n-defaults.js";
 // Styles
 import styles from "./generated/themes/ListItem.css.js";
 
+import { ARIA_LABEL_LIST_ITEM_CHECKBOX } from "./generated/i18n/i18n-defaults.js";
+
 /**
  * @public
  */
@@ -288,6 +290,9 @@ class ListItem extends ListItemBase {
 			role: "option",
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
+			checkbox: {
+				ariaLabel: this.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
+			},
 		};
 	}
 

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -253,6 +253,9 @@ LIST_ITEM_POSITION=List item {0} of {1}
 #XACT: ARIA announcement for the list item selection.
 LIST_ITEM_SELECTED=Is Selected
 
+#XBUT: List Multi Selection Mode Checkbox aria-label text
+ARIA_LABEL_LIST_ITEM_CHECKBOX = Multiple Selection mode.
+
 #XTOL: Tooltip of messgae strip close button
 MESSAGE_STRIP_CLOSE_BUTTON=Message Strip Close
 

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -32,6 +32,10 @@
 	<ui5-checkbox text="Long long long text that should truncate at some point"></ui5-checkbox>
 	<ui5-checkbox wrap text="Longest ever text written in English that have to truncate immediately because it is so long of course!"></ui5-checkbox>
 
+	<br>
+	<ui5-title>ACC test - aria-label</ui5-title>
+	<ui5-checkbox id="accCb" aria-label="Hello world"></ui5-checkbox>
+
 	<script>
 		var hcb = false;
 		var input = document.querySelector("#field");

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -42,4 +42,13 @@ describe("CheckBox general interaction", () => {
 		assert.strictEqual(truncatingCbHeight, CHECKBOX_DEFAULT_HEIGHT, "The size of the checkbox is : " + truncatingCbHeight);
 		assert.ok(wrappingCbHeight > CHECKBOX_DEFAULT_HEIGHT, "The size of the checkbox is more than: " + CHECKBOX_DEFAULT_HEIGHT);
 	});
+
+	it("tests aria-label", () => {
+		const defaultCb = browser.$("#cb2").shadow$(".ui5-checkbox-root");
+		const accCheckBox = browser.$("#accCb").shadow$(".ui5-checkbox-root");
+		const EXPECTED_ARIA_LABEL="Hello world";
+
+		assert.strictEqual(defaultCb.getAttribute("aria-label"), null, "aria-label is not set");
+		assert.strictEqual(accCheckBox.getAttribute("aria-label"), EXPECTED_ARIA_LABEL, "aria-label is set");
+	});
 });


### PR DESCRIPTION
The user now can set an aria-label on the component tag, it will be set on the root element with role="checkbox" and read by the screen readers. This feature is also useful for components that internally use checkbox such as the ListItem, that now can provide aria-label to the CheckBox in MultiSelect mode to meet the ACC requirements for having an accessible name.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1664