### PR TITLE
feat(framework): CLDR location can now be specified

### DIFF
--- a/packages/base/src/AssetRegistry.js
+++ b/packages/base/src/AssetRegistry.js
@@ -1,9 +1,10 @@
 import { registerI18nBundle } from "./asset-registries/i18n.js";
-import { registerCldr } from "./asset-registries/LocaleData.js";
+import { registerCldr, _registerMappingFunction as registerCldrMappingFunction } from "./asset-registries/LocaleData.js";
 import { registerThemeProperties } from "./asset-registries/Themes.js";
 
 export {
 	registerCldr,
+	registerCldrMappingFunction,
 	registerThemeProperties,
 	registerI18nBundle,
 };


### PR DESCRIPTION
The asset registry: `@ui5/webcomponents-base/dist/AssetRegistry.js` now exports a new method:

`registerCldrMappingFunction` 

that can be used to specify custom paths to the CLDR assets whenever they are not bundled.

Example usage:
```js
import { registerCldrMappingFunction } from "@ui5/webcomponents-base/dist/AssetRegistry.js";

registerCldrMappingFunction(locale => {
	return `https://unpkg.com/@ui5/webcomponents-localization@0.19.0/dist/generated/assets/cldr/${locale}.json`
});
```

closes: https://github.com/SAP/ui5-webcomponents/issues/1524