### PR TITLE
chore: remove unnecessary package init code

### DIFF
--- a/packages/tools/lib/init-package/index.js
+++ b/packages/tools/lib/init-package/index.js
@@ -18,8 +18,6 @@ let packageContent;
 
 const DEFAULT_PORT = 8080;
 const DEFAULT_TAG = 'ui5-demo';
-const BETA_VER = "0.20.0";
-const RC_VER = "1.0.0-rc.7";
 
 // from where all the files will be copied
 const RESOURCES_DIR = path.join(`${__dirname}`, `resources/`);
@@ -101,11 +99,6 @@ const updatePackageFile = () => {
 		"create-ui5-element": "wc-create-ui5-element",
 		"prepublishOnly": "npm run build"
 	};
-
-	packageContent.dependencies = packageContent.dependencies || {};
-	packageContent.dependencies["@ui5/webcomponents-base"] = BETA_VER;
-	packageContent.dependencies["@ui5/webcomponents-theme-base"] = RC_VER;
-	packageContent.dependencies["@ui5/webcomponents-tools"] = RC_VER;
 
 	fs.writeFileSync("package.json", beautify(packageContent, null, 2, 100));
 };


### PR DESCRIPTION
We used to update some constants by hand on each release, but it seems like these are not necessary at all, because the code that uses them puts them as dependencies in `package.json`. However, this is already the case because in the tutorial the step before running the script is:
`npm i --save @ui5/webcomponents-base @ui5/webcomponents-theme-base @ui5/webcomponents-tools`

closes: https://github.com/SAP/ui5-webcomponents/issues/1379