### PR TITLE
refactor(components): rename event names to kebab case

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,13 +61,13 @@ The `noConflict` configuration setting allows certain control over this behavior
  The format of this object is as follows:
  ```json
  {
-	 "events": ["selectionChange", "headerClick"]
+	 "events": ["selection-change", "header-click"]
  }
  ```
  *Please note that other keys may be added to this object in the future for the purpose of name conflict resolution.*
  
- In the above example, only the `selectionChange` and `headerClick` events will be fired with a prefix. 
- You can still use them by listening to `ui5-selectionChange` and `ui5-headerClick`, but the names `selectionChange` and `headerClick` will be
+ In the above example, only the `selection-change` and `header-click` events will be fired with a prefix. 
+ You can still use them by listening to `ui5-selection-change` and `ui5-header-click`, but the names `selection-change` and `header-click` will be
  free for use by other UI components and libraries without name collision.
 
 <a name="formatSettings"></a>
@@ -103,7 +103,7 @@ In order to provide configuration settings, include the following ```<script>```
 	},
 	"theme": "sap_belize_hcb",
 	"noConflict": {
-		"events": ["selectionChange", "headerClick"]
+		"events": ["selection-change", "header-click"]
 	}
 }
 </script>

--- a/packages/base/test/pages/ConfigurationScript.html
+++ b/packages/base/test/pages/ConfigurationScript.html
@@ -17,7 +17,7 @@
             },
             "theme": "sap_belize_hcb",
             "noConflict": {
-                "events": ["selectionChange", "headerClick"]
+                "events": ["selection-change", "header-click"]
             }
         }
     </script>

--- a/packages/base/test/specs/ConfigurationChange.spec.js
+++ b/packages/base/test/specs/ConfigurationChange.spec.js
@@ -17,9 +17,9 @@ describe("Some configuration options can be changed at runtime", () => {
 	it("Tests that noConflict can be changed", () => {
 		const res = browser.execute( () => {
 			const config = window['sap-ui-webcomponents-bundle'].configuration;
-			config.setNoConflict({events: ["selectionChange"]});
+			config.setNoConflict({events: ["selection-change"]});
 			return config.getNoConflict();
 		});
-		assert.strictEqual(res.events.includes("selectionChange"), true, "selectionChange was successfully registered as a no conflict event");
+		assert.strictEqual(res.events.includes("selection-change"), true, "selection-change was successfully registered as a no conflict event");
 	});
 });

--- a/packages/base/test/specs/ConfigurationScript.spec.js
+++ b/packages/base/test/specs/ConfigurationScript.spec.js
@@ -48,7 +48,7 @@ describe("Configuration script has effect", () => {
 			const config = window['sap-ui-webcomponents-bundle'].configuration;
 			return config.getNoConflict();
 		});
-		assert.strictEqual(res.events.includes("selectionChange"), true, "selectionChange was successfully registered as a no conflict event");
+		assert.strictEqual(res.events.includes("selection-change"), true, "selectionChange was successfully registered as a no conflict event");
 	});
 
 	it("Tests that animationMode is applied", () => {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -239,7 +239,7 @@ const metadata = {
 		 * Fired, when the notification icon is activated.
 		 *
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#notifications-click
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
@@ -252,7 +252,7 @@ const metadata = {
 		/**
 		 * Fired, when the profile slot is present.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#profile-click
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
@@ -266,7 +266,7 @@ const metadata = {
 		 * Fired, when the product switch icon is activated.
 		 * <b>Note:</b> You can prevent closing of oveflow popover by calling <code>event.preventDefault()</code>.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#product-switch-click
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
@@ -279,7 +279,7 @@ const metadata = {
 		/**
 		 * Fired, when the logo is activated.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#logo-click
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @since 0.10
 		 * @public
@@ -293,7 +293,7 @@ const metadata = {
 		/**
 		 * Fired, when the co pilot is activated.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#co-pilot-click
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @since 0.10
 		 * @public
@@ -308,7 +308,7 @@ const metadata = {
 		 * Fired, when a menu item is activated
 		 * <b>Note:</b> You can prevent closing of oveflow popover by calling <code>event.preventDefault()</code>.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBar#menu-item-click
 		 * @param {HTMLElement} item dom ref of the activated list item
 		 * @since 0.10
 		 * @public

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -243,7 +243,7 @@ const metadata = {
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
-		notificationsClick: {
+		"notifications-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},
@@ -256,7 +256,7 @@ const metadata = {
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
-		profileClick: {
+		"profile-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},
@@ -270,7 +270,7 @@ const metadata = {
 		 * @param {HTMLElement} targetRef dom ref of the activated element
 		 * @public
 		 */
-		productSwitchClick: {
+		"product-switch-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},
@@ -284,7 +284,7 @@ const metadata = {
 		 * @since 0.10
 		 * @public
 		 */
-		logoClick: {
+		"logo-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},
@@ -298,7 +298,7 @@ const metadata = {
 		 * @since 0.10
 		 * @public
 		 */
-		coPilotClick: {
+		"co-pilot-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},
@@ -313,7 +313,7 @@ const metadata = {
 		 * @since 0.10
 		 * @public
 		 */
-		menuItemClick: {
+		"menu-item-click": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -431,13 +431,13 @@ class ShellBar extends UI5Element {
 	}
 
 	_menuItemPress(event) {
-		this.fireEvent("menuItemClick", {
+		this.fireEvent("menu-item-click", {
 			item: event.detail.item,
 		}, true);
 	}
 
 	_logoPress() {
-		this.fireEvent("logoClick", {
+		this.fireEvent("logo-click", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-logo"),
 		});
 	}
@@ -476,7 +476,7 @@ class ShellBar extends UI5Element {
 	}
 
 	_fireCoPilotClick() {
-		this.fireEvent("coPilotClick", {
+		this.fireEvent("co-pilot-click", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-coPilot"),
 		});
 	}
@@ -683,7 +683,7 @@ class ShellBar extends UI5Element {
 				return item.shadowRoot.querySelector(`#${refItemId}`);
 			});
 
-			const prevented = !shellbarItem.fireEvent("itemClick", { targetRef: event.target }, true);
+			const prevented = !shellbarItem.fireEvent("item-click", { targetRef: event.target }, true);
 
 			this._defaultItemPressPrevented = prevented;
 		}
@@ -696,13 +696,13 @@ class ShellBar extends UI5Element {
 	_handleNotificationsPress(event) {
 		const notificationIconRef = this.shadowRoot.querySelector(".ui5-shellbar-bell-button");
 
-		this._defaultItemPressPrevented = !this.fireEvent("notificationsClick", {
+		this._defaultItemPressPrevented = !this.fireEvent("notifications-click", {
 			targetRef: notificationIconRef.classList.contains("ui5-shellbar-hidden-button") ? event.target : notificationIconRef,
 		}, true);
 	}
 
 	_handleProfilePress(event) {
-		this.fireEvent("profileClick", {
+		this.fireEvent("profile-click", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-image-button"),
 		});
 	}
@@ -710,7 +710,7 @@ class ShellBar extends UI5Element {
 	_handleProductSwitchPress(event) {
 		const buttonRef = this.shadowRoot.querySelector(".ui5-shellbar-button-product-switch");
 
-		this._defaultItemPressPrevented = !this.fireEvent("productSwitchClick", {
+		this._defaultItemPressPrevented = !this.fireEvent("product-switch-click", {
 			targetRef: buttonRef.classList.contains("ui5-shellbar-hidden-button") ? event.target : buttonRef,
 		}, true);
 	}

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -50,7 +50,7 @@ const metadata = {
 		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */
-		itemClick: {
+		"item-click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -46,7 +46,7 @@ const metadata = {
 		/**
 		 * Fired, when the item is pressed.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.ShellBarItem#item-click
 		 * @param {HTMLElement} targetRef dom ref of the clicked element
 		 * @public
 		 */

--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -1,9 +1,9 @@
 <ui5-popover class="ui5-shellbar-menu-popover"
 	placement-type="Bottom"
-	@ui5-beforeOpen={{_menuPopoverBeforeOpen}}
-	@ui5-afterClose={{_menuPopoverAfterClose}}
+	@ui5-before-open={{_menuPopoverBeforeOpen}}
+	@ui5-after-close={{_menuPopoverAfterClose}}
 >
-	<ui5-list separators="None" mode="SingleSelect" @ui5-itemPress={{_menuItemPress}}>
+	<ui5-list separators="None" mode="SingleSelect" @ui5-item-press={{_menuItemPress}}>
 		{{#each _menuPopoverItems}}
 			{{ this }}
 		{{/each}}
@@ -14,10 +14,10 @@
 	placement-type="Bottom"
 	horizontal-align="{{popoverHorizontalAlign}}"
 	no-arrow
-	@ui5-beforeOpen={{_overflowPopoverBeforeOpen}}
-	@ui5-afterClose={{_overflowPopoverAfterClose}}
+	@ui5-before-open={{_overflowPopoverBeforeOpen}}
+	@ui5-after-close={{_overflowPopoverAfterClose}}
 >
-	<ui5-list separators="None" @ui5-itemPress="{{_actionList.itemPress}}">
+	<ui5-list separators="None" @ui5-item-press="{{_actionList.itemPress}}">
 		{{#each _hiddenIcons}}
 			<ui5-li
 				data-ui5-external-action-item-id="{{this.refItemid}}"

--- a/packages/fiori/src/UploadCollection.hbs
+++ b/packages/fiori/src/UploadCollection.hbs
@@ -5,8 +5,8 @@
 	<div class="{{classes.content}}">
 		<ui5-list
 			mode="{{mode}}"
-			@ui5-selectionChange="{{_onSelectionChange}}"
-			@ui5-itemDelete="{{_onItemDelete}}"
+			@ui5-selection-change="{{_onSelectionChange}}"
+			@ui5-item-delete="{{_onItemDelete}}"
 		>
 			<slot></slot>
 		</ui5-list>

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -129,7 +129,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> A Delete button is displayed on each item,
 		 * when the <code>ui5-upload-collection</code> <code>mode</code> property is set to <code>Delete</code>.
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.UploadCollection#file-deleted
 		 * @param {HTMLElement} item The <code>ui5-upload-collection-item</code> which was renamed.
 		 * @public
 		 */
@@ -143,7 +143,7 @@ const metadata = {
 		 * Fired when selection is changed by user interaction
 		 * in <code>SingleSelect</code> and <code>MultiSelect</code> modes.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.UploadCollection#selection-change
 		 * @param {Array} selectedItems An array of the selected items.
 		 * @public
 		 */

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -133,7 +133,7 @@ const metadata = {
 		 * @param {HTMLElement} item The <code>ui5-upload-collection-item</code> which was renamed.
 		 * @public
 		 */
-		fileDeleted: {
+		"file-deleted": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -147,7 +147,7 @@ const metadata = {
 		 * @param {Array} selectedItems An array of the selected items.
 		 * @public
 		 */
-		selectionChange: {
+		"selection-change": {
 			detail: {
 				selectedItems: { type: Array },
 			},
@@ -264,11 +264,11 @@ class UploadCollection extends UI5Element {
 	}
 
 	_onItemDelete(event) {
-		this.fireEvent("fileDeleted", { item: event.detail.item });
+		this.fireEvent("file-deleted", { item: event.detail.item });
 	}
 
 	_onSelectionChange(event) {
-		this.fireEvent("selectionChange", { selectedItems: event.detail.selectedItems });
+		this.fireEvent("selection-change", { selectedItems: event.detail.selectedItems });
 	}
 
 	get classes() {

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -58,7 +58,7 @@ const metadata = {
 		},
 
 		/**
-		 * If set to <code>true</code> the file name will be clickable and it will fire <code>fileNameClick</code> event upon click.
+		 * If set to <code>true</code> the file name will be clickable and it will fire <code>file-name-click</code> event upon click.
 		 *
 		 * @type {boolean}
 		 * @defaultvalue false
@@ -174,7 +174,7 @@ const metadata = {
 		 * @event
 		 * @public
 		 */
-		fileNameClick: { },
+		"file-name-click": { },
 
 		/**
 		 * Fired when the <code>fileName</code> property gets changed.
@@ -322,7 +322,7 @@ class UploadCollectionItem extends ListItem {
 	}
 
 	_onFileNameClick(event) {
-		this.fireEvent("fileNameClick");
+		this.fireEvent("file-name-click");
 	}
 
 	_onRetry(event) {

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -171,7 +171,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> This event is only available when <code>fileNameClickable</code> property is <code>true</code>.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.fiori.UploadCollectionItem#file-name-click
 		 * @public
 		 */
 		"file-name-click": { },

--- a/packages/fiori/test/samples/NotificationListGroupItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListGroupItem.sample.html
@@ -130,7 +130,7 @@
 		</ui5-list>
 
 		<script>
-			myList.addEventListener("itemClose", function(e) {
+			myList.addEventListener("item-close", function(e) {
 				e.detail.item.hidden = true;
 			});
 		</script>
@@ -299,7 +299,7 @@
 		</ui5-popover>
 
 		<script>
-			shellbar.addEventListener("ui5-notificationsClick", function(event) {
+			shellbar.addEventListener("ui5-notifications-click", function(event) {
 				event.preventDefault();
 				notificationsPopover.openBy(event.detail.targetRef);
 			});
@@ -346,7 +346,7 @@
 </ui5-popover>
 
 <script>
-	shellbar.addEventListener("ui5-notificationsClick", function(event) {
+	shellbar.addEventListener("ui5-notifications-click", function(event) {
 		notificationsPopover.openBy(event.detail.targetRef);
 	});
 </script>

--- a/packages/fiori/test/samples/NotificationListItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListItem.sample.html
@@ -49,7 +49,7 @@
 		</ui5-list>
 
 		<script>
-			myList.addEventListener("itemClose", function(e) {
+			myList.addEventListener("item-close", function(e) {
 				e.detail.item.hidden = true;
 			});
 		</script>
@@ -81,7 +81,7 @@
 </ui5-list>
 
 <script>
-	myList.addEventListener("itemClose", e => {
+	myList.addEventListener("item-close", e => {
 		e.detail.item.hidden = true;
 	});
 </script>
@@ -219,7 +219,7 @@
 		</ui5-popover>
 
 		<script>
-			shellbar.addEventListener("ui5-notificationsClick", function(event) {
+			shellbar.addEventListener("ui5-notifications-click", function(event) {
 				event.preventDefault();
 				notificationsPopover.openBy(event.detail.targetRef);
 			});
@@ -259,7 +259,7 @@
 </ui5-popover>
 
 <script>
-	shellbar.addEventListener("ui5-notificationsClick", function(event) {
+	shellbar.addEventListener("ui5-notifications-click", function(event) {
 		notificationsPopover.openBy(event.detail.targetRef);
 	});
 </script>

--- a/packages/fiori/test/samples/ProductSwitch.sample.html
+++ b/packages/fiori/test/samples/ProductSwitch.sample.html
@@ -63,7 +63,7 @@
 			var shellBar = document.getElementById("shellbar");
 			var popover = document.getElementById("productswitch-popover");
 
-			shellbar.addEventListener("productSwitchClick", function(event) {
+			shellbar.addEventListener("product-switch-click", function(event) {
 				if (popover.opened) {
 					popover.close();
 				} else {
@@ -105,7 +105,7 @@
 	var shellBar = document.getElementById("shellbar");
 	var popover = document.getElementById("productswitch-popover");
 
-	shellbar.addEventListener("productSwitchClick", function(event) {
+	shellbar.addEventListener("product-switch-click", function(event) {
 		if (popover.opened) {
 			popover.close();
 		} else {

--- a/packages/fiori/test/samples/ShellBar.sample.html
+++ b/packages/fiori/test/samples/ShellBar.sample.html
@@ -56,7 +56,7 @@
 	</ui5-popover>
 
 	<script>
-		shellbar.addEventListener("profileClick", function(event) {
+		shellbar.addEventListener("profile-click", function(event) {
 			window["action-popover"].openBy(event.detail.targetRef);
 		});
 	</script>
@@ -107,7 +107,7 @@
 </ui5-popover>
 
 <script>
-	shellbar.addEventListener("profileClick", function(event) {
+	shellbar.addEventListener("profile-click", function(event) {
 		popover.openBy(event.detail.targetRef);
 	});
 </script>

--- a/packages/main/src/Calendar.hbs
+++ b/packages/main/src/Calendar.hbs
@@ -5,10 +5,10 @@
 		month-text="{{_header.monthText}}"
 		year-text="{{_header.yearText}}"
 		.primaryCalendarType="{{_oMonth.primaryCalendarType}}"
-		@ui5-pressPrevious="{{_header.onPressPrevious}}"
-		@ui5-pressNext="{{_header.onPressNext}}"
-		@ui5-btn1Press="{{_header.onBtn1Press}}"
-		@ui5-btn2Press="{{_header.onBtn2Press}}"
+		@ui5-previous-press="{{_header.onPressPrevious}}"
+		@ui5-next-press="{{_header.onPressNext}}"
+		@ui5-show-month-press="{{_header.onBtn1Press}}"
+		@ui5-show-year-press="{{_header.onBtn2Press}}"
 		._isNextButtonDisabled="{{_header._isNextButtonDisabled}}"
 		._isPrevButtonDisabled="{{_header._isPrevButtonDisabled}}"
 	></ui5-calendar-header>
@@ -24,7 +24,7 @@
 			.minDate="{{_oMonth.minDate}}"
 			.maxDate="{{_oMonth.maxDate}}"
 			timestamp="{{_oMonth.timestamp}}"
-			@ui5-selectionChange="{{_oMonth.onSelectedDatesChange}}"
+			@ui5-change="{{_oMonth.onSelectedDatesChange}}"
 			@ui5-navigate="{{_oMonth.onNavigate}}"
 		></ui5-daypicker>
 
@@ -37,20 +37,20 @@
 			.minDate="{{_oMonth.minDate}}"
 			.maxDate="{{_oMonth.maxDate}}"
 			timestamp="{{_monthPicker.timestamp}}"
-			@ui5-selectedMonthChange="{{_monthPicker.onSelectedMonthChange}}"
+			@ui5-change="{{_monthPicker.onSelectedMonthChange}}"
 		></ui5-monthpicker>
 
 		<ui5-yearpicker
-				id="{{_id}}-YP"
-				class="{{classes.yearPicker}}"
-				format-pattern="{{_oMonth.formatPattern}}"
-				._hidden="{{_yearPicker._hidden}}"
-				.primaryCalendarType="{{_oMonth.primaryCalendarType}}"
-				.minDate="{{_oMonth.minDate}}"
-				.maxDate="{{_oMonth.maxDate}}"
-				timestamp="{{_yearPicker.timestamp}}"
-				._selectedYear="{{_yearPicker._selectedYear}}"
-				@ui5-selectedYearChange="{{_yearPicker.onSelectedYearChange}}"
+			id="{{_id}}-YP"
+			class="{{classes.yearPicker}}"
+			format-pattern="{{_oMonth.formatPattern}}"
+			._hidden="{{_yearPicker._hidden}}"
+			.primaryCalendarType="{{_oMonth.primaryCalendarType}}"
+			.minDate="{{_oMonth.minDate}}"
+			.maxDate="{{_oMonth.maxDate}}"
+			timestamp="{{_yearPicker.timestamp}}"
+			._selectedYear="{{_yearPicker._selectedYear}}"
+			@ui5-change="{{_yearPicker.onSelectedYearChange}}"
 		></ui5-yearpicker>
 	</div>
 </div>

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -115,7 +115,7 @@ const metadata = {
 	events: /** @lends  sap.ui.webcomponents.main.Calendar.prototype */ {
 		/**
 		 * Fired when the selected dates changed.
-		 * @event
+		 * @event sap.ui.webcomponents.main.Calendar#selected-dates-change
 		 * @param {Array} dates The selected dates' timestamps
 		 * @public
 		 */

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -119,7 +119,7 @@ const metadata = {
 		 * @param {Array} dates The selected dates' timestamps
 		 * @public
 		 */
-		selectedDatesChange: { type: Array },
+		"selected-dates-change": { type: Array },
 	},
 };
 
@@ -308,7 +308,7 @@ class Calendar extends UI5Element {
 	_handleSelectedDatesChange(event) {
 		this.selectedDates = [...event.detail.dates];
 
-		this.fireEvent("selectedDatesChange", { dates: event.detail.dates });
+		this.fireEvent("selected-dates-change", { dates: event.detail.dates });
 	}
 
 	_handleMonthNavigate(event) {

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -41,10 +41,10 @@ const metadata = {
 		},
 	},
 	events: {
-		pressPrevious: {},
-		pressNext: {},
-		btn1Press: {},
-		btn2Press: {},
+		"previous-press": {},
+		"next-press": {},
+		"show-month-press": {},
+		"show-year-press": {},
 	},
 };
 
@@ -96,19 +96,19 @@ class CalendarHeader extends UI5Element {
 	}
 
 	_handlePrevPress(event) {
-		this.fireEvent("pressPrevious", event);
+		this.fireEvent("previous-press", event);
 	}
 
 	_handleNextPress(event) {
-		this.fireEvent("pressNext", event);
+		this.fireEvent("next-press", event);
 	}
 
 	_showMonthPicker(event) {
-		this.fireEvent("btn1Press", event);
+		this.fireEvent("show-month-press", event);
 	}
 
 	_showYearPicker(event) {
-		this.fireEvent("btn2Press", event);
+		this.fireEvent("show-year-press", event);
 	}
 
 	_onkeydown(event) {

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -106,7 +106,7 @@ const metadata = {
 		 * by mouse/tap or by using the Enter or Space key.
 		 * <br><br>
 		 * <b>Note:</b> The event would be fired only if the <code>headerInteractive</code> property is set to true.
-		 * @event
+		 * @event sap.ui.webcomponents.main.Card#header-click
 		 * @public
 		 * @since 0.10.0
 		 */

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -110,7 +110,7 @@ const metadata = {
 		 * @public
 		 * @since 0.10.0
 		 */
-		headerClick: {},
+		"header-click": {},
 	},
 };
 
@@ -230,7 +230,7 @@ class Card extends UI5Element {
 
 	_headerClick() {
 		if (this.headerInteractive) {
-			this.fireEvent("headerClick");
+			this.fireEvent("header-click");
 		}
 	}
 
@@ -245,7 +245,7 @@ class Card extends UI5Element {
 		this._headerActive = enter || space;
 
 		if (enter) {
-			this.fireEvent("headerClick");
+			this.fireEvent("header-click");
 			return;
 		}
 
@@ -264,7 +264,7 @@ class Card extends UI5Element {
 		this._headerActive = false;
 
 		if (space) {
-			this.fireEvent("headerClick");
+			this.fireEvent("header-click");
 		}
 	}
 }

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -101,7 +101,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines when the <code>loadMore</code> event is thrown. If not applied the event will not be thrown.
+		 * Defines when the <code>load-more</code> event is thrown. If not applied the event will not be thrown.
 		 * @type {Integer}
 		 * @defaultvalue 1
 		 * @public
@@ -188,9 +188,7 @@ const metadata = {
 		 * @public
 		 * @since 1.0.0-rc.8
 		 */
-		loadMore: {
-
-		},
+		"load-more": {},
 	},
 };
 
@@ -367,7 +365,7 @@ class Carousel extends UI5Element {
 		}
 
 		if (this.pagesCount - this.selectedIndex <= this.infiniteScrollOffset + 1) {
-			this.fireEvent("loadMore");
+			this.fireEvent("load-more");
 		}
 	}
 

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -184,7 +184,7 @@ const metadata = {
 		/**
 		 * Fired for the last items of the <code>ui5-carousel</code> if it is scrolled and the direction of scrolling is to the end.
 		 * The number of items for which the event is thrown is controlled by the <code>infiniteScrollOffset</code> property.
-		 * @event
+		 * @event sap.ui.webcomponents.main.Carousel#load-more
 		 * @public
 		 * @since 1.0.0-rc.8
 		 */

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -4,8 +4,8 @@
 	_disable-initial-focus
 	placement-type="Bottom"
 	horizontal-align="Left"
-	@ui5-afterOpen={{_afterOpenPopover}}
-	@ui5-afterClose={{_afterClosePopover}}
+	@ui5-after-open={{_afterOpenPopover}}
+	@ui5-after-close={{_afterClosePopover}}
 >
 	<ui5-busyindicator
 		?active={{loading}}
@@ -48,7 +48,7 @@
 
 	<ui5-list
 		separators="None"
-		@ui5-itemClick={{_selectItem}}
+		@ui5-item-click={{_selectItem}}
 		mode="SingleSelect"
 	>
 		{{#each _filteredItems}}

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -46,7 +46,7 @@
 		.selectedDates="{{_calendar.selectedDates}}"
 		.minDate="{{_calendar.minDate}}"
 		.maxDate="{{_calendar.maxDate}}"
-		@ui5-selectedDatesChange="{{_calendar.onSelectedDatesChange}}"
+		@ui5-selected-dates-change="{{_calendar.onSelectedDatesChange}}"
 	></ui5-calendar>
 {{/inline}}
 

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -8,8 +8,8 @@
 	with-padding
 	no-stretch
 	?_hide-header={{_shouldHideHeader}}
-	@ui5-afterClose="{{_respPopoverConfig.afterClose}}"
-	@ui5-afterOpen="{{_respPopoverConfig.afterOpen}}"
+	@ui5-after-close="{{_respPopoverConfig.afterClose}}"
+	@ui5-after-open="{{_respPopoverConfig.afterOpen}}"
 >
 	{{#if showHeader}}
 		{{> header}}

--- a/packages/main/src/DateTimePickerPopover.hbs
+++ b/packages/main/src/DateTimePickerPopover.hbs
@@ -23,7 +23,7 @@
 			.selectedDates="{{_calDates}}"
 			.minDate="{{_calendar.minDate}}"
 			.maxDate="{{_calendar.maxDate}}"
-			@ui5-selectedDatesChange="{{_calendar.onSelectedDatesChange}}"
+			@ui5-selected-dates-change="{{_calendar.onSelectedDatesChange}}"
 		>
 		</ui5-calendar>
 

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -118,7 +118,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		selectionChange: {},
+		change: {},
 		/**
 		 * Fired when month, year has changed due to item navigation.
 		 * @public
@@ -433,7 +433,7 @@ class DayPicker extends UI5Element {
 			this.selectedDates = [sNewDate];
 		}
 
-		this.fireEvent("selectionChange", { dates: [...this._selectedDates] });
+		this.fireEvent("change", { dates: [...this._selectedDates] });
 	}
 
 	_handleMonthBottomOverflow(event) {

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -95,7 +95,7 @@ class Dialog extends Popup {
 		super.open();
 
 		this._focusedElementBeforeOpen = getFocusedElement();
-		this.fireEvent("beforeOpen", {});
+		this.fireEvent("before-open", {});
 		this.show();
 		this.applyInitialFocus();
 
@@ -103,7 +103,7 @@ class Dialog extends Popup {
 
 		addOpenedPopup(this);
 		this.opened = true;
-		this.fireEvent("afterOpen", {});
+		this.fireEvent("after-open", {});
 	}
 
 	/**
@@ -111,7 +111,7 @@ class Dialog extends Popup {
 	* @public
 	*/
 	close(escPressed) {
-		const prevented = !this.fireEvent("beforeClose", { escPressed }, true);
+		const prevented = !this.fireEvent("before-close", { escPressed }, true);
 
 		if (prevented || !this.opened) {
 			return;
@@ -121,7 +121,7 @@ class Dialog extends Popup {
 		this.hide();
 		this.opened = false;
 
-		this.fireEvent("afterClose", {});
+		this.fireEvent("after-close", {});
 
 		removeOpenedPopup(this);
 		Dialog.unblockBodyScrolling();

--- a/packages/main/src/DurationPickerPopover.hbs
+++ b/packages/main/src/DurationPickerPopover.hbs
@@ -6,7 +6,7 @@
 	no-stretch
 	horizontal-align="{{_respPopover.horizontalAlign}}"
 	stay-open-on-scroll="{{_respPopover.stayOpenOnScroll}}"
-	@ui5-afterClose="{{_respPopover._onAfterClose}}"
+	@ui5-after-close="{{_respPopover._onAfterClose}}"
 	@keydown="{{_handleKeysDown}}"
 >
 	<div class="{{classes.container}}">

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -109,9 +109,7 @@ const metadata = {
 		 * @private
 		 * @since 1.0.0-rc.8
 		 */
-		click: {
-
-		},
+		click: {},
 	},
 };
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -343,7 +343,7 @@ const metadata = {
 		 * @param {HTMLElement} item The selected item
 		 * @public
 		 */
-		suggestionItemSelect: {
+		"suggestion-item-select": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -430,7 +430,7 @@ class Input extends UI5Element {
 		this.EVENT_SUBMIT = "submit";
 		this.EVENT_CHANGE = "change";
 		this.EVENT_INPUT = "input";
-		this.EVENT_SUGGESTION_ITEM_SELECT = "suggestionItemSelect";
+		this.EVENT_SUGGESTION_ITEM_SELECT = "suggestion-item-select";
 
 		// all user interactions
 		this.ACTION_ENTER = "enter";

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -339,7 +339,7 @@ const metadata = {
 		/**
 		 * Fired when a suggestion item, that is displayed in the suggestion popup, is selected.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Input#suggestion-item-select
 		 * @param {HTMLElement} item The selected item
 		 * @public
 		 */

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -4,8 +4,8 @@
 		_disable-initial-focus
 		placement-type="Bottom"
 		horizontal-align="Left"
-		@ui5-afterOpen="{{_afterOpenPopover}}"
-		@ui5-afterClose="{{_afterClosePopover}}"
+		@ui5-after-open="{{_afterOpenPopover}}"
+		@ui5-after-close="{{_afterClosePopover}}"
 	>
 	{{#if _isPhone}}
 		<div slot="header" class="ui5-responsive-popover-header">
@@ -60,7 +60,7 @@
 						description="{{this.description}}"
 						info="{{this.info}}"
 						info-state="{{this.infoState}}"
-						@ui5-_itemPress="{{ fnOnSuggestionItemPress }}"
+						@ui5-_item-press="{{ fnOnSuggestionItemPress }}"
 					>{{ this.text }}</ui5-li>
 				{{/if}}
 			{{/each}}

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -137,7 +137,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines if the component would fire the <code>loadMore</code> event
+		 * Defines if the component would fire the <code>load-more</code> event
 		 * when the user scrolls to the bottom of the list, and helps achieving an "infinite scroll" effect
 		 * by adding new items each time.
 		 *
@@ -184,7 +184,7 @@ const metadata = {
 		 * @param {HTMLElement} item the clicked item.
 		 * @public
 		 */
-		itemClick: {
+		"item-click": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -194,13 +194,13 @@ const metadata = {
 		 * Fired when the <code>Close</code> button of any item is clicked
 		 * <br><br>
 		 * <b>Note:</b> This event is applicable to <code>ui5-li-notification</code> items only,
-		 * not to be confused with <code>itemDelete</code>.
+		 * not to be confused with <code>item-delete</code>.
 		 * @event
 		 * @param {HTMLElement} item the item about to be closed.
 		 * @public
 		 * @since 1.0.0-rc.8
 		 */
-		itemClose: {
+		"item-close": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -215,7 +215,7 @@ const metadata = {
 		 * @public
 		 * @since 1.0.0-rc.8
 		 */
-		itemToggle: {
+		"item-toggle": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -230,7 +230,7 @@ const metadata = {
 		 * @param {HTMLElement} item the deleted item.
 		 * @public
 		 */
-		itemDelete: {
+		"item-delete": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -245,7 +245,7 @@ const metadata = {
 		 * @param {Array} previouslySelectedItems An array of the previously selected items.
 		 * @public
 		 */
-		selectionChange: {
+		"selection-change": {
 			detail: {
 				selectedItems: { type: Array },
 				previouslySelectedItems: { type: Array },
@@ -262,7 +262,7 @@ const metadata = {
 		 * @public
 		 * @since 1.0.0-rc.6
 		 */
-		loadMore: {},
+		"load-more": {},
 	},
 };
 
@@ -338,9 +338,9 @@ class List extends UI5Element {
 		this.addEventListener("ui5-close", this.onItemClose.bind(this));
 		this.addEventListener("ui5-toggle", this.onItemToggle.bind(this));
 		this.addEventListener("ui5-_focused", this.onItemFocused.bind(this));
-		this.addEventListener("ui5-_forwardAfter", this.onForwardAfter.bind(this));
-		this.addEventListener("ui5-_forwardBefore", this.onForwardBefore.bind(this));
-		this.addEventListener("ui5-_selectionRequested", this.onSelectionRequested.bind(this));
+		this.addEventListener("ui5-_forward-after", this.onForwardAfter.bind(this));
+		this.addEventListener("ui5-_forward-before", this.onForwardBefore.bind(this));
+		this.addEventListener("ui5-_selection-requested", this.onSelectionRequested.bind(this));
 	}
 
 	get shouldRenderH1() {
@@ -407,7 +407,7 @@ class List extends UI5Element {
 		}
 
 		if (selectionChange) {
-			this.fireEvent("selectionChange", {
+			this.fireEvent("selection-change", {
 				selectedItems: this.getSelectedItems(),
 				previouslySelectedItems,
 				selectionComponentPressed: event.detail.selectionComponentPressed,
@@ -441,7 +441,7 @@ class List extends UI5Element {
 	}
 
 	handleDelete(item) {
-		this.fireEvent("itemDelete", { item });
+		this.fireEvent("item-delete", { item });
 	}
 
 	deselectSelectedItems() {
@@ -558,7 +558,7 @@ class List extends UI5Element {
 		const target = event.target;
 
 		this._itemNavigation.update(target);
-		this.fireEvent("itemFocused", { item: target });
+		this.fireEvent("item-focused", { item: target });
 	}
 
 	onItemPress(event) {
@@ -576,19 +576,19 @@ class List extends UI5Element {
 			});
 		}
 
-		this.fireEvent("itemPress", { item: pressedItem });
-		this.fireEvent("itemClick", { item: pressedItem });
+		this.fireEvent("item-press", { item: pressedItem });
+		this.fireEvent("item-click", { item: pressedItem });
 
 		this._selectionRequested = false;
 	}
 
 	// This is applicable to NoficationListItem
 	onItemClose(event) {
-		this.fireEvent("itemClose", { item: event.detail.item });
+		this.fireEvent("item-close", { item: event.detail.item });
 	}
 
 	onItemToggle(event) {
-		this.fireEvent("itemToggle", { item: event.detail.item });
+		this.fireEvent("item-toggle", { item: event.detail.item });
 	}
 
 	onForwardBefore(event) {
@@ -700,7 +700,7 @@ class List extends UI5Element {
 		this.previousScrollPosition = scrollTop;
 
 		if (scrollHeight - BUSYINDICATOR_HEIGHT <= height + scrollTop) {
-			this.fireEvent("loadMore");
+			this.fireEvent("load-more");
 		}
 	}
 

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -180,7 +180,7 @@ const metadata = {
 		 * Fired when an item is activated, unless the item's <code>type</code> property
 		 * is set to <code>Inactive</code>.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.List#item-click
 		 * @param {HTMLElement} item the clicked item.
 		 * @public
 		 */
@@ -195,7 +195,8 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> This event is applicable to <code>ui5-li-notification</code> items only,
 		 * not to be confused with <code>item-delete</code>.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.List#item-close
 		 * @param {HTMLElement} item the item about to be closed.
 		 * @public
 		 * @since 1.0.0-rc.8
@@ -210,7 +211,8 @@ const metadata = {
 		 * Fired when the <code>Toggle</code> button of any item is clicked.
 		 * <br><br>
 		 * <b>Note:</b> This event is applicable to <code>ui5-li-notification-group</code> items only.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.List#item-toggle
 		 * @param {HTMLElement} item the toggled item.
 		 * @public
 		 * @since 1.0.0-rc.8
@@ -226,7 +228,8 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> A Delete button is displayed on each item,
 		 * when the <code>ui5-list</code> <code>mode</code> property is set to <code>Delete</code>.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.List#item-delete
 		 * @param {HTMLElement} item the deleted item.
 		 * @public
 		 */
@@ -240,7 +243,7 @@ const metadata = {
 		 * Fired when selection is changed by user interaction
 		 * in <code>SingleSelect</code>, <code>SingleSelectBegin</code>, <code>SingleSelectEnd</code> and <code>MultiSelect</code> modes.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.List#selection-change
 		 * @param {Array} selectedItems An array of the selected items.
 		 * @param {Array} previouslySelectedItems An array of the previously selected items.
 		 * @public
@@ -258,7 +261,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> The event is fired when the <code>infiniteScroll</code> property is enabled.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.List#load-more
 		 * @public
 		 * @since 1.0.0-rc.6
 		 */

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -61,11 +61,11 @@ const metadata = {
 			noAttribute: true,
 		},
 	},
-	events: {
+	events: /** @lends sap.ui.webcomponents.main.ListItem.prototype */ {
 		/**
 		 * Fired when the user clicks on the detail button when type is <code>Detail</code>.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.ListItem#detail-click
 		 * @public
 		 */
 		"detail-click": {},

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -68,10 +68,10 @@ const metadata = {
 		 * @event
 		 * @public
 		 */
-		detailClick: {},
+		"detail-click": {},
 		_press: {},
 		_focused: {},
-		_focusForward: {},
+		"_selection-requested": {},
 	},
 };
 
@@ -200,7 +200,7 @@ class ListItem extends ListItemBase {
 			return;
 		}
 
-		this.fireEvent("_selectionRequested", { item: this, selected: event.target.checked, selectionComponentPressed: true });
+		this.fireEvent("_selection-requested", { item: this, selected: event.target.checked, selectionComponentPressed: true });
 	}
 
 	onSingleSelectionComponentPress(event) {
@@ -208,7 +208,7 @@ class ListItem extends ListItemBase {
 			return;
 		}
 
-		this.fireEvent("_selectionRequested", { item: this, selected: !event.target.selected, selectionComponentPressed: true });
+		this.fireEvent("_selection-requested", { item: this, selected: !event.target.selected, selectionComponentPressed: true });
 	}
 
 	activate() {
@@ -218,11 +218,11 @@ class ListItem extends ListItemBase {
 	}
 
 	onDelete(event) {
-		this.fireEvent("_selectionRequested", { item: this, selectionComponentPressed: false });
+		this.fireEvent("_selection-requested", { item: this, selectionComponentPressed: false });
 	}
 
 	onDetailClick(event) {
-		this.fireEvent("detailClick", { item: this, selected: this.selected });
+		this.fireEvent("detail-click", { item: this, selected: this.selected });
 	}
 
 	fireItemPress(event) {

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -47,7 +47,8 @@ const metadata = {
 	},
 	events: {
 		_focused: {},
-		_focusForward: {},
+		"_forward-after": {},
+		"_forward-before": {},
 	},
 };
 
@@ -104,7 +105,7 @@ class ListItemBase extends UI5Element {
 		const target = event.target;
 
 		if (this.shouldForwardTabAfter(target)) {
-			this.fireEvent("_forwardAfter", { item: target });
+			this.fireEvent("_forward-after", { item: target });
 		}
 	}
 
@@ -114,7 +115,7 @@ class ListItemBase extends UI5Element {
 		if (this.shouldForwardTabBefore(target)) {
 			const eventData = event;
 			eventData.item = target;
-			this.fireEvent("_forwardBefore", eventData);
+			this.fireEvent("_forward-before", eventData);
 		}
 	}
 

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -89,7 +89,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		selectedMonthChange: {},
+		change: {},
 	},
 };
 
@@ -215,7 +215,7 @@ class MonthPicker extends UI5Element {
 			const timestamp = this.getTimestampFromDOM(event.target);
 			this.timestamp = timestamp;
 			this._itemNav.current = this._month;
-			this.fireEvent("selectedMonthChange", { timestamp });
+			this.fireEvent("change", { timestamp });
 		}
 	}
 
@@ -230,7 +230,7 @@ class MonthPicker extends UI5Element {
 		if (event.target.className.indexOf("ui5-mp-item") > -1) {
 			const timestamp = this.getTimestampFromDOM(event.target);
 			this.timestamp = timestamp;
-			this.fireEvent("selectedMonthChange", { timestamp });
+			this.fireEvent("change", { timestamp });
 		}
 	}
 

--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -12,8 +12,8 @@
 		show-more
 		class="ui5-multi-combobox-tokenizer"
 		?disabled="{{disabled}}"
-		@ui5-showMoreItemsPress="{{_showMorePopover}}"
-		@ui5-tokenDelete="{{_tokenDelete}}"
+		@ui5-showMoreItems-press="{{_showMorePopover}}"
+		@ui5-token-delete="{{_tokenDelete}}"
 		@focusout="{{_tokenizerFocusOut}}"
 		@click={{_click}}
 		?expanded="{{expandedTokenizer}}"

--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -12,7 +12,7 @@
 		show-more
 		class="ui5-multi-combobox-tokenizer"
 		?disabled="{{disabled}}"
-		@ui5-showMoreItems-press="{{_showMorePopover}}"
+		@ui5-show-more-items-press="{{_showMorePopover}}"
 		@ui5-token-delete="{{_tokenDelete}}"
 		@focusout="{{_tokenizerFocusOut}}"
 		@click={{_click}}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -223,7 +223,7 @@ const metadata = {
 		/**
 		 * Fired when the dropdown is opened or closed.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.MultiComboBox#open-change
 		 * @since 1.0.0-rc.5
 		 * @public
 		 */
@@ -233,7 +233,7 @@ const metadata = {
 		 * Fired when selection is changed by user interaction
 		 * in <code>SingleSelect</code> and <code>MultiSelect</code> modes.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.MultiComboBox#selection-change
 		 * @param {Array} items an array of the selected items.
 		 * @public
 		 */

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -227,7 +227,7 @@ const metadata = {
 		 * @since 1.0.0-rc.5
 		 * @public
 		 */
-		openChange: {},
+		"open-change": {},
 
 		/**
 		 * Fired when selection is changed by user interaction
@@ -484,7 +484,7 @@ class MultiComboBox extends UI5Element {
 		this._iconPressed = !this._iconPressed;
 		this.open = this._iconPressed;
 
-		this.fireEvent("openChange");
+		this.fireEvent("open-change");
 
 		if (!this._iconPressed) {
 			this._afterClosePopover();

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -237,7 +237,7 @@ const metadata = {
 		 * @param {Array} items an array of the selected items.
 		 * @public
 		 */
-		selectionChange: {
+		"selection-change": {
 			detail: {
 				items: { type: Array },
 			},
@@ -516,7 +516,7 @@ class MultiComboBox extends UI5Element {
 	}
 
 	fireSelectionChange() {
-		this.fireEvent("selectionChange", { items: this._getSelectedItems() });
+		this.fireEvent("selection-change", { items: this._getSelectedItems() });
 		// Angular 2 way data binding
 		this.fireEvent("value-changed");
 	}

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -5,9 +5,9 @@
 	no-arrow
 	_disable-initial-focus
 	content-only-on-desktop
-	@ui5-selectionChange={{_listSelectionChange}}
-	@ui5-afterClose={{_toggleIcon}}
-	@ui5-afterOpen={{_toggleIcon}}
+	@ui5-selection-change={{_listSelectionChange}}
+	@ui5-after-close={{_toggleIcon}}
+	@ui5-after-open={{_toggleIcon}}
 >
 	<div slot="header" class="ui5-responsive-popover-header">
 		<div class="row">

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -188,7 +188,7 @@ const metadata = {
 		 * Fired before the component is opened.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popover#before-open
 		 */
 		"before-open": {},
 
@@ -196,7 +196,7 @@ const metadata = {
 		 * Fired after the component is opened.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popover#after-open
 		 */
 		"after-open": {},
 
@@ -204,7 +204,7 @@ const metadata = {
 		 * Fired before the component is closed.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popover#before-close
 		 * @param {Boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
 		 */
 		"before-close": {
@@ -215,7 +215,7 @@ const metadata = {
 		 * Fired after the component is closed.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popover#after-close
 		 */
 		"after-close": {},
 	},

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -190,7 +190,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		beforeOpen: {},
+		"before-open": {},
 
 		/**
 		 * Fired after the component is opened.
@@ -198,7 +198,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		afterOpen: {},
+		"after-open": {},
 
 		/**
 		 * Fired before the component is closed.
@@ -207,7 +207,7 @@ const metadata = {
 		 * @event
 		 * @param {Boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
 		 */
-		beforeClose: {
+		"before-close": {
 			escPressed: { type: Boolean },
 		},
 
@@ -217,7 +217,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		afterClose: {},
+		"after-close": {},
 	},
 };
 
@@ -294,14 +294,14 @@ class Popover extends Popup {
 		this._opener = opener;
 		this._focusedElementBeforeOpen = getFocusedElement();
 
-		this.fireEvent("beforeOpen", {});
+		this.fireEvent("before-open", {});
 		this.reposition();
 		this.applyInitialFocus();
 
 		addOpenedPopover(this);
 
 		this.opened = true;
-		this.fireEvent("afterOpen", {});
+		this.fireEvent("after-open", {});
 	}
 
 	/**
@@ -319,7 +319,7 @@ class Popover extends Popup {
 			Popover.unblockBodyScrolling();
 		}
 
-		this.fireEvent("beforeClose", {
+		this.fireEvent("before-close", {
 			escPressed,
 		}, true);
 
@@ -335,7 +335,7 @@ class Popover extends Popup {
 		}
 
 		this.hide();
-		this.fireEvent("afterClose", {});
+		this.fireEvent("after-close", {});
 	}
 
 	get focusedElement() {

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -98,7 +98,7 @@ const metadata = {
 		 * Fired before the component is opened.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popup#before-open
 		 */
 
 		"before-open": {},
@@ -106,7 +106,7 @@ const metadata = {
 		 * Fired after the component is opened.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popup#after-open
 		 */
 
 		"after-open": {},
@@ -114,7 +114,7 @@ const metadata = {
 		 * Fired before the component is closed.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popup#before-close
 		 * @param {Boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
 		 */
 
@@ -126,7 +126,7 @@ const metadata = {
 		 * Fired after the component is closed.
 		 *
 		 * @public
-		 * @event
+		 * @event sap.ui.webcomponents.main.Popup#after-close
 		 */
 		"after-close": {},
 	},

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -101,7 +101,7 @@ const metadata = {
 		 * @event
 		 */
 
-		beforeOpen: {},
+		"before-open": {},
 		/**
 		 * Fired after the component is opened.
 		 *
@@ -109,7 +109,7 @@ const metadata = {
 		 * @event
 		 */
 
-		afterOpen: {},
+		"after-open": {},
 		/**
 		 * Fired before the component is closed.
 		 *
@@ -118,7 +118,7 @@ const metadata = {
 		 * @param {Boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
 		 */
 
-		beforeClose: {
+		"before-close": {
 			escPressed: { type: Boolean },
 		},
 
@@ -128,7 +128,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		afterClose: {},
+		"after-close": {},
 	},
 };
 

--- a/packages/main/src/ResponsivePopover.hbs
+++ b/packages/main/src/ResponsivePopover.hbs
@@ -3,10 +3,10 @@
 		?with-padding={{withPadding}}
 		stretch
 		_disable-initial-focus
-		@ui5-beforeOpen="{{_propagateDialogEvent}}"
-		@ui5-afterOpen="{{_afterDialogOpen}}"
-		@ui5-beforeClose="{{_propagateDialogEvent}}"
-		@ui5-afterClose="{{_afterDialogClose}}"
+		@ui5-before-open="{{_propagateDialogEvent}}"
+		@ui5-after-open="{{_afterDialogOpen}}"
+		@ui5-before-close="{{_propagateDialogEvent}}"
+		@ui5-after-close="{{_afterDialogClose}}"
 	>
 		{{!-- forward slot header to inner dialog slot header --}}
 		{{#unless _hideHeader}}

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -43,7 +43,7 @@ const metadata = {
 		/**
 		 * Fired when the selected button changes.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.SegmentedButton#selection-change
 		 * @param {HTMLElement} selectedButton the pressed button.
 		 * @public
 		 */

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -47,7 +47,7 @@ const metadata = {
 		 * @param {HTMLElement} selectedButton the pressed button.
 		 * @public
 		 */
-		selectionChange: {
+		"selection-change": {
 			detail: {
 				selectedButton: { type: HTMLElement },
 			},
@@ -182,7 +182,7 @@ class SegmentedButton extends UI5Element {
 				this._selectedButton.pressed = false;
 			}
 			this._selectedButton = event.target;
-			this.fireEvent("selectionChange", {
+			this.fireEvent("selection-change", {
 				selectedButton: this._selectedButton,
 			});
 		}

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -5,9 +5,9 @@
 		content-only-on-desktop
 		placement-type="Bottom"
 		horizontal-align="Left"
-		@ui5-afterOpen="{{_applyFocusAfterOpen}}"
-		@ui5-beforeOpen="{{_beforeOpen}}"
-		@ui5-afterClose="{{_afterClose}}"
+		@ui5-after-open="{{_applyFocusAfterOpen}}"
+		@ui5-before-open="{{_beforeOpen}}"
+		@ui5-after-close="{{_afterClose}}"
 		@keydown="{{_onkeydown}}"
 	>
 		<div slot="header" class="ui5-responsive-popover-header">
@@ -23,7 +23,7 @@
 			</div>
 		</div>
 
-		<ui5-list mode="SingleSelect" separators="None" @keydown="{{_handlePickerKeydown}}" @ui5-itemPress="{{_selectionChange}}">
+		<ui5-list mode="SingleSelect" separators="None" @keydown="{{_handlePickerKeydown}}" @ui5-item-press="{{_selectionChange}}">
 			{{#each _syncedOptions}}
 				<ui5-li ?selected="{{this.selected}}" icon="{{this.icon}}" id="{{this.id}}-li">
 					{{this.textContent}}

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -171,7 +171,7 @@ const metadata = {
 		/**
 		 * Fired when a tab is selected.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.TabContainer#tab-select
 		 * @param {HTMLElement} tab The selected <code>tab</code>.
 		 * @param {Number} tabIndex The selected <code>tab</code> index.
 		 * @public

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -176,7 +176,7 @@ const metadata = {
 		 * @param {Number} tabIndex The selected <code>tab</code> index.
 		 * @public
 		 */
-		tabSelect: {
+		"tab-select": {
 			tab: { type: HTMLElement },
 			tabIndex: { type: Number },
 		},
@@ -418,7 +418,7 @@ class TabContainer extends UI5Element {
 	selectTab(selectedTab, selectedTabIndex) {
 		// select the tab
 		this._selectedTab = selectedTab;
-		this.fireEvent("tabSelect", {
+		this.fireEvent("tab-select", {
 			tab: selectedTab,
 			tabIndex: selectedTabIndex,
 		});

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -7,7 +7,7 @@
 	no-arrow
 	_hide-header
 >
-	<ui5-list @ui5-itemPress="{{_onOverflowListItemSelect}}">
+	<ui5-list @ui5-item-press="{{_onOverflowListItemSelect}}">
 		{{#each items}}
 			{{#unless this.isSeparator}}
 				{{this.overflowPresentation}}

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -116,7 +116,7 @@ const metadata = {
 		 * @param {HTMLElement} row the clicked row.
 		 * @public
 		 */
-		rowClick: {
+		"row-click": {
 			detail: {
 				row: { type: HTMLElement },
 			},
@@ -130,7 +130,7 @@ const metadata = {
 		 * @since 1.0.0-rc.6
 		 * @public
 		 */
-		popinChange: {
+		"popin-change": {
 			detail: {
 				poppedColumns: {},
 			},
@@ -277,7 +277,7 @@ class Table extends UI5Element {
 		if (this._hiddenColumns.length !== hiddenColumns.length) {
 			this._hiddenColumns = hiddenColumns;
 			if (hiddenColumns.length) {
-				this.fireEvent("popinChange", {
+				this.fireEvent("popin-change", {
 					poppedColumns: this._hiddenColumns,
 				});
 			}

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -112,7 +112,7 @@ const metadata = {
 		/**
 		 * Fired when a row is clicked.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Table#row-click
 		 * @param {HTMLElement} row the clicked row.
 		 * @public
 		 */
@@ -125,7 +125,7 @@ const metadata = {
 		/**
 		 * Fired when the <code>ui5-table-column</code> is shown as a pop-in instead of hiding it.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Table#popin-change
 		 * @param {Array} poppedColumns popped-in columns.
 		 * @since 1.0.0-rc.6
 		 * @public

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -38,6 +38,7 @@ const metadata = {
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.TableRow.prototype */ {
+		"row-click": {},
 		_focused: {},
 	},
 };
@@ -90,7 +91,7 @@ class TableRow extends UI5Element {
 			this._onfocusin(event, true /* force row focus */);
 		}
 
-		this.fireEvent("rowClick", { row: this });
+		this.fireEvent("row-click", { row: this });
 	}
 
 	_getActiveElementTagName() {

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -7,8 +7,8 @@
 	no-stretch
 	horizontal-align="{{_respPopover.horizontalAlign}}"
 	stay-open-on-scroll="{{_respPopover.stayOpenOnScroll}}"
-	@ui5-afterClose="{{_respPopover.afterClose}}"
-	@ui5-afterOpen="{{_respPopover.afterOpen}}"
+	@ui5-after-close="{{_respPopover.afterClose}}"
+	@ui5-after-open="{{_respPopover.afterOpen}}"
 	class="ui5-timepicker-popover"
 	@keydown="{{_ontimepickerpopoverkeydown}}"
 	@wheel="{{_handleWheel}}"

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -98,7 +98,7 @@ const metadata = {
 		 * <b>Note:</b> The event will not be fired if the <code>item-name-clickable</code>
 		 * attribute is not set.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.TimelineItem#item-name-click
 		 * @public
 		 */
 		"item-name-click": {},

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -101,7 +101,7 @@ const metadata = {
 		 * @event
 		 * @public
 		 */
-		itemNameClick: {},
+		"item-name-click": {},
 	},
 };
 
@@ -141,7 +141,7 @@ class TimelineItem extends UI5Element {
 	}
 
 	onItemNamePress() {
-		this.fireEvent("itemNameClick", {});
+		this.fireEvent("item-name-click", {});
 	}
 
 	get rtl() {

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -42,7 +42,7 @@ const metadata = {
 			},
 		},
 
-		"showMoreItems-press": {
+		"show-more-items-press": {
 			detail: {
 				ref: { type: HTMLElement },
 			},
@@ -128,7 +128,7 @@ class Tokenizer extends UI5Element {
 	}
 
 	_openOverflowPopover() {
-		this.fireEvent("showMoreItems-press");
+		this.fireEvent("show-more-items-press");
 	}
 
 	_getTokens() {

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -36,13 +36,13 @@ const metadata = {
 		_nMoreText: { type: String },
 	},
 	events: /** @lends sap.ui.webcomponents.main.Tokenizer.prototype */ {
-		tokenDelete: {
+		"token-delete": {
 			detail: {
 				ref: { type: HTMLElement },
 			},
 		},
 
-		showMoreItemsPress: {
+		"showMoreItems-press": {
 			detail: {
 				ref: { type: HTMLElement },
 			},
@@ -128,7 +128,7 @@ class Tokenizer extends UI5Element {
 	}
 
 	_openOverflowPopover() {
-		this.fireEvent("showMoreItemsPress");
+		this.fireEvent("showMoreItems-press");
 	}
 
 	_getTokens() {
@@ -154,7 +154,7 @@ class Tokenizer extends UI5Element {
 		}
 
 		this._updateAndFocus();
-		this.fireEvent("tokenDelete", { ref: event.target });
+		this.fireEvent("token-delete", { ref: event.target });
 	}
 
 	/* Keyboard handling */

--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -4,9 +4,9 @@
     .footerText="{{footerText}}"
     .noDataText="{{noDataText}}"
     ._role="{{_role}}"
-    @ui5-itemClick="{{_onListItemClick}}"
-    @ui5-itemDelete="{{_onListItemDelete}}"
-    @ui5-selectionChange="{{_onListSelectionChange}}"
+    @ui5-item-click="{{_onListItemClick}}"
+    @ui5-item-delete="{{_onListItemDelete}}"
+    @ui5-selection-change="{{_onListSelectionChange}}"
 >
     <slot name="header" slot="header"></slot>
     {{#each _listItems}}
@@ -20,8 +20,8 @@
             .selected="{{this.treeItem.selected}}"
             .showToggleButton="{{this.treeItem.requiresToggleButton}}"
             @ui5-toggle="{{../_onListItemToggle}}"
-            @ui5-stepIn="{{../_onListItemStepIn}}"
-            @ui5-stepOut="{{../_onListItemStepOut}}"
+            @ui5-step-in="{{../_onListItemStepIn}}"
+            @ui5-step-out="{{../_onListItemStepOut}}"
         >
             {{this.treeItem.text}}
         </ui5-li-tree>

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -121,7 +121,7 @@ const metadata = {
 		 * @param {HTMLElement} item the toggled item.
 		 * @public
 		 */
-		itemToggle: {
+		"item-toggle": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -134,7 +134,7 @@ const metadata = {
 		 * @param {HTMLElement} item the clicked item.
 		 * @public
 		 */
-		itemClick: {
+		"item-click": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -149,7 +149,7 @@ const metadata = {
 		 * @param {HTMLElement} item the deleted item.
 		 * @public
 		 */
-		itemDelete: {
+		"item-delete": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -164,7 +164,7 @@ const metadata = {
 		 * @param {Array} previouslySelectedItems An array of the previously selected items.
 		 * @public
 		 */
-		selectionChange: {
+		"selection-change": {
 			detail: {
 				selectedItems: { type: Array },
 				previouslySelectedItems: { type: Array },
@@ -282,7 +282,7 @@ class Tree extends UI5Element {
 	_onListItemToggle(event) {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
-		const defaultPrevented = !this.fireEvent("itemToggle", { item: treeItem }, true);
+		const defaultPrevented = !this.fireEvent("item-toggle", { item: treeItem }, true);
 		if (!defaultPrevented) {
 			treeItem.toggle();
 		}
@@ -291,13 +291,13 @@ class Tree extends UI5Element {
 	_onListItemClick(event) {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
-		this.fireEvent("itemClick", { item: treeItem });
+		this.fireEvent("item-click", { item: treeItem });
 	}
 
 	_onListItemDelete(event) {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
-		this.fireEvent("itemDelete", { item: treeItem });
+		this.fireEvent("item-delete", { item: treeItem });
 	}
 
 	_onListSelectionChange(event) {
@@ -311,7 +311,7 @@ class Tree extends UI5Element {
 			item.selected = true;
 		});
 
-		this.fireEvent("selectionChange", {
+		this.fireEvent("selection-change", {
 			previouslySelectedItems,
 			selectedItems,
 		});

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -117,7 +117,7 @@ const metadata = {
 		 * This may be handy for example if you want to dynamically load tree items upon the user expanding a node.
 		 * Even if you prevented the event's default behavior, you can always manually call <code>toggle()</code> on a tree item.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Tree#item-toggle
 		 * @param {HTMLElement} item the toggled item.
 		 * @public
 		 */
@@ -130,7 +130,7 @@ const metadata = {
 		/**
 		 * Fired when a tree item is activated.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Tree#item-click
 		 * @param {HTMLElement} item the clicked item.
 		 * @public
 		 */
@@ -145,7 +145,8 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> A Delete button is displayed on each item,
 		 * when the <code>ui5-tree</code> <code>mode</code> property is set to <code>Delete</code>.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.Tree#item-delete
 		 * @param {HTMLElement} item the deleted item.
 		 * @public
 		 */
@@ -159,7 +160,7 @@ const metadata = {
 		 * Fired when selection is changed by user interaction
 		 * in <code>SingleSelect</code>, <code>SingleSelectBegin</code>, <code>SingleSelectEnd</code> and <code>MultiSelect</code> modes.
 		 *
-		 * @event
+		 * @event sap.ui.webcomponents.main.Tree#selection-change
 		 * @param {Array} selectedItems An array of the selected items.
 		 * @param {Array} previouslySelectedItems An array of the previously selected items.
 		 * @public

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -97,7 +97,7 @@ const metadata = {
 		 * @param {HTMLElement} item the item on which right arrow was pressed.
 		 * @public
 		 */
-		stepIn: {
+		"step-in": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -109,7 +109,7 @@ const metadata = {
 		 * @param {HTMLElement} item the item on which left arrow was pressed.
 		 * @public
 		 */
-		stepOut: {
+		"step-out": {
 			detail: {
 				item: { type: HTMLElement },
 			},
@@ -191,7 +191,7 @@ class TreeListItem extends ListItem {
 			if (!this.expanded) {
 				this.fireEvent("toggle", { item: this });
 			} else {
-				this.fireEvent("stepIn", { item: this });
+				this.fireEvent("step-in", { item: this });
 			}
 		}
 
@@ -199,7 +199,7 @@ class TreeListItem extends ListItem {
 			if (this.expanded) {
 				this.fireEvent("toggle", { item: this });
 			} else if (this.hasParent) {
-				this.fireEvent("stepOut", { item: this });
+				this.fireEvent("step-out", { item: this });
 			}
 		}
 	}

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -77,7 +77,7 @@ const metadata = {
 			type: Node,
 		},
 	},
-	events: {
+	events: /** @lends sap.ui.webcomponents.main.TreeListItem.prototype */ {
 
 		/**
 		 * Fired when the user interacts with the expand/collapse button of the tree list item.
@@ -93,7 +93,8 @@ const metadata = {
 
 		/**
 		 * Fired when the user drills down into the tree hierarchy by pressing the right arrow on the tree node.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.TreeListItem#step-in
 		 * @param {HTMLElement} item the item on which right arrow was pressed.
 		 * @public
 		 */
@@ -105,7 +106,8 @@ const metadata = {
 
 		/**
 		 * Fired when the user goes up the tree hierarchy by pressing the left arrow on the tree node.
-		 * @event
+		 *
+		 * @event sap.ui.webcomponents.main.TreeListItem#step-out
 		 * @param {HTMLElement} item the item on which left arrow was pressed.
 		 * @public
 		 */

--- a/packages/main/src/WheelSlider.js
+++ b/packages/main/src/WheelSlider.js
@@ -103,7 +103,7 @@ const metadata = {
 		/**
 		 *  Fires when new value is selected.
 		 */
-		valueSelect: {
+		select: {
 			value: {
 				type: String,
 			},
@@ -293,7 +293,7 @@ class WheelSlider extends UI5Element {
 			this._scroller.scrollTo(0, scrollBy);
 			this._currentElementIndex = index;
 			this.value = this._items[index - (this._getCurrentRepetition() * this._items.length)];
-			this.fireEvent("valueSelect", { value: this.value });
+			this.fireEvent("select", { value: this.value });
 		}
 	}
 
@@ -359,7 +359,7 @@ class WheelSlider extends UI5Element {
 		if (this._expanded) {
 			this.value = e.target.textContent;
 			this._selectElement(e.target);
-			this.fireEvent("valueSelect", { value: this.value });
+			this.fireEvent("select", { value: this.value });
 		} else {
 			this._expanded = true;
 		}

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -95,7 +95,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 */
-		selectedYearChange: {},
+		change: {},
 	},
 };
 
@@ -241,7 +241,7 @@ class YearPicker extends UI5Element {
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
 			this._itemNav.current = YearPicker._MIDDLE_ITEM_INDEX;
-			this.fireEvent("selectedYearChange", { timestamp });
+			this.fireEvent("change", { timestamp });
 		}
 	}
 
@@ -268,7 +268,7 @@ class YearPicker extends UI5Element {
 			this.timestamp = timestamp;
 			this._selectedYear = this._year;
 			this._itemNav.current = YearPicker._MIDDLE_ITEM_INDEX;
-			this.fireEvent("selectedYearChange", { timestamp });
+			this.fireEvent("change", { timestamp });
 		}
 	}
 

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -151,10 +151,10 @@ class Suggestions {
 
 	async _attachItemsListeners() {
 		const list = await this._getList();
-		list.removeEventListener("ui5-itemPress", this.fnOnSuggestionItemPress);
-		list.addEventListener("ui5-itemPress", this.fnOnSuggestionItemPress);
-		list.removeEventListener("ui5-itemFocused", this.fnOnSuggestionItemFocus);
-		list.addEventListener("ui5-itemFocused", this.fnOnSuggestionItemFocus);
+		list.removeEventListener("ui5-item-press", this.fnOnSuggestionItemPress);
+		list.addEventListener("ui5-item-press", this.fnOnSuggestionItemPress);
+		list.removeEventListener("ui5-item-focused", this.fnOnSuggestionItemFocus);
+		list.addEventListener("ui5-item-focused", this.fnOnSuggestionItemFocus);
 	}
 
 	_attachPopupListeners() {
@@ -163,12 +163,12 @@ class Suggestions {
 		}
 
 		if (!this.attachedAfterOpened) {
-			this._respPopover.addEventListener("ui5-afterOpen", this._onOpen.bind(this));
+			this._respPopover.addEventListener("ui5-after-open", this._onOpen.bind(this));
 			this.attachedAfterOpened = true;
 		}
 
 		if (!this.attachedAfterClose) {
-			this._respPopover.addEventListener("ui5-afterClose", this._onClose.bind(this));
+			this._respPopover.addEventListener("ui5-after-close", this._onClose.bind(this));
 			this.attachedAfterClose = true;
 		}
 	}

--- a/packages/main/src/types/ListItemType.js
+++ b/packages/main/src/types/ListItemType.js
@@ -20,7 +20,7 @@ const ListItemTypes = {
 	Active: "Active",
 
 	/**
-	 * Enables detail button of the list item that fires detailClick event.
+	 * Enables detail button of the list item that fires detail-click event.
 	 * @public
 	 * @type {Detail}
 	 */

--- a/packages/main/test/samples/List.sample.html
+++ b/packages/main/test/samples/List.sample.html
@@ -57,7 +57,7 @@
 <script>
 	const infiniteScrollEx = document.getElementById("infiniteScrollEx");
 
-	infiniteScrollEx.addEventListener("loadMore", (e) => {
+	infiniteScrollEx.addEventListener("load-more", (e) => {
 		infiniteScrollEx.busy = true;
 
 		setTimeout(() => {
@@ -90,7 +90,7 @@
 			}
 		}
 
-		infiniteScrollEx.addEventListener("loadMore", (e) => {
+		infiniteScrollEx.addEventListener("load-more", (e) => {
 			var el = infiniteScrollEx;
 			el.busy = true;
 
@@ -114,7 +114,7 @@
 		</ui5-list>
 
 		<script>
-			document.getElementById('country-selector').addEventListener("selectionChange", function (event) {
+			document.getElementById('country-selector').addEventListener("selection-change", function (event) {
 				var selectedItems = event.detail.selectedItems;
 
 				alert("The selected item:  " + selectedItems[0].textContent);
@@ -130,7 +130,7 @@
 </ui5-list>
 
 <script>
-	document.getElementById('country-selector').addEventListener("selectionChange", function (event) {
+	document.getElementById('country-selector').addEventListener("selection-change", function (event) {
 		var selectedItems = event.detail.selectedItems;
 
 		alert("The selected item:  " + selectedItems[0].textContent);

--- a/packages/main/test/samples/Tree.sample.html
+++ b/packages/main/test/samples/Tree.sample.html
@@ -153,7 +153,7 @@
 <script>
 	var busyIndicator = document.getElementById("busy");
 	var dynamicTree = document.getElementById("treeDynamic");
-	dynamicTree.addEventListener("itemToggle", function(event) {
+	dynamicTree.addEventListener("item-toggle", function(event) {
 		var item = event.detail.item; // get the node that is toggled
 
 		// Only for the dynamic node, and only when it's empty
@@ -175,7 +175,7 @@
 	<script>
 		var busyIndicator = document.getElementById("busy");
 		var dynamicTree = document.getElementById("treeDynamic");
-		dynamicTree.addEventListener("itemToggle", function(event) {
+		dynamicTree.addEventListener("item-toggle", function(event) {
 			var item = event.detail.item; // get the node that is toggled
 
 			// Only for the dynamic node, and only when it's empty


### PR DESCRIPTION
**Rename all components event names that are currently camelCase to kebab-case, but keep the camelCase events firing for backward compatibility for at least one release to allow smooth migrations of the applications.**

**Notes:**
1) All test pages and test specs remains unchanged, they will verify that this change is a non-braking for the time being, testing against the old event names.

2) Several events of internally used components are completely renamed for simplification:
- DayPicker selectionChange-> change
- MonthPicker selectedMonthChange-> change
- YearPicker selectedYearChange -> change
- WheelSlider valueSelect -> select

3) To get the kebab-case names work with the JSDoc plugin we would manually name the event and assign it to the class as a member (auto handled with the camelCase names) as follows:
```js
/**
 * @public
 * @event sap.ui.webcomponents.main.MultiComboBox#open-change
*/
"open-change": {}
```

BREAKING_CHANGE: all event names are renamed from camelCase to kebabCase.
**Examples**: "selectionChange" becomes "selection-change", "itemClose" becomes "item-close",
"afterOpen" becomes "after-open" and so on.