### PR TITLE
fix(ui5-datetime-picker): set min width

### DIFF
--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -35,6 +35,7 @@ import {
 import DateTimePickerPopoverTemplate from "./generated/templates/DateTimePickerPopoverTemplate.lit.js";
 
 // Styles
+import DateTimePickerCss from "./generated/themes/DateTimePicker.css.js";
 import DateTimePickerPopoverCss from "./generated/themes/DateTimePickerPopover.css.js";
 
 const PHONE_MODE_BREAKPOINT = 640; // px
@@ -167,6 +168,10 @@ class DateTimePicker extends DatePicker {
 
 	static get staticAreaTemplate() {
 		return DateTimePickerPopoverTemplate;
+	}
+
+	static get styles() {
+		return [super.styles, DateTimePickerCss];
 	}
 
 	static get staticAreaStyles() {

--- a/packages/main/src/themes/DateTimePicker.css
+++ b/packages/main/src/themes/DateTimePicker.css
@@ -1,0 +1,3 @@
+:host .ui5-datepicker-input {
+	min-width: 14.5rem;
+}

--- a/packages/main/src/themes/DateTimePicker.css
+++ b/packages/main/src/themes/DateTimePicker.css
@@ -1,3 +1,3 @@
 :host .ui5-datepicker-input {
-	min-width: 14.5rem;
+	min-width: 15rem;
 }

--- a/packages/main/test/pages/DateTimePicker.html
+++ b/packages/main/test/pages/DateTimePicker.html
@@ -7,7 +7,11 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>DateTimePicker Test Page</title>
 
-	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script>
+		delete Document.prototype.adoptedStyleSheets;
+    </script>
+
+    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
@@ -17,7 +21,6 @@
 		}
 
 		ui5-datetime-picker {
-			width: 300px;
 			margin-bottom: 0.25rem;
 		}
 	</style>
@@ -100,7 +103,7 @@
 			id="input1"
 			style="width: 300px">
 		</ui5-input>
-	
+
 		<br><ui5-label>Changed value</ui5-label><br>
 		<ui5-input
 			id="input2"


### PR DESCRIPTION
The input length is not enough by several pixels and the text gets truncated/fully displayed whenever you focus/unfocus the component. 
 - set `min-width` just enough to show the whole value
 - remove the fixed width from our test page

closes: https://github.com/SAP/ui5-webcomponents/issues/1696