### PR TITLE
docs: fix spacing

### DIFF
--- a/docs/dev/Creating UI5 Web Components Packages.md
+++ b/docs/dev/Creating UI5 Web Components Packages.md
@@ -19,13 +19,13 @@ The name that you give to your package will be used by the UI5 Web Components to
 
 ## Step 2 - add the UI5 Web Components packages as dependencies
 
-`npm i --save @ui5/webcomponents-base @ui5/webcomponents-theme-base @ui5/webcomponents-tools`
-`npm i --save-dev chromedriver`
+With `npm`:
+ - `npm i --save @ui5/webcomponents-base @ui5/webcomponents-theme-base @ui5/webcomponents-tools`
+ - `npm i --save-dev chromedriver`
 
-or
-
-`yarn add @ui5/webcomponents-base @ui5/webcomponents-theme-base @ui5/webcomponents-tools`
-`yarn add -D chromedriver` 
+or with `yarn`:
+ - `yarn add @ui5/webcomponents-base @ui5/webcomponents-theme-base @ui5/webcomponents-tools`
+ - `yarn add -D chromedriver` 
 
 These three `@ui5/` packages will serve as foundation for your own package and web components.
 


### PR DESCRIPTION
After the last commit I saw that it doesn't look good on github (no new lines) so I changed it to be even more visible.
Now it will look like this:
![image](https://user-images.githubusercontent.com/15844574/83137972-c1ab9a00-a0f2-11ea-8a3e-d3731ef1c990.png)
