### PR TITLE
chore(tools): Improve test setup

### DIFF
--- a/packages/base/test/specs/ConfigurationScript.spec.js
+++ b/packages/base/test/specs/ConfigurationScript.spec.js
@@ -1,7 +1,7 @@
 const assert = require("chai").assert;
 
 describe("Configuration script has effect", () => {
-	browser.url("http://localhost:9191/test-resources/pages/ConfigurationScript.html");
+	browser.url("http://localhost:9191/test-resources/pages/ConfigurationScript.html?do-not-change-configuration");
 
 	it("Tests that RTL is applied", () => {
 		const res = browser.execute( () => {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -69,8 +69,6 @@ describe("Calendar general interaction", () => {
 			calendar._showYearPicker();
 		}, YEAR);
 
-		browser.pause(100);
-
 		assert.strictEqual(yearPicker.getProperty("_selectedYear"), YEAR, "Year is set");
 	})
 });

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -64,7 +64,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// act
 		openPickerById("dtSeconds");
-		browser.pause(500);
 
 		// assert
 		const currentValue = dtPicker.shadow$("ui5-input").getValue();
@@ -84,7 +83,6 @@ describe("DateTimePicker general interaction", () => {
 		picker.$(".ui5-dt-minutes-wheel").setProperty("value","02");
 		picker.$(".ui5-dt-seconds-wheel").setProperty("value","03");
 		picker.$("#ok").click();
-		browser.pause(500);
 
 		// assert
 		const newValue = dtPicker.shadow$("ui5-input").getValue();
@@ -94,21 +92,18 @@ describe("DateTimePicker general interaction", () => {
 	it("tests change event is fired on submit", () => {
 		// test submit from empty value to current date/time value
 		openPickerById("dt1");
-		browser.pause(500);
 
 		const inputCounter = browser.$("#input1");
 		const submitBtn = getSubmitButton("dt1");
 
 		// act
 		submitBtn.click();
-		browser.pause(500);
 
 		// assert
 		assert.strictEqual(inputCounter.getProperty("value"), "1", "Changed should be called 1 time.");
 
 		// tests submit on same value
 		openPickerById("dt1");
-		browser.pause(500);
 
 		// act
 		submitBtn.click();
@@ -120,14 +115,12 @@ describe("DateTimePicker general interaction", () => {
 
 	it("tests change event not fired on cancel", () => {
 		openPickerById("dt2");
-		browser.pause(500);
 
 		const inputCounter = browser.$("#input3");
 		const cancelBtn = getCancelButton("dt2");
 
 		// act
 		cancelBtn.click();
-		browser.pause(500);
 
 		// assert
 		assert.strictEqual(inputCounter.getProperty("value"), "", "Changed should not be called.");
@@ -140,7 +133,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// act
 		openPickerById("dtSeconds");
-		browser.pause(500);
 
 		// assert
 		const hoursMinSecSliders = getTimeSlidersCount("dtSeconds");
@@ -151,7 +143,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// act
 		openPickerById("dtMinutes");
-		browser.pause(500);
 
 		// assert
 		const hoursMinSliders = getTimeSlidersCount("dtMinutes");
@@ -164,7 +155,6 @@ describe("DateTimePicker general interaction", () => {
 	it("tests hours slider is expanded", () => {
 		// act
 		openPickerById("dt");
-		browser.pause(500);
 
 		// assert
 		const picker = getPicker("dt");
@@ -179,7 +169,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// act
 		openPickerById("dtTest12AM");
-		browser.pause(500);
 
 		const picker = getPicker("dtTest12AM");
 		picker.$(".ui5-dt-hours-wheel").setProperty("value","12");
@@ -187,7 +176,6 @@ describe("DateTimePicker general interaction", () => {
 		picker.$(".ui5-dt-seconds-wheel").setProperty("value","00");
 		picker.$(".ui5-dt-periods-wheel").setProperty("value","AM");
 		picker.$("#ok").click();
-		browser.pause(500);
 
 		// assert
 		const newValue = dtPicker.shadow$("ui5-input").getValue();
@@ -199,7 +187,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// act
 		openPickerById("dtTest12PM");
-		browser.pause(500);
 
 		const picker = getPicker("dtTest12PM");
 		picker.$(".ui5-dt-hours-wheel").setProperty("value","12");

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -9,12 +9,10 @@ describe("Item Navigation Tests", () => {
 		const firstItem = $("#item1");
 		const secondItem = $("#item2");
 
-		browser.pause(2000);
 		firstItem.click();
 		firstItem.keys("ArrowUp");
 		assert.strictEqual(firstItem.isFocused(), true, "first item remains focused - border reached.");
 
-		browser.pause(2000);
 		secondItem.click();
 		secondItem.keys("ArrowDown");
 		assert.strictEqual(secondItem.isFocused(), true, "second item remains focused - border reached.");
@@ -29,8 +27,6 @@ describe("Item Navigation Tests", () => {
 		firstItem.click();
 		firstItem.keys("ArrowRight");
 		assert.strictEqual(firstItem.isFocused(), true, "first item remains focused - horizontal navigation prevented.");
-
-		browser.pause(2000);
 
 		// verical navigation is allowed
 		firstItem.keys("ArrowDown");

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -64,13 +64,13 @@ describe("Popover general interaction", () => {
 
 		manyItemsSelect.click();
 
-		const lastListItem = items[items.length - 1];
+		const itemBeforeLastItem = items[items.length - 2];
 
-		assert.strictEqual(lastListItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
+		assert.strictEqual(itemBeforeLastItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
 
-		lastListItem.scrollIntoView();
+		itemBeforeLastItem.scrollIntoView();
 
-		assert.strictEqual(lastListItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
+		assert.strictEqual(itemBeforeLastItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
 
 		manyItemsSelect.click();
 	});
@@ -82,13 +82,13 @@ describe("Popover general interaction", () => {
 
 		openBigPopoverButton.click();
 
-		const lastListItem = items[items.length - 1];
+		const itemBeforeLastItem = items[items.length - 2];
 
-		assert.strictEqual(lastListItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
+		assert.strictEqual(itemBeforeLastItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
 
-		lastListItem.scrollIntoView();
+		itemBeforeLastItem.scrollIntoView();
 
-		assert.strictEqual(lastListItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
+		assert.strictEqual(itemBeforeLastItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
 	});
 
 	it("tests modal popover", () => {
@@ -134,7 +134,7 @@ describe("Popover general interaction", () => {
 		browser.keys("Tab");
 
 		assert.ok(!ff.getProperty("focused"), "The first focusable element is focused.");
-		
+
 		// button
 		browser.keys("Tab");
 

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -29,7 +29,6 @@ describe("TabContainer general interaction", () => {
 
 	it("scroll works on iconsOnly TabContainer", () => {
 		browser.setWindowSize(520, 1080);
-		browser.pause(2000);
 
 		const arrowLeft = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowLeft");
 		const arrowRight = $("#tabContainerIconOnly").shadow$(".ui5-tc__headerArrowRight");
@@ -51,7 +50,6 @@ describe("TabContainer general interaction", () => {
 
 	it("scroll works on textOnly TabContainer", () => {
 		browser.setWindowSize(520, 1080);
-		browser.pause(2000);
 
 		let arrowLeft = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowLeft");
 		let arrowRight = browser.$("#tabContainerTextOnly").shadow$(".ui5-tc__headerArrowRight");

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -8,7 +8,6 @@ describe("Table general interaction", () => {
 		const headerTableRow = browser.$("#tbl").shadow$("thead tr");
 
 		btn.click();
-		browser.pause(300);
 
 		assert.strictEqual((headerTableRow.getHTML(false).split("</slot>").length - 1), 4, "Columns should be 4");
 	});
@@ -19,7 +18,7 @@ describe("Table general interaction", () => {
 		const popinRows = browser.$("#roll-0").shadow$$(".ui5-table-popin-row");
 
 		btn.click();
-		browser.pause(300);
+
 		assert.strictEqual((headerTableRow.getHTML(false).split("</slot>").length - 1), 2, "Columns should be 4");
 		assert.strictEqual($("#roll-0").shadow$$(".ui5-table-popin-row").length, 2, "popin rows should be 2");
 	});
@@ -38,11 +37,10 @@ describe("Table general interaction", () => {
 	it("tests if popinChange is fired when min-width is reacted (500px)", () => {
 		let tableLabel = browser.$("#tableLabel");
 		const btn = browser.$("#size-btn-500");
-		
-		btn.click();
-		browser.pause(300);
 
-		assert.strictEqual(tableLabel.getHTML(false), "Number of poppedColumns: 2", "popinChange should be fired and columns should be 4");
+		btn.click();
+
+		assert.strictEqual(tableLabel.getHTML(false), "Number of poppedColumns: 4", "popinChange should be fired and columns should be 4");
 	});
 
 	it("tests rowClick is fired", () => {

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -278,6 +278,14 @@ exports.config = {
 	 * @param {Object} error error object if any
 	 */
 	afterCommand: function (commandName, args, result, error) {
+
+		// url -> set configuration first
+		if (commandName === "url" && !args[0].includes("do-not-change-configuration")) {
+			browser.execute(function() {
+				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
+			});
+		}
+
 		const waitFor = [
 			"addValue",
 			"clearValue",
@@ -291,15 +299,9 @@ exports.config = {
 			"setProperty", // custom
 			"setValue",
 			"setWindowSize",
-			"scrollIntoView",
 			"touchAction",
 			"url"
 		];
-		if (commandName === "url" && !args[0].includes("do-not-change-configuration")) {
-			browser.execute(function() {
-				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
-			});
-		}
 		if (waitFor.includes(commandName)) {
 			browser.executeAsync(function (done) {
 				window.RenderScheduler.whenFinished().then(done);

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -295,7 +295,7 @@ exports.config = {
 			"touchAction",
 			"url"
 		];
-		if (commandName === "url") {
+		if (commandName === "url" && !args[0].includes("do-not-change-configuration")) {
 			browser.execute(function() {
 				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
 			});

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -204,8 +204,34 @@ exports.config = {
 	 * @param {String} commandName hook command name
 	 * @param {Array} args arguments that command would receive
 	 */
-	// beforeCommand: function (commandName, args) {
-	// },
+	beforeCommand: function (commandName, args) {
+		const waitFor = [
+			"$",
+			"$$",
+			"getAttribute",
+			"getCSSProperty",
+			"getHTML",
+			"getProperty",
+			"getSize",
+			"getStaticAreaItemClassName", // custom
+			"getText",
+			"getValue",
+			"hasClass", // custom
+			"isDisplayed",
+			"isDisplayedInViewport",
+			"isEnabled",
+			"isExisting",
+			"isFocused",
+			"isFocusedDeep", // custom
+			"shadow$",
+			"shadow$$",
+		];
+		if (waitFor.includes(commandName)) {
+			browser.executeAsync(function (done) {
+				window.RenderScheduler.whenFinished().then(done);
+			});
+		}
+	},
 
 	/**
 	 * Hook that gets executed before the suite starts
@@ -252,11 +278,30 @@ exports.config = {
 	 * @param {Object} error error object if any
 	 */
 	afterCommand: function (commandName, args, result, error) {
-		const waitFor = ["$", "$$", "shadow$", "shadow$$", "getStaticAreaItemClassName", "click", "performActions", "elementClick", "keys", "sendKeys", "findElement", "elementClear", "elementSendKeys", "setValue", "addValue", "getHTML", "getProperty", "setProperty", "setAttribute", "removeAttribute", "getElementProperty"];
+		const waitFor = [
+			"addValue",
+			"clearValue",
+			"click",
+			"doubleClick",
+			"dragAndDrop",
+			"keys",
+			"pause",
+			"removeAttribute", // custom
+			"setAttribute", // custom
+			"setProperty", // custom
+			"setValue",
+			"setWindowSize",
+			"scrollIntoView",
+			"touchAction",
+			"url"
+		];
+		if (commandName === "url") {
+			browser.execute(function() {
+				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
+			});
+		}
 		if (waitFor.includes(commandName)) {
 			browser.executeAsync(function (done) {
-				// run all the tests in no conflict mode
-				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
 				window.RenderScheduler.whenFinished().then(done);
 			});
 		}


### PR DESCRIPTION
The goal of this change is to improve the test setup in several ways:

Stability and cleanup:
 - Await for `RenderScheduler.whenFinished()` **before** read commands, such as `getAttribute` and not after them, as we did until now
 - Await for `RenderScheduler.whenFinished()` **after** write/action/change commands, such as `click`, `setAttribute` as before
 - wait for all commands that we use (or may use in the future), as some were still missing
 - Remove obsolete commands such as `performActions`, `sendKeys`, etc... that we no longer use
 - Await for `RenderScheduler.whenFinished()` after `url` and `pause` as it makes sense to await for all rendering after a page is loaded or after a pause (normally pauses should be an exception).

Performance:
 - set "no conflict mode" only after a `url` command, and not before/after each command as before. For one particular configuration test, this must not be done, so there is a URL parameter that can disable this behavior.
 - remove unnecessary `pause` calls. Many were set due to no framework synchronization after things such as `setWindowSize` or before read operations, because we used to wait for the framework after, and not before read operations. These are now redundant. The only case when `pause` should be used is for animations and simulated load events.

In addition: 
 - After the fixes, a table test was failing. It expects "Number of poppedColumns: 2" and the explanation of the test is "popinChange should be fired and columns should be 4". Fixing it to 4 makes it work. Probably didn't work with 4 before (but with 2) because of the lack of synchronization. This is how it looks like in the browser:
![image](https://user-images.githubusercontent.com/15844574/83242848-bf564800-a1a5-11ea-97b2-dd374268f3a8.png)

 - One popover test was unstable. The reason is that `scrollIntoView` sometimes does not scroll the last item completely into view and `isDisplayedInViewport` returns false. It's much more reliable to use the item before the last item. See the image for the bad scroll into view:
![image](https://user-images.githubusercontent.com/15844574/83242265-c29d0400-a1a4-11ea-98f8-65b86c94a005.png)
