### PR TITLE
chore(tools): run single test spec

### DIFF
--- a/packages/tools/bin/dev.js
+++ b/packages/tools/bin/dev.js
@@ -2,4 +2,14 @@
 
 const child_process = require("child_process");
 
-child_process.execSync(`npx nps ${process.argv[2]}`, {stdio: 'inherit'});
+let command = process.argv[2];
+
+// Support for running the test task with a spec parameter
+if (command === "test") {
+	const spec = process.argv[3];
+	if (spec) {
+		command = `test.spec --spec ${spec}`;
+	}
+}
+
+child_process.execSync(`npx nps "${command}"`, {stdio: 'inherit'});

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -68,6 +68,7 @@ const getScripts = (options) => {
 			// --success first - report the exit code of the test run (first command to finish), as serve is always terminated and has a non-0 exit code
 			default: 'concurrently "nps serve" "nps test.run" --kill-others --success first',
 			run: "cross-env WDIO_LOG_LEVEL=error FORCE_COLOR=0 wdio config/wdio.conf.js",
+			spec: "wdio run config/wdio.conf.js",
 		},
 	};
 


### PR DESCRIPTION
Currently the standard way to run a single test spec is as follows:
```
yarn run wdio ../tools/components-package/wdio.js --spec test/specs/Button.spec.js
```
After this change you can run "yarn test `<spec name>`", for example:
```
yarn test test/specs/Button.spec.js
```

*Note:*
What happens when you run "yarn test"
 - The static server runs
 - All test specs are executed

What happens when you run "yarn test `<spec name>`"
 - Only the selected spec is executed (it is intended that you're already running `start` during development and testing anyway)

