### PR TITLE
chore: fix button slot display

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -284,7 +284,7 @@ class Button extends UI5Element {
 			console.warn(`In order for the "submits" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line
 		}
 
-		this.iconOnly = !this.textContent;
+		this.iconOnly = this.isIconOnly;
 		this.hasIcon = !!this.icon;
 	}
 
@@ -336,6 +336,10 @@ class Button extends UI5Element {
 
 	get hasButtonType() {
 		return this.design !== ButtonDesign.Default && this.design !== ButtonDesign.Transparent;
+	}
+
+	get isIconOnly() {
+		return !Array.from(this.childNodes).filter(node => node.nodeType !== Node.COMMENT_NODE).length;
 	}
 
 	get accInfo() {

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -31,6 +31,13 @@
 <body style="background-color: var(--sapBackgroundColor);">
 
 	<ui5-button icon="home"><!----><!----></ui5-button>
+	<ui5-button>
+		<ui5-avatar
+			id="btnImage"
+			size="XS"
+			image="https://openui5nightly.hana.ondemand.com/test-resources/sap/f/images/Woman_avatar_01.png">
+		</ui5-avatar>
+	</ui5-button>
 	<ui5-icon name="invalid_name"></ui5-icon>
 	<ui5-button design="Emphasized" icon="invalid_name">Press</ui5-button>
 

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -21,6 +21,11 @@ describe("Button general interaction", () => {
 		assert.strictEqual(button.shadow$$("ui5-icon").length, 0, "icon is not present");
 	});
 
+	it("tests button's slot rendering", () => {
+		const btnImage = browser.$("#btnImage");
+		assert.strictEqual(btnImage.isDisplayed(), true, "Btn image is rendered");
+	});
+
 	it("tests click event", () => {
 		const button = browser.$("#button1");
 		const field = browser.$("#click-counter");


### PR DESCRIPTION
Recent fix for how icon-only button with just comment nodes is rendered, has affected rendering of images, avatars inside the button.
This can be seen in the [ShellBar page](https://sap.github.io/ui5-webcomponents/master/playground/components/ShellBar/), where ui5-avatar is used for profile slot, internally slotted in a ui5-button. The profile image is not visible as "display: none" is applied due to the icon-only state of the ui5-button. 
Now we filter the comment nodes and check for the childNodes length to determine if its icon-only button or not.

Master and after this change
![imgonline-com-ua-twotoone-mWlNoTNrMyU](https://user-images.githubusercontent.com/15702139/83477631-63890900-a49c-11ea-9050-97641746f027.jpg)

