### PR TITLE
fix(ui5-file-uploader): setting the value to an empty string also res…

### DIFF
--- a/packages/fiori/test/pages/uploadCollectionScript.js
+++ b/packages/fiori/test/pages/uploadCollectionScript.js
@@ -62,6 +62,7 @@
 		for (var i = 0; i < files.length; i++) {
 			uploadCollection.appendChild(createUCI(files[i]));
 		}
+		document.getElementById("fileUploader").value = "";
 	});
 
 	uploadCollection.addEventListener("ui5-selectionChange", function (event) {
@@ -86,7 +87,7 @@
 		uploadCollection.items.forEach(function (item) {
 			if (item.uploadState === "Ready" && item.file) {
 				var oXHR = new XMLHttpRequest();
-				
+
 				oXHR.open("POST", "/upload", true);
 				oXHR.onreadystatechange  = function () {
 					if (this.status !== 200) {

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -247,6 +247,12 @@ class FileUploader extends UI5Element {
 		this._enableFormSupport();
 	}
 
+	onAfterRendering() {
+		if (!this.value) {
+			this.getDomRef().querySelector(`input[type="file"]`).value = "";
+		}
+	}
+
 	_enableFormSupport() {
 		const FormSupport = getFeature("FormSupport");
 


### PR DESCRIPTION
Currently it is not possible to upload the same file twice in a row, as the `change` event is never fired. There are use cases when the user uploaded a file, then removed it (f.e. from the UploadCollection) and then they try to upload the same file again. However, nothing happens as no `change` event is fired form the native `input`. Even if the developer sets `value` to an empty string, this only affects `ui5-file-uploader`, but does not affect the native `input` in any way, so it's stuck with the old file despite the fact that `ui5-file-uploader` looks empty to the user.

The implementation is in `onAfterRendering` for a reason. The native file input's `value` property is read-only, but can be set to an empty string, and only to that, so it's almost like a public method. Trying to bind this property is problematic, because `lit-html` should never try to change it, but only to set it to an empty string, which makes it hard to keep the state up to date. Therefore it's safest to do this imperatively.

In addition: The UploadCollection sample was updated to reset the file uploader each time the user uploads a file, so they can upload the same file twice now.

closes: https://github.com/SAP/ui5-webcomponents/issues/1709