### PR TITLE
fix(framework): Allow users to override default language translations

### DIFF
--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -28,7 +28,8 @@ const getI18nBundleData = packageName => {
  * @public
  */
 const registerI18nBundle = (packageName, bundle) => {
-	bundleURLs.set(packageName, bundle);
+	const oldBundle = bundleURLs.get(packageName) || {};
+	bundleURLs.set(packageName, Object.assign({}, oldBundle, bundle));
 };
 
 /**

--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -52,11 +52,11 @@ const fetchI18nBundle = async packageName => {
 	const language = getLocale().getLanguage();
 
 	let localeId = normalizeLocale(language);
-	while (!bundlesForPackage[localeId]) {
+	while (localeId !== DEFAULT_LANGUAGE && !bundlesForPackage[localeId]) {
 		localeId = nextFallbackLocale(localeId);
 	}
 
-	if (localeId === DEFAULT_LANGUAGE) {
+	if (!bundlesForPackage[localeId]) {
 		return;
 	}
 

--- a/packages/tools/lib/generate-json-imports/i18n.js
+++ b/packages/tools/lib/generate-json-imports/i18n.js
@@ -1,18 +1,21 @@
 const fs = require("fs");
 const path = require('path');
 const mkdirp = require("mkdirp");
+const assets = require("../../assets-meta.js");
 
 const packageName = JSON.parse(fs.readFileSync("package.json")).name;
 
 const inputFolder = path.normalize(process.argv[2]);
 const outputFile = path.normalize(`${process.argv[3]}/i18n.js`);
 
+const defaultLanguage = assets.languages.default;
+
 // All languages present in the file system
 const files = fs.readdirSync(inputFolder);
 const languages = files.map(file => {
   const matches = file.match(/messagebundle_(.+?).json$/);
   return matches ? matches[1] : undefined;
-}).filter(key => !!key);
+}).filter(key => !!key).filter(key => key !== defaultLanguage);
 
 let content;
 

--- a/packages/tools/lib/generate-json-imports/i18n.js
+++ b/packages/tools/lib/generate-json-imports/i18n.js
@@ -15,7 +15,7 @@ const files = fs.readdirSync(inputFolder);
 const languages = files.map(file => {
   const matches = file.match(/messagebundle_(.+?).json$/);
   return matches ? matches[1] : undefined;
-}).filter(key => !!key).filter(key => key !== defaultLanguage);
+}).filter(key => !!key && key !== defaultLanguage);
 
 let content;
 


### PR DESCRIPTION
The goal of this change is to facilitate (and fix) custom i18n bundles, provided by users for our packages.

Currently it is already possible for the user to provide custom translations for our packages. For example:

```js
import { registerI18nBundle } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";
registerI18nBundle("@ui5/webcomponents", {
	en: "./lang/en.json",
	es: "./lang/es.json",
});
```

The code above will register these 2 URLs for fetching the translations for the respective package.

However, this works for all languages *except for the default language*. There is an optimization in the `i18n` asset registry: 
`if (localeId === DEFAULT_LANGUAGE)` 
that forces the components to use the built-in default language even if the user provided custom translations from their own message bundle. Therefore, the check is changed to:
`if (!bundlesForPackage[localeId])`
so that we only use the default built-in translations only when no bundle was provided. 
Therefore, in the JSON imports generation script, we no longer register a bundle for the default language.

In addition: now it is possible to register just some keys for a package, without overriding the whole bundle. This makes it very easy for users to provide just a few keys, and let the others remain from our translations. 

In addition: fixed a bug that caused an infinite `while` loop if the user sets in the URL a language that doesn't have a registered bundle. In that case, the default language should be used.

closes: https://github.com/SAP/ui5-webcomponents/issues/1680