### PR TITLE
fix(ui5-select): fix use of ESC leads to wrong selection

### DIFF
--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -395,7 +395,7 @@ class Select extends UI5Element {
 			}
 		}
 
-		if (isEscape(event)) {
+		if (isEscape(event) && this._isPickerOpen) {
 			this._escapePressed = true;
 		}
 

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -60,6 +60,12 @@
 		<ui5-option>Opt3</ui5-option>
 	</ui5-select>
 
+	<ui5-select id="mySelectEsc">
+		<ui5-option>Cozy</ui5-option>
+		<ui5-option selected>Compact</ui5-option>
+		<ui5-option>Condensed</ui5-option>
+	</ui5-select>
+
 	<h2> Change event counter holder</h2>
 	<ui5-input id="inputResult"></ui5-input>
 

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -228,4 +228,27 @@ describe("Select general interaction", () => {
 
 		assert.strictEqual(inputResult.getProperty("value"), "7", "Change event should be fired");
 	});
+
+	it("tests ESC on closed picker", () => {
+		const select = $("#mySelectEsc");
+		const selectText = browser.$("#mySelectEsc").shadow$("ui5-label");
+		const EXPECTED_SELECTION_TEXT = "Cozy";
+		const EXPECTED_SELECTION_TEXT2 = "Condensed";
+
+		select.click();
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#mySelectEsc")
+		const firstItem = browser.$(`.${staticAreaItemClassName}`).shadow$$("ui5-li")[0];
+		const thirdItem = browser.$(`.${staticAreaItemClassName}`).shadow$$("ui5-li")[2];
+
+		firstItem.click();
+
+		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT) !== -1, "Select label is correct.");
+
+		// verify that ESC does not interfere when the picker is closed
+		select.keys("Escape"); 
+		select.click();
+		thirdItem.click();
+
+		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT2) !== -1, "Select label is correct.");
+	});
 });


### PR DESCRIPTION
When the picker is closed and the user hits ESC, the component saves that action
and cancels the next selection. Now ESC cancels selection only if the picker is opened.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1721