### PR TITLE
ui5-table: design implemented for popped-in columns

### DIFF
--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -19,7 +19,7 @@
 
 {{#if shouldPopin}}
 	{{#each popinCells}}
-		<tr part="popin-row" class="ui5-table-popin-row" @click="{{../_onrowclick}}">
+		<tr part="popin-row" class="{{this.classes}}" @click="{{../_onrowclick}}">
 			<td colspan="{{../visibleCellsCount}}">
 				{{#if this.popinText}}
 					<span class="ui5-table-row-popin-title">{{this.popinText}}:</span>

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -104,6 +104,10 @@ class TableRow extends UI5Element {
 		}).length;
 	}
 
+	get allColumnsPoppedIn() {
+		return this._columnsInfo.every(el => el.demandPopin && !el.visible);
+	}
+
 	onBeforeRendering() {
 		if (!this.shouldPopin) {
 			return;
@@ -116,6 +120,7 @@ class TableRow extends UI5Element {
 			return;
 		}
 
+		const allColumnsPoppedInClass = this.allColumnsPoppedIn ? "all-columns-popped-in" : "";
 		this._columnsInfo.forEach((info, index) => {
 			const cell = this.cells[index];
 
@@ -128,9 +133,11 @@ class TableRow extends UI5Element {
 				cell.firstInRow = (index === 0);
 				cell.popined = false;
 			} else if (info.demandPopin) {
+				const popinHeaderClass = this.popinCells.length === 0 ? "popin-header" : "";
 				this.popinCells.push({
 					cell,
 					popinText: info.popinText,
+					classes: `ui5-table-popin-row ${allColumnsPoppedInClass} ${popinHeaderClass}`,
 				});
 
 				cell.popined = true;

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -12,6 +12,14 @@
 	outline-offset: -0.125rem;
 }
 
+.ui5-table-popin-row {
+    background-color: var(--sapList_Background);
+}
+
+.ui5-table-popin-row.all-columns-popped-in.popin-header {
+    border-top: 1px solid var(--sapList_BorderColor);
+}
+
 .ui5-table-popin-row td {
 	padding: .25rem;
 	padding-left: 1rem;

--- a/packages/main/test/pages/TableAllPopin.html
+++ b/packages/main/test/pages/TableAllPopin.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Web components Table</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <script data-ui5-config type="application/json">
+        {
+            "language": "EN"
+        }
+    </script>
+
+    <script>
+		delete Document.prototype.adoptedStyleSheets
+    </script>
+
+    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../resources/bundle.esm.js" type="module"></script>
+    <script nomodule src="../../resources/bundle.es5.js"></script>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+<ui5-table class="demo-table" id="tbl">
+    <!-- Columns -->
+    <ui5-table-column class="title-column" slot="columns" min-width="640" popin-text="Product" demand-popin>
+        <ui5-label>Product</ui5-label>
+    </ui5-table-column>
+
+    <ui5-table-column class="supplier-column" slot="columns" min-width="1024" popin-text="Supplier" demand-popin>
+        <ui5-label>Supplier</ui5-label>
+    </ui5-table-column>
+
+    <ui5-table-column class="dim-column" slot="columns" min-width="800" popin-text="Dimensions" demand-popin>
+        <div class="column-content">
+            <ui5-label>Dimensions</ui5-label>
+        </div>
+    </ui5-table-column>
+
+    <ui5-table-column class="weight-column" slot="columns" min-width="640" popin-text="Weight" demand-popin>
+        <ui5-label>Weight</ui5-label>
+    </ui5-table-column>
+
+    <ui5-table-column class="price-column" slot="columns" min-width="640" popin-text="Price" demand-popin>
+        <ui5-label>Price</ui5-label>
+    </ui5-table-column>
+
+
+    <ui5-table-row id="row1">
+        <ui5-table-cell class="title-cell">Notebook Basic 15</ui5-table-cell>
+        <ui5-table-cell>Very Best Screens</ui5-table-cell>
+        <ui5-table-cell>30 x 18 x 3 cm</ui5-table-cell>
+        <ui5-table-cell>4.2 KG</ui5-table-cell>
+        <ui5-table-cell class="price-cell">956 EUR</ui5-table-cell>
+    </ui5-table-row>
+
+    <ui5-table-row id="row2">
+        <ui5-table-cell class="title-cell">Notebook Basic 17</ui5-table-cell>
+        <ui5-table-cell>Very Best Screens</ui5-table-cell>
+        <ui5-table-cell>40 x 18 x 3 cm</ui5-table-cell>
+        <ui5-table-cell>4.6 KG</ui5-table-cell>
+        <ui5-table-cell class="price-cell">1956 EUR</ui5-table-cell>
+    </ui5-table-row>
+
+    <ui5-table-row id="row3">
+        <ui5-table-cell class="title-cell">Notebook Basic 19</ui5-table-cell>
+        <ui5-table-cell>Very Best Screens</ui5-table-cell>
+        <ui5-table-cell>50 x 18 x 3 cm</ui5-table-cell>
+        <ui5-table-cell>4.9 KG</ui5-table-cell>
+        <ui5-table-cell class="price-cell">2956 EUR</ui5-table-cell>
+    </ui5-table-row>
+
+</ui5-table>
+
+</body>
+
+</html>


### PR DESCRIPTION
This change fixes two issues:
 - The `popin` rows had the wrong color until now, and they must be exactly the same color as the normal rows by design
 - When all columns are popped in, since there is no normal row, there is nothing to provide the border. Therefore, the top popin row for the first column of for each group should do it.

closes: https://github.com/SAP/ui5-webcomponents/issues/1710