### PR TITLE
feature(framework): Deprecate the RTL configuration setting

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,9 +32,9 @@ The `theme` setting values above are the technical names of our themes.
 ### RTL
 **Deprecated as of 1.0.0-rc.8**
 
-In order to have RTL mode, just set the HTML attribute `dir` to `rtl` on the `body` or `html`, or any other relevant region of your application.
+In order to have RTL mode, just set the HTML attribute `dir` to `rtl` on the `body`, `html` or any other relevant region of your application.
 
-This configuration setting should not be used by applications.
+This configuration setting should not be used by applications. It is only internally used for specific integration scenarios.
 
 <a name="animationMode"></a>
 ### Animation Mode

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -9,7 +9,7 @@ There are several configuration settings that affect all UI5 Web Components glob
 ------------ | ----------------------------------------------- | ------------- | -------------------------------------------------------------
 [theme](#theme)        | sap_fiori_3, sap_fiori_3_dark, sap_belize, sap_belize_hcb, sap_belize_hcw | sap_fiori_3   | Visual theme
 language     | en, de, es, etc...                              | en            | Language to be used for translatable texts
-[RTL](#rtl) (**deprecated since 0.0.0-rc.8**)    | true, false                                     | false         | When true, sets global text direction to right-to-left
+[RTL](#rtl) (**deprecated since 1.0.0-rc.8**)    | true, false                                     | false         | When true, sets global text direction to right-to-left
 [animationMode](#animationMode)  | full, basic, minimal, none  | full          | Defines different animation scenarios or levels
 calendarType | Gregorian, Islamic, Buddhist, Japanese, Persian | Gregorian     | Default calendar type for date-related web components
 [noConflict](#noConflict)  | true, false | false                            | When set to true, all events will be fired with a "ui5-" prefix only

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -9,7 +9,7 @@ There are several configuration settings that affect all UI5 Web Components glob
 ------------ | ----------------------------------------------- | ------------- | -------------------------------------------------------------
 [theme](#theme)        | sap_fiori_3, sap_fiori_3_dark, sap_belize, sap_belize_hcb, sap_belize_hcw | sap_fiori_3   | Visual theme
 language     | en, de, es, etc...                              | en            | Language to be used for translatable texts
-[RTL](#rtl)          | true, false                                     | false         | When true, sets global text direction to right-to-left
+[RTL](#rtl) (**deprecated since 0.0.0-rc.8**)    | true, false                                     | false         | When true, sets global text direction to right-to-left
 [animationMode](#animationMode)  | full, basic, minimal, none  | full          | Defines different animation scenarios or levels
 calendarType | Gregorian, Islamic, Buddhist, Japanese, Persian | Gregorian     | Default calendar type for date-related web components
 [noConflict](#noConflict)  | true, false | false                            | When set to true, all events will be fired with a "ui5-" prefix only
@@ -30,10 +30,11 @@ The `theme` setting values above are the technical names of our themes.
 
 <a name="rtl"></a>
 ### RTL
- 
-When the `rtl` setting is set to `true`, UI5 Web Components will adjust their styling accordingly.
-However, you should also set the HTML attribute `dir` to `rtl` on the `body` or `html`, or any other relevant region of your application
-so that the rest of your application is also affected. 
+**Deprecated as of 1.0.0-rc.8**
+
+In order to have RTL mode, just set the HTML attribute `dir` to `rtl` on the `body` or `html`, or any other relevant region of your application.
+
+This configuration setting should not be used by applications.
 
 <a name="animationMode"></a>
 ### Animation Mode
@@ -95,7 +96,6 @@ In order to provide configuration settings, include the following ```<script>```
 ```html
 <script data-ui5-config type="application/json">
 {
-	"rtl": true,
 	"language": "ja",
 	"calendarType": "Japanese",
 	"formatSettings": {
@@ -121,7 +121,6 @@ To do so, please import the desired functionality from the respective `"@ui5/web
 ```js
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { getNoConflict, setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";

--- a/docs/Public Module Imports.md
+++ b/docs/Public Module Imports.md
@@ -342,7 +342,6 @@ In order to be able to use Buddhist, Islamic, Japanese, or Persian calendar with
 ```js
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { getNoConflict, setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
@@ -362,7 +361,7 @@ from OpenUI5 configuration and resources.
 
 When you import the above module:
  1. OpenUI5 configuration takes precedence over UI5 Web Components configuration
- for all common entities (theme, language, RTL, etc...). In addition, changing the theme
+ for all common entities (theme, language, etc...). In addition, changing the theme
  in OpenUI5 will also change the theme in UI5 Web Components.
  2. Fonts will not be loaded twice (just once by OpenUI5, and reused).
  3. Locale Data assets will not be fetched twice (just once by OpenUI5, and reused).

--- a/packages/base/src/SystemCSSVars.js
+++ b/packages/base/src/SystemCSSVars.js
@@ -2,21 +2,21 @@ import createStyleInHead from "./util/createStyleInHead.js";
 
 const systemCSSVars = `
 	:root {
-		--_ui5_content_density: cozy;
+		--_ui5_content_density:cozy;
 	}
 	
 	[data-ui5-compact-size],
 	.ui5-content-density-compact,
 	.sapUiSizeCompact {
-		--_ui5_content_density: compact;
+		--_ui5_content_density:compact;
 	}
 	
 	[dir="rtl"] {
-		--_ui5_dir: rtl;
+		--_ui5_dir:rtl;
 	}
 	
 	[dir="ltr"] {
-		--_ui5_dir: ltr;
+		--_ui5_dir:ltr;
 	}
 `;
 

--- a/packages/base/src/SystemCSSVars.js
+++ b/packages/base/src/SystemCSSVars.js
@@ -1,0 +1,31 @@
+import createStyleInHead from "./util/createStyleInHead.js";
+
+const systemCSSVars = `
+	:root {
+		--_ui5_content_density: cozy;
+	}
+	
+	[data-ui5-compact-size],
+	.ui5-content-density-compact,
+	.sapUiSizeCompact {
+		--_ui5_content_density: compact;
+	}
+	
+	[dir="rtl"] {
+		--_ui5_dir: rtl;
+	}
+	
+	[dir="ltr"] {
+		--_ui5_dir: ltr;
+	}
+`;
+
+const insertSystemCSSVars = () => {
+	if (document.querySelector(`head>style[data-ui5-system-css-vars]`)) {
+		return;
+	}
+
+	createStyleInHead(systemCSSVars, { "data-ui5-system-css-vars": "" });
+};
+
+export default insertSystemCSSVars;

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -668,17 +668,22 @@ class UI5Element extends HTMLElement {
 	 * @returns {String|undefined}
 	 */
 	get effectiveDir() {
-		// For modern browsers - check the CSS Var and apply its value to the shadow DOM, if set explicitly (rtl|ltr)
-		// For IE "dir" will be naturally applied since there is no Shadow DOM.
-		if (!window.ShadyDOM) {
-			const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
-			const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
-			if (dirValues.includes(locallyAppliedDir)) {
-				return locallyAppliedDir;
-			}
+		const doc = window.document;
+		const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
+		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
+
+		// In that order, inspect the CSS Var (for modern browsers), html and body (for IE fallback)
+		if (dirValues.includes(locallyAppliedDir)) {
+			return locallyAppliedDir;
+		}
+		if (dirValues.includes(doc.documentElement.dir)) {
+			return doc.documentElement.dir;
+		}
+		if (dirValues.includes(doc.body.dir)) {
+			return doc.body.dir;
 		}
 
-		// Finally, check the configuration for explicitly set RTL or language-implied RTL - if so, enforce it
+		// Finally, check the configuration for explicitly set RTL or language-implied RTL
 		return getRTL() ? "rtl" : undefined;
 	}
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -668,15 +668,14 @@ class UI5Element extends HTMLElement {
 	 * @returns {String|undefined}
 	 */
 	get effectiveDir() {
-		// Modern browsers - detect if "dir" was set anywhere in the DOM
+		const doc = window.document;
+		const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
 		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
-		if (locallyAppliedDir !== undefined) {
+
+		// In that order, inspect the CSS Var (for modern browsers), html and body (for IE fallback)
+		if (dirValues.includes(locallyAppliedDir)) {
 			return locallyAppliedDir;
 		}
-
-		// IE fallback - since getComputedStyle will return undefined for the CSS var, manually look for "dir=ltr|rtl" on the <html> and <body> tags
-		const doc = window.document;
-		const dirValues = ["ltr", "rtl"];
 		if (dirValues.includes(doc.documentElement.dir)) {
 			return doc.documentElement.dir;
 		}
@@ -685,8 +684,7 @@ class UI5Element extends HTMLElement {
 		}
 
 		// Finally, check the configuration for explicitly set RTL or language-implied RTL
-		const configuredDir = getRTL();
-		return configuredDir ? "rtl" : undefined;
+		return getRTL() ? "rtl" : undefined;
 	}
 
 	updateStaticAreaItemContentDensity() {

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -668,22 +668,17 @@ class UI5Element extends HTMLElement {
 	 * @returns {String|undefined}
 	 */
 	get effectiveDir() {
-		const doc = window.document;
-		const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
-		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
-
-		// In that order, inspect the CSS Var (for modern browsers), html and body (for IE fallback)
-		if (dirValues.includes(locallyAppliedDir)) {
-			return locallyAppliedDir;
-		}
-		if (dirValues.includes(doc.documentElement.dir)) {
-			return doc.documentElement.dir;
-		}
-		if (dirValues.includes(doc.body.dir)) {
-			return doc.body.dir;
+		// For modern browsers - check the CSS Var and apply its value to the shadow DOM, if set explicitly (rtl|ltr)
+		// For IE "dir" will be naturally applied since there is no Shadow DOM.
+		if (!window.ShadyDOM) {
+			const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
+			const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
+			if (dirValues.includes(locallyAppliedDir)) {
+				return locallyAppliedDir;
+			}
 		}
 
-		// Finally, check the configuration for explicitly set RTL or language-implied RTL
+		// Finally, check the configuration for explicitly set RTL or language-implied RTL - if so, enforce it
 		return getRTL() ? "rtl" : undefined;
 	}
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -660,12 +660,31 @@ class UI5Element extends HTMLElement {
 		return getComputedStyle(this).getPropertyValue(GLOBAL_CONTENT_DENSITY_CSS_VAR) === "compact";
 	}
 
+	/**
+	 * Determines whether the component should be rendered in RTL mode or not.
+	 * Returns: "rtl", "ltr" or undefined
+	 *
+	 * @public
+	 * @returns {String|undefined}
+	 */
 	get effectiveDir() {
+		// Modern browsers - detect if "dir" was set anywhere in the DOM
 		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
 		if (locallyAppliedDir !== undefined) {
 			return locallyAppliedDir;
 		}
 
+		// IE fallback - since getComputedStyle will return undefined for the CSS var, manually look for "dir=ltr|rtl" on the <html> and <body> tags
+		const doc = window.document;
+		const dirValues = ["ltr", "rtl"];
+		if (dirValues.includes(doc.documentElement.dir)) {
+			return doc.documentElement.dir;
+		}
+		if (dirValues.includes(doc.body.dir)) {
+			return doc.body.dir;
+		}
+
+		// Finally, check the configuration for explicitly set RTL or language-implied RTL
 		const configuredDir = getRTL();
 		return configuredDir ? "rtl" : undefined;
 	}

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -672,9 +672,12 @@ class UI5Element extends HTMLElement {
 		const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
 		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
 
-		// In that order, inspect the CSS Var (for modern browsers), html and body (for IE fallback)
+		// In that order, inspect the CSS Var (for modern browsers), the element itself, html and body (for IE fallback)
 		if (dirValues.includes(locallyAppliedDir)) {
 			return locallyAppliedDir;
+		}
+		if (dirValues.includes(this.dir)) {
+			return this.dir;
 		}
 		if (dirValues.includes(doc.documentElement.dir)) {
 			return doc.documentElement.dir;

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -6,6 +6,7 @@ import RenderScheduler from "./RenderScheduler.js";
 import { registerTag, isTagRegistered, recordTagRegistrationFailure } from "./CustomElementsRegistry.js";
 import DOMObserver from "./compatibility/DOMObserver.js";
 import { skipOriginalEvent } from "./config/NoConflict.js";
+import { getRTL } from "./config/RTL.js";
 import getConstructableStyle from "./theming/getConstructableStyle.js";
 import createComponentStyleTag from "./theming/createComponentStyleTag.js";
 import getEffectiveStyle from "./theming/getEffectiveStyle.js";
@@ -25,6 +26,8 @@ let autoId = 0;
 const elementTimeouts = new Map();
 
 const GLOBAL_CONTENT_DENSITY_CSS_VAR = "--_ui5_content_density";
+const GLOBAL_DIR_CSS_VAR = "--_ui5_dir";
+
 /**
  * Base class for all UI5 Web Components
  *
@@ -655,6 +658,16 @@ class UI5Element extends HTMLElement {
 
 	get isCompact() {
 		return getComputedStyle(this).getPropertyValue(GLOBAL_CONTENT_DENSITY_CSS_VAR) === "compact";
+	}
+
+	get effectiveDir() {
+		const locallyAppliedDir = getComputedStyle(this).getPropertyValue(GLOBAL_DIR_CSS_VAR);
+		if (locallyAppliedDir !== undefined) {
+			return locallyAppliedDir;
+		}
+
+		const configuredDir = getRTL();
+		return configuredDir ? "rtl" : undefined;
 	}
 
 	updateStaticAreaItemContentDensity() {

--- a/packages/base/src/boot.js
+++ b/packages/base/src/boot.js
@@ -1,5 +1,6 @@
 import whenDOMReady from "./util/whenDOMReady.js";
 import insertFontFace from "./FontFace.js";
+import insertSystemCSSVars from "./SystemCSSVars.js";
 import { getTheme } from "./config/Theme.js";
 import applyTheme from "./theming/applyTheme.js";
 import whenPolyfillLoaded from "./compatibility/whenPolyfillLoaded.js";
@@ -22,6 +23,7 @@ const boot = () => {
 		await applyTheme(getTheme());
 		OpenUI5Support && OpenUI5Support.attachListeners();
 		insertFontFace();
+		insertSystemCSSVars();
 		await whenPolyfillLoaded();
 		resolve();
 	});

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -5,7 +5,7 @@
 	@keydown="{{_onkeydown}}"
 	role="option"
 	tabindex="{{_tabIndex}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	aria-labelledby="{{ariaLabelledBy}}"
 >
 	<div class="ui5-nli-group-header">
@@ -75,7 +75,7 @@
 		<slot></slot>
 	</ui5-list>
 
-	{{#if busy}} 
+	{{#if busy}}
 		<ui5-busyindicator active size="Medium" class="ui5-nli-busy"></ui5-busyindicator>
 	{{/if}}
 </li>

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -7,7 +7,7 @@
 	@click="{{_onclick}}"
 	role="option"
 	tabindex="{{_tabIndex}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	aria-labelledby="{{ariaLabelledBy}}"
 >
 	<div class="ui5-nli-actions">
@@ -92,7 +92,7 @@
 		<slot name="avatar"></slot>
 	</div>
 
-	{{#if busy}} 
+	{{#if busy}}
 		<ui5-busyindicator active size="Medium" class="ui5-nli-busy"></ui5-busyindicator>
 	{{/if}}
 </li>

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -1,5 +1,4 @@
 import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
@@ -182,10 +181,6 @@ class NotificationListItemBase extends ListItemBase {
 				design: action.design,
 			};
 		});
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	/**

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -1,6 +1,6 @@
 <div
 	class="{{classes.wrapper}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	role="banner"
 	aria-label="{{_shellbarText}}"
 >

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -4,7 +4,6 @@ import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.j
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
@@ -570,7 +569,7 @@ class ShellBar extends UI5Element {
 	_handleActionsOverflow() {
 		const rightContainerRect = this.shadowRoot.querySelector(".ui5-shellbar-overflow-container-right").getBoundingClientRect();
 		const icons = this.shadowRoot.querySelectorAll(".ui5-shellbar-button:not(.ui5-shellbar-overflow-button):not(.ui5-shellbar-invisible-button)");
-		const isRTL = getRTL();
+		const isRTL = this.effectiveDir === "rtl";
 
 		let overflowCount = [].filter.call(icons, icon => {
 			const iconRect = icon.getBoundingClientRect();
@@ -645,7 +644,7 @@ class ShellBar extends UI5Element {
 		const triggeredByOverflow = event.target.tagName.toLowerCase() === "ui5-li";
 		const overflowButton = this.shadowRoot.querySelector(".ui5-shellbar-overflow-button");
 		const overflowButtonRect = overflowButton.getBoundingClientRect();
-		const isRTL = getRTL();
+		const isRTL = this.effectiveDir === "rtl";
 		let right = "";
 
 		if (isRTL) {
@@ -880,7 +879,7 @@ class ShellBar extends UI5Element {
 	get styles() {
 		return {
 			searchField: {
-				[getRTL() ? "left" : "right"]: this._searchField.right,
+				[this.effectiveDir === "rtl" ? "left" : "right"]: this._searchField.right,
 				"top": `${parseInt(this._searchField.top)}px`,
 			},
 			items: {
@@ -921,7 +920,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get popoverHorizontalAlign() {
-		return getRTL() ? "Left" : "Right";
+		return this.effectiveDir === "rtl" ? "Left" : "Right";
 	}
 
 	get hasSearchField() {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -924,10 +924,6 @@ class ShellBar extends UI5Element {
 		return getRTL() ? "Left" : "Right";
 	}
 
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
-	}
-
 	get hasSearchField() {
 		return !!this.searchField.length;
 	}

--- a/packages/main/src/Badge.hbs
+++ b/packages/main/src/Badge.hbs
@@ -1,4 +1,4 @@
-<div class="ui5-badge-root" dir="{{rtl}}">
+<div class="ui5-badge-root" dir="{{effectiveDir}}">
 	{{#if hasIcon}}
 		<slot name="icon"></slot>
 	{{/if}}

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 
 // Template
 import BadgeTemplate from "./generated/templates/BadgeTemplate.lit.js";
@@ -127,10 +126,6 @@ class Badge extends UI5Element {
 
 	get hasIcon() {
 		return !!this.icon.length;
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get badgeDescription() {

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -4,7 +4,7 @@
 		?disabled="{{disabled}}"
 		data-sap-focus-ref
 		{{> ariaPressed}}
-		dir="{{rtl}}"
+		dir="{{effectiveDir}}"
 		@focusout={{_onfocusout}}
 		@focusin={{_onfocusin}}
 		@click={{_onclick}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import findNodeOwner from "@ui5/webcomponents-base/dist/util/findNodeOwner.js";
@@ -328,10 +327,6 @@ class Button extends UI5Element {
 	_onfocusin(event) {
 		event.isMarked = "button";
 		this.focused = true;
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get hasButtonType() {

--- a/packages/main/src/CalendarHeader.hbs
+++ b/packages/main/src/CalendarHeader.hbs
@@ -1,6 +1,6 @@
 <div
 	class="ui5-calheader-root"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	@keydown={{_onkeydown}}
 >
 	<div

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-left.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-right.js";
 import Button from "./Button.js";
@@ -119,10 +118,6 @@ class CalendarHeader extends UI5Element {
 				this[`_show${showPickerButton}Picker`]();
 			}
 		}
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/Card.hbs
+++ b/packages/main/src/Card.hbs
@@ -1,6 +1,6 @@
 <div
 	class="{{classes.main}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	role="region"
 	aria-labelledby="{{_id}}-desc {{_id}}-heading">
 	{{#if hasHeader}}

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -2,7 +2,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import CardTemplate from "./generated/templates/CardTemplate.lit.js";
 import Icon from "./Icon.js";
 
@@ -195,10 +194,6 @@ class Card extends UI5Element {
 
 	get hasHeader() {
 		return !!(this.heading || this.subheading || this.status || this.avatar);
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get ariaCardRoleDescription() {

--- a/packages/main/src/CheckBox.hbs
+++ b/packages/main/src/CheckBox.hbs
@@ -11,7 +11,7 @@
 	@keydown="{{_onkeydown}}"
 	@keyup="{{_onkeyup}}"
 	@click="{{_onclick}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 >
 		<div id="{{_id}}-CbBg" class="ui5-checkbox-inner">
 			{{#if checked}}

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -4,7 +4,6 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/icons/accept.js";
 import Icon from "./Icon.js";
@@ -316,10 +315,6 @@ class CheckBox extends UI5Element {
 	get tabIndex() {
 		const tabindex = this.getAttribute("tabindex");
 		return this.disabled ? undefined : tabindex || "0";
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/ComboBox.hbs
+++ b/packages/main/src/ComboBox.hbs
@@ -32,7 +32,7 @@
 			input-icon
 			?pressed="{{_iconPressed}}"
 			@click="{{_arrowClick}}"
-			dir="{{dir}}"
+			dir="{{effectiveDir}}"
 			accessible-name="{{_iconAccessibleNameText}}"
 		></ui5-icon>
 	{{/unless}}

--- a/packages/main/src/DatePicker.hbs
+++ b/packages/main/src/DatePicker.hbs
@@ -33,7 +33,7 @@
 				@click="{{togglePicker}}"
 				input-icon
 				?pressed="{{_isPickerOpen}}"
-				dir="{{dir}}"
+				dir="{{effectiveDir}}"
 			></ui5-icon>
 		{{/unless}}
 	</ui5-input>

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -10,7 +10,6 @@ import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import { isShow } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/icons/appointment-2.js";
@@ -630,10 +629,6 @@ class DatePicker extends UI5Element {
 
 	get dateAriaDescription() {
 		return this.i18nBundle.getText(DATEPICKER_DATE_ACC_TEXT);
-	}
-
-	get dir() {
-		return getRTL() ? "rtl" : "ltr";
 	}
 
 	/**

--- a/packages/main/src/Icon.hbs
+++ b/packages/main/src/Icon.hbs
@@ -1,7 +1,7 @@
 <svg
 	class="ui5-icon-root"
 	tabindex="{{tabIndex}}"
-	dir="{{dir}}"
+	dir="{{effectiveDir}}"
 	viewBox="0 0 512 512"
 	role="{{role}}"
 	focusable="false"

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getIconData, getIconDataSync } from "@ui5/webcomponents-base/dist/SVGIconRegistry.js";
 import createStyleInHead from "@ui5/webcomponents-base/dist/util/createStyleInHead.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -261,10 +260,6 @@ class Icon extends UI5Element {
 		}
 
 		return this.i18nBundle.getText(this.accData) || undefined;
-	}
-
-	get dir() {
-		return getRTL() ? "rtl" : "ltr";
 	}
 
 	async onEnterDOM() {

--- a/packages/main/src/Label.hbs
+++ b/packages/main/src/Label.hbs
@@ -1,7 +1,7 @@
 <label
 		class="ui5-label-root"
-		dir="{{rtl}}"
-		@click={{_onclick}} 
+		dir="{{effectiveDir}}"
+		@click={{_onclick}}
 		for="{{for}}"
 	>
 	<span class="ui5-label-text-wrapper">

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 
 // Template
 import LabelTemplate from "./generated/templates/LabelTemplate.lit.js";
@@ -130,10 +129,6 @@ class Label extends UI5Element {
 		if (elementToFocus) {
 			elementToFocus.focus();
 		}
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 }
 

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -1,7 +1,7 @@
 <li
 	tabindex="{{_tabIndex}}"
 	class="{{classes.main}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	@focusin="{{_onfocusin}}"
 	@focusout="{{_onfocusout}}"
 	@keyup="{{_onkeyup}}"

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -2,7 +2,6 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { getTabbableElements } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
 import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 
 // Styles
 import styles from "./generated/themes/ListItemBase.css.js";
@@ -147,10 +146,6 @@ class ListItemBase extends UI5Element {
 				"ui5-li--focusable": true,
 			},
 		};
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 }
 

--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -62,7 +62,7 @@
 			tabindex="-1"
 			@click={{togglePopover}}
 			?pressed="{{_iconPressed}}"
-			dir="{{dir}}"
+			dir="{{effectiveDir}}"
 			accessible-name="{{_iconAccessibleNameText}}"
 		></ui5-icon>
 	{{/unless}}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -5,7 +5,6 @@ import {
 	isShow, isDown, isBackSpace, isSpace,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-down.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { isIE, isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/icons/decline.js";
@@ -618,10 +617,6 @@ class MultiComboBox extends UI5Element {
 
 	get editable() {
 		return !this.readonly;
-	}
-
-	get dir() {
-		return getRTL() ? "rtl" : "ltr";
 	}
 
 	get selectedItemsListMode() {

--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -6,7 +6,7 @@
 	aria-labelledby="{{ariaLabelledBy}}"
 	aria-describedby="{{ariaDescribedBy}}"
 	tabindex="{{tabIndex}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	@click="{{_onclick}}"
 	@keydown="{{_onkeydown}}"
 	@keyup="{{_onkeyup}}"

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -1,5 +1,4 @@
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
@@ -402,10 +401,6 @@ class RadioButton extends UI5Element {
 
 	get strokeWidth() {
 		return this.valueState === "None" ? "1" : "2";
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 }
 

--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -1,6 +1,6 @@
 <div
 	class="ui5-select-root"
-	dir="{{dir}}"
+	dir="{{effectiveDir}}"
 	tabindex="{{tabIndex}}"
 	id="{{_id}}-select"
 	role="button"
@@ -22,7 +22,7 @@
 		name="slim-arrow-down"
 		input-icon
 		?pressed="{{_iconPressed}}"
-		dir="{{dir}}"
+		dir="{{effectiveDir}}"
 	></ui5-icon>
 
 	{{#if hasValueState}}

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -9,7 +9,6 @@ import {
 	isShow,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-down.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -478,10 +477,6 @@ class Select extends UI5Element {
 
 	get tabIndex() {
 		return this.disabled ? "-1" : "0";
-	}
-
-	get dir() {
-		return getRTL() ? "rtl" : "ltr";
 	}
 
 	static async onDefine() {

--- a/packages/main/src/Switch.hbs
+++ b/packages/main/src/Switch.hbs
@@ -8,7 +8,7 @@
 	@keyup="{{_onkeyup}}"
 	@keydown="{{_onkeydown}}"
 	tabindex="{{tabIndex}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 >
 	<div class="ui5-switch-inner">
 		<div class="ui5-switch-track" part="slider">

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -2,7 +2,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/icons/accept.js";
 import "@ui5/webcomponents-icons/dist/icons/decline.js";
@@ -213,10 +212,6 @@ class Switch extends UI5Element {
 
 	get ariaDisabled() {
 		return this.disabled ? "true" : undefined;
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get accessibilityOnText() {

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -1,6 +1,6 @@
 <div
 	class="{{classes.root}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 >
 	{{#if tabsAtTheBottom}}
 		{{> contentArea}}

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -8,7 +8,6 @@ import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-up.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-down.js";
@@ -547,10 +546,6 @@ class TabContainer extends UI5Element {
 
 	get overflowMenuIcon() {
 		return this.tabsAtTheBottom ? "slim-arrow-up" : "slim-arrow-down";
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get animate() {

--- a/packages/main/src/TimelineItem.hbs
+++ b/packages/main/src/TimelineItem.hbs
@@ -1,6 +1,6 @@
 <div
 	class="ui5-tli-root"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 >
 	<div class="ui5-tli-indicator">
 		{{#if icon}}

--- a/packages/main/src/TimelineItem.js
+++ b/packages/main/src/TimelineItem.js
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import Icon from "./Icon.js";
 import Link from "./Link.js";
 import TimelineItemTemplate from "./generated/templates/TimelineItemTemplate.lit.js";
@@ -142,10 +141,6 @@ class TimelineItem extends UI5Element {
 
 	onItemNamePress() {
 		this.fireEvent("item-name-click", {});
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/Toast.hbs
+++ b/packages/main/src/Toast.hbs
@@ -1,7 +1,7 @@
 <div class="ui5-toast-root"
 	role="alert"
 	style="{{styles.root}}"
-	dir="{{rtl}}"
+	dir="{{effectiveDir}}"
 	@mouseover="{{_onmouseover}}"
 	@mouseleave="{{_onmouseleave}}"
 	@transitionend="{{_ontransitionend}}">

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -1,7 +1,6 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import ToastTemplate from "./generated/templates/ToastTemplate.lit.js";
 import ToastPlacement from "./types/ToastPlacement.js";
 
@@ -180,10 +179,6 @@ class Toast extends UI5Element {
 	 */
 	get effectiveDuration() {
 		return this.duration < MIN_DURATION ? MIN_DURATION : this.duration;
-	}
-
-	get rtl() {
-		return getRTL() ? "rtl" : undefined;
 	}
 
 	get styles() {

--- a/packages/main/src/Token.hbs
+++ b/packages/main/src/Token.hbs
@@ -3,7 +3,7 @@
 	@click="{{_select}}"
 	@keydown="{{_keydown}}"
 	class="ui5-token--wrapper"
-	dir="{{dir}}"
+	dir="{{effectiveDir}}"
 	role="option"
 	aria-selected="{{selected}}"
 >

--- a/packages/main/src/Token.js
+++ b/packages/main/src/Token.js
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
-import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import {
 	isBackSpace,
 	isEnter,
@@ -159,10 +158,6 @@ class Token extends UI5Element {
 
 	get tokenDeletableText() {
 		return this.i18nBundle.getText(TOKEN_ARIA_DELETABLE);
-	}
-
-	get dir() {
-		return getRTL() ? "rtl" : "ltr";
 	}
 
 	get iconURI() {

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -1,5 +1,4 @@
 :root {
-	--_ui5_content_density: cozy;
 	--_ui5_calendar_header_height: 3rem;
 	--_ui5_calendar_header_arrow_button_width: 2.5rem;
 	--_ui5_calendar_header_padding: 0.25rem 0;
@@ -72,7 +71,6 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--_ui5_content_density: compact;
 	--_ui5_button_base_height: 1.625rem;
 	--_ui5_button_base_padding: 0.4375rem;
 	--_ui5_button_base_min_width: 2rem;
@@ -187,12 +185,4 @@
 	--_ui5-tree-toggle-box-width: 2rem;
 	--_ui5-tree-toggle-box-height: 1.5rem;
 	--_ui5-tree-toggle-icon-size: 0.8125rem;
-}
-
-[dir="rtl"] {
-    --_ui5_dir: rtl;
-}
-
-[dir="ltr"] {
-    --_ui5_dir: ltr;
 }

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -188,3 +188,11 @@
 	--_ui5-tree-toggle-box-height: 1.5rem;
 	--_ui5-tree-toggle-icon-size: 0.8125rem;
 }
+
+[dir="rtl"] {
+    --_ui5_dir: rtl;
+}
+
+[dir="ltr"] {
+    --_ui5_dir: ltr;
+}

--- a/packages/main/test/pages/RTL.html
+++ b/packages/main/test/pages/RTL.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<title>Button</title>
+	<script>
+		delete Document.prototype.adoptedStyleSheets
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+    <style>
+        section {
+            border: 2px solid black;
+            padding: 20px;
+        }
+    </style>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);" dir="rtl">
+    <ui5-title>BODY is rtl</ui5-title>
+
+    <section>
+        <ui5-title>This section does not define dir</ui5-title>
+        <br>
+        <ui5-checkbox text="Click me"></ui5-checkbox>
+        <br>
+        <ui5-checkbox text="Click me"></ui5-checkbox>
+        <br>
+        <ui5-checkbox text="Click me"></ui5-checkbox>
+    </section>
+
+    <section dir="ltr">
+        <ui5-title>This section defines dir=ltr</ui5-title>
+        <br>
+        <ui5-checkbox text="Click me"></ui5-checkbox>
+        <br>
+        <ui5-checkbox text="Click me"></ui5-checkbox>
+        <br>
+        <ui5-checkbox text="This checkbox however defines dir=rtl" dir="rtl"></ui5-checkbox>
+    </section>
+
+
+
+</body>
+</html>

--- a/packages/main/test/specs/RTL.spec.js
+++ b/packages/main/test/specs/RTL.spec.js
@@ -5,20 +5,20 @@ describe("RTL", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-language=he");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.strictEqual(buttonRoot.getProperty("effectiveDir"), "rtl", "dir is correctly set");
+		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
 	});
 
 	it("config forces RTL", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=true");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.strictEqual(buttonRoot.getProperty("effectiveDir"), "rtl", "dir is correctly set");
+		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
 	});
 
 	it("config unsets RTL, although rtl language is used", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=false&sap-ui-language=he");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.notOk(buttonRoot.getProperty("effectiveDir"), "dir is not present");
+		assert.notOk(buttonRoot.getProperty("dir"), "dir is not present");
 	});
 });

--- a/packages/main/test/specs/RTL.spec.js
+++ b/packages/main/test/specs/RTL.spec.js
@@ -5,20 +5,20 @@ describe("RTL", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-language=he");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
+		assert.strictEqual(buttonRoot.getProperty("effectiveDir"), "rtl", "dir is correctly set");
 	});
 
 	it("config forces RTL", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=true");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
+		assert.strictEqual(buttonRoot.getProperty("effectiveDir"), "rtl", "dir is correctly set");
 	});
 
 	it("config unsets RTL, although rtl language is used", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=false&sap-ui-language=he");
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
-		assert.notOk(buttonRoot.getProperty("dir"), "dir is not present");
+		assert.notOk(buttonRoot.getProperty("effectiveDir"), "dir is not present");
 	});
 });


### PR DESCRIPTION
The configuration `rtl` setting is now deprecated and will only be used for OpenUI5 integration scenarios.

Currently in order to have RTL enabled, you need to do 2 things:
 - Set `rtl: true` in the configuration
 - Set `dir=rtl` in the DOM.

After this change, it will be enough to just set `dir=rtl` in the DOM (works only for the element itself, `body` and `html` for IE). The configuration setting is checked last and is only useful in one scenario - when OpenUI5 is the one to set the "dir" on the body (instead of the app). In such a case, it's still useful to render the components with the correct "dir" in the shadow roots, so that later on, when OpenUI5 finally applies "dir" to the body, the components will have been rendered with the correct shadow roots. But in all other scenarios - when the app is the one to set "dir" on the body/html or other element, the configuration will never be read and applied at all. Therefore it's now deprecated and removed from public documentation.

`UI5Element.js` now has a new public getter:
 - `effectiveDir`: returns `ltr`, `rtl` or `undefined`. All components should use this for CSS purposes.

**Important:** Some components accidentally defined a `dir` getter. This should be avoided as it collides with the native `dir` attribute. All such have been removed from the respective components in favor of the new `effectiveDir` getter.

**Important:** Until now the `--_ui5_content_density` CSS Var was declared in the `main` package, but was checked for in the `base` package. This means that some `UI5Element.js` functionality: `isCompact` does not work for third-party libraries, but only for our components. With this change, the `--_ui5_content_density` var and the new `--_ui5_dir` var are managed by the framework and inserted in the `head` right after the font face. This guarantees they will be available even if `sizes-parameters.css` from `main` is not loaded.