### PR TITLE
fix(ui5-timepicker): adjust hours in 12hours format only

### DIFF
--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -511,16 +511,19 @@ class TimePicker extends UI5Element {
 			periodsSlider = this.periodsSlider,
 			minutes = minutesSlider ? minutesSlider.getAttribute("value") : "0",
 			seconds = secondsSlider ? secondsSlider.getAttribute("value") : "0",
-			period = periodsSlider ? periodsSlider.getAttribute("value") : this.periodsArray[0];
+			period = periodsSlider ? periodsSlider.getAttribute("value") : this.periodsArray[0],
+			isTwelveHoursFormat = this._hoursParameters.isTwelveHoursFormat;
 
 		let hours = hoursSlider ? hoursSlider.getAttribute("value") : this._hoursParameters.minHour.toString();
 
-		if (period === this.periodsArray[0]) { // AM
-			hours = hours === "12" ? 0 : hours;
-		}
+		if (isTwelveHoursFormat) {
+			if (period === this.periodsArray[0]) { // AM
+				hours = hours === "12" ? 0 : hours;
+			}
 
-		if (period === this.periodsArray[1]) { // PM
-			hours = hours === "12" ? hours : hours * 1 + 12;
+			if (period === this.periodsArray[1]) { // PM
+				hours = hours === "12" ? hours : hours * 1 + 12;
+			}
 		}
 
 		selectedDate.setHours(hours);

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -23,7 +23,8 @@
 		<ui5-timepicker id="timepicker" format-pattern="HH:mm:ss"></ui5-timepicker>
 		<ui5-timepicker id="timepicker2" format-pattern="hh:mm:ss" value=""></ui5-timepicker>
 		<ui5-timepicker id="timepicker3" format-pattern="hh:mm:ss a"></ui5-timepicker>
-		<ui5-timepicker id="timepicker3" format-pattern="HH:mm"></ui5-timepicker>
+		<ui5-timepicker id="timepicker4" format-pattern="HH:mm" value="12:05"></ui5-timepicker>
+		<ui5-timepicker id="timepicker5" format-pattern="hh:mm:ss" value="12:00:01"></ui5-timepicker>
 		<br>
 		<ui5-timepicker style="width:100%"></ui5-timepicker>
 


### PR DESCRIPTION
Consider AM/PM periods in determining hours when 12h format is set, there is no need to adjust the hours in 24hours format. Previously we used to recalculate the hours for both formats, leading to a bug in 24hours format.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1714

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15702139/84106895-fee22700-aa24-11ea-8434-b0ac091ca127.gif)

