### PR TITLE
fix(ui5-datepicker): set focus to selected day

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -1,5 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import RenderScheduler from "@ui5/webcomponents-base/dist/RenderScheduler.js";
 import { fetchCldr } from "@ui5/webcomponents-base/dist/asset-registries/LocaleData.js";
 import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
@@ -342,22 +343,6 @@ class DatePicker extends UI5Element {
 					calendar._hideYearPicker();
 				}
 			},
-			afterOpen: () => {
-				const calendar = this.calendar;
-
-				if (!calendar) {
-					return;
-				}
-
-				const focusableDay = this.findFocusableDay();
-
-				if (this._focusInputAfterOpen) {
-					this._focusInputAfterOpen = false;
-					this._getInput().focus();
-				} else if (focusableDay) {
-					this.focusDay(focusableDay);
-				}
-			},
 		};
 
 		this._calendar = {
@@ -404,13 +389,16 @@ class DatePicker extends UI5Element {
 	}
 
 	onAfterRendering() {
-		requestAnimationFrame(() => {
-			this._applyDayFocus();
-		});
+		this._applyDayFocus();
 	}
 
-	_applyDayFocus() {
-		if (!this._focusInputAfterOpen) {
+	async _applyDayFocus() {
+		await RenderScheduler.whenFinished();
+
+		if (this._focusInputAfterOpen) {
+			this._getInput().focus();
+			this._focusInputAfterOpen = false;
+		} else {
 			this.focusFirstFocusableDay();
 		}
 	}

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -10,7 +10,6 @@
 	?_hide-header={{_shouldHideHeader}}
 	@keydown="{{_onkeydown}}"
 	@ui5-after-close="{{_respPopoverConfig.afterClose}}"
-	@ui5-after-open="{{_respPopoverConfig.afterOpen}}"
 >
 	{{#if showHeader}}
 		{{> header}}

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -119,6 +119,8 @@
 			</div>
 		</section>
 
+		<ui5-button id="btnSelectionTimeout">Change Jun 16 after 3s</ui5-button></br>
+		<ui5-datepicker id='dpProgramaticSelection' value="Jun 10, 2020"></ui5-datepicker>
 	</div>
 	<script>
 		var dp = document.getElementById('dp5');
@@ -169,6 +171,11 @@
 			dp11.setAttribute("value", dp11.formatValue(new Date(2018, 11, 11)));
 		});
 
+		btnSelectionTimeout.addEventListener("click", function(e) {
+			setTimeout(() => {
+				dpProgramaticSelection.value="Jun 16, 2020";
+			}, 3000)
+		});
 	</script>
 </body>
 </html>


### PR DESCRIPTION
When the DatePicker's value is changed via JS (not by user interaction), the focus remains on the previously selected day. Now we apply the focus after the component re-renders.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15702139/84263704-9f6d3f80-ab28-11ea-9001-653300f9cb2f.gif)



