### PR TITLE
fix(ui5-upload-collection): Provide min-height also when DND mode is on

### DIFF
--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -276,7 +276,7 @@ class UploadCollection extends UI5Element {
 		return {
 			content: {
 				"ui5-uc-content": true,
-				"ui5-uc-content-no-data": this._showNoData,
+				"ui5-uc-content-no-data": this.items.length === 0,
 			},
 			dndOverlay: {
 				"uc-dnd-overlay": true,


### PR DESCRIPTION
The condition to set `min-height` excluded DND mode, so when the user starts dragging a file, the drop area suddenly collapses.