### PR TITLE
fix(ui5-custom-li): display component on IE

### DIFF
--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -12,6 +12,7 @@ import { DELETE, ARIA_LABEL_LIST_ITEM_CHECKBOX } from "./generated/i18n/i18n-def
 
 // Styles
 import styles from "./generated/themes/ListItem.css.js";
+import invisibleTextStyles from "./generated/themes/InvisibleTextStyles.css.js";
 
 /**
  * @public
@@ -93,7 +94,7 @@ class ListItem extends ListItemBase {
 	}
 
 	static get styles() {
-		return [ListItemBase.styles, styles];
+		return [invisibleTextStyles, ListItemBase.styles, styles];
 	}
 
 	constructor() {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -1,4 +1,3 @@
-@import "./InvisibleTextStyles.css";
 
 /* actionable (type="Active" + desktop) */
 :host([actionable]) {


### PR DESCRIPTION
- having an import in the css file is not correctly parsed for IE, which leads to incorrect styles applied to elements
- NOTE: this is a workaround until we resolve the real issue

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1766
