### PR TITLE
fix: the styles getter always expects an array of strings

### DIFF
--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -233,7 +233,7 @@ class UploadCollectionItem extends ListItem {
 	}
 
 	static get styles() {
-		return [ListItem.styles, UploadCollectionItemCss];
+		return [...ListItem.styles, UploadCollectionItemCss];
 	}
 
 	static get template() {

--- a/packages/main/src/CustomListItem.js
+++ b/packages/main/src/CustomListItem.js
@@ -2,7 +2,7 @@ import ListItem from "./ListItem.js";
 import CustomListItemTemplate from "./generated/templates/CustomListItemTemplate.lit.js";
 
 // Styles
-import columnListItemCss from "./generated/themes/CustomListItem.css.js";
+import customListItemCss from "./generated/themes/CustomListItem.css.js";
 
 /**
  * @public
@@ -50,7 +50,7 @@ class CustomListItem extends ListItem {
 	}
 
 	static get styles() {
-		return [ListItem.styles, columnListItemCss];
+		return [...ListItem.styles, customListItemCss];
 	}
 
 	get classes() {

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -140,7 +140,7 @@ class TreeListItem extends ListItem {
 	}
 
 	static get styles() {
-		return [ListItem.styles, treeListItemCss];
+		return [...ListItem.styles, treeListItemCss];
 	}
 
 	static get metadata() {


### PR DESCRIPTION
For some components, the styles are not built correctly, because the `static get styles` of their parent class returns an array and not a string. When these arrays are not properly destructured, they are interpreted as strings with a `,` between them.

Then during the IE CSS transformation, this `,` is translated to a selector with just the tag of the component.

Example:
`........pointer-events:none},.ui5-hidden-text........` (notice the comma that appears in the middle.

After IE transformation:
```css
ui5-li-custom,
ui5-li-custom .ui5-hidden-text {
	position: absolute;
	clip: rect(1px, 1px, 1px, 1px);
	user-select: none;
	left: 0;
	top: 0
}
```
(notice the tag that appears before the comma).