### PR TITLE
fix(tools): Polyfill copied correctly in all scenarios

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -1,9 +1,9 @@
 const path = require("path");
 
 const LIB = path.join(__dirname, `../lib/`);
-const NODE_MODULES_PATH = path.join(__dirname, `../../../node_modules/`);
 const serveConfig = path.join(__dirname, `serve.json`);
-const polyfillPath = path.join(NODE_MODULES_PATH, `/@webcomponents/webcomponentsjs/**/*.*`);
+const polyfillDir = path.dirname(require.resolve("@webcomponents/webcomponentsjs"));
+const polyfillPath = path.join(polyfillDir, "/**/*.*");
 
 const getScripts = (options) => {
 


### PR DESCRIPTION
The webcomponents polyfill was not copied correctly to the `dist/` directory for third-party packages, created with the init package script. The reason is that the path to `node_modules/` used to be hard-coded relatively to the packages in the UI5 Web Components project. The path is not the same however for third-party packages. Therefore the it is no longer guessed, but derived properly with `require.resolve` instead.

closes: https://github.com/SAP/ui5-webcomponents/issues/1762