### PR TITLE
fix(ui5-panel): The expand/collapse button is not in the DOM when fixed

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -14,18 +14,18 @@
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"
 	>
-		<div
-			class="ui5-panel-header-button-root"
-		>
-			<ui5-button
-				design="Transparent"
-				class="ui5-panel-header-button {{classes.headerBtn}}"
-				icon="navigation-right-arrow"
-				?non-focusable="{{nonFocusableButton}}"
-				@click="{{_toggleButtonClick}}"
-				._buttonAccInfo="{{accInfo.button}}"
-			></ui5-button>
-		</div>
+		{{#unless fixed}}
+			<div class="ui5-panel-header-button-root">
+				<ui5-button
+					design="Transparent"
+					class="ui5-panel-header-button {{classes.headerBtn}}"
+					icon="navigation-right-arrow"
+					?non-focusable="{{nonFocusableButton}}"
+					@click="{{_toggleButtonClick}}"
+					._buttonAccInfo="{{accInfo.button}}"
+				></ui5-button>
+			</div>
+		{{/unless}}
 
 		{{#if _hasHeader}}
 			<slot name="header"></slot>

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -12,10 +12,6 @@
 	border-bottom: 1px solid var(--sapGroup_TitleBorderColor);
 }
 
-:host([fixed]) .ui5-panel-header-button-root {
-	display: none;
-}
-
 :host([fixed]) .ui5-panel-header {
 	padding-left: 1rem;
 }


### PR DESCRIPTION
When the panel is `fixed`, the expand/collapse button should not be in the DOM at all. The current implementation violates accessibility best practices.

closes: https://github.com/SAP/ui5-webcomponents/issues/1753