### PR TITLE
refactor: document Popup.js and improve consistency

### DIFF
--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,4 +1,4 @@
-<section style="{{styles.root}}" class="ui5-popup-root" role="dialog" aria-modal="true" aria-labelledby="ui5-popup-header">
+<section style="{{styles.root}}" class="ui5-popup-root" role="dialog" aria-modal="{{ariaModal}}" aria-labelledby="ui5-popup-header">
 
 	{{> beforeHeader}}
 
@@ -33,7 +33,7 @@
 			{{#if header.length }}
 				<slot name="header"></slot>
 			{{else}}
-				<h2 class="ui5-popup-header-text" id="ui5-popup-header">{{headerText}}</h2>
+				<h2 class="ui5-popup-header-text">{{headerText}}</h2>
 			{{/if}}
 		</header>
 	{{/if}}

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,4 +1,4 @@
-<section style="{{styles.root}}" class="ui5-popup-root" role="dialog" aria-modal="{{ariaModal}}" aria-labelledby="ui5-popup-header">
+<section style="{{styles.root}}" class="ui5-popup-root" role="dialog" aria-modal="true" aria-labelledby="ui5-popup-header">
 
 	{{> beforeHeader}}
 

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -350,15 +350,6 @@ class Popup extends UI5Element {
 	 */
 	get _displayFooter() {} // eslint-disable-line
 
-	/**
-	 * Determines the value of "aria-model" for this popup
-	 * @private
-	 * @returns {*}
-	 */
-	get ariaModal() {
-		return this.isModal ? "true" : undefined;
-	}
-
 	get styles() {
 		return {
 			content: {},

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -1,6 +1,7 @@
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { getFirstFocusableElement, getLastFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
+import createStyleInHead from "@ui5/webcomponents-base/dist/util/createStyleInHead.js";
 import PopupTemplate from "./generated/templates/PopupTemplate.lit.js";
 import PopupBlockLayer from "./generated/templates/PopupBlockLayerTemplate.lit.js";
 import { getNextZIndex } from "./popup-utils/PopupUtils.js";
@@ -139,20 +140,16 @@ const createBlockingStyle = () => {
 		return;
 	}
 
-	const styleTag = document.createElement("style");
-
-	styleTag.innerHTML = `
-		.ui5-dialog-scroll-blocker {
+	createStyleInHead(`
+		.ui5-popup-scroll-blocker {
 			width: 100%;
 			height: 100%;
 			position: fixed;
 			overflow: hidden;
 		}
-	`;
+	`, { "data-ui5-popup-scroll-blocker": "" });
 
 	customBlockingStyleInserted = true;
-
-	document.head.appendChild(styleTag);
 };
 
 createBlockingStyle();
@@ -160,7 +157,31 @@ createBlockingStyle();
 /**
  * @class
  * <h3 class="comment-api-title">Overview</h3>
- * Represents a base class for all popup Web Components.
+ * Base class for all popup Web Components.
+ *
+ * If you need to create your own popup-like custom UI5 Web Components, it is highly recommended that you extend
+ * at least Popup in order to have consistency with other popups in terms of modal behavior and z-index management.
+ *
+ * 1. The Popup class handles modality:
+ *  - The "isModal" getter can be overridden by derivatives to provide their own conditions when they are modal or not
+ *  - Derivatives may call the "blockBodyScrolling" and "unblockBodyScrolling" static methods to temporarily remove scrollbars on the body
+ *  - Derivatives may call the "open" and "close" methods which, for modal popups, manage the blocking layer
+ *
+ *  2. Provides blocking layer (relevant for modal popups only):
+ *   - It is in the static area
+ *   - Controlled by the "open" and "close" methods
+ *
+ * 3. The Popup class "traps" focus:
+ *  - Derivatives may call the "applyInitialFocus" method (usually when opening, to transfer focus inside the popup)
+ *
+ * 4. The Popup class automatically assigns "z-index"
+ *  - Each time a popup is opened, it gets a higher than the previously opened popup z-index
+ *
+ * 5. The template of this component exposes several inline partials you can override in derivatives:
+ *  - beforeHeader (useful for visual elements outside of the popup "box", such as for example an arrow pointing to the opener element)
+ *  - header (upper part of the box, useful for title/close button area)
+ *  - footer (lower part, useful for OK/Cancel button area)
+ *  - Implement the abstract "_displayHeader" and "_displayFooter" getters to control when header and footer are shown
  *
  * @constructor
  * @author SAP SE
@@ -193,17 +214,29 @@ class Popup extends UI5Element {
 		return staticAreaStyles;
 	}
 
+	/**
+	 * Temporarily removes scrollbars from the body
+	 * @protected
+	 */
 	static blockBodyScrolling() {
 		document.body.style.top = `-${window.pageYOffset}px`;
-		document.body.classList.add("ui5-dialog-scroll-blocker");
+		document.body.classList.add("ui5-popup-scroll-blocker");
 	}
 
+	/**
+	 * Restores scrollbars on the body, if needed
+	 * @protected
+	 */
 	static unblockBodyScrolling() {
-		document.body.classList.remove("ui5-dialog-scroll-blocker");
+		document.body.classList.remove("ui5-popup-scroll-blocker");
 		window.scrollTo(0, -parseFloat(document.body.style.top));
 		document.body.style.top = "";
 	}
 
+	/**
+	 * Focus trapping
+	 * @private
+	 */
 	forwardToFirst() {
 		const firstFocusable = getFirstFocusableElement(this);
 
@@ -212,6 +245,10 @@ class Popup extends UI5Element {
 		}
 	}
 
+	/**
+	 * Focus trapping
+	 * @private
+	 */
 	forwardToLast() {
 		const lastFocusable = getLastFocusableElement(this);
 
@@ -220,6 +257,10 @@ class Popup extends UI5Element {
 		}
 	}
 
+	/**
+	 * Use this method to focus the element denoted by "initialFocus", if provided, or the first focusable element otherwise.
+	 * @protected
+	 */
 	applyInitialFocus() {
 		if (this._disableInitialFocus) {
 			return;
@@ -234,10 +275,19 @@ class Popup extends UI5Element {
 		}
 	}
 
+	/**
+	 * Override this method to provide custom logic for the popup's open/closed state. Maps to the "opened" property by default.
+	 * @protected
+	 * @returns {boolean}
+	 */
 	isOpen() {
 		return this.opened;
 	}
 
+	/**
+	 * Shows the block layer (for modal popups only) and sets the correct z-index for the purpose of popup stacking
+	 * @protected
+	 */
 	open() {
 		if (this.isModal) {
 			// create static area item ref for block layer
@@ -250,6 +300,10 @@ class Popup extends UI5Element {
 		this._blockLayerHidden = false;
 	}
 
+	/**
+	 * Hides the block layer (for modal popups only)
+	 * @protected
+	 */
 	close() {
 		if (this.isModal) {
 			this._blockLayerHidden = true;
@@ -258,7 +312,6 @@ class Popup extends UI5Element {
 
 	/**
 	 * Sets "inline-block" display to the popup
-	 *
 	 * @protected
 	 */
 	show() {
@@ -268,15 +321,42 @@ class Popup extends UI5Element {
 
 	/**
 	 * Sets "none" display to the popup
-	 *
 	 * @protected
 	 */
 	hide() {
 		this.style.display = "none";
 	}
 
-	get isModal() {
-		return false;
+	/**
+	 * Implement this getter with relevant logic regarding the modality of the popup (f.e. based on a public property)
+	 *
+	 * @protected
+	 * @abstract
+	 * @returns {boolean}
+	 */
+	get isModal() {} // eslint-disable-line
+
+	/**
+	 * Hook for descendants to hide header.
+	 * @abstract
+	 * @protected
+	 */
+	get _displayHeader() {} // eslint-disable-line
+
+	/**
+	 * Hook for descendants to hide footer.
+	 * @abstract
+	 * @protected
+	 */
+	get _displayFooter() {} // eslint-disable-line
+
+	/**
+	 * Determines the value of "aria-model" for this popup
+	 * @private
+	 * @returns {*}
+	 */
+	get ariaModal() {
+		return this.isModal ? "true" : undefined;
 	}
 
 	get styles() {

--- a/packages/main/src/themes/MultiComboBox.css
+++ b/packages/main/src/themes/MultiComboBox.css
@@ -4,7 +4,7 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
-	--_ui5_popover_content_padding: 0;
+	--_ui5_popup_content_padding: 0;
 }
 
 .ui5-multi-combobox-root {

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -43,7 +43,7 @@
 :host([actual-placement-type="Top"]) .ui5-popover-arrow {
 	left: calc(50% - 0.5625rem);
 	height: 0.5625rem;
-	bottom: calc(-1 * (var(--_ui5_popover_content_padding) + 2px));
+	bottom: calc(-1 * (var(--_ui5_popup_content_padding) + 2px));
 }
 
 :host([actual-placement-type="Top"]) .ui5-popover-arrow:after {

--- a/packages/main/src/themes/Popup.css
+++ b/packages/main/src/themes/Popup.css
@@ -56,7 +56,7 @@
 	overflow: auto;
 
 	/* Consider how to make this top level */
-	padding: var(--_ui5_popover_content_padding);
+	padding: var(--_ui5_popup_content_padding);
 	box-sizing: border-box;
 }
 

--- a/packages/main/src/themes/ResponsivePopover.css
+++ b/packages/main/src/themes/ResponsivePopover.css
@@ -5,7 +5,7 @@
 }
 
 :host(:not([with-padding])) {
-	--_ui5_popover_content_padding: 0;
+	--_ui5_popup_content_padding: 0;
 }
 
 :host([opened]) {

--- a/packages/main/src/themes/base/Popover-parameters.css
+++ b/packages/main/src/themes/base/Popover-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_popover_content_padding: .4375em;
-}

--- a/packages/main/src/themes/base/Popup-parameters.css
+++ b/packages/main/src/themes/base/Popup-parameters.css
@@ -1,0 +1,3 @@
+:root {
+	--_ui5_popup_content_padding: .4375em;
+}

--- a/packages/main/src/themes/sap_belize/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize/parameters-bundle.css
@@ -17,7 +17,7 @@
 @import "../base/MessageStrip-parameters.css";
 @import "../base/MonthPicker-parameters.css";
 @import "../base/Panel-parameters.css";
-@import "../base/Popover-parameters.css";
+@import "../base/Popup-parameters.css";
 @import "../base/RadioButton-parameters.css";
 @import "../base/Select-parameters.css";
 @import "../base/Switch-parameters.css";

--- a/packages/main/src/themes/sap_belize_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize_hcb/parameters-bundle.css
@@ -17,7 +17,7 @@
 @import "./MonthPicker-parameters.css";
 @import "./MessageStrip-parameters.css";
 @import "./Panel-parameters.css";
-@import "../base/Popover-parameters.css";
+@import "../base/Popup-parameters.css";
 @import "./RadioButton-parameters.css";
 @import "./Select-parameters.css";
 @import "./Switch-parameters.css";

--- a/packages/main/src/themes/sap_belize_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize_hcw/parameters-bundle.css
@@ -17,7 +17,7 @@
 @import "./MonthPicker-parameters.css";
 @import "./MessageStrip-parameters.css";
 @import "./Panel-parameters.css";
-@import "../base/Popover-parameters.css";
+@import "../base/Popup-parameters.css";
 @import "./RadioButton-parameters.css";
 @import "./Select-parameters.css";
 @import "./Switch-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
@@ -16,7 +16,7 @@
 @import "./MonthPicker-parameters.css";
 @import "../base/MessageStrip-parameters.css";
 @import "./Panel-parameters.css";
-@import "../base/Popover-parameters.css";
+@import "../base/Popup-parameters.css";
 @import "../base/RadioButton-parameters.css";
 @import "../base/Select-parameters.css";
 @import "../base/Switch-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -16,7 +16,7 @@
 @import "./MonthPicker-parameters.css";
 @import "../base/MessageStrip-parameters.css";
 @import "./Panel-parameters.css";
-@import "../base/Popover-parameters.css";
+@import "../base/Popup-parameters.css";
 @import "../base/RadioButton-parameters.css";
 @import "../base/Select-parameters.css";
 @import "../base/Switch-parameters.css";


### PR DESCRIPTION
This change establishes a contract with third parties in terms of **protected** `Popup.js` APIs.
 - `Popup.js` documented for the purpose of component development
 - `createStyleInHead` used, and a data attribute given to the `style` tag for readability in the DOM. In addition, `ui5-dialog-scroll-blocker` renamed to `ui5-popup-scroll-blocker`.
 - `id="ui5-popup-header"` is now set only on the div, wrapping the slot/`h2`. Otherwise it is duplicated inside the same instance.
 - getters, intended to be overridden by derivatives, are now abstract (return undefined), and listed here. These are: `isModal` (used to return false), `_displayHeader` and `_displayFooter`.
 - `--_ui5_popover_content_padding` renamed to `--_ui5_popup_content_padding:` and `Popover-parameters.css` renamed to `Popup-parameters.css`.

With these changes `Popup.js` is clear of `Dialog` and `Popover` semantics and should also keep stable `protected` APIs from now on. `private` members can still be changed freely.

closes: https://github.com/SAP/ui5-webcomponents/issues/1787