### PR TITLE
docs: fix Toast sample for IE

### DIFF
--- a/packages/main/test/samples/Toast.sample.html
+++ b/packages/main/test/samples/Toast.sample.html
@@ -154,7 +154,7 @@
 <script>
 
 	// Attaching click listeners to the buttons which show the toasts
-	document.querySelectorAll("ui5-button").forEach(function(button){
+	Array.from(document.querySelectorAll("ui5-button")).forEach(button => {
 		button.addEventListener('click', function () {
 			document.querySelector("#" + button.id.replace("BtnShow", "")).show();
 		});
@@ -167,7 +167,7 @@
 <script>
 
 	// Attaching click listeners to the buttons which show the toasts
-	document.querySelectorAll("ui5-button").forEach(function(button){
+	[].slice.call(document.querySelectorAll("ui5-button")).forEach(function(button){
 		button.addEventListener('click', function () {
 			document.querySelector("#" + button.id.replace("BtnShow", "")).show();
 		});


### PR DESCRIPTION
The statement "document.querySelectorAll("ui5-button").foeEach" used to throw an error, now it should not. (In addition make the code the users see es6).

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1794