### PR TITLE
fix(ui5-shellbar): Profile is styled correctly on IE

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -78,7 +78,7 @@ slot[name="profile"] {
 	min-width: 0;
 }
 
-::slotted(ui5-avatar) {
+::slotted(ui5-avatar[slot="profile"]) {
 	min-width: 0;
 	width: 2.25rem;
 	height: 2.25rem;


### PR DESCRIPTION
The CSS generated for IE for `::slotted(ui5-avatar)` is `ui5-shellbar ui5-avatar`, which is weaker than `ui5-avatar[size=S]`. Therefore, it is not applied.  This is unfortunately unavoidable because IE does not support `::slotted` and it's hard to replace it with an equally strong selector. Therefore in such cases it's best to make the expression inside `::slotted()` equally strong, if possible. Here it is by setting the slot name too. Now it generates `ui5-shellbar ui5-avatar[slot="profile"]` which is stronger than `ui5-avatar[size=S]`.

closes: https://github.com/SAP/ui5-webcomponents/issues/1806