### PR TITLE
fix(ui5-tabcontainer): aria-controls now points to an existing ID

### DIFF
--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -55,12 +55,12 @@
 		{{#each items}}
 			{{#unless this.isSeparator}}
 				<div
-                    class="ui5-tc__contentItem"
-                    id="ui5-tc-contentItem-{{this._posinset}}"
-                    ?hidden="{{this.effectiveHidden}}"
-                    role="tabpanel"
-                    aria-labelledby="{{this._id}}"
-                >
+					class="ui5-tc__contentItem"
+					id="ui5-tc-contentItem-{{this._posinset}}"
+					?hidden="{{this.effectiveHidden}}"
+					role="tabpanel"
+					aria-labelledby="{{this._id}}"
+				>
 					<slot name="{{this._individualSlot}}"></slot>
 				</div>
 			{{/unless}}

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -54,7 +54,13 @@
 	<div class="{{classes.content}}">
 		{{#each items}}
 			{{#unless this.isSeparator}}
-				<div class="ui5-tc__contentItem" id="ui5-tc-contentItem-{{this._position}}" ?hidden="{{this.effectiveHidden}}" role="tabpanel" aria-labelledby="{{this._id}}">
+				<div
+                    class="ui5-tc__contentItem"
+                    id="ui5-tc-contentItem-{{this._posinset}}"
+                    ?hidden="{{this.effectiveHidden}}"
+                    role="tabpanel"
+                    aria-labelledby="{{this._id}}"
+                >
 					<slot name="{{this._individualSlot}}"></slot>
 				</div>
 			{{/unless}}


### PR DESCRIPTION
There was a typo in the template: `_position` should have been `_posinset`.

closes: https://github.com/SAP/ui5-webcomponents/issues/1808