### PR TITLE
chore(ui5-input):  make ariaLabel private

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -273,7 +273,8 @@ const metadata = {
 		/**
 		 * @type {String}
 		 * @since 1.0.0-rc.8
-		 * @public
+		 * @private
+		 * @defaultvalue ""
 		 */
 		ariaLabel: {
 			type: String,


### PR DESCRIPTION
As we did for the Button, those aria stuff should be private to hide them from the API reference