### PR TITLE
chore(ui5-input): change event detail

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -364,12 +364,14 @@ const metadata = {
 		 * as a preview, before the final selection.
 		 *
 		 * @event sap.ui.webcomponents.main.Input#suggestion-item-preview
-		 * @param {HTMLElement} item The previewed item
+		 * @param {HTMLElement} item The previewed suggestion item
+		 * @param {HTMLElement} targetRef The DOM ref of the suggestion item.
 		 * @public
 		 */
 		"suggestion-item-preview": {
 			detail: {
 				item: { type: HTMLElement },
+				targetRef: { type: HTMLElement },
 			},
 		},
 	},
@@ -842,7 +844,9 @@ class Input extends UI5Element {
 
 	onItemPreviewed(item) {
 		this.previewSuggestion(item);
-		this.fireEvent("suggestion-item-preview", { item });
+		const suggestionItem = this.getSuggestionByListItem(item);
+
+		this.fireEvent("suggestion-item-preview",{ item: suggestionItem, targetRef: item });
 	}
 
 	onOpen() {}

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -846,7 +846,10 @@ class Input extends UI5Element {
 		this.previewSuggestion(item);
 		const suggestionItem = this.getSuggestionByListItem(item);
 
-		this.fireEvent("suggestion-item-preview",{ item: suggestionItem, targetRef: item });
+		this.fireEvent("suggestion-item-preview", {
+			item: suggestionItem,
+			targetRef: item,
+		});
 	}
 
 	onOpen() {}

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -337,7 +337,7 @@
 
 		// Preview suggestion item events
 		inputPreview.addEventListener("ui5-suggestion-item-preview", function (event) {
-			var item = event.detail.item;
+			var item = event.detail.targetRef;
 			inputItemPreviewRes.value = item.textContent;
 
 			quickViewCard.close(false, true, true);


### PR DESCRIPTION
In order to be more consistent with similar cases, when the user needs to open a popover from internal popover, as in the Shellbar, we provide the real DOM ref to an item (ui5-li) as "targetRef" param  in the event detail and leave "item" param for the external ui5-suggestion-item the user set.