### PR TITLE
chore(ui5-rating-indicator): enable aria-label and tooltip

### DIFF
--- a/packages/base/src/util/isValidPropertyName.js
+++ b/packages/base/src/util/isValidPropertyName.js
@@ -4,6 +4,7 @@ const whitelist = [
 	"disabled",
 	"ariaLabel",
 	"ariaExpanded",
+	"title",
 ];
 
 /**

--- a/packages/main/src/RatingIndicator.hbs
+++ b/packages/main/src/RatingIndicator.hbs
@@ -12,6 +12,8 @@
 	@focusout="{{_onfocusout}}"
 	@click="{{_onclick}}"
 	@keydown="{{_onkeydown}}"
+	title="{{tooltip}}"
+	aria-label="{{ariaLabel}}"
 >
 	<div
 		class="ui5-rating-indicator-stars-wrapper"

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -13,6 +13,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
 import {
 	RATING_INDICATOR_TEXT,
+	RATING_INDICATOR_TOOLTIP_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
 import RatingIndicatorTemplate from "./generated/templates/RatingIndicatorTemplate.lit.js";
 
@@ -81,6 +82,30 @@ const metadata = {
 		 */
 		readonly: {
 			type: Boolean,
+		},
+
+		/**
+		 * Defines the aria-label attribute for the rating indicator.
+		 * @type {String}
+		 * @defaultvalue: undefined
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		ariaLabel: {
+			type: String,
+			defaultValue: undefined,
+		},
+
+		/**
+		 * Defines the tooltip for the rating indicator.
+		 * @type {String}
+		 * @defaultvalue: undefined
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		title: {
+			type: String,
+			defaultValue: undefined,
 		},
 
 		/**
@@ -175,6 +200,10 @@ class RatingIndicator extends UI5Element {
 		this.calcState();
 	}
 
+	onAfterRendering() {
+		this._title = this.getAttribute("title");
+	}
+
 	calcState() {
 		this._stars = [];
 
@@ -252,6 +281,14 @@ class RatingIndicator extends UI5Element {
 
 	get tabIndex() {
 		return this.disabled ? "-1" : "0";
+	}
+
+	get tooltip() {
+		return this.title || this.defaultTooltip;
+	}
+
+	get defaultTooltip() {
+		return this.i18nBundle.getText(RATING_INDICATOR_TOOLTIP_TEXT);
 	}
 
 	get _ariaRoleDescription() {

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -200,10 +200,6 @@ class RatingIndicator extends UI5Element {
 		this.calcState();
 	}
 
-	onAfterRendering() {
-		this._title = this.getAttribute("title");
-	}
-
 	calcState() {
 		this._stars = [];
 

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -265,6 +265,9 @@ MULTIINPUT_SHOW_MORE_TOKENS={0} More
 #XTOL: Tooltip for panel expand title
 PANEL_ICON=Expand/Collapse
 
+#XBUT: Rating indicator tooltip text
+RATING_INDICATOR_TOOLTIP_TEXT=Rating
+
 #XBUT: Rating indicator aria-roledescription text
 RATING_INDICATOR_TEXT=Rating Indicator
 

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -19,17 +19,17 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 
-	<ui5-rating-indicator id="rating-indicator1"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-indicator1" aria-label="Hello World"></ui5-rating-indicator>
 	<br>
 	<br>
 	<br>
 
-	<ui5-rating-indicator id="rating-indicator2" max-value="10" value="6"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-indicator2" max-value="10" value="6" aria-label="Hello World"></ui5-rating-indicator>
 	<br>
 	<br>
 	<br>
 
-	<ui5-rating-indicator id="rating-indicator3" max-value="10" value="6"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-indicator3" max-value="10" value="6" aria-label="Hello World"></ui5-rating-indicator>
 	<br>
 	<br>
 	<br>

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -63,4 +63,16 @@ describe("Rating Indicator general interaction", () => {
 
 		assert.strictEqual(input.getProperty("value"), "12", "Input event is always fired")
 	});
+
+	it("Tests ACC attrs", () => {
+		const ratingIndicator = browser.$("#rating-indicator1").shadow$(".ui5-rating-indicator-root");
+		const TOOLTIP = "Rating";
+		const ARIA_LABEL = "Hello World";
+
+		assert.strictEqual(ratingIndicator.getAttribute("aria-label"), ARIA_LABEL,
+			"The aria-label is set");
+
+		assert.strictEqual(ratingIndicator.getAttribute("title"), TOOLTIP,
+			"The default tooltip is displayed");
+	});
 });


### PR DESCRIPTION
Add private aria-label and title props so the user can set them outside and ensure default tooltip ("Rating") is present when title is not provided, as elements with role="slider" needs aria-label, aria-labelledby or tooltip. 
A default aria-label was not an option as the word "Rating" would have been read twice as aria-roledescription="Rating Indicator" is already set.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1819