### PR TITLE
fix(framework): fix component lifecycle issues

### DIFF
--- a/packages/base/src/RenderQueue.js
+++ b/packages/base/src/RenderQueue.js
@@ -10,14 +10,24 @@ class RenderQueue {
 		}
 
 		let deferredResolve;
-		const promise = new Promise(resolve => {
+		let deferredReject;
+		const promise = new Promise((resolve, reject) => {
 			deferredResolve = resolve;
+			deferredReject = reject;
 		});
 		promise._deferredResolve = deferredResolve;
+		promise._deferredReject = deferredReject;
 
 		this.list.push(webComponent);
 		this.promises.set(webComponent, promise);
 
+		return promise;
+	}
+
+	remove(webComponent) {
+		const promise = this.promises.get(webComponent);
+		this.list = this.list.filter(item => item !== webComponent);
+		this.promises.delete(webComponent);
 		return promise;
 	}
 

--- a/packages/base/src/RenderScheduler.js
+++ b/packages/base/src/RenderScheduler.js
@@ -32,20 +32,27 @@ class RenderScheduler {
 	 */
 	static renderDeferred(webComponent) {
 		// Enqueue the web component
-		const res = invalidatedWebComponents.add(webComponent);
+		const promise = invalidatedWebComponents.add(webComponent);
 
 		// Schedule a rendering task
 		RenderScheduler.scheduleRenderTask();
-		return res;
+		return promise;
 	}
 
 	static renderImmediately(webComponent) {
 		// Enqueue the web component
-		const res = invalidatedWebComponents.add(webComponent);
+		const promise = invalidatedWebComponents.add(webComponent);
 
 		// Immediately start a render task
 		RenderScheduler.runRenderTask();
-		return res;
+		return promise;
+	}
+
+	static cancelRender(webComponent) {
+		const promise = invalidatedWebComponents.remove(webComponent);
+		if (promise) {
+			promise._deferredReject(new Error("Element removed from DOM before having been rendered."));
+		}
 	}
 
 	/**

--- a/packages/base/src/delegate/ResizeHandler.js
+++ b/packages/base/src/delegate/ResizeHandler.js
@@ -52,6 +52,10 @@ class ResizeHandler {
 	 * @memberof ResizeHandler
 	 */
 	static deregister(ref, callback) {
+		if (!ref) { // This may be undefined if onExitDOM is called before onEnterDOM async work has finished
+			return;
+		}
+
 		if (ref.isUI5Element) {
 			ref = ref.getDomRef();
 		}

--- a/packages/main/test/pages/DialogLifecycle.html
+++ b/packages/main/test/pages/DialogLifecycle.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta charset="utf-8">
+
+    <title>Button</title>
+
+    <script data-ui5-config type="application/json">
+        {
+            "language": "EN",
+            "noConflict": {
+                "events": ["click"]
+            },
+            "calendarType": "Islamic"
+        }
+    </script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+    <script nomodule src="../../resources/bundle.es5.js"></script>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+<ui5-button id="openDialogButton">Open Dialog</ui5-button>
+<br />
+
+<template id="dt">
+    <ui5-dialog id="hello-dialog" header-text="Dialogs are easy!">
+        <div stype="padding: 2rem; display:flex; justify-content: center;">
+            Hello World!
+            <ui5-button id="closeDialogButton">Dismiss</ui5-button>
+        </div>
+    </ui5-dialog>
+</template>
+
+<script>
+	const openBtn = document.getElementById("openDialogButton");
+	openBtn.addEventListener("click", () => {
+		const clone = document.getElementById("dt").content.cloneNode(true);
+		document.body.appendChild(clone);
+		const dialog = document.getElementById("hello-dialog");
+		const closeBtn = dialog.querySelector("#closeDialogButton");
+		closeBtn.addEventListener("click", () => {
+			dialog.addEventListener("afterClose", () => {
+				dialog.parentElement.removeChild(dialog);
+			});
+			dialog.close();
+		});
+
+		document.body.appendChild(dialog);
+		dialog.open();
+	});
+</script>
+
+</body>
+</html>

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -10,7 +10,6 @@ describe("Dialog general interaction", () => {
 		btnOpenDialog.click();
 
 		const dialog = browser.$("#dialog");
-		
 		assert.ok(dialog.isDisplayedInViewport(), "Dialog is opened.");
 
 		btnCloseDialog.click();
@@ -30,5 +29,21 @@ describe("Dialog general interaction", () => {
 		const popoverZIndex = parseInt(browser.$(`.${select.getProperty("_id")}`).shadow$("ui5-responsive-popover").getCSSProperty('z-index').value);
 
 		assert.ok(popoverZIndex > dialogZIndex, "Popover is above dialog.");
+	});
+
+	it("tests dialog lifecycle", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DialogLifecycle.html");
+
+		assert.ok(!browser.$("ui5-static-area").length, "No static area.");
+
+		const openDialogButton = browser.$("#openDialogButton");
+		openDialogButton.click();
+
+		assert.ok(browser.$("ui5-static-area>ui5-static-area-item"), "Static area item exists.");
+
+		const closeDialogButton= browser.$("#closeDialogButton");
+		closeDialogButton.click();
+
+		assert.ok(!browser.$("ui5-static-area").length, "No static area.");
 	});
 });


### PR DESCRIPTION
This change addresses some edge-case issues in `UI5Element.js` lifecycle:
 - When a component is removed from DOM, its belonging static area item is removed as well (in `disconnectedCallback`). However, if the component was invalidated before being removed from DOM, some time later it will be rendered by `RenderScheduler.js` and its static area item will be recreated in `_render`, thus causing a memory leak. Other side effects are possible also after calling `onAfterRendering`. Therefore, components that are removed from DOM, must be removed from the `RenderScheduler.js` queue.
 - Removing an item from `RenderScheduler.js` queue must reject its promise. Otherwise code that awaits for the promise to resolve, would fail. As a consequence, all calls to `renderDeferred` and `renderImmediately` must also handle errors.
 - `connectedCallback` does async work for components with managed slots, therefore a call such as: 
```js
x = document.createElement('ui5-table'); 
document.body.appendChild(x); 
document.body.removeChild(x);
```
will cause `onExitDOM` to be run before `_render`. Therefore a change was made to `ResizeHandler.js` to prevent such errors for components, deregistering in `onExitDOM` (before having a DOM ref at all).
 - A test was added, demonstrating that cloning a dialog and then removing it from DOM does not leave its static area item behind.
 - Check the test page: `packages/main/test/pages/DialogLifecycle.html` for an example how to use this.

BREAKING CHANGE: `renderDeferred` and `renderImmediately` will now start rejecting promises for components, removed from the render queue. Make sure you handle them, if using these methods in your code.

closes: https://github.com/SAP/ui5-webcomponents/issues/1821