### PR TITLE
chore: fix NotificationList tests

### DIFF
--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -26,7 +26,7 @@ describe("Notification List Item Tests", () => {
 		const firstItem = $("#nli1");
 		const btnListGroupItemClose = firstGroupItem.shadow$("[close-btn]");
 		const btnListItemClose = firstItem.shadow$("[close-btn]");
-	
+
 		// act
 		btnListGroupItemClose.click();
 
@@ -46,8 +46,8 @@ describe("Notification List Item Tests", () => {
 		const customActionInput = $("#customActionInput");
 		const secondItem = $("#nli2");
 		const customAction =  secondItem.shadow$(".ui5-nli-action");
-	
-		// act	
+
+		// act
 		customAction.click();
 
 		// assert
@@ -60,7 +60,7 @@ describe("Notification List Item Tests", () => {
 		const EXPECTED_RESULT = "Orders";
 		const firstGroupItem = $("#nlgi1");
 		const btnListGroupItemToggle = firstGroupItem.shadow$(".ui5-nli-group-toggle-btn");
-	
+
 		// act
 		btnListGroupItemToggle.click();
 
@@ -118,7 +118,7 @@ describe("Notification List Item Tests", () => {
 		const invisibleText = firstGroupItem.shadow$(".ui5-hidden-text");
 
 		// assert
-		assert.strictEqual(invisibleText.getText(), EXPECTED_RESULT,
+		assert.strictEqual(invisibleText.getText().toLowerCase(), EXPECTED_RESULT.toLowerCase(),
 			"The invisible text is correct.");
 	});
 
@@ -140,7 +140,7 @@ describe("Notification List Item Tests", () => {
 		const invisibleText = firstItem.shadow$(".ui5-hidden-text");
 
 		// assert
-		assert.strictEqual(invisibleText.getText(), EXPECTED_RESULT,
+		assert.strictEqual(invisibleText.getText().toLowerCase(), EXPECTED_RESULT.toLowerCase(),
 			"The invisible text is correct.");
 	});
 


### PR DESCRIPTION
Translation delivery fails with:

`AssertionError: The invisible text is correct.: expected 'Notification Group High Priority Counter 2' to equal 'Notification group High Priority Counter 2'`

and

`AssertionError: The invisible text is correct.: expected 'Notification Unread High Priority' to equal 'Notification unread High Priority'`

since the texts in the latest delivery have changed a bit.  The only difference is that some words are in small-case. However, changing the texts to the new ones won't be mergeable now, before the translation, so the simplest solution would be to check for case-insensitive.