### PR TITLE
refactor(framework): make _id only generated on demand

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -43,7 +43,6 @@ const GLOBAL_DIR_CSS_VAR = "--_ui5_dir";
 class UI5Element extends HTMLElement {
 	constructor() {
 		super();
-		this._generateId();
 		this._initializeState();
 		this._upgradeAllProperties();
 		this._initializeContainers();
@@ -60,10 +59,17 @@ class UI5Element extends HTMLElement {
 	}
 
 	/**
-	 * @private
+	 * Returns a unique ID for this UI5 Element
+	 *
+	 * @deprecated - This property is not guaranteed in future releases
+	 * @protected
 	 */
-	_generateId() {
-		this._id = `ui5wc_${++autoId}`;
+	get _id() {
+		if (!this.__id) {
+			this.__id = `ui5wc_${++autoId}`;
+		}
+
+		return this.__id;
 	}
 
 	/**

--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -11,7 +11,6 @@
     <slot name="header" slot="header"></slot>
     {{#each _listItems}}
         <ui5-li-tree
-            ._id="{{this.treeItem._id}}"
             type="Active"
             level="{{this.level}}"
             icon="{{this.treeItem.icon}}"

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -264,8 +264,8 @@ class Tree extends UI5Element {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
 		if (treeItem.items.length > 0) {
-			const firstChildId = treeItem.items[0]._id;
-			const firstChildListItem = this.list.getSlottedNodes("items").find(item => item._id === firstChildId);
+			const firstChild = treeItem.items[0];
+			const firstChildListItem = this.list.getSlottedNodes("items").find(li => li.treeItem === firstChild);
 			firstChildListItem && this.list.focusItem(firstChildListItem);
 		}
 	}
@@ -274,8 +274,8 @@ class Tree extends UI5Element {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
 		if (treeItem.parentElement !== this) {
-			const parentId = treeItem.parentElement._id;
-			const parentListItem = this.list.getSlottedNodes("items").find(item => item._id === parentId);
+			const parent = treeItem.parentElement;
+			const parentListItem = this.list.getSlottedNodes("items").find(li => li.treeItem === parent);
 			parentListItem && this.list.focusItem(parentListItem);
 		}
 	}

--- a/packages/main/test/pages/LitKeyFunction.html
+++ b/packages/main/test/pages/LitKeyFunction.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>LitHTML key function test page</title>
+	<script>
+		delete Document.prototype.adoptedStyleSheets
+	</script>
+
+	<script data-ui5-config type="application/json">
+		{
+			"rtl": false
+		}
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+	<style>
+		ui5-multi-combobox {
+			max-width: 560px;
+			width: 100%;
+		}
+	</style>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+
+		<ui5-multi-combobox id="mcb" >
+			<ui5-mcb-item text="<empty>"></ui5-mcb-item>
+			<ui5-mcb-item text="Algeria"></ui5-mcb-item>
+			<ui5-mcb-item text="China"></ui5-mcb-item>
+			<ui5-mcb-item text="USA"></ui5-mcb-item>
+		</ui5-multi-combobox>
+
+</body>
+
+</html>

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -17,11 +17,12 @@ describe("Lit HTML key function for #each", () => {
 
 		// Click on the first item
 		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-multi-combobox-all-items-responsive-popover");
-		const firstItem = popover.$(".ui5-multi-combobox-all-items-list > ui5-li");
+		const firstItem = popover.$$(".ui5-multi-combobox-all-items-list > ui5-li")[0];
 		firstItem.click();
 
 		// Open the popover with the arrow
 		const icon = browser.$("#mcb").shadow$("[input-icon]");
+		icon.click();
 
 		// The first item (<empty>) should not be selected
 		const newFirstItem = popover.$$(".ui5-multi-combobox-all-items-list > ui5-li")[0];

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -1,0 +1,36 @@
+const assert = require("chai").assert;
+
+describe("Lit HTML key function for #each", () => {
+	browser.url("http://localhost:8080/test-resources/pages/LitKeyFunction.html");
+
+	it("LIT HTML does not mess up keys when looping over lists", () => {
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#mcb");
+
+		// Focus the input
+		const input = browser.$("#mcb").shadow$("[inner-input]");
+		input.click();
+
+		// Type "usa"
+		input.keys("u");
+		input.keys("s");
+		input.keys("a");
+
+		// Click on the first item
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-multi-combobox-all-items-responsive-popover");
+		const firstItem = popover.$(".ui5-multi-combobox-all-items-list > ui5-li");
+		firstItem.click();
+
+		// Open the popover with the arrow
+		const icon = browser.$("#mcb").shadow$("[input-icon]");
+
+		// The first item (<empty>) should not be selected
+		const newFirstItem = popover.$$(".ui5-multi-combobox-all-items-list > ui5-li")[0];
+		assert.ok(newFirstItem.getHTML(false).includes("empty"), "First item is <empty>");
+		assert.ok(!newFirstItem.getProperty("selected"), "<empty> is not selected");
+
+		// The last item (USA) should be selected
+		const lastItem = popover.$$(".ui5-multi-combobox-all-items-list > ui5-li")[3];
+		assert.ok(lastItem.getHTML(false).includes("USA"), "Last item is USA");
+		assert.ok(lastItem.getProperty("selected"), "USA is  selected");
+	});
+});

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -135,7 +135,7 @@ function visitEachBlock(block) {
 	var bParamAdded = false;
 	visitSubExpression.call(this, block);
 
-	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", (item, index) => item._id || index, (item, index) => ";
+	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", (item, index) => item || index, (item, index) => ";
 	this.paths.push(normalizePath.call(this, block.params[0].original));
 	this.blockPath = "item";
 

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -135,7 +135,7 @@ function visitEachBlock(block) {
 	var bParamAdded = false;
 	visitSubExpression.call(this, block);
 
-	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", (item, index) => item || index, (item, index) => ";
+	this.blocks[this.currentKey()] += "${ repeat(" + normalizePath.call(this, block.params[0].original) + ", (item, index) => item._id || index, (item, index) => ";
 	this.paths.push(normalizePath.call(this, block.params[0].original));
 	this.blockPath = "item";
 


### PR DESCRIPTION
This change is a step towards removing the auto-generated `_id` from the framework:
 - What used to be `_id` is now instead `get _id()` which is created on demand only for components that use it. The first time some functionality needs to read `_id` from a UI5 Element, it will be guaranteed (and unique), but otherwise it will not exist. The real internal variable will be `__id`.
 - `ui5-tree` used to override the `_id` of its list items (for matching tree items with list items) which is wrong. Now the checks are done by reference instead. `_id` cannot be set.
 - Documented the famous "test" for the lit key function with a multi combo box, which filters the list of items until only one is visible, selects it, and then opens the popup, and verifies that the first item in the popup is not selected (it has the same index, but is another item) and the real item is selected (different index, but the same item).

BREAKING CHANGE: `_id` is now read-only. 