### PR TITLE
feat(ui5-popup): custom popups work with focusable elements in the sh…

### DIFF
--- a/packages/base/src/util/FocusableElements.js
+++ b/packages/base/src/util/FocusableElements.js
@@ -1,6 +1,10 @@
 import isNodeHidden from "./isNodeHidden.js";
 import isNodeClickable from "./isNodeClickable.js";
 
+const isFocusTrap = el => {
+	return el.hasAttribute("data-ui5-focus-trap");
+};
+
 const getFirstFocusableElement = container => {
 	if (!container || isNodeHidden(container)) {
 		return null;
@@ -19,7 +23,10 @@ const getLastFocusableElement = container => {
 
 const findFocusableElement = (container, forward) => {
 	let child;
-	if (container.assignedNodes && container.assignedNodes()) {
+
+	if (container.shadowRoot) {
+		child = forward ? container.shadowRoot.firstChild : container.shadowRoot.lastChild;
+	} else if (container.assignedNodes && container.assignedNodes()) {
 		const assignedElements = container.assignedNodes();
 		child = forward ? assignedElements[0] : assignedElements[assignedElements.length - 1];
 	} else {
@@ -36,7 +43,7 @@ const findFocusableElement = (container, forward) => {
 			return null;
 		}
 
-		if (child.nodeType === 1 && !isNodeHidden(child)) {
+		if (child.nodeType === 1 && !isNodeHidden(child) && !isFocusTrap(child)) {
 			if (isNodeClickable(child)) {
 				return (child && typeof child.focus === "function") ? child : null;
 			}

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -2,7 +2,7 @@
 
 	{{> beforeHeader}}
 
-	<span class="first-fe" tabindex="0" @focusin={{forwardToLast}}></span>
+	<span class="first-fe" data-ui5-focus-trap tabindex="0" @focusin={{forwardToLast}}></span>
 
 	{{> header}}
 
@@ -12,7 +12,7 @@
 
 	{{> footer}}
 
-	<span class="last-fe" tabindex="0" @focusin={{forwardToFirst}}></span>
+	<span class="last-fe" data-ui5-focus-trap tabindex="0" @focusin={{forwardToFirst}}></span>
 
 </section>
 

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -311,11 +311,11 @@ class Popup extends UI5Element {
 	}
 
 	/**
-	 * Sets "inline-block" display to the popup
+	 * Sets "block" display to the popup
 	 * @protected
 	 */
 	show() {
-		this.style.display = "inline-block";
+		this.style.display = "block";
 	}
 
 

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -37,6 +37,8 @@
 	<ui5-button id="modals-open">Open Multiple modals</ui5-button>
 	<br>
 	<br>
+	<ui5-button id="empty-open">Open empty dialog (no focusable element)</ui5-button>
+	<br><br>
 
 	<ui5-block-layer></ui5-block-layer>
 
@@ -198,6 +200,8 @@
 		</ui5-list>
 	</ui5-popover>
 
+	<ui5-dialog id="empty-dialog">Empty</ui5-dialog>
+
 	<script>
 
 		let preventClosing = true;
@@ -248,6 +252,8 @@
 		bigDanger.addEventListener('click', function (event) {
 			bigDangerPop.openBy(bigDanger);
 		});
+
+		window["empty-open"].addEventListener("click", function (event) { window["empty-dialog"].open(); });
 	</script>
 </body>
 


### PR DESCRIPTION
This change addresses two issues:
 - The `show` function in `Popup.js` sets `inline-block` rather than `block`, which breaks focus behavior in terms of the `isNodeHidden` function, when the custom element needs to be analyzed by it. Since popups are always absolutely positioned, and never in the stream of other elements, `block` should be as good as `inline-block`.
 - When looking for focusable elements inside popups, the `getFirstFocusableElement` and `getLastFocusableElement` functions completely skip shadow roots. Therefore focusable elements in the shadow root will be excluded from the focus chain. The fix allows these functions to drill down into shadow roots.

**Important:** when scanning shadow roots, the focus traps should always be skipped, otherwise infinite loops are possible! For this purpose they are marked more explicitly with `data-ui5-focus-trap`.

The entirety of these changes will make it possible to have custom popups with predefined buttons (or other focusable elements) and they will now be in the focus chain (and will be focused upon opening the popup, if they are the first focusable element).

closes: https://github.com/SAP/ui5-webcomponents/issues/1838