### PR TITLE
fix(ui5-input): fix scrolling item into view

### DIFF
--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -280,12 +280,13 @@ class Suggestions {
 		const rectInput = this._getComponent().getDomRef().getBoundingClientRect();
 		const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
 
-		return (rectItem.top <= windowHeight) && (rectItem.top >= rectInput.top);
+		return (rectItem.top + Suggestions.SCROLL_STEP <= windowHeight) && (rectItem.top >= rectInput.top);
 	}
 
-	_scrollItemIntoView(item) {
-		const pos = item.getDomRef().offsetTop - Suggestions.SCROLL_STEP;
-		this._getScrollContainer().scrollTop = pos;
+	async _scrollItemIntoView(item) {
+		const pos = item.getDomRef().offsetTop;
+		const scrollContainer  = await this._getScrollContainer();
+		scrollContainer.scrollTop = pos;
 	}
 
 	async _getScrollContainer() {
@@ -338,7 +339,7 @@ class Suggestions {
 	}
 }
 
-Suggestions.SCROLL_STEP = 48;
+Suggestions.SCROLL_STEP = 60;
 
 // The List and Popover components would be rendered
 // by the issuer component`s template.

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -285,7 +285,7 @@ class Suggestions {
 
 	async _scrollItemIntoView(item) {
 		const pos = item.getDomRef().offsetTop;
-		const scrollContainer  = await this._getScrollContainer();
+		const scrollContainer = await this._getScrollContainer();
 		scrollContainer.scrollTop = pos;
 	}
 


### PR DESCRIPTION
The scroll container should be awaited before we use it. Additionally, we use the step constant in the "isIteminView" method to avoid half visible items, because previously the input used to scroll if the item is entirely out of view (60 is the maximum height of a standard list item).

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1847