### PR TITLE
chore(ui5-input): set data-key to group item

### DIFF
--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -51,7 +51,7 @@
 		<ui5-list separators="Inner">
 			{{#each suggestionsTexts}}
 				{{#if group}}
-					<ui5-li-groupheader>{{ this.text }}</ui5-li-groupheader>
+					<ui5-li-groupheader data-ui5-key="{{key}}">{{ this.text }}</ui5-li-groupheader>
 				{{else}}
 					<ui5-li
 						image="{{this.image}}"


### PR DESCRIPTION
There is data-key set on the standard suggestions, but it's missing on the group suggestion. It is used for the mouseover/out events. Currently, if the users hovers on a group item, error is thrown as the corresponding suggestion item cant be found without this data-key attribute. Other way would be to not fire the events for hovering over group items, but at the end I think this is better.