### PR TITLE
fix(tools): strip unnecessary whitespaces

### DIFF
--- a/packages/tools/lib/hbs2lit/src/compiler.js
+++ b/packages/tools/lib/hbs2lit/src/compiler.js
@@ -6,11 +6,10 @@ const svgProcessor = require("./svgProcessor");
 
 const removeWhiteSpaces = (source) => {
 	return source
-		.replace(/\n+/g, "")
-		.replace(/\s*<\s*/g, "<")
-		.replace(/\s*>\s*/g, ">")
-		.replace(/}}\s+{{/g, "}}{{")
-		.replace(/\t+/g, " ");
+		.replace(/\s*\r*\n+\s*/g, " ") // Replace new lines and all whitespace between them with a space
+		.replace(/\s*<\s*/g, "<") // Strip whitespace round <
+		.replace(/\s*>\s*/g, ">") // Strip whitespace round >
+		.replace(/}}\s+{{/g, "}}{{"); // Remove whitespace between }} and {{
 };
 
 const compileString = async (sInput, config) => {


### PR DESCRIPTION
Now we no longer blindly replace `tab`s, but we strip whitespace around new lines. This way it also works if the `.hbs` uses spaces rather than tabs.

Changes: 
 - the first expression `.replace(/\n+/g, "")` is enriched
 - the last expression `.replace(/\t+/g, " ")` is removed.

close: https://github.com/SAP/ui5-webcomponents/issues/1804