### PR TITLE
fix(ui5-input): stop firing focusout on suggestion click

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -582,6 +582,7 @@ class Input extends UI5Element {
 		// if focusout is triggered by pressing on suggestion item or value state message popover, skip invalidation, because re-rendering
 		// will happen before "itemPress" event, which will make item "active" state not visualized
 		if (focusedOutToSuggestions	|| focusedOutToValueStateMessage) {
+			event.stopImmediatePropagation();
 			return;
 		}
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -366,6 +366,10 @@
 				quickViewCard.close(false, true, true);
 			});
 		});
+
+		inputPreview.addEventListener("focusout", function (event) {
+			console.log("focusout");
+		});
 	</script>
 </body>
 </html>


### PR DESCRIPTION
The "focusout" event used to be fired whenever the user interacts with the suggestion lists, misleading the ones that listens for the event, that the user has clicked somewhere outside. Now, it is not fired.

Fixes: #1846