### PR TITLE
feat(tools): Templates can be imported from node_modules/

### DIFF
--- a/packages/fiori/.npmignore
+++ b/packages/fiori/.npmignore
@@ -3,7 +3,6 @@ dist/resources
 dist/test-resources
 lib/
 node_modules/
-src/
 test/
 bundle.*.js
 .eslintrc.js

--- a/packages/main/.npmignore
+++ b/packages/main/.npmignore
@@ -3,7 +3,6 @@ dist/resources
 dist/test-resources
 lib/
 node_modules/
-src/
 test/
 bundle.*.js
 .eslintrc.js

--- a/packages/tools/lib/hbs2lit/index.js
+++ b/packages/tools/lib/hbs2lit/index.js
@@ -1,5 +1,3 @@
-const compiler = require("./src/compiler");
+const hbs2lit = require("./src/compiler");
 
-module.exports = {
-	compileString: compiler.compileString
-};
+module.exports = hbs2lit;

--- a/packages/tools/lib/hbs2lit/src/compiler.js
+++ b/packages/tools/lib/hbs2lit/src/compiler.js
@@ -12,10 +12,9 @@ const removeWhiteSpaces = (source) => {
 		.replace(/}}\s+{{/g, "}}{{"); // Remove whitespace between }} and {{
 };
 
-const compileString = async (sInput, config) => {
-	let sPreprocessed = sInput;
+const hbs2lit = (file) => {
+	let sPreprocessed = includesReplacer.replace(file);
 
-	sPreprocessed = includesReplacer.replace(sPreprocessed, config);
 	sPreprocessed = removeWhiteSpaces(sPreprocessed);
 
 	const ast = Handlebars.parse(sPreprocessed);
@@ -38,6 +37,4 @@ const compileString = async (sInput, config) => {
 	return result;
 };
 
-module.exports = {
-	compileString
-};
+module.exports = hbs2lit;

--- a/packages/tools/lib/hbs2ui5/index.js
+++ b/packages/tools/lib/hbs2ui5/index.js
@@ -18,26 +18,18 @@ const args = getopts(process.argv.slice(2), {
 
 const onError = (place) => {
 	console.log(`A problem occoured when reading ${place}. Please recheck passed parameters.`);
-}
+};
+
 const isHandlebars = (fileName) => fileName.indexOf('.hbs') !== -1;
-const parseFile = (filePath, inputDir, outputDir) => {
-	fs.readFile(filePath, 'utf-8', (err, content) => {
 
-		if (err) {
-			onError('file');
-		}
+const processFile = (file, outputDir) => {
 
-		hbs2lit.compileString(content, {
-			templatesPath: inputDir,
-			compiledTemplatesPath: outputDir
-		}).then((litCode) => {
-			const componentNameMatcher = /(\w+)(\.hbs)/gim;
-			const componentName = componentNameMatcher.exec(filePath)[1];
+	const litCode = hbs2lit(file);
 
-			writeRenderers(outputDir, componentName, litRenderer.generateTemplate(componentName, litCode));
-		});
-	});
-}
+	const componentNameMatcher = /(\w+)(\.hbs)/gim;
+	const componentName = componentNameMatcher.exec(file)[1];
+	writeRenderers(outputDir, componentName, litRenderer.generateTemplate(componentName, litCode));
+};
 
 const wrapDirectory = (directory, outputDir) => {
 	directory = path.normalize(directory);
@@ -51,9 +43,7 @@ const wrapDirectory = (directory, outputDir) => {
 
 		files.forEach(fileName => {
 			if (isHandlebars(fileName)) {
-
-				// could be refactored a bit
-				parseFile(directory + fileName, directory, outputDir);
+				processFile(path.join(directory, fileName), outputDir);
 			}
 		});
 	})


### PR DESCRIPTION
This feature allows `.hbs` template authors to:
 - Import other `.hbs` files from anywhere in the local filesystem: path starting with `.` or `..`
 - Import other `.hbs` files from `node_modules/`

Examples:
```{{>include "./Popup.hbs"}}```
```{{>include "../my_partials/Header.hbs"}}```
```{{>include "@ui5/webcomponents/src/ListItem.hbs"}}```

This will enable third party developers to extend our components and implement the partials.

For the purpose, we need to start shipping the `src/` directory of `main` and `fiori`.

In addition, some parts of the `hbs2lit` and `hbs2ui5` libs have been improved, most notably `includesReplacer` in order to be able to recursively parse include statements while **simultaneously** keeping track of the current relative path of the currently parsed file so that relative references inside it can work properly.

closes: https://github.com/SAP/ui5-webcomponents/issues/1859