### PR TITLE
chore(ui5-dialog): allow content max-width 100%

### DIFF
--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -23,6 +23,7 @@
 .ui5-popup-root {
 	display: flex;
 	flex-direction: column;
+	max-width: 100vw;
 }
 
 .ui5-popup-content {

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -39,6 +39,10 @@
 	<br>
 	<ui5-button id="empty-open">Open empty dialog (no focusable element)</ui5-button>
 	<br><br>
+	<ui5-button id="wide-open">Open wide dialog</ui5-button>
+	<br><br>
+	<ui5-button id="wide-open2">Open wide dialog 2</ui5-button>
+	<br><br>
 
 	<ui5-block-layer></ui5-block-layer>
 
@@ -138,6 +142,46 @@
 		<div>
 			<ui5-button id="yes">YES</ui5-button>
 			<ui5-button id="no">NO</ui5-button>
+		</div>
+	</ui5-dialog>
+
+	<ui5-dialog id="wide-dialog" header-text="Wide dialog" style="width: 100%">
+		<p>That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+
+		<div slot="footer" style="display: flex; justify-content: flex-end; width: 100%; padding: .25rem 1rem;">
+			<ui5-button design="Emphasized">OK</ui5-button>
+		</div>
+	</ui5-dialog>
+
+	<ui5-dialog id="wide-dialog2" header-text="Wide dialog" stretch style="width: 100%">
+		<p>That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
+			That´s OpenUI5.</p>
+
+		<div slot="footer" style="display: flex; justify-content: flex-end; width: 100%; padding: .25rem 1rem;">
+			<ui5-button design="Emphasized">OK</ui5-button>
 		</div>
 	</ui5-dialog>
 
@@ -254,6 +298,8 @@
 		});
 
 		window["empty-open"].addEventListener("click", function (event) { window["empty-dialog"].open(); });
+		window["wide-open"].addEventListener("click", function (event) { window["wide-dialog"].open(); });
+		window["wide-open2"].addEventListener("click", function (event) { window["wide-dialog2"].open(); });
 	</script>
 </body>
 


### PR DESCRIPTION
The max-width of the Dialog content has been restricted to 90vh, however after the refactoring the Dialog can be expanded to 100% width with standard CSS (although not recommended by Fiori 3), causing visual issue.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1862