### PR TITLE
fix(ui5-sebmentedbutton): fix intermittent js error

### DIFF
--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -212,7 +212,7 @@ class SegmentedButton extends UI5Element {
 	}
 
 	async _handleResize() {
-		const buttonsHaveWidth = this.widths.some(button => button.offsetWidth > 2); // 2 are the pixel's added for rounding & IE
+		const buttonsHaveWidth = this.widths && this.widths.some(button => button.offsetWidth > 2); // 2 are the pixel's added for rounding & IE
 		if (!buttonsHaveWidth) {
 			await this.measureButtonsWidth();
 		}


### PR DESCRIPTION
It is possible that `_handleResize` be called before `onAfterRendering` and then `this.buttons` will be `undefined`, producing a JS error in the console.