### PR TITLE
chore: create a test page for ResizeHandler

### DIFF
--- a/packages/main/bundle.es5.js
+++ b/packages/main/bundle.es5.js
@@ -11,6 +11,7 @@ import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
 import { getRegisteredNames as getIconNames } from  "@ui5/webcomponents-base/dist/SVGIconRegistry.js";
 import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
+import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 const configuration = {
 	getAnimationMode,
 	getTheme,
@@ -25,4 +26,5 @@ export {
 	configuration,
 	getIconNames,
 	applyDirection,
+	ResizeHandler,
 };

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -94,6 +94,7 @@ import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
 import { getRegisteredNames as getIconNames } from  "@ui5/webcomponents-base/dist/SVGIconRegistry.js";
 import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
+import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 window["sap-ui-webcomponents-bundle"] = {
 	configuration : {
 		getAnimationMode,
@@ -108,4 +109,5 @@ window["sap-ui-webcomponents-bundle"] = {
 	getIconNames,
 	getLocaleData,
 	applyDirection,
+	ResizeHandler,
 };

--- a/packages/main/test/pages/ResizeHandler.html
+++ b/packages/main/test/pages/ResizeHandler.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta charset="utf-8">
+
+    <title>Button</title>
+
+    <script data-ui5-config type="application/json">
+        {
+            "language": "EN",
+            "noConflict": {
+                "events": ["click"]
+            },
+            "calendarType": "Islamic"
+        }
+    </script>
+
+	<script src="../../resources/bundle.esm.js"></script>
+
+	<style>
+		.filler {
+			width: 100%;
+			height: 100%;
+			background: white;
+		}
+		.demo {
+			box-sizing: border-box;
+			border: 1px solid black;
+		}
+
+		.big {
+			width: 100%;
+			height: 300px;
+		}
+
+		.small {
+			width: 50%;
+			height: 300px;
+		}
+
+		.green {
+			background: #5bf59c;
+		}
+
+		.red {
+			background: red;
+		}
+
+
+		@media (min-width: 1025px) {
+			#media .demo {
+				padding: 30px;
+			}
+		}
+		@media (min-width: 641px) and (max-width: 1024px) {
+			#media .demo {
+				padding: 15px;
+			}
+		}
+		@media (max-width: 640px) {
+			#media .demo {
+				padding: 5px;
+			}
+		}
+
+
+		.phone {
+			padding: 5px;
+		}
+
+		.tablet {
+			padding: 15px;
+		}
+
+		.desktop {
+			padding: 30px;
+		}
+
+
+	</style>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+<ui5-title>With media queries</ui5-title>
+
+<div id="media">
+	<div class="demo big red"><div class="filler"></div></div>
+	<br>
+	<div style="display: flex;">
+		<div class="demo small red"><div class="filler"></div></div>
+		<div class="demo small red"><div class="filler"></div></div>
+	</div>
+</div>
+<br><br>
+<ui5-title>With ResizeHandler</ui5-title>
+
+<div id="rh">
+	<div class="demo big green"><div class="filler"></div></div>
+	<br>
+	<div style="display: flex;">
+		<div class="demo small green"><div class="filler"></div></div>
+		<div class="demo small green"><div class="filler"></div></div>
+	</div>
+</div>
+
+<script>
+
+	const RH = window["sap-ui-webcomponents-bundle"].ResizeHandler;
+
+	[...document.querySelectorAll("#rh .demo")].forEach(div => {
+		RH.register(div, () => {
+			const w = div.offsetWidth;
+			if (w <= 640) {
+				div.classList.remove("tablet", "desktop");
+				div.classList.add("phone");
+			} else if (w <= 1024) {
+				div.classList.remove("phone", "desktop");
+				div.classList.add("tablet");
+			} else {
+				div.classList.remove("phone", "tablet");
+				div.classList.add("desktop");
+			}
+		});
+	});
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This test page demonstrates how app can use `ResizeHandler` for a cross-browser responsive paddings/margins solution.

The page compares media queries to `ResizeHandler` to showcase the differences between a full-page-width container and a container that only takes a part of the page (but needs to have responsive paddings/margins).