### PR TITLE
fix(ui5-tabcontainer): correct selected text color used for sap_belize

### DIFF
--- a/packages/main/src/themes/sap_belize/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize/TabContainer-parameters.css
@@ -2,5 +2,5 @@
 
 :root {
 	--_ui5_tc_headeritem_text_selected_color: #3b6f9a;
-    --_ui5_tc_headerItemIcon_selected_background: #3b6f9a;
+	--_ui5_tc_headerItemIcon_selected_background: #3b6f9a;
 }

--- a/packages/main/src/themes/sap_belize/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize/TabContainer-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/TabContainer-parameters.css";
+
+:root {
+	--_ui5_tc_headeritem_text_selected_color: #3B6F9A;
+}

--- a/packages/main/src/themes/sap_belize/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize/TabContainer-parameters.css
@@ -1,5 +1,6 @@
 @import "../base/TabContainer-parameters.css";
 
 :root {
-	--_ui5_tc_headeritem_text_selected_color: #3B6F9A;
+	--_ui5_tc_headeritem_text_selected_color: #3b6f9a;
+    --_ui5_tc_headerItemIcon_selected_background: #3b6f9a;
 }

--- a/packages/main/src/themes/sap_belize/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize/parameters-bundle.css
@@ -21,7 +21,7 @@
 @import "../base/RadioButton-parameters.css";
 @import "../base/Select-parameters.css";
 @import "../base/Switch-parameters.css";
-@import "../base/TabContainer-parameters.css";
+@import "./TabContainer-parameters.css";
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
 @import "../base/TextArea-parameters.css";


### PR DESCRIPTION
In OpenUI5 for `sap_belize` the tab container selected color is darkened by 5. We need to use this color as well to achieve the desired color contrast.

closes: https://github.com/SAP/ui5-webcomponents/issues/1870