### PR TITLE
chore(ui5-tree): extract tree list item partial

### DIFF
--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -22,7 +22,11 @@
             @ui5-step-in="{{../_onListItemStepIn}}"
             @ui5-step-out="{{../_onListItemStepOut}}"
         >
-            {{this.treeItem.text}}
+            {{> treeListItemContent}}
         </ui5-li-tree>
     {{/each}}
 </ui5-list>
+
+{{#*inline "treeListItemContent"}}
+	{{this.treeItem.text}}
+{{/inline}}


### PR DESCRIPTION
This change simplifies a bit the process of extending `ui5-tree` and overriding the tree list item content.

closes: https://github.com/SAP/ui5-webcomponents/issues/1845