### PR TITLE
chore: improve pre-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prerelease": "node ./.github/actions/pre-release.js"
   },
   "devDependencies": {
+    "command-line-args": "^5.1.1",
     "cross-env": "^5.2.0",
     "glob-promise": "^3.4.0",
     "npm-run-all": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,7 +2240,7 @@ colors@^1.3.3:
 
 command-line-args@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
   integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
   dependencies:
     array-back "^3.0.1"


### PR DESCRIPTION
The script currently auto generates and releases versions based on the last commit - 0.0.0-2dsdsdds, 0.0.0-a4d5sdsd, etc. Now ,it can also release a specific version and tag, passed as an argument - 0.21.6, 0.21.7, etc.

```js
yarn prerelease // default: --tag=next, version=0.0.0-{commit_id}
yarn prerelease --tag sf --version 0.21.6
```