### PR TITLE
chore(FCL): run column animation with display:none

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -2,7 +2,6 @@
 	<div
 		role="region"
 		class="{{classes.columns.start}}"
-		style="{{styles.columns.start}}"
 		aria-labelledby="{{_id}}-startColumnText"
 	>
 		<slot name="startColumn"></slot>
@@ -21,7 +20,6 @@
 	<div
 		role="region"
 		class="{{classes.columns.middle}}"
-		style="{{styles.columns.middle}}"
 		aria-labelledby="{{_id}}-midColumnText"
 	>
 		<slot name="midColumn"></slot>
@@ -40,7 +38,6 @@
 	<div
 		role="region"
 		class="{{classes.columns.end}}"
-		style="{{styles.columns.end}}"
 		aria-labelledby="{{_id}}-endColumnText"
 	>
 		<slot name="endColumn"></slot>

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -45,10 +45,7 @@
 }
 
 .ui5-fcl-column--hidden {
-	height: 0;
-	width: 0;
-	position: absolute;
-	visibility: hidden;
+	display: none;
 }
 
 /* arrow */


### PR DESCRIPTION
In the initial implementation we removed "display: none" and start hiding the columns with width="0px" and position="absolute" and thus not having any issues with the column animation. Because in general the width animation can not run from 33% to display:none, when "display:none" and the "width" are set in same browser reflow. 

But, not using "display:none" leads to other issues, mainly accessibility. The slotted content within hidden columns might be accessed by TAB even if we set tabindex="-1" in the shadowRoot it does not help, the user should do the same to the external content. Also, if the app needs to start with OneColumn and later open the other columns, having display:none set will reduce the browser work on initial rendering.

With this change we have the same experience and having "display:none" to the hidden columns.