### PR TITLE
feature(tools): Support unsafeHTML in HBS compiler

### DIFF
--- a/packages/base/src/renderer/LitRenderer.js
+++ b/packages/base/src/renderer/LitRenderer.js
@@ -11,5 +11,6 @@ export { html, svg } from "lit-html/lit-html.js";
 export { repeat } from "lit-html/directives/repeat.js";
 export { classMap } from "lit-html/directives/class-map.js";
 export { styleMap } from "lit-html/directives/style-map.js";
+export { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 
 export default litRender;

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -76,7 +76,11 @@ HTMLLitVisitor.prototype.MustacheStatement = function(mustache) {
 		} else if (skipIfDefined){
 			parsedCode = `\${${path}}`;
 		} else {
-			parsedCode = `\${ifDefined(${path})}`;
+			if (!mustache.escaped) {
+				parsedCode = `\${ifDefined(unsafeHTML(${path}))}`;
+			} else {
+				parsedCode = `\${ifDefined(${path})}`;
+			}
 		}
 
 		this.blocks[this.currentKey()] += parsedCode;

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -56,7 +56,7 @@ HTMLLitVisitor.prototype.ContentStatement = function(content) {
 
 	const contentStatement = content.original;
 	skipIfDefined = !!dynamicAttributeRgx.exec(contentStatement);
-	isNodeValue = contentStatement.endsWith(">");
+	isNodeValue = contentStatement.lastIndexOf(">") > contentStatement.lastIndexOf("<");
 
 	this.blocks[this.currentKey()] += contentStatement;
 };

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -56,7 +56,12 @@ HTMLLitVisitor.prototype.ContentStatement = function(content) {
 
 	const contentStatement = content.original;
 	skipIfDefined = !!dynamicAttributeRgx.exec(contentStatement);
-	isNodeValue = contentStatement.lastIndexOf(">") > contentStatement.lastIndexOf("<");
+
+	const closingIndex = contentStatement.lastIndexOf(">");
+	const openingIndex = contentStatement.lastIndexOf("<");
+	if (closingIndex !== -1 || openingIndex !== -1) { // Only change isNodeValue whenever < or > is found in the content statement
+		isNodeValue = closingIndex > openingIndex;
+	}
 
 	this.blocks[this.currentKey()] += contentStatement;
 };

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -74,7 +74,7 @@ HTMLLitVisitor.prototype.MustacheStatement = function(mustache) {
 		let parsedCode = "";
 
 		if (isNodeValue && !mustache.escaped) {
-			parsedCode = `\${ifDefined(unsafeHTML(${path}))}`;
+			parsedCode = `\${unsafeHTML(${path})}`;
 		} else if (hasCalculatingClasses) {
 			parsedCode = `\${classMap(${path})}`;
 		} else if (hasStylesCalculation) {

--- a/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
+++ b/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
@@ -2,7 +2,7 @@ const buildRenderer = (controlName, litTemplate) => {
 	return `
 /* eslint no-unused-vars: 0 */
 import ifDefined from '@ui5/webcomponents-base/dist/renderer/ifDefined.js';
-import { html, svg, repeat, classMap, styleMap } from '@ui5/webcomponents-base/dist/renderer/LitRenderer.js';
+import { html, svg, repeat, classMap, styleMap, unsafeHTML } from '@ui5/webcomponents-base/dist/renderer/LitRenderer.js';
 ${litTemplate}
 export default block0;`
 };


### PR DESCRIPTION
Now developers can use `{{{` and `}}}` to pass unescaped text to lit-html.
*Note:* This is only allowed for node values.

✔️ Example:
```html
<div>{{{myUnescapedText}}}</div>
```

❌ But this won't work:
```html
<div class="{{{myUnescapedText}}}"></div>
```