### PR TITLE
chore: add tagname to api.json

### DIFF
--- a/packages/tools/lib/jsdoc/plugin.js
+++ b/packages/tools/lib/jsdoc/plugin.js
@@ -29,7 +29,7 @@
  *
  *   appenddocs
  *
- *   customtag
+ *   tagname
  *
  * It furthermore listens to the following JSDoc3 events to implement additional functionality
  *
@@ -2073,10 +2073,10 @@ exports.defineTags = function(dictionary) {
 		}
 	});
 
-	dictionary.defineTag('customtag', {
+	dictionary.defineTag('tagname', {
 		mustHaveValue: true,
 		onTagged: function(doclet, tag) {
-			doclet.customtag = tag.value;
+			doclet.tagname = tag.value;
 		}
 	});
 };

--- a/packages/tools/lib/jsdoc/template/publish.js
+++ b/packages/tools/lib/jsdoc/template/publish.js
@@ -2651,8 +2651,8 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 
 	attrib("name", symbol.longname);
 	attrib("basename", symbol.name);
-	if (symbol.customtag) {
-		attrib("customTag", symbol.customtag);
+	if (symbol.tagname) {
+		attrib("tagname", symbol.tagname);
 	}
 	if (symbol.appenddocs) {
 		attrib("appenddocs", symbol.appenddocs);


### PR DESCRIPTION
The script that generates `api.json` had an unused entity `customTag` (probably leftover) which has been changed to tagname, which is used in our JSDoc.

![image](https://user-images.githubusercontent.com/15844574/86226875-f2b93780-bb94-11ea-81f8-913e6223d5dd.png)


closes: https://github.com/SAP/ui5-webcomponents/issues/1884