### PR TITLE
fix(ui5-upload-collection): The component does not get stuck

### DIFF
--- a/packages/fiori/src/upload-utils/UploadCollectionBodyDnD.js
+++ b/packages/fiori/src/upload-utils/UploadCollectionBodyDnD.js
@@ -36,16 +36,22 @@ const ondrop = event => {
 	eventProvider.fireEvent(EVENT, { mode: UploadCollectionDnDOverlayMode.None });
 };
 
+const ondragover = event => {
+	event.preventDefault();
+};
+
 const attachGlobalHandlers = () => {
 	document.body.addEventListener("dragenter", ondragenter);
 	document.body.addEventListener("dragleave", ondragleave);
 	document.body.addEventListener("drop", ondrop);
+	document.body.addEventListener("dragover", ondragover);
 };
 
 const detachGlobalHandlers = () => {
 	document.body.removeEventListener("dragenter", ondragenter);
 	document.body.removeEventListener("dragleave", ondragleave);
 	document.body.removeEventListener("drop", ondrop);
+	document.body.removeEventListener("dragover", ondragover);
 	globalHandlersAttached = false;
 };
 


### PR DESCRIPTION
If you drag a file over `ui5-upload-collection` and then drop it somewhere on the page, all upload collections get stuck with the "drop file" UI.

Example: drag a `.zip` file (downloadable by the browser, so it won't open in the same tab) but don't drop it on any upload collection, drop it **between them** instead
![image](https://user-images.githubusercontent.com/15844574/86235303-e509af00-bba0-11ea-961c-aa0ae954404f.png)

What happens then is that the browser downloads the file. When the file is downloaded, all instances get stuck:
![image](https://user-images.githubusercontent.com/15844574/86235426-0f5b6c80-bba1-11ea-8a69-bef6cca4f850.png)

In this case, the `drop` event is never fired by the browser, unless the `dragover` event is prevented.