### PR TITLE
feat(ui5-popup): add support for aria-label

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -127,7 +127,7 @@ class Dialog extends Popup {
 	}
 
 	get _ariaLabelledBy() { // Required by Popup.js
-		return "ui5-popup-header";
+		return this.ariaLabel ? undefined : "ui5-popup-header";
 	}
 
 	get _ariaModal() { // Required by Popup.js

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -272,6 +272,8 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the aria-label attribute for the input
+		 *
 		 * @type {String}
 		 * @since 1.0.0-rc.8
 		 * @private

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -599,7 +599,7 @@ class Popover extends Popup {
 	}
 
 	get _ariaLabelledBy() { // Required by Popup.js
-		return "ui5-popup-header";
+		return this.ariaLabel ? undefined : "ui5-popup-header";
 	}
 
 	get _ariaModal() { // Required by Popup.js

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,4 +1,10 @@
-<section style="{{styles.root}}" class="{{classes.root}}" role="dialog" aria-modal="{{_ariaModal}}" aria-labelledby="{{_ariaLabelledBy}}">
+<section
+	style="{{styles.root}}"
+	class="{{classes.root}}"
+	role="dialog" aria-modal="{{_ariaModal}}"
+	aria-label="{{_ariaLabel}}"
+	aria-labelledby="{{_ariaLabelledBy}}"
+>
 
 	<span class="first-fe" data-ui5-focus-trap tabindex="0" @focusin={{forwardToLast}}></span>
 

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,7 +1,8 @@
 <section
 	style="{{styles.root}}"
 	class="{{classes.root}}"
-	role="dialog" aria-modal="{{_ariaModal}}"
+	role="dialog"
+	aria-modal="{{_ariaModal}}"
 	aria-label="{{_ariaLabel}}"
 	aria-labelledby="{{_ariaLabelledBy}}"
 >

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -49,6 +49,19 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the aria-label attribute for the popup
+		 *
+		 * @type {String}
+		 * @defaultvalue: ""
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		ariaLabel: {
+			type: String,
+			defaultValue: undefined,
+		},
+
+		/**
 		 * @private
 		 */
 		_disableInitialFocus: {
@@ -390,6 +403,14 @@ class Popup extends UI5Element {
 	 */
 	get _ariaModal() {} // eslint-disable-line
 
+	/**
+	 * Ensures ariaLabel is never null or empty string
+	 * @returns {String|undefined}
+	 * @protected
+	 */
+	get _ariaLabel() {
+		return this.ariaLabel || undefined;
+	}
 
 	get styles() {
 		return {

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -60,7 +60,7 @@
 
 	<ui5-button id="btn">Click me !</ui5-button>
 
-	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top">
+	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top" aria-label="This popover is important">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -10,7 +10,7 @@ describe("Dialog general interaction", () => {
 		btnOpenDialog.click();
 
 		const dialog = browser.$("#dialog");
-		
+
 		assert.ok(dialog.isDisplayedInViewport(), "Dialog is opened.");
 
 		btnCloseDialog.click();
@@ -30,5 +30,21 @@ describe("Dialog general interaction", () => {
 		const popoverZIndex = parseInt(browser.$(`.${select.getProperty("_id")}`).shadow$("ui5-responsive-popover").getCSSProperty('z-index').value);
 
 		assert.ok(popoverZIndex > dialogZIndex, "Popover is above dialog.");
+	});
+});
+
+
+describe("Acc", () => {
+	browser.url("http://localhost:8080/test-resources/pages/Dialog.html");
+
+	it("tests aria-labelledby and aria-label", () => {
+		const dialog = browser.$("ui5-dialog");
+		dialog.removeAttribute("aria-label");
+		assert.ok(dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby").length, "dialog has aria-labelledby.");
+		assert.ok(!dialog.shadow$(".ui5-popup-root").getAttribute("aria-label"), "dialog does not have aria-label.");
+
+		dialog.setAttribute("aria-label", "text");
+		assert.ok(!dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "dialog does not have aria-labelledby.");
+		assert.ok(dialog.shadow$(".ui5-popup-root").getAttribute("aria-label").length, "dialog has aria-label.");
 	});
 });

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -180,3 +180,18 @@ describe("Popover general interaction", () => {
 		assert.ok(ff.getProperty("focused"), "The first focusable element is focused.");
 	});
 });
+
+describe("Acc", () => {
+	browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+
+	it("tests aria-labelledby and aria-label", () => {
+		const popover = browser.$("ui5-popover");
+		popover.removeAttribute("aria-label");
+		assert.ok(popover.shadow$(".ui5-popup-root").getAttribute("aria-labelledby").length, "Popover has aria-labelledby.");
+		assert.ok(!popover.shadow$(".ui5-popup-root").getAttribute("aria-label"), "Popover does not have aria-label.");
+
+		popover.setAttribute("aria-label", "text");
+		assert.ok(!popover.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "Popover does not have aria-labelledby.");
+		assert.ok(popover.shadow$(".ui5-popup-root").getAttribute("aria-label").length, "Popover has aria-label.");
+	});
+});


### PR DESCRIPTION
This change adds `aria-label` support for `ui5-popup`. The implementation in `ui5-popover` and `ui5-dialog` is:
 - if the user passed `aria-label`, use it and do not set `aria-labelledby` in the shadow root (as it is stronger and will suppress `aria-label`)
 - otherwise, set `aria-labelledby` normally (to point to the id of the popup's header).

Third-party popups will have full freedom to determine when `aria-label` and `aria-labelledby` are set by overriding the protected methods, as before.

In addition, added the missing description for `ariaLabel` for `ui5-input`.

closes: https://github.com/SAP/ui5-webcomponents/issues/1896