### PR TITLE
docs: Document the usage of i18n for apps

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -41,7 +41,7 @@ This tutorial will demonstrate how you can use the UI5 Web Components `i18n` fun
 	```
 	
 	The first argument is an ID that will be used to reference this message bundle and the second, an object,
-	providing the URLS where the `i18n` assets can be found.
+	providing the URLs where the `i18n` assets can be found.
 	
 	*Note:* This is just asset registration, no data will be fetched at that point.
 	
@@ -62,9 +62,9 @@ This tutorial will demonstrate how you can use the UI5 Web Components `i18n` fun
 	```
 	
 	The `getText` method expects an object as the first argument, with 2 properties:
-	 - `key` - the key in the texts file
+	 - `key` - the key for the required text (must match a key in the assets file)
 	 - `defaultText` - fallback text that will be used if you did not register a bundle for the default language (`en`).
-	The second parameter is not mandatory.
+	This property is optional.
 	
 	You can pass multiple additional values to `getText` for texts with placeholders, for example:
 	
@@ -117,12 +117,14 @@ get a reference to the bundle and call the `getText` method to get texts for you
  ```
  and provide the data directly in `.json` format, if you want to load a little bit less code in the runtime.
  
-    File    |  Content
- 	------------ | ---------------------------
- 	 `assets/messagebundle_de.properties`  | `{PLEASE_WAIT: "Bitte warten"}`
- 	 `assets/messagebundle_fr.properties`  | `{PLEASE_WAIT: "Patientez."}`
- 	 `assets/messagebundle_es.properties`  | `{PLEASE_WAIT: "Espere"}`
- 	 `assets/messagebundle_en.properties`  | `{PLEASE_WAIT: "Please wait"}`
+ 
+File    |  Content
+------------ | ---------------------------
+`assets/messagebundle_de.properties`  | `{PLEASE_WAIT: "Bitte warten"}`
+`assets/messagebundle_fr.properties`  | `{PLEASE_WAIT: "Patientez."}`
+`assets/messagebundle_es.properties`  | `{PLEASE_WAIT: "Espere"}`
+`assets/messagebundle_en.properties`  | `{PLEASE_WAIT: "Please wait"}`
+ 	
 
  - If you don't register a bundle for the default language (`en`), the fallback text (`defaultText`) for `getText` will be used instead.
    This way you can skip fetching the text bundle for the default language altogether, provided you pass the `defaultText`

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -66,6 +66,10 @@ This tutorial will demonstrate how you can use the UI5 Web Components `i18n` fun
 	 - `defaultText` - fallback text that will be used if you did not register a bundle for the default language (`en`).
 	This property is optional.
 	
+	Alternatively, the first parameter of `getText` can be the key only:
+	
+	`bundle.getText("PLEASE WAIT")`.
+	
 	You can pass multiple additional values to `getText` for texts with placeholders, for example:
 	
 	If your text looks like this:

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,129 @@
+# UI5 Web Components i18n for apps (valid since 1.0.0-rc.8)
+
+*Note:* For information on how to setup `i18n` for your custom components, please see [Developing Web Components](./dev/Developing%20Web%20Components.md).
+
+The `@ui5/webcomponents-base` package allows the usage of `i18n` functionality not just for third-party UI5 components,
+but for apps as well.
+
+## Step by step tutorial
+
+This tutorial will demonstrate how you can use the UI5 Web Components `i18n` functionality for the purpose of your apps.
+
+1. Start by creating some `i18n` resources in a directory that can be served, for example:
+
+	 File    |  Content
+	------------ | ---------------------------
+	 `assets/messagebundle_de.properties`  | `PLEASE_WAIT=Bitte warten`
+	 `assets/messagebundle_fr.properties`  | `PLEASE_WAIT=Patientez.`
+	 `assets/messagebundle_es.properties`  | `PLEASE_WAIT=Espere`
+	 `assets/messagebundle_en.properties`  | `PLEASE_WAIT=Please wait`
+
+
+2. Import the following `i18n`-related modules to your app:
+	
+	```js
+	import "@ui5/webcomponents-base/dist/features/PropertiesFormatSupport.js";
+	import { registerI18nBundle, fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+	```
+
+	The first one provides support for `.properties` files, as used in the example and the second one - the functions
+	that will allow you to take advantage of the `i18n` functionality.
+
+3. Register your message bundles:
+
+	```js
+	registerI18nBundle("myApp", {
+        de: "./assets/messagebundle_de.properties",
+        es: "./assets/messagebundle_es.properties",
+        fr: "./assets/messagebundle_fr.properties",
+        en: "./assets/messagebundle_en.properties",
+    });
+	```
+	
+	The first argument is an ID that will be used to reference this message bundle and the second, an object,
+	providing the URLS where the `i18n` assets can be found.
+	
+	*Note:* This is just asset registration, no data will be fetched at that point.
+	
+4. Fetch the texts for the current language:
+
+	```js
+	await fetchI18nBundle("myApp");
+	```
+	
+	This will fetch the appropriate texts for the currently configured language.
+	
+5. Get and use the bundle
+
+	```js
+	const bundle = getI18nBundle("myApp");
+	const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (some fallback text)"});
+	console.log("Please wait in the current language is: ", pleaseWait);
+	```
+	
+	The `getText` method expects an object as the first argument, with 2 properties:
+	 - `key` - the key in the texts file
+	 - `defaultText` - fallback text that will be used if you did not register a bundle for the default language (`en`).
+	The second parameter is not mandatory.
+	
+	You can pass multiple additional values to `getText` for texts with placeholders, for example:
+	
+	If your text looks like this:
+	
+	`CAROUSEL_DOT_TEXT=Item {0} of {1} displayed`
+	
+	you can call `getText` like this:
+	
+	`bundle.getText({key: "CAROUSEL_DOT_TEXT"}, 5, 20);`
+	
+	which will finally result in, for example:
+	
+	`Item 5 of 20 displayed`. 
+
+6. Test your page using different languages, f.e. set `?sap-ui-language=de` in the URL or change the configuration.	
+		
+## Summary
+
+The whole code would look like this:
+
+```js
+import "@ui5/webcomponents-base/dist/features/PropertiesFormatSupport.js";
+import { registerI18nBundle, fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+
+registerI18nBundle("myApp", {
+	de: "./assets/messagebundle_de.properties",
+	es: "./assets/messagebundle_es.properties",
+	fr: "./assets/messagebundle_fr.properties",
+	en: "./assets/messagebundle_en.properties",
+});
+
+await fetchI18nBundle("myApp");
+
+const bundle = getI18nBundle("myApp");
+
+const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
+console.log("Please wait in the current language is: ", pleaseWait);
+```		
+
+You register your assets for all supported languages, then you fetch the data for the currently active language,
+get a reference to the bundle and call the `getText` method to get texts for your app.
+
+## Tips and tricks
+
+ - You can skip the `.properties` format support import
+
+ ```js
+ import "@ui5/webcomponents-base/dist/features/PropertiesFormatSupport.js";
+ ```
+ and provide the data directly in `.json` format, if you want to load a little bit less code in the runtime.
+ 
+    File    |  Content
+ 	------------ | ---------------------------
+ 	 `assets/messagebundle_de.properties`  | `{PLEASE_WAIT: "Bitte warten"}`
+ 	 `assets/messagebundle_fr.properties`  | `{PLEASE_WAIT: "Patientez."}`
+ 	 `assets/messagebundle_es.properties`  | `{PLEASE_WAIT: "Espere"}`
+ 	 `assets/messagebundle_en.properties`  | `{PLEASE_WAIT: "Please wait"}`
+
+ - If you don't register a bundle for the default language (`en`), the fallback text (`defaultText`) for `getText` will be used instead.
+   This way you can skip fetching the text bundle for the default language altogether, provided you pass the `defaultText`
+   each time you call `getText`.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -106,7 +106,9 @@ await fetchI18nBundle("myApp");
 const bundle = getI18nBundle("myApp");
 
 const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
+const pleaseWait2 = bundle.getText("PLEASE_WAIT");	
 console.log("Please wait in the current language is: ", pleaseWait);
+console.log("Please wait in the current language is: ", pleaseWait2);
 ```		
 
 You register your assets for all supported languages, then you fetch the data for the currently active language,

--- a/packages/base/bundle.esm.js
+++ b/packages/base/bundle.esm.js
@@ -24,6 +24,10 @@ window.isIE = isIE; // attached to the window object for testing purposes
 // used for tests - to register a custom theme
 window.registerThemeProperties = registerThemeProperties;
 
+// i18n
+import "./dist/features/PropertiesFormatSupport.js";
+import { registerI18nBundle, fetchI18nBundle, getI18nBundle } from "./dist/i18nBundle.js";
+
 // Note: keep in sync with rollup.config value for IIFE
 import { getAnimationMode } from "./dist/config/AnimationMode.js";
 import { getLanguage } from "./dist/config/Language.js";
@@ -46,4 +50,7 @@ window["sap-ui-webcomponents-bundle"] = {
 		getFirstDayOfWeek,
 	},
 	getIconNames,
+	registerI18nBundle,
+	fetchI18nBundle,
+	getI18nBundle,
 };

--- a/packages/base/src/i18nBundle.js
+++ b/packages/base/src/i18nBundle.js
@@ -3,18 +3,33 @@ import formatMessage from "./util/formatMessage.js";
 
 const I18nBundleInstances = new Map();
 
+/**
+ * @class
+ * @public
+ */
 class I18nBundle {
 	constructor(packageName) {
 		this.packageName = packageName;
 	}
 
+	/**
+	 * Returns a text in the currently loaded language
+	 *
+	 * @param {Object|String} textObj key/defaultText pair or just the key
+	 * @param params Values for the placeholders
+	 * @returns {*}
+	 */
 	getText(textObj, ...params) {
-		if (!textObj || !textObj.key || !textObj.defaultText) {
+		if (typeof textObj === "string") {
+			textObj = { key: textObj, defaultText: "MISSING TEXT" };
+		}
+
+		if (!textObj || !textObj.key) {
 			return "";
 		}
 
 		const bundle = getI18nBundleData(this.packageName);
-		const messageText = bundle && bundle[textObj.key] ? bundle[textObj.key] : textObj.defaultText;
+		const messageText = bundle && bundle[textObj.key] ? bundle[textObj.key] : (textObj.defaultText || "");
 
 		return formatMessage(messageText, params);
 	}

--- a/packages/base/src/i18nBundle.js
+++ b/packages/base/src/i18nBundle.js
@@ -1,4 +1,4 @@
-import { fetchI18nBundle, getI18nBundleData } from "./asset-registries/i18n.js";
+import { registerI18nBundle, fetchI18nBundle, getI18nBundleData } from "./asset-registries/i18n.js";
 import formatMessage from "./util/formatMessage.js";
 
 const I18nBundleInstances = new Map();
@@ -30,4 +30,8 @@ const getI18nBundle = packageName => {
 	return i18nBundle;
 };
 
-export { fetchI18nBundle, getI18nBundle };
+export {
+	registerI18nBundle,
+	fetchI18nBundle,
+	getI18nBundle,
+};

--- a/packages/base/test/pages/assets/messagebundle_de.properties
+++ b/packages/base/test/pages/assets/messagebundle_de.properties
@@ -1,0 +1,1 @@
+PLEASE_WAIT=Bitte warten

--- a/packages/base/test/pages/assets/messagebundle_en.properties
+++ b/packages/base/test/pages/assets/messagebundle_en.properties
@@ -1,0 +1,1 @@
+PLEASE_WAIT=Please wait

--- a/packages/base/test/pages/assets/messagebundle_es.properties
+++ b/packages/base/test/pages/assets/messagebundle_es.properties
@@ -1,0 +1,1 @@
+PLEASE_WAIT=Espere

--- a/packages/base/test/pages/assets/messagebundle_fr.properties
+++ b/packages/base/test/pages/assets/messagebundle_fr.properties
@@ -1,0 +1,1 @@
+PLEASE_WAIT=Patientez.

--- a/packages/base/test/pages/i18n.html
+++ b/packages/base/test/pages/i18n.html
@@ -27,8 +27,9 @@
 			const bundle = getI18nBundle("myApp");
 
 			const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
-
+			const pleaseWait2 = bundle.getText("PLEASE_WAIT");
 			console.log("Please wait in the current language is: ", pleaseWait);
+			console.log("Please wait in the current language is: ", pleaseWait2);
 		};
 
 		demo();

--- a/packages/base/test/pages/i18n.html
+++ b/packages/base/test/pages/i18n.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<title>i18n</title>
+
+	<script src="../../resources/bundle.esm.js" ></script>
+
+</head>
+
+<body>
+
+	<script>
+
+		const demo = async () => {
+			registerI18nBundle("myApp", {
+				de: "./assets/messagebundle_de.properties",
+				es: "./assets/messagebundle_es.properties",
+				fr: "./assets/messagebundle_fr.properties",
+				en: "./assets/messagebundle_en.properties",
+			});
+
+			await fetchI18nBundle("myApp");
+
+			const bundle = getI18nBundle("myApp");
+
+			const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
+
+			console.log("Please wait in the current language is: ", pleaseWait);
+		};
+
+		demo();
+
+
+	</script>
+
+
+</body>
+</html>


### PR DESCRIPTION
This tutorial shows how apps (not components) can use our `i18n` functionality.

Read the tutorial here: https://github.com/SAP/ui5-webcomponents/blob/document-i18n/docs/i18n.md

Changes to the actual code:
- For simplicity  `registerI18nBundle` is now also proxied by `i18nBundle.js`. This however makes the tutorial valid only for `rc.8` onwards. For current usage, import `registerI18nBundle` from `asset-registries/i18n.js` directly.
- `getText` may now have just the key as `String` as a first parameter (rather than an object with key and defaultText properties). This is useful for apps that wish to fetch the default language too, and never use fallback texts.

closes: https://github.com/SAP/ui5-webcomponents/issues/1713