### PR TITLE
chore(framework): extend the functionality of findNodeOwner

### DIFF
--- a/packages/base/src/util/findNodeOwner.js
+++ b/packages/base/src/util/findNodeOwner.js
@@ -1,4 +1,11 @@
-const findNodeOwner = node => {
+/**
+ *  @param node - DOM Node
+ *  @param {Object} settings - Defines the following settings: isInLightDOM, startFromParent
+ */
+const findNodeOwner = (node, settings = {
+	isInLightDOM: false,
+	startFromParent: false,
+}) => {
 	if (!(node instanceof HTMLElement)) {
 		throw new Error("Argument node should be of type HTMLElement");
 	}
@@ -6,6 +13,10 @@ const findNodeOwner = node => {
 	const ownerTypes = [HTMLHtmlElement, HTMLIFrameElement];
 	let currentShadowRootFlag = true;
 	let currentCustomElementFlag = true;
+
+	if (settings.startFromParent) {
+		node = node.parentNode || node.host;
+	}
 
 	while (node) {
 		if (node.toString() === "[object ShadowRoot]") {
@@ -18,7 +29,7 @@ const findNodeOwner = node => {
 				return node;
 			}
 		} else if (node.tagName && node.tagName.indexOf("-") > -1) {
-			if (currentCustomElementFlag) {
+			if (currentCustomElementFlag && !settings.isInLightDOM) {
 				currentCustomElementFlag = false;
 			} else {
 				return node;

--- a/packages/base/src/util/getEffectiveAriaLabelText.js
+++ b/packages/base/src/util/getEffectiveAriaLabelText.js
@@ -1,6 +1,10 @@
 import findNodeOwner from "./findNodeOwner.js";
 
-const getEffectiveAriaLabelText = el => {
+/**
+ *  @param element - DOM Node
+ *  @param {Object} settings - Defines the following settings: isInLightDOM, startFromParent
+ */
+const getEffectiveAriaLabelText = (el, settings) => {
 	if (!el.ariaLabelledby) {
 		if (el.ariaLabel) {
 			return el.ariaLabel;
@@ -10,7 +14,7 @@ const getEffectiveAriaLabelText = el => {
 	}
 
 	const ids = el.ariaLabelledby.split(" ");
-	const owner = findNodeOwner(el);
+	const owner = findNodeOwner(el, settings);
 	let result = "";
 
 	ids.forEach((elementId, index) => {


### PR DESCRIPTION
Prerequisite for #1880

Two options are added to the findNodeOwner method:
- ```isInLightDOM```: now element can be found in the Light DOM as well(prior to this PR, when it comes to custom elements, the method was only looking in the shadow root.) This is the first use case that we need to search inside the light DOM
- ```startFromParent```: Currently the algorithm started the search from the passed node. Now it can start from its parent.