### PR TITLE
refactor(framework): getText uses the key as fallback, simplify docs

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -115,7 +115,7 @@ get a reference to the bundle and call the `getText` method to get texts for you
  
 File    |  Content
 ------------ | ---------------------------
-`assets/messagebundle_de.json`  | `{PLEASE_WAIT: "Bitte warten"}`
-`assets/messagebundle_fr.json`  | `{PLEASE_WAIT: "Patientez."}`
-`assets/messagebundle_es.json`  | `{PLEASE_WAIT: "Espere"}`
-`assets/messagebundle_en.json`  | `{PLEASE_WAIT: "Please wait"}`
+`assets/messagebundle_de.json`  | `{"PLEASE_WAIT": "Bitte warten"}`
+`assets/messagebundle_fr.json`  | `{"PLEASE_WAIT": "Patientez."}`
+`assets/messagebundle_es.json`  | `{"PLEASE_WAIT": "Espere"}`
+`assets/messagebundle_en.json`  | `{"PLEASE_WAIT": "Please wait"}`

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -57,18 +57,9 @@ This tutorial will demonstrate how you can use the UI5 Web Components `i18n` fun
 
 	```js
 	const bundle = getI18nBundle("myApp");
-	const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (some fallback text)"});
+	const pleaseWait = bundle.getText("PLEASE_WAIT");
 	console.log("Please wait in the current language is: ", pleaseWait);
 	```
-	
-	The `getText` method expects an object as the first argument, with 2 properties:
-	 - `key` - the key for the required text (must match a key in the assets file)
-	 - `defaultText` - fallback text that will be used if you did not register a bundle for the default language (`en`).
-	This property is optional.
-	
-	Alternatively, the first parameter of `getText` can be the key only:
-	
-	`bundle.getText("PLEASE WAIT")`.
 	
 	You can pass multiple additional values to `getText` for texts with placeholders, for example:
 	
@@ -78,7 +69,7 @@ This tutorial will demonstrate how you can use the UI5 Web Components `i18n` fun
 	
 	you can call `getText` like this:
 	
-	`bundle.getText({key: "CAROUSEL_DOT_TEXT"}, 5, 20);`
+	`bundle.getText("CAROUSEL_DOT_TEXT", 5, 20);`
 	
 	which will finally result in, for example:
 	
@@ -105,10 +96,8 @@ await fetchI18nBundle("myApp");
 
 const bundle = getI18nBundle("myApp");
 
-const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
-const pleaseWait2 = bundle.getText("PLEASE_WAIT");	
+const pleaseWait = bundle.getText("PLEASE_WAIT");	
 console.log("Please wait in the current language is: ", pleaseWait);
-console.log("Please wait in the current language is: ", pleaseWait2);
 ```		
 
 You register your assets for all supported languages, then you fetch the data for the currently active language,
@@ -126,12 +115,7 @@ get a reference to the bundle and call the `getText` method to get texts for you
  
 File    |  Content
 ------------ | ---------------------------
-`assets/messagebundle_de.properties`  | `{PLEASE_WAIT: "Bitte warten"}`
-`assets/messagebundle_fr.properties`  | `{PLEASE_WAIT: "Patientez."}`
-`assets/messagebundle_es.properties`  | `{PLEASE_WAIT: "Espere"}`
-`assets/messagebundle_en.properties`  | `{PLEASE_WAIT: "Please wait"}`
- 	
-
- - If you don't register a bundle for the default language (`en`), the fallback text (`defaultText`) for `getText` will be used instead.
-   This way you can skip fetching the text bundle for the default language altogether, provided you pass the `defaultText`
-   each time you call `getText`.
+`assets/messagebundle_de.json`  | `{PLEASE_WAIT: "Bitte warten"}`
+`assets/messagebundle_fr.json`  | `{PLEASE_WAIT: "Patientez."}`
+`assets/messagebundle_es.json`  | `{PLEASE_WAIT: "Espere"}`
+`assets/messagebundle_en.json`  | `{PLEASE_WAIT: "Please wait"}`

--- a/packages/base/src/i18nBundle.js
+++ b/packages/base/src/i18nBundle.js
@@ -21,7 +21,7 @@ class I18nBundle {
 	 */
 	getText(textObj, ...params) {
 		if (typeof textObj === "string") {
-			textObj = { key: textObj, defaultText: "MISSING TEXT" };
+			textObj = { key: textObj, defaultText: textObj };
 		}
 
 		if (!textObj || !textObj.key) {
@@ -29,7 +29,7 @@ class I18nBundle {
 		}
 
 		const bundle = getI18nBundleData(this.packageName);
-		const messageText = bundle && bundle[textObj.key] ? bundle[textObj.key] : (textObj.defaultText || "");
+		const messageText = bundle && bundle[textObj.key] ? bundle[textObj.key] : (textObj.defaultText || textObj.key);
 
 		return formatMessage(messageText, params);
 	}

--- a/packages/base/test/pages/i18n.html
+++ b/packages/base/test/pages/i18n.html
@@ -26,10 +26,8 @@
 
 			const bundle = getI18nBundle("myApp");
 
-			const pleaseWait = bundle.getText({key: "PLEASE_WAIT", defaultText: "Please wait (fallback)"});
-			const pleaseWait2 = bundle.getText("PLEASE_WAIT");
+			const pleaseWait = bundle.getText("PLEASE_WAIT");
 			console.log("Please wait in the current language is: ", pleaseWait);
-			console.log("Please wait in the current language is: ", pleaseWait2);
 		};
 
 		demo();


### PR DESCRIPTION
- `getText` now returns the key if no `defaultText` is given
- do not document the complex `getText` syntax, just the one with `key` as the first parameter