### PR TITLE
chore(ui5-input): add isSuggestionsScrollable method

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -862,6 +862,20 @@ class Input extends UI5Element {
 		return this.suggestionItems[key];
 	}
 
+	/**
+	 * Returns if the suggestions popover is scrollable.
+	 * <br><br>
+	 * <b>Note:</b> the method is async
+	 * @returns {boolean} true if the popover is scrollable, false otherwise
+	 */
+	async isSuggestionsScrollable() {
+		if (!this.Suggestions) {
+			return false;
+		}
+
+		return (await this.Suggestions._isScrollable());
+	}
+
 	getInputId() {
 		return `${this._id}-inner`;
 	}

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -864,11 +864,11 @@ class Input extends UI5Element {
 
 	/**
 	 * Returns if the suggestions popover is scrollable.
-	 * The method is async and returns a Promise and resolves to true,
+	 * The method returns <code>Promise</code> that resolves to true,
 	 * if the popup is scrollable and false otherwise.
 	 * @returns {Promise}
 	 */
-	async isSuggestionsScrollable() {
+	isSuggestionsScrollable() {
 		return this.Suggestions && this.Suggestions._isScrollable();
 	}
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -869,7 +869,11 @@ class Input extends UI5Element {
 	 * @returns {Promise}
 	 */
 	isSuggestionsScrollable() {
-		return this.Suggestions && this.Suggestions._isScrollable();
+		if (!this.Suggestions) {
+			return Promise.resolve(false);
+		}
+
+		return this.Suggestions._isScrollable();
 	}
 
 	getInputId() {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -864,16 +864,12 @@ class Input extends UI5Element {
 
 	/**
 	 * Returns if the suggestions popover is scrollable.
-	 * <br><br>
-	 * <b>Note:</b> the method is async
-	 * @returns {boolean} true if the popover is scrollable, false otherwise
+	 * The method is async and returns a Promise and resolves to true,
+	 * if the popup is scrollable and false otherwise.
+	 * @returns {Promise}
 	 */
 	async isSuggestionsScrollable() {
-		if (!this.Suggestions) {
-			return false;
-		}
-
-		return (await this.Suggestions._isScrollable());
+		return this.Suggestions && this.Suggestions._isScrollable();
 	}
 
 	getInputId() {

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -102,6 +102,11 @@ class Suggestions {
 		}
 	}
 
+	async _isScrollable() {
+		const sc = await this._getScrollContainer();
+		return sc.offsetHeight < sc.scrollHeight;
+	}
+
 	async open() {
 		this.responsivePopover = await this._respPopover();
 		this._beforeOpen();

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -314,7 +314,7 @@
 
 		var suggestionSelectedCounterWithGrouping = 0;
 
-		var suggest = function (event) {
+		var suggest = async function (event) {
 			var input = event.target;
 			var value = input.value;
 			var suggestionItems = [];
@@ -342,6 +342,11 @@
 			});
 
 			labelLiveChange.innerHTML = "Event [input] :: " + value;
+
+			await window.RenderScheduler.whenFinished();
+			const scrollable = await input.isSuggestionsScrollable();
+
+			console.log("Suggestions are scrollable", scrollable);
 		};
 
 		input.addEventListener("ui5-input", suggest);

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -343,7 +343,10 @@
 
 			labelLiveChange.innerHTML = "Event [input] :: " + value;
 
+			// wait the DOM update
 			await window.RenderScheduler.whenFinished();
+
+			// check if the suggestions popup is scrollable
 			const scrollable = await input.isSuggestionsScrollable();
 
 			console.log("Suggestions are scrollable", scrollable);

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -159,8 +159,7 @@ describe("Input general interaction", () => {
 		// assert isSuggestionsScrollable
 		const suggestionsScrollable = browser.execute(async () => {
 			const input = document.getElementById("scrollInput");
-			await window.RenderScheduler.whenFinished();
-			return await input.isSuggestionsScrollable();
+			return (await input.isSuggestionsScrollable());
 		});
 		assert.equal(suggestionsScrollable, true, "The suggestions popup is scrolalble");
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -143,12 +143,11 @@ describe("Input general interaction", () => {
 		const input = $("#scrollInput").shadow$("input");
 		const scrollResult = $("#scrollResult");
 
-		// act
-		// open suggestions
+		// act - open suggestions
 		input.click();
 		input.keys("a");
 
-		// scroll with keyboard
+		// act - scroll with keyboard
 		input.keys("ArrowUp");
 		input.keys("ArrowUp");
 		input.keys("ArrowUp");
@@ -157,7 +156,16 @@ describe("Input general interaction", () => {
 		const scrollTop = scrollResult.getProperty("value");
 		assert.ok(scrollTop > 0, "The suggestion-scroll event fired");
 
-		input.keys("Enter"); // close suggestions
+		// assert isSuggestionsScrollable
+		const suggestionsScrollable = browser.execute(async () => {
+			const input = document.getElementById("scrollInput");
+			await window.RenderScheduler.whenFinished();
+			return await input.isSuggestionsScrollable();
+		});
+		assert.equal(suggestionsScrollable, true, "The suggestions popup is scrolalble");
+
+		// close suggestions
+		input.keys("Enter"); 
 	});
 
 	it("handles suggestions", () => {


### PR DESCRIPTION
Add a method (isSuggestionsScrollable) that returns if the suggestions popup is currently scrollable or not.
- Note: the method is async.
- Note: call the method after the DOM is updated, otherwise you might get wrong result.

```js

// ensure the DOM has been updated
await RenderScheduler.whenFinished();

// check if the suggestions pop up is scrollable
const scrollable = await input.isSuggestionsScrollable();
```

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1902