### PR TITLE
feat(tools): Add more commands to package.json

### DIFF
--- a/docs/dev/Creating UI5 Web Components Packages.md
+++ b/docs/dev/Creating UI5 Web Components Packages.md
@@ -108,8 +108,10 @@ Task | Purpose
 clean | Deletes the `dist/` directory with the build output
 build | Production build to the `dist/` directory
 lint | Run a static code scan with `eslint`
-start | Build the project for development and run the dev server
-test | Run the test specs from the `test/specs/` directory
+start | Build the project for development, run the dev server and watch for changes
+watch | Watch for changes only
+serve | Run the dev server only
+test | Run the dev server and execute the specs from the `test/specs/` directory
 create-ui5-element | Create an empty web component with the given name
 
 ### Files in the main directory

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -14,6 +14,8 @@
     "clean": "wc-dev clean",
     "lint": "wc-dev lint",
     "start": "wc-dev start",
+    "watch": "wc-dev watch",
+    "serve": "wc-dev serve",
     "build": "wc-dev build",
     "test": "wc-dev test",
     "create-ui5-element": "wc-create-ui5-element",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -14,6 +14,8 @@
     "clean": "wc-dev clean",
     "lint": "wc-dev lint",
     "start": "wc-dev start",
+    "watch": "wc-dev watch",
+    "serve": "wc-dev serve",
     "build": "wc-dev build",
     "test": "wc-dev test",
     "create-ui5-element": "wc-create-ui5-element",

--- a/packages/tools/bin/dev.js
+++ b/packages/tools/bin/dev.js
@@ -3,12 +3,17 @@
 const child_process = require("child_process");
 
 let command = process.argv[2];
+const argument = process.argv[3];
 
-// Support for running the test task with a spec parameter
-if (command === "test") {
-	const spec = process.argv[3];
-	if (spec) {
-		command = `test.spec --spec ${spec}`;
+if (command === "watch") {
+	if (["src", "test", "bundles", "styles", "templates", "samples"].includes(argument)) {
+		command = `watch.${argument}`;
+	}
+} else if (command === "test") {
+	if (argument === "--no-server") { // yarn test --no-server
+		command = `test.run`;
+	} else if (argument) { // yarn test test/specs/Button.spec.js
+		command = `test.spec --spec ${argument}`;
 	}
 }
 

--- a/packages/tools/lib/init-package/index.js
+++ b/packages/tools/lib/init-package/index.js
@@ -94,6 +94,8 @@ const updatePackageFile = () => {
 		"clean": "wc-dev clean",
 		"lint": "wc-dev lint",
 		"start": "wc-dev start",
+		"watch": "wc-dev watch",
+		"serve": "wc-dev serve",
 		"build": "wc-dev build",
 		"test": "wc-dev test",
 		"create-ui5-element": "wc-create-ui5-element",


### PR DESCRIPTION
This change exposes two more `nps` commands as package scripts: `serve` and `watch`,  and additionally enhances the `test` command.

Examples:

Command | What it does
-----|-------
`yarn test` | Runs the dev server and executes all tests
`yarn test --no-server` | Executes all tests only
`yarn test test/specs/Button.spec.js` | Executes a single spec only (does not run server, no changes)
`yarn serve` | Runs the test server only
`yarn watch` | Runs the watch utility only
`yarn watch test` | Only watches for changes in the test files
`yarn watch src` | Only watches for changes in the source files
`yarn watch templates` | Only watches for template changes

This granularity would allow package authors greater flexibility, f.e. they could combine:
-  `yarn serve`
- `yarn test --no-server` 
- `yarn watch test`
arbitrarily based on specific use-cases.

related to: https://github.com/SAP/ui5-webcomponents/issues/1767