### PR TITLE
fix(ui5-textarea): Add missing dependency, extract .hbs partial

### DIFF
--- a/packages/main/src/TextArea.hbs
+++ b/packages/main/src/TextArea.hbs
@@ -34,9 +34,13 @@
 		part="textarea">
 	</textarea>
 
+	{{> afterTextarea}}
+
 	{{#if showExceededText}}
 		<span id="{{_id}}-exceededText" class="ui5-textarea-exceeded-text">{{_exceededTextProps.exceededText}}</span>
 	{{/if}}
 
 	<slot name="formSupport"></slot>
 </div>
+
+{{#*inline "afterTextarea"}}{{/inline}}

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -6,6 +6,7 @@ import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
+import Popover from "./Popover.js";
 
 import TextAreaTemplate from "./generated/templates/TextAreaTemplate.lit.js";
 import TextAreaPopoverTemplate from "./generated/templates/TextAreaPopoverTemplate.lit.js";
@@ -585,7 +586,10 @@ class TextArea extends UI5Element {
 	}
 
 	static async onDefine() {
-		await fetchI18nBundle("@ui5/webcomponents");
+		await Promise.all([
+			Popover.define(),
+			fetchI18nBundle("@ui5/webcomponents"),
+		]);
 	}
 }
 


### PR DESCRIPTION
This change:
 - fixes missing `Popover.js` dependency due to value state
 - adds a new partial that can be used for third-party development

For example, it would be possible to create a text area with a "clear button":
![image](https://user-images.githubusercontent.com/15844574/86600432-b9bfff00-bfa8-11ea-9e66-8bfddf3bf959.png)

closes: https://github.com/SAP/ui5-webcomponents/issues/1879