### PR TITLE
feat(ui5-panel): support aria-label and aria-labelledby

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -24,8 +24,6 @@
 					icon="navigation-right-arrow"
 					?non-focusable="{{nonFocusableButton}}"
 					@click="{{_toggleButtonClick}}"
-					@keydown="{{_headerKeyDown}}"
-					@keyup="{{_headerKeyUp}}"
 					._buttonAccInfo="{{accInfo.button}}"
 					aria-label="{{accInfo.ariaLabel}}"
 					aria-labelledby="{{accInfo.ariaLabelledBy}}"

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -13,6 +13,8 @@
 		role="{{accInfo.role}}"
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"
+		aria-label="{{accInfo.ariaLabel}}"
+		aria-labelledby="{{accInfo.ariaLabelledBy}}"
 	>
 		{{#unless fixed}}
 			<div class="ui5-panel-header-button-root">
@@ -22,7 +24,11 @@
 					icon="navigation-right-arrow"
 					?non-focusable="{{nonFocusableButton}}"
 					@click="{{_toggleButtonClick}}"
+					@keydown="{{_headerKeyDown}}"
+					@keyup="{{_headerKeyUp}}"
 					._buttonAccInfo="{{accInfo.button}}"
+					aria-label="{{accInfo.ariaLabel}}"
+					aria-labelledby="{{accInfo.ariaLabelledBy}}"
 				></ui5-button>
 			</div>
 		{{/unless}}
@@ -31,6 +37,7 @@
 			<slot name="header"></slot>
 		{{else}}
 			<div
+				id="{{_id}}-header-title"
 				role="heading"
 				aria-level="{{headerAriaLevel}}"
 				class="ui5-panel-header-title"

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -14,7 +14,7 @@
 		aria-expanded="{{accInfo.ariaExpanded}}"
 		aria-controls="{{accInfo.ariaControls}}"
 		aria-label="{{accInfo.ariaLabel}}"
-		aria-labelledby="{{accInfo.ariaLabelledBy}}"
+		aria-labelledby="{{accInfo.ariaLabelledby}}"
 	>
 		{{#unless fixed}}
 			<div class="ui5-panel-header-button-root">
@@ -25,8 +25,8 @@
 					?non-focusable="{{nonFocusableButton}}"
 					@click="{{_toggleButtonClick}}"
 					._buttonAccInfo="{{accInfo.button}}"
-					aria-label="{{accInfo.ariaLabel}}"
-					aria-labelledby="{{accInfo.ariaLabelledBy}}"
+					aria-label="{{accInfo.ariaLabelButton}}"
+					aria-labelledby="{{accInfo.ariaLabelledbyButton}}"
 				></ui5-button>
 			</div>
 		{{/unless}}

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -374,11 +374,11 @@ class Panel extends UI5Element {
 				"ariaControls": this._hasHeader ? `${this._id}-content` : undefined,
 				"title": this.toggleButtonTitle,
 			},
-			"ariaExpanded": this.notFixedInternalHeader ? this.expanded : undefined,
-			"ariaControls": this.notFixedInternalHeader ? `${this._id}-content` : undefined,
+			"ariaExpanded": this.hasUnfixedInternalHeader ? this.expanded : undefined,
+			"ariaControls": this.hasUnfixedInternalHeader ? `${this._id}-content` : undefined,
 			"ariaLabelledBy": this.ariaLabelledBy,
 			"ariaLabel": this.ariaLabelTxt,
-			"role": this.notFixedInternalHeader ? "button" : undefined,
+			"role": this.hasUnfixedInternalHeader ? "button" : undefined,
 		};
 	}
 

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -374,15 +374,17 @@ class Panel extends UI5Element {
 				"ariaControls": this._hasHeader ? `${this._id}-content` : undefined,
 				"title": this.toggleButtonTitle,
 			},
-			"ariaExpanded": this.hasUnfixedInternalHeader ? this.expanded : undefined,
-			"ariaControls": this.hasUnfixedInternalHeader ? `${this._id}-content` : undefined,
-			"ariaLabelledBy": this.ariaLabelledBy,
-			"ariaLabel": this.ariaLabelTxt,
-			"role": this.hasUnfixedInternalHeader ? "button" : undefined,
+			"ariaExpanded": this.nonFixedInternalHeader ? this.expanded : undefined,
+			"ariaControls": this.nonFixedInternalHeader ? `${this._id}-content` : undefined,
+			"ariaLabelledby": this.nonFocusableButton ? this.ariaLabelledbyReference : undefined,
+			"ariaLabel": this.nonFocusableButton ? this.ariaLabelTxt : undefined,
+			"ariaLabelledbyButton": this.nonFocusableButton ? undefined : this.ariaLabelledbyReference,
+			"ariaLabelButton": this.nonFocusableButton ? undefined : this.ariaLabelTxt,
+			"role": this.nonFixedInternalHeader ? "button" : undefined,
 		};
 	}
 
-	get ariaLabelledBy() {
+	get ariaLabelledbyReference() {
 		if (this.ariaLabelledby || this.ariaLabel) {
 			return undefined;
 		}
@@ -402,7 +404,7 @@ class Panel extends UI5Element {
 		return (this.header.length || this.fixed) ? "-1" : "0";
 	}
 
-	get hasUnfixedInternalHeader() {
+	get nonFixedInternalHeader() {
 		return !this._hasHeader && !this.fixed;
 	}
 

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -4,6 +4,7 @@ import slideDown from "@ui5/webcomponents-base/dist/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/dist/animations/slideUp.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
+import getEffectiveAriaLabelText from "@ui5/webcomponents-base/dist/util/getEffectiveAriaLabelText.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/icons/navigation-right-arrow.js";
@@ -117,7 +118,27 @@ const metadata = {
 			type: TitleLevel,
 			defaultValue: TitleLevel.H2,
 		},
-
+		/**
+		 * @type {String}
+		 * @defaultvalue ""
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		ariaLabel: {
+			type: String,
+		},
+		/**
+		 * Receives id(or many ids) of the elements that label the panel
+		 *
+		 * @type {String}
+		 * @defaultvalue ""
+		 * @private
+		 * @since 1.0.0-rc.8
+		 */
+		ariaLabelledby: {
+			type: String,
+			defaultValue: "",
+		},
 		/**
 		 * @private
 		 */
@@ -342,10 +363,6 @@ class Panel extends UI5Element {
 		return !this.collapsed;
 	}
 
-	get ariaLabelledBy() {
-		return this.header.length ? "" : `${this._id}-header`;
-	}
-
 	get accRole() {
 		return this.accessibleRole.toLowerCase();
 	}
@@ -357,10 +374,24 @@ class Panel extends UI5Element {
 				"ariaControls": this._hasHeader ? `${this._id}-content` : undefined,
 				"title": this.toggleButtonTitle,
 			},
-			"ariaExpanded": !this._hasHeader ? this.expanded : undefined,
-			"ariaControls": !this._hasHeader ? `${this._id}-content` : undefined,
-			"role": !this._hasHeader ? "button" : undefined,
+			"ariaExpanded": this.notFixedInternalHeader ? this.expanded : undefined,
+			"ariaControls": this.notFixedInternalHeader ? `${this._id}-content` : undefined,
+			"ariaLabelledBy": this.ariaLabelledBy,
+			"ariaLabel": this.ariaLabelTxt,
+			"role": this.notFixedInternalHeader ? "button" : undefined,
 		};
+	}
+
+	get ariaLabelledBy() {
+		if (this.ariaLabelledby || this.ariaLabel) {
+			return undefined;
+		}
+
+		return (this.nonFocusableButton && this.headerText) ? `${this._id}-header-title` : undefined;
+	}
+
+	get ariaLabelTxt() {
+		return getEffectiveAriaLabelText(this);
 	}
 
 	get headerAriaLevel() {
@@ -369,6 +400,10 @@ class Panel extends UI5Element {
 
 	get headerTabIndex() {
 		return (this.header.length || this.fixed) ? "-1" : "0";
+	}
+
+	get hasUnfixedInternalHeader() {
+		return !this._hasHeader && !this.fixed;
 	}
 
 	get nonFocusableButton() {

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -61,11 +61,11 @@
 	}
 </style>
 
-	<ui5-panel id="p1" collapsed accessible-role="Complementary">
+	<ui5-panel id="p1" collapsed accessible-role="Complementary" aria-labelledby="p1-title">
 
 		<!-- Panel header -->
 		<div slot="header" class="header">
-			<ui5-title>Expandable but not expanded</ui5-title>
+			<ui5-title id="p1-title">Expandable but not expanded</ui5-title>
 			<ui5-button id="b1">Add child </ui5-button>
 			<ui5-label id="l1">No new children added yet.</ui5-label>
 			<ui5-button design="Reject" icon="cancel">Cancel</ui5-button>

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -116,15 +116,15 @@ describe("Panel general interaction", () => {
 
 		it("tests aria-label and aria-labelledby attributes", () => {
 			const panelWithNativeHeader = $("#panel-expandable");
-			const nativeHeader = panelWithNativeHeader.shadow$("ui5-panel-header");
+			const nativeHeader = panelWithNativeHeader.shadow$(".ui5-panel-header");
 			const panelWithNativeHeaderId = panelWithNativeHeader.getProperty("_id");
 
 			assert.strictEqual(nativeHeader.getAttribute("aria-label"), null, "aria-label is not present");
 			assert.strictEqual(nativeHeader.getAttribute("aria-labelledby"),
 				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");
 
-			const panelWithCustomHeader = $("p1");
-			const headerButton = panelWithCustomHeader.shadow$("ui5-panel-header-button");
+			const panelWithCustomHeader = $("#p1");
+			const headerButton = panelWithCustomHeader.shadow$(".ui5-panel-header-button");
 			const expectedText = "Expandable but not expanded";
 
 			assert.strictEqual(headerButton.getAttribute("aria-label"), expectedText,

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -114,6 +114,31 @@ describe("Panel general interaction", () => {
 			assert.strictEqual(title.getAttribute("aria-level"), "3", "title aria-level is set to 3 correctly");
 		});
 
+		it("tests aria-label and aria-labelledby attributes", () => {
+			const panelWithNativeHeader = $("#panel-expandable");
+			const nativeHeader = panelWithNativeHeader.shadow$("ui5-panel-header");
+			const panelWithNativeHeaderId = panelWithNativeHeader.getProperty("_id");
+
+			assert.strictEqual(nativeHeader.getAttribute("aria-label"), null, "aria-label is not present");
+			assert.strictEqual(nativeHeader.getAttribute("aria-labelledby"),
+				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");
+
+			const panelWithCustomHeader = $("p1");
+			const headerButton = panelWithCustomHeader.shadow$("ui5-panel-header-button");
+			const expectedText = "Expandable but not expanded";
+
+			assert.strictEqual(headerButton.getAttribute("aria-label"), expectedText,
+				"aria-labelledby is propagated correctly to the expand/collapse button");
+		});
+
+		it("tests whether aria attributes are set correctly with fixed header", () => {
+			const header = browser.$("#panel-fixed").shadow$(".ui5-panel-header");
+
+			assert.ok(header.getAttribute("aria-expanded") === null, "aria-expanded shouldn't be set on the fixed header");
+			assert.ok(header.getAttribute("aria-controls") === null, "aria-controls shouldn't be set on the fixed header");
+			assert.ok(header.getAttribute("role") === null, "role shouldn't be set on the fixed header");
+		});
+
 		it("tests whether aria attributes are set correctly in case of custom header", () => {
 			const button = browser.$("#panel2").shadow$(".ui5-panel-header-button").shadow$(".ui5-button-root");
 			const header = browser.$("#panel2").shadow$(".ui5-panel-header");

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -134,9 +134,9 @@ describe("Panel general interaction", () => {
 		it("tests whether aria attributes are set correctly with fixed header", () => {
 			const header = browser.$("#panel-fixed").shadow$(".ui5-panel-header");
 
-			assert.ok(header.getAttribute("aria-expanded") === null, "aria-expanded shouldn't be set on the fixed header");
-			assert.ok(header.getAttribute("aria-controls") === null, "aria-controls shouldn't be set on the fixed header");
-			assert.ok(header.getAttribute("role") === null, "role shouldn't be set on the fixed header");
+			assert.ok(!header.getAttribute("aria-expanded"), "aria-expanded shouldn't be set on the fixed header");
+			assert.ok(!header.getAttribute("aria-controls"), "aria-controls shouldn't be set on the fixed header");
+			assert.ok(!header.getAttribute("role"), "role shouldn't be set on the fixed header");
 		});
 
 		it("tests whether aria attributes are set correctly in case of custom header", () => {


### PR DESCRIPTION
Added support for **aria-label** and **aria-labelledby**
* if **aria-label** or **aria-labelledby** are set externally, **aria-label** is set inside the shadowDOM.
* if not, **aria-labelledby** is automatically set to the reference of internal title, when the header-text property is set.
* if panel has items in **header** slot these values are propagated to expand/collapse button.

In addition:
* accessibility attributes are removed from header container when the panel is fixed.
* panel could be expanded/collapsed throught expand/collapse button when it has items in **header** slot.

#1880 