### PR TITLE
feat(ui5-popover): prevent closing when no opener

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -531,7 +531,9 @@ class Input extends UI5Element {
 			const shouldOpenSuggestions = this.shouldOpenSuggestions();
 
 			this.updateStaticAreaItemContentDensity();
-			this.Suggestions.toggle(shouldOpenSuggestions);
+			this.Suggestions.toggle(shouldOpenSuggestions, {
+				preventFocusRestore: !this.hasSuggestionItemSelected,
+			});
 
 			RenderScheduler.whenFinished().then(async () => {
 				this._listWidth = await this.Suggestions._getListWidth();

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -253,13 +253,16 @@ class Popover extends Popup {
 	 * Opens the popover.
 	 * @param {HTMLElement} opener the element that the popover is opened by
 	 * @param {boolean} preventInitialFocus prevents applying the focus inside the popover
+	 * @param {boolean} closeWithOpener defines if the popover would closes when its opener is no longer visible (true by default)
 	 * @public
 	 */
-	openBy(opener, preventInitialFocus = false) {
+	openBy(opener, preventInitialFocus = false, closeWithOpener = true) {
 		if (!opener || this.opened) {
 			return;
 		}
+
 		this._opener = opener;
+		this._closeWithOpener = closeWithOpener;
 
 		super.open(preventInitialFocus);
 	}
@@ -314,9 +317,17 @@ class Popover extends Popup {
 	}
 
 	show() {
+		let placement;
 		const popoverSize = this.popoverSize;
 		const openerRect = this._opener.getBoundingClientRect();
-		const placement = this.calcPlacement(openerRect, popoverSize);
+
+		if (!this._closeWithOpener && this.shouldCloseDueToNoOpener(openerRect)) {
+			// use the old placement when the opener is gone
+			placement = this._oldPlacement;
+		} else {
+			placement = this.calcPlacement(openerRect, popoverSize);
+		}
+
 		const stretching = this.horizontalAlign === PopoverHorizontalAlign.Stretch;
 
 		if (this._preventRepositionAndClose) {
@@ -396,7 +407,11 @@ class Popover extends Popup {
 
 		const placementType = this.getActualPlacementType(targetRect, popoverSize);
 
-		this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placementType, targetRect);
+		if (!this._closeWithOpener) {
+			this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placementType, targetRect);
+		} else {
+			this._preventRepositionAndClose = false;
+		}
 
 		const isVertical = placementType === PopoverPlacementType.Top
 			|| placementType === PopoverPlacementType.Bottom;

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -246,6 +246,15 @@ class Popup extends UI5Element {
 	 * @protected
 	 */
 	applyInitialFocus() {
+		this.applyFocus();
+	}
+
+	/**
+	 * Focuses the element denoted by <code>initialFocus</code>, if provided,
+	 * or the first focusable element otherwise.
+	 * @public
+	 */
+	applyFocus() {
 		const element = this.getRootNode().getElementById(this.initialFocus)
 			|| document.getElementById(this.initialFocus)
 			|| getFirstFocusableElement(this);

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -124,9 +124,9 @@ class ResponsivePopover extends Popover {
 	 * Closes the popover/dialog.
 	 * @public
 	 */
-	close() {
+	close(escPressed = false, preventRegistryUpdate = false, preventFocusRestore = false) {
 		if (!isPhone()) {
-			super.close();
+			super.close(escPressed, preventRegistryUpdate, preventFocusRestore);
 		} else {
 			this._dialog.close();
 		}

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -92,13 +92,13 @@ class Suggestions {
 		return false;
 	}
 
-	toggle(bToggle) {
+	toggle(bToggle, { preventFocusRestore }) {
 		const toggle = bToggle !== undefined ? bToggle : !this.isOpened();
 
 		if (toggle) {
 			this.open();
 		} else {
-			this.close();
+			this.close(preventFocusRestore);
 		}
 	}
 
@@ -113,9 +113,9 @@ class Suggestions {
 		this.responsivePopover.open(this._getComponent());
 	}
 
-	async close() {
+	async close(preventFocusRestore = false) {
 		this.responsivePopover = await this._respPopover();
-		this.responsivePopover.close();
+		this.responsivePopover.close(false, false, preventFocusRestore);
 	}
 
 	updateSelectedItemPosition(pos) {

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -65,7 +65,7 @@
 		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
 	</ui5-input>
 
-	<ui5-popover id="quickViewCard" no-arrow id="pop" placement-type="Right" height="500px">
+	<ui5-popover id="quickViewCard" no-arrow placement-type="Right" height="500px">
 		<ui5-input id="searchInput" style="width: 300px">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>
@@ -422,8 +422,8 @@
 
 		inputPreview.addEventListener("ui5-suggestion-item-preview", function (event) {
 			var item = event.detail.targetRef;
-			quickViewCard.close(false, false, true);
-			quickViewCard.openBy(item, true, false);
+			quickViewCard.close();
+			quickViewCard.openBy(item, true /* preventInitialFocus */, false /* closeWithOpener */);
 			
 			// log info
 			inputItemPreviewRes.value = item.textContent;
@@ -437,7 +437,7 @@
 			if (combination) {
 				focusQuickView = true;
 				await RenderScheduler.whenFinished();
-				quickViewCard.applyInitialFocus();
+				quickViewCard.applyFocus();
 				console.log("set focus to quickcard");
 			}
 
@@ -449,8 +449,8 @@
 		[].slice.call(document.querySelectorAll(".suggestionItem")).forEach(function(el) {
 			el.addEventListener("mouseover", function (event) {
 				const targetRef = event.detail.targetRef;
-				quickViewCard.close(false, false, true);
-				quickViewCard.openBy(targetRef, true, false);
+				quickViewCard.close();
+				quickViewCard.openBy(item, true /* preventInitialFocus */, false /* closeWithOpener */);
 
 				// log info
 				mouseoverResult.value = targetRef.textContent;

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -58,16 +58,27 @@
 	<br><br>
 
 	<ui5-input id="inputPreview" show-suggestions style="width: 200px">
-		<ui5-suggestion-item class="suggestionItem" text="Cozy"></ui5-suggestion-item>
-		<ui5-suggestion-item class="suggestionItem" text="Compact"></ui5-suggestion-item>
-		<ui5-suggestion-item class="suggestionItem" text="Condensed"></ui5-suggestion-item>
-		<ui5-suggestion-item class="suggestionItem" text="Cozy"></ui5-suggestion-item>
-		<ui5-suggestion-item class="suggestionItem" text="Compact"></ui5-suggestion-item>
-		<ui5-suggestion-item class="suggestionItem" text="Condensed"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="Laptop Lenovo"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="HP Monitor 24"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="IPhone 6s"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="Dell"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
 	</ui5-input>
 
-	<ui5-popover id="quickViewCard" header-text="My Heading" id="pop" placement-type="Right">
-		<ui5-button>Click me</ui5-button>
+	<ui5-popover id="quickViewCard" no-arrow id="pop" placement-type="Right" height="500px">
+		<ui5-input id="searchInput" style="width: 300px">
+			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
+		</ui5-input>
+		<ui5-list style="height: 400px">
+			<ui5-li-groupheader>Actions</ui5-li-groupheader>
+			<ui5-li>Delete Product</ui5-li>
+			<ui5-li>Audit Log Settings</ui5-li>
+			<ui5-li>OData API Audit</ui5-li>
+			<ui5-li-groupheader>Products</ui5-li-groupheader>
+			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Error">IPhone 3</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
+		</ui5-list>
 	</ui5-popover>
 
 	<br/>
@@ -406,40 +417,65 @@
 			inputChangeResult.value = ++inputChangeResultCounter;
 		});
 
-		// Preview suggestion item events
+		// Quick View Card sample
+		var focusQuickView = false;
+
 		inputPreview.addEventListener("ui5-suggestion-item-preview", function (event) {
 			var item = event.detail.targetRef;
+			quickViewCard.close(false, false, true);
+			quickViewCard.openBy(item, true, false);
+			
+			// log info
 			inputItemPreviewRes.value = item.textContent;
-
-			quickViewCard.close(false, true, true);
-			quickViewCard.openBy(item, true);
+			console.log("suggestion-item-preview", item);
 		});
 
-		inputPreview.addEventListener("keyup", function (event) {
+		inputPreview.addEventListener("keyup", async function (event) {
 			const item = event.target.previewItem;
-			const combination = event.key === "1" && event.shiftKey && event.ctrlKey;
+			const combination = event.key === "1";
 
-			keyupResult.value = combination ? "[ctr+shift+1] on item: " + (item && item.text) : event.key;
+			if (combination) {
+				focusQuickView = true;
+				await RenderScheduler.whenFinished();
+				quickViewCard.applyInitialFocus();
+				console.log("set focus to quickcard");
+			}
+
+			// log info
+			keyupResult.value = event.key + " on item: " + (item && item.text);
+			console.log("keyup", event.key);
 		});
 
 		[].slice.call(document.querySelectorAll(".suggestionItem")).forEach(function(el) {
 			el.addEventListener("mouseover", function (event) {
 				const targetRef = event.detail.targetRef;
+				quickViewCard.close(false, false, true);
+				quickViewCard.openBy(targetRef, true, false);
 
+				// log info
 				mouseoverResult.value = targetRef.textContent;
-				quickViewCard.openBy(targetRef, true);
+				console.log("mouseover");
 			});
 
 			el.addEventListener("mouseout", function (event) {
-				const targetRef = event.detail.targetRef;
+				if (!focusQuickView) {
+					quickViewCard.close(false, false, true);
+				}
 
-				mouseoutResult.value = targetRef.textContent;
-				quickViewCard.close(false, true, true);
+				focusQuickView = false;
+
+				// log info
+				mouseoutResult.value = event.detail.targetRef.textContent;
+				console.log("mouseout");
 			});
 		});
 
 		inputPreview.addEventListener("ui5-suggestion-scroll", function (event) {
 			console.log("scroll", { scrolltop: event.detail.scrollTop });
+		});
+
+		inputPreview.addEventListener("focusin", function (event) {
+			console.log("focusin");
 		});
 
 		inputPreview.addEventListener("focusout", function (event) {

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Input Quick View</title>
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+	<h1> Quick View sample</h1>
+	<ul>
+		<li>hover on item to see quick view</li>
+		<li>navigate via the arrows to see quick view</li>
+		<li>press [ctrl + shift + 1] to enter the quick view</li>
+	</ul>
+	<ui5-input id="inputPreview" show-suggestions style="width: 200px; margin-top: 50px">
+		<ui5-suggestion-item class="suggestionItem" text="Laptop Lenovo"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="HP Monitor 24"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="IPhone 6s"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="Dell"></ui5-suggestion-item>
+		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
+	</ui5-input>
+
+	<ui5-popover id="quickViewCard" no-arrow id="pop" placement-type="Right" height="500px">
+		<ui5-input id="searchInput" style="width: 300px">
+			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
+		</ui5-input>
+		<ui5-list style="height: 400px">
+			<ui5-li-groupheader>Actions</ui5-li-groupheader>
+			<ui5-li>Delete Product</ui5-li>
+			<ui5-li>Audit Log Settings</ui5-li>
+			<ui5-li>OData API Audit</ui5-li>
+			<ui5-li-groupheader>Products</ui5-li-groupheader>
+			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Error">IPhone 3</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
+	<script>
+		var focusQuickView = false;
+
+		// open quick view on suggestion-item-preview
+		inputPreview.addEventListener("suggestion-item-preview", function (event) {
+			var item = event.detail.targetRef;
+
+			quickViewCard.close(false, false, true);
+			quickViewCard.openBy(item, true, false);
+		});
+
+		// focus quick view on [ctrl + shift + 1]
+		inputPreview.addEventListener("keyup", async function (event) {
+			const combination = event.key === "1" && event.ctrlKey && event.shiftKey;
+
+			if (combination) {
+				focusQuickView = true;
+				await RenderScheduler.whenFinished();
+				quickViewCard.applyInitialFocus();
+			}
+		});
+
+		// toggle quick view on mouseover/mouseout
+		[].slice.call(document.querySelectorAll(".suggestionItem")).forEach(function(el) {
+			el.addEventListener("mouseover", function (event) {
+				const targetRef = event.detail.targetRef;
+				quickViewCard.close(false, false, true);
+				quickViewCard.openBy(targetRef, true, false);
+			});
+
+			el.addEventListener("mouseout", function (event) {
+				if (!focusQuickView) {
+					quickViewCard.close(false, false, true);
+				}
+
+				focusQuickView = false;
+			});
+		});
+	</script>
+</body>
+</html>

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -26,7 +26,7 @@
 		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
 	</ui5-input>
 
-	<ui5-popover id="quickViewCard" no-arrow id="pop" placement-type="Right" height="500px">
+	<ui5-popover id="quickViewCard" no-arrow placement-type="Right" height="500px">
 		<ui5-input id="searchInput" style="width: 300px">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>
@@ -45,39 +45,46 @@
 	<script>
 		var focusQuickView = false;
 
-		// open quick view on suggestion-item-preview
+		/* 
+		 * Open quick view on suggestion-item-preview
+		 */
 		inputPreview.addEventListener("suggestion-item-preview", function (event) {
-			var item = event.detail.targetRef;
+			const targetRef = event.detail.targetRef;
 
-			quickViewCard.close(false, false, true);
-			quickViewCard.openBy(item, true, false);
+			quickViewCard.close();
+			quickViewCard.openBy(targetRef, true /* preventInitialFocus */, false /* closeWithOpener */); 
 		});
 
-		// focus quick view on [ctrl + shift + 1]
+		/* 
+		 * Focus quick view on [ctrl + shift + 1]
+		 */
 		inputPreview.addEventListener("keyup", async function (event) {
 			const combination = event.key === "1" && event.ctrlKey && event.shiftKey;
 
 			if (combination) {
 				focusQuickView = true;
 				await RenderScheduler.whenFinished();
-				quickViewCard.applyInitialFocus();
+				quickViewCard.applyFocus();
 			}
 		});
 
-		// toggle quick view on mouseover/mouseout
+		/* 
+		 * Toggle quick view on mouseover/mouseout
+		 */
 		[].slice.call(document.querySelectorAll(".suggestionItem")).forEach(function(el) {
 			el.addEventListener("mouseover", function (event) {
 				const targetRef = event.detail.targetRef;
-				quickViewCard.close(false, false, true);
-				quickViewCard.openBy(targetRef, true, false);
+
+				quickViewCard.close();
+				quickViewCard.openBy(targetRef, true /* preventInitialFocus */, false /* closeWithOpener */);
 			});
 
 			el.addEventListener("mouseout", function (event) {
-				if (!focusQuickView) {
-					quickViewCard.close(false, false, true);
-				}
+				// if (!focusQuickView) {
+				// 	quickViewCard.close(false, false, true);
+				// }
 
-				focusQuickView = false;
+				// focusQuickView = false;
 			});
 		});
 	</script>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -187,6 +187,11 @@
 
 	<br>
 	<br>
+	<ui5-title>Test open popup and hide opener</ui5-title>
+	<ui5-button id="btnQuickViewCardOpener">Open popup and hide myself</ui5-button>
+	<ui5-button id="btnMoveFocus">focusable element</ui5-button>
+	<br>
+	<br>
 	<ui5-title>placement-type="Right", but no space on the right</ui5-title>
 	<p>No space on the Right, try Left, Bottom, Top</p>
 	<ui5-button id="btnFullWidth" style="width: 100%">Click me !</ui5-button>
@@ -292,6 +297,23 @@
 		</ui5-list>
 	</ui5-popover>
 
+
+	<ui5-popover id="quickViewCard" placement-type="Right" height="500px">
+		<ui5-input id="searchInput" style="width: 300px">
+			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
+		</ui5-input>
+		<ui5-list style="height: 400px">
+			<ui5-li-groupheader>Actions</ui5-li-groupheader>
+			<ui5-li>Delete Product</ui5-li>
+			<ui5-li>Audit Log Settings</ui5-li>
+			<ui5-li>OData API Audit</ui5-li>
+			<ui5-li-groupheader>Products</ui5-li-groupheader>
+			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Error">IPhone 3</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
 	<script>
 		btn.addEventListener("click", function (event) {
 			pop.openBy(btn);
@@ -352,6 +374,12 @@
 		btnFullWidthBottom.addEventListener("click", function (event) {
 			popFullWidthBottom.openBy(btnFullWidthBottom);
 		});
+
+		btnQuickViewCardOpener.addEventListener("click", function (event) {
+			quickViewCard.openBy(btnQuickViewCardOpener, true, false);
+
+			btnQuickViewCardOpener.setAttribute("hidden", true);
+		})
 	</script>
 </body>
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -136,7 +136,7 @@ describe("Input general interaction", () => {
 		inputItemPreview.click();
 		inputItemPreview.keys("ArrowDown");
 
-		assert.strictEqual(inputItemPreviewRes.getValue(), "Cozy", "First item has been previewed");
+		assert.strictEqual(inputItemPreviewRes.getValue(), "Laptop Lenovo", "First item has been previewed");
 	});
 
 	it("fires suggestion-scroll event", () => {

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -44,6 +44,28 @@ describe("Popover general interaction", () => {
 		assert.ok(!popover.isDisplayedInViewport(), "Popover is closed.");
 	});
 
+	it("tests popover does not close with opener", () => {
+		const popover = browser.$("#quickViewCard");
+		const btnOpenPopover = $("#btnQuickViewCardOpener");
+		const btnMoveFocus = $("#btnMoveFocus");
+
+		// assert - the opener is visible
+		assert.strictEqual(btnOpenPopover.isDisplayedInViewport(), true,
+			"Opener is available.");
+
+		// act - open popover and hide opener
+		btnOpenPopover.click();
+
+		// assert - the popover remains open, although opener is not visible
+		assert.strictEqual(popover.getAttribute("open"), "true",
+			"Popover remains open.");
+		assert.strictEqual(btnOpenPopover.isDisplayedInViewport(), false,
+			"Opener is not available.");
+
+		// close the popover
+		btnMoveFocus.click();
+	});
+
 	it("tests clicking inside the popover does not close it", () => {
 		const btnOpenPopover = $("#btn");
 		const btnInPopover = $("#popbtn");


### PR DESCRIPTION
The change is related to the Quick View topic and affects the Input, InputSuggestions and Popover, and enables the following behaviour: (1) open an additional Popover from a suggestion on mouseover and suggestion-item-preview events, (2) to move the focus in that Popover, (3) to keep it open without a visible opener, and (4) the ability to get back via ESC.

- Add parameter to the openBy  method to prevent the popover from closing when its opener is not visible anymore
and use the old placement when the opener is gone (by default the popover would go to the top-left most corner).

- Add public method Popup.prototype.applyFocus (the logic has been extracted from applyInitialFocus) that focuses the first focusable element inside the Popup

- Change the focus retaining logic in Input/InputSuggestions as follows: returns the focus to the input field only when a suggestion is selected by the user, in other cases - does not, because otherwise focusing another popover would not be possible as the Input keeps getting focus again and again.

- Previously it was not possible to use the "close" params with the ResponsivePopover, now it forwards them to the Popover.

- Create a test page to show the entire flow

Related to: https://github.com/SAP/ui5-webcomponents/issues/1768