### PR TITLE
chore(ui5-input): Enable separators customization

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -1005,6 +1005,10 @@ class Input extends UI5Element {
 		};
 	}
 
+	get suggestionSeparators() {
+		return "None";
+	}
+
 	get valueStateMessageText() {
 		return this.getSlottedNodes("valueStateMessage").map(el => el.cloneNode(true));
 	}

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -49,7 +49,7 @@
 		{{/if}}
 	{{/unless}}
 
-		<ui5-list separators="Inner">
+		<ui5-list separators="{{suggestionSeparators}}">
 			{{#each suggestionsTexts}}
 				{{#if group}}
 					<ui5-li-groupheader data-ui5-key="{{key}}">{{ this.text }}</ui5-li-groupheader>


### PR DESCRIPTION
Enable suggestion list separators customization
- add suggestionSeparators getter that can overwritten in order to have different separators type
- change the default separators type of the suggestion list to "None" as in classic UI5

Related to: https://github.com/SAP/ui5-webcomponents/issues/1919