### PR TITLE
fix(framework): Remove ES6 code in IE polyfill

### DIFF
--- a/packages/base/src/thirdparty/Map.prototype.keys.js
+++ b/packages/base/src/thirdparty/Map.prototype.keys.js
@@ -1,7 +1,7 @@
 if (!Map.prototype.keys) {
 	Map.prototype.keys = function() {
-		const keys = [];
-		this.forEach((value, key) => {
+		var keys = [];
+		this.forEach(function(value, key) {
 			keys.push(key);
 		});
 		return keys;


### PR DESCRIPTION
The `Map.prototype.keys` polyfill had ES6 code, which, under certain scenarios, does not get transpiled. All `thirdparty/` implementations need to be ES5.

closes: https://github.com/SAP/ui5-webcomponents/issues/1917