### PR TITLE
refactor(ui5-input): Add template hook for the suggestions

### DIFF
--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -49,24 +49,8 @@
 		{{/if}}
 	{{/unless}}
 
-		<ui5-list separators="{{suggestionSeparators}}">
-			{{#each suggestionsTexts}}
-				{{#if group}}
-					<ui5-li-groupheader data-ui5-key="{{key}}">{{ this.text }}</ui5-li-groupheader>
-				{{else}}
-					<ui5-li
-						image="{{this.image}}"
-						icon="{{this.icon}}"
-						description="{{this.description}}"
-						info="{{this.info}}"
-						type="{{this.type}}"
-						info-state="{{this.infoState}}"
-						@ui5-_item-press="{{ fnOnSuggestionItemPress }}"
-						data-ui5-key="{{key}}"
-					>{{ this.text }}</ui5-li>
-				{{/if}}
-			{{/each}}
-		</ui5-list>
+		{{> suggestionsList}}
+
 		{{#if _isPhone}}
 			<div slot="footer" class="ui5-responsive-popover-footer">
 				<ui5-button
@@ -100,4 +84,25 @@
 			{{this}}
 		{{/each}}
 	{{/if}}
+{{/inline}}
+
+{{#*inline "suggestionsList"}}
+	<ui5-list separators="{{suggestionSeparators}}">
+		{{#each suggestionsTexts}}
+			{{#if group}}
+				<ui5-li-groupheader data-ui5-key="{{key}}">{{ this.text }}</ui5-li-groupheader>
+			{{else}}
+				<ui5-li
+					image="{{this.image}}"
+					icon="{{this.icon}}"
+					description="{{this.description}}"
+					info="{{this.info}}"
+					type="{{this.type}}"
+					info-state="{{this.infoState}}"
+					@ui5-_item-press="{{ fnOnSuggestionItemPress }}"
+					data-ui5-key="{{key}}"
+				>{{ this.text }}</ui5-li>
+			{{/if}}
+		{{/each}}
+	</ui5-list>
 {{/inline}}


### PR DESCRIPTION
Add template hook for the suggestions list, so the third party components can entirely replace our list with another and to fully control the appearance of the suggestion items.

```js
// CustomInputPopoverTemplate.hbs
{{>include "InputPopoverTemplate"}}

{{#*inline "suggestionsList"}}
	<ui5-my-list>
	</ui5-my-list>
{{/inline}}
```