### PR TITLE
fix(framework): make renderImmediately sync, fix lifecycle issues

### DIFF
--- a/packages/base/src/RenderQueue.js
+++ b/packages/base/src/RenderQueue.js
@@ -1,41 +1,41 @@
 class RenderQueue {
 	constructor() {
 		this.list = []; // Used to store the web components in order
-		this.promises = new Map(); // Used to store promises for web component rendering
+		this.lookup = new Set(); // Used for faster search
 	}
 
 	add(webComponent) {
-		if (this.promises.has(webComponent)) {
-			return this.promises.get(webComponent);
+		if (this.lookup.has(webComponent)) {
+			return;
 		}
 
-		let deferredResolve;
-		const promise = new Promise(resolve => {
-			deferredResolve = resolve;
-		});
-		promise._deferredResolve = deferredResolve;
-
 		this.list.push(webComponent);
-		this.promises.set(webComponent, promise);
+		this.lookup.add(webComponent);
+	}
 
-		return promise;
+	remove(webComponent) {
+		if (!this.lookup.has(webComponent)) {
+			return;
+		}
+
+		this.list = this.list.filter(item => item !== webComponent);
+		this.lookup.delete(webComponent);
 	}
 
 	shift() {
 		const webComponent = this.list.shift();
 		if (webComponent) {
-			const promise = this.promises.get(webComponent);
-			this.promises.delete(webComponent);
-			return { webComponent, promise };
+			this.lookup.delete(webComponent);
+			return webComponent;
 		}
 	}
 
-	getList() {
-		return this.list;
+	isEmpty() {
+		return this.list.length === 0;
 	}
 
 	isAdded(webComponent) {
-		return this.promises.has(webComponent);
+		return this.lookup.has(webComponent);
 	}
 }
 

--- a/packages/base/src/RenderQueue.js
+++ b/packages/base/src/RenderQueue.js
@@ -1,16 +1,29 @@
+const MAX_PROCESS_COUNT = 10;
+
 class RenderQueue {
 	constructor() {
 		this.list = []; // Used to store the web components in order
 		this.lookup = new Set(); // Used for faster search
+
+		this.promise = null; // Will be resolved when the queue is processed
+		this.resolve = null; // Deferred resolve for the promise
 	}
 
 	add(webComponent) {
 		if (this.lookup.has(webComponent)) {
-			return;
+			return this.promise;
 		}
 
 		this.list.push(webComponent);
 		this.lookup.add(webComponent);
+
+		if (!this.promise) {
+			this.promise = new Promise(resolve => {
+				this.resolve = resolve;
+			});
+		}
+
+		return this.promise;
 	}
 
 	remove(webComponent) {
@@ -36,6 +49,34 @@ class RenderQueue {
 
 	isAdded(webComponent) {
 		return this.lookup.has(webComponent);
+	}
+
+	/**
+	 * Processes the whole queue by executing the callback on each component,
+	 * while also imposing restrictions on how many times a component may be processed.
+	 *
+	 * @param callback - function with one argument (the web component to be processed)
+	 */
+	process(callback) {
+		let webComponent;
+		const stats = new Map();
+
+		webComponent = this.shift();
+		while (webComponent) {
+			const timesProcessed = stats.get(webComponent) || 0;
+			if (timesProcessed > MAX_PROCESS_COUNT) {
+				throw new Error(`Web component processed too many times this task, max allowed is: ${MAX_PROCESS_COUNT}`);
+			}
+			callback(webComponent);
+			stats.set(webComponent, timesProcessed + 1);
+			webComponent = this.shift();
+		}
+
+		if (this.resolve) {
+			this.resolve();
+			this.resolve = null;
+			this.promise = null;
+		}
 	}
 }
 

--- a/packages/base/src/RenderQueue.js
+++ b/packages/base/src/RenderQueue.js
@@ -4,26 +4,15 @@ class RenderQueue {
 	constructor() {
 		this.list = []; // Used to store the web components in order
 		this.lookup = new Set(); // Used for faster search
-
-		this.promise = null; // Will be resolved when the queue is processed
-		this.resolve = null; // Deferred resolve for the promise
 	}
 
 	add(webComponent) {
 		if (this.lookup.has(webComponent)) {
-			return this.promise;
+			return;
 		}
 
 		this.list.push(webComponent);
 		this.lookup.add(webComponent);
-
-		if (!this.promise) {
-			this.promise = new Promise(resolve => {
-				this.resolve = resolve;
-			});
-		}
-
-		return this.promise;
 	}
 
 	remove(webComponent) {
@@ -70,12 +59,6 @@ class RenderQueue {
 			callback(webComponent);
 			stats.set(webComponent, timesProcessed + 1);
 			webComponent = this.shift();
-		}
-
-		if (this.resolve) {
-			this.resolve();
-			this.resolve = null;
-			this.promise = null;
 		}
 	}
 }

--- a/packages/base/src/RenderScheduler.js
+++ b/packages/base/src/RenderScheduler.js
@@ -66,8 +66,8 @@ class RenderScheduler {
 					invalidatedWebComponents.process(component => component._render());
 
 					// Resolve the promise so that callers of renderDeferred can continue
-					resolve();
 					queuePromise = null;
+					resolve();
 
 					// Wait for Mutation observer before the render task is considered finished
 					if (!mutationObserverTimer) {

--- a/packages/base/src/RenderScheduler.js
+++ b/packages/base/src/RenderScheduler.js
@@ -70,8 +70,6 @@ class RenderScheduler {
 			// renderTaskId = Promise.resolve().then(RenderScheduler.renderWebComponents); // Micro task
 			renderTaskId = window.requestAnimationFrame(RenderScheduler.renderWebComponents); // AF
 		}
-
-		return RenderScheduler.whenDOMUpdated();
 	}
 
 	static runRenderTask() {
@@ -79,8 +77,6 @@ class RenderScheduler {
 			renderTaskId = 1; // prevent another rendering task from being scheduled, all web components should use this task
 			RenderScheduler.renderWebComponents();
 		}
-
-		return RenderScheduler.whenDOMUpdated();
 	}
 
 	static renderWebComponents() {

--- a/packages/base/test/specs/UI5ElementLifecycle.js
+++ b/packages/base/test/specs/UI5ElementLifecycle.js
@@ -79,6 +79,9 @@ describe("Lifecycle works", () => {
 			});
 
 			document.body.appendChild(el);
+
+			await window.RenderScheduler.whenFinished(); // Must wait, otherwise onExitDOM won't be called
+
 			document.body.removeChild(el);
 
 			await window.RenderScheduler.whenFinished();

--- a/packages/main/test/pages/DialogLifecycle.html
+++ b/packages/main/test/pages/DialogLifecycle.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<title>Button</title>
+
+	<script data-ui5-config type="application/json">
+		{
+			"language": "EN",
+			"noConflict": {
+				"events": ["click"]
+			},
+			"calendarType": "Islamic"
+		}
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+<ui5-button id="openDialogButton">Open Dialog</ui5-button>
+<br />
+
+<template id="dt">
+	<ui5-dialog id="hello-dialog" header-text="Dialogs are easy!">
+		<div stype="padding: 2rem; display:flex; justify-content: center;">
+			Hello World!
+			<ui5-button id="closeDialogButton">Dismiss</ui5-button>
+		</div>
+	</ui5-dialog>
+</template>
+
+<script>
+	const openBtn = document.getElementById("openDialogButton");
+	openBtn.addEventListener("click", () => {
+		const clone = document.getElementById("dt").content.cloneNode(true);
+		document.body.appendChild(clone);
+		const dialog = document.getElementById("hello-dialog");
+		const closeBtn = dialog.querySelector("#closeDialogButton");
+		closeBtn.addEventListener("click", () => {
+			dialog.addEventListener("afterClose", () => {
+				dialog.parentElement.removeChild(dialog);
+			});
+			dialog.close();
+		});
+
+		document.body.appendChild(dialog);
+		dialog.open();
+	});
+</script>
+
+</body>
+</html>

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -31,6 +31,22 @@ describe("Dialog general interaction", () => {
 
 		assert.ok(popoverZIndex > dialogZIndex, "Popover is above dialog.");
 	});
+
+	it("tests dialog lifecycle", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DialogLifecycle.html");
+
+		assert.ok(!browser.$("ui5-static-area").length, "No static area.");
+
+		const openDialogButton = browser.$("#openDialogButton");
+		openDialogButton.click();
+
+		assert.ok(browser.$("ui5-static-area>ui5-static-area-item"), "Static area item exists.");
+
+		const closeDialogButton= browser.$("#closeDialogButton");
+		closeDialogButton.click();
+
+		assert.ok(!browser.$("ui5-static-area").length, "No static area.");
+	});
 });
 
 


### PR DESCRIPTION
 - `RenderQueue.js` no longer manages promises at all
 - `renderImmediately` is completely sync now and does not use the render queue. The render queue is only used by `renderDeferred`. `renderDeferred` is async and awaits for queue processing to be over (but does not await for the "official" end of the render task - the Mutation Observer).
 - In `UI5Element.js` there are 2 new flags: `_inDOM` which is set immediately when `connectedCallback` is called, and is unset immediately when `disconnectedCallback` is called. It prevents the component from entering the render queue if removed from DOM before it gets to it. And `_fullyConnected` which is set before calling `onEnterDOM` and unset after calling `onExitDOM`. Thus we call `onExitDOM` only if we called `onEnterDOM`, thus preventing lifecycle issues in the components implementation. 

So the following code:
```js
x = document.createElement('ui5-table'); 
document.body.appendChild(x); 
document.body.removeChild(x);
```
can now run without exceptions thrown by `ResizeHandler.js` (as it is deregistered before ever being registered).

 - Test added

closes: https://github.com/SAP/ui5-webcomponents/issues/1821