### PR TITLE
fix(framework): Fix openui5 css varaibles detection

### DIFF
--- a/packages/base/src/features/OpenUI5Support.js
+++ b/packages/base/src/features/OpenUI5Support.js
@@ -74,8 +74,8 @@ const cssVariablesLoaded = () => {
 	if (!link) {
 		return;
 	}
-
-	return !!link.href.match(/\/css-variables\.css/);
+debugger;
+	return !!link.href.match(/\/css(-|_)variables\.css/);
 };
 
 const OpenUI5Support = {

--- a/packages/base/src/features/OpenUI5Support.js
+++ b/packages/base/src/features/OpenUI5Support.js
@@ -74,7 +74,7 @@ const cssVariablesLoaded = () => {
 	if (!link) {
 		return;
 	}
-debugger;
+
 	return !!link.href.match(/\/css(-|_)variables\.css/);
 };
 


### PR DESCRIPTION
Change the regex to detect the openui5 CSS variables properly as from 1.79 the CSS Variables filename has changed to **css_variables.css** (previously css-varaibles.css with dash). 
But, the script will match the old name with "-" dash as well, if we need to support it, otherwise we can leave "_" only to support the latest name.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1932