### PR TITLE
fix(ui5-shellbar): Fix profile bg-color

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -83,7 +83,6 @@ slot[name="profile"] {
 	width: 2.25rem;
 	height: 2.25rem;
 	padding: .25rem;
-	background-color: transparent;
 	pointer-events: none;
 }
 

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -80,8 +80,8 @@ slot[name="profile"] {
 
 ::slotted(ui5-avatar[slot="profile"]) {
 	min-width: 0;
-	width: 2.25rem;
-	height: 2.25rem;
+	width: 2rem;
+	height: 2rem;
 	padding: .25rem;
 	pointer-events: none;
 }


### PR DESCRIPTION
We used to force` background-color: transparent` to the ui5-avatar, when used as profile. But, it turns out that this is not needed, in classic UI5, the Avatar is displayed with its default AccentBGColor6 and we align to this with the change.
Moreover, in Fiori3 Dark, the transparent Avatar leads to missing color contrast as shown in the issue.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/1944