### PR TITLE
fix(ui5-input): Fix selection color and bg

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -66,10 +66,9 @@
 	font-family: inherit;
 }
 
-[inner-input]::selection,
-[inner-input]::-moz-selection {
-	background: var(--sapSelected);
-	color: var(--sapContent_contrastTextColor);
+[inner-input]::selection {
+	background: var(--sapSelectedColor);
+	color: var(--sapContent_ContrastTextColor);
 }
 
 /* Input placeholder */


### PR DESCRIPTION
The selection color and bg-color variables used to be wrong. In Chrome and Safari these values fallback to their defaults and the bug is more difficult to be seen, but in FF the color and bg color become unset, and you cant see any selection with ctr+a or cmd+a.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1951