### PR TITLE
chore(framework): Allow the hidden property for custom elements

### DIFF
--- a/packages/base/src/util/isValidPropertyName.js
+++ b/packages/base/src/util/isValidPropertyName.js
@@ -5,6 +5,7 @@ const whitelist = [
 	"ariaLabel",
 	"ariaExpanded",
 	"title",
+	"hidden",
 ];
 
 /**


### PR DESCRIPTION
It would be useful to be able to support the `hidden` property for abstract elements, which don't have their own rendering, and marking them as hidden makes sense.