### PR TITLE
fix(ui5-input): Suggestions can now be arbitrary list items

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -799,18 +799,19 @@ class Input extends UI5Element {
 	}
 
 	previewSuggestion(item) {
-		const emptyValue = item.type === "Inactive" || item.group;
 		this.valueBeforeItemSelection = this.value;
-		this.updateValueOnPreview(emptyValue ? "" : item.effectiveTitle);
+		this.updateValueOnPreview(item);
 		this.announceSelectedItem();
 		this._previewItem = item;
 	}
 
 	/**
 	 * Updates the input value on item preview.
-	 * @param {itemValue} itemValue The value of the item that is on preview
+	 * @param {Object} item The item that is on preview
 	 */
-	updateValueOnPreview(itemValue) {
+	updateValueOnPreview(item) {
+		const noPreview = item.type === "Inactive" || item.group;
+		const itemValue = noPreview ? "" : (item.effectiveTitle || item.textContent);
 		this.value = itemValue;
 	}
 

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -318,7 +318,7 @@ class Suggestions {
 	}
 
 	_getItems() {
-		return [].slice.call(this.responsivePopover.querySelectorAll("ui5-li-groupheader, ui5-li-suggestion-item"));
+		return [...this.responsivePopover.querySelectorAll("ui5-list>*")];
 	}
 
 	_getComponent() {


### PR DESCRIPTION
Changes:
 - The `_getItems` function now reads all children of the list, regardless of tag name, so that for example `ui5-li-custom` will also work.
 - The `updateValueOnPreview` hook now gets not just a string, but the whole item as a parameter. This gives developers more freedom in determining what exactly is considered as the "preview value" of the item. This is handy for example if `ui5-li-custom` is used and the value is just part of that.

closes: https://github.com/SAP/ui5-webcomponents/issues/1967

BREAKING CHANGE: the format of the `updateValueOnPreview` hook has changed. The parameter is no longer a string (`itemValue`), but the whole `item` object now. It is this hook's responsibility to determine whether/how to preview group items and inactive items too.