### PR TITLE
fix(ui5-tabcontainer): prevent the tabcontainer from setting the selected property on ui5-tab internally

### DIFF
--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -265,12 +265,6 @@ class TabContainer extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		// Set selected
-		const hasSelected = this.items.some(item => item.selected);
-		if (this.items.length && !hasSelected) {
-			this.items[0].selected = true;
-		}
-
 		// Set external properties to items
 		this.items.forEach((item, index) => {
 			item._isInline = this.tabLayout === TabLayout.Inline;


### PR DESCRIPTION
Fixes #1953

BREAKING CHANGE: Tab Container will no longer automatically select the first tab, if no tab is selected. If you relied on this behavior, you should now explicitly set the `selected` property on the first tab.