### PR TITLE
fix(framework): Take region into account for i18n assets

### DIFF
--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -57,8 +57,9 @@ const fetchI18nBundle = async packageName => {
 	}
 
 	const language = getLocale().getLanguage();
+	const region = getLocale().getRegion();
 
-	let localeId = normalizeLocale(language);
+	let localeId = normalizeLocale(language + (region ? `-${region}` : ``));
 	while (localeId !== DEFAULT_LANGUAGE && !bundlesForPackage[localeId]) {
 		localeId = nextFallbackLocale(localeId);
 	}


### PR DESCRIPTION
Currently region is not taken into account, so if you set `?sap-ui-language=zh_CN` for example, the framework will try to load `messagebundle_zh.json` which does not exist. The same bug would be observed for all languages that don't have an i18n file for the base language, but only for regions.