### PR TITLE
chore: Fix Popover test

### DIFF
--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -376,7 +376,7 @@
 		});
 
 		btnQuickViewCardOpener.addEventListener("click", function (event) {
-			quickViewCard.openBy(btnQuickViewCardOpener, true, false);
+			quickViewCard.openBy(btnQuickViewCardOpener);
 
 			btnQuickViewCardOpener.setAttribute("hidden", true);
 		})

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -56,8 +56,12 @@ describe("Popover general interaction", () => {
 		// act - open popover and hide opener
 		btnOpenPopover.click();
 
+		browser.pause(500);
+
 		// assert - the popover remains open, although opener is not visible
 		assert.strictEqual(popover.getAttribute("open"), "true",
+			"Popover remains open.");
+		assert.strictEqual(popover.isDisplayedInViewport(), true,
 			"Popover remains open.");
 		assert.strictEqual(btnOpenPopover.isDisplayedInViewport(), false,
 			"Opener is not available.");


### PR DESCRIPTION
- openBy has no third parameter anymore
- add some delay, because even if the popover closes the test would not fail, because it is checked immediately.
*The test asserts that the popover will not close, when its opener is gone, as long it has the focus within.