### PR TITLE
chore(ui5-button): fix docs

### DIFF
--- a/packages/base/src/util/isValidPropertyName.js
+++ b/packages/base/src/util/isValidPropertyName.js
@@ -1,9 +1,7 @@
 // Note: disabled is present in IE so we explicitly allow it here.
-// Others, such as ariaLabel, we explicitly override, so valid too
+// Others, such as title/hidden, we explicitly override, so valid too
 const whitelist = [
 	"disabled",
-	"ariaLabel",
-	"ariaExpanded",
 	"title",
 	"hidden",
 ];
@@ -15,7 +13,7 @@ const whitelist = [
  * @returns {boolean}
  */
 const isValidPropertyName = name => {
-	if (whitelist.includes(name)) {
+	if (whitelist.includes(name) || name.startsWith("aria")) {
 		return true;
 	}
 	const classes = [

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -156,7 +156,7 @@ const metadata = {
 		/**
 		 * @type {String}
 		 * @defaultvalue ""
-		 * @public
+		 * @private
 		 * @since 1.0.0-rc.8
 		 */
 		ariaExpanded: {


### PR DESCRIPTION
Properties that already exist on HTML elements should be declared as `@private` in metadata, as we just want to integrate them in the lifecycle of the framework, without them appearing in the help.

Additionally: we now automatically whitelist all properties starting with `aria` without needing to enter them one by one.