### PR TITLE
docs: add missing tagname

### DIFF
--- a/packages/main/src/ComboBoxItem.js
+++ b/packages/main/src/ComboBoxItem.js
@@ -36,6 +36,7 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ComboBoxItem
  * @extends UI5Element
+ * @tagname ui5-cb-item
  * @public
  */
 class ComboBoxItem extends UI5Element {

--- a/packages/main/src/MultiComboBoxItem.js
+++ b/packages/main/src/MultiComboBoxItem.js
@@ -24,6 +24,7 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MultiComboBoxItem
  * @extends ComboBoxItem
+ * @tagname ui5-mcb-item
  * @public
  */
 class MultiComboBoxItem extends ComboBoxItem {

--- a/packages/main/src/SuggestionListItem.js
+++ b/packages/main/src/SuggestionListItem.js
@@ -35,6 +35,7 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SuggestionListItem
  * @extends UI5Element
+ * @tagname ui5-suggestion-item
  */
 class SuggestionListItem extends StandardListItem {
 	static get metadata() {


### PR DESCRIPTION
Added jsdoc directive `tagname` to:
- `ui5-cb-item`
- `ui5-mcb-item`
- `ui5-suggestion-item`