### PR TITLE
fix: lists no longer show a dot on IE

### DIFF
--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -7,6 +7,7 @@
 	tabindex="{{_tabIndex}}"
 	dir="{{effectiveDir}}"
 	aria-labelledby="{{ariaLabelledBy}}"
+	style="list-style-type: none;"
 >
 	<div class="ui5-nli-group-header">
 		<ui5-button

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -9,6 +9,7 @@
 	tabindex="{{_tabIndex}}"
 	dir="{{effectiveDir}}"
 	aria-labelledby="{{ariaLabelledBy}}"
+	style="list-style-type: none;"
 >
 	<div class="ui5-nli-actions">
 		{{#if showOverflow}}

--- a/packages/main/src/GroupHeaderListItem.hbs
+++ b/packages/main/src/GroupHeaderListItem.hbs
@@ -5,6 +5,7 @@
 	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	role="option"
+	style="list-style-type: none;"
 >
 	<span class="ui5-hidden-text">{{groupHeaderText}}</span>
 

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -26,7 +26,7 @@
 		<slot></slot>
 
 		{{#if showNoDataText}}
-			<li id="{{_id}}-nodata" class="ui5-list-nodata" tabindex="{{noDataTabIndex}}">
+			<li id="{{_id}}-nodata" class="ui5-list-nodata" tabindex="{{noDataTabIndex}}" style="list-style-type: none;">
 				<div id="{{_id}}-nodata-text" class="ui5-list-nodata-text">
 					{{noDataText}}
 				</div>

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -15,6 +15,7 @@
 	role="{{_accInfo.role}}"
 	aria-expanded="{{_accInfo.ariaExpanded}}"
 	aria-level="{{_accInfo.ariaLevel}}"
+	style="list-style-type: none;"
 >
 		{{> listItemPreContent}}
 

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -23,7 +23,7 @@
 						{{this.stripPresentation}}
 					{{/unless}}
 					{{#if this.isSeparator}}
-						<li id="{{this._id}}" role="separator" class="{{../classes.separator}}"></li>
+						<li id="{{this._id}}" role="separator" class="{{../classes.separator}}" style="list-style-type: none;"></li>
 					{{/if}}
 				{{/each}}
 			</ul>

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -10,6 +10,7 @@
 	?disabled="{{this.effectiveDisabled}}"
 	aria-labelledby="{{this.ariaLabelledBy}}"
 	data-ui5-stable="{{this.stableDomRef}}"
+	style="list-style-type: none;"
 >
 
 	{{#if this.icon}}

--- a/packages/main/src/TabSeparator.hbs
+++ b/packages/main/src/TabSeparator.hbs
@@ -1,1 +1,1 @@
-<li id="{{_id}}" role="separator"></li>
+<li id="{{_id}}" role="separator" style="list-style-type: none;"></li>

--- a/packages/main/src/Timeline.hbs
+++ b/packages/main/src/Timeline.hbs
@@ -1,7 +1,7 @@
 <div class="ui5-timeline-root">
 	<ul class="ui5-timeline-list" role="listbox" aria-live="polite" aria-label="{{ariaLabel}}">
 		{{#each items}}
-			<li class="ui5-timeline-list-item">
+			<li class="ui5-timeline-list-item" style="list-style-type: none;">
 				<slot name="{{this._individualSlot}}"></slot>
 			</li>
 		{{/each}}

--- a/packages/main/src/WheelSlider.hbs
+++ b/packages/main/src/WheelSlider.hbs
@@ -1,4 +1,4 @@
-<div 
+<div
 	id="{{this._id}}"
 	?disabled= "{{disabled}}"
 	value = "{{value}}"
@@ -25,12 +25,12 @@
 			{{#if _expanded}}
 				<ul id="{{this._id}}--items-list">
 					{{#each _itemsToShow}}
-						<li class="ui5-wheelslider-item" data-item-index="{{@index}}">{{this}}</li>
+						<li class="ui5-wheelslider-item" data-item-index="{{@index}}" style="list-style-type: none;">{{this}}</li>
 					{{/each}}
 				</ul>
 			{{else}}
 				<ul id="{{this._id}}--items-list">
-					<li class="ui5-wheelslider-item">{{value}}</li>
+					<li class="ui5-wheelslider-item" style="list-style-type: none;">{{value}}</li>
 				</ul>
 			{{/if}}
 		</div>


### PR DESCRIPTION
Despite having the right CSS style, for some reason it is not applied on IE until the component is repainted by the browser.

![image](https://user-images.githubusercontent.com/15844574/88542446-1a2de380-d01f-11ea-8e0f-286d8d45b6a6.png)

After the fix: 

![image](https://user-images.githubusercontent.com/15844574/88542467-2154f180-d01f-11ea-95f0-0c7149378570.png)

there are no dots already on the first load.