### PR TITLE
fix(ui5-combobox): Close popup on focusout

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -323,6 +323,7 @@ class ComboBox extends UI5Element {
 
 		this._filteredItems = [];
 		this._initialRendering = true;
+		this._itemFocused = false;
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 	}
 
@@ -356,6 +357,16 @@ class ComboBox extends UI5Element {
 			// Set initial focus to the native input
 			this.inner.focus();
 		}
+
+		if (this.shouldClosePopover()) {
+			this.responsivePopover.close(false, false, true);
+		}
+
+		this._itemFocused = false;
+	}
+
+	shouldClosePopover() {
+		return this.responsivePopover.opened && !this.focused && !this._itemFocused;
 	}
 
 	_focusin(event) {
@@ -506,6 +517,10 @@ class ComboBox extends UI5Element {
 		});
 
 		this._inputChange();
+	}
+
+	_onItemFocus(event) {
+		this._itemFocused = true;
 	}
 
 	get _headerTitleText() {

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -49,6 +49,7 @@
 	<ui5-list
 		separators="None"
 		@ui5-item-click={{_selectItem}}
+		@ui5-item-focused={{_onItemFocus}}
 		mode="SingleSelect"
 	>
 		{{#each _filteredItems}}


### PR DESCRIPTION
Now the popup closes on focusout, except the case when the focusout is due to focusin of the items

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2009