### PR TITLE
fix(ui5-file-uploader): Fix JS error thrown in IE

### DIFF
--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -250,7 +250,7 @@ class FileUploader extends UI5Element {
 
 	onAfterRendering() {
 		if (!this.value) {
-			this.getDomRef().querySelector(`input[type="file"]`).value = "";
+			this._input.value = "";
 		}
 	}
 


### PR DESCRIPTION
In IE, the native "input" element is not inside the ShadowDOM, but in the Light one, so the following statement fails to get it:
`this.getDomRef().querySelector(`input[type="file"]`)`. 
Instead, we should use the safe "_input" getter that looks in the Light DOM.

```js
get _input() {
	return this.shadowRoot.querySelector("input[type=file]")
            || this.querySelector("input[type=file][data-ui5-form-support]");
}
```

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2018