### PR TITLE
fix(ui5-messagestrip): Close button now has the correct design

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -22,6 +22,7 @@
 >
 	{{#if icon}}
 		<ui5-icon
+			style="{{styles.icon}}"
 			class="ui5-button-icon"
 			name="{{icon}}"
 			show-tooltip={{iconOnly}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -83,6 +83,19 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the size of the icon inside the <code>ui5-button</code>.
+		 *
+		 * @type {string}
+		 * @defaultvalue undefined
+		 * @public
+		 * @since 1.0.0-rc.8
+		 */
+		iconSize: {
+			type: String,
+			defaultValue: undefined,
+		},
+
+		/**
 		 * When set to <code>true</code>, the <code>ui5-button</code> will
 		 * automatically submit the nearest form element upon <code>press</code>.
 		 * <br><br>
@@ -381,6 +394,15 @@ class Button extends UI5Element {
 		}
 
 		return this.nonFocusable ? "-1" : this._tabIndex;
+	}
+
+	get styles() {
+		return {
+			icon: {
+				width: this.iconSize,
+				height: this.iconSize,
+			},
+		};
 	}
 
 	static async onDefine() {

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -1,4 +1,4 @@
-<div class="{{classes.main}}"
+<div class="{{classes.root}}"
 	id="{{_id}}"
 	role="alert"
 	dir="{{effectiveDir}}"
@@ -16,19 +16,15 @@
 	{{/unless}}
 
 	<span class="ui5-hidden-text">{{hiddenText}}</span>
-	<span class="{{classes.label}}"><slot></slot></span>
+	<span class="ui5-messagestrip-text"><slot></slot></span>
 
 	{{#unless noCloseButton}}
-		<button
-			class="ui5-messagestrip-close-icon-wrapper"
-			title="{{_closeButtonText}}"
-			@click={{_closeClick}}
-		>
-			<ui5-icon
-				class="ui5-messagestrip-close-icon"
-				name="decline"
-			>
-			</ui5-icon>
-		</button>
+		<ui5-button
+				icon="decline"
+				design="Transparent"
+				class="ui5-messagestrip-close-button"
+				title="{{_closeButtonText}}"
+				@click={{_closeClick}}
+		></ui5-button>
 	{{/unless}}
 </div>

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -21,6 +21,7 @@
 	{{#unless noCloseButton}}
 		<ui5-button
 				icon="decline"
+				icon-size=".75rem"
 				design="Transparent"
 				class="ui5-messagestrip-close-button"
 				title="{{_closeButtonText}}"

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { isEnter, isSpace } from "@ui5/webcomponents-base/src/Keys.js";
 import "@ui5/webcomponents-icons/dist/icons/decline.js";
 import "@ui5/webcomponents-icons/dist/icons/message-information.js";
 import "@ui5/webcomponents-icons/dist/icons/message-success.js";
@@ -10,6 +9,7 @@ import "@ui5/webcomponents-icons/dist/icons/message-warning.js";
 import MessageStripType from "./types/MessageStripType.js";
 import MessageStripTemplate from "./generated/templates/MessageStripTemplate.lit.js";
 import Icon from "./Icon.js";
+import Button from "./Button.js";
 import { MESSAGE_STRIP_CLOSE_BUTTON } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -153,7 +153,6 @@ class MessageStrip extends UI5Element {
 
 	constructor() {
 		super();
-
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 	}
 
@@ -161,34 +160,20 @@ class MessageStrip extends UI5Element {
 		this.fireEvent("close", {});
 	}
 
-	_closeKeyDown(event) {
-		if (isEnter(event)) {
-			this.fireEvent("close");
-		}
-
-		if (isSpace(event)) {
-			event.preventDefault();
-		}
-	}
-
-	_closeKeyUp(event) {
-		if (isSpace(event)) {
-			this.fireEvent("close");
-		}
-	}
-
 	static async onDefine() {
-		await fetchI18nBundle("@ui5/webcomponents");
-
-		await Icon.define();
+		await Promise.all([
+			fetchI18nBundle("@ui5/webcomponents"),
+			Icon.define(),
+			Button.define(),
+		]);
 	}
 
 	static typeClassesMappings() {
 		return {
-			"Information": "ui5-messagestrip--info",
-			"Positive": "ui5-messagestrip--positive",
-			"Negative": "ui5-messagestrip--negative",
-			"Warning": "ui5-messagestrip--warning",
+			"Information": "ui5-messagestrip-root--info",
+			"Positive": "ui5-messagestrip-root--positive",
+			"Negative": "ui5-messagestrip-root--negative",
+			"Warning": "ui5-messagestrip-root--warning",
 		};
 	}
 
@@ -211,14 +196,10 @@ class MessageStrip extends UI5Element {
 
 	get classes() {
 		return {
-			label: {
-				"ui5-messagestrip-text": true,
-				"ui5-messagestripNoCloseButton": this.noCloseButton,
-			},
-			main: {
+			root: {
 				"ui5-messagestrip-root": true,
-				"ui5-messagestrip-icon--hidden": this.noIcon,
-				"ui5-messagestrip-close-icon--hidden": this.noCloseButton,
+				"ui5-messagestrip-root-no-icon": this.noIcon,
+				"ui5-messagestrip-root-no-close-button": this.noCloseButton,
 				[this.typeClasses]: true,
 			},
 		};

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -64,10 +64,6 @@
 }
 
 .ui5-button-icon {
-	font-size: var(--_ui5_button_icon_font_size);
-	height: 0;
-	top: -.5rem;
-	position: relative;
 	color: inherit;
 	flex-shrink: 0;
 }
@@ -82,6 +78,7 @@
 
 :host([icon-only]) .ui5-button-root {
 	min-width: auto;
+	padding: 0;
 }
 
 :host([icon-only]) .ui5-button-text {

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -19,48 +19,48 @@
 }
 
 .ui5-messagestrip-root-no-icon {
-    padding: var(--_ui5_messagestrip_padding_no_icon);
+	padding: var(--_ui5_messagestrip_padding_no_icon);
 }
 
 .ui5-messagestrip-root-no-close-button {
-    padding-right: 1rem;
+	padding-right: 1rem;
 }
 
 .ui5-messagestrip-root--info {
-    background-color: var(--sapInformationBackground);
-    border-color: var(--sapInformationBorderColor);
-    color: var(--sapTextColor);
+	background-color: var(--sapInformationBackground);
+	border-color: var(--sapInformationBorderColor);
+	color: var(--sapTextColor);
 }
 
 .ui5-messagestrip-root--info .ui5-messagestrip-icon {
-    color: var(--sapInformativeElementColor);
+	color: var(--sapInformativeElementColor);
 }
 
 .ui5-messagestrip-root--positive {
-    background-color: var(--sapSuccessBackground);
-    border-color: var(--sapSuccessBorderColor);
+	background-color: var(--sapSuccessBackground);
+	border-color: var(--sapSuccessBorderColor);
 }
 
 .ui5-messagestrip-root--positive .ui5-messagestrip-icon {
-    color: var(--sapPositiveElementColor);
+	color: var(--sapPositiveElementColor);
 }
 
 .ui5-messagestrip-root--negative {
-    background-color: var(--sapErrorBackground);
-    border-color: var(--sapErrorBorderColor);
+	background-color: var(--sapErrorBackground);
+	border-color: var(--sapErrorBorderColor);
 }
 
 .ui5-messagestrip-root--negative .ui5-messagestrip-icon {
-    color: var(--sapNegativeElementColor);
+	color: var(--sapNegativeElementColor);
 }
 
 .ui5-messagestrip-root--warning {
-    background-color: var(--sapWarningBackground);
-    border-color: var(--sapWarningBorderColor);
+	background-color: var(--sapWarningBackground);
+	border-color: var(--sapWarningBorderColor);
 }
 
 .ui5-messagestrip-root--warning .ui5-messagestrip-icon {
-    color: var(--sapCriticalElementColor);
+	color: var(--sapCriticalElementColor);
 }
 
 /** Icon wrapper **/
@@ -76,17 +76,17 @@
 	width: 100%;
 	color: var(--sapTextColor);
 	line-height: 1.2;
-    font-family: var(--sapFontFamily);
-    font-size: var(--sapFontSize);
+	font-family: var(--sapFontFamily);
+	font-size: var(--sapFontSize);
 }
 
 /** Close button **/
 .ui5-messagestrip-close-button {
-    width: var(--_ui5_messagestrip_close_button_size);
-    height: var(--_ui5_messagestrip_close_button_size);
-    position: absolute;
-    right: 0.125rem;
-    top: 0.125rem;
+	width: var(--_ui5_messagestrip_close_button_size);
+	height: var(--_ui5_messagestrip_close_button_size);
+	position: absolute;
+	right: 0.125rem;
+	top: 0.125rem;
 }
 
 /* RTL */
@@ -96,13 +96,13 @@
 }
 
 [dir="rtl"] .ui5-messagestrip-root-no-icon {
-    padding-right: 1rem;
-    padding-left: 2rem;
+	padding-right: 1rem;
+	padding-left: 2rem;
 }
 
 [dir="rtl"] .ui5-messagestrip-root-no-close-button {
-    padding-left: 1rem;
-    padding-right: 0;
+	padding-left: 1rem;
+	padding-right: 0;
 }
 
 [dir="rtl"] .ui5-messagestrip-icon-wrapper {
@@ -111,6 +111,6 @@
 }
 
 [dir="rtl"] .ui5-messagestrip-close-button {
-    left: 0.125rem;
-    right: auto;
+	left: 0.125rem;
+	right: auto;
 }

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -83,10 +83,16 @@
 /** Close button **/
 .ui5-messagestrip-close-button {
 	width: var(--_ui5_messagestrip_close_button_size);
+	min-width: var(--_ui5_messagestrip_close_button_size);
 	height: var(--_ui5_messagestrip_close_button_size);
+	min-height: var(--_ui5_messagestrip_close_button_size);
 	position: absolute;
 	right: 0.125rem;
 	top: 0.125rem;
+	color: var(--sapTextColor);
+}
+.ui5-messagestrip-close-button[active] {
+	color: var(--sapButton_Active_TextColor);
 }
 
 /* RTL */

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -5,6 +5,7 @@
 	width: 100%;
 }
 
+/** Root classes **/
 .ui5-messagestrip-root {
 	width: 100%;
 	height: 100%;
@@ -14,124 +15,78 @@
 	border-width: var(--_ui5_messagestrip_border_width);
 	border-style: solid;
 	box-sizing: border-box;
-	padding: 0.4375rem 2rem 0.4375rem 2.5rem;
 	position: relative;
 }
 
-.ui5-messagestrip-root .ui5-messagestrip-icon-wrapper {
+.ui5-messagestrip-root-no-icon {
+    padding: var(--_ui5_messagestrip_padding_no_icon);
+}
+
+.ui5-messagestrip-root-no-close-button {
+    padding-right: 1rem;
+}
+
+.ui5-messagestrip-root--info {
+    background-color: var(--sapInformationBackground);
+    border-color: var(--sapInformationBorderColor);
+    color: var(--sapTextColor);
+}
+
+.ui5-messagestrip-root--info .ui5-messagestrip-icon {
+    color: var(--sapInformativeElementColor);
+}
+
+.ui5-messagestrip-root--positive {
+    background-color: var(--sapSuccessBackground);
+    border-color: var(--sapSuccessBorderColor);
+}
+
+.ui5-messagestrip-root--positive .ui5-messagestrip-icon {
+    color: var(--sapPositiveElementColor);
+}
+
+.ui5-messagestrip-root--negative {
+    background-color: var(--sapErrorBackground);
+    border-color: var(--sapErrorBorderColor);
+}
+
+.ui5-messagestrip-root--negative .ui5-messagestrip-icon {
+    color: var(--sapNegativeElementColor);
+}
+
+.ui5-messagestrip-root--warning {
+    background-color: var(--sapWarningBackground);
+    border-color: var(--sapWarningBorderColor);
+}
+
+.ui5-messagestrip-root--warning .ui5-messagestrip-icon {
+    color: var(--sapCriticalElementColor);
+}
+
+/** Icon wrapper **/
+.ui5-messagestrip-icon-wrapper {
 	position: absolute;
 	top: var(--_ui5_messagestrip_icon_top);
 	left: 0.75rem;
 	box-sizing: border-box;
 }
 
-.ui5-messagestrip-root .ui5-messagestrip-text {
+/** Text **/
+.ui5-messagestrip-text {
 	width: 100%;
 	color: var(--sapTextColor);
 	line-height: 1.2;
+    font-family: var(--sapFontFamily);
+    font-size: var(--sapFontSize);
 }
 
-.ui5-messagestrip-icon--hidden {
-	padding: 0.4375rem 2rem 0.4375rem 1rem;
-}
-
-.ui5-messagestrip-close-icon--hidden {
-	padding-right: 1rem;
-}
-
-.ui5-messagestrip-text {
-	font-family: var(--sapFontFamily);
-	font-size: var(--sapFontSize);
-}
-
-.ui5-messagestrip--info {
-	background-color: var(--sapInformationBackground);
-	border-color: var(--sapInformationBorderColor);
-	color: var(--sapTextColor);
-}
-
-.ui5-messagestrip--info .ui5-messagestrip-icon {
-	color: var(--sapInformativeElementColor);
-}
-
-.ui5-messagestrip--positive {
-	background-color: var(--sapSuccessBackground);
-	border-color: var(--sapSuccessBorderColor);
-}
-
-.ui5-messagestrip--positive .ui5-messagestrip-icon {
-	color: var(--sapPositiveElementColor);
-}
-
-.ui5-messagestrip--negative {
-	background-color: var(--sapErrorBackground);
-	border-color: var(--sapErrorBorderColor);
-}
-
-.ui5-messagestrip--negative .ui5-messagestrip-icon {
-	color: var(--sapNegativeElementColor);
-}
-
-.ui5-messagestrip--warning {
-	background-color: var(--sapWarningBackground);
-	border-color: var(--sapWarningBorderColor);
-}
-
-.ui5-messagestrip--warning .ui5-messagestrip-icon {
-	color: var(--sapCriticalElementColor);
-}
-
-.ui5-messagestrip-close-icon-wrapper {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: var(--_ui5_messagestrip_close_button_size);
-	height: var(--_ui5_messagestrip_close_button_size);
-	border-radius: 0.25rem;
-	background: transparent;
-	color: var(--sapTextColor);
-	cursor: pointer;
-	position: absolute;
-	right: 0.125rem;
-	top: 0.125rem;
-	outline: none;
-	border: var(--_ui5_messagestrip_close_button_border);
-	-webkit-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-.ui5-messagestrip-close-icon-wrapper:hover {
-	background-color: var(--sapButton_Lite_Hover_Background);
-}
-
-.ui5-messagestrip-close-icon-wrapper:active {
-	background-color: var(--sapButton_Active_Background);
-	color: var(--sapButton_Active_TextColor);
-}
-
-.ui5-messagestrip-close-icon {
-	width: 0.75rem;
-	height: 0.75rem;
-	pointer-events: none;
-}
-
-.ui5-messagestrip-close-icon-wrapper:active .ui5-messagestrip-close-icon {
-	color: currentColor;
-}
-
-.ui5-messagestrip-close-icon-wrapper:focus {
-	outline-offset: var(--_ui5_messagestrip_focus_offset);
-	outline: var(--_ui5_messagestrip_focus_width) dotted var(--sapContent_FocusColor);
-}
-
-.ui5-messagestrip-close-icon-wrapper:active:focus {
-	outline: var(--_ui5_messagestrip_focus_width) dotted var(--sapContent_ContrastFocusColor);
-}
-
-/* FF renders outine around element content, causing double outline - around the button and the icon */
-.ui5-messagestrip-close-icon-wrapper::-moz-focus-inner {
-	border: none;
+/** Close button **/
+.ui5-messagestrip-close-button {
+    width: var(--_ui5_messagestrip_close_button_size);
+    height: var(--_ui5_messagestrip_close_button_size);
+    position: absolute;
+    right: 0.125rem;
+    top: 0.125rem;
 }
 
 /* RTL */
@@ -140,22 +95,22 @@
 	padding-left: 2rem;
 }
 
+[dir="rtl"] .ui5-messagestrip-root-no-icon {
+    padding-right: 1rem;
+    padding-left: 2rem;
+}
+
+[dir="rtl"] .ui5-messagestrip-root-no-close-button {
+    padding-left: 1rem;
+    padding-right: 0;
+}
+
 [dir="rtl"] .ui5-messagestrip-icon-wrapper {
 	right: 0.75rem;
 	left: 0;
 }
 
-[dir="rtl"] .ui5-messagestrip-icon--hidden {
-	padding-right: 1rem;
-	padding-left: 2rem;
-}
-
-[dir="rtl"] .ui5-messagestrip-close-icon--hidden {
-	padding-left: 1rem;
-	padding-right: 0;
-}
-
-[dir="rtl"] .ui5-messagestrip-close-icon-wrapper {
-	left: 0.125rem;
-	right: auto;
+[dir="rtl"] .ui5-messagestrip-close-button {
+    left: 0.125rem;
+    right: auto;
 }

--- a/packages/main/src/themes/base/MessageStrip-parameters.css
+++ b/packages/main/src/themes/base/MessageStrip-parameters.css
@@ -5,7 +5,8 @@
 	--_ui5_messagestrip_button_border_style: none;
 	--_ui5_messagestrip_button_border_color: transparent;
 	--_ui5_messagestrip_button_border_radius: 0;
-	--_ui5_messagestrip_padding: 0.125rem .125rem;
+	--_ui5_messagestrip_padding: 0.4375rem 2.5rem 0.4375rem 2.5rem;
+    --_ui5_messagestrip_padding_no_icon: 0.4375rem 2.5rem 0.4375rem 1rem;
 	--_ui5_messagestrip_button_height: 1.625rem;
 	--_ui5_messagestrip_border_width: 1px;
 	--_ui5_messagestrip_close_button_border: none;

--- a/packages/main/src/themes/base/MessageStrip-parameters.css
+++ b/packages/main/src/themes/base/MessageStrip-parameters.css
@@ -6,7 +6,7 @@
 	--_ui5_messagestrip_button_border_color: transparent;
 	--_ui5_messagestrip_button_border_radius: 0;
 	--_ui5_messagestrip_padding: 0.4375rem 2.5rem 0.4375rem 2.5rem;
-    --_ui5_messagestrip_padding_no_icon: 0.4375rem 2.5rem 0.4375rem 1rem;
+	--_ui5_messagestrip_padding_no_icon: 0.4375rem 2.5rem 0.4375rem 1rem;
 	--_ui5_messagestrip_button_height: 1.625rem;
 	--_ui5_messagestrip_border_width: 1px;
 	--_ui5_messagestrip_close_button_border: none;

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -5,7 +5,7 @@ describe("MessageStrip general interaction", () => {
 
 	it("tests close event", () => {
 
-		const closeButton = browser.$("#messageStrip").shadow$(".ui5-messagestrip-close-icon-wrapper");
+		const closeButton = browser.$("#messageStrip").shadow$(".ui5-messagestrip-close-button");
 		const input = browser.$("#inputField");
 
 		closeButton.click();


### PR DESCRIPTION
Changes to `ui5-button` to support this change:
 - new property `iconSize` added, allowing the user control not only over the button size, but over the icon size as well
 - padding removed for `iconOnly` mode, icon is now centered

Buttons like this are now possible:
![image](https://user-images.githubusercontent.com/15844574/88807212-1d110b80-d1ba-11ea-8abb-9f9c11010cc0.png)
with the following markup:
![image](https://user-images.githubusercontent.com/15844574/88807338-46ca3280-d1ba-11ea-89b1-343e803e892d.png)


`ui5-messagestrip` was refactored:
 - `ui5-button` used to achieve the desired design and behavior for the close button (kb handling, hover, focus, etc..)
 - CSS simplified (same rules merged, duplicate selectors removed, redundant CSS removed after the close icon removal, etc...)
 - CSS classes renamed and reordered
 - keyboard handling logic and all code that simulates `ui5-button` behavior deleted
 - `onDefine` now awaits all resources simultaneously

The close button looks like:
![image](https://user-images.githubusercontent.com/15844574/88807645-a7f20600-d1ba-11ea-80ad-f55ba4803783.png)

closes: https://github.com/SAP/ui5-webcomponents/issues/1989