### PR TITLE
fix(ui5-select): Selection now changes instantly

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -471,6 +471,10 @@ class List extends UI5Element {
 		return this.handleSingleSelect(item);
 	}
 
+	handleSingleSelectAuto(item) {
+		return this.handleSingleSelect(item);
+	}
+
 	handleMultiSelect(item, selected) {
 		item.selected = selected;
 		return true;
@@ -595,6 +599,17 @@ class List extends UI5Element {
 
 		this._itemNavigation.update(target);
 		this.fireEvent("item-focused", { item: target });
+
+		if (this.mode === ListMode.SingleSelectAuto) {
+			this.onSelectionRequested({
+				detail: {
+					item: target,
+					selectionComponentPressed: false,
+					selected: true,
+					key: event.detail.key,
+				},
+			});
+		}
 	}
 
 	onItemPress(event) {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -360,11 +360,24 @@ class Select extends UI5Element {
 		this.options[index].selected = true;
 	}
 
-	_selectionChange(event) {
+	/**
+	 * The user clicked on an item from the list
+	 * @private
+	 */
+	_handleItemPress(event) {
 		const selectedItemIndex = this._getSelectedItemIndex(event.detail.item);
-
 		this._select(selectedItemIndex);
 		this._toggleRespPopover();
+	}
+
+	/**
+	 * The user used arrow up/down on the list
+	 * @private
+	 */
+	_handleSelectionChange(event) {
+		const item = event.detail.selectedItems[0];
+		const selectedItemIndex = this._getSelectedItemIndex(item);
+		this._select(selectedItemIndex);
 	}
 
 	_applyFocusAfterOpen() {
@@ -379,7 +392,13 @@ class Select extends UI5Element {
 	}
 
 	_handlePickerKeydown(event) {
-		this._handleArrowNavigation(event, false);
+		if (isEscape(event) && this._isPickerOpen) {
+			this._escapePressed = true;
+		}
+
+		if (isEnter(event) || isSpace(event)) {
+			this._shouldClosePopover = true;
+		}
 	}
 
 	_handleArrowNavigation(event, shouldFireEvent) {
@@ -402,14 +421,6 @@ class Select extends UI5Element {
 			if (shouldFireEvent) {
 				this._fireChangeEvent(this.options[nextIndex]);
 			}
-		}
-
-		if (isEscape(event) && this._isPickerOpen) {
-			this._escapePressed = true;
-		}
-
-		if (isEnter(event) || isSpace(event)) {
-			this._shouldClosePopover = true;
 		}
 	}
 

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -365,8 +365,10 @@ class Select extends UI5Element {
 	 * @private
 	 */
 	_handleItemPress(event) {
-		const selectedItemIndex = this._getSelectedItemIndex(event.detail.item);
+		const item = event.detail.item;
+		const selectedItemIndex = this._getSelectedItemIndex(item);
 		this._select(selectedItemIndex);
+
 		this._toggleRespPopover();
 	}
 

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -23,7 +23,7 @@
 			</div>
 		</div>
 
-		<ui5-list mode="SingleSelect" separators="None" @keydown="{{_handlePickerKeydown}}" @ui5-item-press="{{_selectionChange}}">
+		<ui5-list mode="SingleSelectAuto" separators="None" @keydown="{{_handlePickerKeydown}}" @ui5-selection-change="{{_handleSelectionChange}}" @ui5-item-press="{{_handleItemPress}}">
 			{{#each _syncedOptions}}
 				<ui5-li ?selected="{{this.selected}}" icon="{{this.icon}}" id="{{this.id}}-li">
 					{{this.textContent}}

--- a/packages/main/src/types/ListMode.js
+++ b/packages/main/src/types/ListMode.js
@@ -35,6 +35,14 @@ const ListModes = {
 	SingleSelectEnd: "SingleSelectEnd",
 
 	/**
+	 * Selected item is highlighted and selection is changed upon arrow navigation
+	 * (only one list item can be selected - this is always the focused item).
+	 * @public
+	 * @type {SingleSelectAuto}
+	 */
+	SingleSelectAuto: "SingleSelectAuto",
+
+	/**
 	 * Multi selection mode (more than one list item can be selected).
 	 * @public
 	 * @type {MultiSelect}


### PR DESCRIPTION
In order for the selection to be smooth, the focus/selection handling should be done internally by the list. Otherwise the select will always be one step behind and the focus will always lag behind the selected item.

Changes:
 - The list gets a new mode: `SingleSelectAuto` that changes the selection when the user presses the arrows. So in fact the focused item is always selected (automatically, hence the name).
 - The select uses the new list mode and handles selection change and item click. The only difference is that on selection change the popup is not closed and on item click it is.
 - The keyboard handling code that used to be in one function for both modes (when popup closed, when popup open) is now naturally split in 2 parts: when the popup is open, handle only esc/enter, as the list already handles everything else internally, and when the popup is closed, handle only arrow up/arrow down.

closes: https://github.com/SAP/ui5-webcomponents/issues/1992