### PR TITLE
fix(ui5-flexible-column-layout): Fix arrow misplacement in IE

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -1,4 +1,4 @@
-<div class="ui5-fcl-root">
+<div class="{{classes.root}}">
 	<div
 		role="region"
 		class="{{classes.columns.start}}"

--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -6,6 +6,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
+import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-left.js";
 import "@ui5/webcomponents-icons/dist/icons/slim-arrow-right.js";
@@ -490,6 +491,10 @@ class FlexibleColumnLayout extends UI5Element {
 		const hasAnimation = getAnimationMode() !== AnimationMode.None;
 
 		return {
+			root: {
+				"ui5-fcl-root": true,
+				"ui5-fcl--ie": isIE(),
+			},
 			columns: {
 				start: {
 					"ui5-fcl-column": true,

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -100,3 +100,12 @@
 .ui5-fcl-arrow:hover:after {
 	height: 7rem;
 }
+
+/*
+ * IE FIX:
+ * The collumn separator, that is also the arrow container, is 1rem,
+ * whereas the arrow button is 1.5rem and the arrows just doesnt center within the 
+*/
+.ui5-fcl--ie .ui5-fcl-arrow {
+	margin: 0 -0.75rem;
+}

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -103,7 +103,7 @@
 
 /*
  * IE FIX:
- * The collumn separator, that is also the arrow container, is 1rem,
+ * The column separator, that is also the arrow container, is 1rem,
  * whereas the arrow button is 1.5rem and the arrows just doesnt center within the 
 */
 .ui5-fcl--ie .ui5-fcl-arrow {


### PR DESCRIPTION
**Note:** The Icon inside Button cantering change should be merged first: https://github.com/SAP/ui5-webcomponents/pull/2029

Fixes: https://github.com/SAP/ui5-webcomponents/issues/1998