### PR TITLE
chore(ui5-side-navigation): subitems may have icons, appenddocs fixed

### DIFF
--- a/packages/fiori/src/SideNavigation.hbs
+++ b/packages/fiori/src/SideNavigation.hbs
@@ -23,6 +23,7 @@
 							<ui5-tree-item
 								.associatedItem="{{this}}"
 								text="{{this.text}}"
+								icon="{{this.icon}}"
 								?selected="{{this.selected}}"
 							>
 							</ui5-tree-item>

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -104,8 +104,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-side-navigation
  * @since 1.0.0-rc.8
- * @appenddocs SideNavigationItem
- * @appenddocs SideNavigationSubItem
+ * @appenddocs SideNavigationItem SideNavigationSubItem
  * @public
  */
 class SideNavigation extends UI5Element {

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -83,12 +83,17 @@ const metadata = {
  *
  * <h3 class="comment-api-title">Overview</h3>
  *
- *
+ * The <code>SideNavigation</code> is used as a standard menu in applications.
+ * It consists of two containers: the main navigation section (top-aligned) and the secondary section (bottom-aligned).
+ * Usually the main navigation section is related to the user’s current work context,
+ * whereas the secondary section is mostly used to link additional information that may be of interest (legal information, developer communities, external help, contact information and so on).
+
  * <h3>Usage</h3>
+ * 
+ * Use the available <code>ui5-side-navigation-item</code> and <code>ui5-side-navigation-sub-item</code> components to build your menu.
+ * The items can consist of text only or an icon with text. The use or non-use of icons must be consistent for all items on one level.
+ * You must not combine entries with and without icons on the same level. We strongly recommend that you do not use icons on the second level.
  *
- * <code>ui5-side-navigation</code> is used as a standard menu in applications. In order to add menu items use <code>ui5-side-navigation-items</code>.
- *
- * For the <code>ui5-side-navigation</code>
  * <h3>ES6 Module Import</h3>
  *
  * <code>import @ui5/webcomponents/dist/SideNavigation.js";</code>
@@ -100,6 +105,7 @@ const metadata = {
  * @tagname ui5-side-navigation
  * @since 1.0.0-rc.8
  * @appenddocs SideNavigationItem
+ * @appenddocs SideNavigationSubItem
  * @public
  */
 class SideNavigation extends UI5Element {

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -89,7 +89,7 @@ const metadata = {
  * whereas the secondary section is mostly used to link additional information that may be of interest (legal information, developer communities, external help, contact information and so on).
 
  * <h3>Usage</h3>
- * 
+ *
  * Use the available <code>ui5-side-navigation-item</code> and <code>ui5-side-navigation-sub-item</code> components to build your menu.
  * The items can consist of text only or an icon with text. The use or non-use of icons must be consistent for all items on one level.
  * You must not combine entries with and without icons on the same level. We strongly recommend that you do not use icons on the second level.

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -20,7 +20,11 @@ const metadata = {
 
 		/**
 		 * Defines the icon of the item.
+		 * <br><br>
 		 *
+		 * The SAP-icons font provides numerous options.
+		 * <br>
+		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 * @public
 		 * @type {string}
 		 * @defaultvalue ""
@@ -72,11 +76,9 @@ const metadata = {
  *
  * <h3 class="comment-api-title">Overview</h3>
  *
+ * The <code>ui5-side-navigation-item</code> is used within <code>ui5-side-navigation</code> only.
+ * Via the <code>ui5-side-navigation-item</code> you control the content of the <code>SideNavigation</code>.
  *
- * <h3>Usage</h3>
- *
- * <code>ui5-side-navigation-item</code> is used within <code>ui5-side-navigation</code> only. Via the <code>ui5-side-navigation-item</code> you control the content of the side navigation.
- * For the <code>ui5-side-navigation-item</code>
  * <h3>ES6 Module Import</h3>
  *
  * <code>import @ui5/webcomponents-fiori/dist/SideNavigationItem.js";</code>

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -18,7 +18,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines whether the subitem is selected
+		 * Defines whether the subitem is selected.
 		 *
 		 * @public
 		 * @type {boolean}
@@ -26,6 +26,21 @@ const metadata = {
 		 */
 		selected: {
 			type: Boolean,
+		},
+
+		/**
+		 * Defines the icon of the item.
+		 * <br><br>
+		 *
+		 * The SAP-icons font provides numerous options.
+		 * <br>
+		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
+		 * @public
+		 * @type {string}
+		 * @defaultvalue ""
+		 */
+		icon: {
+			type: String,
 		},
 	},
 };
@@ -35,12 +50,8 @@ const metadata = {
  *
  * <h3 class="comment-api-title">Overview</h3>
  *
- *
- * <h3>Usage</h3>
- *
  * The <code>ui5-side-navigation-sub-item</code> is intended to be used inside a <code>ui5-side-navigation-item</code> only.
  *
- * For the <code>ui5-side-navigation-sub-item</code>
  * <h3>ES6 Module Import</h3>
  *
  * <code>import @ui5/webcomponents-fiori/dist/SideNavigationSubItem.js";</code>

--- a/packages/fiori/test/samples/SideNavigation.sample.html
+++ b/packages/fiori/test/samples/SideNavigation.sample.html
@@ -20,8 +20,8 @@
 		<ui5-side-navigation>
 			<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
 			<ui5-side-navigation-item text="People" expanded icon="group">
-				<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
-				<ui5-side-navigation-sub-item text="From Other Teams" icon="employee-rejections"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 			</ui5-side-navigation-item>
 			<ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
 			<ui5-side-navigation-item text="Events" icon="calendar">
@@ -52,8 +52,8 @@ show-co-pilot
 <ui5-side-navigation>
 	<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
 	<ui5-side-navigation-item text="People" expanded icon="group">
-		<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
-		<ui5-side-navigation-sub-item text="From Other Teams" icon="employee-rejections"></ui5-side-navigation-sub-item>
+		<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
+		<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 	</ui5-side-navigation-item>
 	<ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
 	<ui5-side-navigation-item text="Events" icon="calendar">


### PR DESCRIPTION
Now we support icon on the subitem, but strongly recommend not to to be used as this by the Fiori 3 guidelines. The icons on the second level are removed from the sample. The JSDOC has been improved.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2033