### PR TITLE
fix(ui5-tabcontainer): Fix ARIA posinset and setsize values

### DIFF
--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -266,11 +266,11 @@ class TabContainer extends UI5Element {
 
 	onBeforeRendering() {
 		// Set external properties to items
-		this.items.forEach((item, index) => {
+		this.items.filter(item => !item.isSeparator).forEach((item, index, arr) => {
 			item._isInline = this.tabLayout === TabLayout.Inline;
 			item._mixedMode = this.mixedMode;
 			item._posinset = index + 1;
-			item._setsize = this.items.length;
+			item._setsize = arr.length;
 			item._getTabContainerHeaderItemCallback = _ => {
 				return this.getDomRef().querySelector(`#${item._id}`);
 			};

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -109,4 +109,15 @@ describe("TabContainer general interaction", () => {
 		assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
 		assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
 	});
+
+	it("tests aria attrs", () => {
+		const tabContainer = browser.$("#tabContainer1");
+		const tab4 = tabContainer.shadow$(".ui5-tab-strip-item:nth-child(4)");
+
+		// assert: The TabContainer has 8 children, 7 tabs and 1 separator (at position 2)
+		// and the separator should be skipped in terms of aria-posinset and aria-setsize,
+		// so for child number 4 ("Monitors") we expect the following attributes aria-posinset="3" and aria-setsize="7".
+		assert.strictEqual(tab4.getAttribute("aria-posinset"), "3", "The aria-posinset is correct.");
+		assert.strictEqual(tab4.getAttribute("aria-setsize"), "7", "The aria-setsize is correct.");
+	});
 });


### PR DESCRIPTION
The separator should be excluded, when calculating the aria-posinset and aria-setsize values.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2035