### PR TITLE
feat(ui5-li): Add "image" slot

### DIFF
--- a/packages/main/src/StandardListItem.hbs
+++ b/packages/main/src/StandardListItem.hbs
@@ -19,7 +19,7 @@
 
 {{#*inline "imageBegin"}}
 	{{#if displayImage}}
-		<img part="img" src="{{image}}" class="ui5-li-img">
+		<div class="ui5-li-img"><slot name="image"></slot></div>
 	{{/if}}
 {{/inline}}
 

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -8,6 +8,7 @@ import StandardListItemTemplate from "./generated/templates/StandardListItemTemp
  */
 const metadata = {
 	tag: "ui5-li",
+	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.main.StandardListItem.prototype */ {
 
 		/**
@@ -46,18 +47,6 @@ const metadata = {
 		 */
 		iconEnd: {
 			type: Boolean,
-		},
-
-		/**
-		 * Defines the <code>image</code> source URI.
-		 * <br><br>
-		 * <b>Note:</b> The <code>image</code> would be displayed in the beginning of the list item.
-		 *
-		 * @type {string}
-		 * @public
-		 */
-		image: {
-			type: String,
 		},
 
 		/**
@@ -106,6 +95,20 @@ const metadata = {
 		"default": {
 			type: Node,
 		},
+
+		/**
+		 * Defines the image of the <code>ui5-li</code>.
+		 * <br><br>
+		 * <b>Note:</b> The element would be restricted in height and width, because of UX reasons.
+		 *
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @public
+		 * @since 1.0.0-rc.9
+		 */
+		image: {
+			type: HTMLElement,
+		},
 	},
 };
 
@@ -139,7 +142,7 @@ class StandardListItem extends ListItem {
 	}
 
 	get displayImage() {
-		return !!this.image;
+		return !!this.image.length;
 	}
 
 	get displayIconBegin() {

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -101,11 +101,12 @@
 }
 
 .ui5-li-img {
-	width: var(--_ui5_list_item_img_size);
-	min-width: var(--_ui5_list_item_img_size);
-	height: var(--_ui5_list_item_img_size);
-	min-height: var(--_ui5_list_item_img_size);
 	margin: var(--_ui5_list_item_img_margin);
+}
+
+::slotted([slot="image"]) {
+	max-height: var(--_ui5_list_item_img_size);
+	max-width: var(--_ui5_list_item_img_size);
 }
 
 .ui5-li-icon {

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -19,19 +19,46 @@
 	<label style="font-size:2rem;">new items loaded:</label><label id="result" style="font-size:2rem;"> 0 times: 0</label>
 	<ui5-list id="infiniteScrollEx" style="height: 300px" infinite-scroll>
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" info="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Available">
+			<ui5-avatar shape="Square" image="./img/HT-1000.jpg" slot="image"></ui5-avatar>
+			Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">
+			<img src="./img/HT-1000.jpg" slot="image" />
+			Laptop Lenovo
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Information">
+			<ui5-avatar shape="Square" image="./img/HT-1022.jpg" slot="image"></ui5-avatar>
+			IPhone 3
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Available" info-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" info="Reuqired" info-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">
+			<ui5-avatar shape="Square" image="./img/HT-1030.jpg" slot="image"></ui5-avatar>
+			HP Monitor 24
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  info="Available" info-state="Success">
+			<ui5-avatar shape="Square" image="./img/HT-2026.jpg" slot="image"></ui5-avatar>
+			Audio cabel
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" info="Reuqired" info-state="Warning">
+			<ui5-avatar shape="Square" image="./img/HT-2002.jpg" slot="image"></ui5-avatar>
+			DVD set
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">
+			<ui5-avatar shape="Square" image="./img/HT-1030.jpg" slot="image"></ui5-avatar>
+			HP Monitor 24
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">
+			<ui5-avatar shape="Square" image="./img/HT-2026.jpg" slot="image"></ui5-avatar>
+			Audio cabel
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">
+			<ui5-avatar shape="Square" image="./img/HT-2002.jpg" slot="image"></ui5-avatar>
+			DVD set
+		</ui5-li>
 	</ui5-list>
 
 
@@ -39,45 +66,80 @@
 
 	<ui5-list header-text="API: GroupHeaderListItem" mode="MultiSelect">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" info="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Error">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Available">
+			<ui5-avatar shape="Square" image="./img/HT-1010.jpg" slot="image"></ui5-avatar>
+			Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Re-stock" description="#12331232131" info-state="Error">
+			<ui5-avatar shape="Square" image="./img/HT-1010.jpg" slot="image"></ui5-avatar>
+			Laptop Lenovo
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" info="Re-stock" description="#12331232131"  info-state="Error">
+			<ui5-avatar shape="Square" image="./img/HT-1022.jpg" slot="image"></ui5-avatar>
+			IPhone 3
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Available" info-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" info="Reuqired" info-state="Warning">DVD set</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">
+			<ui5-avatar shape="Square" image="./img/HT-1030.jpg" slot="image"></ui5-avatar>
+			HP Monitor 24
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  info="Available" info-state="Success">
+			<ui5-avatar shape="Square" image="./img/HT-2026.jpg" slot="image"></ui5-avatar>
+			Audio cabel
+		</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow" info="Reuqired" info-state="Warning">
+			<ui5-avatar shape="Square" image="./img/HT-2002.jpg" slot="image"></ui5-avatar>
+			DVD set
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow">
+			<ui5-avatar shape="Square" image="./img/HT-1030.jpg" slot="image"></ui5-avatar>
+			HP Monitor 24
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" >
+			<ui5-avatar shape="Square" image="./img/HT-2026.jpg" slot="image"></ui5-avatar>
+			Audio cabel
+		</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow">
+			<ui5-avatar shape="Square" image="./img/HT-2002.jpg" slot="image"></ui5-avatar>
+			DVD set
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
 
 	<ui5-list header-text="API: icon">
-		<ui5-li  icon="navigation-right-arrow">Option 1</ui5-li>
-		<ui5-li  icon="navigation-right-arrow">Option 2</ui5-li>
-		<ui5-li  icon="navigation-right-arrow">Option 3</ui5-li>
-		<ui5-li  icon-end icon="navigation-right-arrow">Option 1</ui5-li>
-		<ui5-li  icon-end icon="navigation-right-arrow">Option 2</ui5-li>
-		<ui5-li  icon-end icon="navigation-right-arrow">Option 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Option 1</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Option 2</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Option 3</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow">Option 1</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow">Option 2</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow">Option 3</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
 
 	<ui5-list header-text="API: image">
-		<ui5-li image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
+		<ui5-li>
+			<ui5-avatar shape="Square" image="./img/HT-1000.jpg" slot="image"></ui5-avatar>
+			Laptop HP
+		</ui5-li>
+		<ui5-li>
+			<ui5-avatar shape="Square" image="./img/HT-1010.jpg" slot="image"></ui5-avatar>
+			laptop Lenovо
+		</ui5-li>
+		<ui5-li>
+			<ui5-avatar shape="Square" image="./img/HT-1022.jpg" slot="image"></ui5-avatar>
+			IPhone 3
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
 
 	<ui5-list header-text="API: ListItem type='Active/Inactive/Detail'" mode="SingleSelect">
-		<ui5-li >Active item - press</ui5-li>
-		<ui5-li >Active item - press</ui5-li>
+		<ui5-li>Active item - press</ui5-li>
+		<ui5-li>Active item - press</ui5-li>
 		<ui5-li selected type="Inactive">Inactive item</ui5-li>
 		<ui5-li type="Inactive">Inactive item</ui5-li>
 		<ui5-li type="Detail">Detail item</ui5-li>
@@ -155,9 +217,18 @@
 	<br/><br/>
 
 	<ui5-list header-text="API: ListItem selected">
-		<ui5-li selected="selected" image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
+		<ui5-li selected>
+			<ui5-avatar shape="Square" image="./img/HT-1000.jpg" slot="image"></ui5-avatar>
+			Laptop HP
+		</ui5-li>
+		<ui5-li>
+			<ui5-avatar shape="Square" image="./img/HT-1010.jpg" slot="image"></ui5-avatar>
+			laptop Lenovо
+		</ui5-li>
+		<ui5-li>
+			<ui5-avatar shape="Square" image="./img/HT-1022.jpg" slot="image"></ui5-avatar>
+			IPhone 3
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>

--- a/packages/main/test/samples/List.sample.html
+++ b/packages/main/test/samples/List.sample.html
@@ -177,37 +177,91 @@
 	<div class="snippet">
 		<ui5-list header-text="Community" mode="MultiSelect">
 			<ui5-li-groupheader>Front End Developers</ui5-li-groupheader>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Jennifer</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_4.png" icon="navigation-right-arrow" icon-end>Lora</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_5.png" icon="navigation-right-arrow" icon-end>Carlotta</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				Jennifer
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_3.png" slot="image"></ui5-avatar>
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				Lora
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_4.png" slot="image"></ui5-avatar>
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				Carlotta
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_5.png" slot="image"></ui5-avatar>
+			</ui5-li>
 
 			<ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
-			<ui5-li image="../../../assets/images/avatars/man_avatar_1.png"  icon="navigation-right-arrow" icon-end>Clark</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" icon="navigation-right-arrow" icon-end>Ellen</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" icon="navigation-right-arrow" icon-end>Adam</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				Clark
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_1.png" slot="image"></ui5-avatar>
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				Ellen
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_1.png" slot="image"></ui5-avatar>
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_2.png" slot="image"></ui5-avatar>
+				Adam
+			</ui5-li>
 
 			<ui5-li-groupheader>FullStack Developers</ui5-li-groupheader>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" icon="navigation-right-arrow" icon-end>Susan</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" icon="navigation-right-arrow" icon-end>David</ui5-li>
-			<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Natalie</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_2.png" slot="image"></ui5-avatar>
+				Susan
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_3.png" slot="image"></ui5-avatar>
+				David
+			</ui5-li>
+			<ui5-li icon="navigation-right-arrow" icon-end>
+				<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_3.png" slot="image"></ui5-avatar>
+				Natalie
+			</ui5-li>
 		</ui5-list>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-list header-text="Team Members" mode="MultiSelect">
 	<ui5-li-groupheader>Front End Developers</ui5-li-groupheader>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Jennifer</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_4.png" icon="navigation-right-arrow" icon-end>Lora</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_5.png" icon="navigation-right-arrow" icon-end>Carlotta</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_3.png" slot="image"></ui5-avatar>
+		Jennifer
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_4.png" slot="image"></ui5-avatar>
+		Lora
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_5.png" slot="image"></ui5-avatar>
+		Carlotta
+	</ui5-li>
 
 	<ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
-	<ui5-li image="../../../assets/images/avatars/man_avatar_1.png"  icon="navigation-right-arrow" icon-end>Clark</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" icon="navigation-right-arrow" icon-end>Ellen</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" icon="navigation-right-arrow" icon-end>Adam</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		Clark
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_1.png" slot="image"></ui5-avatar>
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		Ellen
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_1.png" slot="image"></ui5-avatar>
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_2.png" slot="image"></ui5-avatar>
+		Adam
+	</ui5-li>
 
 	<ui5-li-groupheader>FullStack Developers</ui5-li-groupheader>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" icon="navigation-right-arrow" icon-end>Susan</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" icon="navigation-right-arrow" icon-end>David</ui5-li>
-	<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Natalie</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_2.png" slot="image"></ui5-avatar>
+		Susan
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/man_avatar_3.png" slot="image"></ui5-avatar>
+		David
+	</ui5-li>
+	<ui5-li icon="navigation-right-arrow" icon-end>
+		<ui5-avatar shape="Square" image="../../../assets/images/avatars/woman_avatar_3.png" slot="image"></ui5-avatar>
+		Natalie
+	</ui5-li>
 </ui5-list>
 	</xmp></pre>
 </section>


### PR DESCRIPTION
Add new slot to enable users control the display of the image, to stretch or scale. We always render the image as square and portrait oriented images do not look ok. Now, the user can use the ui5-avatar and make use of  the property "image-fit-type"=Cover or Contain and the shape="Square|Circle", or use own `img` tag.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2045

BREAKING CHANGE: The "image" property is removed, use the "image" slot instead

```html
<ui5-li icon="navigation-right-arrow" icon-end>
   Jennifer
   <ui5-avatar image-fit-type="Contain" image="../../../assets/images/avatars/woman_avatar_3.png" slot="image"></ui5-avatar>
</ui5-li>
```
<img width="128" alt="Screenshot 2020-07-31 at 4 07 05 PM" src="https://user-images.githubusercontent.com/15702139/89037826-e5d06500-d347-11ea-8d8b-ea2ee975ce32.png">

