### PR TITLE
docs: mention UI5 Web Components for React

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ UI5 Web Components support different calendar types (Gregorian, Islamic, Japanes
 </script>
 ```
 
+## Related Projects
+
+### UI5 Web Components for React
+
+[UI5 Web Components for React](https://github.com/SAP/ui5-webcomponents-react) is a wrapper implementation around 
+UI5 Web Components which makes using them in React even more comfortable. The current version of React (`react 16`) has some
+shortcomings when it comes to handling Custom Elements, namly the binding of `boolean` attributes as well as adding event listeners to custom event names like `selection-change`. With the help of UI5 Web Components for React, you can use the UI5 Web Components in React as if they were native React components. In addition to that, this library is also offering TypeScript definitions for all components, some complex layout components built on top of UI5 Web Components as well as Charting Components.
+
 ## Develop
 
 ### Requirements

--- a/docs/React-tutorial.md
+++ b/docs/React-tutorial.md
@@ -2,6 +2,8 @@
 
 In this tutorial you will learn how to add UI5 Web Components to your application. The UI5 Web Components can be added both to new React applications, as well as already existing ones.
 
+In order to have a better development expierence, we would also recommend to take a look at our dedicated wrapper for UI5 Web Components in React, [UI5 Web Components for React](https://github.com/SAP/ui5-webcomponents-react) and check out [their tutorial](https://developers.sap.com/mission.react-spa.html) as well.
+
 ## Step 1. Start New Application. For Example with create-react-app
 
 ```bash


### PR DESCRIPTION
Every now and then the question comes up how UI5 Web Components and UI5 Web Components for React are relating to each other. As we are more or less the "official" wrapper for UI5 Web Components, I though adding a couple of sentences about our wrapper to your README would make sense.

Example for such a question: https://openui5.slack.com/archives/CSQEJ2J04/p1596300002038000
