### PR TITLE
refactor(ui5-multicombobox): simplify state

### DIFF
--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -16,7 +16,7 @@
 		@ui5-token-delete="{{_tokenDelete}}"
 		@focusout="{{_tokenizerFocusOut}}"
 		@click={{_click}}
-		?expanded="{{expandedTokenizer}}"
+		?expanded="{{_tokenizerExpanded}}"
 	>
 		{{#each items}}
 			{{#if this.selected}}
@@ -44,8 +44,6 @@
 		@change={{_inputChange}}
 		@keydown="{{_onkeydown}}"
 		@keyup="{{_onkeyup}}"
-		@focusin="{{_focusin}}"
-		@focusout="{{_focusout}}"
 		@click={{_click}}
 		role="combobox"
 		aria-haspopup="listbox"
@@ -61,7 +59,7 @@
 			slot="icon"
 			tabindex="-1"
 			@click={{togglePopover}}
-			?pressed="{{_iconPressed}}"
+			?pressed="{{open}}"
 			dir="{{effectiveDir}}"
 			accessible-name="{{_iconAccessibleNameText}}"
 		></ui5-icon>

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -174,32 +174,16 @@ const metadata = {
 			type: Boolean,
 		},
 
-		/**
-		 * Indicates whether the input is focssed
-		 * @private
-		 */
-		focused: {
-			type: Boolean,
-		},
-
 		_filteredItems: {
 			type: Object,
 		},
 
-		_iconPressed: {
-			type: Boolean,
-			noAttribute: true,
-		},
-
-		/**
-		 * Indicates whether the tokenizer is expanded or collapsed(shows the n more label)
-		 * @private
-		 */
-		expandedTokenizer: {
-			type: Boolean,
-		},
 
 		filterSelected: {
+			type: Boolean,
+		},
+
+		_rootFocused: {
 			type: Boolean,
 		},
 	},
@@ -480,13 +464,11 @@ class MultiComboBox extends UI5Element {
 		});
 	}
 
-	_toggleIcon() {
-		this._iconPressed = !this._iconPressed;
-		this.open = this._iconPressed;
-
+	_toggle() {
+		this.open = !this.open;
 		this.fireEvent("open-change");
 
-		if (!this._iconPressed) {
+		if (!this.open) {
 			this._afterClosePopover();
 		}
 	}
@@ -534,14 +516,6 @@ class MultiComboBox extends UI5Element {
 	_toggleRespPopover() {
 		this.updateStaticAreaItemContentDensity();
 		this.allItemsPopover.toggle(this);
-	}
-
-	_focusin() {
-		this.focused = true;
-	}
-
-	_focusout() {
-		this.focused = false;
 	}
 
 	_click(event) {
@@ -606,13 +580,13 @@ class MultiComboBox extends UI5Element {
 
 	rootFocusIn() {
 		if (!isPhone()) {
-			this.expandedTokenizer = true;
+			this._rootFocused = true;
 		}
 	}
 
 	rootFocusOut(event) {
 		if (!this.shadowRoot.contains(event.relatedTarget) && !this._deleting) {
-			this.expandedTokenizer = false;
+			this._rootFocused = false;
 		}
 	}
 
@@ -652,6 +626,10 @@ class MultiComboBox extends UI5Element {
 
 	get _iconAccessibleNameText() {
 		return this.i18nBundle.getText(ICON_ACCESSIBLE_NAME);
+	}
+
+	get _tokenizerExpanded() {
+		return this._rootFocused || this.open;
 	}
 
 	static async onDefine() {

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -6,8 +6,8 @@
 	_disable-initial-focus
 	content-only-on-desktop
 	@ui5-selection-change={{_listSelectionChange}}
-	@ui5-after-close={{_toggleIcon}}
-	@ui5-after-open={{_toggleIcon}}
+	@ui5-after-close={{_toggle}}
+	@ui5-after-open={{_toggle}}
 >
 	<div slot="header" class="ui5-responsive-popover-header">
 		<div class="row">


### PR DESCRIPTION
`MultiComboBox` state is currently reduntant:
 - `_toggleIcon` renamed to `_toggle` as it does more than just that
 - `_iconPressed` removed (same as `open`)
 - `focused` is removed (never used, not even in CSS, only set)
 - `expandedTokenizer` is not real state, it is computed state, so removed and replaced with a getter. It depends on `_rootFocused` (new state) and the `open` property:

```js
get _tokenizerExpanded() {
	return this._rootFocused || this.open;
}
```

closes: https://github.com/SAP/ui5-webcomponents/issues/1991