### PR TITLE
feat(tools): ES5 build supports dynamic imports (inlined)

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -108,6 +108,7 @@ const getES5Config = () => {
 		output: {
 			dir: "dist/resources",
 			format: "iife",
+			inlineDynamicImports: true,
 			name: "sap-ui-webcomponents-bundle",
 			extend: "true",	// Whether or not to extend the global variable defined by the name option in umd or iife formats.
 			sourcemap: true


### PR DESCRIPTION
If dynamic imports are used, the ES5 build fails due to the inability to create several chunks for the `eefe` format. The ES5 build should always treat dynamic imports as standard, and always create one single file.

closes: https://github.com/SAP/ui5-webcomponents/issues/1946