### PR TITLE
@vladitasev fix(tools): UI5 Web Components are now correctly transpiled

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -52,7 +52,7 @@ const getPlugins = ({ transpile }) => {
 	if (transpile) {
 		plugins.push(babel({
 			presets: ["@babel/preset-env"],
-			exclude: "node_modules/**",
+			exclude: /node_modules\/(?!(@ui5\/webcomponents))/, //exclude all node_modules/ except all starting with @ui5/webcomponents
 			sourcemap: true,
 		}));
 	}

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -52,7 +52,7 @@ const getPlugins = ({ transpile }) => {
 	if (transpile) {
 		plugins.push(babel({
 			presets: ["@babel/preset-env"],
-			exclude: /node_modules\/(?!(@ui5\/webcomponents))/, //exclude all node_modules/ except all starting with @ui5/webcomponents
+			exclude: /node_modules\/(?!(lit-html|@ui5\/webcomponents))/, //exclude all node_modules/ except lit-html and all starting with @ui5/webcomponents
 			sourcemap: true,
 		}));
 	}


### PR DESCRIPTION
The current rollup configuration works for `@ui5/webcomponents` and related projects (`-base`, `-fiori`, etc...) but for third parties, all of our packages are actually in `node_modules/` and they don't get transpiled at all because of this rule. The solution is to either remove the rule altogether, or to allow `node_modules/lit-html` and `node_modules/@ui5-webcomponents` and the rest.

closes: https://github.com/SAP/ui5-webcomponents/issues/1959