### PR TITLE
fix(ui5-input): fix value state msg appearance

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -732,7 +732,7 @@ class Input extends UI5Element {
 	}
 
 	/**
-	 * Checks if the popover is open.
+	 * Checks if the value state popover is open.
 	 * @returns {Boolean} true if the popover is open, false otherwise
 	 * @public
 	 */
@@ -1034,6 +1034,7 @@ class Input extends UI5Element {
 		return {
 			popoverValueState: {
 				"ui5-valuestatemessage-root": true,
+				"ui5-responsive-popover-header": !this.isOpen(),
 				"ui5-valuestatemessage--success": this.valueState === ValueState.Success,
 				"ui5-valuestatemessage--error": this.valueState === ValueState.Error,
 				"ui5-valuestatemessage--warning": this.valueState === ValueState.Warning,

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -72,7 +72,7 @@
 			class="ui5-valuestatemessage-popover"
 			placement-type="Bottom"
 		>
-			<div slot="header" class="ui5-responsive-popover-header {{classes.popoverValueState}}" style="{{styles.popoverHeader}}">
+			<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">
 				{{> valueStateMessage}}
 			</div>
 		</ui5-popover>

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -123,7 +123,7 @@
 .ui5-responsive-popover-header .row {
 	box-sizing: border-box;
 	padding: 0.25rem 1rem;
-	height: 2.5rem;
+	min-height: 2.5rem;
 	display: flex;
 	justify-content: center;
 	align-items: center;


### PR DESCRIPTION
- Fixes the height when the value state msg is displayed as standalone popover, previously too large. 
- Fixes the height within the suggestions popover, previously the message used to be cut off.

FIXES https://github.com/SAP/ui5-webcomponents/issues/2070

Before
<img width="225" alt="Screenshot 2020-08-07 at 10 53 36 AM" src="https://user-images.githubusercontent.com/15702139/89623583-88836900-d89d-11ea-8962-cb1c245d3d4a.png">
<img width="373" alt="Screenshot 2020-08-07 at 10 41 28 AM" src="https://user-images.githubusercontent.com/15702139/89623592-8a4d2c80-d89d-11ea-9d33-9cb92d784610.png">

After
<img width="216" alt="Screenshot 2020-08-07 at 10 54 28 AM" src="https://user-images.githubusercontent.com/15702139/89623603-92a56780-d89d-11ea-9b18-c161c52447bb.png">
<img width="316" alt="Screenshot 2020-08-07 at 10 54 47 AM" src="https://user-images.githubusercontent.com/15702139/89623633-9cc76600-d89d-11ea-8783-01141fc3fb96.png">

