### PR TITLE
fix(ui5-shellbar): remove width limitation of logo

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -196,7 +196,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-logo {
 	cursor: pointer;
-	height: 1.675rem;
+	max-height: 2rem;
 }
 
 .ui5-shellbar-logo:focus {
@@ -377,8 +377,7 @@ slot[name="profile"] {
 }
 
 ::slotted([slot="logo"]) {
-	height: 1.675rem;
-	max-width: 3rem;
+	max-height: 2rem;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
By specification logo should have only 2rem height limitation.

Fixes #2066
