### PR TITLE
fix(ui5-toast) avoid overlaying  Dialog and Popover

### DIFF
--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -1,3 +1,4 @@
+import { getNextZIndex } from "./popup-utils/PopupUtils.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
@@ -196,6 +197,8 @@ class Toast extends UI5Element {
 
 				// We alter the opacity property, in order to trigger transition
 				"opacity": this.open && !this.hover ? "0" : "",
+
+				"z-index": getNextZIndex(),
 			},
 		};
 	}

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -1,9 +1,11 @@
-import { getNextZIndex } from "./popup-utils/PopupUtils.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import ToastTemplate from "./generated/templates/ToastTemplate.lit.js";
 import ToastPlacement from "./types/ToastPlacement.js";
+import { getNextZIndex } from "./popup-utils/PopupUtils.js";
+
+// Template
+import ToastTemplate from "./generated/templates/ToastTemplate.lit.js";
 
 // Styles
 import ToastCss from "./generated/themes/Toast.css.js";

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -28,7 +28,6 @@
 	text-align: center;
 	text-overflow: ellipsis;
 	white-space: pre-line;
-	z-index: 999;
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/packages/main/test/pages/Toast.html
+++ b/packages/main/test/pages/Toast.html
@@ -74,6 +74,19 @@
 	<ui5-button id="wcBtnShowToastBE">Show BottomEnd Toast</ui5-button>
 	<ui5-toast id="wcToastBE" placement="BottomEnd">BottomEnd</ui5-toast>
 
+
+	<!--Toast and Dialog-->
+	<ui5-dialog id="dialog">
+		<div>Hello World</div>
+		<ui5-button id="btnDialog2">Close Dialog</ui5-button>
+
+		<ui5-button id="btnToastInDialog">Open Toast</ui5-button>
+		<ui5-toast id="toastInDialog" placement="BottomEnd">Toast</ui5-toast>
+	</ui5-dialog>
+
+	<h3>Test Dialog and Toast</h3>
+	<ui5-button id="btnDialog">Open Dialog</ui5-button>
+
 	<script>
 
 		// Attaching click listeners to the buttons which show the toasts
@@ -81,6 +94,18 @@
 			button.addEventListener('click', function () {
 				document.querySelector("#" + button.id.replace("BtnShow", "")).show();
 			});
+		});
+
+		btnDialog.addEventListener('click', function () {
+			dialog.open();
+		});
+
+		btnDialog2.addEventListener('click', function () {
+			dialog.close();
+		});
+
+		btnToastInDialog.addEventListener('click', function () {
+			toastInDialog.show();
 		});
 
 	</script>

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -54,11 +54,11 @@ describe("Toast general interaction", () => {
 	it("tests shadow content div inline styles with default duration", () => {
 		const button = browser.$("#wcBtnShowToastBE");
 		const toastShadowContent = browser.$("#wcToastBE").shadow$(".ui5-toast-root");
+		const EXPECTED_STYLES = "transition-duration: 1000ms; transition-delay: 2000ms; opacity: 0;";
 
 		button.click();
 
-		assert.strictEqual(toastShadowContent.getAttribute("style"),
-			"transition-duration: 1000ms; transition-delay: 2000ms; opacity: 0;",
+		assert.ok(toastShadowContent.getAttribute("style").indexOf(EXPECTED_STYLES) !== -1,
 			"The correct default inline styles are applied to the shadow ui5-toast-root");
 	});
 
@@ -74,8 +74,9 @@ describe("Toast general interaction", () => {
 
 		calculatedDelay = `${durationProperty - maximumAllowedTransition}ms`;
 
-		assert.strictEqual(toastShadowContent.getAttribute("style"),
-				`transition-duration: ${maximumAllowedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`,
+		const EXPECTED_STYLES = `transition-duration: ${maximumAllowedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
+
+		assert.ok(toastShadowContent.getAttribute("style").indexOf(EXPECTED_STYLES) !== -1,
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is longer than default. Transition is not longer than allowed (1000ms).");
 	});
@@ -92,8 +93,9 @@ describe("Toast general interaction", () => {
 		calculatedTransition = durationProperty / 3;
 		calculatedDelay = `${durationProperty - calculatedTransition}ms`;
 
-		assert.strictEqual(toastShadowContent.getAttribute("style"),
-				`transition-duration: ${calculatedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`,
+		const EXPECTED_STYLES = `transition-duration: ${calculatedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
+
+		assert.ok(toastShadowContent.getAttribute("style").indexOf(EXPECTED_STYLES) !== -1,
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is shorter than default. Transition is a third of the duration.");
 	});


### PR DESCRIPTION
Remove hardcoded z-index of 999. As the Toast is not a popup by implementation, 
but is a popup by nature, it should use the shared "z-index" between the Popups (Dialog and Popover) to appear correctly under or over them, depending on the place it has been opened.

FIXES https://github.com/SAP/ui5-webcomponents/issues/2110