### PR TITLE
fix(ui5-input): announce custom valueStateMessage

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -53,7 +53,7 @@
 		{{/if}}
 
 		{{#if hasValueState}}
-			<span id="{{_id}}-valueStateDesc" class="ui5-hidden-text">{{valueStateText}}</span>
+			<span id="{{_id}}-valueStateDesc" class="ui5-hidden-text">{{ariaValueStateHiddenText}}</span>
 		{{/if}}
 	</div>
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -1018,6 +1018,18 @@ class Input extends UI5Element {
 		};
 	}
 
+	get ariaValueStateHiddenText() {
+		if (!this.hasValueStateMessage) {
+			return;
+		}
+
+		if (this.shouldDisplayDefaultValueStateMessage) {
+			return this.valueStateText;
+		}
+
+		return this.valueStateMessageText.map(el => el.textContent).join(" ");
+	}
+
 	get itemSelectionAnnounce() {
 		return this.Suggestions ? this.Suggestions.itemSelectionAnnounce : undefined;
 	}


### PR DESCRIPTION
Previously just the buil-in text of a certain value state has been set to the hidden element that is being read out. Now the custom value state msg is also taken into account.

Related to: https://github.com/SAP/ui5-webcomponents/issues/2106