### PR TITLE
feat(ui5-textarea): add ariaLabel and ariaLabelledby properties

### DIFF
--- a/packages/main/src/TextArea.hbs
+++ b/packages/main/src/TextArea.hbs
@@ -24,7 +24,7 @@
 		?readonly="{{readonly}}"
 		?required="{{required}}"
 		aria-required="{{required}}"
-		aria-labelledby={{ariaLabelledBy}}
+		aria-label="{{ariaLabelText}}"
 		maxlength="{{_exceededTextProps.calcedMaxLength}}"
 		.value="{{value}}"
 		@input="{{_oninput}}"
@@ -38,7 +38,7 @@
 	{{> afterTextarea}}
 
 	{{#if showExceededText}}
-		<span id="{{_id}}-exceededText" class="ui5-textarea-exceeded-text">{{_exceededTextProps.exceededText}}</span>
+		<span class="ui5-textarea-exceeded-text">{{_exceededTextProps.exceededText}}</span>
 	{{/if}}
 
 	<slot name="formSupport"></slot>

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -2,6 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
+import getEffectiveAriaLabelText from "@ui5/webcomponents-base/dist/util/getEffectiveAriaLabelText.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
@@ -206,6 +207,31 @@ const metadata = {
 		 * @public
 		 */
 		name: {
+			type: String,
+		},
+
+		/**
+		 * Defines the aria-label attribute for the textarea.
+		 *
+		 * @type {String}
+		 * @since 1.0.0-rc.9
+		 * @private
+		 * @defaultvalue ""
+		 */
+		ariaLabel: {
+			type: String,
+		},
+
+
+		/**
+		 * Receives id(or many ids) of the elements that label the textarea.
+		 *
+		 * @type {String}
+		 * @defaultvalue ""
+		 * @private
+		 * @since 1.0.0-rc.9
+		 */
+		ariaLabelledby: {
 			type: String,
 		},
 
@@ -539,8 +565,18 @@ class TextArea extends UI5Element {
 		return this.disabled ? undefined : "0";
 	}
 
-	get ariaLabelledBy() {
-		return this.showExceededText ? `${this._id}-exceededText` : undefined;
+	get ariaLabelText() {
+		const effectiveAriaLabelText = getEffectiveAriaLabelText(this);
+
+		if (this.showExceededText) {
+			if (effectiveAriaLabelText) {
+				return `${effectiveAriaLabelText} ${this._exceededTextProps.exceededText}`;
+			}
+
+			return this._exceededTextProps.exceededText;
+		}
+
+		return effectiveAriaLabelText;
 	}
 
 	get ariaInvalid() {

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -199,6 +199,12 @@
 		<ui5-textarea growing growing-max-lines="4"></ui5-textarea>
 	</section>
 
+	<section class="aria-label and aria-labelledby">
+		<span id="infoText">info text</span>
+		<ui5-textarea id="textAreaAriaLabel" aria-label="Hello World"></ui5-textarea>
+		<ui5-textarea id="textAreaAriaLabelledBy" maxlength="20" show-exceeded-text aria-labelledby="infoText" class="fixed-width fixed-height"></ui5-textarea>
+	</section>
+
 	<script>
 		var changeCounter = 0;
 		var inputCounter = 0;

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -35,6 +35,18 @@ describe("Attributes propagation", () => {
 
 		assert.strictEqual(browser.$("#basic-textarea").shadow$("textarea").getValue(), sExpectedValue, "Value property was set correctly");
 	});
+
+	it("Tests aria-label and aria-labelledby", () => {
+		const textArea1 = browser.$("#textAreaAriaLabel").shadow$("textarea");
+		const textArea2 = browser.$("#textAreaAriaLabelledBy").shadow$("textarea");
+		const EXPECTED_ARIA_LABEL1 = "Hello World";
+		const EXPECTED_ARIA_LABEL2 = "info text 20 characters remaining";
+
+		assert.strictEqual(textArea1.getAttribute("aria-label"), EXPECTED_ARIA_LABEL1,
+			"The aria-label is correctly set internally.");
+		assert.strictEqual(textArea2.getAttribute("aria-label"), EXPECTED_ARIA_LABEL2,
+			"The aria-label is correctly set internally.");
+	});
 });
 
 describe("disabled and readonly textarea", () => {


### PR DESCRIPTION
As the Input, the TextArea should support aria-label and aria-labelledby set on the custom element.
Note: internally we also set aria-label, using the base method "getEffectiveAriaLabelText" for the purpose.

Related to https://github.com/SAP/ui5-webcomponents/issues/2107