### PR TITLE
fix(ui5-popover): fix arrow horizontal position

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -489,7 +489,8 @@ class Popover extends Popup {
 
 		this._maxContentHeight = maxContentHeight;
 
-		const arrowTranslateX = isVertical ? targetRect.left + targetRect.width / 2 - left - popoverSize.width / 2 : 0;
+		const arrowXCentered = this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch;
+		const arrowTranslateX = isVertical && arrowXCentered ? targetRect.left + targetRect.width / 2 - left - popoverSize.width / 2 : 0;
 		const arrowTranslateY = !isVertical ? targetRect.top + targetRect.height / 2 - top - popoverSize.height / 2 : 0;
 
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -58,48 +58,6 @@
 
 	<ui5-input id="field"></ui5-input> -->
 
-	<div id="targetOpener" style="height: 3rem; background: red;"></div>
-
-	<ui5-button id="btnOpenXLeft">Open Popup Left aligned</ui5-button>
-
-	<ui5-popover
-		header-text="My Heading"
-		id="popXLeft" horizontal-align="Left"
-		style="width: 300px">
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-		<div>
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-		<div>
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-	</ui5-popover>
-
-	<br>
-	<br>
-	<div id="targetOpener2" style="height: 3rem; background: yellow;"></div>
-
-	<ui5-button id="btnOpenXRight">Open Popup Right aligned</ui5-button>
-
-	<ui5-popover
-		header-text="My Heading"
-		id="popXRight" horizontal-align="Right"
-		style="width: 300px">
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-		<div>
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-		<div>
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-	</ui5-popover>
-
-	<br>
-	<br>
 	<ui5-button id="btn">Click me !</ui5-button>
 
 	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top" aria-label="This popover is important">
@@ -355,6 +313,49 @@
 			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  info="Reuqired" info-state="Error">HP Monitor 24</ui5-li>
 		</ui5-list>
 	</ui5-popover>
+
+	<br>
+	<br>
+	<div id="targetOpener" style="height: 3rem; background: red;"></div>
+
+	<ui5-button id="btnOpenXLeft">Open Popup Left aligned</ui5-button>
+
+	<ui5-popover
+		header-text="My Heading"
+		id="popXLeft" horizontal-align="Left"
+		style="width: 300px">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+	</ui5-popover>
+
+	<div id="targetOpener2" style="height: 3rem; background: yellow;"></div>
+
+	<ui5-button id="btnOpenXRight">Open Popup Right aligned</ui5-button>
+
+	<ui5-popover
+		header-text="My Heading"
+		id="popXRight" horizontal-align="Right"
+		style="width: 300px">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+	</ui5-popover>
+
+	<br>
+	<br>
 
 	<script>
 		btn.addEventListener("click", function (event) {

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -58,6 +58,48 @@
 
 	<ui5-input id="field"></ui5-input> -->
 
+	<div id="targetBug" style="height: 3rem; background: red;"></div>
+
+	<ui5-button id="btnNew">Open Popup Left aligned</ui5-button>
+
+	<ui5-popover
+		header-text="My Heading"
+		id="popNew" horizontal-align="Left"
+		style="width: 300px">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+	</ui5-popover>
+
+	<br>
+	<br>
+	<div id="targetBug2" style="height: 3rem; background: yellow;"></div>
+
+	<ui5-button id="btnNew2">Open Popup Right aligned</ui5-button>
+
+	<ui5-popover
+		header-text="My Heading"
+		id="popNew2" horizontal-align="Right"
+		style="width: 300px">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+		<div>
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+	</ui5-popover>
+
+	<br>
+	<br>
 	<ui5-button id="btn">Click me !</ui5-button>
 
 	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top" aria-label="This popover is important">
@@ -380,6 +422,12 @@
 
 			btnQuickViewCardOpener.setAttribute("hidden", true);
 		})
+		btnNew.addEventListener("click", function (event) {
+			popNew.openBy(targetBug);
+		});
+		btnNew2.addEventListener("click", function (event) {
+			popNew2.openBy(targetBug2);
+		});
 	</script>
 </body>
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -58,13 +58,13 @@
 
 	<ui5-input id="field"></ui5-input> -->
 
-	<div id="targetBug" style="height: 3rem; background: red;"></div>
+	<div id="targetOpener" style="height: 3rem; background: red;"></div>
 
-	<ui5-button id="btnNew">Open Popup Left aligned</ui5-button>
+	<ui5-button id="btnOpenXLeft">Open Popup Left aligned</ui5-button>
 
 	<ui5-popover
 		header-text="My Heading"
-		id="popNew" horizontal-align="Left"
+		id="popXLeft" horizontal-align="Left"
 		style="width: 300px">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
@@ -79,13 +79,13 @@
 
 	<br>
 	<br>
-	<div id="targetBug2" style="height: 3rem; background: yellow;"></div>
+	<div id="targetOpener2" style="height: 3rem; background: yellow;"></div>
 
-	<ui5-button id="btnNew2">Open Popup Right aligned</ui5-button>
+	<ui5-button id="btnOpenXRight">Open Popup Right aligned</ui5-button>
 
 	<ui5-popover
 		header-text="My Heading"
-		id="popNew2" horizontal-align="Right"
+		id="popXRight" horizontal-align="Right"
 		style="width: 300px">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
@@ -422,11 +422,11 @@
 
 			btnQuickViewCardOpener.setAttribute("hidden", true);
 		})
-		btnNew.addEventListener("click", function (event) {
-			popNew.openBy(targetBug);
+		btnOpenXLeft.addEventListener("click", function (event) {
+			popXLeft.openBy(targetOpener);
 		});
-		btnNew2.addEventListener("click", function (event) {
-			popNew2.openBy(targetBug2);
+		btnOpenXRight.addEventListener("click", function (event) {
+			popXRight.openBy(targetOpener2);
 		});
 	</script>
 </body>


### PR DESCRIPTION
Fix Popover's arrow horizontal position, when horizontalPlacement is either "Left", or "Right".

FIXES  https://github.com/SAP/ui5-webcomponents/issues/2111

Perviously
<img width="790" alt="Screenshot 2020-08-20 at 9 50 45 AM" src="https://user-images.githubusercontent.com/15702139/90726579-a227a600-e2ca-11ea-9f3f-a04d25da3951.png">


Now the arrow position is correct
<img width="855" alt="Screenshot 2020-08-20 at 9 41 21 AM" src="https://user-images.githubusercontent.com/15702139/90726359-40ffd280-e2ca-11ea-84ae-0bb1b4013f2b.png">
<img width="860" alt="Screenshot 2020-08-20 at 9 41 31 AM" src="https://user-images.githubusercontent.com/15702139/90726363-42c99600-e2ca-11ea-968a-3d39440d0ab6.png">

