### PR TITLE
chore(ui5-daterange-picker): fix min-width

### DIFF
--- a/packages/main/src/themes/DateRangePicker.css
+++ b/packages/main/src/themes/DateRangePicker.css
@@ -2,7 +2,7 @@
 	display: inline-block;
 }
 
-:host .ui5-datepicker-input {
+:host .ui5-date-picker-input {
 	width: 100%;
 	min-width: 15rem;
 }


### PR DESCRIPTION
When the ui5-datepicker has been renamed to ui5-date-picker, and the class .ui5-datepicker-input to .ui5-date-picker-input, the DateRangePicker.css has not been updated.
