### PR TITLE
fix(ui5-table-row): announce entire row and columns

### DIFF
--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -296,6 +296,7 @@ class Table extends UI5Element {
 				index,
 				minWidth: column.minWidth,
 				demandPopin: column.demandPopin,
+				text: column.textContent,
 				popinText: column.popinText,
 				visible: !this._hiddenColumns[index],
 			};

--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -3,6 +3,7 @@
 	tabindex="{{_tabIndex}}"
 	@focusin="{{_onfocusin}}"
 	@click="{{_onrowclick}}"
+	aria-label="{{ariaLabelText}}"
 	data-sap-focus-ref
 	part="row"
 >

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -156,6 +156,32 @@ class TableRow extends UI5Element {
 	get visibleCellsCount() {
 		return this.visibleCells.length;
 	}
+
+	get ariaLabelText() {
+		return this.cells.map((cell, index) => {
+			const columText = this.getColumnTextByIdx(index);
+			const cellText = this.getCellText(cell);
+			return `${columText} ${cellText}`;
+		}).join(" ");
+	}
+
+	getCellText(cell) {
+		return this.getNormilzedTextContent(cell.textContent);
+	}
+
+	getColumnTextByIdx(index) {
+		const columnInfo = this._columnsInfo[index];
+
+		if (!columnInfo) {
+			return "";
+		}
+
+		return this.getNormilzedTextContent(columnInfo.text);
+	}
+
+	getNormilzedTextContent(textContent) {
+		return textContent.replace(/[\n\r\t]/g, "").trim();
+	}
 }
 
 TableRow.define();

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -56,4 +56,13 @@ describe("Table general interaction", () => {
 		cellInRow2.click();
 		assert.ok(lbl.getHTML().indexOf(row2Data), "Event rowClick fired and intercepted.");
 	});
+
+	it("tests row aria-label value", () => {
+		const row = browser.$("#roll-0").shadow$(".ui5-table-row-root");
+
+		const EXPECTED_TEXT = "Product Notebook Basic 15HT-1000 Supplier Very Best Screens Dimensions 30 x 18 x 3 cm Weight 4.2 KG Price 956 EUR";
+
+		assert.strictEqual(row.getAttribute("aria-label"), EXPECTED_TEXT, 
+			"The aria-label value is correct.");
+	});
 });


### PR DESCRIPTION
Upon accessing the row, all cells and the respective columns they are within, should be announced in the following order: column - cell, column - cell, etc.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2160