### PR TITLE
feat(framework): make assets path configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - gem install jekyll-seo-tag
 
 script:
-- yarn build
+- DEPLOY_PUBLIC_PATH=/resources/ yarn build
 - yarn test
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,12 @@ yarn build # to build the project
 Afterwards, you can find the build output in the `dist` folder of the corresponding package folder.
 For example, to find the Button component (that belongs to the `main` package), look inside the `packages/main/dist` folder.
 
-*Note: before building the project you can also set the `PUBLIC_DEPLOY_PATH` environment variable to specify the path where non-bundled assets will be fetched from*
+**Note:** Before building the project you can also set the `DEPLOY_PUBLIC_PATH` environment variable to specify the path where non-bundled assets will be fetched from, for example:
+
+```
+DEPLOY_PUBLIC_PATH=/my/resources/ yarn build
+```
+(for Windows: `DEPLOY_PUBLIC_PATH="\/my\/resources\/" yarn build`)
 
 ## Limitations
 None as of 1.0.0-rc.8 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ yarn build # to build the project
 Afterwards, you can find the build output in the `dist` folder of the corresponding package folder.
 For example, to find the Button component (that belongs to the `main` package), look inside the `packages/main/dist` folder.
 
+*Note: before building the project you can also set the `PUBLIC_DEPLOY_PATH` environment variable to specify the path where non-bundled assets will be fetched from*
+
+*For example: ``
+
 ## Limitations
 None as of 1.0.0-rc.8 
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ For example, to find the Button component (that belongs to the `main` package), 
 
 *Note: before building the project you can also set the `PUBLIC_DEPLOY_PATH` environment variable to specify the path where non-bundled assets will be fetched from*
 
-*For example: ``
-
 ## Limitations
 None as of 1.0.0-rc.8 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,6 +14,7 @@ language     | en, de, es, etc...                              | en            |
 calendarType | Gregorian, Islamic, Buddhist, Japanese, Persian | Gregorian     | Default calendar type for date-related web components
 [noConflict](#noConflict)  | true, false | false                            | When set to true, all events will be fired with a "ui5-" prefix only
 [formatSettings](#formatSettings)| See the [Format settings](#formatSettings) section below		| Empty object | Allows to override locale-specific configuration
+[assetsPath](#assetsPath)| See the [Assets path](#assetsPath) section below		| `/resources/` | Allows to set the assets path at runtime
 
 ### Content Density
 
@@ -100,6 +101,26 @@ For example, to force the first day of week to Sunday, no matter the locale:
   Setting    |                     Values                      | Default value |                          Description
 ------------ | ----------------------------------------------- | ------------- | -------------------------------------------------------------
 firstDayOfWeek | 0 (Sunday) through 6 (Saturday) | *Depends on locale*     | When set, overrides the locale's default value
+
+<a name="assetsPath"></a>
+### Assets path
+
+<b>Note:</b> This configuration setting only has effect for bundles, created with the UI5 Web Components tools (`@ui5/webcomponents-tools`).
+
+The `assetsPath` setting allows to override the path where asset files (most commonly `.json` ) are located. UI5 Web Components `tools` use `rollup`
+with the `rollup-plugin-url` plugin and `/resources/` is set as the default directory for all non-bundled assets.
+
+For some scenarios the same bundle will be reused from different directories, or the directory structure is unknown in advance. Therefore it's
+necessary to be able to pass the right directory at runtime, most commonly inside the configuration script directly:
+
+Example:
+```html
+<script data-ui5-config type="application/json">
+{
+	"assetsPath": "/my/custom/assets/path"
+}
+</script>
+```
 
 
 ## Configuration script

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@ language     | en, de, es, etc...                              | en            |
 calendarType | Gregorian, Islamic, Buddhist, Japanese, Persian | Gregorian     | Default calendar type for date-related web components
 [noConflict](#noConflict)  | true, false | false                            | When set to true, all events will be fired with a "ui5-" prefix only
 [formatSettings](#formatSettings)| See the [Format settings](#formatSettings) section below		| Empty object | Allows to override locale-specific configuration
-[assetsPath](#assetsPath)| See the [Assets path](#assetsPath) section below		| `/resources/` | Allows to set the assets path at runtime
+[assetsPath](#assetsPath)| See the [Assets path](#assetsPath) section below		| Empty string | Allows to set the assets path at runtime
 
 ### Content Density
 
@@ -105,10 +105,11 @@ firstDayOfWeek | 0 (Sunday) through 6 (Saturday) | *Depends on locale*     | Whe
 <a name="assetsPath"></a>
 ### Assets path
 
-<b>Note:</b> This configuration setting only has effect for bundles, created with the UI5 Web Components tools (`@ui5/webcomponents-tools`).
-
-The `assetsPath` setting allows to override the path where asset files (most commonly `.json` ) are located. UI5 Web Components `tools` use `rollup`
-with the `rollup-plugin-url` plugin and `/resources/` is set as the default directory for all non-bundled assets.
+This configuration setting allows to set the path where asset files (most commonly `.json` ) that are to be fetched at runtime, are located. These are:
+ - Icon collections
+ - `i18n` message bundles
+ - `CLDR` files
+ - Additional themes
 
 For some scenarios the same bundle will be reused from different directories, or the directory structure is unknown in advance. Therefore it's
 necessary to be able to pass the right directory at runtime, most commonly inside the configuration script directly:
@@ -121,7 +122,6 @@ Example:
 }
 </script>
 ```
-
 
 ## Configuration script
 

--- a/packages/base/src/InitialConfiguration.js
+++ b/packages/base/src/InitialConfiguration.js
@@ -13,7 +13,7 @@ let initialConfig = {
 	noConflict: false, // no URL
 	formatSettings: {},
 	useDefaultLanguage: false,
-	assetsPath: "/resources/",
+	assetsPath: "",
 };
 
 /* General settings */

--- a/packages/base/src/InitialConfiguration.js
+++ b/packages/base/src/InitialConfiguration.js
@@ -12,6 +12,7 @@ let initialConfig = {
 	calendarType: null,
 	noConflict: false, // no URL
 	formatSettings: {},
+	assetsPath: "/resources/",
 };
 
 /* General settings */
@@ -48,6 +49,11 @@ const getCalendarType = () => {
 const getFormatSettings = () => {
 	initConfiguration();
 	return initialConfig.formatSettings;
+};
+
+const getAssetsPath = () => {
+	initConfiguration();
+	return initialConfig.assetsPath;
 };
 
 const booleanMapping = new Map();
@@ -128,4 +134,5 @@ export {
 	getNoConflict,
 	getCalendarType,
 	getFormatSettings,
+	getAssetsPath,
 };

--- a/packages/base/src/asset-registries/Icons.js
+++ b/packages/base/src/asset-registries/Icons.js
@@ -1,5 +1,6 @@
 import { registerIcon, registerCollectionPromise } from "../SVGIconRegistry.js";
 import { fetchJsonOnce } from "../util/FetchHelper.js";
+import getEffectiveAssetPath from "../util/getEffectiveAssetPath.js";
 
 const registerIconBundle = async (collectionName, bundleData) => {
 	let resolveFn;
@@ -9,7 +10,7 @@ const registerIconBundle = async (collectionName, bundleData) => {
 	registerCollectionPromise(collectionName, collectionFetched);
 
 	if (typeof bundleData !== "object") { // not inlined from build -> fetch it
-		bundleData = await fetchJsonOnce(bundleData);
+		bundleData = await fetchJsonOnce(getEffectiveAssetPath(bundleData));
 	}
 	fillRegistry(bundleData);
 	resolveFn();

--- a/packages/base/src/asset-registries/LocaleData.js
+++ b/packages/base/src/asset-registries/LocaleData.js
@@ -1,6 +1,7 @@
 import { fetchJsonOnce } from "../util/FetchHelper.js";
 import { getFeature } from "../FeaturesRegistry.js";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../generated/AssetParameters.js";
+import getEffectiveAssetPath from "../util/getEffectiveAssetPath.js";
 
 const resources = new Map();
 const cldrData = {};
@@ -94,7 +95,7 @@ const fetchCldr = async (language, region, script) => {
 		registerModuleContent(`sap/ui/core/cldr/${localeId}.json`, cldrObj);
 	} else if (url) {
 		// fetch it
-		const cldrContent = await fetchJsonOnce(url);
+		const cldrContent = await fetchJsonOnce(getEffectiveAssetPath(url));
 		registerModuleContent(`sap/ui/core/cldr/${localeId}.json`, cldrContent);
 	}
 };

--- a/packages/base/src/asset-registries/Themes.js
+++ b/packages/base/src/asset-registries/Themes.js
@@ -1,6 +1,7 @@
 import { fetchJsonOnce, fetchTextOnce } from "../util/FetchHelper.js";
 import { DEFAULT_THEME } from "../generated/AssetParameters.js";
 import getFileExtension from "../util/getFileExtension.js";
+import getEffectiveAssetPath from "../util/getEffectiveAssetPath.js";
 
 const themeURLs = new Map();
 const themeStyles = new Map();
@@ -68,7 +69,7 @@ const fetchThemeProperties = async (packageName, themeName) => {
 		throw new Error(`You have to import the ${packageName}/dist/Assets.js module to switch to additional themes`);
 	}
 
-	return getFileExtension(url) === ".css" ? fetchTextOnce(url) : fetchJsonOnce(url);
+	return getFileExtension(url) === ".css" ? fetchTextOnce(url) : fetchJsonOnce(getEffectiveAssetPath(url));
 };
 
 const getRegisteredPackages = () => {

--- a/packages/base/src/asset-registries/i18n.js
+++ b/packages/base/src/asset-registries/i18n.js
@@ -5,6 +5,7 @@ import { fetchTextOnce } from "../util/FetchHelper.js";
 import normalizeLocale from "../locale/normalizeLocale.js";
 import nextFallbackLocale from "../locale/nextFallbackLocale.js";
 import { DEFAULT_LANGUAGE } from "../generated/AssetParameters.js";
+import getEffectiveAssetPath from "../util/getEffectiveAssetPath.js";
 
 const bundleData = new Map();
 const bundleURLs = new Map();
@@ -76,7 +77,7 @@ const fetchI18nBundle = async packageName => {
 		return;
 	}
 
-	const content = await fetchTextOnce(bundleURL);
+	const content = await fetchTextOnce(getEffectiveAssetPath(bundleURL));
 	let parser;
 	if (content.startsWith("{")) {
 		parser = JSON.parse;

--- a/packages/base/src/config/AssetsPath.js
+++ b/packages/base/src/config/AssetsPath.js
@@ -1,0 +1,17 @@
+import { getAssetsPath as getConfiguredAssetsPath } from "../InitialConfiguration.js";
+
+let assetsPath;
+
+const getAssetsPath = () => {
+	if (assetsPath === undefined) {
+		assetsPath = getConfiguredAssetsPath();
+	}
+
+	return assetsPath;
+};
+
+const setAssetsPath = newAssetsPath => {
+	assetsPath = newAssetsPath;
+};
+
+export { getAssetsPath, setAssetsPath }; // eslint-disable-line

--- a/packages/base/src/util/getEffectiveAssetPath.js
+++ b/packages/base/src/util/getEffectiveAssetPath.js
@@ -2,8 +2,8 @@ import { getAssetsPath } from "../config/AssetsPath.js";
 
 const getEffectiveAssetPath = asset => {
 	const assetsPath = getAssetsPath();
-	if (assetsPath !== undefined && assetsPath !== "/resources/" && asset.startsWith("/resources/")) {
-		return asset.replace(/^\/resources\//, assetsPath);
+	if (asset.startsWith("/UI5_RESOURCES_PATH/")) {
+		return asset.replace(/^\/UI5_RESOURCES_PATH\//, assetsPath);
 	}
 
 	return asset;

--- a/packages/base/src/util/getEffectiveAssetPath.js
+++ b/packages/base/src/util/getEffectiveAssetPath.js
@@ -1,0 +1,12 @@
+import { getAssetsPath } from "../config/AssetsPath.js";
+
+const getEffectiveAssetPath = asset => {
+	const assetsPath = getAssetsPath();
+	if (assetsPath !== undefined && assetsPath !== "/resources/" && asset.startsWith("/resources/")) {
+		return asset.replace(/^\/resources\//, assetsPath);
+	}
+
+	return asset;
+};
+
+export default getEffectiveAssetPath;

--- a/packages/base/src/util/getEffectiveAssetPath.js
+++ b/packages/base/src/util/getEffectiveAssetPath.js
@@ -2,7 +2,7 @@ import { getAssetsPath } from "../config/AssetsPath.js";
 
 const getEffectiveAssetPath = asset => {
 	const assetsPath = getAssetsPath();
-	if (asset.startsWith("/UI5_RESOURCES_PATH/")) {
+	if (typeof asset === "string" && asset.startsWith("/UI5_RESOURCES_PATH/")) {
 		return asset.replace(/^\/UI5_RESOURCES_PATH\//, assetsPath);
 	}
 

--- a/packages/base/src/util/getEffectiveAssetPath.js
+++ b/packages/base/src/util/getEffectiveAssetPath.js
@@ -2,8 +2,8 @@ import { getAssetsPath } from "../config/AssetsPath.js";
 
 const getEffectiveAssetPath = asset => {
 	const assetsPath = getAssetsPath();
-	if (typeof asset === "string" && asset.startsWith("/UI5_RESOURCES_PATH/")) {
-		return asset.replace(/^\/UI5_RESOURCES_PATH\//, assetsPath);
+	if (assetsPath && typeof asset === "string") {
+		return `${assetsPath}${asset}`;
 	}
 
 	return asset;

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -1,4 +1,5 @@
 import { getAssetsPath, setAssetsPath } from "@ui5/webcomponents-base/dist/config/AssetsPath.js";
+// setAssetsPath("/my-resources/");
 
 // OpenUI5 integration
 import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -1,3 +1,5 @@
+import { getAssetsPath, setAssetsPath } from "@ui5/webcomponents-base/dist/config/AssetsPath.js";
+
 // OpenUI5 integration
 import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
 
@@ -109,6 +111,8 @@ const testAssets = {
 		setNoConflict,
 		getRTL,
 		getFirstDayOfWeek,
+		getAssetsPath,
+		setAssetsPath
 	},
 	getLocaleData,
 	applyDirection,

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -119,7 +119,7 @@
 			<ui5-label id="infoText">info text</ui5-label>
 			<ui5-date-picker id="dpAriaLabelledBy" aria-labelledby="infoText"></ui5-date-picker>
 		</section>
-		
+
 		<section class="ui5-content-density-compact">
 			<h3>DatePicker in Compact</h3>
 			<div>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -9,7 +9,7 @@
 
 	<script data-ui5-config type="application/json">
 		{
-			"assetsPath": "/resources/"
+			"assetsPath": ""
 		}
 	</script>
 

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -7,6 +7,12 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
+	<script data-ui5-config type="application/json">
+		{
+			"assetsPath": "/resources/"
+		}
+	</script>
+
 	<link rel="stylesheet" type="text/css" href="./kitchen-styles.css">
 
 	<style>

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -48,7 +48,7 @@ const getScripts = (options) => {
 			default: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle" "nps watch.styles"',
 			src: 'nps "copy.src --watch --safe --skip-initial-copy"',
 			test: 'nps "copy.test --watch --safe --skip-initial-copy"',
-			bundle: "rollup --config config/rollup.config.js -w --environment ES5_BUILD,DEV",
+			bundle: "rollup --config config/rollup.config.js -w --environment ES5_BUILD,DEV,DEPLOY_PUBLIC_PATH:/resources/",
 			styles: {
 				default: 'concurrently "nps watch.styles.themes" "nps watch.styles.components"',
 				themes: 'nps "build.styles.themes -w"',

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -26,7 +26,7 @@ function ui5DevImportCheckerPlugin() {
 
 const getPlugins = ({ transpile }) => {
 	const plugins = [];
-	let publicPath = DEPLOY_PUBLIC_PATH || "/UI5_RESOURCES_PATH/";
+	let publicPath = DEPLOY_PUBLIC_PATH;
 
 	if (!process.env.DEV) {
 		plugins.push(filesize({

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -26,7 +26,7 @@ function ui5DevImportCheckerPlugin() {
 
 const getPlugins = ({ transpile }) => {
 	const plugins = [];
-	let publicPath = DEPLOY_PUBLIC_PATH || "/resources/";
+	let publicPath = DEPLOY_PUBLIC_PATH || "/UI5_RESOURCES_PATH/";
 
 	if (!process.env.DEV) {
 		plugins.push(filesize({

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -1,7 +1,7 @@
 const babel = require("rollup-plugin-babel");
 const process = require("process");
 const resolve = require("rollup-plugin-node-resolve");
-const url = require("rollup-plugin-url");
+const url = require("@rollup/plugin-url");
 const { terser } = require("rollup-plugin-terser");
 const notify = require('rollup-plugin-notify');
 const filesize = require('rollup-plugin-filesize');

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -26,6 +26,7 @@
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.1.0",
+    "@rollup/plugin-url": "^5.0.1",
     "@wdio/cli": "^6.1.3",
     "@wdio/dot-reporter": "^6.0.16",
     "@wdio/local-runner": "^6.1.3",
@@ -69,7 +70,6 @@
     "rollup-plugin-notify": "^1.1.0",
     "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-terser": "^5.1.3",
-    "rollup-plugin-url": "^2.2.0",
     "rollup-plugin-visualizer": "^0.9.2",
     "serve": "^10.1.1",
     "wdio-chromedriver-service": "^6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,6 +714,24 @@
   resolved "https://registry.yarnpkg.com/@openui5/sap.ui.core/-/sap.ui.core-1.76.0.tgz#351fe3b11922fa7100d7c88bdf5138ad025e531e"
   integrity sha512-b2+LPxORY4qKgGggqGeP4ckEuMqG0HHy7zwT/vMGGl1L2zLJ/xzruVvsl46KfOcCqEcdjxW+tSGP7dLEe1O4bQ==
 
+"@rollup/plugin-url@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-url/-/plugin-url-5.0.1.tgz#77fc9f56100cd83cfb45109adf7d48af1c8ecdbf"
+  integrity sha512-/dO8Ic+vR9VtMkHjmFBWzISjX0iDwrB3vLg8sy4A7hxu2Uk0J09kAXbtku7gJb1fqVcJUIByFG5d/4sgNh1DvA==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    make-dir "^3.0.0"
+    mime "^2.4.4"
+
+"@rollup/pluginutils@^3.0.4":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@sap-theming/theming-base-content@11.1.19":
   version "11.1.19"
   resolved "https://registry.yarnpkg.com/@sap-theming/theming-base-content/-/theming-base-content-11.1.19.tgz#301b8085807cd410e5c7269cca55cd4ca385534c"
@@ -751,7 +769,7 @@
   resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
@@ -1984,6 +2002,21 @@ chokidar@^3.0.0:
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
     readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+chokidar@^3.x:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -3251,6 +3284,11 @@ estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -5370,6 +5408,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-dir@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 manage-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/manage-path/-/manage-path-2.0.0.tgz#f4cf8457b926eeee2a83b173501414bc76eb9597"
@@ -5636,10 +5681,15 @@ mime-types@~2.1.24:
   dependencies:
     mime-db "1.40.0"
 
-mime@^2.0.3, mime@^2.4.4:
+mime@^2.0.3:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
+
+mime@^2.4.4:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -6493,7 +6543,7 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
-picomatch@^2.0.7, picomatch@^2.2.1:
+picomatch@^2.0.7, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -7390,6 +7440,13 @@ readdirp@~3.3.0:
   dependencies:
     picomatch "^2.0.7"
 
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 readline-sync@^1.4.7:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
@@ -7790,15 +7847,6 @@ rollup-plugin-terser@^5.1.3:
     serialize-javascript "^2.1.2"
     terser "^4.1.0"
 
-rollup-plugin-url@^2.2.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-url/-/rollup-plugin-url-2.2.4.tgz#36a6dedb709f73647bed7b253b9dcd4f3e781af4"
-  integrity sha512-vQjMgJj3tYrg6nKYO/Tvc8s1WTqbaLzHXia17358E6vO0Iq4Ih5WcWYRPopLMUx0x63/31+9ezApAL0HFd998w==
-  dependencies:
-    mime "^2.4.4"
-    mkdirp "^0.5.1"
-    rollup-pluginutils "^2.8.2"
-
 rollup-plugin-visualizer@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-0.9.2.tgz#bbc8e8e67d5aa3e6c188c5ca0fcfa57234fb9f92"
@@ -7817,7 +7865,7 @@ rollup-pluginutils@^1.5.0:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -7898,7 +7946,7 @@ sax@^1.2.4, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
This has been a highly requested feature for a long time. Although resource path is a build-time artefact, it often makes sense to build once and deploy in multiple, previously unknown directories. 

Changes:
- New configuration setting: `assetsPath`
- Users have the capability to build with `DEPLOY_PUBLIC_PATH` or to use `assetsPath` at runtime (or both).

**Option1**: build-time
```
DEPLOY_PUBLIC_PATH=/my/resources/ yarn build
```
(for Windows: `DEPLOY_PUBLIC_PATH="\/my\/resources\/" yarn build`)

**Option2**: runtime
```html
	<script data-ui5-config type="application/json">
		{
			"assetsPath": "/my/resources/"
		}
	</script>
```

BREAKING CHANGE: Running the production build command: `yarn build` will now generate the `.json` resources asset paths without `/resources/` in the beginning. The `yarn start` command remains unchanged - it will implicitly set `DEPLOY_PUBLIC_PATH` to `/resources/` as before.

Before the change, the build generates for example:
```js
var SAPIcons = "/resources/SAP-icons.33a03c68298d0449.json";
registerIconBundle("SAP-icons", SAPIcons);
```

After the change, without setting `DEPLOY_PUBLIC_PATH` it will generate:
```
var SAPIcons = "SAP-icons.33a03c68298d0449.json";
registerIconBundle("SAP-icons", SAPIcons);
```

In order to have the old `yarn build` behavior run:
```
DEPLOY_PUBLIC_PATH=/resources/ yarn build
```
(for Windows: `DEPLOY_PUBLIC_PATH="\/resources\/" yarn build`)

closes: https://github.com/SAP/ui5-webcomponents/issues/2167
closes: https://github.com/SAP/ui5-webcomponents/issues/2169
related to: https://github.com/SAP/ui5-webcomponents/issues/2205