### PR TITLE
chore(framework): Do not use insensitive words

### DIFF
--- a/packages/base/src/util/isValidPropertyName.js
+++ b/packages/base/src/util/isValidPropertyName.js
@@ -1,6 +1,6 @@
 // Note: disabled is present in IE so we explicitly allow it here.
 // Others, such as title/hidden, we explicitly override, so valid too
-const whitelist = [
+const allowList = [
 	"disabled",
 	"title",
 	"hidden",
@@ -13,7 +13,7 @@ const whitelist = [
  * @returns {boolean}
  */
 const isValidPropertyName = name => {
-	if (whitelist.includes(name) || name.startsWith("aria")) {
+	if (allowList.includes(name) || name.startsWith("aria")) {
 		return true;
 	}
 	const classes = [


### PR DESCRIPTION
According to SAP guidelines the words `slave`, `master`, `whitelist` and `blacklist` should be avoided due to being insensitive. These terms should be replaced with the recommended ones.

https://help.sap.com/doc/b0322267728e48a28b0c8ee7dd1ab4c7/1.0/en-US/Inclusive%20Language%20Guidelines.pdf