### PR TITLE
chore(ui5-date-*): make width customizable

### DIFF
--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -7,4 +7,5 @@
 
 :host .ui5-date-picker-input {
 	width: 100%;
+	min-width: inherit;
 }

--- a/packages/main/src/themes/DateRangePicker.css
+++ b/packages/main/src/themes/DateRangePicker.css
@@ -2,7 +2,11 @@
 	display: inline-block;
 }
 
+:host {
+	min-width: 15rem;
+}
+
 :host .ui5-date-picker-input {
 	width: 100%;
-	min-width: 15rem;
+	min-width:inherit;
 }

--- a/packages/main/src/themes/DateTimePicker.css
+++ b/packages/main/src/themes/DateTimePicker.css
@@ -1,3 +1,7 @@
-:host .ui5-date-picker-input {
+:host {
 	min-width: 15rem;
+}
+
+:host .ui5-date-picker-input {
+	min-width: inherit;
 }

--- a/packages/theme-base/css-vars-usage.json
+++ b/packages/theme-base/css-vars-usage.json
@@ -147,7 +147,6 @@
   "--sapLegendColor6",
   "--sapLegendColor7",
   "--sapLegendColor8",
-  "--sapLegendColor9",
   "--sapLegendColor10",
   "--sapLegendColor20",
   "--sapLink_SubtleColor",


### PR DESCRIPTION
Until now the user can not set a DateRangePicker, DateTimePicker to a width smaller than 15rem, as 15 rem is their min-width.
Now we enable that by making the min-width propagated from the host to inner input.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2194