### PR TITLE
fix(ui5-flexible-column-layout) fix arrows screen reader suport

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -14,6 +14,8 @@
 			design="Transparent"
 			@click="{{startArrowClick}}"
 			style="{{styles.arrows.start}}"
+			aria-label="{{accStartArrowText}}"
+			title="{{accStartArrowText}}"
 		></ui5-button>
 	</div>
 
@@ -32,6 +34,8 @@
 			icon="slim-arrow-left"
 			design="Transparent"
 			@click="{{endArrowClick}}"
+			aria-label="{{accEndArrowText}}"
+			title="{{accEndArrowText}}"
 		></ui5-button>
 	</div>
 

--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -22,6 +22,10 @@ import {
 	FCL_START_COLUMN_TXT,
 	FCL_MIDDLE_COLUMN_TXT,
 	FCL_END_COLUMN_TXT,
+	FCL_START_COLUMN_EXPAND_BUTTON_TOOLTIP,
+	FCL_START_COLUMN_COLLAPSE_BUTTON_TOOLTIP,
+	FCL_END_COLUMN_EXPAND_BUTTON_TOOLTIP,
+	FCL_END_COLUMN_COLLAPSE_BUTTON_TOOLTIP,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Template
@@ -629,6 +633,22 @@ class FlexibleColumnLayout extends UI5Element {
 
 	get _effectiveLayoutsByMedia() {
 		return this._layoutsConfiguration || getLayoutsByMedia();
+	}
+
+	get accStartArrowText() {
+		if (this.startArrowDirection === "mirror") {
+			return this.i18nBundle.getText(FCL_START_COLUMN_COLLAPSE_BUTTON_TOOLTIP);
+		}
+
+		return this.i18nBundle.getText(FCL_START_COLUMN_EXPAND_BUTTON_TOOLTIP);
+	}
+
+	get accEndArrowText() {
+		if (this.endArrowDirection === "mirror") {
+			return this.i18nBundle.getText(FCL_END_COLUMN_COLLAPSE_BUTTON_TOOLTIP);
+		}
+
+		return this.i18nBundle.getText(FCL_END_COLUMN_EXPAND_BUTTON_TOOLTIP);
 	}
 }
 

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -10,6 +10,18 @@ FCL_MIDDLE_COLUMN_TXT=Middle column
 #XTXT: Text for the FlexibleColumnLayout end column
 FCL_END_COLUMN_TXT=Last column
 
+#XACT: ARIA announcement for the Expand start column arrow button
+FCL_START_COLUMN_EXPAND_BUTTON_TOOLTIP=Expand the first column
+
+#XACT: ARIA announcement for the Collapse start column arrow button
+FCL_START_COLUMN_COLLAPSE_BUTTON_TOOLTIP=Collapse the first column
+
+#XACT: ARIA announcement for the Expand end column arrow button
+FCL_END_COLUMN_EXPAND_BUTTON_TOOLTIP=Expand the last column
+
+#XACT: ARIA announcement for the Collapse end column arrow button
+FCL_END_COLUMN_COLLAPSE_BUTTON_TOOLTIP=Collapse the last column
+
 #XTXT: Text for the NotificationListGroupItem
 NOTIFICATION_LIST_ITEM_TXT=Notification
 

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -281,7 +281,7 @@
 	<ui5-title class="sectionTitle">Master-Detail-Detail: Detail expanded, Detail-Detail hidden</ui5-title>
 	<br><br>
 
-	<ui5-flexible-column-layout layout="ThreeColumnsMidExpandedEndHidden">
+	<ui5-flexible-column-layout id="fclAcc" layout="ThreeColumnsMidExpandedEndHidden">
 		<!-- start column -->
 		<div style="box-sizing: border-box;" slot="startColumn">
 			<div style="padding: 1rem">

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -96,5 +96,34 @@ describe("FlexibleColumnLayout Behavior", () => {
 
 		// assert
 		assert.strictEqual(visibleColumns, "3", "3 columns are visible");
-		assert.strictEqual(fcl.getProperty("layout"), "ThreeColumnsMidExpanded", "new layout set");	});
+		assert.strictEqual(fcl.getProperty("layout"), "ThreeColumnsMidExpanded", "new layout set");
+	});
+
+	it("tests arrows acc attrs", () => {
+		const fcl = browser.$("#fclAcc");
+		const startArrow = fcl.shadow$(".ui5-fcl-arrow--start");
+		const endArrow = fcl.shadow$(".ui5-fcl-arrow--end");
+		const startArrowText1 = "Expand the first column";
+		const startArrowText2 = "Collapse the first column";
+		const endArrowText = "Expand the last column";
+
+		// assert
+		assert.strictEqual(startArrow.getAttribute("title"), startArrowText1,
+			"Start arrow has the correct tooltip.");
+		assert.strictEqual(startArrow.getAttribute("aria-label"), startArrowText1,
+			"Start arrow has the correct aria-label.");
+		assert.strictEqual(endArrow.getAttribute("title"), endArrowText,
+			"End arrow has the correct tooltip.");
+		assert.strictEqual(endArrow.getAttribute("aria-label"), endArrowText,
+			"End arrow has the correct aria-label.");
+
+		// act
+		startArrow.click();
+
+		// assert
+		assert.strictEqual(startArrow.getAttribute("title"), startArrowText2,
+			"Start arrow has the correct tooltip.");
+		assert.strictEqual(startArrow.getAttribute("aria-label"), startArrowText2,
+			"Start arrow has the correct aria-label.");
+	});
 });


### PR DESCRIPTION
Add tooltip and aria-label to the toggle columns arrow to match the screen reader spec.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2226