### PR TITLE
feat(framework): Limited support for campact size on IE

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -45,6 +45,7 @@ const GLOBAL_DIR_CSS_VAR = "--_ui5_dir";
 class UI5Element extends HTMLElement {
 	constructor() {
 		super();
+		this._propertyChangeListeners = new Set();
 		this._initializeState();
 		this._upgradeAllProperties();
 		this._initializeContainers();
@@ -59,7 +60,6 @@ class UI5Element extends HTMLElement {
 		this._domRefReadyPromise._deferredResolve = deferredResolve;
 
 		this._monitoredChildProps = new Map();
-		this._propertyChangeListeners = new Set();
 		this._shouldInvalidateParent = false;
 	}
 

--- a/packages/base/src/theming/CSSVarsPonyfill.js
+++ b/packages/base/src/theming/CSSVarsPonyfill.js
@@ -26,14 +26,14 @@ const isCompact = () => {
 const getCompactModeVars = () => {
 	const compactVars = {};
 	[...document.querySelectorAll(`[data-ui5-theme-properties]`)].forEach(el => {
-		const cssContent = el.textContent.replace("/n", "");
+		const cssContent = el.textContent.replace("\n", "");
 		let match;
 		const regExp = new RegExp("data-ui5-compact-size[^{]*{(.*?)}", "g");
 		while ((match = regExp.exec(cssContent)) !== null) { // eslint-disable-line
 			const compactCSS = match[1];
 			compactCSS.split(";").forEach(declaration => {
 				const pair = declaration.split(":");
-				compactVars[pair[0]] = pair[1];
+				compactVars[pair[0].trim()] = pair[1].trim();
 			});
 		}
 	});

--- a/packages/base/src/theming/CSSVarsPonyfill.js
+++ b/packages/base/src/theming/CSSVarsPonyfill.js
@@ -7,6 +7,7 @@ const runPonyfill = () => {
 
 	window.CSSVarsPonyfill.cssVars({
 		rootElement: document.head,
+		variables: isCompact() ? getCompactModeVars() : {},
 		silent: true,
 	});
 };
@@ -15,6 +16,29 @@ const schedulePonyfill = () => {
 	if (!ponyfillTimer) {
 		ponyfillTimer = window.setTimeout(runPonyfill, 0);
 	}
+};
+
+const isCompact = () => {
+	const b = document.body;
+	return b.hasAttribute("data-ui5-compact-size") || b.classList.contains("ui5-content-density-compact") || b.classList.contains("sapUiSizeCompact");
+};
+
+const getCompactModeVars = () => {
+	const compactVars = {};
+	[...document.querySelectorAll(`[data-ui5-theme-properties]`)].forEach(el => {
+		const cssContent = el.textContent.replace("/n", "");
+		let match;
+		const regExp = new RegExp("data-ui5-compact-size[^{]*{(.*?)}", "g");
+		while ((match = regExp.exec(cssContent)) !== null) { // eslint-disable-line
+			const compactCSS = match[1];
+			compactCSS.split(";").forEach(declaration => {
+				const pair = declaration.split(":");
+				compactVars[pair[0]] = pair[1];
+			});
+		}
+	});
+
+	return compactVars;
 };
 
 export {


### PR DESCRIPTION
The goal of this change is to provide **limited** support for `compact` mode to IE11.

*Background:* Compact mode is entirely dynamic. The way to achieve it is with CSS variables, defined for compact mode markers (attribute or class). Example:
```css
[data-ui5-compact-size],
.ui5-content-density-compact,
.sapUiSizeCompact {
	--_ui5_button_base_height: 1.625rem;
...................................
}
```
The IE CSS Vars ponyfill on the other hand can only handle variables on `:root` and `:host` since it needs to generate static CSS declarations.

*IE11 limitation*: 
 - Compact mode only works for the page as a whole - you must set the `data-ui5-compact-size` attribute, the `ui5-content-density-compact` class or the `sapUiSizeCompact` class on the **body** element only.
 - Compact mode is **not dynamic** - if you change cozy/compact at runtime, nothing will happen out of the box.

*How does it work*: The CSS Vars Ponyfill has the `variables` feature that lets you override some of the variables before the calculations take place. If the body has compact size set, the framework reads all `style[data-ui5-theme-properties]` tags' content and detects the compact size variables based on the `[data-ui5-compact-size]` rule, which is the official one and is mandatory. Then it passes the values of these variables to the ponyfill which effectively looks like this:
```js
window.CSSVarsPonyfill.cssVars({
	rootElement: document.head,
	variables: {
               "_ui5_button_base_height": "1.625rem",
              ....................................
        },
	silent: true,
});
```

Additionally, a bug on IE11 was fixed in `UI5Element.js`. On IE11 the lifecycle is a bit different and it's possible to access the listeners set before it has been defined. Therefore it's moved up in the constructor before properties upgrade.

closes: https://github.com/SAP/ui5-webcomponents/issues/2211