### PR TITLE
chore(ui5-fcl): add template hooks for toggle arrows

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -8,15 +8,7 @@
 	</div>
 
 	<div class="ui5-fcl-arrow-container" style="{{styles.arrowsContainer.start}}">
-		<ui5-button
-			class="ui5-fcl-arrow ui5-fcl-arrow--start"
-			icon="slim-arrow-right"
-			design="Transparent"
-			@click="{{startArrowClick}}"
-			style="{{styles.arrows.start}}"
-			aria-label="{{accStartArrowText}}"
-			title="{{accStartArrowText}}"
-		></ui5-button>
+		{{> startArrow}}
 	</div>
 
 	<div
@@ -28,15 +20,7 @@
 	</div>
 
 	<div class="ui5-fcl-arrow-container" style="{{styles.arrowsContainer.end}}">
-		<ui5-button
-			class="ui5-fcl-arrow ui5-fcl-arrow--end"
-			style="{{styles.arrows.end}}"
-			icon="slim-arrow-left"
-			design="Transparent"
-			@click="{{endArrowClick}}"
-			aria-label="{{accEndArrowText}}"
-			title="{{accEndArrowText}}"
-		></ui5-button>
+		{{> endArrow}}
 	</div>
 
 	<div
@@ -51,3 +35,28 @@
 	<span id="{{_id}}-midColumnText" class="ui5-hidden-text">{{accMiddleColumnText}}</span>
 	<span id="{{_id}}-endColumnText" class="ui5-hidden-text">{{accEndColumnText}}</span>
 </div>
+
+{{#*inline "startArrow"}}
+	<ui5-button
+		class="ui5-fcl-arrow ui5-fcl-arrow--start"
+		icon="slim-arrow-right"
+		design="Transparent"
+		@click="{{startArrowClick}}"
+		style="{{styles.arrows.start}}"
+		aria-label="{{accStartArrowText}}"
+		title="{{accStartArrowText}}"
+	></ui5-button>
+{{/inline}}
+
+
+{{#*inline "endArrow"}}
+	<ui5-button
+		class="ui5-fcl-arrow ui5-fcl-arrow--end"
+		style="{{styles.arrows.end}}"
+		icon="slim-arrow-left"
+		design="Transparent"
+		@click="{{endArrowClick}}"
+		aria-label="{{accEndArrowText}}"
+		title="{{accEndArrowText}}"
+	></ui5-button>
+{{/inline}}


### PR DESCRIPTION
Add template hooks for the toggle arrows of thew Flexible Column Layout, so that a derived class can fully customize them.
For example: provide different or new ARIA attributes, change the values of existing ones, etc. 
In order to that, the derived class should include the FCL template and overwrite the newly added "startArrow" and "endArrow" template hooks.
_Note: We considered providing slots or properties, but we wanted to keep the API more simple and agreed on this solution._

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2183