### PR TITLE
fix(ui5-calendar-header): prevent scrolling when month/year picker is selected

### DIFF
--- a/packages/main/src/CalendarHeader.hbs
+++ b/packages/main/src/CalendarHeader.hbs
@@ -17,7 +17,10 @@
 		</ui5-icon>
 	</div>
 
-	<div class="ui5-calheader-midcontainer">
+	<div
+		class="ui5-calheader-midcontainer"
+		@keydown="{{_onMidContainerKeyDown}}"
+	>
 		<div
 			id="{{_id}}-btn1"
 			class="ui5-calheader-arrowbtn ui5-calheader-middlebtn"

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -131,6 +131,12 @@ class CalendarHeader extends UI5Element {
 		}
 	}
 
+	_onMidContainerKeyDown(event) {
+		if (isSpace(event)) {
+			event.preventDefault();
+		}
+	}
+
 	static async onDefine() {
 		await fetchI18nBundle("@ui5/webcomponents");
 	}


### PR DESCRIPTION
Part of #2268