### PR TITLE
chore: fix imports

### DIFF
--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -29,8 +29,8 @@ import calculateWeekNumber from "@ui5/webcomponents-localization/dist/dates/calc
 import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import ItemNavigationBehavior from "@ui5/webcomponents-base/dist/types/ItemNavigationBehavior.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import RenderScheduler from "@ui5/webcomponents-base/dist/RenderScheduler.js";
 import DayPickerTemplate from "./generated/templates/DayPickerTemplate.lit.js";
-import RenderScheduler from "../../base/src/RenderScheduler.js";
 
 import {
 	DAY_PICKER_WEEK_NUMBER_TEXT,

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -20,7 +20,7 @@ import {
 	isPageDownShift,
 	isPageUpShiftCtrl,
 	isPageDownShiftCtrl,
-} from "@ui5/webcomponents-base/src/Keys.js";
+} from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/icons/time-entry-request.js";
 import Icon from "./Icon.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";

--- a/packages/main/src/WheelSlider.js
+++ b/packages/main/src/WheelSlider.js
@@ -6,7 +6,7 @@ import {
 	isUp,
 	isPageUp,
 	isPageDown,
-} from "@ui5/webcomponents-base/src/Keys.js";
+} from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/icons/navigation-up-arrow.js";
 import "@ui5/webcomponents-icons/dist/icons/navigation-down-arrow.js";
 import ScrollEnablement from "@ui5/webcomponents-base/dist/delegate/ScrollEnablement.js";


### PR DESCRIPTION
Several modules were imported incorrectly, breaking the OpenUI5 retrofit builds.

Import rules:
 - only import from `dist/`, never from `src/`
 - imports from other packages must be with the full qualifier, e.g. `@ui5/webcomponents-base/...`, never with relative paths