### PR TITLE
fix(ui5-date-picker): select date with SPACE on keyup

### DIFF
--- a/packages/main/src/DayPicker.hbs
+++ b/packages/main/src/DayPicker.hbs
@@ -2,6 +2,7 @@
 	class="ui5-dp-root"
 	style="{{styles.wrapper}}"
 	@keydown={{_onkeydown}}
+	@keyup={{_onkeyup}}
 	@mousedown={{_onmousedown}}
 	@mouseup={{_onmouseup}}
 >

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -453,7 +453,8 @@ class DayPicker extends UI5Element {
 		}
 
 		if (isSpace(event)) {
-			return this._handleSpace(event);
+			event.preventDefault();
+			return;
 		}
 
 		if (isHomeCtrl(event)) {
@@ -478,6 +479,12 @@ class DayPicker extends UI5Element {
 
 		if (isPageDownShiftCtrl(event)) {
 			this._changeYears(event, true, 10);
+		}
+	}
+
+	_onkeyup(event) {
+		if (isSpace(event)) {
+			this._handleSpace(event);
 		}
 	}
 


### PR DESCRIPTION
This PR complements the following PR https://github.com/SAP/ui5-webcomponents/pull/2276
to fix everything requested by the referenced issue, more specifically forcing date selection with SPACE to take place on keyup, instead of keydown as at the moment.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2268