### PR TITLE
chore(playground): fix ui5-side-navigation sample

### DIFF
--- a/packages/fiori/test/samples/SideNavigation.sample.html
+++ b/packages/fiori/test/samples/SideNavigation.sample.html
@@ -10,6 +10,11 @@
 <div class="control-tag">&lt;ui5-side-navigation&gt;</div>
 
 <section>
+	<style>
+		.ui5-side-nav {
+			height: 93%;
+		}	
+	</style>
 	<h3>Side Navigation in Application</h3>
 	<div class="snippet" style="height: 40rem;">
 			<ui5-shellbar primary-title="UI5 Web Components" secondary-title="The Best Run SAP" show-co-pilot
@@ -17,7 +22,7 @@
 			<ui5-button icon="menu" slot="startButton" id="startButton"></ui5-button>
 		</ui5-shellbar>
 
-		<ui5-side-navigation>
+		<ui5-side-navigation class="ui5-side-nav">
 			<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
 			<ui5-side-navigation-item text="People" expanded icon="group">
 				<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>


### PR DESCRIPTION
Prior to this change, the ```ui5-side-navigation``` sample used to overflow out of its parent div