### PR TITLE
fix(framework): Do not create IE styles with disabled

### DIFF
--- a/packages/base/src/theming/createComponentStyleTag.js
+++ b/packages/base/src/theming/createComponentStyleTag.js
@@ -43,7 +43,6 @@ const createComponentStyleTag = ElementClass => {
 
 	createStyleInHead(cssContent, {
 		"data-ui5-element-styles": tag,
-		"disabled": "disabled",
 	});
 	if (ponyfillNeeded()) {
 		schedulePonyfill();


### PR DESCRIPTION
Do not create component styles for IE11 with `disabled`, because if they don't contain at least one CSS Variable, they will not be processed by the CSS Vars ponyfill. It will skip them, and not create new styles with the compiled static CSS. Thus they will remain `disabled` and not have any effect on the page.

The bug can only be seen with components that don't have at least one CSS Var in their styles.

closes: https://github.com/SAP/ui5-webcomponents/issues/2283