### PR TITLE
fix(ui5-li): correct image size

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -116,6 +116,12 @@
 	padding-right: 0.5rem;
 }
 
+:host([description]) .ui5-li-img {
+	width: 3rem;
+	height: 3rem;
+	border-radius: 0.25rem;
+}
+
 .ui5-li-content {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
When **ui5-li** has image and byline (description), the image should have 3rem height and 3rem width in Compact and Cozy mode. In addition its angles should be rounded.

Part of #2218 