### PR TITLE
fix(ui5-switch): fix focus border position

### DIFF
--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -101,7 +101,8 @@
 	left: -var(--_ui5_switch_outline);
 	top: 0;
 	bottom: 0;
-	width: 100%;
+	left: 0;
+	right: 0;
 	border: var(--_ui5_switch_outline) dotted var(--sapContent_FocusColor);
 	pointer-events: none;
 }


### PR DESCRIPTION
This change fixes the wrong focus border position:
![Screen Shot 2020-10-07 at 22 03 10](https://user-images.githubusercontent.com/748043/95381814-fde4d780-08e8-11eb-9391-e8a1d16161c1.png)

It's 2px more from the right side because the border itself is not considered.

Alternative solution would be:
```
box-sizing: border-box;
```

But using `width=100%` with absolutely positioned elements in general is not a best practice.