### PR TITLE
fix(ui5-day-picker): fix color contrast of selected day in HCB

### DIFF
--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -133,7 +133,7 @@
 }
 
 .ui5-dp-item.ui5-dp-item--selected.ui5-dp-item--now .ui5-dp-daytext {
-	border: 1px solid var(--sapList_Background);
+	border: 1px solid var(--_ui5_daypicker_item_selected_border_color);
 	border-radius: var(--_ui5_daypicker_item_now_inner_border_radius);
 }
 

--- a/packages/main/src/themes/base/DayPicker-parameters.css
+++ b/packages/main/src/themes/base/DayPicker-parameters.css
@@ -1,6 +1,7 @@
 :root {
 	--_ui5_daypicker_item_margin: 2px;
 	--_ui5_daypicker_item_border: none;
+	--_ui5_daypicker_item_selected_border_color: var(--sapList_Background);
 	--_ui5_daypicker_item_outline_width: 1px;
 	--_ui5_daypicker_item_outline_offset: 1px;
 	--_ui5_daypicker_daynames_container_height: 2rem;

--- a/packages/main/src/themes/sap_belize_hcb/DatePicker-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/DatePicker-parameters.css
@@ -2,4 +2,5 @@
 
 :root {
 	--_ui5_datepicker_icon_border: 1px solid transparent;
+	--_ui5_daypicker_item_selected_border_color: var(--sapList_SelectionBorderColor);
 }

--- a/packages/main/src/themes/sap_belize_hcw/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/DayPicker-parameters.css
@@ -9,4 +9,5 @@
 	--_ui5_daypicker_weekname_color: var(--sapHC_ReducedForeground);
 	--_ui5_daypicker_item_now_selected_focus_after_width: calc(100% - 0.25rem);
 	--_ui5_daypicker_item_now_selected_focus_after_height: calc(100% - 0.25rem);
+	--_ui5_daypicker_item_selected_border_color: transparent;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/DayPicker-parameters.css
@@ -10,4 +10,5 @@
 	--_ui5_daypicker_weekname_color: var(--sapTextColor);
 	--_ui5_daypicker_item_now_selected_focus_after_width: calc(100% - 0.25rem);
 	--_ui5_daypicker_item_now_selected_focus_after_height: calc(100% - 0.25rem);
+	--_ui5_daypicker_item_selected_border_color: var(--sapList_SelectionBorderColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/DayPicker-parameters.css
@@ -10,4 +10,5 @@
 	--_ui5_daypicker_weekname_color: var(--sapTextColor);
 	--_ui5_daypicker_item_now_selected_focus_after_width: calc(100% - 0.25rem);
 	--_ui5_daypicker_item_now_selected_focus_after_height: calc(100% - 0.25rem);
+	--_ui5_daypicker_item_selected_border_color: transparent;
 }


### PR DESCRIPTION
We had contrast ratio issue between the purple outline and black border around the selected day:

<img width="40" alt="Screenshot 2020-10-20 at 2 14 40 PM" src="https://user-images.githubusercontent.com/15702139/96578954-b98d0a80-12de-11eb-8c9b-9edaed097529.png">

The black border turns out to be wrong,  by design it should have been white and can be seen after the change:

<img width="46" alt="Screenshot 2020-10-20 at 2 14 54 PM" src="https://user-images.githubusercontent.com/15702139/96579030-d45f7f00-12de-11eb-89e2-a14a9b3fad87.png">

FIXES https://github.com/SAP/ui5-webcomponents/issues/2372