### PR TITLE
feat(framework): add override font-family for glyphs with diacritics

### DIFF
--- a/packages/base/src/FontFace.js
+++ b/packages/base/src/FontFace.js
@@ -70,7 +70,7 @@ const fontFaceCSS = `
  *  * Hook above
  *
  *
- * Fallback for the characters that aren't covered by the '72' font to other system fonts
+ * Override for the characters that aren't covered by the '72' font to other system fonts
  *
  * U+0102-0103: A and a with Breve
  * U+01A0-01A1: O and o with Horn
@@ -83,9 +83,9 @@ const fontFaceCSS = `
  * U+1EF4-1EF7: Y and y with diacritics that are not supported by the font and combination of multiple diacritics
  *
  */
-const fallbackFontFaceCSS = `
+const overrideFontFaceCSS = `
 	@font-face {
-		font-family: '72fallback';
+		font-family: '72override';
 		unicode-range: U+0102-0103, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EB7, U+1EB8-1EC7, U+1EC8-1ECB, U+1ECC-1EE3, U+1EE4-1EF1, U+1EF4-1EF7;
 		src: local('Arial'), local('Helvetica'), local('sans-serif');
 	}
@@ -99,8 +99,8 @@ const insertFontFace = () => {
 		insertMainFontFace();
 	}
 
-	// Always set the fallback font - OpenUI5 in CSS Vars mode does not set it, unlike the main font
-	insertFallbackFontFace();
+	// Always set the override font - OpenUI5 in CSS Vars mode does not set it, unlike the main font
+	insertOverrideFontFace();
 };
 
 const insertMainFontFace = () => {
@@ -109,9 +109,9 @@ const insertMainFontFace = () => {
 	}
 };
 
-const insertFallbackFontFace = () => {
-	if (!document.querySelector(`head>style[data-ui5-font-face-fallback]`)) {
-		createStyleInHead(fallbackFontFaceCSS, { "data-ui5-font-face-fallback": "" });
+const insertOverrideFontFace = () => {
+	if (!document.querySelector(`head>style[data-ui5-font-face-override]`)) {
+		createStyleInHead(overrideFontFaceCSS, { "data-ui5-font-face-override": "" });
 	}
 };
 

--- a/packages/base/src/FontFace.js
+++ b/packages/base/src/FontFace.js
@@ -56,18 +56,63 @@ const fontFaceCSS = `
 	}
 `;
 
+/**
+ * Some diacritics are supported by the 72 font:
+ *  * Grave
+ *  * Acute
+ *  * Circumflex
+ *  * Tilde
+ *
+ * However, the following diacritics and the combination of multiple diacritics (including the supported ones) are not supported:
+ *  * Breve
+ *  * Horn
+ *  * Dot below
+ *  * Hook above
+ *
+ *
+ * Fallback for the characters that aren't covered by the '72' font to other system fonts
+ *
+ * U+0102-0103: A and a with Breve
+ * U+01A0-01A1: O and o with Horn
+ * U+01AF-01B0: U and u with Horn
+ * U+1EA0-1EB7: A and a with diacritics that are not supported by the font and combination of multiple diacritics
+ * U+1EB8-1EC7: E and e with diacritics that are not supported by the font and combination of multiple diacritics
+ * U+1EC8-1ECB: I and i with diacritics that are not supported by the font and combination of multiple diacritics
+ * U+1ECC-1EE3: O and o with diacritics that are not supported by the font and combination of multiple diacritics
+ * U+1EE4-1EF1: U and u with diacritics that are not supported by the font and combination of multiple diacritics
+ * U+1EF4-1EF7: Y and y with diacritics that are not supported by the font and combination of multiple diacritics
+ *
+ */
+const fallbackFontFaceCSS = `
+	@font-face {
+		font-family: '72fallback';
+		unicode-range: U+0102-0103, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EB7, U+1EB8-1EC7, U+1EC8-1ECB, U+1ECC-1EE3, U+1EE4-1EF1, U+1EF4-1EF7;
+		src: local('Arial'), local('Helvetica'), local('sans-serif');
+	}
+`;
+
 const insertFontFace = () => {
-	if (document.querySelector(`head>style[data-ui5-font-face]`)) {
-		return;
-	}
-
-	// If OpenUI5 is found, let it set the font
 	const OpenUI5Support = getFeature("OpenUI5Support");
-	if (OpenUI5Support && OpenUI5Support.isLoaded()) {
-		return;
+
+	// Only set the main font if there is no OpenUI5 support, or there is, but OpenUI5 is not loaded
+	if (!OpenUI5Support || !OpenUI5Support.isLoaded()) {
+		insertMainFontFace();
 	}
 
-	createStyleInHead(fontFaceCSS, { "data-ui5-font-face": "" });
+	// Always set the fallback font - OpenUI5 in CSS Vars mode does not set it, unlike the main font
+	insertFallbackFontFace();
+};
+
+const insertMainFontFace = () => {
+	if (!document.querySelector(`head>style[data-ui5-font-face]`)) {
+		createStyleInHead(fontFaceCSS, { "data-ui5-font-face": "" });
+	}
+};
+
+const insertFallbackFontFace = () => {
+	if (!document.querySelector(`head>style[data-ui5-font-face-fallback]`)) {
+		createStyleInHead(fallbackFontFaceCSS, { "data-ui5-font-face-fallback": "" });
+	}
 };
 
 export default insertFontFace;

--- a/packages/fiori/src/themes/NotificationListGroupItem.css
+++ b/packages/fiori/src/themes/NotificationListGroupItem.css
@@ -34,7 +34,7 @@
 
 .ui5-nli-group-heading {
 	color: var(--sapGroup_TitleTextColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontHeader6Size);
 	white-space: nowrap;
 	overflow: hidden;
@@ -50,7 +50,7 @@
 	margin-right: 1rem;
 	color: var(--sapList_TableGroupHeaderTextColor);
 	font-size: var(--sapFontHeader6Size);
-	font-family: "72fallback", var(--sapFontHeaderFamily);
+	font-family: "72override", var(--sapFontHeaderFamily);
 }
 
 [dir="rtl"] .ui5-nli-group-toggle-btn {

--- a/packages/fiori/src/themes/NotificationListGroupItem.css
+++ b/packages/fiori/src/themes/NotificationListGroupItem.css
@@ -34,7 +34,7 @@
 
 .ui5-nli-group-heading {
 	color: var(--sapGroup_TitleTextColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontHeader6Size);
 	white-space: nowrap;
 	overflow: hidden;
@@ -50,7 +50,7 @@
 	margin-right: 1rem;
 	color: var(--sapList_TableGroupHeaderTextColor);
 	font-size: var(--sapFontHeader6Size);
-	font-family: var(--sapFontHeaderFamily);
+	font-family: "72fallback", var(--sapFontHeaderFamily);
 }
 
 [dir="rtl"] .ui5-nli-group-toggle-btn {

--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -61,7 +61,7 @@
 	flex: 1;
 	width: 100%;
 	padding: 0 1rem 0 0.75rem;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	box-sizing: border-box;
 }
 

--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -61,7 +61,7 @@
 	flex: 1;
 	width: 100%;
 	padding: 0 1rem 0 0.75rem;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	box-sizing: border-box;
 }
 

--- a/packages/fiori/src/themes/ProductSwitch.css
+++ b/packages/fiori/src/themes/ProductSwitch.css
@@ -1,5 +1,5 @@
 :host {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 

--- a/packages/fiori/src/themes/ProductSwitch.css
+++ b/packages/fiori/src/themes/ProductSwitch.css
@@ -1,5 +1,5 @@
 :host {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -10,7 +10,7 @@
 	align-items: center;
 	background: var(--sapShellColor);
 	height: 2.75rem;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	box-sizing: border-box;
@@ -92,7 +92,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-menu-button-title {
 	display: inline-block;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	margin: 0;
 	font-size: 0.75rem;
 	white-space: nowrap;
@@ -340,7 +340,7 @@ slot[name="profile"] {
 	justify-content: center;
 	align-items: center;
 	font-size: var(--sapFontSmallSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	z-index: 2;
 	box-sizing: border-box;
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -10,7 +10,7 @@
 	align-items: center;
 	background: var(--sapShellColor);
 	height: 2.75rem;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	box-sizing: border-box;
@@ -92,7 +92,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-menu-button-title {
 	display: inline-block;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	margin: 0;
 	font-size: 0.75rem;
 	white-space: nowrap;
@@ -340,7 +340,7 @@ slot[name="profile"] {
 	justify-content: center;
 	align-items: center;
 	font-size: var(--sapFontSmallSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	z-index: 2;
 	box-sizing: border-box;
 }

--- a/packages/fiori/src/themes/UploadCollection.css
+++ b/packages/fiori/src/themes/UploadCollection.css
@@ -110,7 +110,7 @@
 }
 
 .uc-dnd-overlay .dnd-overlay-text {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapMFontHeader4Size);
 	color: var(--sapContent_NonInteractiveIconColor);
 }

--- a/packages/fiori/src/themes/UploadCollection.css
+++ b/packages/fiori/src/themes/UploadCollection.css
@@ -110,7 +110,7 @@
 }
 
 .uc-dnd-overlay .dnd-overlay-text {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapMFontHeader4Size);
 	color: var(--sapContent_NonInteractiveIconColor);
 }

--- a/packages/fiori/src/themes/UploadCollectionItem.css
+++ b/packages/fiori/src/themes/UploadCollectionItem.css
@@ -53,7 +53,7 @@
 
 .ui5-uci-file-name {
 	display: block;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontLargeSize);
 	color: var(--sapTextColor);
 	margin-bottom: 0.25rem;
@@ -66,7 +66,7 @@
 
 .ui5-uci-description {
 	margin-top: 0.375rem;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontMediumSize);
 	color: var(--sapContent_LabelColor);
 	white-space: initial;
@@ -80,7 +80,7 @@
 }
 
 .ui5-uci-file-extension {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontMediumSize);
 	color: var(--sapTextColor);
 	white-space: no-wrap;

--- a/packages/fiori/src/themes/UploadCollectionItem.css
+++ b/packages/fiori/src/themes/UploadCollectionItem.css
@@ -53,7 +53,7 @@
 
 .ui5-uci-file-name {
 	display: block;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontLargeSize);
 	color: var(--sapTextColor);
 	margin-bottom: 0.25rem;
@@ -66,7 +66,7 @@
 
 .ui5-uci-description {
 	margin-top: 0.375rem;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontMediumSize);
 	color: var(--sapContent_LabelColor);
 	white-space: initial;
@@ -80,7 +80,7 @@
 }
 
 .ui5-uci-file-extension {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontMediumSize);
 	color: var(--sapTextColor);
 	white-space: no-wrap;

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -11,7 +11,7 @@
 	border: solid 1px var(--sapLegendColor1);
 	border-radius: 1.125em;
 	box-sizing: border-box;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	text-align: center;
 }
 

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -11,7 +11,7 @@
 	border: solid 1px var(--sapLegendColor1);
 	border-radius: 1.125em;
 	box-sizing: border-box;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	text-align: center;
 }
 

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -7,7 +7,7 @@
 :host {
 	min-width: var(--_ui5_button_base_min_width);
 	height: var(--_ui5_button_base_height);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	text-shadow: var(--_ui5_button_text_shadow);
 	border-radius: var(--_ui5_button_border_radius);

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -7,7 +7,7 @@
 :host {
 	min-width: var(--_ui5_button_base_min_width);
 	height: var(--_ui5_button_base_height);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	text-shadow: var(--_ui5_button_text_shadow);
 	border-radius: var(--_ui5_button_border_radius);

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -76,7 +76,7 @@
 }
 
 .ui5-calheader-middlebtn {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	width: var(--_ui5_calendar_header_middle_button_width);
 	flex: var(--_ui5_calendar_header_middle_button_flex);
 	position: relative;

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -76,7 +76,7 @@
 }
 
 .ui5-calheader-middlebtn {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	width: var(--_ui5_calendar_header_middle_button_width);
 	flex: var(--_ui5_calendar_header_middle_button_flex);
 	position: relative;

--- a/packages/main/src/themes/Card.css
+++ b/packages/main/src/themes/Card.css
@@ -14,7 +14,7 @@
 	border-radius: .25rem;
 	border: 1px solid var(--_ui5_card_border_color);
 	overflow: hidden;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	box-sizing: border-box;
 }
@@ -93,7 +93,7 @@
 
 .ui5-card-header .ui5-card-status {
 	display: inline-block;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSmallSize);
 	color: var(--sapTile_TextColor);
 	text-align: left;
@@ -106,7 +106,7 @@
 }
 
 .ui5-card-header .ui5-card-header-text .ui5-card-heading {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapMFontHeader5Size);
 	font-weight: normal;
 	color: var(--sapTile_TitleTextColor);
@@ -114,7 +114,7 @@
 }
 
 .ui5-card-header .ui5-card-header-text .ui5-card-subheading {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	color: var(--sapTile_TextColor);

--- a/packages/main/src/themes/Card.css
+++ b/packages/main/src/themes/Card.css
@@ -14,7 +14,7 @@
 	border-radius: .25rem;
 	border: 1px solid var(--_ui5_card_border_color);
 	overflow: hidden;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	box-sizing: border-box;
 }
@@ -93,7 +93,7 @@
 
 .ui5-card-header .ui5-card-status {
 	display: inline-block;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSmallSize);
 	color: var(--sapTile_TextColor);
 	text-align: left;
@@ -106,7 +106,7 @@
 }
 
 .ui5-card-header .ui5-card-header-text .ui5-card-heading {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapMFontHeader5Size);
 	font-weight: normal;
 	color: var(--sapTile_TitleTextColor);
@@ -114,7 +114,7 @@
 }
 
 .ui5-card-header .ui5-card-header-text .ui5-card-subheading {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	color: var(--sapTile_TextColor);

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -19,7 +19,7 @@
 	height: var(--_ui5_day_picker_item_height);
 	margin-top: var(--_ui5_daypicker_item_margin);
 	margin-right: var(--_ui5_daypicker_item_margin);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	border-radius: var(--_ui5_daypicker_item_border_radius);
 }
 
@@ -31,7 +31,7 @@
 	display: flex;
 	flex-basis: 87.5%;
 	flex-direction: column;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 }
 
 .ui5-dp-days-names-container {

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -19,7 +19,7 @@
 	height: var(--_ui5_day_picker_item_height);
 	margin-top: var(--_ui5_daypicker_item_margin);
 	margin-right: var(--_ui5_daypicker_item_margin);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	border-radius: var(--_ui5_daypicker_item_border_radius);
 }
 
@@ -31,7 +31,7 @@
 	display: flex;
 	flex-basis: 87.5%;
 	flex-direction: column;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 }
 
 .ui5-dp-days-names-container {

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -10,7 +10,7 @@
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-style: normal;
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -10,7 +10,7 @@
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-style: normal;
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -5,7 +5,7 @@
 :host {
 	max-width: 100%;
 	color: var(--sapContent_LabelColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	cursor: text;

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -5,7 +5,7 @@
 :host {
 	max-width: 100%;
 	color: var(--sapContent_LabelColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 	cursor: text;

--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -7,7 +7,7 @@
 :host {
 	max-width: 100%;
 	color: var(--sapLinkColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	cursor: pointer;
 	outline: none;

--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -7,7 +7,7 @@
 :host {
 	max-width: 100%;
 	color: var(--sapLinkColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	cursor: pointer;
 	outline: none;

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -40,7 +40,7 @@
 	text-overflow: ellipsis;
 	box-sizing: border-box;
 	font-size: var(--sapMFontHeader4Size);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	color: var(--sapGroup_TitleTextColor);
 	height: 3rem;
 	line-height: 3rem;
@@ -54,7 +54,7 @@
 	box-sizing: border-box;
 	-webkit-text-size-adjust: none;	/* To improve readability Mobile Safari automatically increases the size of small text so let's disable this */
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	line-height: 2rem;
 	background-color: var(--sapList_FooterBackground);
 	color: var(--ui5_list_footer_text_color);

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -40,7 +40,7 @@
 	text-overflow: ellipsis;
 	box-sizing: border-box;
 	font-size: var(--sapMFontHeader4Size);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	color: var(--sapGroup_TitleTextColor);
 	height: 3rem;
 	line-height: 3rem;
@@ -54,7 +54,7 @@
 	box-sizing: border-box;
 	-webkit-text-size-adjust: none;	/* To improve readability Mobile Safari automatically increases the size of small text so let's disable this */
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	line-height: 2rem;
 	background-color: var(--sapList_FooterBackground);
 	color: var(--ui5_list_footer_text_color);

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -69,6 +69,6 @@
 .ui5-li-content {
 	max-width: 100%;
 	min-height: 1px; /* IE specific: fixes vertical centering with flex  */
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	pointer-events: none;  /* IE specific: fixes focus crrectly applied*/
 }

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -69,6 +69,6 @@
 .ui5-li-content {
 	max-width: 100%;
 	min-height: 1px; /* IE specific: fixes vertical centering with flex  */
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	pointer-events: none;  /* IE specific: fixes focus crrectly applied*/
 }

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -76,7 +76,7 @@
 	width: 100%;
 	color: var(--sapTextColor);
 	line-height: 1.2;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -76,7 +76,7 @@
 	width: 100%;
 	color: var(--sapTextColor);
 	line-height: 1.2;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -11,7 +11,7 @@
 	padding: 2rem 0 1rem 0;
 	display: flex;
 	flex-direction: column;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -11,7 +11,7 @@
 	padding: 2rem 0 1rem 0;
 	display: flex;
 	flex-direction: column;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -5,7 +5,7 @@
 }
 
 :host {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	background-color: var(--sapGroup_TitleBackground);
 	border-bottom: 1px solid var(--sapGroup_TitleBorderColor);
 }
@@ -57,7 +57,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-family: var(--sapFontHeaderFamily);
+	font-family: "72fallback", var(--sapFontHeaderFamily);
 	font-size: var(--sapFontHeader5Size);
 	font-weight: normal;
 	color: var(--sapGroup_TitleTextColor);

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -5,7 +5,7 @@
 }
 
 :host {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	background-color: var(--sapGroup_TitleBackground);
 	border-bottom: 1px solid var(--sapGroup_TitleBorderColor);
 }
@@ -57,7 +57,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-family: "72fallback", var(--sapFontHeaderFamily);
+	font-family: "72override", var(--sapFontHeaderFamily);
 	font-size: var(--sapFontHeader5Size);
 	font-weight: normal;
 	color: var(--sapGroup_TitleTextColor);

--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -46,7 +46,7 @@
     color: var(--sapPageHeader_TextColor);
     font-size: 1rem;
     font-weight: 400;
-    font-family: "72fallback", var(--sapFontFamily);
+    font-family: "72override", var(--sapFontFamily);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -46,7 +46,7 @@
     color: var(--sapPageHeader_TextColor);
     font-size: 1rem;
     font-weight: 400;
-    font-family: var(--sapFontFamily);
+    font-family: "72fallback", var(--sapFontFamily);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -17,7 +17,7 @@
     height: 100%;
     width: 100%;
     font-size: var(--sapFontSmallSize);
-    font-family: var(--sapFontFamily);
+    font-family: "72fallback", var(--sapFontFamily);
 }
 
 .ui5-progress-indicator-bar {

--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -17,7 +17,7 @@
     height: 100%;
     width: 100%;
     font-size: var(--sapFontSmallSize);
-    font-family: "72fallback", var(--sapFontFamily);
+    font-family: "72override", var(--sapFontFamily);
 }
 
 .ui5-progress-indicator-bar {

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -4,7 +4,7 @@
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -4,7 +4,7 @@
 	height: var(--_ui5_input_height);
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -70,7 +70,7 @@
 	min-width: 1.625rem;
 	padding: 0 0.125rem;
 	font-size: var(--sapFontSmallSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	text-transform: uppercase;
 	text-align: center;
 	color: var(--sapTextColor);

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -70,7 +70,7 @@
 	min-width: 1.625rem;
 	padding: 0 0.125rem;
 	font-size: var(--sapFontSmallSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	text-transform: uppercase;
 	text-align: center;
 	color: var(--sapTextColor);

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -11,7 +11,7 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: 1rem;
 }
 

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -11,7 +11,7 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: 1rem;
 }
 

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -12,7 +12,7 @@ table {
 .ui5-table-header-row {
 	color: var(--sapTextColor);
 	height: 3rem;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 
@@ -33,7 +33,7 @@ tr {
 	justify-content: center;
 	text-align: center;
 	padding: 0.5rem 1rem;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: 0.875rem;
 	box-sizing: border-box;
 	color: var(--sapTextColor);

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -12,7 +12,7 @@ table {
 .ui5-table-header-row {
 	color: var(--sapTextColor);
 	height: 3rem;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }
 
@@ -33,7 +33,7 @@ tr {
 	justify-content: center;
 	text-align: center;
 	padding: 0.5rem 1rem;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: 0.875rem;
 	box-sizing: border-box;
 	color: var(--sapTextColor);

--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -1,6 +1,6 @@
 :host {
 	display: contents;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: 0.875rem;
 	height: 100%;
 	box-sizing: border-box;

--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -1,6 +1,6 @@
 :host {
 	display: contents;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: 0.875rem;
 	height: 100%;
 	box-sizing: border-box;

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -27,6 +27,6 @@
 
 .ui5-table-row-popin-title {
 	color: var(--sapContent_LabelColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -27,6 +27,6 @@
 
 .ui5-table-row-popin-title {
 	color: var(--sapContent_LabelColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 }

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -8,7 +8,7 @@
 	width: 100%;
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-style: normal;
 	border-color: var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
@@ -94,7 +94,7 @@
 	word-break: break-all;
 	padding: var(--_ui5_textarea_padding);
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	white-space: pre-wrap;
 	box-sizing: border-box;
 }
@@ -201,6 +201,6 @@
 	align-self: flex-end;
 	padding: 0.125rem 0.125rem 0.5rem;
 	color: var(--sapContent_LabelColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSmallSize);
 }

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -8,7 +8,7 @@
 	width: 100%;
 	color: var(--sapField_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-style: normal;
 	border-color: var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
@@ -94,7 +94,7 @@
 	word-break: break-all;
 	padding: var(--_ui5_textarea_padding);
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	white-space: pre-wrap;
 	box-sizing: border-box;
 }
@@ -201,6 +201,6 @@
 	align-self: flex-end;
 	padding: 0.125rem 0.125rem 0.5rem;
 	color: var(--sapContent_LabelColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSmallSize);
 }

--- a/packages/main/src/themes/TimelineItem.css
+++ b/packages/main/src/themes/TimelineItem.css
@@ -125,7 +125,7 @@
 .ui5-tli-title,
 .ui5-tli-desc {
 	color: var(--sapTextColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-weight: 400;
 	font-size: var(--sapFontSize);
 }
@@ -137,7 +137,7 @@
 
 .ui5-tli-subtitle {
 	color: var(--sapContent_LabelColor);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-weight: 400;
 	font-size: var(--sapFontSmallSize);
 	padding-top: .375rem;

--- a/packages/main/src/themes/TimelineItem.css
+++ b/packages/main/src/themes/TimelineItem.css
@@ -125,7 +125,7 @@
 .ui5-tli-title,
 .ui5-tli-desc {
 	color: var(--sapTextColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-weight: 400;
 	font-size: var(--sapFontSize);
 }
@@ -137,7 +137,7 @@
 
 .ui5-tli-subtitle {
 	color: var(--sapContent_LabelColor);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-weight: 400;
 	font-size: var(--sapFontSmallSize);
 	padding-top: .375rem;

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -7,7 +7,7 @@
 	max-width: 100%;
 	color: var(--sapGroup_TitleTextColor);
 	font-size: var(--ui5_title_level_2Size);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	text-shadow: var(--sapContent_TextShadow);
 }
 

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -7,7 +7,7 @@
 	max-width: 100%;
 	color: var(--sapGroup_TitleTextColor);
 	font-size: var(--ui5_title_level_2Size);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	text-shadow: var(--sapContent_TextShadow);
 }
 

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -1,5 +1,5 @@
 :host {
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	color: var(--sapTextColor);
 	font-size: var(--sapFontSize);
 }

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -1,5 +1,5 @@
 :host {
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	color: var(--sapTextColor);
 	font-size: var(--sapFontSize);
 }

--- a/packages/main/src/themes/Token.css
+++ b/packages/main/src/themes/Token.css
@@ -53,7 +53,7 @@
 	padding-bottom: 0.25rem;
 	box-sizing: border-box;
 	font-size: var(--sapFontSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	user-select: none;
 }
 

--- a/packages/main/src/themes/Token.css
+++ b/packages/main/src/themes/Token.css
@@ -53,7 +53,7 @@
 	padding-bottom: 0.25rem;
 	box-sizing: border-box;
 	font-size: var(--sapFontSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	user-select: none;
 }
 

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -14,7 +14,7 @@
 	padding: var(--_ui5_tokenizer_root_padding);
 	overflow-x: scroll;
 	box-sizing: border-box;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 }
 
 .ui5-tokenizer-no-padding {

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -14,7 +14,7 @@
 	padding: var(--_ui5_tokenizer_root_padding);
 	overflow-x: scroll;
 	box-sizing: border-box;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 }
 
 .ui5-tokenizer-no-padding {

--- a/packages/main/src/themes/ValueStateMessage.css
+++ b/packages/main/src/themes/ValueStateMessage.css
@@ -8,7 +8,7 @@
 	display: inline-block;
 	color: var(--sapUiBaseColor);
 	font-size: var(--sapFontSmallSize);
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	padding: .3rem .625rem;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/main/src/themes/ValueStateMessage.css
+++ b/packages/main/src/themes/ValueStateMessage.css
@@ -8,7 +8,7 @@
 	display: inline-block;
 	color: var(--sapUiBaseColor);
 	font-size: var(--sapFontSmallSize);
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	padding: .3rem .625rem;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/main/src/themes/WheelSlider.css
+++ b/packages/main/src/themes/WheelSlider.css
@@ -4,7 +4,7 @@
 	vertical-align: middle;
 	text-align: center;
 	box-sizing: border-box;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	justify-content: space-between;
 	flex-direction: column;
 	display: inline-flex;

--- a/packages/main/src/themes/WheelSlider.css
+++ b/packages/main/src/themes/WheelSlider.css
@@ -4,7 +4,7 @@
 	vertical-align: middle;
 	text-align: center;
 	box-sizing: border-box;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	justify-content: space-between;
 	flex-direction: column;
 	display: inline-flex;

--- a/packages/main/src/themes/YearPicker.css
+++ b/packages/main/src/themes/YearPicker.css
@@ -11,7 +11,7 @@
 	padding: 2rem 0 1rem 0;
 	display: flex;
 	flex-direction: column;
-	font-family: "72fallback", var(--sapFontFamily);
+	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;

--- a/packages/main/src/themes/YearPicker.css
+++ b/packages/main/src/themes/YearPicker.css
@@ -11,7 +11,7 @@
 	padding: 2rem 0 1rem 0;
 	display: flex;
 	flex-direction: column;
-	font-family: var(--sapFontFamily);
+	font-family: "72fallback", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	justify-content: center;
 	align-items: center;

--- a/packages/main/test/pages/72override.html
+++ b/packages/main/test/pages/72override.html
@@ -25,7 +25,7 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 
-<ui5-button icon="download"></ui5-button>
+<ui5-button>Đỗ</ui5-button>
 
 </body>
 </html>

--- a/packages/main/test/pages/Simple.html
+++ b/packages/main/test/pages/Simple.html
@@ -25,7 +25,7 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 
-<ui5-button icon="download"></ui5-button>
+<ui5-button icon="download">Đỗ</ui5-button>
 
 </body>
 </html>


### PR DESCRIPTION
The `72` font has limited support for diacritics and should not be used for certain Unicode characters (for example ones used in the Vietnamese language). 

Therefore this change introduces the `72override` font family that will be used for these characters only, and it will fallback to the system fonts - Arial, etc... that display them properly.

Consider the following HTML:
```
<ui5-button>Đỗ</ui5-button>
```
Before the fix, the wrong diacritics are displayed:
![image](https://user-images.githubusercontent.com/15844574/97284617-ee9edd00-1849-11eb-92ec-90b951e66677.png)

After the fix, the correct ones:
![image](https://user-images.githubusercontent.com/15844574/97284553-d929b300-1849-11eb-9946-1b7439b9df60.png)

Changes:
 - `insertFontFace.js` is split into 2 parts: normal font part (that works as before - only applied when there is no OpenUI5 present) and override part, which is applied unconditionally. The reason is that OpenUI5 does not provide the override 72 font when used in CSS Vars mode, but only with `.less` files. Therefore we always need it.
 - All components now use this font family explicitly, before falling back to the `--sapFontFamily` fonts. This is necessary to ensure that languages such as Vietnamese will work properly no matter where the CSS Variables for `theme-base` come from: UI5 Web components, OpenUI5 or Theme Designer.

**Important:** This is a temporary fix until this feature is implemented in https://github.com/SAP/theming-base-content. Then it will work out of the box for both UI5 Web Components and OpenUI5 in CSS Vars mode.

closes: https://github.com/SAP/ui5-webcomponents/issues/2399