### PR TITLE
fix(ui5-busy-indicator): improve accessibility

### DIFF
--- a/packages/main/src/BusyIndicator.hbs
+++ b/packages/main/src/BusyIndicator.hbs
@@ -22,5 +22,5 @@
 		{{/if}}
 	</div>
 
-	<slot tabindex="-1"></slot>
+	<slot tabindex="{{slotTabindex}}"></slot>
 </div>

--- a/packages/main/src/BusyIndicator.hbs
+++ b/packages/main/src/BusyIndicator.hbs
@@ -1,6 +1,6 @@
 <div
 	class="{{classes.root}}"
-	tabindex="1"
+	tabindex="0"
 	title="{{ariaTitle}}"
 	aria-label="{{rootAriaLabel}}"
 	@focusin="{{_onfocusin}}"

--- a/packages/main/src/BusyIndicator.hbs
+++ b/packages/main/src/BusyIndicator.hbs
@@ -1,7 +1,15 @@
-<div class="{{classes.root}}">
+<div
+	class="{{classes.root}}"
+	tabindex="1"
+	title="{{ariaTitle}}"
+	aria-label="{{rootAriaLabel}}"
+	@focusin="{{_onfocusin}}"
+	@focusout="{{_onfocusout}}"
+>
+
 	<div class="ui5-busyindicator-wrapper">
 		{{#if active}}
-			<div class="ui5-busyindicator-dynamic-content" role="progressbar" aria-valuemin="0" aria-valuemax="100" title="{{ariaTitle}}">
+			<div class="ui5-busyindicator-dynamic-content" role="progressbar" aria-valuemin="0" aria-valuemax="100">
 				<div class="ui5-busyindicator-circle circle-animation-0"></div>
 				<div class="ui5-busyindicator-circle circle-animation-1"></div>
 				<div class="ui5-busyindicator-circle circle-animation-2"></div>
@@ -14,5 +22,5 @@
 		{{/if}}
 	</div>
 
-	<slot></slot>
+	<slot tabindex="-1"></slot>
 </div>

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -173,6 +173,10 @@ class BusyIndicator extends UI5Element {
 		return this.active ? `${this.i18nBundle.getText(BUSY_INDICATOR_TITLE)} ${this.text}` : "";
 	}
 
+	get slotTabindex() {
+		return this.active ? "-1" : "0";
+	}
+
 	get classes() {
 		return {
 			root: {

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -2,6 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import BusyIndicatorSize from "./types/BusyIndicatorSize.js";
 import Label from "./Label.js";
 
@@ -69,6 +70,13 @@ const metadata = {
 		active: {
 			type: Boolean,
 		},
+
+		/**
+		 * @private
+		 */
+		focused: {
+			type: Boolean,
+		},
 	},
 };
 
@@ -110,14 +118,6 @@ class BusyIndicator extends UI5Element {
 		this._preventHandler = this._preventEvent.bind(this);
 	}
 
-	onBeforeRendering() {
-		if (this.active) {
-			this.tabIndex = -1;
-		} else {
-			this.removeAttribute("tabindex");
-		}
-	}
-
 	onEnterDOM() {
 		this.addEventListener("keyup", this._preventHandler, {
 			capture: true,
@@ -157,8 +157,20 @@ class BusyIndicator extends UI5Element {
 		await fetchI18nBundle("@ui5/webcomponents");
 	}
 
+	_onfocusin() {
+		this.focused = true;
+	}
+
+	_onfocusout() {
+		this.focused = false;
+	}
+
 	get ariaTitle() {
 		return this.i18nBundle.getText(BUSY_INDICATOR_TITLE);
+	}
+
+	get rootAriaLabel() {
+		return this.active ? `${this.i18nBundle.getText(BUSY_INDICATOR_TITLE)} ${this.text}` : "";
 	}
 
 	get classes() {
@@ -173,6 +185,10 @@ class BusyIndicator extends UI5Element {
 	_preventEvent(event) {
 		if (this.active) {
 			event.stopImmediatePropagation();
+
+			if (isSpace(event)) {
+				event.preventDefault();
+			}
 		}
 	}
 }

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -2,17 +2,25 @@
 	display: inline-block;
 }
 
+:host(:not([hidden])[focused]) .ui5-busyindicator-root {
+	border: 1px dotted var(--sapContent_FocusColor);
+	outline: none;
+}
+
 :host(:not([active])) .ui5-busyindicator-wrapper {
 	display: none;
 }
 
 :host([active]) {
 	color: var(--sapContent_IconColor);
-	pointer-events: none;
 }
 
 :host([active]) :not(.ui5-busyindicator-root--ie) ::slotted(:not([class^="ui5-busyindicator-"])) {
 	opacity: 0.6;
+}
+
+slot {
+	pointer-events: none;
 }
 
 /**
@@ -73,6 +81,7 @@
 	align-items: center;
 	position: relative;
 	background-color: inherit;
+	border: 1px solid transparent;
 }
 
 .ui5-busyindicator-wrapper {

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -19,7 +19,7 @@
 	opacity: 0.6;
 }
 
-slot {
+:host([active]) slot {
 	pointer-events: none;
 }
 


### PR DESCRIPTION
Fixes #2381

After this change:
- A tooltip should be present
- The ```ui5-busy-indicator``` should be focusable
- When focused, the screen reader should read out the information
- When active is set to true, the content of the default slot of the busy indicator should not be reachable via keyboard/mouse
- When active is set to false, the content of the default slot of the busy indicator should be reachable via keyboard/mouse