### PR TITLE
fix(ui5-ComboBox):  avoid flickering problem

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -420,9 +420,9 @@ class ComboBox extends UI5Element {
 
 		if (this._isKeyNavigation && this.responsivePopover && this.responsivePopover.opened) {
 			this.focused = false;
-		} else {
-			this.focused = this === document.activeElement;
-		}
+		} else if (this.shadowRoot.activeElement) {
+            this.focused = this.shadowRoot.activeElement.id === 'ui5-combobox-input';
+        }
 
 		this._initialRendering = false;
 		this._isKeyNavigation = false;

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -421,8 +421,8 @@ class ComboBox extends UI5Element {
 		if (this._isKeyNavigation && this.responsivePopover && this.responsivePopover.opened) {
 			this.focused = false;
 		} else if (this.shadowRoot.activeElement) {
-            this.focused = this.shadowRoot.activeElement.id === 'ui5-combobox-input';
-        }
+			this.focused = this.shadowRoot.activeElement.id === "ui5-combobox-input";
+		}
 
 		this._initialRendering = false;
 		this._isKeyNavigation = false;

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -98,7 +98,7 @@ describe("General interaction", () => {
 
 		// act
 		input.keys("u");
-		
+
 		// assert
 		listItems = popover.$("ui5-list").$$("ui5-li");
 		assert.strictEqual(listItems.length, 2, "Items should be 2");
@@ -288,5 +288,31 @@ describe("General interaction", () => {
 		listItem.click();
 
 		assert.strictEqual(label.getText(), listItem.shadow$(".ui5-li-title").getText(), "event is fired correctly");
+	});
+
+	it ("Tests focused property when clicking on the arrow", () => {
+		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+
+		const combo = $("#combo");
+		const arrow = combo.shadow$("[input-icon]");
+
+		assert.ok(!combo.getProperty("focused"), "property focused should be false");
+
+		arrow.click();
+
+		assert.ok(combo.getProperty("focused"), "property focused should be true");
+	});
+
+	it ("Tests focused property when clicking on the input", () => {
+		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+
+		const combo = $("#combo");
+		const input = combo.shadow$("#ui5-combobox-input");
+
+		assert.ok(!combo.getProperty("focused"), "property focused should be false");
+
+		input.click();
+
+		assert.ok(combo.getProperty("focused"), "property focused should be true");
 	});
 });


### PR DESCRIPTION
fix(ui5-ComboBox):  avoid flickering problem

use the right activeElement by focus-checking to solve the flickering problem of the comboBox.

Fixes #2365