### PR TITLE
fix(ui5-list): remove focus trap for empty list

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -14,7 +14,7 @@
 		</header>
 	{{/if}}
 
-	{{#if noData}}
+	{{#if hasData}}
 		<div id="{{_id}}-before" tabindex="0" class="ui5-list-focusarea"></div>
 	{{/if}}
 
@@ -48,7 +48,7 @@
 		</div>
 	{{/if}}
 
-	{{#if noData}}
+	{{#if hasData}}
 		<div id="{{_id}}-after" tabindex="0" class="ui5-list-focusarea"></div>
 	{{/if}}
 </div>

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -14,7 +14,9 @@
 		</header>
 	{{/if}}
 
-	<div id="{{_id}}-before" tabindex="0" class="ui5-list-focusarea"></div>
+	{{#if noData}}
+		<div id="{{_id}}-before" tabindex="0" class="ui5-list-focusarea"></div>
+	{{/if}}
 
 	<ul id="{{_id}}-listUl"
 		class="ui5-list-ul"
@@ -46,5 +48,7 @@
 		</div>
 	{{/if}}
 
-	<div id="{{_id}}-after" tabindex="0" class="ui5-list-focusarea"></div>
+	{{#if noData}}
+		<div id="{{_id}}-after" tabindex="0" class="ui5-list-focusarea"></div>
+	{{/if}}
 </div>

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -381,12 +381,12 @@ class List extends UI5Element {
 		return `${this._id}-header`;
 	}
 
-	get noData() {
+	get hasData() {
 		return this.items.length !== 0;
 	}
 
 	get showNoDataText() {
-		return !this.noData && this.noDataText;
+		return !this.hasData && this.noDataText;
 	}
 
 	get showBusy() {

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -381,8 +381,12 @@ class List extends UI5Element {
 		return `${this._id}-header`;
 	}
 
+	get noData() {
+		return this.items.length !== 0;
+	}
+
 	get showNoDataText() {
-		return this.items.length === 0 && this.noDataText;
+		return !this.noData && this.noDataText;
 	}
 
 	get showBusy() {


### PR DESCRIPTION
This PR fixes a problem in ```ui5-list```.
Prior to this change, two divs for focus trapping were always rendered.

After this change they are only rendered if there is at least one item in the list.(Not rendered for empty lists)