### PR TITLE
fix(ui5-combobox): allow typing in input on mobile devices

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -435,7 +435,7 @@ class ComboBox extends UI5Element {
 			this.inner.focus();
 		}
 
-		if (this.shouldClosePopover()) {
+		if (this.shouldClosePopover() && !isPhone()) {
 			this.responsivePopover.close(false, false, true);
 		}
 
@@ -456,13 +456,14 @@ class ComboBox extends UI5Element {
 			this.filterValue = this.value;
 		}
 
-		event.target.setSelectionRange(0, this.value.length);
+		!isPhone() && event.target.setSelectionRange(0, this.value.length);
 	}
 
 	_focusout() {
 		this.focused = false;
 
 		this._inputChange();
+		!isPhone() && this._closeRespPopover();
 	}
 
 	_afterOpenPopover() {
@@ -545,6 +546,10 @@ class ComboBox extends UI5Element {
 
 		this._filteredItems = this._filterItems(value);
 
+		if (isPhone()) {
+			return;
+		}
+
 		if (!this._filteredItems.length) {
 			this._closeRespPopover();
 		} else {
@@ -610,6 +615,7 @@ class ComboBox extends UI5Element {
 
 		if (isEnter(event)) {
 			this._inputChange();
+			this._closeRespPopover();
 		}
 
 		if (isShow(event) && !this.readonly && !this.disabled) {
@@ -677,8 +683,6 @@ class ComboBox extends UI5Element {
 			this.fireEvent("change");
 			this.inner.setSelectionRange(this.value.length, this.value.length);
 		}
-
-		this._closeRespPopover();
 	}
 
 	_itemMousedown(event) {
@@ -706,6 +710,7 @@ class ComboBox extends UI5Element {
 		});
 
 		this._inputChange();
+		this._closeRespPopover();
 	}
 
 	_onItemFocus(event) {


### PR DESCRIPTION
Allow typing in the input field when using a mobile device.

FIXES: #2324 