### PR TITLE
fix(ui5-dialog): Texts are no longer blurred in Chromium-based browsers

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -153,6 +153,18 @@ const metadata = {
  * @public
  */
 class Dialog extends Popup {
+	constructor() {
+		super();
+
+		this._screenResizeHandler = this._center.bind(this);
+
+		this._dragMouseMoveHandler = this._onDragMouseMove.bind(this);
+		this._dragMouseUpHandler = this._onDragMouseUp.bind(this);
+
+		this._resizeMouseMoveHandler = this._onResizeMouseMove.bind(this);
+		this._resizeMouseUpHandler = this._onResizeMouseUp.bind(this);
+	}
+
 	static get metadata() {
 		return metadata;
 	}
@@ -202,16 +214,6 @@ class Dialog extends Popup {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
 		this.onDesktop = isDesktop();
-	}
-
-	onEnterDOM() {
-		this._screenResizeHandler = this._center.bind(this);
-
-		this._dragMouseMoveHandler = this._onDragMouseMove.bind(this);
-		this._dragMouseUpHandler = this._onDragMouseUp.bind(this);
-
-		this._resizeMouseMoveHandler = this._onResizeMouseMove.bind(this);
-		this._resizeMouseUpHandler = this._onResizeMouseUp.bind(this);
 	}
 
 	show() {

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -214,21 +214,19 @@ class Dialog extends Popup {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
 		this.onDesktop = isDesktop();
+
+		ResizeHandler.deregister(this, this._screenResizeHandler);
+		ResizeHandler.deregister(document.body, this._screenResizeHandler);
+	}
+
+	onAfterRendering() {
+		ResizeHandler.register(this, this._screenResizeHandler);
+		ResizeHandler.register(document.body, this._screenResizeHandler);
 	}
 
 	show() {
-		ResizeHandler.register(this, this._screenResizeHandler);
-		ResizeHandler.register(document.body, this._screenResizeHandler);
-
 		super.show();
 		this._center();
-	}
-
-	close() {
-		ResizeHandler.deregister(this, this._screenResizeHandler);
-		ResizeHandler.deregister(document.body, this._screenResizeHandler);
-
-		super.close();
 	}
 
 	_center() {

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -214,24 +214,12 @@ class Dialog extends Popup {
 		this._resizeMouseUpHandler = this._onResizeMouseUp.bind(this);
 	}
 
-	onExitDOM() {
-		delete this._screenResizeHandler;
-		delete this._dragMouseMoveHandler;
-		delete this._dragMouseUpHandler;
-		delete this._resizeMouseMoveHandler;
-		delete this._resizeMouseUpHandler;
-	}
-
 	show() {
 		ResizeHandler.register(this, this._screenResizeHandler);
 		ResizeHandler.register(document.body, this._screenResizeHandler);
 
-		this.style.visibility = "hidden";
-
 		super.show();
 		this._center();
-
-		this.style.visibility = "";
 	}
 
 	close() {

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -206,6 +206,11 @@ class Dialog extends Popup {
 		};
 	}
 
+	show() {
+		super.show();
+		this._center();
+	}
+
 	_clamp(val, min, max) {
 		return Math.min(Math.max(val, min), max);
 	}
@@ -214,19 +219,16 @@ class Dialog extends Popup {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
 		this.onDesktop = isDesktop();
-
-		ResizeHandler.deregister(this, this._screenResizeHandler);
-		ResizeHandler.deregister(document.body, this._screenResizeHandler);
 	}
 
-	onAfterRendering() {
+	onEnterDOM() {
 		ResizeHandler.register(this, this._screenResizeHandler);
 		ResizeHandler.register(document.body, this._screenResizeHandler);
 	}
 
-	show() {
-		super.show();
-		this._center();
+	onExitDOM() {
+		ResizeHandler.deregister(this, this._screenResizeHandler);
+		ResizeHandler.deregister(document.body, this._screenResizeHandler);
 	}
 
 	_center() {
@@ -239,6 +241,15 @@ class Dialog extends Popup {
 		});
 	}
 
+	_revertSize() {
+		Object.assign(this.style, {
+			top: "",
+			left: "",
+			width: "",
+			height: "",
+		});
+		this.removeEventListener("ui5-before-close", this._revertSize);
+	}
 
 	/**
 	 * Event handlers
@@ -305,6 +316,9 @@ class Dialog extends Popup {
 	}
 
 	_attachDragHandlers() {
+		ResizeHandler.deregister(this, this._screenResizeHandler);
+		ResizeHandler.deregister(document.body, this._screenResizeHandler);
+
 		window.addEventListener("mousemove", this._dragMouseMoveHandler);
 		window.addEventListener("mouseup", this._dragMouseUpHandler);
 	}
@@ -403,6 +417,7 @@ class Dialog extends Popup {
 
 	_attachResizeHandlers() {
 		ResizeHandler.deregister(this, this._screenResizeHandler);
+		ResizeHandler.deregister(document.body, this._screenResizeHandler);
 
 		window.addEventListener("mousemove", this._resizeMouseMoveHandler);
 		window.addEventListener("mouseup", this._resizeMouseUpHandler);
@@ -412,16 +427,6 @@ class Dialog extends Popup {
 	_detachResizeHandlers() {
 		window.removeEventListener("mousemove", this._resizeMouseMoveHandler);
 		window.removeEventListener("mouseup", this._resizeMouseUpHandler);
-	}
-
-	_revertSize() {
-		Object.assign(this.style, {
-			top: "",
-			left: "",
-			width: "",
-			height: "",
-		});
-		this.removeEventListener("ui5-before-close", this._revertSize);
 	}
 }
 

--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -1,7 +1,4 @@
 :host {
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
 	min-width: 20rem;
 	min-height: 6rem;
 	box-shadow: var(--sapContent_Shadow3);

--- a/packages/main/test/pages/DialogLifecycle.html
+++ b/packages/main/test/pages/DialogLifecycle.html
@@ -30,7 +30,7 @@
 
 <template id="dt">
 	<ui5-dialog id="hello-dialog" header-text="Dialogs are easy!">
-		<div stype="padding: 2rem; display:flex; justify-content: center;">
+		<div style="padding: 2rem; display:flex; justify-content: center;">
 			Hello World!
 			<ui5-button id="closeDialogButton">Dismiss</ui5-button>
 		</div>


### PR DESCRIPTION
Fixes: #2270

Bug in Chromium-based browsers (https://bugs.chromium.org/p/chromium/issues/detail?id=783388)
causes elements with transform translate applied to be blurred
due to values ending up resulting in fractional values.

As a workaround, ui5-dialog is now centered using position fixed (with top and left).