### PR TITLE
chore(framework): Improve behavior with multiple CSSVarsPonyfills

### DIFF
--- a/packages/base/src/theming/CSSVarsPonyfill.js
+++ b/packages/base/src/theming/CSSVarsPonyfill.js
@@ -2,9 +2,29 @@ let ponyfillTimer;
 
 const ponyfillNeeded = () => !!window.CSSVarsPonyfill;
 
+/**
+ * Removes the "data-cssvars-group" attribute for all element styles and their respective out nodes.
+ * CSSVarsPonyfill has internal counters for "group" and "job" and running several instances of the ponyfill may lead to issues, since these counters are not shared
+ * Therefore we remove them for our "data-ui5-element-styles"
+ *
+ * @param rootElement
+ */
+const cleanPonyfillMetadata = (rootElement = document.head) => {
+	rootElement.querySelectorAll(`style[data-ui5-element-styles][data-cssvars="src"]`).forEach(tag => {
+		const group = tag.getAttribute("data-cssvars-group");
+		tag.removeAttribute("data-cssvars-group");
+		tag.disabled = false;
+		const outNode = rootElement.querySelector(`style[data-cssvars="out"][data-cssvars-group="${group}"]`);
+		if (outNode) {
+			outNode.removeAttribute("data-cssvars-group");
+		}
+	});
+};
+
 const runPonyfill = () => {
 	ponyfillTimer = undefined;
 
+	cleanPonyfillMetadata();
 	window.CSSVarsPonyfill.cssVars({
 		rootElement: document.head,
 		variables: isCompact() ? getCompactModeVars() : {},


### PR DESCRIPTION
CSSVarsPonyfill creates the following attributes:
- `data-cssvars`
- `data-cssvars-job`
- `data-cssvars-group`

![image](https://user-images.githubusercontent.com/15844574/97553994-d613fb80-19de-11eb-9341-2dcacfd55772.png)

The counters for "job" and "group" are internal and are not shared among all instances of the ponyfill. Therefore if several ponyfills operate on the same page, there might be inconsistencies and some styles may not be processed.

Therefore we remove the `data-cssvars-group` attribute for all elements' styles before running the ponyfill to make sure all will be processed.
