### PR TITLE
fix: set string props to "default" when null

### DIFF
--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -176,7 +176,10 @@ const validateSingleProperty = (value, propData) => {
 		return typeof value === "boolean" ? value : false;
 	}
 	if (propertyType === String) {
-		return (typeof value === "string" || typeof value === "undefined" || value === null) ? value : value.toString();
+		if ( typeof value === "undefined" || value === null) {
+			return propData.defaultValue;
+		}
+		return typeof value === "string" ? value : value.toString();
 	}
 	if (propertyType === Object) {
 		return typeof value === "object" ? value : propData.defaultValue;

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -176,7 +176,7 @@ const validateSingleProperty = (value, propData) => {
 		return typeof value === "boolean" ? value : false;
 	}
 	if (propertyType === String) {
-		if ( typeof value === "undefined" || value === null) {
+		if (typeof value === "undefined" || value === null) {
 			return propData.defaultValue;
 		}
 		return typeof value === "string" ? value : value.toString();

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -107,6 +107,7 @@ const metadata = {
 		 */
 		placeholder: {
 			type: String,
+			defaultValue: "",
 		},
 
 		/**

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -163,6 +163,7 @@ const metadata = {
 		 */
 		placeholder: {
 			type: String,
+			defaultValue: "",
 		},
 
 		/**

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -91,6 +91,7 @@ const metadata = {
 		 */
 		placeholder: {
 			type: String,
+			defaultValue: "",
 		},
 
 		/**

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -179,7 +179,17 @@
 		</div>
 	</section>
 
-    <script type="module">
+	<h3>Test placeholder removal</h3>
+	<section style="display: flex; flex-direction: column;">
+		<ui5-button id="buttonCleanPlaceholder" style="width: 200px;">Remove placholder</ui5-button>
+		<ui5-combobox id="cbxWithPlaceholder" placeholder="Hello World">
+			<ui5-cb-item text="Argentina"></ui5-cb-item>
+			<ui5-cb-item text="United States of America"></ui5-cb-item>
+			<ui5-cb-item text="Canada"></ui5-cb-item>
+		</ui5-combobox>
+	</section>
+
+	<script type="module">
 		document.getElementById("lazy").addEventListener("ui5-input", async event => {
 			const { filterValue } = event.target;
 
@@ -224,6 +234,10 @@
 		document.getElementById("input-cb").addEventListener("ui5-input", function(event) {
 			document.getElementById("input-placeholder").innerHTML = event.target.filterValue;
 			document.getElementById("input-count").innerHTML = parseInt(document.getElementById("input-count").innerHTML) + 1;
+		});
+
+		buttonCleanPlaceholder.addEventListener("click", function (event) {
+			cbxWithPlaceholder.removeAttribute("placeholder");
 		});
 	</script>
 

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -23,8 +23,8 @@
 		{
 			"rtl": false,
 			"formatSettings": {
-                "firstDayOfWeek": 0
-            }
+				"firstDayOfWeek": 0
+			}
 		}
 	</script>
 
@@ -91,7 +91,7 @@
 		<h3>japanese calendar type</h3>
 		<ui5-date-picker primary-calendar-type='Japanese'></ui5-date-picker>
 
-        <h3>explicitly set empty placeholder</h3>
+		<h3>explicitly set empty placeholder</h3>
 		<ui5-date-picker placeholder=""></ui5-date-picker>
 
 		<h3>Date picker with min and max date 9/1/2019 - 11/1/2019</h3>

--- a/packages/main/test/pages/FileUploader.html
+++ b/packages/main/test/pages/FileUploader.html
@@ -116,6 +116,13 @@
 			<ui5-button id="uploadBtn">Upload</ui5-button>
 		</div>
 	</div>
+
+	<h3>Test placeholder removal</h3>
+	<section style="display: flex; flex-direction: column;">
+		<ui5-button id="buttonCleanPlaceholder" style="width: 200px;">Remove placholder</ui5-button>
+		<ui5-file-uploader id="fuWithPlaceholder" placeholder="Hello World"></ui5-file-uploader>
+	</section>
+
 	<script>
 		document.getElementById("uploadBtn").addEventListener("click", function() {
 			var fu = document.getElementById("fuFetch");
@@ -135,6 +142,10 @@
 			.catch(function(err) {
 				console.log("Error")
 			})
+		});
+
+		buttonCleanPlaceholder.addEventListener("click", function (event) {
+			fuWithPlaceholder.removeAttribute("placeholder");
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -295,6 +295,12 @@
 		<ui5-li>Argentinaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</ui5-li>
 	</ui5-input>
 
+	<h3>Test placeholder removal</h3>
+	<div style="display: flex;">
+		<ui5-input id="inputWithPlaceholder" placeholder="Hello World"></ui5-input>
+		<ui5-button id="buttonCleanPlaceholder">Remove placholder</ui5-button>
+	</div>
+
 	<script>
 		var sap_database_entries = [{ key: "A", text: "A" }, { key: "Afg", text: "Afghanistan" }, { key: "Arg", text: "Argentina" }, { key: "Alb", text: "Albania" }, { key: "Arm", text: "Armenia" }, { key: "Alg", text: "Algeria" }, { key: "And", text: "Andorra" }, { key: "Ang", text: "Angola" }, { key: "Ast", text: "Austria" }, { key: "Aus", text: "Australia" }, { key: "Aze", text: "Azerbaijan" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "B", text: "B" }, { key: "Bel", text: "Belarus" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }, { key: "C", text: "C" }, { key: "Ch", text: "China" }, { key: "Cub", text: "Cuba" }, { key: "Chil", text: "Chili" }, { key: "L", text: "L" }, { key: "Lat", text: "Latvia" }, { key: "Lit", text: "Litva" }, { key: "P", text: "P" }, { key: "Prt", text: "Portugal" }, { key: "S", text: "S" }, { key: "Sen", text: "Senegal" }, { key: "Ser", text: "Serbia" }, { key: "Sey", text: "Seychelles" }, { key: "Sierra", text: "Sierra Leone" }, { key: "Sgp", text: "Singapore" }, { key: "Sint", text: "Sint Maarten" }, { key: "Slv", text: "Slovakia" }, { key: "Slo", text: "Slovenia" }];
 
@@ -401,6 +407,10 @@
 		scrollInput.addEventListener("ui5-suggestion-scroll", function (event) {
 			scrollResult.value = event.detail.scrollTop;
 			console.log("scroll", { scrolltop: event.detail.scrollTop, container: event.detail.scrollContainer });
+		});
+
+		buttonCleanPlaceholder.addEventListener("click", function (event) {
+			inputWithPlaceholder.removeAttribute("placeholder");
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -205,6 +205,12 @@
 		<ui5-textarea id="textAreaAriaLabelledBy" maxlength="20" show-exceeded-text aria-labelledby="infoText" class="fixed-width fixed-height"></ui5-textarea>
 	</section>
 
+	<h3>Test placeholder removal</h3>
+	<section style="display: flex; flex-direction: column;">
+		<ui5-button id="buttonCleanPlaceholder" style="width: 200px;">Remove placholder</ui5-button>
+		<ui5-textarea id="textareaWithPlaceholder" placeholder="Hello World"></ui5-textarea>
+	</section>
+
 	<script>
 		var changeCounter = 0;
 		var inputCounter = 0;
@@ -217,6 +223,10 @@
 		document.getElementById('textarea-input').addEventListener("ui5-input", function (event) {
 			inputCounter += 1;
 			document.getElementById('inputResult').value = inputCounter;
+		});
+
+		buttonCleanPlaceholder.addEventListener("click", function (event) {
+			textareaWithPlaceholder.removeAttribute("placeholder");
 		});
 	</script>
 

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -315,4 +315,21 @@ describe("General interaction", () => {
 
 		assert.ok(combo.getProperty("focused"), "property focused should be true");
 	});
+
+	it("Tests removing placeholder does not display null", () => {
+		const INITIAL_PLACEHOLDER = "Hello World";
+		const cbx = browser.$("#cbxWithPlaceholder");
+		const btn = browser.$("#buttonCleanPlaceholder");
+
+		// assert
+		assert.strictEqual(cbx.getProperty("placeholder"), INITIAL_PLACEHOLDER,
+			"The initial placeholder is set.");
+
+		// act
+		btn.click();
+
+		// assert
+		assert.strictEqual(cbx.getProperty("placeholder"), "",
+			"The placeholder is reset to empty string.");
+	});
 });

--- a/packages/main/test/specs/FileUploader.spec.js
+++ b/packages/main/test/specs/FileUploader.spec.js
@@ -31,4 +31,21 @@ describe("API", () => {
 		const input = fileUploader.shadow$("input");
 		assert.strictEqual(input.getProperty("accept"), ".txt,.docx", "Native input is has the rignt accept property.");
 	});
+
+	it("Tests removing placeholder does not display null", () => {
+		const INITIAL_PLACEHOLDER = "Hello World";
+		const fu = browser.$("#fuWithPlaceholder");
+		const btn = browser.$("#buttonCleanPlaceholder");
+
+		// assert
+		assert.strictEqual(fu.getProperty("placeholder"), INITIAL_PLACEHOLDER,
+			"The initial placeholder is set.");
+
+		// act
+		btn.click();
+
+		// assert
+		assert.strictEqual(fu.getProperty("placeholder"), "",
+			"The placeholder is reset to empty string.");
+	});
 });

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -333,6 +333,23 @@ describe("Input general interaction", () => {
 		assert.strictEqual(parseFloat(input.getProperty("value")).toPrecision(3), "1.22", "Value is not lost");
 	});
 
+	it("Tests removing placeholder does not display null", () => {
+		const INITIAL_PLACEHOLDER = "Hello World";
+		const input = browser.$("#inputWithPlaceholder");
+		const btn = browser.$("#buttonCleanPlaceholder");
+
+		// assert
+		assert.strictEqual(input.getProperty("placeholder"), INITIAL_PLACEHOLDER,
+			"The initial placeholder is set.");
+
+		// act
+		btn.click();
+
+		// assert
+		assert.strictEqual(input.getProperty("placeholder"), "",
+			"The placeholder is reset to empty string.");
+	});
+
 	it("fires suggestion-item-preview", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Input_quickview.html");
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -25,12 +25,12 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(mcb.getProperty("focused"), "MultiComboBox should be focused.");
 
 			input.keys("ArrowLeft");
-			browser.pause(100);
+			browser.pause(300);
 
 			assert.notOk(mcb.getProperty("focused"), "MultiComboBox should no longer be focused.");
 
 			input.keys("ArrowRight");
-			browser.pause(100);
+			browser.pause(300);
 
 			assert.ok(mcb.getProperty("focused"), "MultiComboBox should be focused again.");
 		});

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -47,6 +47,23 @@ describe("Attributes propagation", () => {
 		assert.strictEqual(textArea2.getAttribute("aria-label"), EXPECTED_ARIA_LABEL2,
 			"The aria-label is correctly set internally.");
 	});
+
+	it("Tests removing placeholder does not display null", () => {
+		const INITIAL_PLACEHOLDER = "Hello World";
+		const textarea = browser.$("#textareaWithPlaceholder");
+		const btn = browser.$("#buttonCleanPlaceholder");
+
+		// assert
+		assert.strictEqual(textarea.getProperty("placeholder"), INITIAL_PLACEHOLDER,
+			"The initial placeholder is set.");
+
+		// act
+		btn.click();
+
+		// assert
+		assert.strictEqual(textarea.getProperty("placeholder"), "",
+			"The placeholder is reset to empty string.");
+	});
 });
 
 describe("disabled and readonly textarea", () => {


### PR DESCRIPTION
Fallback to prop's default value, defined in the metadata, whenever we try to set null or undefined to a property from type String.

FIXES #2384
Related to: https://github.com/SAP/ui5-webcomponents/pull/2419