### PR TITLE
fix(ui5-select): remove aria-roledescription

### DIFF
--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -11,7 +11,6 @@
 	aria-disabled="{{isDisabled}}"
 	aria-required="{{required}}"
 	aria-expanded="{{_isPickerOpen}}"
-	aria-roledescription="{{selectRoleDescription}}"
 	@keydown="{{_onkeydown}}"
 	@keyup="{{_onkeyup}}"
 	@focusin="{{_onfocusin}}"

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -24,7 +24,6 @@ import {
 	VALUE_STATE_ERROR,
 	VALUE_STATE_WARNING,
 	INPUT_SUGGESTIONS_TITLE,
-	SELECT_ROLE_DESCRIPTION,
 } from "./generated/i18n/i18n-defaults.js";
 import Option from "./Option.js";
 import Label from "./Label.js";
@@ -559,10 +558,6 @@ class Select extends UI5Element {
 
 	get isDisabled() {
 		return this.disabled || undefined;
-	}
-
-	get selectRoleDescription() {
-		return this.i18nBundle.getText(SELECT_ROLE_DESCRIPTION);
 	}
 
 	get _headerTitleText() {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -286,9 +286,6 @@ RATING_INDICATOR_TEXT=Rating Indicator
 #XACT: ARIA description for the segmented button
 SEGMENTEDBUTTON_ARIA_DESCRIPTION=Segmented button
 
-#XACT: ARIA announcement for the Select`s roledescription attribute
-SELECT_ROLE_DESCRIPTION=Select
-
 #XACT: ARIA announcement for the switch on
 SWITCH_ON=On
 


### PR DESCRIPTION
The reledescription prevents its role button to be read by JAWS
so it is now removed following consultation with ACC expert.

Fixes #2358
