### PR TITLE
feat(framework): Always fire _property-change for OpenUI5 controls

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -17,6 +17,7 @@ import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
 import isValidPropertyName from "./util/isValidPropertyName.js";
 import isSlot from "./util/isSlot.js";
 import { markAsRtlAware } from "./locale/RTLAwareRegistry.js";
+import { getFeature } from "./FeaturesRegistry.js";
 
 const metadata = {
 	events: {
@@ -444,7 +445,7 @@ class UI5Element extends HTMLElement {
 	_propertyChange(name, value) {
 		this._updateAttribute(name, value);
 
-		if (this._hasPropertyChangeListeners()) {
+		if (this._hasPropertyChangeListeners() || this.isOpenUI5Control) {
 			this.dispatchEvent(new CustomEvent("_property-change", {
 				detail: { name, newValue: value },
 				composed: false,
@@ -781,6 +782,15 @@ class UI5Element extends HTMLElement {
 	 */
 	get isUI5Element() {
 		return true;
+	}
+
+	/**
+	 * Used to determine whether an HTML element is an OpenUI5 control
+	 * @returns {*}
+	 */
+	get isOpenUI5Control() {
+		const OpenUI5Support = getFeature("OpenUI5Support");
+		return OpenUI5Support && OpenUI5Support.isOpenUI5Control(this);
 	}
 
 	/**

--- a/packages/base/src/features/OpenUI5Support.js
+++ b/packages/base/src/features/OpenUI5Support.js
@@ -78,6 +78,12 @@ const cssVariablesLoaded = () => {
 	return !!link.href.match(/\/css(-|_)variables\.css/);
 };
 
+const isOpenUI5Control = element => {
+	const sapUiId = element.getAttribute("data-sap-ui");
+	const id = element.getAttribute("id");
+	return id && sapUiId && id === sapUiId;
+};
+
 const OpenUI5Support = {
 	isLoaded,
 	init,
@@ -85,6 +91,7 @@ const OpenUI5Support = {
 	getLocaleDataObject,
 	attachListeners,
 	cssVariablesLoaded,
+	isOpenUI5Control,
 };
 
 registerFeature("OpenUI5Support", OpenUI5Support);


### PR DESCRIPTION
The `_property-change` event is normally used for child-parent communication: when a parent component listens for property changes of its children, they use this event. Additionally, the event is only fired if there are listeners for it. This is achieved by overriding `addEventListener`.

OpenUI5 needs the `_property-change` event to always be fired so that OpenUI5 control properties can stay synchronized with the internal component's properties. However OpenUI5 calls `addEventListener` before the custom element has been upgraded, therefore the overridden `addEventListener` is not executed.

To overcome this we always fire the event for OpenUI5 controls without checking for listeners registration.