### PR TITLE
feat(ui5-tabcontainer): Expose dynamic shadow parts

### DIFF
--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -10,8 +10,8 @@ import executeTemplate from "./renderer/executeTemplate.js";
  * Defines and takes care of ui5-static-are-item items
  */
 class StaticAreaItem {
-	constructor(_ui5ElementContext) {
-		this.ui5ElementContext = _ui5ElementContext;
+	constructor(ui5Element) {
+		this.ui5Element = ui5Element;
 		this._rendered = false;
 	}
 
@@ -23,22 +23,26 @@ class StaticAreaItem {
 	 * @protected
 	 */
 	_updateFragment() {
-		const renderResult = executeTemplate(this.ui5ElementContext.constructor.staticAreaTemplate, this.ui5ElementContext),
-			stylesToAdd = window.ShadyDOM ? false : getStylesString(this.ui5ElementContext.constructor.staticAreaStyles);
+		const renderResult = executeTemplate(this.ui5Element.constructor.staticAreaTemplate, this.ui5Element),
+			stylesToAdd = window.ShadyDOM ? false : getStylesString(this.ui5Element.constructor.staticAreaStyles);
 
 		if (!this.staticAreaItemDomRef) {
-			// Initial rendering of fragment
+			const id = this.ui5Element.getAttribute("id");
 
+			// Initial rendering of fragment
 			this.staticAreaItemDomRef = document.createElement("ui5-static-area-item");
 			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
-			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
+			this.staticAreaItemDomRef.classList.add(this.ui5Element._id); // used for getting the popover in the tests
+			if (id) {
+				this.staticAreaItemDomRef.setAttribute("id", `${id}--static-area`);
+			}
 
 			getStaticAreaInstance().appendChild(this.staticAreaItemDomRef);
 			this._rendered = true;
 		}
 
-		this._updateContentDensity(this.ui5ElementContext.isCompact);
-		this.ui5ElementContext.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
+		this._updateContentDensity(this.ui5Element.isCompact);
+		this.ui5Element.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5Element });
 	}
 
 	/**

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -33,7 +33,7 @@ class StaticAreaItem {
 			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
 			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
 
-			const id = this.ui5Element.getAttribute("id");
+			const id = this.ui5ElementContext.getAttribute("id");
 			if (id) {
 				this.staticAreaItemDomRef.setAttribute("id", `${id}--static-area`);
 			}

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -33,9 +33,9 @@ class StaticAreaItem {
 			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
 			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
 
-			const id = this.ui5ElementContext.getAttribute("id");
-			if (id) {
-				this.staticAreaItemDomRef.setAttribute("id", `${id}--static-area`);
+			const staticAreaItemId = this.ui5ElementContext.staticAreaItemId;
+			if (staticAreaItemId) {
+				this.staticAreaItemDomRef.setAttribute("id", staticAreaItemId);
 			}
 
 			getStaticAreaInstance().appendChild(this.staticAreaItemDomRef);

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -10,8 +10,8 @@ import executeTemplate from "./renderer/executeTemplate.js";
  * Defines and takes care of ui5-static-are-item items
  */
 class StaticAreaItem {
-	constructor(ui5Element) {
-		this.ui5Element = ui5Element;
+	constructor(_ui5ElementContext) {
+		this.ui5ElementContext = _ui5ElementContext;
 		this._rendered = false;
 	}
 
@@ -23,16 +23,17 @@ class StaticAreaItem {
 	 * @protected
 	 */
 	_updateFragment() {
-		const renderResult = executeTemplate(this.ui5Element.constructor.staticAreaTemplate, this.ui5Element),
-			stylesToAdd = window.ShadyDOM ? false : getStylesString(this.ui5Element.constructor.staticAreaStyles);
+		const renderResult = executeTemplate(this.ui5ElementContext.constructor.staticAreaTemplate, this.ui5ElementContext),
+			stylesToAdd = window.ShadyDOM ? false : getStylesString(this.ui5ElementContext.constructor.staticAreaStyles);
 
 		if (!this.staticAreaItemDomRef) {
-			const id = this.ui5Element.getAttribute("id");
-
 			// Initial rendering of fragment
+
 			this.staticAreaItemDomRef = document.createElement("ui5-static-area-item");
 			this.staticAreaItemDomRef.attachShadow({ mode: "open" });
-			this.staticAreaItemDomRef.classList.add(this.ui5Element._id); // used for getting the popover in the tests
+			this.staticAreaItemDomRef.classList.add(this.ui5ElementContext._id); // used for getting the popover in the tests
+
+			const id = this.ui5Element.getAttribute("id");
 			if (id) {
 				this.staticAreaItemDomRef.setAttribute("id", `${id}--static-area`);
 			}
@@ -41,8 +42,8 @@ class StaticAreaItem {
 			this._rendered = true;
 		}
 
-		this._updateContentDensity(this.ui5Element.isCompact);
-		this.ui5Element.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5Element });
+		this._updateContentDensity(this.ui5ElementContext.isCompact);
+		this.ui5ElementContext.constructor.render(renderResult, this.staticAreaItemDomRef.shadowRoot, stylesToAdd, { eventContext: this.ui5ElementContext });
 	}
 
 	/**

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -19,6 +19,11 @@ import isSlot from "./util/isSlot.js";
 import { markAsRtlAware } from "./locale/RTLAwareRegistry.js";
 
 const metadata = {
+	properties: {
+		staticAreaItemId: {
+			type: String,
+		},
+	},
 	events: {
 		"_property-change": {},
 	},

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -1,6 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import executeTemplate from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
+import { kebabToCamelCase } from "@ui5/webcomponents-base/dist/util/StringHelper.js";
 import SemanticColor from "./types/SemanticColor.js";
 import TabLayout from "./types/TabLayout.js";
 import TabContainer from "./TabContainer.js";
@@ -302,6 +303,13 @@ class Tab extends UI5Element {
 
 	get overflowState() {
 		return this.disabled ? "Inactive" : "Active";
+	}
+
+	get shadowParts() {
+		return ["tab", "tab-icon-outer", "tab-icon", "tab-text"].reduce((acc, current) => {
+			acc[kebabToCamelCase(current)] = this.id ? `${current} ${current}--${this.id}` : current;
+			return acc;
+		}, {});
 	}
 }
 

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -7,14 +7,14 @@
 	aria-disabled="{{this.effectiveDisabled}}"
 	aria-selected="{{this.effectiveSelected}}"
 	aria-labelledby="{{this.ariaLabelledBy}}"
-	part="tab {{this.id}}"
+	part="{{this.shadowParts.tab}}"
 >
 	<div class="ui5-tab-overflow-itemContent">
 		{{#if this.icon}}
-			<ui5-icon name="{{this.icon}}" part="tab-icon {{this.id}}"></ui5-icon>
+			<ui5-icon name="{{this.icon}}" part="{{this.shadowParts.tabIcon}}"></ui5-icon>
 		{{/if}}
 
-		<span part="tab-text {{this.id}}">
+		<span part="{{this.shadowParts.tabText}}">
 			{{this.text}}
 
 			{{#if this.additionalText}}

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -7,16 +7,19 @@
 	aria-disabled="{{this.effectiveDisabled}}"
 	aria-selected="{{this.effectiveSelected}}"
 	aria-labelledby="{{this.ariaLabelledBy}}"
+	part="tab {{this.id}}"
 >
 	<div class="ui5-tab-overflow-itemContent">
 		{{#if this.icon}}
-			<ui5-icon name="{{this.icon}}"></ui5-icon>
+			<ui5-icon name="{{this.icon}}" part="tab-icon {{this.id}}"></ui5-icon>
 		{{/if}}
 
-		{{this.text}}
+		<span part="tab-text {{this.id}}">
+			{{this.text}}
 
-		{{#if this.additionalText}}
-			({{this.additionalText}})
-		{{/if}}
+			{{#if this.additionalText}}
+				({{this.additionalText}})
+			{{/if}}
+		</span>
 	</div>
 </ui5-li-custom>

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -11,15 +11,16 @@
 	aria-labelledby="{{this.ariaLabelledBy}}"
 	data-ui5-stable="{{this.stableDomRef}}"
 	style="list-style-type: none;"
+    part="tab {{this.id}}"
 >
 
 	{{#if this.icon}}
-		<div class="ui5-tab-strip-item-icon-outer">
-			<ui5-icon name="{{this.icon}}" class="ui5-tab-strip-item-icon"></ui5-icon>
+		<div class="ui5-tab-strip-item-icon-outer" part="tab-icon-outer {{this.id}}">
+			<ui5-icon name="{{this.icon}}" class="ui5-tab-strip-item-icon" part="tab-icon {{this.id}}"></ui5-icon>
 		</div>
 	{{/if}}
 
-	<div class="ui5-tab-strip-itemContent">
+	<div class="ui5-tab-strip-itemContent" part="tab-text {{this.id}}">
 
 		{{#unless this._isInline}}
 			{{> additionalText}}

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -11,7 +11,7 @@
 	aria-labelledby="{{this.ariaLabelledBy}}"
 	data-ui5-stable="{{this.stableDomRef}}"
 	style="list-style-type: none;"
-    part="tab {{this.id}}"
+	part="tab {{this.id}}"
 >
 
 	{{#if this.icon}}

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -11,16 +11,16 @@
 	aria-labelledby="{{this.ariaLabelledBy}}"
 	data-ui5-stable="{{this.stableDomRef}}"
 	style="list-style-type: none;"
-	part="tab {{this.id}}"
+	part="{{this.shadowParts.tab}}"
 >
 
 	{{#if this.icon}}
-		<div class="ui5-tab-strip-item-icon-outer" part="tab-icon-outer {{this.id}}">
-			<ui5-icon name="{{this.icon}}" class="ui5-tab-strip-item-icon" part="tab-icon {{this.id}}"></ui5-icon>
+		<div class="ui5-tab-strip-item-icon-outer" part="{{this.shadowParts.tabIconOuter}}">
+			<ui5-icon name="{{this.icon}}" class="ui5-tab-strip-item-icon" part="{{this.shadowParts.tabIcon}}"></ui5-icon>
 		</div>
 	{{/if}}
 
-	<div class="ui5-tab-strip-itemContent" part="tab-text {{this.id}}">
+	<div class="ui5-tab-strip-itemContent" part="{{this.shadowParts.tabText}}">
 
 		{{#unless this._isInline}}
 			{{> additionalText}}

--- a/packages/main/test/pages/TabContainerParts.html
+++ b/packages/main/test/pages/TabContainerParts.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>Tab Container</title>
+
+	<script data-ui5-config type="application/json">
+		{
+			"theme": "sap_fiori_3",
+			"language": "EN"
+		}
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+
+	<style>
+		html,
+		body {
+			margin: 0;
+		}
+
+		/*
+		#tc::part(tab),
+		#tc--static-area::part(tab){
+			background: orange;
+		}
+
+		#tc::part(tab):hover,
+		#tc--static-area::part(tab):hover{
+			background: purple;
+		}
+
+		#tc::part(tab products),
+		#tc--static-area::part(tab products){
+			background: pink;
+			color: green;
+		}
+
+		#tc::part(tab laptops),
+		#tc--static-area::part(tab laptops){
+			color: white;
+			background: black;
+		}
+		*/
+
+		#tc::part(tab-icon laptops),
+		#tc--static-area::part(tab-icon laptops) {
+			color: purple;
+		}
+
+		#tc::part(tab-icon-outer laptops) {
+			background: lawngreen;
+		}
+
+		#tc::part(tab-text laptops),
+		#tc--static-area::part(tab-text laptops) {
+			color: orangered;
+			font-weight: bold;
+		}
+
+		#tc::part(tab monitors),
+		#tc--static-area::part(tab monitors) {
+			color: pink;
+		}
+
+
+	</style>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+		<ui5-tabcontainer id="tc" show-overflow>
+			<ui5-tab id="products" text="Products" additional-text="125">
+				<ui5-label>Tab 1 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab-separator></ui5-tab-separator>
+			<ui5-tab id="laptops" icon="sap-icon://menu2" text="Laptops" semantic-color="Positive" additional-text="25">
+				<ui5-label>Tab 2 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab id="monitors" icon="sap-icon://menu" text="Monitors" selected semantic-color="Critical" additional-text="45">
+				<ui5-label>Tab 3 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab id="keyboards" icon="sap-icon://menu2" text="Keyboards" semantic-color="Negative" additional-text="15">
+				<ui5-label>Tab 4 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab id="disabled" icon="sap-icon://menu2" disabled text="Disabled" semantic-color="Negative" additional-text="40">
+				<ui5-label>Tab 5 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab id="neutral" icon="sap-icon://menu2" text="Neutral" semantic-color="Neutral" additional-text="40">
+				<ui5-label>Tab 6 content</ui5-label>
+			</ui5-tab>
+			<ui5-tab id="default" icon="sap-icon://menu2" text="Default" additional-text="40">
+				<ui5-label>Tab 7 content</ui5-label>
+			</ui5-tab>
+		</ui5-tabcontainer>
+
+	</body>
+</html>

--- a/packages/main/test/pages/TabContainerParts.html
+++ b/packages/main/test/pages/TabContainerParts.html
@@ -37,39 +37,38 @@
 			background: purple;
 		}
 
-		#tc::part(tab products),
-		#tc--static-area::part(tab products){
+		#tc::part(tab--products),
+		#tc--static-area::part(tab--products){
 			background: pink;
 			color: green;
 		}
 
-		#tc::part(tab laptops),
-		#tc--static-area::part(tab laptops){
+		#tc::part(tab--laptops),
+		#tc--static-area::part(tab--laptops){
 			color: white;
 			background: black;
 		}
 		*/
 
 		#tc::part(tab-icon laptops),
-		#tc--static-area::part(tab-icon laptops) {
+		#tc--static-area::part(tab-icon--laptops) {
 			color: purple;
 		}
 
-		#tc::part(tab-icon-outer laptops) {
+		#tc::part(tab-icon-outer--laptops) {
 			background: lawngreen;
 		}
 
-		#tc::part(tab-text laptops),
-		#tc--static-area::part(tab-text laptops) {
+		#tc::part(tab-text--laptops),
+		#tc--static-area::part(tab-text--laptops) {
 			color: orangered;
 			font-weight: bold;
 		}
 
 		#tc::part(tab monitors),
-		#tc--static-area::part(tab monitors) {
+		#tc--static-area::part(tab--monitors) {
 			color: pink;
 		}
-
 
 	</style>
 </head>

--- a/packages/main/test/pages/TabContainerParts.html
+++ b/packages/main/test/pages/TabContainerParts.html
@@ -75,7 +75,7 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 
-		<ui5-tabcontainer id="tc" show-overflow>
+		<ui5-tabcontainer id="tc" static-area-item-id="tc--static-area" show-overflow>
 			<ui5-tab id="products" text="Products" additional-text="125">
 				<ui5-label>Tab 1 content</ui5-label>
 			</ui5-tab>


### PR DESCRIPTION
# Dynamic shadow parts

This change introduces the concept of dynamic shadow parts. This is relevant for components that slot abstract items and render something else physically inside the shadow root. Dynamic shadow parts are shadow parts, unique to each element.

## Usage:
Given this HTML:
```html
<ui5-tabcontainer id="tc" show-overflow>
	<ui5-tab id="laptops" icon="sap-icon://menu2" text="Laptops" semantic-color="Positive" additional-text="25">
		<ui5-label>Tab 2 content</ui5-label>
	</ui5-tab>
</ui5-tabcontainer>
```

users can now use CSS such as:

```css
#tc::part(tab-icon--laptops),
#tc--static-area::part(tab-icon--laptops) {
	color: purple;
}
```
The CSS above makes the icon purple for the `id="laptops"` `ui5-tab` only, for both the strip part (`#tc::part`) and overflow part - which is in the static area (`#tc--static-area::part`)

## Changes to `StaticAreaItem` 
For each UI5 Component that has an `id` the static area item has the same id with `--static-area` suffix. Example:

![image](https://user-images.githubusercontent.com/15844574/99083175-d363f980-25cd-11eb-81c5-e0adb54352cb.png)

This change makes it possible to select `::part`s inside static area shadow roots. Currently it's only possible to do so for standard shadow roots.

## Changes to `TabContainer`
For each tab with an `id` there are additional parts ending with `--` followed by the `id` of the tab. This makes it possible to apply CSS to tabs separately both in the strip and in the overflow menu.

Examples:

For `<ui5-tab id="products">` the following parts will be generated:
```html
part="tab tab--products"
part="tab-icon tab-icon--products"
part="tab-text tab-text--products"
```

while for a tab with no `id`:  `<ui5-tab>` the following parts will be generated:
```html
part="tab"
part="tab-icon"
part="tab-text"
```

## Strip tabs
New parts in `TabInStrip.hbs` (static and dynamic): `tab`, `icon-outer`, `icon`, `text`.

## Overflow tabs
New parts in `TabInOverflow.hbs` (static and dynamic): `tab`, `icon`, `text`.


