### PR TITLE
feat(ui5-tree): implement acc spec

### DIFF
--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -15,6 +15,7 @@
 	role="{{_accInfo.role}}"
 	aria-expanded="{{_accInfo.ariaExpanded}}"
 	aria-level="{{_accInfo.ariaLevel}}"
+	aria-labelledby="{{_id}}-invisibleText {{_id}}-content"
 	style="list-style-type: none;"
 >
 		{{> listItemPreContent}}
@@ -43,6 +44,8 @@
 		{{#if placeSelectionElementAfter}}
 			{{> selectionElement}}
 		{{/if}}
+
+		<span id="{{_id}}-invisibleText" class="ui5-hidden-text">{{_accInfo.listItemAriaLabel}}</span>
 </li>
 
 {{#*inline "listItemPreContent"}}{{/inline}}

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -311,6 +311,7 @@ class ListItem extends ListItemBase {
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: this.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
+			listItemAriaLabel: undefined,
 		};
 	}
 

--- a/packages/main/src/TreeListItem.hbs
+++ b/packages/main/src/TreeListItem.hbs
@@ -1,11 +1,16 @@
 {{>include "./ListItem.hbs"}}
 
 {{#*inline "listItemPreContent"}}
-	<div class="ui5-li-tree-toggle-box" style="padding-left: {{effectiveLevel}}rem; padding-left: calc(var(--_ui5-tree-indent-step) * {{effectiveLevel}});">
+	<div
+		class="ui5-li-tree-toggle-box"
+		style="padding-left: {{effectiveLevel}}rem; padding-left: calc(var(--_ui5-tree-indent-step) * {{effectiveLevel}});"
+	>
 		{{#if _showToggleButtonBeginning}}
 			<ui5-icon
 				class="ui5-li-tree-toggle-icon"
 				name="{{_toggleIconName}}"
+				show-tooltip
+				accessible-name="{{iconAccessibleName}}"
 				@click="{{_toggleClick}}"
 			></ui5-icon>
 		{{/if}}

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -227,7 +227,7 @@ class TreeListItem extends ListItem {
 		return {
 			role: "treeitem",
 			ariaExpanded: this.showToggleButton ? this.expanded : undefined,
-			ariaLevel: this.level + 1,
+			ariaLevel: this.level,
 			listItemAriaLabel: this.ariaLabelText,
 		};
 	}

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -1,9 +1,16 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isLeft, isRight } from "@ui5/webcomponents-base/dist/Keys.js";
+import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ListItem from "./ListItem.js";
 import Icon from "./Icon.js";
 import "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";
 import "@ui5/webcomponents-icons/dist/navigation-down-arrow.js";
+import {
+	ACC_CTR_TYPE_TREEITEM,
+	TREE_ITEM_EXPAND_NODE,
+	TREE_ITEM_COLLAPSE_NODE,
+	LIST_ITEM_SELECTED,
+} from "./generated/i18n/i18n-defaults.js";
 
 // Template
 import TreeListItemTemplate from "./generated/templates/TreeListItemTemplate.lit.js";
@@ -16,6 +23,7 @@ import treeListItemCss from "./generated/themes/TreeListItem.css.js";
  */
 const metadata = {
 	tag: "ui5-li-tree",
+	languageAware: true,
 	properties: /** @lends sap.ui.webcomponents.main.TreeListItem.prototype */ {
 
 		/**
@@ -175,6 +183,12 @@ class TreeListItem extends ListItem {
 		];
 	}
 
+	constructor() {
+		super();
+
+		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
+	}
+
 	onBeforeRendering() {
 		this.actionable = false;
 	}
@@ -213,7 +227,8 @@ class TreeListItem extends ListItem {
 		return {
 			role: "treeitem",
 			ariaExpanded: this.showToggleButton ? this.expanded : undefined,
-			ariaLevel: this.level,
+			ariaLevel: this.level + 1,
+			listItemAriaLabel: this.ariaLabelText,
 		};
 	}
 
@@ -240,6 +255,24 @@ class TreeListItem extends ListItem {
 				this.fireEvent("step-out", { item: this });
 			}
 		}
+	}
+
+	get ariaLabelText() {
+		let text = this.i18nBundle.getText(ACC_CTR_TYPE_TREEITEM);
+
+		if (this.selected) {
+			text += ` ${this.i18nBundle.getText(LIST_ITEM_SELECTED)}`;
+		}
+
+		return text;
+	}
+
+	get iconAccessibleName() {
+		return this.expanded ? this.i18nBundle.getText(TREE_ITEM_COLLAPSE_NODE) : this.i18nBundle.getText(TREE_ITEM_EXPAND_NODE);
+	}
+
+	static async onDefine() {
+		await fetchI18nBundle("@ui5/webcomponents");
 	}
 }
 

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -260,7 +260,7 @@ LINK_EMPHASIZED=Emphasized
 LIST_ITEM_POSITION=List item {0} of {1}
 
 #XACT: ARIA announcement for the list item selection.
-LIST_ITEM_SELECTED=Is Selected
+LIST_ITEM_SELECTED=Selected
 
 #XBUT: List Multi Selection Mode Checkbox aria-label text
 ARIA_LABEL_LIST_ITEM_CHECKBOX = Multiple Selection mode.
@@ -354,6 +354,15 @@ TOKENIZER_ARIA_LABEL=Tokenizer
 
 #XFLD: Remove label for Tokenizer's Dialog on phone
 TOKENIZER_POPOVER_REMOVE=Remove
+
+#XACT: type of of an UI control is a tree item
+ACC_CTR_TYPE_TREEITEM=Tree Item
+
+#XTOL: tooltip for expand icon in a tree item
+TREE_ITEM_EXPAND_NODE=Expand Node
+
+#XTOL: tooltip for collapse icon in a tree item
+TREE_ITEM_COLLAPSE_NODE=Collapse Node
 
 #XTOL: text that is appended to the tooltips of input fields etc. which are marked to have an error
 VALUE_STATE_ERROR=Invalid entry

--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -1,3 +1,5 @@
+@import "./InvisibleTextStyles.css";
+
 :host(:not([hidden])) {
 	display: block;
     cursor: pointer;


### PR DESCRIPTION
Fixes  #2465

Done:
- Tooltip for the expand/collapse icon is added
- Tree item is now announced
- Selected state is now announced
- Announced level is fixed
- Translation for LIST_ITEM_SELECTED is fixed

TODO:
- Tree view is still read out twice.
Findings: If you remove the ```role="tree"``` from the list it is no more read out. The default value for the list role is read out.