### PR TITLE
feat(ui5-button): implement title property

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -25,7 +25,7 @@
 			style="{{styles.icon}}"
 			class="ui5-button-icon"
 			name="{{icon}}"
-			show-tooltip={{iconOnly}}
+			show-tooltip={{showIconTooltip}}
 		></ui5-icon>
 	{{/if}}
 

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -119,7 +119,7 @@ const metadata = {
 		 * @public
 		 * @since 1.0.0-rc.11
 		 */
-		tooltip: {
+		title: {
 			type: String,
 		},
 
@@ -384,7 +384,7 @@ class Button extends UI5Element {
 			"ariaExpanded": this.ariaExpanded || (this._buttonAccInfo && this._buttonAccInfo.ariaExpanded),
 			"ariaControls": this._buttonAccInfo && this._buttonAccInfo.ariaControls,
 			"ariaHaspopup": this._buttonAccInfo && this._buttonAccInfo.ariaHaspopup,
-			"title": this.tooltip || (this._buttonAccInfo && this._buttonAccInfo.title),
+			"title": this.title || (this._buttonAccInfo && this._buttonAccInfo.title),
 		};
 	}
 
@@ -412,6 +412,10 @@ class Button extends UI5Element {
 		}
 
 		return this.nonFocusable ? "-1" : this._tabIndex;
+	}
+
+	get showIconTooltip() {
+		return this.iconOnly && !this.title;
 	}
 
 	get styles() {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -116,7 +116,7 @@ const metadata = {
 		 * <b>Important:</b> Tooltips should only be set to icon only buttons.
 		 * @type {string}
 		 * @defaultvalue: ""
-		 * @public
+		 * @private
 		 * @since 1.0.0-rc.11
 		 */
 		title: {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -111,6 +111,19 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the tooltip of the button.
+		 * <br>
+		 * <b>Important:</b> Tooltips should only be set to icon only buttons.
+		 * @type {string}
+		 * @defaultvalue: ""
+		 * @public
+		 * @since 1.0.0-rc.11
+		 */
+		tooltip: {
+			type: String,
+		},
+
+		/**
 		 * Used to switch the active state (pressed or not) of the <code>ui5-button</code>.
 		 * @private
 		 */
@@ -187,6 +200,7 @@ const metadata = {
 		_iconSettings: {
 			type: Object,
 		},
+
 		_buttonAccInfo: {
 			type: Object,
 		},
@@ -370,7 +384,7 @@ class Button extends UI5Element {
 			"ariaExpanded": this.ariaExpanded || (this._buttonAccInfo && this._buttonAccInfo.ariaExpanded),
 			"ariaControls": this._buttonAccInfo && this._buttonAccInfo.ariaControls,
 			"ariaHaspopup": this._buttonAccInfo && this._buttonAccInfo.ariaHaspopup,
-			"title": this._buttonAccInfo && this._buttonAccInfo.title,
+			"title": this.tooltip || (this._buttonAccInfo && this._buttonAccInfo.title),
 		};
 	}
 

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -192,11 +192,11 @@
 	<br/>
 	<ui5-title>Buttons with tooltip</ui5-title>
 	<br/>
-	<ui5-button icon="home" tooltip="Go home"></ui5-button>
-	<ui5-button icon="accept" tooltip="Accept terms & conditions"></ui5-button>
-	<ui5-button icon="action-settings" tooltip="Go to settings"></ui5-button>
-	<ui5-button icon="alert" tooltip="Fire an alert"></ui5-button>
-	<ui5-button icon="arrow-down" tooltip="Go down"></ui5-button>
+	<ui5-button icon="home" title="Go home"></ui5-button>
+	<ui5-button icon="accept" title="Accept terms & conditions"></ui5-button>
+	<ui5-button icon="action-settings" title="Go to settings"></ui5-button>
+	<ui5-button icon="alert" title="Fire an alert"></ui5-button>
+	<ui5-button icon="arrow-down" title="Go down"></ui5-button>
 
     <script>
 		var clickCounter = document.querySelector("#click-counter");

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -188,6 +188,15 @@
     <ui5-button class="long-button" icon="download">Download</ui5-button>
     <ui5-button class="long-button long-button-end" icon="download">Download</ui5-button>
 
+	<br/>
+	<br/>
+	<ui5-title>Buttons with tooltip</ui5-title>
+	<br/>
+	<ui5-button icon="home" tooltip="Go home"></ui5-button>
+	<ui5-button icon="accept" tooltip="Accept terms & conditions"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings"></ui5-button>
+	<ui5-button icon="alert" tooltip="Fire an alert"></ui5-button>
+	<ui5-button icon="arrow-down" tooltip="Go down"></ui5-button>
 
     <script>
 		var clickCounter = document.querySelector("#click-counter");


### PR DESCRIPTION
Fixes #2393
Going for this implementation as the tooltip is not read out twice.

Note: Tooltips should only be set to icon only buttons.