### PR TITLE
feat(ui5-combobox): аdd two-column layout support

### DIFF
--- a/packages/main/src/ComboBoxItem.js
+++ b/packages/main/src/ComboBoxItem.js
@@ -24,6 +24,7 @@ const metadata = {
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
+		 * @since 1.0.0-rc.11
 		 * @public
 		 */
 		additionalText: { type: String },

--- a/packages/main/src/ComboBoxItem.js
+++ b/packages/main/src/ComboBoxItem.js
@@ -19,6 +19,14 @@ const metadata = {
 		 * @public
 		 */
 		text: { type: String },
+		/**
+		 * Defines the additional text of the <code>ui5-cb-item</code>.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @public
+		 */
+		additionalText: { type: String },
 	},
 	slots: {
 		//

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -70,11 +70,11 @@
 		{{#each _filteredItems}}
 			<ui5-li
 				type="Active"
+				.info={{this.additionalText}}
 				._tabIndex={{itemTabIndex}}
 				.mappedItem={{this}}
 				?selected={{this.selected}}
 				?focused={{this.focused}}
-				info={{this.additionalText}}
 			>
 				{{this.text}}
 			</ui5-li>

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -74,6 +74,7 @@
 				.mappedItem={{this}}
 				?selected={{this.selected}}
 				?focused={{this.focused}}
+				info={{this.additionalText}}
 			>
 				{{this.text}}
 			</ui5-li>

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -70,7 +70,7 @@
 		{{#each _filteredItems}}
 			<ui5-li
 				type="Active"
-				.info={{this.additionalText}}
+				info={{this.additionalText}}
 				._tabIndex={{itemTabIndex}}
 				.mappedItem={{this}}
 				?selected={{this.selected}}

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -96,8 +96,8 @@
 	</div>
 
 	<div class="demo-section">
-		<ui5-label id="countryLabel">Items with additional text: </ui5-label>
-		<ui5-combobox id="combo" style="width: 360px;" value="Bulgaria" aria-labelledby="countryLabel">
+		<ui5-label id="combo-additional-text">Items with additional text: </ui5-label>
+		<ui5-combobox id="combobox-two-column-layout" style="width: 360px;" value="Bulgaria" aria-labelledby="countryLabel">
 			<ui5-cb-item text="Algeria" additional-text="DZ"></ui5-cb-item>
 			<ui5-cb-item text="Argentina" additional-text="AR"></ui5-cb-item>
 			<ui5-cb-item text="Australia" additional-text="AU"></ui5-cb-item>

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -96,6 +96,22 @@
 	</div>
 
 	<div class="demo-section">
+		<ui5-label id="countryLabel">Items with additional text: </ui5-label>
+		<ui5-combobox id="combo" style="width: 360px;" value="Bulgaria" aria-labelledby="countryLabel">
+			<ui5-cb-item text="Algeria" additional-text="DZ"></ui5-cb-item>
+			<ui5-cb-item text="Argentina" additional-text="AR"></ui5-cb-item>
+			<ui5-cb-item text="Australia" additional-text="AU"></ui5-cb-item>
+			<ui5-cb-item text="Austria" additional-text="AT"></ui5-cb-item>
+			<ui5-cb-item text="Bahrain" additional-text="BH"></ui5-cb-item>
+			<ui5-cb-item text="Belgium" additional-text="BE"></ui5-cb-item>
+			<ui5-cb-item text="Brazil" additional-text="BR"></ui5-cb-item>
+			<ui5-cb-item text="Bulgaria" additional-text="BG"></ui5-cb-item>
+			<ui5-cb-item text="Canada" additional-text="CA"></ui5-cb-item>
+			<ui5-cb-item text="Chile" additional-text="CL"></ui5-cb-item>
+		</ui5-combobox>
+	</div>
+
+	<div class="demo-section">
 		<span id="change-event-result"></span>
 		<br />
 		<span id="selection-change-event-result"></span>

--- a/packages/main/test/samples/ComboBox.sample.html
+++ b/packages/main/test/samples/ComboBox.sample.html
@@ -137,6 +137,34 @@
 </section>
 
 <section>
+	<h3>ComboBox with Two-Column Layout Items</h3>
+	<div class="snippet responsive-snippet">
+		<ui5-combobox placeholder="Two-column Layout">
+			<ui5-cb-item text="Austria" additional-text="AT"></ui5-cb-item>
+			<ui5-cb-item text="Belgium" additional-text="BE"></ui5-cb-item>
+			<ui5-cb-item text="Brazil" additional-text="BR"></ui5-cb-item>
+			<ui5-cb-item text="Bulgaria" additional-text="BG"></ui5-cb-item>
+			<ui5-cb-item text="Canada" additional-text="CA"></ui5-cb-item>
+		</ui5-combobox>
+	</div>
+
+<pre class="prettyprint lang-html"><xmp>
+
+<ui5-combobox placeholder="Two-column layout">
+	<ui5-cb-item text="Austria" additional-text="AT"></ui5-cb-item>
+	<ui5-cb-item text="Belgium" additional-text="BE"></ui5-cb-item>
+	<ui5-cb-item text="Brazil" additional-text="BR"></ui5-cb-item>
+	<ui5-cb-item text="Bulgaria" additional-text="BG"></ui5-cb-item>
+	<ui5-cb-item text="Canada" additional-text="CA"></ui5-cb-item>
+</ui5-combobox>
+
+</xmp></pre>
+
+
+</section>
+
+
+<section>
 	<h3>Lazy loading</h3>
 
 	<div class="snippet responsive-snippet">

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -315,4 +315,15 @@ describe("General interaction", () => {
 
 		assert.ok(combo.getProperty("focused"), "property focused should be true");
 	});
+	
+	it ("Tests Combo with two-column layout", () => {
+		const combo = $("#combobox-two-column-layout");
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#combobox-two-column-layout");
+		const arrow = combo.shadow$("[input-icon]");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItem = popover.$("ui5-list").$$("ui5-li")[0];
+
+		arrow.click();
+		assert.strictEqual(listItem.shadow$(".ui5-li-info").getText(), "DZ", "Additional item text should be displayed");
+	});
 });


### PR DESCRIPTION
This change adds support for two-column layout in the ComboBox web component so that the apps can display additional information for the selection options, such as currencies, country abbreviations, or system abbreviations. 

**Overview**

New property `additionalText` is added to the ComboBoxItem.js

**Usage**

```
<ui5-combobox>
     <ui5-cb-item text="Bulgaria" additional-text="BG"></ui5-cb-item>
</ui5-combobox>
```


Feature request: #2450

![Capture2](https://user-images.githubusercontent.com/1590151/99838818-607cf480-2b72-11eb-8e6c-1a00352fa33b.png)
