### PR TITLE
docs: fix (Range)Slider API ref

### DIFF
--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -78,10 +78,9 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.RangeSlider
- * @extends sap.ui.webcomponents.main.SliderBase
+ * @extends SliderBase
  * @tagname ui5-range-slider
  * @since 1.0.0-rc.11
- * @appenddocs SliderBase
  * @public
  */
 class RangeSlider extends SliderBase {

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -65,10 +65,9 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Slider
- * @extends sap.ui.webcomponents.base.UI5Element
+ * @extends SliderBase
  * @tagname ui5-slider
  * @since 1.0.0-rc.11
- * @appenddocs SliderBase
  * @public
  */
 class Slider extends SliderBase {

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -113,7 +113,7 @@ const metadata = {
 	},
 	slots: /** @lends sap.ui.webcomponents.main.SliderBase.prototype */ {
 		/**
-		 * Defines the text of the <code>ui5-range-slider</code>.
+		 * Defines the text of the <code>slider</code>.
 		 * <br><b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
@@ -509,8 +509,6 @@ class SliderBase extends UI5Element {
 
 	/**
 	 * Returns the start side of a direction - left for LTR, right for RTL
-	 *
-	 * @protected
 	 */
 	get directionStart() {
 		return this.effectiveDir === "rtl" ? "right" : "left";

--- a/packages/main/test/samples/RangeSlider.sample.html
+++ b/packages/main/test/samples/RangeSlider.sample.html
@@ -12,7 +12,7 @@
 <section>
 	<h3>Basic Range Slider</h3>
 	<div class="snippet">
-		<ui5-range-slider class="samples-margin" end-value="20"></ui5-range-slider>
+		<ui5-range-slider end-value="20"></ui5-range-slider>
 	</div>
 
 	<pre class="prettyprint lang-html"><xmp>
@@ -23,7 +23,7 @@
 <section>
 	<h3>Range Slider with Custom 'min', 'max', 'startValue' and 'endValue' Properties</h3>
 	<div class="snippet">
-		<ui5-range-slider class="samples-margin" min="100" max="200" start-value="120" end-value="150"></ui5-range-slider>
+		<ui5-range-slider min="100" max="200" start-value="120" end-value="150"></ui5-range-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-range-slider  min="100" max="200" start-value="120" end-value="150"></ui5-range-slider>
@@ -33,7 +33,7 @@
 <section>
 	<h3>Range Slider with Tooltips</h3>
 	<div class="snippet">
-		<ui5-range-slider class="samples-margin" start-value="3" end-value="13" show-tooltip></ui5-range-slider>
+		<ui5-range-slider start-value="3" end-value="13" show-tooltip></ui5-range-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-range-slider start-value="3" end-value="13" show-tooltip></ui5-range-slider>
@@ -43,7 +43,7 @@
 <section>
 	<h3>Range Slider with Tickmarks and Custom Step</h3>
 	<div class="snippet">
-		<ui5-range-slider class="samples-margin" step="2" start-value="12" end-value="24" show-tickmarks></ui5-range-slider>
+		<ui5-range-slider step="2" start-value="12" end-value="24" show-tickmarks></ui5-range-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-range-slider step="2" start-value="4" end-value="12" show-tickmarks></ui5-range-slider>
@@ -53,7 +53,7 @@
 <section>
 	<h3>Range Slider with Tooltips, Tickmarks and Labels</h3>
 	<div class="snippet">
-		<ui5-range-slider class="samples-margin" min="0" max="112" step="2" start-value="4" end-value="12" show-tooltip label-interval="2" show-tickmarks></ui5-range-slider>
+		<ui5-range-slider min="0" max="112" step="2" start-value="4" end-value="12" show-tooltip label-interval="2" show-tickmarks></ui5-range-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-range-slider min="0" max="112" step="2" start-value="4" end-value="12" show-tooltip label-interval="2" show-tickmarks></ui5-range-slider>

--- a/packages/main/test/samples/Slider.sample.html
+++ b/packages/main/test/samples/Slider.sample.html
@@ -12,7 +12,7 @@
 <section>
 	<h3>Basic Slider</h3>
 	<div class="snippet">
-		<ui5-slider class="samples-margin"></ui5-slider>
+		<ui5-slider></ui5-slider>
 	</div>
 
 	<pre class="prettyprint lang-html"><xmp>
@@ -23,7 +23,7 @@
 <section>
 	<h3>Slider with Tooltip</h3>
 	<div class="snippet">
-		<ui5-slider class="samples-margin" min="0" max="20" show-tooltip></ui5-slider>
+		<ui5-slider min="0" max="20" show-tooltip></ui5-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-slider min="0" max="20" show-tooltip></ui5-slider>
@@ -33,8 +33,7 @@
 <section>
 	<h3>Disabled Slider with Tickmarks and Labels</h3>
 	<div class="snippet">
-		<ui5-slider class="samples-margin" min="20" max="100" label-interval="5" disabled show-tickmarks></ui5-slider>
-		<ui5-slider class="samples-margin" min="20" max="100" label-interval="5" disabled show-tickmarks></ui5-slider>
+		<ui5-slider min="20" max="100" label-interval="5" disabled show-tickmarks></ui5-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-slider min="20" max="100" label-interval="5" disabled show-tickmarks></ui5-slider>
@@ -42,16 +41,14 @@
 </section>
 
 <section>
-	<h3>Slider tooltip, tickmarks and labels</h3>
+	<h3>Slider Tooltip, Tickmarks and Labels</h3>
 	<div class="snippet">
-		<ui5-slider class="samples-margin" min="-20" max="20" step="2" value="12" show-tooltip label-interval="2" show-tickmarks></ui5-slider>
+		<ui5-slider min="-20" max="20" step="2" value="12" show-tooltip label-interval="2" show-tickmarks></ui5-slider>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-slider min="-20" max="20" step="2" value="12" show-tooltip label-interval="2" show-tickmarks></ui5-slider>
 	</xmp></pre>
 </section>
-<ui5-slider min="-20" max="20" step="2" value="12" show-tooltip label-interval="2" show-tickmarks></ui5-slider>
-	</xmp></pre>
-</section>
+
 
 <!-- JSDoc marker -->

--- a/packages/playground/build-scripts/samples-prepare.js
+++ b/packages/playground/build-scripts/samples-prepare.js
@@ -13,6 +13,8 @@ const components = [];
  // Add new components here
 const newComponents = [
 	"MultiInput",
+	"RangeSlider",
+	"Slider",
 	"Wizard",
 ];
 


### PR DESCRIPTION
- "appendocs SliderBase" is creating a section for the SliderBase, but instead we want to show the API of the Slider (and the RangeSLider) as it's own,
without any mentions of SliderBase 
- the directionStart getter used to appear as public property (this is some jsdoc plugin related bug), I had to make it private
- mark Slider and RangeSlider as new components