### PR TITLE
fix: build error on MacOS 11 from rollup-plugin-terser

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -60,7 +60,9 @@ const getPlugins = ({ transpile }) => {
 	plugins.push(nodeResolve());
 
 	if (!process.env.DEV) {
-		plugins.push(terser());
+		plugins.push(terser({
+			numWorkers: 1,	// temp workaround for `Error: kill EPERM` error on MacOS 11
+		}));
 	}
 
 	if (process.env.DEV) {


### PR DESCRIPTION
fix for the build time `Error: kill EPERM`
