### PR TITLE
feat(ui5-side-navigation): introduce alignItems property

### DIFF
--- a/packages/fiori/src/SideNavigation.hbs
+++ b/packages/fiori/src/SideNavigation.hbs
@@ -38,13 +38,14 @@
 	<div class="ui5-sn-spacer"></div>
 
 	{{#if fixedItems.length}}
-	   <div>
+		<div>
 			<div class="ui5-sn-bottom-content-border">
 				<span></span>
 			</div>
 			<ui5-tree
 				id="ui5-sn-fixed-items-tree"
 				mode="None"
+				align-items="{{alignItems}}"
 				?_minimal="{{collapsed}}"
 				_toggle-button-end
 				@ui5-item-click="{{handleTreeItemClick}}"
@@ -71,7 +72,7 @@
 					</ui5-tree-item>
 				{{/each}}
 			</ui5-tree>
-	   </div>
+		</div>
 	{{/if}}
 
 	{{> footer }}

--- a/packages/fiori/src/SideNavigation.hbs
+++ b/packages/fiori/src/SideNavigation.hbs
@@ -5,6 +5,7 @@
 		<ui5-tree
 			id="ui5-sn-items-tree"
 			mode="None"
+			align-items="{{alignItems}}"
 			?_minimal="{{collapsed}}"
 			_toggle-button-end
 			@ui5-item-click="{{handleTreeItemClick}}"

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -5,6 +5,10 @@ import List from "@ui5/webcomponents/dist/List.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import Tree from "@ui5/webcomponents/dist/Tree.js";
 import TreeItem from "@ui5/webcomponents/dist/TreeItem.js";
+
+import SideNavItemsAlign from "./types/SideNavItemsAlign.js";
+
+// Template
 import SideNavigationTemplate from "./generated/templates/SideNavigationTemplate.lit.js";
 import SideNavigationItemPopoverContentTemplate from "./generated/templates/SideNavigationItemPopoverContentTemplate.lit.js";
 
@@ -27,6 +31,27 @@ const metadata = {
 		 */
 		collapsed: {
 			type: Boolean,
+		},
+
+		/**
+		 * Defines the items alignment.
+		 * <br><br>
+		 * Available options are <code>Start</code> and <code>Text (default)</code>.
+		 * <br>
+		 * The <code>Text</code> option means the items
+		 * will be aligned by their text - the items without icon will be indented.
+		 * <br>
+		 * The <code>Start</code> option means the items
+		 * will be aligned from the start - the items without icon will not be indented.
+		 *
+		 * @public
+		 * @type {SideNavItemsAlign}
+		 * @defaultvalue "Text"
+		 * @since 1.0.0-rc.11
+		 */
+		alignItems: {
+			type: String,
+			defaultValue: SideNavItemsAlign.Text,
 		},
 
 		/**

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -36,9 +36,9 @@ const metadata = {
 		/**
 		 * Defines the items alignment.
 		 * <br><br>
-		 * Available options are <code>Start</code> and <code>Text (default)</code>.
+		 * Available options are <code>Start</code> and <code>Indent (default)</code>.
 		 * <br>
-		 * The <code>Text</code> option means the items
+		 * The <code>Indent</code> option means the items
 		 * will be aligned by their text - the items without icon will be indented.
 		 * <br>
 		 * The <code>Start</code> option means the items
@@ -51,7 +51,7 @@ const metadata = {
 		 */
 		alignItems: {
 			type: String,
-			defaultValue: SideNavItemsAlign.Text,
+			defaultValue: SideNavItemsAlign.Indent,
 		},
 
 		/**

--- a/packages/fiori/src/types/SideNavItemsAlign.js
+++ b/packages/fiori/src/types/SideNavItemsAlign.js
@@ -9,9 +9,9 @@ const SideNavItemsAlignments = {
 	/**
 	 * The items will be aligned by their text - the items without icons will be indented.
 	 * @public
-	 * @type {Text}
+	 * @type {Indent}
 	 */
-	Text: "Text",
+	Indent: "Indent",
 
 	/**
 	 * The items will be aligned from the start - the items without icons will not be indented.

--- a/packages/fiori/src/types/SideNavItemsAlign.js
+++ b/packages/fiori/src/types/SideNavItemsAlign.js
@@ -1,0 +1,42 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * Different types of items alignment in the SideNavigation.
+ * @lends sap.ui.webcomponents.fiori.types.SideNavItemsAlign.prototype
+ * @public
+ */
+const SideNavItemsAlignments = {
+	/**
+	 * The items will be aligned by their text - the items without icons will be indented.
+	 * @public
+	 * @type {Text}
+	 */
+	Text: "Text",
+
+	/**
+	 * The items will be aligned from the start - the items without icons will not be indented.
+	 * @public
+	 * @type {Start}
+	 */
+	Start: "Start",
+};
+
+/**
+ * Different types of items alignment in the <code>ui5-side-navigation</code>.
+ *
+ * @class
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.fiori.types.SideNavItemsAlign
+ * @public
+ * @enum {string}
+ */
+class SideNavItemsAlign extends DataType {
+	static isValid(value) {
+		return !!SideNavItemsAlignments[value];
+	}
+}
+
+SideNavItemsAlign.generateTypeAcessors(SideNavItemsAlignments);
+
+export default SideNavItemsAlign;

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -73,8 +73,78 @@
 		<ui5-input id="counter" value="0"></ui5-input>
 	</div>
 
+	<br><br>
 
+	<ui5-title>SideNavigation align-items="Text"</ui5-title>
+	<br>
+	<div style="display: flex; flex-direction: row;">
+		<div class="content">
+			<ui5-side-navigation>
+				<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" icon="group" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events">
+					<ui5-side-navigation-sub-item text="Local" icon="employee-rejections"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
 
+		<div class="content">
+			<ui5-side-navigation>
+				<ui5-side-navigation-item text="Home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events">
+					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+	</div>
+
+	<br><br>
+	<br><br>
+
+	<ui5-title>SideNavigation align-items="Start" (Default)</ui5-title>
+	<br>
+	<div style="display: flex; flex-direction: row;">
+		<div class="content">
+			<ui5-side-navigation align-items="Start">
+				<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" icon="group" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events">
+					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+
+		<div class="content">
+			<ui5-side-navigation align-items="Start">
+				<ui5-side-navigation-item text="Home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events">
+					<ui5-side-navigation-sub-item text="Local" icon="employee-rejections"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+	</div>
 
 	<script>
 		var sideNavigation = document.querySelector("ui5-side-navigation"),
@@ -87,7 +157,6 @@
 		sideNavigation.addEventListener("ui5-selection-change", function() {
 			input.value = ++counter;
 		});
-
 	</script>
 </body>
 </html>

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -75,7 +75,7 @@
 
 	<br><br>
 
-	<ui5-title>SideNavigation align-items="Text"</ui5-title>
+	<ui5-title>SideNavigation align-items="Indent" (Default)</ui5-title>
 	<br>
 	<div style="display: flex; flex-direction: row;">
 		<div class="content">
@@ -112,7 +112,7 @@
 	<br><br>
 	<br><br>
 
-	<ui5-title>SideNavigation align-items="Start" (Default)</ui5-title>
+	<ui5-title>SideNavigation align-items="Start"</ui5-title>
 	<br>
 	<div style="display: flex; flex-direction: row;">
 		<div class="content">

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -86,8 +86,23 @@
 					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
 				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Events">
-					<ui5-side-navigation-sub-item text="Local" icon="employee-rejections"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-item icon="employee-approvals" text="Events" expanded>
+					<ui5-side-navigation-sub-item icon="employee-approvals" text="Local"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+
+		<div class="content">
+			<ui5-side-navigation>
+				<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" icon="group" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
+					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
 			</ui5-side-navigation>
@@ -100,8 +115,23 @@
 					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Events">
+				<ui5-side-navigation-item text="Locations" expanded selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
+					<ui5-side-navigation-sub-item text="Local" icon="employee-rejections"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+
+		<div class="content">
+			<ui5-side-navigation>
+				<ui5-side-navigation-item text="Home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" expanded>
+					<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations"  selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
 					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
@@ -123,7 +153,22 @@
 					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
 				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Events">
+				<ui5-side-navigation-item icon="employee-approvals" text="Events" expanded>
+					<ui5-side-navigation-sub-item icon="employee-approvals" text="Local"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+
+		<div class="content">
+			<ui5-side-navigation align-items="Start">
+				<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" icon="group" expanded>
+					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
 					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
@@ -137,9 +182,24 @@
 					<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Locations" selected></ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Events">
+				<ui5-side-navigation-item text="Locations" expanded selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
 					<ui5-side-navigation-sub-item text="Local" icon="employee-rejections"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		</div>
+
+		<div class="content">
+			<ui5-side-navigation align-items="Start">
+				<ui5-side-navigation-item text="Home"></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="People" expanded>
+					<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
+					<ui5-side-navigation-sub-item text="From Other Teams"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Locations"  selected></ui5-side-navigation-item>
+				<ui5-side-navigation-item text="Events" expanded>
+					<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
 			</ui5-side-navigation>

--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -14,6 +14,7 @@
             type="Active"
             level="{{this.level}}"
             icon="{{this.treeItem.icon}}"
+            ?indent="{{this.indent}}"
             ?_toggle-button-end="{{../_toggleButtonEnd}}"
             ?_minimal="{{../_minimal}}"
             .treeItem="{{this.treeItem}}"

--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -15,6 +15,7 @@
             level="{{this.level}}"
             icon="{{this.treeItem.icon}}"
             ?indent="{{this.indent}}"
+            ?indent-text="{{this.indentText}}"
             ?_toggle-button-end="{{../_toggleButtonEnd}}"
             ?_minimal="{{../_minimal}}"
             .treeItem="{{this.treeItem}}"

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -104,11 +104,11 @@ const metadata = {
 		 * <br><br>
 		 * Available options are <code>Start (default)</code> and <code>Indent</code>.
 		 * <br>
-		 * The <code>Indent</code> option means the items
-		 * will be aligned by their text - the items without icon will be indented.
-		 * <br>
 		 * The <code>Start</code> option means the items
 		 * will be aligned from the start - the items without icon will not be indented.
+		 * <br>
+		 * The <code>Indent</code> option means the items
+		 * will be aligned from the start for a tree branch - the items without icon will not be indented.
 		 *
 		 * @private
 		 * @type {TreeItemsAlign}
@@ -302,29 +302,33 @@ class Tree extends UI5Element {
 	 *  that consists of mixture of items with and without icons.
 	 */
 	applyItemsAlignment() {
-		if (!this.alignItemsIndented || !this.depth) {
+		if (!this.alignItemsIndent || !this.depth) {
 			return;
 		}
 
+		let parentIndented = false;
 		for (let i = 1; i <= this.depth; i++) {
-			const itemsForLevel = this.getItemsByLevel(this._listItems, i);
-			this.indentItems(itemsForLevel);
+			const items = this.getItemsByLevel(this._listItems, i);
+			const hasMixedItems = this.hasMixedItems(items);
+
+			this.indentItems(items, parentIndented, hasMixedItems);
+
+			if (hasMixedItems) {
+				parentIndented = true;
+			}
 		}
 	}
 
 	/**
 	 * Marks the items that needs to be idented.
 	 * @param {Array} items
+	 * @param {Array} indent to indent the entire item
+	 * @param {Array} items to indent the text only
 	 */
-	indentItems(items) {
-		const hasMixedItems = this.hasMixedItems(items);
-
-		if (!hasMixedItems) {
-			return;
-		}
-
+	indentItems(items, indent, indentText) {
 		items.forEach(item => {
-			item.indent = !item.treeItem.icon;
+			item.indent = indent;
+			item.indentText = indentText && !item.treeItem.icon;
 		});
 	}
 
@@ -374,7 +378,7 @@ class Tree extends UI5Element {
 		return null;
 	}
 
-	get alignItemsIndented() {
+	get alignItemsIndent() {
 		return this.alignItems === TreeItemsAlign.Indent;
 	}
 

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -102,9 +102,9 @@ const metadata = {
 		/**
 		 * Defines the items alignment.
 		 * <br><br>
-		 * Available options are <code>Start</code> and <code>Text (default)</code>.
+		 * Available options are <code>Start (default)</code> and <code>Indent</code>.
 		 * <br>
-		 * The <code>Text</code> option means the items
+		 * The <code>Indent</code> option means the items
 		 * will be aligned by their text - the items without icon will be indented.
 		 * <br>
 		 * The <code>Start</code> option means the items
@@ -298,11 +298,11 @@ class Tree extends UI5Element {
 	/**
 	 * Analyzes each level and applies identation if necessary.
 	 * - alignItems="Start": does not provide additional indentation
-	 * - alignItems="Text": provides additional indentation for tree level,
+	 * - alignItems="Indent": provides additional indentation for tree level,
 	 *  that consists of mixture of items with and without icons.
 	 */
 	applyItemsAlignment() {
-		if (!this.alignItemsByText || !this.depth) {
+		if (!this.alignItemsIndented || !this.depth) {
 			return;
 		}
 
@@ -374,8 +374,8 @@ class Tree extends UI5Element {
 		return null;
 	}
 
-	get alignItemsByText() {
-		return this.alignItems === TreeItemsAlign.Text;
+	get alignItemsIndented() {
+		return this.alignItems === TreeItemsAlign.Indent;
 	}
 
 	_onListItemStepIn(event) {

--- a/packages/main/src/TreeListItem.hbs
+++ b/packages/main/src/TreeListItem.hbs
@@ -1,7 +1,7 @@
 {{>include "./ListItem.hbs"}}
 
 {{#*inline "listItemPreContent"}}
-	<div class="ui5-li-tree-toggle-box" style="padding-left: {{effectiveLevel}}rem; padding-left: calc(var(--_ui5-tree-indent-step) * {{effectiveLevel}});">
+	<div class="ui5-li-tree-toggle-box" style="padding-left: {{effectiveLevel}}rem; padding-left: calc(var(--_ui5-tree-indent-step) * {{effectiveLevel}} + {{indentOffset}});">
 		{{#if _showToggleButtonBeginning}}
 			<ui5-icon
 				class="ui5-li-tree-toggle-icon"

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -84,13 +84,24 @@ const metadata = {
 		},
 
 		/**
-		 * Defines if the item text will be indented with a predefined offset.
+		 * Defines if the item will be indented with a predefined offset.
 		 * @private
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @since 1.0.0-rc.11
 		 */
 		indent: {
+			type: Boolean,
+		},
+
+		/**
+		 * Defines if the item text will be indented with a predefined offset.
+		 * @private
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @since 1.0.0-rc.11
+		 */
+		indentText: {
 			type: Boolean,
 		},
 	},
@@ -201,6 +212,10 @@ class TreeListItem extends ListItem {
 
 	get hasParent() {
 		return this.level > 1;
+	}
+
+	get indentOffset() {
+		return this.indent ? "1.5rem" : "0px";
 	}
 
 	get _toggleIconName() {

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -83,6 +83,16 @@ const metadata = {
 			type: Boolean,
 		},
 
+		/**
+		 * Defines if the item text will have a predefined offset.
+		 * @private
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @since 1.0.0-rc.11
+		 */
+		indent: {
+			type: Boolean,
+		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.TreeListItem.prototype */ {
 		/**

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -84,7 +84,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines if the item text will have a predefined offset.
+		 * Defines if the item text will be indented with a predefined offset.
 		 * @private
 		 * @type {boolean}
 		 * @defaultvalue false

--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -16,6 +16,10 @@
     justify-content: center;
 }
 
+:host([indent]) .ui5-li-content {
+    padding-left: var(--_ui5-tree-indent-padding);
+}
+
 :host([_minimal]) .ui5-li-root-tree {
     padding: 0;
 }
@@ -80,4 +84,9 @@
 
 :host([active][actionable]) .ui5-li-tree-toggle-icon {
     color: var(--sapList_Active_TextColor);
+}
+
+:host([indent]) [dir="rtl"] .ui5-li-content {
+    padding-left: 0;
+    padding-right: 1.625rem;
 }

--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -16,7 +16,7 @@
     justify-content: center;
 }
 
-:host([indent]) .ui5-li-content {
+:host([indent-text]) .ui5-li-content {
     padding-left: var(--_ui5-tree-indent-padding);
 }
 
@@ -86,7 +86,7 @@
     color: var(--sapList_Active_TextColor);
 }
 
-:host([indent]) [dir="rtl"] .ui5-li-content {
+:host([indent-text]) [dir="rtl"] .ui5-li-content {
     padding-left: 0;
     padding-right: 1.625rem;
 }

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -72,6 +72,7 @@
 
 	/* Tree */
 	--_ui5-tree-indent-step: 1.5rem;
+	--_ui5-tree-indent-padding: 1.625rem;
 	--_ui5-tree-toggle-box-width: 2.75rem;
 	--_ui5-tree-toggle-box-height: 2.25rem;
 	--_ui5-tree-toggle-icon-size: 1.0625rem;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -72,7 +72,7 @@
 
 	/* Tree */
 	--_ui5-tree-indent-step: 1.5rem;
-	--_ui5-tree-indent-padding: 1.625rem;
+	--_ui5-tree-indent-padding: 1.5rem;
 	--_ui5-tree-toggle-box-width: 2.75rem;
 	--_ui5-tree-toggle-box-height: 2.25rem;
 	--_ui5-tree-toggle-icon-size: 1.0625rem;

--- a/packages/main/src/types/TreeItemsAlign.js
+++ b/packages/main/src/types/TreeItemsAlign.js
@@ -1,0 +1,42 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * Different types of items alignment in the Tree.
+ * @lends sap.ui.webcomponents.main.types.TreeItemsAlign.prototype
+ * @public
+ */
+const TreeItemsAlignments = {
+	/**
+	 * The tree items will be aligned by their text - the items without icons will be indented.
+	 * @public
+	 * @type {Text}
+	 */
+	Text: "Text",
+
+	/**
+	 * The tree items will be aligned from the start - the items without icons will not be indented.
+	 * @public
+	 * @type {Start}
+	 */
+	Start: "Start",
+};
+
+/**
+ * Different types of items alignment in the <code>ui5-tree</code>.
+ *
+ * @class
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.types.TreeItemsAlign
+ * @public
+ * @enum {string}
+ */
+class TreeItemsAlign extends DataType {
+	static isValid(value) {
+		return !!TreeItemsAlignments[value];
+	}
+}
+
+TreeItemsAlign.generateTypeAcessors(TreeItemsAlignments);
+
+export default TreeItemsAlign;

--- a/packages/main/src/types/TreeItemsAlign.js
+++ b/packages/main/src/types/TreeItemsAlign.js
@@ -9,9 +9,9 @@ const TreeItemsAlignments = {
 	/**
 	 * The tree items will be aligned by their text - the items without icons will be indented.
 	 * @public
-	 * @type {Text}
+	 * @type {Indent}
 	 */
-	Text: "Text",
+	Indent: "Indent",
 
 	/**
 	 * The tree items will be aligned from the start - the items without icons will not be indented.

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -119,10 +119,10 @@
 	</ui5-busyindicator>
 
 	<br><br>
-	<ui5-title>Tree with align-items="Text"</ui5-title>
+	<ui5-title>Tree with align-items="Indent"</ui5-title>
 	<br><br>
 
-	<ui5-tree id="treeTextAligned" align-items="Text">
+	<ui5-tree id="treeTextAligned" align-items="Indent">
 		<ui5-tree-item id="treeTextAligned1" text="Tree 1" selected expanded>
 			<ui5-tree-item id="treeTextAligned1.1" icon="home" text="Tree 1.1" selected>
 				<ui5-tree-item id="treeTextAligned1.1.1" icon="home" text="Tree 1.1.1"></ui5-tree-item>

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -118,6 +118,70 @@
 		</ui5-tree>
 	</ui5-busyindicator>
 
+	<br><br>
+	<ui5-title>Tree with align-items="Text"</ui5-title>
+	<br><br>
+
+	<ui5-tree id="treeTextAligned" align-items="Text">
+		<ui5-tree-item id="treeTextAligned1" text="Tree 1" selected expanded>
+			<ui5-tree-item id="treeTextAligned1.1" icon="home" text="Tree 1.1" selected>
+				<ui5-tree-item id="treeTextAligned1.1.1" icon="home" text="Tree 1.1.1"></ui5-tree-item>
+				<ui5-tree-item id="treeTextAligned1.1.2" text="Tree 1.1.2"></ui5-tree-item>
+			</ui5-tree-item>
+		</ui5-tree-item>
+
+		<ui5-tree-item id="treeTextAligned2" text="Tree 2" icon="paste" expanded>
+			<ui5-tree-item id="treeTextAligned2.1" text="Tree 2.1">
+				<ui5-tree-item id="treeTextAligned2.1.1" text="Tree 2.1.1"></ui5-tree-item>
+				<ui5-tree-item id="treeTextAligned2.1.2" text="Tree 2.1.2">
+					<ui5-tree-item text="Tree 2.1.2.1"></ui5-tree-item>
+					<ui5-tree-item icon="home" text="Tree 2.1.2.2"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.3"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.5"></ui5-tree-item>
+				</ui5-tree-item>
+				<ui5-tree-item icon="home" text="Tree 2.2">
+					<ui5-tree-item text="Tree 2.1.2.1"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.2"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.3"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.5"></ui5-tree-item>
+				</ui5-tree-item>
+			</ui5-tree-item>
+			<ui5-tree-item id="treeTextAligned2.2" text="Tree 2.2"></ui5-tree-item>
+		</ui5-tree-item>
+	</ui5-tree>
+
+	<br><br>
+	<ui5-title>Tree with align-items="Start"</ui5-title>
+	<br><br>
+
+	<ui5-tree id="treeStartAligned">
+		<ui5-tree-item id="treeStartAligned1" text="Tree 1" expanded selected>
+			<ui5-tree-item icon="home" text="Tree 1.1" selected>
+				<ui5-tree-item icon="home" text="Tree 1.1.1"></ui5-tree-item>
+				<ui5-tree-item text="Tree 1.1.2"></ui5-tree-item>
+			</ui5-tree-item>
+		</ui5-tree-item>
+
+		<ui5-tree-item id="treeStartAligned2" text="Tree 2" icon="paste" expanded>
+			<ui5-tree-item id="treeStartAligned2.1" text="Tree 2.1">
+				<ui5-tree-item text="Tree 2.1.1"></ui5-tree-item>
+				<ui5-tree-item text="Tree 2.1.2">
+					<ui5-tree-item text="Tree 2.1.2.1"></ui5-tree-item>
+					<ui5-tree-item icon="home" text="Tree 2.1.2.2"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.3"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.5"></ui5-tree-item>
+				</ui5-tree-item>
+				<ui5-tree-item icon="home" text="Tree 2.1.2">
+					<ui5-tree-item text="Tree 2.1.2.1"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.2"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.3"></ui5-tree-item>
+					<ui5-tree-item text="Tree 2.1.2.5"></ui5-tree-item>
+				</ui5-tree-item>
+			</ui5-tree-item>
+			<ui5-tree-item id="treeStartAligned2.2" text="Tree 2.2"></ui5-tree-item>
+		</ui5-tree-item>
+	</ui5-tree>
+
 	<script>
 
 		document.getElementById("density").addEventListener("selectionChange", function(event) {

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -31,7 +31,7 @@ describe("Tree general interaction", () => {
 	it("Tree items are aligned by their start", () => {
 		const tree = browser.$("#treeStartAligned");
 		const listItems = tree.shadow$$("ui5-li-tree");
-		const itemsNotIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === false);
+		const itemsNotIndented = [0, 3, 4].every(index => listItems[index].getProperty("indentText") === false);
 
 		assert.strictEqual(itemsNotIndented, true,  "The items without an icon are not indented");
 	});
@@ -39,7 +39,7 @@ describe("Tree general interaction", () => {
 	it("Tree items are aligned by their text", () => {
 		const tree = browser.$("#treeTextAligned");
 		const listItems = tree.shadow$$("ui5-li-tree");
-		const itemsIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === true);
+		const itemsIndented = [0, 3, 4].every(index => listItems[index].getProperty("indentText") === true);
 
 		assert.strictEqual(itemsIndented, true, "The items without an icon are indented");
 	});

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -26,8 +26,23 @@ describe("Tree general interaction", () => {
 		toggleButton.click();
 		const listItemsAfter = tree.shadow$$("ui5-li-tree").length;
 		assert.ok(listItemsAfter > listItemsBefore, "After expanding a node, there are more items in the list");
-	})
+	});
 
+	it("Tree items are aligned by their start", () => {
+		const tree = browser.$("#treeStartAligned");
+		const listItems = tree.shadow$$("ui5-li-tree");
+		const itemsIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === false);
+
+		assert.strictEqual(itemsIndented, true,  "The items without an icon are indented");
+	});
+
+	it("Tree items are aligned by their text", () => {
+		const tree = browser.$("#treeTextAligned");
+		const listItems = tree.shadow$$("ui5-li-tree");
+		const itemsIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === true);
+
+		assert.strictEqual(itemsIndented, true, "The items without an icon are indented");
+	});
 });
 
 describe("Tree proxies properties to list", () => {

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -31,9 +31,9 @@ describe("Tree general interaction", () => {
 	it("Tree items are aligned by their start", () => {
 		const tree = browser.$("#treeStartAligned");
 		const listItems = tree.shadow$$("ui5-li-tree");
-		const itemsIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === false);
+		const itemsNotIndented = [0, 3, 4].every(index => listItems[index].getProperty("indent") === false);
 
-		assert.strictEqual(itemsIndented, true,  "The items without an icon are indented");
+		assert.strictEqual(itemsNotIndented, true,  "The items without an icon are not indented");
 	});
 
 	it("Tree items are aligned by their text", () => {


### PR DESCRIPTION
First of all, the change fixes the default alignment of the items in the SideNavigation. After the change the items are aligned by their text, which means in case we have a mixture of items with and without icons, the ones without an icon will be indented.
But, we also provide the option to set a second type of alignment by introducing a new property on SideNavigation level, called **alignItems** that will apply to both levels of items.
Available options are **Start** and **Indent** (default).
- The Indent option means the items will be aligned by their text - the items without icon will be indented.
- The Start option means the items will be aligned from the start - without any additional indentation.

FIXES https://github.com/SAP/ui5-webcomponents/issues/2522
<img width="980" alt="Screenshot 2020-11-27 at 11 36 38 AM" src="https://user-images.githubusercontent.com/15702139/100434424-2301f500-30a5-11eb-85fd-a7023b36f68a.png">

<img width="978" alt="Screenshot 2020-11-27 at 11 36 44 AM" src="https://user-images.githubusercontent.com/15702139/100434433-25fce580-30a5-11eb-9ef7-cbd317bf576c.png">

The implementation itself is provided by the Tree via private(protected) property, that the SideNavigation sets.
Added sample for testing purposes. The default alignment in the Tree is "Start" as it is now.
<img width="316" alt="Screenshot 2020-11-27 at 11 40 50 AM" src="https://user-images.githubusercontent.com/15702139/100434613-6b211780-30a5-11eb-82e5-86a907784968.png">


