### PR TITLE
fix(ui5-wizard): fix styling issues

### DIFF
--- a/packages/fiori/src/themes/Wizard.css
+++ b/packages/fiori/src/themes/Wizard.css
@@ -44,8 +44,9 @@
 	position: relative;
 	padding: 5rem 1rem 1rem 1rem;
 	overflow: auto;
-	height: calc(100% - 4rem);
+	height: 100%;
 	box-sizing: border-box;
+	background: var(--sapBackgroundColor);
 }
 
 .ui5-wiz-content-item {


### PR DESCRIPTION
- set default content background (equivalent to Standard in openui5)
- remove additional space from the content bottom

FIXES https://github.com/SAP/ui5-webcomponents/issues/2523