### PR TITLE
fix(ui5-mcb): always show the last token

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -759,11 +759,19 @@ class MultiComboBox extends UI5Element {
 		if (!isPhone()) {
 			this.focused = true;
 		}
+
+		// ensure the last token is in view by scrolling the tokenizer to its end
+		this._tokenizer.scrollToEnd();
 	}
 
 	inputFocusOut(event) {
 		if (!this.shadowRoot.contains(event.relatedTarget) && !this._deleting) {
 			this.focused = false;
+		}
+
+		// restore tokenizer's scroll position
+		if (!event.relatedTarget || event.relatedTarget.localName !== "ui5-token") {
+			this._tokenizer.scrollToStart();
 		}
 	}
 

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -161,6 +161,7 @@ class Tokenizer extends UI5Element {
 			popover.open(this.morePopoverOpener || this);
 		}
 
+		this.scrollToEnd();
 		this.fireEvent("show-more-items-press");
 	}
 
@@ -263,10 +264,21 @@ class Tokenizer extends UI5Element {
 		this.contentDom.scrollLeft = 0;
 	}
 
+	/**
+	 * Scrolls the container of the tokens to its end.
+	 * This method is used by MultiInput and MultiComboBox.
+	 * @private
+	 */
+	scrollToEnd() {
+		this.contentDom.scrollLeft = Math.ceil(this.getBoundingClientRect().width);
+	}
+
 	async closeMorePopover() {
 		const popover = await this.getPopover();
 
 		popover.close();
+
+		this.scrollToStart();
 	}
 
 	get _nMoreText() {


### PR DESCRIPTION
**What is the issue:** Currently when the tokenizer expands either when the user clicks in the input field or the showMore, the last token can be cut off, because the tokens are displayed, starting from the first. But this is not how it is supposed to work.
**How it works after the change:** Now, when focusing the input field, the tokens are cut from the left side and the last one is always visible. Same goes when the user press the showMore. And as previously, the user still can scroll the tokens by dragging them to the left or to the right.
**Implementation detail:** calling scrollToEnd when the input is focused or the showMore popover opens, and scrollToStart when the input is focused out or the showMore popover closes. 

FIXES https://github.com/SAP/ui5-webcomponents/issues/2262

<img width="373" alt="Screenshot 2020-12-04 at 4 18 34 PM" src="https://user-images.githubusercontent.com/15702139/101174347-6aabf200-364c-11eb-8d4d-8bc354194c3f.png">
<img width="372" alt="Screenshot 2020-12-04 at 4 18 41 PM" src="https://user-images.githubusercontent.com/15702139/101174372-739cc380-364c-11eb-941b-505948a508f0.png">

Previously
<img width="413" alt="Screenshot 2020-12-04 at 4 21 33 PM" src="https://user-images.githubusercontent.com/15702139/101174658-dd1cd200-364c-11eb-9225-180c4c11028c.png">



