### PR TITLE
chore: exclude thirdparty from jsdoc generation

### DIFF
--- a/packages/main/.eslintignore
+++ b/packages/main/.eslintignore
@@ -8,4 +8,3 @@ rollup.config*.js
 wdio.conf.js
 postcss.config.js
 package-scripts.js
-thirdparty

--- a/packages/main/.eslintignore
+++ b/packages/main/.eslintignore
@@ -8,3 +8,4 @@ rollup.config*.js
 wdio.conf.js
 postcss.config.js
 package-scripts.js
+thirdparty

--- a/packages/tools/lib/jsdoc/config.json
+++ b/packages/tools/lib/jsdoc/config.json
@@ -1,7 +1,7 @@
 {
 	"source": {
 		"include": "src",
-		"excludePattern": "(/|\\\\)library-all\\.js|(/|\\\\).*-preload\\.js|^jquery-.*\\.js|^sap-.*\\.js|.+Renderer\\.lit\\.js|.*library\\.js"
+		"excludePattern": "(/|\\\\)library-all\\.js|(/|\\\\).*-preload\\.js|^jquery-.*\\.js|^sap-.*\\.js|.+Renderer\\.lit\\.js|.*library\\.js|thirdparty"
 	},
 	"opts" : {
 		"recurse": true,


### PR DESCRIPTION
Exclude directory, named "thirdparty" from jsdoc generation.