### PR TITLE
fix(ui5-dialog): apply initial focus after rendering

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -639,6 +639,16 @@ class UI5Element extends HTMLElement {
 	}
 
 	/**
+	 * Waits for dom ref and then returns the DOM Element marked with "data-sap-focus-ref" inside the template.
+	 * This is the element that will receive the focus by default.
+	 * @public
+	 */
+	async getFocusDomRefAsync() {
+		await this._waitForDomRef();
+		return this.getFocusDomRef();
+	}
+
+	/**
 	 * Use this method in order to get a reference to an element in the shadow root of the web component or the static area item of the component
 	 * @public
 	 * @method

--- a/packages/base/src/util/FocusableElements.js
+++ b/packages/base/src/util/FocusableElements.js
@@ -38,6 +38,11 @@ const findFocusableElement = (container, forward) => {
 	while (child) {
 		const originalChild = child;
 
+		// @todo discuss
+		if (child.isUI5Element) {
+			return child;
+		}
+
 		child = child.isUI5Element ? child.getFocusDomRef() : child;
 		if (!child) {
 			return null;

--- a/packages/base/src/util/FocusableElements.js
+++ b/packages/base/src/util/FocusableElements.js
@@ -40,7 +40,10 @@ const findFocusableElement = async (container, forward) => {
 	while (child) {
 		const originalChild = child;
 
-		child = child.isUI5Element ? await child.getFocusDomRefAsync() : child;
+		if (child.isUI5Element) {
+			child = await child.getFocusDomRefAsync();
+		}
+
 		if (!child) {
 			return null;
 		}

--- a/packages/base/src/util/FocusableElements.js
+++ b/packages/base/src/util/FocusableElements.js
@@ -5,7 +5,7 @@ const isFocusTrap = el => {
 	return el.hasAttribute("data-ui5-focus-trap");
 };
 
-const getFirstFocusableElement = container => {
+const getFirstFocusableElement = async container => {
 	if (!container || isNodeHidden(container)) {
 		return null;
 	}
@@ -13,7 +13,7 @@ const getFirstFocusableElement = container => {
 	return findFocusableElement(container, true);
 };
 
-const getLastFocusableElement = container => {
+const getLastFocusableElement = async container => {
 	if (!container || isNodeHidden(container)) {
 		return null;
 	}
@@ -21,7 +21,7 @@ const getLastFocusableElement = container => {
 	return findFocusableElement(container, false);
 };
 
-const findFocusableElement = (container, forward) => {
+const findFocusableElement = async (container, forward) => {
 	let child;
 
 	if (container.shadowRoot) {
@@ -35,15 +35,12 @@ const findFocusableElement = (container, forward) => {
 
 	let focusableDescendant;
 
+	/* eslint-disable no-await-in-loop */
+
 	while (child) {
 		const originalChild = child;
 
-		// @todo discuss
-		if (child.isUI5Element) {
-			return child;
-		}
-
-		child = child.isUI5Element ? child.getFocusDomRef() : child;
+		child = child.isUI5Element ? await child.getFocusDomRefAsync() : child;
 		if (!child) {
 			return null;
 		}
@@ -53,7 +50,7 @@ const findFocusableElement = (container, forward) => {
 				return (child && typeof child.focus === "function") ? child : null;
 			}
 
-			focusableDescendant = findFocusableElement(child, forward);
+			focusableDescendant = await findFocusableElement(child, forward);
 			if (focusableDescendant) {
 				return (focusableDescendant && typeof focusableDescendant.focus === "function") ? focusableDescendant : null;
 			}
@@ -61,6 +58,8 @@ const findFocusableElement = (container, forward) => {
 
 		child = forward ? originalChild.nextSibling : originalChild.previousSibling;
 	}
+
+	/* eslint-enable no-await-in-loop */
 
 	return null;
 };

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -79,7 +79,15 @@ const metadata = {
 		/**
 		 * @private
 		 */
-		_disableInitialFocus: {
+		// _disableInitialFocus: {
+		// 	type: Boolean,
+		// },
+
+		/**
+		 * True if the initial focus is already internally applied.
+		 * @private
+		 */
+		_initialFocusApplied: {
 			type: Boolean,
 		},
 
@@ -325,14 +333,23 @@ class Popup extends UI5Element {
 		this._focusedElementBeforeOpen = getFocusedElement();
 		this.show();
 
-		if (!this._disableInitialFocus && !preventInitialFocus) {
-			this.applyInitialFocus();
-		}
+		// this._preventInitialFocus = preventInitialFocus;
 
 		this._addOpenedPopup();
 
 		this.opened = true;
 		this.fireEvent("after-open", {}, false, false);
+	}
+
+	onAfterRendering() {
+		if (this.opened &&
+			// !this._disableInitialFocus &&
+			// !this._preventInitialFocus &&
+			!this._initialFocusApplied) {
+
+			this.applyInitialFocus();
+			this._initialFocusApplied = true;
+		}
 	}
 
 	/**
@@ -372,6 +389,8 @@ class Popup extends UI5Element {
 		if (!this.preventFocusRestore && !preventFocusRestore) {
 			this.resetFocus();
 		}
+
+		this._initialFocusApplied = false;
 
 		this.fireEvent("after-close", {}, false, false);
 	}

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -77,7 +77,7 @@ const metadata = {
 		},
 
 		/**
-		 * @private
+		 * @protected
 		 */
 		// _disableInitialFocus: {
 		// 	type: Boolean,
@@ -88,6 +88,14 @@ const metadata = {
 		 * @private
 		 */
 		_initialFocusApplied: {
+			type: Boolean,
+		},
+
+		/**
+		 * True if the initial focus is already internally applied.
+		 * @private
+		 */
+		_focusAppliedAfterOpen: {
 			type: Boolean,
 		},
 
@@ -298,6 +306,23 @@ class Popup extends UI5Element {
 	}
 
 	/**
+	 * @private
+	 */
+	_applyFocusAfterOpen() {
+		const shouldApply = !(this._focusAppliedAfterOpen || this._disableInitialFocus /* || this._preventInitialFocus */);
+
+		if (this.isOpen() && shouldApply) {
+
+			// @todo discuss
+			// setTimeout(() => {
+				this.applyInitialFocus();
+			// }, 0);
+
+			this._focusAppliedAfterOpen = true;
+		}
+	}
+
+	/**
 	 * Override this method to provide custom logic for the popup's open/closed state. Maps to the "opened" property by default.
 	 * @public
 	 * @returns {boolean}
@@ -342,14 +367,7 @@ class Popup extends UI5Element {
 	}
 
 	onAfterRendering() {
-		if (this.opened &&
-			// !this._disableInitialFocus &&
-			// !this._preventInitialFocus &&
-			!this._initialFocusApplied) {
-
-			this.applyInitialFocus();
-			this._initialFocusApplied = true;
-		}
+		this._applyFocusAfterOpen();
 	}
 
 	/**
@@ -390,7 +408,7 @@ class Popup extends UI5Element {
 			this.resetFocus();
 		}
 
-		this._initialFocusApplied = false;
+		this._focusAppliedAfterOpen = false;
 
 		this.fireEvent("after-close", {}, false, false);
 	}

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -77,7 +77,7 @@ const metadata = {
 		},
 
 		/**
-		 * @protected
+		 * @private
 		 */
 		_disableInitialFocus: {
 			type: Boolean,

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -336,19 +336,22 @@
 
 
 		window["dynamic-open"].addEventListener("click", function () {
-			let dialog = document.createElement("ui5-dialog"),
-				button = document.createElement("ui5-button");
+            let dialog = document.createElement("ui5-dialog"),
+                button = document.createElement("ui5-button");
 
-			button.setAttribute("id", "dynamic-dialog-button");
-			button.appendChild(document.createTextNode("Ok"));
+            button.setAttribute("id", "dynamic-dialog-close-button");
+            button.appendChild(document.createTextNode("Close"));
+            button.addEventListener("click", function () {
+                dialog.close();
+            });
 
-			dialog.setAttribute("id", "dynamic-dialog");
-			dialog.appendChild(button);
+            dialog.setAttribute("id", "dynamic-dialog");
+            dialog.appendChild(button);
 
-			document.body.appendChild(dialog);
+            document.body.appendChild(dialog);
 
-			dialog.open();
-		});
+            dialog.open();
+        });
 	</script>
 </body>
 

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -50,6 +50,9 @@
 	<br>
 	<br>
 	<ui5-button id="resizable-open">Open resizable dialog</ui5-button>
+	<br>
+	<br>
+	<ui5-button id="dynamic-open">Open dialog which is created dynamically</ui5-button>
 
 	<ui5-block-layer></ui5-block-layer>
 
@@ -330,6 +333,19 @@
 		window["draggable-close"].addEventListener("click", function () { window["draggable-dialog"].close(); });
 		window["resizable-open"].addEventListener("click", function () { window["resizable-dialog"].open(); });
 		window["resizable-close"].addEventListener("click", function () { window["resizable-dialog"].close(); });
+
+
+		window["dynamic-open"].addEventListener("click", function () {
+			let dialog = document.createElement("ui5-dialog"),
+				button = document.createElement("ui5-button");
+
+			button.appendChild(document.createTextNode("Ok"));
+			dialog.appendChild(button);
+
+			document.body.appendChild(dialog);
+
+			dialog.open();
+		});
 	</script>
 </body>
 

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -339,7 +339,10 @@
 			let dialog = document.createElement("ui5-dialog"),
 				button = document.createElement("ui5-button");
 
+			button.setAttribute("id", "dynamic-dialog-button");
 			button.appendChild(document.createTextNode("Ok"));
+
+			dialog.setAttribute("id", "dynamic-dialog");
 			dialog.appendChild(button);
 
 			document.body.appendChild(dialog);

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -334,24 +334,23 @@
 		window["resizable-open"].addEventListener("click", function () { window["resizable-dialog"].open(); });
 		window["resizable-close"].addEventListener("click", function () { window["resizable-dialog"].close(); });
 
-
 		window["dynamic-open"].addEventListener("click", function () {
-            let dialog = document.createElement("ui5-dialog"),
-                button = document.createElement("ui5-button");
+			var dialog = document.createElement("ui5-dialog"),
+				button = document.createElement("ui5-button");
 
-            button.setAttribute("id", "dynamic-dialog-close-button");
-            button.appendChild(document.createTextNode("Close"));
-            button.addEventListener("click", function () {
-                dialog.close();
-            });
+			button.setAttribute("id", "dynamic-dialog-close-button");
+			button.appendChild(document.createTextNode("Close"));
+			button.addEventListener("click", function () {
+				dialog.close();
+			});
 
-            dialog.setAttribute("id", "dynamic-dialog");
-            dialog.appendChild(button);
+			dialog.setAttribute("id", "dynamic-dialog");
+			dialog.appendChild(button);
 
-            document.body.appendChild(dialog);
+			document.body.appendChild(dialog);
 
-            dialog.open();
-        });
+			dialog.open();
+		});
 	</script>
 </body>
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -119,11 +119,12 @@ describe("Dialog general interaction", () => {
 		openDynamicDialog.click();
 
 		const dialog = browser.$("#dynamic-dialog");
+		dialog.waitForExist();
+
 		const button = dialog.shadow$("#dynamic-dialog-button");
-
-		dialog.open();
-
 		button.waitForExist();
+
+		browser.pause(500);
 
 		assert.strictEqual(document.activeElement, button, "the active element is the first button");
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -126,7 +126,7 @@ describe("Dialog general interaction", () => {
 		assert.strictEqual(activeElement.getProperty("id"), closeButton.getProperty("id"), "the active element is the close button");
 
 		closeButton.click();
-	}​​);
+	});
 });
 
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -113,6 +113,22 @@ describe("Dialog general interaction", () => {
 
 		closeResizableDialogButton.click();
 	});
+
+	it("initial focus after dynamic dialog creation", () => {
+		const openDynamicDialog = browser.$("#dynamic-open");
+		openDynamicDialog.click();
+
+		const dialog = browser.$("#dynamic-dialog");
+		const button = dialog.shadow$("#dynamic-dialog-button");
+
+		dialog.open();
+
+		button.waitForExist();
+
+		assert.strictEqual(document.activeElement, button, "the active element is the first button");
+
+		dialog.close();
+	});
 });
 
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -114,19 +114,19 @@ describe("Dialog general interaction", () => {
 		closeResizableDialogButton.click();
 	});
 
-	it("initial focus after dynamic dialog creation", () => {​​
-        const openDynamicDialog = browser.$("#dynamic-open");
+	it("initial focus after dynamic dialog creation", () => {
+		const openDynamicDialog = browser.$("#dynamic-open");
 		openDynamicDialog.click();
 
-        const closeButton = browser.$("#dynamic-dialog-close-button");
+		const closeButton = browser.$("#dynamic-dialog-close-button");
 
-        browser.pause(500);
+		browser.pause(500);
 
-        const activeElement = $(browser.getActiveElement());
+		const activeElement = $(browser.getActiveElement());
 		assert.strictEqual(activeElement.getProperty("id"), closeButton.getProperty("id"), "the active element is the close button");
 
-        closeButton.click();
-    }​​);
+		closeButton.click();
+	}​​);
 });
 
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -114,22 +114,19 @@ describe("Dialog general interaction", () => {
 		closeResizableDialogButton.click();
 	});
 
-	it("initial focus after dynamic dialog creation", () => {
-		const openDynamicDialog = browser.$("#dynamic-open");
+	it("initial focus after dynamic dialog creation", () => {​​
+        const openDynamicDialog = browser.$("#dynamic-open");
 		openDynamicDialog.click();
 
-		const dialog = browser.$("#dynamic-dialog");
-		dialog.waitForExist();
+        const closeButton = browser.$("#dynamic-dialog-close-button");
 
-		const button = dialog.shadow$("#dynamic-dialog-button");
-		button.waitForExist();
+        browser.pause(500);
 
-		browser.pause(500);
+        const activeElement = $(browser.getActiveElement());
+		assert.strictEqual(activeElement.getProperty("id"), closeButton.getProperty("id"), "the active element is the close button");
 
-		assert.strictEqual(document.activeElement, button, "the active element is the first button");
-
-		dialog.close();
-	});
+        closeButton.click();
+    }​​);
 });
 
 


### PR DESCRIPTION
Now the initial focus is applied also in cases when the dialog
is opened before it is fully rendered.

Fixes: #2537

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
