### PR TITLE
fix(BarDesign/AvatarGroupType): fix call of generateTypeAcessors

### DIFF
--- a/packages/fiori/src/types/BarDesign.js
+++ b/packages/fiori/src/types/BarDesign.js
@@ -49,6 +49,6 @@ class BarDesign extends DataType {
 	}
 }
 
-BarDesign.generateTypeAcessors(BarTypes);
+BarDesign.generataTypeAcessors(BarTypes);
 
 export default BarDesign;

--- a/packages/main/src/types/AvatarGroupType.js
+++ b/packages/main/src/types/AvatarGroupType.js
@@ -38,6 +38,6 @@ class AvatarGroupType extends DataType {
 	}
 }
 
-AvatarGroupType.generateTypeAcessors(AvatarGroupTypes);
+AvatarGroupType.generataTypeAcessors(AvatarGroupTypes);
 
 export default AvatarGroupType;


### PR DESCRIPTION
There are two types on `generataTypeAcessors` but one of them was not was present in those two enums, so the `ui5-bar` and the `ui5-avatar-group` were crashing.

Example: https://codesandbox.io/s/unruffled-shamir-p2099?file=/src/App.js

I wasn't brave enough to fix the typo in DataType.ts 🙂 