### PR TITLE
fix(ui5-badge): fix RTL appearance

### DIFF
--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -36,7 +36,8 @@
 }
 
 /* RTL */
-:host([__has-icon]) .ui5-badge-root[rtl] .ui5-badge-text {
+:host([__has-icon]) .ui5-badge-root[dir="rtl"] .ui5-badge-text {
+	padding-left: 0;
 	padding-right: 0.1875em;
 }
 


### PR DESCRIPTION
The RTL styles would be applied when we use the right selector [dir="rtl"], not just [rtl].