### PR TITLE
fix(ui5-avatar): fix XS size

### DIFF
--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -42,6 +42,8 @@
 
 :host([_size="XS"]),
 :host([size="XS"]) {
+	height: 2rem;
+	width: 2rem;
 	min-height: 2rem;
 	min-width: 2rem;
 	font-size: .75rem;

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -108,39 +108,39 @@
 			</div>
 		</ui5-popover>
 		<ui5-avatar-group type="Individual" avatar-size="XL" id="avatar-group-individual">
-			<ui5-avatar interactive initials="LL" id="avatar-1"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
-			<ui5-avatar interactive initials="LL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL" id="avatar-1"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
+			<ui5-avatar interactive initials="XL"></ui5-avatar> 
 		</ui5-avatar-group>
 		<br>
 		<ui5-avatar-group type="Group" avatar-size="M" id="avatar-group-group">
-			<ui5-avatar initials="LL" image="./img/woman_avatar_5.png"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL" image="./img/Lamp_avatar_01.jpg"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL" image="./img/John_Miller.png"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL" image="./img/woman_avatar_5.png"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL" image="./img/Lamp_avatar_01.jpg"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
-			<ui5-avatar initials="LL"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/woman_avatar_5.png"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/Lamp_avatar_01.jpg"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/John_MiMer.png"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/woman_avatar_5.png"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/Lamp_avatar_01.jpg"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
+			<ui5-avatar initials="M"></ui5-avatar>
 		</ui5-avatar-group>
 		<br>
 
@@ -160,6 +160,20 @@
 			<button id="reset-btn">Reset fields</button>
 		</div>
 	
+		<ui5-avatar-group type="Individual" avatar-size="XS">
+			<ui5-avatar interactive initials="XS" id="avatar-1"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+		</ui5-avatar-group>
 	</div>
 
 <script>

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -130,7 +130,7 @@
 			<ui5-avatar initials="M"></ui5-avatar>
 			<ui5-avatar initials="M"></ui5-avatar>
 			<ui5-avatar initials="M"></ui5-avatar>
-			<ui5-avatar initials="M" image="./img/John_MiMer.png"></ui5-avatar>
+			<ui5-avatar initials="M" image="./img/John_Miller.png"></ui5-avatar>
 			<ui5-avatar initials="M"></ui5-avatar>
 			<ui5-avatar initials="M"></ui5-avatar>
 			<ui5-avatar initials="M"></ui5-avatar>

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -159,20 +159,59 @@
 	
 			<button id="reset-btn">Reset fields</button>
 		</div>
-	
+		<br>
+		<br>
+
+		<h3>"XS" size</h3>
 		<ui5-avatar-group type="Individual" avatar-size="XS">
-			<ui5-avatar interactive initials="XS" id="avatar-1"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
-			<ui5-avatar interactive initials="XS"></ui5-avatar> 
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+			<ui5-avatar interactive initials="XS"></ui5-avatar>
+		</ui5-avatar-group>
+
+		<br>
+		<br>
+
+		<h3>"S" size</h3>
+		<ui5-avatar-group type="Individual" avatar-size="S">
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+			<ui5-avatar interactive initials="S"></ui5-avatar>
+		</ui5-avatar-group>
+
+		<br>
+		<br>
+
+		<h3>Unordinary group</h3>
+		<ui5-avatar-group type="Individual">
+			<ui5-avatar size="XS" interactive initials="XS"></ui5-avatar>
+			<ui5-avatar size="S" interactive initials="S"></ui5-avatar>
+			<ui5-avatar size="M" interactive initials="M"></ui5-avatar>
+			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
+			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
+			<ui5-avatar size="XS" interactive initials="XS"></ui5-avatar>
+			<ui5-avatar size="S" interactive initials="S"></ui5-avatar>
+			<ui5-avatar size="M" interactive initials="M"></ui5-avatar>
+			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
+			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
 		</ui5-avatar-group>
 	</div>
 


### PR DESCRIPTION
With the introduce of the AvatarGroup the XS size of the Avatar has been broken. Due to the following css the XS size appeared 3rem X 3rem, instead of 2rem X 2rem (as it is by spec). The "XS" styles define min-height and min-width, but the default styles make it 3rem by 3rem.

```css
:host {
	height: 3rem;
	width: 3rem;
}
:host([_size="XS"]),
:host([size="XS"]) {
	min-height: 2rem;
	min-width: 2rem;
	font-size: .75rem;
}
```