### PR TITLE
refactor: use ItemNavigation optimally

### DIFF
--- a/packages/fiori/src/ProductSwitch.js
+++ b/packages/fiori/src/ProductSwitch.js
@@ -62,12 +62,10 @@ class ProductSwitch extends UI5Element {
 	constructor() {
 		super();
 
-		this.initItemNavigation();
-	}
-
-	initItemNavigation() {
-		this._itemNavigation = new ItemNavigation(this, { rowSize: 4 });
-		this._itemNavigation.getItemsCallback = () => this.items;
+		this._itemNavigation = new ItemNavigation(this, {
+			rowSize: 4,
+			getItemsCallback: () => this.items,
+		});
 	}
 
 	static get metadata() {

--- a/packages/fiori/src/Timeline.hbs
+++ b/packages/fiori/src/Timeline.hbs
@@ -1,4 +1,4 @@
-<div class="ui5-timeline-root">
+<div class="ui5-timeline-root" @focusin={{_onfocusin}}>
 	<ul class="ui5-timeline-list" role="listbox" aria-live="polite" aria-label="{{ariaLabel}}">
 		{{#each items}}
 			<li class="ui5-timeline-list-item" style="list-style-type: none;">

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -72,7 +72,10 @@ class Timeline extends UI5Element {
 	constructor() {
 		super();
 
-		this.initItemNavigation();
+		this._itemNavigation = new ItemNavigation(this, {
+			getItemsCallback: () => this.items,
+		});
+
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents-fiori");
 	}
 
@@ -84,13 +87,14 @@ class Timeline extends UI5Element {
 		await fetchI18nBundle("@ui5/webcomponents-fiori");
 	}
 
-	initItemNavigation() {
-		this._itemNavigation = new ItemNavigation(this);
-		this._itemNavigation.getItemsCallback = () => this.items;
-	}
-
 	get ariaLabel() {
 		return this.i18nBundle.getText(TIMELINE_ARIA_LABEL);
+	}
+
+	_onfocusin(event) {
+		const target = event.target;
+
+		this._itemNavigation.update(target);
 	}
 }
 

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -176,7 +176,10 @@ class Wizard extends UI5Element {
 		// due to user scroll.
 		this.selectionRequestedByScroll = false;
 
-		this.initItemNavigation();
+		this._itemNavigation = new ItemNavigation(this, {
+			navigationMode: NavigationMode.Horizontal,
+			getItemsCallback: () => this.enabledStepsInHeaderDOM,
+		});
 
 		this._onResize = this.onResize.bind(this);
 
@@ -655,19 +658,6 @@ class Wizard extends UI5Element {
 
 			this.selectedStepIndex = selectedStepIndex;
 		}
-	}
-
-	/**
-	 * Initializes the <code>ItemNavigation</code>
-	 * that controls the navigation between the steps in the navigation header.
-	 * @private
-	 */
-	initItemNavigation() {
-		this._itemNavigation = new ItemNavigation(this, {
-			navigationMode: NavigationMode.Horizontal,
-		});
-
-		this._itemNavigation.getItemsCallback = () => this.enabledStepsInHeaderDOM;
 	}
 
 	/**

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -181,7 +181,12 @@ const metadata = {
 class AvatarGroup extends UI5Element {
 	constructor() {
 		super();
-		this._itemNavigation = new ItemNavigation(this);
+
+		this._itemNavigation = new ItemNavigation(this, {
+			getItemsCallback: () => {
+				return this._isGroup ? [] : this.items.slice(0, this._hiddenStartIndex);
+			},
+		});
 
 		this._colorIndex = 0;
 		this._hiddenItems = 0;
@@ -289,12 +294,6 @@ class AvatarGroup extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		if (this._isGroup) {
-			this._itemNavigation.getItemsCallback = () => [];
-		} else {
-			this._itemNavigation.getItemsCallback = () => this.items.slice(0, this._hiddenStartIndex);
-		}
-
 		this._prepareAvatars();
 	}
 

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -416,9 +416,8 @@ class List extends UI5Element {
 	initItemNavigation() {
 		this._itemNavigation = new ItemNavigation(this, {
 			navigationMode: NavigationMode.Vertical,
+			getItemsCallback: () => this.getSlottedNodes("items"),
 		});
-
-		this._itemNavigation.getItemsCallback = () => this.getSlottedNodes("items");
 	}
 
 	prepareListItems() {

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -106,7 +106,10 @@ class SegmentedButton extends UI5Element {
 
 	constructor() {
 		super();
-		this.initItemNavigation();
+
+		this._itemNavigation = new ItemNavigation(this, {
+			getItemsCallback: () => this.getSlottedNodes("buttons"),
+		});
 
 		this.absoluteWidthSet = false; // set to true whenever we set absolute width to the component
 		this.percentageWidthSet = false; //  set to true whenever we set 100% width to the component
@@ -155,12 +158,6 @@ class SegmentedButton extends UI5Element {
 
 			return width;
 		});
-	}
-
-	initItemNavigation() {
-		this._itemNavigation = new ItemNavigation(this);
-
-		this._itemNavigation.getItemsCallback = () => this.getSlottedNodes("buttons");
 	}
 
 	normalizeSelection() {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -274,7 +274,9 @@ class TabContainer extends UI5Element {
 		this._scrollEnablement.attachEvent("scroll", this._updateScrolling.bind(this));
 
 		// Init ItemNavigation
-		this._initItemNavigation();
+		this._itemNavigation = new ItemNavigation(this, {
+			getItemsCallback: () => this._getTabs(),
+		});
 
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 	}
@@ -346,11 +348,6 @@ class TabContainer extends UI5Element {
 		}
 	}
 
-	_initItemNavigation() {
-		this._itemNavigation = new ItemNavigation(this);
-		this._itemNavigation.getItemsCallback = () => this._getTabs();
-	}
-
 	_onHeaderItemSelect(tab) {
 		if (!tab.hasAttribute("disabled")) {
 			this._onItemSelect(tab);
@@ -375,7 +372,7 @@ class TabContainer extends UI5Element {
 				item.selected = selected;
 
 				if (selected) {
-					this._itemNavigation.current = selectedTabIndex;
+					this._itemNavigation.update(item);
 				}
 			}
 		}, this);


### PR DESCRIPTION
This change refactors the usage of `ItemNavigation.js` for all components except date/time related ones (which will be addressed separately).

Changes:
 - Now that `getItemsCallback` can be set in the constructor, this is the preferable way of passing it. This also eliminates the need of a separate `initItemNavigation` function that many components had as they needed 2 lines of code - `new ItemNavigation` and to set the callback.
 - Implement the `focusin` event for `Timeline.js` as it did not update the item navigation like the rest of the components whenever the user clicks with the mouse.
 - Do not use `ItemNavigation.prototype.current` any more (it is marked as deprecated). Always call `update` instead.
 - Do not use `ItemNavigation.prototype.currentIndex` any more (it is private). Always call `update` instead.
 - Do not use `ItemNavigation.prototype.focusCurrent` any more (marked as deprecated). Use the item that was passed to `update` directly (see `Tokenizer.js` for example).
 - Do not re-initialize `getItemsCallback` in `onBeforeRendering` - it is a callback exactly for the reason that based on the state of the component, it may return completely different data (see `AvatarGroup.js` for an example)

Summary: 
 - Initialize `ItemNavigation` in the constructor of the component and pass the callback there
 - Implement a `focusin` event for your component and call `update` with the newly focused item to synchronize the item navigation. Do not use `current` or `currentIndex`.