### PR TITLE
refactor: Date/time components refactoring part 1

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.js
+++ b/packages/base/src/delegate/ItemNavigation.js
@@ -71,8 +71,6 @@ class ItemNavigation extends EventProvider {
 		this.currentIndex = options.currentIndex || 0;
 		this.rowSize = options.rowSize || 1;
 		this.behavior = options.behavior || ItemNavigationBehavior.Static;
-		this.hasNextPage = true; // used in Paging mode and controlled from the rootWebComponent
-		this.hasPrevPage = true; // used in Paging mode and controlled from the rootWebComponent
 		const navigationMode = options.navigationMode;
 		const autoNavigation = !navigationMode || navigationMode === NavigationMode.Auto;
 		this.horizontalNavigationOn = autoNavigation || navigationMode === NavigationMode.Horizontal;
@@ -87,6 +85,10 @@ class ItemNavigation extends EventProvider {
 		if (options.getItemsCallback) {
 			this._getItems = options.getItemsCallback;
 		}
+
+		const trueFunction = () => true;
+		this._hasNextPage = typeof options.hasNextPageCallback === "function" ? options.hasNextPageCallback : trueFunction;
+		this._hasPreviousPage = typeof options.hasPreviousPageCallback === "function" ? options.hasPreviousPageCallback : trueFunction;
 
 		this.rootWebComponent = rootWebComponent;
 		this.rootWebComponent.addEventListener("keydown", this.onkeydown.bind(this));
@@ -367,10 +369,9 @@ class ItemNavigation extends EventProvider {
 	}
 
 	_handleNextPage() {
-		this.fireEvent(ItemNavigation.PAGE_BOTTOM);
 		const items = this._getItems();
 
-		if (!this.hasNextPage) {
+		if (!this._hasNextPage()) {
 			this.currentIndex = items.length - 1;
 		} else {
 			this.currentIndex -= this.pageSize;
@@ -378,9 +379,7 @@ class ItemNavigation extends EventProvider {
 	}
 
 	_handlePrevPage() {
-		this.fireEvent(ItemNavigation.PAGE_TOP);
-
-		if (!this.hasPrevPage) {
+		if (!this._hasPreviousPage()) {
 			this.currentIndex = 0;
 		} else {
 			this.currentIndex = this.pageSize + this.currentIndex;
@@ -388,8 +387,6 @@ class ItemNavigation extends EventProvider {
 	}
 }
 
-ItemNavigation.PAGE_TOP = "PageTop";
-ItemNavigation.PAGE_BOTTOM = "PageBottom";
 ItemNavigation.BORDER_REACH = "_borderReach";
 ItemNavigation.AFTER_FOCUS = "_afterFocus";
 

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -3,7 +3,6 @@ import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import CalendarSelection from "@ui5/webcomponents-base/dist/types/CalendarSelection.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import {
 	isF4,
 	isF4Shift,
@@ -48,16 +47,6 @@ const metadata = {
 		selection: {
 			type: CalendarSelection,
 			defaultValue: CalendarSelection.Single,
-		},
-
-		/**
-		 * Defines the selected dates as UTC timestamps.
-		 * @type {Array}
-		 * @public
-		 */
-		selectedDates: {
-			type: Integer,
-			multiple: true,
 		},
 
 		/**
@@ -351,10 +340,6 @@ class Calendar extends PickerBase {
 
 	get yearButton() {
 		return this.header.shadowRoot.querySelector("[data-sap-show-picker='Year']");
-	}
-
-	get _selectedDates() {
-		return this.selectedDates || [];
 	}
 
 	_onkeydown(event) {
@@ -714,7 +699,7 @@ class Calendar extends PickerBase {
 		this._calendarHeight = calendarRect.height.toString();
 
 		const monthPicker = this.shadowRoot.querySelector("[ui5-monthpicker]");
-		monthPicker._selectedDates = [...this.selectedDates];
+		monthPicker.selectedDates = [...this.selectedDates];
 		const currentMonthIndex = monthPicker._itemNav._getItems().findIndex(item => {
 			const calDate = CalendarDate.fromTimestamp(parseInt(item.timestamp) * 1000, this._primaryCalendarType);
 			return calDate.getMonth() === this._calendarDate.getMonth();
@@ -738,7 +723,7 @@ class Calendar extends PickerBase {
 		this._calendarHeight = calendarRect.height.toString();
 
 		const yearPicker = this.shadowRoot.querySelector("[ui5-yearpicker]");
-		yearPicker._selectedDates = [...this.selectedDates];
+		yearPicker.selectedDates = [...this.selectedDates];
 		const currentYearIndex = yearPicker._itemNav._getItems().findIndex(item => {
 			const calDate = CalendarDate.fromTimestamp(parseInt(item.timestamp) * 1000, this._primaryCalendarType);
 			return calDate.getYear() === this._calendarDate.getYear();

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -1,12 +1,7 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { fetchCldr } from "@ui5/webcomponents-base/dist/asset-registries/LocaleData.js";
-import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
-import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import CalendarSelection from "@ui5/webcomponents-base/dist/types/CalendarSelection.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import {
@@ -16,6 +11,7 @@ import {
 	isTabPrevious,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import RenderScheduler from "@ui5/webcomponents-base/dist/RenderScheduler.js";
+import PickerBase from "./PickerBase.js";
 import CalendarHeader from "./CalendarHeader.js";
 import DayPicker from "./DayPicker.js";
 import MonthPicker from "./MonthPicker.js";
@@ -36,17 +32,6 @@ import calendarCSS from "./generated/themes/Calendar.css.js";
 const metadata = {
 	tag: "ui5-calendar",
 	properties: /** @lends  sap.ui.webcomponents.main.Calendar.prototype */ {
-		/**
-		 * Defines the calendar type used for display.
-		 * If not defined, the calendar type of the global configuration is used.
-		 * Available options are: "Gregorian", "Islamic", "Japanese", "Buddhist" and "Persian".
-		 * @type {CalendarType}
-		 * @public
-		 */
-		primaryCalendarType: {
-			type: CalendarType,
-		},
-
 		/**
 		 * Defines the type of selection used in the calendar component.
 		 * The property takes as value an object of type <code>CalendarSelection</code>.
@@ -76,28 +61,6 @@ const metadata = {
 		},
 
 		/**
-		 * Determines the мinimum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @public
-		 */
-		minDate: {
-			type: String,
-		},
-
-		/**
-		 * Determines the maximum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @public
-		 */
-		maxDate: {
-			type: String,
-		},
-
-		/**
 		 * Defines the visibility of the week numbers column.
 		 * <br><br>
 		 *
@@ -110,15 +73,6 @@ const metadata = {
 		 */
 		hideWeekNumbers: {
 			type: Boolean,
-		},
-
-		/**
-		 * Defines the UNIX timestamp - seconds since 00:00:00 UTC on Jan 1, 1970.
-		 * @type {Integer}
-		 * @private
-		*/
-		timestamp: {
-			type: Integer,
 		},
 
 		_header: {
@@ -145,10 +99,6 @@ const metadata = {
 		_calendarHeight: {
 			type: String,
 			noAttribute: true,
-		},
-
-		formatPattern: {
-			type: String,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.Calendar.prototype */ {
@@ -227,18 +177,14 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Calendar
- * @extends sap.ui.webcomponents.base.UI5Element
+ * @extends sap.ui.webcomponents.main.PickerBase
  * @tagname ui5-calendar
  * @public
  * @since 1.0.0-rc.11
  */
-class Calendar extends UI5Element {
+class Calendar extends PickerBase {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get template() {
@@ -407,72 +353,8 @@ class Calendar extends UI5Element {
 		return this.header.shadowRoot.querySelector("[data-sap-show-picker='Year']");
 	}
 
-	get _timestamp() {
-		return this.timestamp !== undefined ? this.timestamp : Math.floor(new Date().getTime() / 1000);
-	}
-
-	get _localDate() {
-		return new Date(this._timestamp * 1000);
-	}
-
-	get _calendarDate() {
-		return CalendarDate.fromTimestamp(this._localDate.getTime(), this._primaryCalendarType);
-	}
-
-	get _month() {
-		return this._calendarDate.getMonth();
-	}
-
-	get _primaryCalendarType() {
-		const localeData = getCachedLocaleDataInstance(getLocale());
-		return this.primaryCalendarType || getCalendarType() || localeData.getPreferredCalendarType();
-	}
-
-	get _formatPattern() {
-		return this.formatPattern || "medium"; // get from config
-	}
-
-	get _isPattern() {
-		return this._formatPattern !== "medium" && this._formatPattern !== "short" && this._formatPattern !== "long";
-	}
-
 	get _selectedDates() {
 		return this.selectedDates || [];
-	}
-
-	get _maxDate() {
-		return this.maxDate ? this._getTimeStampFromString(this.maxDate) : this._getMaxCalendarDate();
-	}
-
-	get _minDate() {
-		return this.minDate ? this._getTimeStampFromString(this.minDate) : this._getMinCalendarDate();
-	}
-
-	_getTimeStampFromString(value) {
-		const jsDate = this.getFormat().parse(value);
-		if (jsDate) {
-			return CalendarDate.fromLocalJSDate(jsDate, this._primaryCalendarType).toUTCJSDate().valueOf();
-		}
-		return undefined;
-	}
-
-	_getMinCalendarDate() {
-		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		minDate.setYear(1);
-		minDate.setMonth(0);
-		minDate.setDate(1);
-		return minDate.valueOf();
-	}
-
-	_getMaxCalendarDate() {
-		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		maxDate.setYear(9999);
-		maxDate.setMonth(11);
-		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
-		tempDate.setDate(1);
-		tempDate.setMonth(tempDate.getMonth() + 1, 0);
-		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
-		return maxDate.valueOf();
 	}
 
 	_onkeydown(event) {
@@ -941,21 +823,6 @@ class Calendar extends UI5Element {
 		return false;
 	}
 
-	getFormat() {
-		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
-				pattern: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		} else {
-			this._oDateFormat = DateFormat.getInstance({
-				style: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		}
-		return this._oDateFormat;
-	}
-
 	get styles() {
 		return {
 			main: {
@@ -972,10 +839,6 @@ class Calendar extends UI5Element {
 			MonthPicker,
 			YearPicker,
 		];
-	}
-
-	static async onDefine() {
-		await fetchCldr(getLocale().getLanguage(), getLocale().getRegion(), getLocale().getScript());
 	}
 }
 

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -28,6 +28,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 import CalendarSelection from "@ui5/webcomponents-base/dist/types/CalendarSelection.js";
 import RenderScheduler from "@ui5/webcomponents-base/dist/RenderScheduler.js";
 import { DATEPICKER_OPEN_ICON_TITLE, DATEPICKER_DATE_ACC_TEXT, INPUT_SUGGESTIONS_TITLE } from "./generated/i18n/i18n-defaults.js";
+import { getMaxCalendarDate, getMinCalendarDate } from "./util/DateTime.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
 import ResponsivePopover from "./ResponsivePopover.js";
@@ -837,22 +838,11 @@ class DatePicker extends UI5Element {
 	}
 
 	_getMinCalendarDate() {
-		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		minDate.setYear(1);
-		minDate.setMonth(0);
-		minDate.setDate(1);
-		return minDate.valueOf();
+		return getMinCalendarDate(this._primaryCalendarType);
 	}
 
 	_getMaxCalendarDate() {
-		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		maxDate.setYear(9999);
-		maxDate.setMonth(11);
-		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
-		tempDate.setDate(1);
-		tempDate.setMonth(tempDate.getMonth() + 1, 0);
-		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
-		return maxDate.valueOf();
+		return getMaxCalendarDate(this._primaryCalendarType);
 	}
 
 	get openIconTitle() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -800,18 +800,19 @@ class DatePicker extends UI5Element {
 	}
 
 	getFormat() {
+		let dateFormat;
 		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				pattern: this._formatPattern,
 				calendarType: this._primaryCalendarType,
 			});
 		} else {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				style: this._formatPattern,
 				calendarType: this._primaryCalendarType,
 			});
 		}
-		return this._oDateFormat;
+		return dateFormat;
 	}
 
 	get accInfo() {

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -18,7 +18,6 @@ import {
 	isPageDownShift,
 	isPageDownShiftCtrl,
 } from "@ui5/webcomponents-base/dist/Keys.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import calculateWeekNumber from "@ui5/webcomponents-localization/dist/dates/calculateWeekNumber.js";
 import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
@@ -69,16 +68,6 @@ const metadata = {
 		selection: {
 			type: CalendarSelection,
 			defaultValue: CalendarSelection.Single,
-		},
-
-		/**
-		 * Sets the selected dates as UTC timestamps.
-		 * @type {Array}
-		 * @public
-		 */
-		selectedDates: {
-			type: Integer,
-			multiple: true,
 		},
 
 		/**
@@ -325,8 +314,8 @@ class DayPicker extends PickerBase {
 		const visualizedDates = this._getVisualizedSelectedDates();
 		if (this.selection === CalendarSelection.Range && visualizedDates.length > 0) {
 			const dayItems = this.getDomRef().querySelectorAll(".ui5-dp-item");
-			const firstTimestamp = this._selectedDates[0];
-			const lastTimestamp = (visualizedDates.length === 1) ? parseInt(dayItems[this._itemNav.currentIndex].dataset.sapTimestamp) : this._selectedDates[1];
+			const firstTimestamp = this.selectedDates[0];
+			const lastTimestamp = (visualizedDates.length === 1) ? parseInt(dayItems[this._itemNav.currentIndex].dataset.sapTimestamp) : this.selectedDates[1];
 
 			this._updateSelectionBetween(dayItems, firstTimestamp, lastTimestamp);
 		}
@@ -389,7 +378,7 @@ class DayPicker extends PickerBase {
 		const hoveredItem = event.target.classList.contains("ui5-dp-item") ? event.target : event.target.parentElement;
 		if (this.selectedDates.length === 1 && this.selection === CalendarSelection.Range && hoveredItem.classList.contains("ui5-dp-item")) {
 			const dayItems = this.getDomRef().querySelectorAll(".ui5-dp-item");
-			const firstTimestamp = this._selectedDates[0];
+			const firstTimestamp = this.selectedDates[0];
 			const lastTimestamp = parseInt(hoveredItem.dataset.sapTimestamp);
 
 			this._updateSelectionBetween(dayItems, firstTimestamp, lastTimestamp);
@@ -544,10 +533,6 @@ class DayPicker extends PickerBase {
 		return CalendarDate.fromTimestamp(new Date().getTime(), this._primaryCalendarType);
 	}
 
-	get _selectedDates() {
-		return this.selectedDates || [];
-	}
-
 	get focusableDays() {
 		const focusableDays = [];
 
@@ -582,17 +567,17 @@ class DayPicker extends PickerBase {
 		case CalendarSelection.Multiple:
 			this.selectedDates = this.selectedDates.includes(timestamp)
 				? this.selectedDates.filter(value => value !== timestamp)
-				: [...this._selectedDates, timestamp];
+				: [...this.selectedDates, timestamp];
 			break;
 		case CalendarSelection.Range:
 			this.selectedDates = (this.selectedDates.length === 1)
-				? [...this._selectedDates, timestamp]
+				? [...this.selectedDates, timestamp]
 				: [timestamp];
 			break;
 		default:
 		}
 
-		this.fireEvent("change", { dates: [...this._selectedDates] });
+		this.fireEvent("change", { dates: [...this.selectedDates] });
 	}
 
 	_hasNextMonth() {

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -237,9 +237,10 @@ class DayPicker extends UI5Element {
 			pageSize: 42,
 			behavior: ItemNavigationBehavior.Paging,
 			affectedPropertiesNames: ["_weeks"],
+			getItemsCallback: () => this.focusableDays,
+			hasNextPageCallback: this._hasNextMonth.bind(this),
+			hasPreviousPageCallback: this._hasPrevMonth.bind(this),
 		});
-
-		this._itemNav.getItemsCallback = () => this.focusableDays;
 
 		this._itemNav.attachEvent(
 			ItemNavigation.BORDER_REACH,
@@ -249,16 +250,6 @@ class DayPicker extends UI5Element {
 		this._itemNav.attachEvent(
 			ItemNavigation.AFTER_FOCUS,
 			this._handleItemNavigationAfterFocus.bind(this)
-		);
-
-		this._itemNav.attachEvent(
-			"PageBottom",
-			this._handleMonthBottomOverflow.bind(this)
-		);
-
-		this._itemNav.attachEvent(
-			"PageTop",
-			this._handleMonthTopOverflow.bind(this)
 		);
 
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
@@ -697,14 +688,6 @@ class DayPicker extends UI5Element {
 		}
 
 		this.fireEvent("change", { dates: [...this._selectedDates] });
-	}
-
-	_handleMonthBottomOverflow(event) {
-		this._itemNav.hasNextPage = this._hasNextMonth();
-	}
-
-	_handleMonthTopOverflow(event) {
-		this._itemNav.hasPrevPage = this._hasPrevMonth();
 	}
 
 	_hasNextMonth() {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -1,15 +1,10 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
-import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
-import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
-import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import ItemNavigationBehavior from "@ui5/webcomponents-base/dist/types/ItemNavigationBehavior.js";
+import PickerBase from "./PickerBase.js";
 import MonthPickerTemplate from "./generated/templates/MonthPickerTemplate.lit.js";
 
 // Styles
@@ -19,51 +14,7 @@ import styles from "./generated/themes/MonthPicker.css.js";
  */
 const metadata = {
 	tag: "ui5-monthpicker",
-	languageAware: true,
 	properties: /** @lends  sap.ui.webcomponents.main.MonthPicker.prototype */ {
-		/**
-		 * A UNIX timestamp - seconds since 00:00:00 UTC on Jan 1, 1970.
-		 * @type {Integer}
-		 * @public
-		 */
-		timestamp: {
-			type: Integer,
-		},
-
-		/**
-		 * Sets a calendar type used for display.
-		 * If not set, the calendar type of the global configuration is used.
-		 * @type {CalendarType}
-		 * @public
-		 */
-		primaryCalendarType: {
-			type: CalendarType,
-		},
-
-		/**
-		 * Determines the мinimum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @since 1.0.0-rc.6
-		 * @public
-		 */
-		minDate: {
-			type: String,
-		},
-
-		/**
-		 * Determines the maximum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @since 1.0.0-rc.6
-		 * @public
-		 */
-		maxDate: {
-			type: String,
-		},
-
 		_selectedDates: {
 			type: Integer,
 			multiple: true,
@@ -77,16 +28,6 @@ const metadata = {
 		_hidden: {
 			type: Boolean,
 			noAttribute: true,
-		},
-		/**
-		 * Determines the format, displayed in the input field.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @public
-		 */
-		formatPattern: {
-			type: String,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.MonthPicker.prototype */ {
@@ -116,17 +57,13 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MonthPicker
- * @extends sap.ui.webcomponents.base.UI5Element
+ * @extends sap.ui.webcomponents.main.PickerBase
  * @tagname ui5-monthpicker
  * @public
  */
-class MonthPicker extends UI5Element {
+class MonthPicker extends PickerBase {
 	static get metadata() {
 		return metadata;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get template() {
@@ -211,31 +148,6 @@ class MonthPicker extends UI5Element {
 		this._itemNav.focusCurrent();
 	}
 
-	get _timestamp() {
-		return this.timestamp !== undefined ? this.timestamp : Math.floor(new Date().getTime() / 1000);
-	}
-
-	get _localDate() {
-		return new Date(this._timestamp * 1000);
-	}
-
-	get _calendarDate() {
-		return CalendarDate.fromTimestamp(this._localDate.getTime(), this._primaryCalendarType);
-	}
-
-	get _month() {
-		return this._calendarDate.getMonth();
-	}
-
-	get _primaryCalendarType() {
-		const localeData = getCachedLocaleDataInstance(getLocale());
-		return this.primaryCalendarType || getCalendarType() || localeData.getPreferredCalendarType();
-	}
-
-	get _isPattern() {
-		return this._formatPattern !== "medium" && this._formatPattern !== "short" && this._formatPattern !== "long";
-	}
-
 	_setCurrentItemTabIndex(index) {
 		const currentItem = this._itemNav._getCurrentItem();
 		if (currentItem) {
@@ -245,7 +157,7 @@ class MonthPicker extends UI5Element {
 
 	_onmousedown(event) {
 		if (event.target.className.indexOf("ui5-mp-item") > -1) {
-			const targetTimestamp = this.getTimestampFromDOM(event.target);
+			const targetTimestamp = this.getTimestampFromDom(event.target);
 			const focusedItemIndex = this._itemNav._getItems().findIndex(item => parseInt(item.timestamp) === targetTimestamp);
 			this._itemNav.currentIndex = focusedItemIndex;
 			this._itemNav.focusCurrent();
@@ -254,7 +166,7 @@ class MonthPicker extends UI5Element {
 
 	_onmouseup(event) {
 		if (event.target.className.indexOf("ui5-mp-item") > -1) {
-			const timestamp = this.getTimestampFromDOM(event.target);
+			const timestamp = this.getTimestampFromDom(event.target);
 			this.timestamp = timestamp;
 			this.fireEvent("change", { timestamp });
 		}
@@ -269,7 +181,7 @@ class MonthPicker extends UI5Element {
 	_activateMonth(event) {
 		event.preventDefault();
 		if (event.target.className.indexOf("ui5-mp-item") > -1) {
-			const timestamp = this.getTimestampFromDOM(event.target);
+			const timestamp = this.getTimestampFromDom(event.target);
 			this.timestamp = timestamp;
 			this.fireEvent("change", { timestamp });
 		}
@@ -291,65 +203,6 @@ class MonthPicker extends UI5Element {
 			maxDateCheck = maxDate && ((currentDateYear === maxDate.getFullYear() && monthIndex > maxDate.getMonth()) || (currentDateYear > maxDate.getFullYear()));
 
 		return maxDateCheck || minDateCheck;
-	}
-
-	get _maxDate() {
-		return this.maxDate ? this._getTimeStampFromString(this.maxDate) : this._getMaxCalendarDate();
-	}
-
-	get _minDate() {
-		return this.minDate ? this._getTimeStampFromString(this.minDate) : this._getMinCalendarDate();
-	}
-
-	_getTimeStampFromString(value) {
-		const jsDate = this.getFormat().parse(value);
-		if (jsDate) {
-			return CalendarDate.fromLocalJSDate(jsDate, this._primaryCalendarType).toUTCJSDate().valueOf();
-		}
-		return undefined;
-	}
-
-	_getMinCalendarDate() {
-		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		minDate.setYear(1);
-		minDate.setMonth(0);
-		minDate.setDate(1);
-		return minDate.valueOf();
-	}
-
-	_getMaxCalendarDate() {
-		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		maxDate.setYear(9999);
-		maxDate.setMonth(11);
-		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
-		tempDate.setDate(1);
-		tempDate.setMonth(tempDate.getMonth() + 1, 0);
-		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
-		return maxDate.valueOf();
-	}
-
-	getFormat() {
-		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
-				pattern: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		} else {
-			this._oDateFormat = DateFormat.getInstance({
-				style: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		}
-		return this._oDateFormat;
-	}
-
-	get _formatPattern() {
-		return this.formatPattern || "medium"; // get from config
-	}
-
-	getTimestampFromDOM(domNode) {
-		const oMonthDomRef = domNode.getAttribute("data-sap-timestamp");
-		return parseInt(oMonthDomRef);
 	}
 
 	get styles() {

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -1,6 +1,5 @@
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import ItemNavigationBehavior from "@ui5/webcomponents-base/dist/types/ItemNavigationBehavior.js";
@@ -15,11 +14,6 @@ import styles from "./generated/themes/MonthPicker.css.js";
 const metadata = {
 	tag: "ui5-monthpicker",
 	properties: /** @lends  sap.ui.webcomponents.main.MonthPicker.prototype */ {
-		_selectedDates: {
-			type: Integer,
-			multiple: true,
-		},
-
 		_quarters: {
 			type: Object,
 			multiple: true,
@@ -99,8 +93,6 @@ class MonthPicker extends PickerBase {
 			ItemNavigation.BORDER_REACH,
 			this._handleItemNavigationBorderReach.bind(this)
 		);
-
-		this._selectedDates = [];
 	}
 
 	onBeforeRendering() {
@@ -118,7 +110,7 @@ class MonthPicker extends PickerBase {
 			const month = {
 				timestamp: timestamp.toString(),
 				id: `${this._id}-m${i}`,
-				selected: this._selectedDates.some(d => d === timestamp),
+				selected: this.selectedDates.some(d => d === timestamp),
 				name: localeData.getMonths("wide", this._primaryCalendarType)[i],
 				classes: "ui5-mp-item",
 			};

--- a/packages/main/src/PickerBase.js
+++ b/packages/main/src/PickerBase.js
@@ -1,0 +1,200 @@
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import { fetchCldr } from "@ui5/webcomponents-base/dist/asset-registries/LocaleData.js";
+import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
+import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
+import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
+import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
+import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
+import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
+import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
+
+/**
+ * @public
+ */
+const metadata = {
+	properties: /** @lends  sap.ui.webcomponents.main.MonthPicker.prototype */ {
+		/**
+		 * A UNIX timestamp - seconds since 00:00:00 UTC on Jan 1, 1970.
+		 * @type {Integer}
+		 * @public
+		 */
+		timestamp: {
+			type: Integer,
+		},
+
+		/**
+		 * Sets a calendar type used for display.
+		 * If not set, the calendar type of the global configuration is used.
+		 * @type {CalendarType}
+		 * @public
+		 */
+		primaryCalendarType: {
+			type: CalendarType,
+		},
+
+		/**
+		 * Determines the мinimum date available for selection.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @since 1.0.0-rc.6
+		 * @public
+		 */
+		minDate: {
+			type: String,
+		},
+
+		/**
+		 * Determines the maximum date available for selection.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @since 1.0.0-rc.6
+		 * @public
+		 */
+		maxDate: {
+			type: String,
+		},
+
+		/**
+		 * Determines the format, displayed in the input field.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @public
+		 */
+		formatPattern: {
+			type: String,
+		},
+	},
+};
+
+/**
+ * Base picker component.
+ *
+ * @class
+ *
+ * Abstract class for Calendar, DayPicker, MonthPicker and YearPicker
+ *
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.PickerBase
+ * @extends sap.ui.webcomponents.base.UI5Element
+ * @tagname ui5-monthpicker
+ * @public
+ */
+class PickerBase extends UI5Element {
+	static get metadata() {
+		return metadata;
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	constructor() {
+		super();
+
+		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
+	}
+
+	get _timestamp() {
+		return this.timestamp !== undefined ? this.timestamp : Math.floor(new Date().getTime() / 1000);
+	}
+
+	get _localDate() {
+		return new Date(this._timestamp * 1000);
+	}
+
+	get _calendarDate() {
+		return CalendarDate.fromTimestamp(this._localDate.getTime(), this._primaryCalendarType);
+	}
+
+	get _month() {
+		return this._calendarDate.getMonth();
+	}
+
+	get _year() {
+		return this._calendarDate.getYear();
+	}
+
+	get _primaryCalendarType() {
+		const localeData = getCachedLocaleDataInstance(getLocale());
+		return this.primaryCalendarType || getCalendarType() || localeData.getPreferredCalendarType();
+	}
+
+	get _isPattern() {
+		return this._formatPattern !== "medium" && this._formatPattern !== "short" && this._formatPattern !== "long";
+	}
+
+	get _maxDate() {
+		return this.maxDate ? this._getTimeStampFromString(this.maxDate) : this._getMaxCalendarDate();
+	}
+
+	get _minDate() {
+		return this.minDate ? this._getTimeStampFromString(this.minDate) : this._getMinCalendarDate();
+	}
+
+	_getTimeStampFromString(value) {
+		const jsDate = this.getFormat().parse(value);
+		if (jsDate) {
+			const calDate = CalendarDate.fromLocalJSDate(jsDate, this._primaryCalendarType);
+			return calDate.toUTCJSDate().valueOf();
+		}
+		return undefined;
+	}
+
+	_getMinCalendarDate() {
+		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
+		minDate.setYear(1);
+		minDate.setMonth(0);
+		minDate.setDate(1);
+		return minDate.toUTCJSDate().valueOf();
+	}
+
+	_getMaxCalendarDate() {
+		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
+		maxDate.setYear(9999);
+		maxDate.setMonth(11);
+		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
+		tempDate.setDate(1);
+		tempDate.setMonth(tempDate.getMonth() + 1, 0);
+		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
+		return maxDate.toUTCJSDate().valueOf();
+	}
+
+	getFormat() {
+		if (this._isPattern) {
+			this._oDateFormat = DateFormat.getInstance({
+				pattern: this._formatPattern,
+				calendarType: this._primaryCalendarType,
+			});
+		} else {
+			this._oDateFormat = DateFormat.getInstance({
+				style: this._formatPattern,
+				calendarType: this._primaryCalendarType,
+			});
+		}
+		return this._oDateFormat;
+	}
+
+	get _formatPattern() {
+		return this.formatPattern || "medium"; // get from config
+	}
+
+	getTimestampFromDom(domNode) {
+		const oMonthDomRef = domNode.getAttribute("data-sap-timestamp");
+		return parseInt(oMonthDomRef);
+	}
+
+	static async onDefine() {
+		await Promise.all([
+			fetchCldr(getLocale().getLanguage(), getLocale().getRegion(), getLocale().getScript()),
+			fetchI18nBundle("@ui5/webcomponents"),
+		]);
+	}
+}
+
+export default PickerBase;

--- a/packages/main/src/PickerBase.js
+++ b/packages/main/src/PickerBase.js
@@ -166,18 +166,19 @@ class PickerBase extends UI5Element {
 	}
 
 	getFormat() {
+		let dateFormat;
 		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				pattern: this._formatPattern,
 				calendarType: this._primaryCalendarType,
 			});
 		} else {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				style: this._formatPattern,
 				calendarType: this._primaryCalendarType,
 			});
 		}
-		return this._oDateFormat;
+		return dateFormat;
 	}
 
 	get _formatPattern() {

--- a/packages/main/src/PickerBase.js
+++ b/packages/main/src/PickerBase.js
@@ -9,6 +9,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
+import { getMinCalendarDate, getMaxCalendarDate } from "./util/DateTime.js";
 
 /**
  * @public
@@ -147,22 +148,11 @@ class PickerBase extends UI5Element {
 	}
 
 	_getMinCalendarDate() {
-		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		minDate.setYear(1);
-		minDate.setMonth(0);
-		minDate.setDate(1);
-		return minDate.toUTCJSDate().valueOf();
+		return getMinCalendarDate(this._primaryCalendarType);
 	}
 
 	_getMaxCalendarDate() {
-		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		maxDate.setYear(9999);
-		maxDate.setMonth(11);
-		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
-		tempDate.setDate(1);
-		tempDate.setMonth(tempDate.getMonth() + 1, 0);
-		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
-		return maxDate.toUTCJSDate().valueOf();
+		return getMaxCalendarDate(this._primaryCalendarType);
 	}
 
 	getFormat() {

--- a/packages/main/src/PickerBase.js
+++ b/packages/main/src/PickerBase.js
@@ -69,6 +69,16 @@ const metadata = {
 		formatPattern: {
 			type: String,
 		},
+
+		/**
+		 * Defines the selected dates as UTC timestamps.
+		 * @type {Array}
+		 * @public
+		 */
+		selectedDates: {
+			type: Integer,
+			multiple: true,
+		},
 	},
 };
 

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -763,17 +763,18 @@ class TimePicker extends UI5Element {
 	}
 
 	getFormat() {
+		let dateFormat;
 		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				pattern: this._formatPattern,
 			});
 		} else {
-			this._oDateFormat = DateFormat.getInstance({
+			dateFormat = DateFormat.getInstance({
 				style: this._formatPattern,
 			});
 		}
 
-		return this._oDateFormat;
+		return dateFormat;
 	}
 
 	setValue(value) {

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -1,15 +1,11 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
-import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
 import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
-import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import ItemNavigationBehavior from "@ui5/webcomponents-base/dist/types/ItemNavigationBehavior.js";
+import PickerBase from "./PickerBase.js";
 import YearPickerTemplate from "./generated/templates/YearPickerTemplate.lit.js";
 
 // Styles
@@ -20,52 +16,7 @@ import styles from "./generated/themes/YearPicker.css.js";
  */
 const metadata = {
 	tag: "ui5-yearpicker",
-	languageAware: true,
 	properties: /** @lends  sap.ui.webcomponents.main.YearPicker.prototype */ {
-		/**
-		 * A UNIX timestamp - seconds since 00:00:00 UTC on Jan 1, 1970.
-		 * @type {Integer}
-		 * @public
-		 */
-		timestamp: {
-			type: Integer,
-		},
-
-		/**
-		 * Sets a calendar type used for display.
-		 * If not set, the calendar type of the global configuration is used.
-		 * @type {CalendarType}
-		 * @public
-		 */
-		primaryCalendarType: {
-			type: CalendarType,
-		},
-
-		/**
-		 * Determines the мinimum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue ""
-		 * @since 1.0.0-rc.6
-		 * @public
-		 */
-		minDate: {
-			type: String,
-		},
-
-		/**
-		 * Determines the maximum date available for selection.
-		 *
-		 * @type {string}
-		 * @defaultvalue undefined
-		 * @since 1.0.0-rc.6
-		 * @public
-		 */
-		maxDate: {
-			type: String,
-			defaultValue: undefined,
-		},
-
 		_selectedDates: {
 			type: Integer,
 			multiple: true,
@@ -85,16 +36,6 @@ const metadata = {
 			type: Boolean,
 			noAttribute: true,
 		},
-		/**
-		* Determines the format, displayed in the input field.
-		*
-		* @type {string}
-		* @defaultvalue ""
-		* @public
-		*/
-	   formatPattern: {
-		   type: String,
-	   },
 	},
 	events: /** @lends  sap.ui.webcomponents.main.YearPicker.prototype */ {
 		/**
@@ -121,21 +62,17 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.YearPicker
- * @extends sap.ui.webcomponents.base.UI5Element
+ * @extends sap.ui.webcomponents.main.PickerBase
  * @tagname ui5-yearpicker
  * @public
  */
-class YearPicker extends UI5Element {
+class YearPicker extends PickerBase {
 	static get metadata() {
 		return metadata;
 	}
 
 	static get styles() {
 		return styles;
-	}
-
-	static get render() {
-		return litRender;
 	}
 
 	static get template() {
@@ -240,31 +177,6 @@ class YearPicker extends UI5Element {
 		this._itemNav.focusCurrent();
 	}
 
-	get _timestamp() {
-		return this.timestamp !== undefined ? this.timestamp : Math.floor(new Date().getTime() / 1000);
-	}
-
-	get _localDate() {
-		return new Date(this._timestamp * 1000);
-	}
-
-	get _calendarDate() {
-		return CalendarDate.fromTimestamp(this._localDate.getTime(), this._primaryCalendarType);
-	}
-
-	get _year() {
-		return this._calendarDate.getYear();
-	}
-
-	get _primaryCalendarType() {
-		const localeData = getCachedLocaleDataInstance(getLocale());
-		return this.primaryCalendarType || getCalendarType() || localeData.getPreferredCalendarType();
-	}
-
-	get _isPattern() {
-		return this._formatPattern !== "medium" && this._formatPattern !== "short" && this._formatPattern !== "long";
-	}
-
 	_setCurrentItemTabIndex(index) {
 		const currentItem = this._itemNav._getCurrentItem();
 		if (currentItem) {
@@ -288,11 +200,6 @@ class YearPicker extends UI5Element {
 			this._selectedYear = this._year;
 			this.fireEvent("change", { timestamp });
 		}
-	}
-
-	getTimestampFromDom(domNode) {
-		const sTimestamp = domNode.getAttribute("data-sap-timestamp");
-		return parseInt(sTimestamp);
 	}
 
 	_onkeydown(event) {
@@ -359,10 +266,6 @@ class YearPicker extends UI5Element {
 		this.fireEvent("navigate", event);
 	}
 
-	get _formatPattern() {
-		return this.formatPattern || "medium"; // get from config
-	}
-
 	_isOutOfSelectableRange(year) {
 		const minDate = new Date(this._minDate),
 			maxDate = new Date(this._maxDate),
@@ -370,56 +273,6 @@ class YearPicker extends UI5Element {
 			maxDateCheck = maxDate && year > maxDate.getFullYear();
 
 		return minDateCheck || maxDateCheck;
-	}
-
-	get _maxDate() {
-		return this.maxDate ? this._getTimeStampFromString(this.maxDate) : this._getMaxCalendarDate();
-	}
-
-	get _minDate() {
-		return this.minDate ? this._getTimeStampFromString(this.minDate) : this._getMinCalendarDate();
-	}
-
-	_getTimeStampFromString(value) {
-		const jsDate = this.getFormat().parse(value);
-		if (jsDate) {
-			return CalendarDate.fromLocalJSDate(jsDate, this._primaryCalendarType).toUTCJSDate().valueOf();
-		}
-		return undefined;
-	}
-
-	_getMinCalendarDate() {
-		const minDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		minDate.setYear(1);
-		minDate.setMonth(0);
-		minDate.setDate(1);
-		return minDate.valueOf();
-	}
-
-	_getMaxCalendarDate() {
-		const maxDate = new CalendarDate(1, 0, 1, this._primaryCalendarType);
-		maxDate.setYear(9999);
-		maxDate.setMonth(11);
-		const tempDate = new CalendarDate(maxDate, this._primaryCalendarType);
-		tempDate.setDate(1);
-		tempDate.setMonth(tempDate.getMonth() + 1, 0);
-		maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
-		return maxDate.valueOf();
-	}
-
-	getFormat() {
-		if (this._isPattern) {
-			this._oDateFormat = DateFormat.getInstance({
-				pattern: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		} else {
-			this._oDateFormat = DateFormat.getInstance({
-				style: this._formatPattern,
-				calendarType: this._primaryCalendarType,
-			});
-		}
-		return this._oDateFormat;
 	}
 
 	get styles() {

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -17,11 +17,6 @@ import styles from "./generated/themes/YearPicker.css.js";
 const metadata = {
 	tag: "ui5-yearpicker",
 	properties: /** @lends  sap.ui.webcomponents.main.YearPicker.prototype */ {
-		_selectedDates: {
-			type: Integer,
-			multiple: true,
-		},
-
 		_selectedYear: {
 			type: Integer,
 			noAttribute: true,
@@ -108,7 +103,6 @@ class YearPicker extends PickerBase {
 		);
 
 		this._yearIntervals = [];
-		this._selectedDates = [];
 	}
 
 	onBeforeRendering() {
@@ -148,7 +142,7 @@ class YearPicker extends PickerBase {
 			const year = {
 				timestamp: timestamp.toString(),
 				id: `${this._id}-y${timestamp}`,
-				selected: this._selectedDates.some(itemTimestamp => {
+				selected: this.selectedDates.some(itemTimestamp => {
 					const date = CalendarDate.fromTimestamp(itemTimestamp * 1000, this._primaryCalendarType);
 					return date.getYear() === oCalDate.getYear();
 				}),

--- a/packages/main/src/util/DateTime.js
+++ b/packages/main/src/util/DateTime.js
@@ -1,0 +1,25 @@
+import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
+
+const getMinCalendarDate = primaryCalendarType => {
+	const minDate = new CalendarDate(1, 0, 1, primaryCalendarType);
+	minDate.setYear(1);
+	minDate.setMonth(0);
+	minDate.setDate(1);
+	return minDate.valueOf();
+};
+
+const getMaxCalendarDate = primaryCalendarType => {
+	const maxDate = new CalendarDate(1, 0, 1, primaryCalendarType);
+	maxDate.setYear(9999);
+	maxDate.setMonth(11);
+	const tempDate = new CalendarDate(maxDate, primaryCalendarType);
+	tempDate.setDate(1);
+	tempDate.setMonth(tempDate.getMonth() + 1, 0);
+	maxDate.setDate(tempDate.getDate());// 31st for Gregorian Calendar
+	return maxDate.valueOf();
+};
+
+export {
+	getMinCalendarDate,
+	getMaxCalendarDate,
+};


### PR DESCRIPTION
Changes:
 - The `PageBottom` and `PageUp` events used only in `DayPicker.js` were removed from `ItemNavigation.js` and replaced with callbacks. Publish/subscribe is not the ideal design pattern for this type of communication, because the communication is two-directional. ItemNavigation tells DayPicker that it needs to know whether there is a previous/next page, and DayPicker responds back (by changing ItemNavigation state - prevPage/nextPage in the callback). Then, based on this state ItemNavigation continues execution. This is more transparently achieved with callbacks.
 - All copy/pasted code (about 200 lines) between `Calendar`, `DayPicker`, `MonthPicker` and `YearPicker` was moved to a base class for these 4. There were only 2 different things: 

`return minDate.valueOf();`  vs  `return minDate.toUTCJSDate().valueOf();`

and

`return maxDate.valueOf();` vs `return maxDate.toUTCJSDate().valueOf();`

It seems it was only fixed for DayPicker. Now the `.toUTCJSDate()` form is used in the base class for all 4.

Also `getTimestampFromDom` vs `getTimestampFromDOM` - otherwise exactly identical, now harmonized and moved to the base class.

 - A redundant `this._oDateFormat` property was removed from several files (`TimePicker`, `DatePicker` and the new `PickerBase` - used to be copied in the 4 child classes as well).
 - `selectedDates` was harmonized (some had `_selectedDates`) and moved to the base class. Redundant getters removed (properties of `multiple: true` are always guaranteed to be arrays, no need for code such as: `this.selectedDates || []`
 - the functions to get min date/max date were moved to a separate util file as they were both in the new base class and in DatePicker.js