### PR TITLE
fix(ui5-select): correct role and screen reader speech out

### DIFF
--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -3,10 +3,10 @@
 	dir="{{effectiveDir}}"
 	tabindex="{{tabIndex}}"
 	id="{{_id}}-select"
-	role="button"
+	role="combobox"
+	value="{{_text}}"
 	aria-haspopup="listbox"
 	aria-label="{{ariaLabelText}}"
-	aria-labelledby="{{_id}}-label"
 	aria-describedby="{{valueStateTextId}}"
 	aria-disabled="{{isDisabled}}"
 	aria-required="{{required}}"
@@ -18,7 +18,7 @@
 	@click="{{_toggleRespPopover}}"
 >
 	<div class="ui5-select-label-root">
-		<ui5-label id="{{_id}}-label" for="{{_id}}-select">{{_text}}</ui5-label>
+		<ui5-label>{{_text}}</ui5-label>
 	</div>
 
 	<ui5-icon

--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -4,12 +4,7 @@
 	id="{{_id}}-select"
 	@click="{{_toggleRespPopover}}"
 >
-	<div class="ui5-select-label-root">
-		<ui5-label>{{_text}}</ui5-label>
-	</div>
-
-	<div
-		class="ui5-hidden-text"
+	<div class="ui5-select-label-root"
 		tabindex="{{tabIndex}}"
 		role="combobox"
 		aria-haspopup="listbox"
@@ -25,6 +20,8 @@
 	>
 		{{_text}}
 	</div>
+
+	<span id="{{_id}}-selectionText" class="ui5-hidden-text" aria-live="polite" role="status"></span>
 
 	<ui5-icon
 		name="slim-arrow-down"

--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -1,24 +1,29 @@
 <div
 	class="ui5-select-root"
 	dir="{{effectiveDir}}"
-	tabindex="{{tabIndex}}"
 	id="{{_id}}-select"
-	role="combobox"
-	value="{{_text}}"
-	aria-haspopup="listbox"
-	aria-label="{{ariaLabelText}}"
-	aria-describedby="{{valueStateTextId}}"
-	aria-disabled="{{isDisabled}}"
-	aria-required="{{required}}"
-	aria-expanded="{{_isPickerOpen}}"
-	@keydown="{{_onkeydown}}"
-	@keyup="{{_onkeyup}}"
-	@focusin="{{_onfocusin}}"
-	@focusout="{{_onfocusout}}"
 	@click="{{_toggleRespPopover}}"
 >
 	<div class="ui5-select-label-root">
 		<ui5-label>{{_text}}</ui5-label>
+	</div>
+
+	<div
+		class="ui5-hidden-text"
+		tabindex="{{tabIndex}}"
+		role="combobox"
+		aria-haspopup="listbox"
+		aria-label="{{ariaLabelText}}"
+		aria-describedby="{{valueStateTextId}}"
+		aria-disabled="{{isDisabled}}"
+		aria-required="{{required}}"
+		aria-expanded="{{_isPickerOpen}}"
+		@keydown="{{_onkeydown}}"
+		@keyup="{{_onkeyup}}"
+		@focusin="{{_onfocusin}}"
+		@focusout="{{_onfocusout}}"
+	>
+		{{_text}}
 	</div>
 
 	<ui5-icon

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -311,6 +311,7 @@ class Select extends UI5Element {
 
 	_onfocusout() {
 		this.focused = false;
+		this.itemSelectionAnnounce();
 	}
 
 	get _isPickerOpen() {
@@ -478,6 +479,7 @@ class Select extends UI5Element {
 
 	_handleArrowNavigation(event, shouldFireEvent) {
 		let nextIndex = -1;
+		const currentIndex = this._selectedIndex;
 		const isDownKey = isDown(event);
 		const isUpKey = isUp(event);
 
@@ -492,6 +494,10 @@ class Select extends UI5Element {
 			this.options[this._selectedIndex].selected = false;
 			this.options[nextIndex].selected = true;
 			this._selectedIndex = nextIndex === -1 ? this._selectedIndex : nextIndex;
+
+			if (currentIndex !== this._selectedIndex) {
+				this.itemSelectionAnnounce();
+			}
 
 			if (shouldFireEvent) {
 				this._fireChangeEvent(this.options[nextIndex]);
@@ -625,6 +631,16 @@ class Select extends UI5Element {
 
 	get _isPhone() {
 		return isPhone();
+	}
+
+	itemSelectionAnnounce() {
+		const invisibleText = this.shadowRoot.querySelector(`#${this._id}-selectionText`);
+
+		if (this.focused && !this._isPickerOpen && this._currentlySelectedOption) {
+			invisibleText.textContent = this._currentlySelectedOption.textContent;
+		} else {
+			invisibleText.textContent = "";
+		}
 	}
 
 	async openValueStatePopover() {

--- a/packages/main/src/themes/Select.css
+++ b/packages/main/src/themes/Select.css
@@ -11,17 +11,20 @@
 }
 
 .ui5-select-label-root {
-	display: inline-flex;
-	align-items: center;
 	flex-shrink: 1;
 	flex-grow: 1;
-	height: 100%;
+	align-self: center;
 	min-width: 1rem;
 	padding-left: 0.5rem;
-}
-
-.ui5-select-label-root [ui5-label] {
 	cursor: pointer;
+	outline: none;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: var(--sapContent_LabelColor);
+	font-family: "72override", var(--sapFontFamily);
+	font-size: var(--sapFontSize);
+	font-weight: normal;
 }
 
 :host [dir="rtl"].ui5-select-root .ui5-select-label-root {

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -17,25 +17,187 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-	<h2>Select without aria-label and aria-labelledby</h2>
-	<ui5-select>
+	<ui5-togglebutton id="myBtn">turn lights</ui5-togglebutton>
+	<ui5-button id="add-items-btn">Add new Items</ui5-button>
+	<ui5-button id="restore-items-btn">Restore Items</ui5-button>
+	<ui5-button id="myBtn2">click</ui5-button>
+
+
+	<h2>Content size</h2>
+	<ui5-label id="lblResult"></ui5-label>
+	<ui5-select id="mySelect">
 		<ui5-option selected>Cozy</ui5-option>
 		<ui5-option selected>Compact</ui5-option>
 		<ui5-option selected>Condensed</ui5-option>
 	</ui5-select>
-	<h2>Select with aria-label</h2>
-	<ui5-select aria-label="Test aria-label text">
+
+	<h2>Error Select</h2>
+	<ui5-select id="mySelect2" value-state="Error">
 		<ui5-option selected>Cozy</ui5-option>
 		<ui5-option selected>Compact</ui5-option>
 		<ui5-option selected>Condensed</ui5-option>
 	</ui5-select>
-	<h2>Select with aria-labelledby</h2>
-	<ui5-label id="test2" for="test">Test aria-labelledby text</ui5-label>
-	<ui5-select id="test" aria-labelledby="test2">
-		<ui5-option selected>Cozy</ui5-option>
-		<ui5-option selected>Compact</ui5-option>
-		<ui5-option selected>Condensed</ui5-option>
+
+	<h2>Warning Select</h2>
+	<ui5-select id="mySelect3" value-state="Warning"></ui5-select>
+
+	<h2>Disabled Select</h2>
+	<ui5-select id="mySelect4" disabled value-state="Success"></ui5-select>
+
+	<h2> Input with suggestions</h2>
+	<ui5-input id="myInput" show-suggestions placeholder="Search for a country ..."></ui5-input>
+
+	<h2>Selection not cycling</h2>
+	<ui5-select id="selectionNotCycling">
+		<ui5-option>Opt1</ui5-option>
+		<ui5-option>Opt2</ui5-option>
+		<ui5-option selected>Opt3</ui5-option>
 	</ui5-select>
+
+	<ui5-select id="selectionNotCycling2">
+		<ui5-option selected>Opt1</ui5-option>
+		<ui5-option>Opt2</ui5-option>
+		<ui5-option>Opt3</ui5-option>
+	</ui5-select>
+
+	<ui5-select id="mySelectEsc">
+		<ui5-option>Cozy</ui5-option>
+		<ui5-option selected>Compact</ui5-option>
+		<ui5-option>Condensed</ui5-option>
+	</ui5-select>
+
+	<ui5-select id="keyboardHandling">
+		<ui5-option>Banana</ui5-option>
+		<ui5-option selected>Orange</ui5-option>
+		<ui5-option>Watermelon</ui5-option>
+	</ui5-select>
+
+	<h2> Change event counter holder</h2>
+	<ui5-input id="inputResult"></ui5-input>
+
+	<section>
+		<h3>Select aria-label and aria-labelledby</h3>
+		<span id="infoText">info text</span>
+		<div>
+			<ui5-select id="textAreaAriaLabel" aria-label="Hello World">
+				<ui5-option selected>First</ui5-option>
+				<ui5-option selected>Second</ui5-option>
+				<ui5-option selected>Third</ui5-option>
+			</ui5-select>
+
+			<ui5-select id="textAreaAriaLabelledBy" aria-labelledby="infoText">
+				<ui5-option selected>One</ui5-option>
+				<ui5-option selected>Two</ui5-option>
+				<ui5-option selected>Three</ui5-option>
+			</ui5-select>
+		</div>
+	</section>
+
+	<section class="ui5-content-density-compact">
+		<h3>Select in Compact</h3>
+		<div>
+			<ui5-select>
+				<ui5-option selected>Cozy</ui5-option>
+				<ui5-option selected>Compact</ui5-option>
+				<ui5-option selected>Condensed</ui5-option>
+			</ui5-select>
+		</div>
+	</section>
 </body>
+<script>
+	var countries =  [{ key: "Aus", text: "Australia" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }];
+	var new_countries =  [{ key: "Aus", text: "Australia1" }, { key: "Aruba", text: "Aruba1" }, { key: "Antigua", text: "Antigua and Barbuda1" }, { key: "Bel", text: "Belgium1" }, { key: "Bg", text: "Bulgaria1" }, { key: "Bra", text: "Brazil1" }];
+	var sap_database_entries = [{ key: "Afg", text: "Afghanistan" }, { key: "Arg", text: "Argentina" }, { key: "Alb", text: "Albania" }, { key: "Arm", text: "Armenia" }, { key: "Alg", text: "Algeria" }, { key: "And", text: "Andorra" }, { key: "Ang", text: "Angola" }, { key: "Ast", text: "Austria" }, { key: "Aus", text: "Australia" }, { key: "Aze", text: "Azerbaijan" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "Bel", text: "Belarus" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }, { key: "Ch", text: "China" }, { key: "Cub", text: "Cuba" }, { key: "Chil", text: "Chili" }, { key: "Lat", text: "Latvia" }, { key: "Lit", text: "Litva" }, { key: "Prt", text: "Portugal" }, { key: "Sen", text: "Senegal" }, { key: "Ser", text: "Serbia" }, { key: "Afg", text: "Seychelles" }, { key: "Sierra", text: "Sierra Leone" }, { key: "Sgp", text: "Singapore" }, { key: "Sint", text: "Sint Maarten" }, { key: "Slv", text: "Slovakia" }, { key: "Slo", text: "Slovenia" }];
+
+	var btn = document.getElementById('myBtn');
+	var addItemsBtn = document.getElementById('add-items-btn');
+	var restoreItemsBtn = document.getElementById('restore-items-btn');
+	var input = document.getElementById('myInput');
+	var inputResult = document.getElementById('inputResult');
+	var select = document.getElementById('mySelect');
+	var select2 = document.getElementById('mySelect2');
+	var select3 = document.getElementById('mySelect3');
+	var lbl = document.getElementById('lblResult');
+	var counter = 0;
+
+	// Select
+	select.addEventListener("ui5-change", function(e) {
+		lbl.innerHTML = "selected item :: " + e.detail.selectedOption.textContent + " :: " + (++counter);
+		inputResult.value = counter;
+	});
+
+	select.addEventListener("change", function(e) {
+		console.log("Select change event fired", e);
+	});
+
+	select2.addEventListener("ui5-change", function(e) {
+		++counter;
+		inputResult.value = counter;
+	});
+
+	// Input with Suggestions
+	input.addEventListener("ui5-input", function (event) {
+		var value = event.target.value;
+		var suggestionItems = [];
+
+		if (value) {
+			suggestionItems = sap_database_entries.filter(function (item) {
+				return item.text.toUpperCase().indexOf(value.toUpperCase()) === 0;
+			});
+		}
+
+		while (input.firstChild) {
+			input.removeChild(input.firstChild);
+		}
+
+		suggestionItems.forEach(function(item) {
+			var li = document.createElement("ui5-li");
+			li.id = item.key;
+			li.textContent = item.text;
+			input.appendChild(li);
+		});
+	});
+
+
+	// HCB button
+	btn.addEventListener("click", function(event) {
+		var hcb = event.target.pressed;
+		var styles = hcb ? "background:#333;color:palegoldenrod;" : "background:#fff;color:#333;";
+		var theme = hcb ? "sap_belize_hcb" : "sap_fiori_3";
+
+		document.body.setAttribute("style", styles);
+		var Conf = window["sap-ui-webcomponents-bundle"].configuration;
+		Conf.setTheme(theme);
+	});
+
+	countries.forEach(function(item, idx) {
+		var li = document.createElement("ui5-option");
+		li.id = item.key;
+
+		if (idx === 0) {
+			li.selected = true;
+		}
+
+		li.textContent = item.text;
+		select3.appendChild(li);
+	});
+
+	var initialItemsHTML = "";
+
+	addItemsBtn.addEventListener("click", function(event) {
+		initialItemsHTML = select.innerHTML;
+
+		var li = document.createElement('ui5-option');
+
+		li.textContent = "New";
+
+		select.innerHTML = "";
+		select.appendChild(li);
+	});
+
+	restoreItemsBtn.addEventListener("click", function(event) {
+		select.innerHTML = initialItemsHTML;
+	});
+</script>
 </body>
 </html>

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -17,187 +17,25 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-	<ui5-togglebutton id="myBtn">turn lights</ui5-togglebutton>
-	<ui5-button id="add-items-btn">Add new Items</ui5-button>
-	<ui5-button id="restore-items-btn">Restore Items</ui5-button>
-	<ui5-button id="myBtn2">click</ui5-button>
-
-
-	<h2>Content size</h2>
-	<ui5-label id="lblResult"></ui5-label>
-	<ui5-select id="mySelect">
+	<h2>Select without aria-label and aria-labelledby</h2>
+	<ui5-select>
 		<ui5-option selected>Cozy</ui5-option>
 		<ui5-option selected>Compact</ui5-option>
 		<ui5-option selected>Condensed</ui5-option>
 	</ui5-select>
-
-	<h2>Error Select</h2>
-	<ui5-select id="mySelect2" value-state="Error">
+	<h2>Select with aria-label</h2>
+	<ui5-select aria-label="Test aria-label text">
 		<ui5-option selected>Cozy</ui5-option>
 		<ui5-option selected>Compact</ui5-option>
 		<ui5-option selected>Condensed</ui5-option>
 	</ui5-select>
-
-	<h2>Warning Select</h2>
-	<ui5-select id="mySelect3" value-state="Warning"></ui5-select>
-
-	<h2>Disabled Select</h2>
-	<ui5-select id="mySelect4" disabled value-state="Success"></ui5-select>
-
-	<h2> Input with suggestions</h2>
-	<ui5-input id="myInput" show-suggestions placeholder="Search for a country ..."></ui5-input>
-
-	<h2>Selection not cycling</h2>
-	<ui5-select id="selectionNotCycling">
-		<ui5-option>Opt1</ui5-option>
-		<ui5-option>Opt2</ui5-option>
-		<ui5-option selected>Opt3</ui5-option>
-	</ui5-select>
-
-	<ui5-select id="selectionNotCycling2">
-		<ui5-option selected>Opt1</ui5-option>
-		<ui5-option>Opt2</ui5-option>
-		<ui5-option>Opt3</ui5-option>
-	</ui5-select>
-
-	<ui5-select id="mySelectEsc">
-		<ui5-option>Cozy</ui5-option>
+	<h2>Select with aria-labelledby</h2>
+	<ui5-label id="test2" for="test">Test aria-labelledby text</ui5-label>
+	<ui5-select id="test" aria-labelledby="test2">
+		<ui5-option selected>Cozy</ui5-option>
 		<ui5-option selected>Compact</ui5-option>
-		<ui5-option>Condensed</ui5-option>
+		<ui5-option selected>Condensed</ui5-option>
 	</ui5-select>
-
-	<ui5-select id="keyboardHandling">
-		<ui5-option>Banana</ui5-option>
-		<ui5-option selected>Orange</ui5-option>
-		<ui5-option>Watermelon</ui5-option>
-	</ui5-select>
-
-	<h2> Change event counter holder</h2>
-	<ui5-input id="inputResult"></ui5-input>
-
-	<section>
-		<h3>Select aria-label and aria-labelledby</h3>
-		<span id="infoText">info text</span>
-		<div>
-			<ui5-select id="textAreaAriaLabel" aria-label="Hello World">
-				<ui5-option selected>First</ui5-option>
-				<ui5-option selected>Second</ui5-option>
-				<ui5-option selected>Third</ui5-option>
-			</ui5-select>
-
-			<ui5-select id="textAreaAriaLabelledBy" aria-labelledby="infoText">
-				<ui5-option selected>One</ui5-option>
-				<ui5-option selected>Two</ui5-option>
-				<ui5-option selected>Three</ui5-option>
-			</ui5-select>
-		</div>
-	</section>
-
-	<section class="ui5-content-density-compact">
-		<h3>Select in Compact</h3>
-		<div>
-			<ui5-select>
-				<ui5-option selected>Cozy</ui5-option>
-				<ui5-option selected>Compact</ui5-option>
-				<ui5-option selected>Condensed</ui5-option>
-			</ui5-select>
-		</div>
-	</section>
 </body>
-<script>
-	var countries =  [{ key: "Aus", text: "Australia" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }];
-	var new_countries =  [{ key: "Aus", text: "Australia1" }, { key: "Aruba", text: "Aruba1" }, { key: "Antigua", text: "Antigua and Barbuda1" }, { key: "Bel", text: "Belgium1" }, { key: "Bg", text: "Bulgaria1" }, { key: "Bra", text: "Brazil1" }];
-	var sap_database_entries = [{ key: "Afg", text: "Afghanistan" }, { key: "Arg", text: "Argentina" }, { key: "Alb", text: "Albania" }, { key: "Arm", text: "Armenia" }, { key: "Alg", text: "Algeria" }, { key: "And", text: "Andorra" }, { key: "Ang", text: "Angola" }, { key: "Ast", text: "Austria" }, { key: "Aus", text: "Australia" }, { key: "Aze", text: "Azerbaijan" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "Bel", text: "Belarus" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }, { key: "Ch", text: "China" }, { key: "Cub", text: "Cuba" }, { key: "Chil", text: "Chili" }, { key: "Lat", text: "Latvia" }, { key: "Lit", text: "Litva" }, { key: "Prt", text: "Portugal" }, { key: "Sen", text: "Senegal" }, { key: "Ser", text: "Serbia" }, { key: "Afg", text: "Seychelles" }, { key: "Sierra", text: "Sierra Leone" }, { key: "Sgp", text: "Singapore" }, { key: "Sint", text: "Sint Maarten" }, { key: "Slv", text: "Slovakia" }, { key: "Slo", text: "Slovenia" }];
-
-	var btn = document.getElementById('myBtn');
-	var addItemsBtn = document.getElementById('add-items-btn');
-	var restoreItemsBtn = document.getElementById('restore-items-btn');
-	var input = document.getElementById('myInput');
-	var inputResult = document.getElementById('inputResult');
-	var select = document.getElementById('mySelect');
-	var select2 = document.getElementById('mySelect2');
-	var select3 = document.getElementById('mySelect3');
-	var lbl = document.getElementById('lblResult');
-	var counter = 0;
-
-	// Select
-	select.addEventListener("ui5-change", function(e) {
-		lbl.innerHTML = "selected item :: " + e.detail.selectedOption.textContent + " :: " + (++counter);
-		inputResult.value = counter;
-	});
-
-	select.addEventListener("change", function(e) {
-		console.log("Select change event fired", e);
-	});
-
-	select2.addEventListener("ui5-change", function(e) {
-		++counter;
-		inputResult.value = counter;
-	});
-
-	// Input with Suggestions
-	input.addEventListener("ui5-input", function (event) {
-		var value = event.target.value;
-		var suggestionItems = [];
-
-		if (value) {
-			suggestionItems = sap_database_entries.filter(function (item) {
-				return item.text.toUpperCase().indexOf(value.toUpperCase()) === 0;
-			});
-		}
-
-		while (input.firstChild) {
-			input.removeChild(input.firstChild);
-		}
-
-		suggestionItems.forEach(function(item) {
-			var li = document.createElement("ui5-li");
-			li.id = item.key;
-			li.textContent = item.text;
-			input.appendChild(li);
-		});
-	});
-
-
-	// HCB button
-	btn.addEventListener("click", function(event) {
-		var hcb = event.target.pressed;
-		var styles = hcb ? "background:#333;color:palegoldenrod;" : "background:#fff;color:#333;";
-		var theme = hcb ? "sap_belize_hcb" : "sap_fiori_3";
-
-		document.body.setAttribute("style", styles);
-		var Conf = window["sap-ui-webcomponents-bundle"].configuration;
-		Conf.setTheme(theme);
-	});
-
-	countries.forEach(function(item, idx) {
-		var li = document.createElement("ui5-option");
-		li.id = item.key;
-
-		if (idx === 0) {
-			li.selected = true;
-		}
-
-		li.textContent = item.text;
-		select3.appendChild(li);
-	});
-
-	var initialItemsHTML = "";
-
-	addItemsBtn.addEventListener("click", function(event) {
-		initialItemsHTML = select.innerHTML;
-
-		var li = document.createElement('ui5-option');
-
-		li.textContent = "New";
-
-		select.innerHTML = "";
-		select.appendChild(li);
-	});
-
-	restoreItemsBtn.addEventListener("click", function(event) {
-		select.innerHTML = initialItemsHTML;
-	});
-</script>
 </body>
 </html>

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -5,7 +5,7 @@ describe("Select general interaction", () => {
 
 	it("fires change on selection", () => {
 		const select = $("#mySelect");
-		const selectText = browser.$("#mySelect").shadow$("ui5-label");
+		const selectText = browser.$("#mySelect").shadow$(".ui5-select-label-root");
 		const inputResult = browser.$("#inputResult").shadow$("input");
 		const EXPECTED_SELECTION_TEXT = "Cozy";
 
@@ -34,7 +34,7 @@ describe("Select general interaction", () => {
 
 	it("fires change on selection with keyboard handling", () => {
 		const select = $("#mySelect2").shadow$(".ui5-select-root");
-		const selectText = browser.$("#mySelect2").shadow$("ui5-label");
+		const selectText = browser.$("#mySelect2").shadow$(".ui5-select-label-root");
 		const inputResult = browser.$("#inputResult");
 		const EXPECTED_SELECTION_TEXT1 = "Compact";
 		const EXPECTED_SELECTION_TEXT2 = "Condensed";
@@ -57,7 +57,7 @@ describe("Select general interaction", () => {
 	it("changes selection while closed with Arrow Up/Down", () => {
 		const inputResult = browser.$("#inputResult").shadow$("input");
 		const select = $("#mySelect2");
-		const selectText = browser.$("#mySelect2").shadow$("ui5-label");
+		const selectText = browser.$("#mySelect2").shadow$(".ui5-select-label-root");
 		const EXPECTED_SELECTION_TEXT1 = "Compact";
 		const EXPECTED_SELECTION_TEXT2 = "Condensed";
 
@@ -74,6 +74,39 @@ describe("Select general interaction", () => {
 		assert.strictEqual(inputResult.getProperty("value"), "5", "Change event should have fired twice");
 	});
 
+	it("changes selection sync with selection announcement", () => {
+		const btn = $("#myBtn2");
+		const inputResult = browser.$("#inputResult").shadow$("input");
+		const select = $("#mySelect2");
+		const selectId = select.getProperty("_id")
+		const selectText = browser.$("#mySelect2").shadow$(".ui5-select-label-root");
+		const selectionText = browser.$("#mySelect2").shadow$(`#${selectId}-selectionText`);
+		const EXPECTED_SELECTION_TEXT1 = "Compact";
+		const EXPECTED_SELECTION_TEXT2 = "Condensed";
+
+		select.click();
+		select.keys("Escape");
+
+		assert.strictEqual(selectionText.getHTML(false), "", "Selection announcement text should be clear if there is no interaction");
+
+		select.keys("ArrowUp");
+		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT1), "Arrow Up should change selected item");
+		assert.strictEqual(selectionText.getHTML(false), EXPECTED_SELECTION_TEXT1, "Selection announcement text should be equalt to the current selected item's text");
+
+		select.click();
+		select.keys("Escape");
+		assert.strictEqual(selectionText.getHTML(false), "", "Selection announcement text should be cleared if the picker is opened");
+
+		select.keys("ArrowDown");
+		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT2), "Arrow Up should change selected item");
+		assert.strictEqual(selectionText.getHTML(false), EXPECTED_SELECTION_TEXT2, "Selection announcement text should be equalt to the current selected item's text");
+
+		btn.click();
+		assert.strictEqual(selectionText.getHTML(false), "", "Selection announcement text should be cleared on focusout");
+
+		assert.strictEqual(inputResult.getProperty("value"), "7", "Change event should have fired twice");
+	});
+
 	it("changes selection on Tab", () => {
 		const select = browser.$("#keyboardHandling");
 		const EXPECTED_SELECTION_TEXT = "Banana";
@@ -84,7 +117,7 @@ describe("Select general interaction", () => {
 
 		select.keys("ArrowUp");
 		select.keys("Tab");
-		const selectText = select.shadow$("ui5-label");
+		const selectText = select.shadow$(".ui5-select-label-root");
 
 		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Arrow Up should change selected item");
 		
@@ -105,7 +138,7 @@ describe("Select general interaction", () => {
 
 		select.keys("ArrowDown");
 		browser.keys(["Shift", "Tab"]);
-		const selectText = select.shadow$("ui5-label");
+		const selectText = select.shadow$(".ui5-select-label-root");
 
 		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Arrow Down should change selected item");
 		
@@ -119,7 +152,7 @@ describe("Select general interaction", () => {
 	it("tests selection does not cycle with ArrowDown", () => {
 		const select = $("#selectionNotCycling");
 		const EXPECTED_SELECTION_TEXT = "Opt3";
-		const selectOptionText = select.shadow$("ui5-label");
+		const selectOptionText = select.shadow$(".ui5-select-label-root");
 
 		select.click();
 		assert.ok(selectOptionText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text is " + EXPECTED_SELECTION_TEXT);
@@ -135,7 +168,7 @@ describe("Select general interaction", () => {
 	it("tests selection does not cycle with ArrowUp", () => {
 		const select = $("#selectionNotCycling2");
 		const EXPECTED_SELECTION_TEXT = "Opt1";
-		const selectOptionText = select.shadow$("ui5-label");
+		const selectOptionText = select.shadow$(".ui5-select-label-root");
 
 		select.click();
 		assert.ok(selectOptionText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text is " + EXPECTED_SELECTION_TEXT);
@@ -223,7 +256,7 @@ describe("Select general interaction", () => {
 
 	it("reverts value before open after clicking on escape", () => {
 		const select = $("#mySelect");
-		const selectText = browser.$("#mySelect").shadow$("ui5-label").getHTML(false);
+		const selectText = browser.$("#mySelect").shadow$(".ui5-select-label-root").getHTML(false);
 		const inputResult = browser.$("#inputResult").shadow$("input");
 
 		select.click();
@@ -231,10 +264,10 @@ describe("Select general interaction", () => {
 		select.keys("Escape");
 
 		const selectedOption = browser.$("#mySelect ui5-option[selected]");
-		const selectTextAfterEscape = browser.$("#mySelect").shadow$("ui5-label").getHTML(false);
+		const selectTextAfterEscape = browser.$("#mySelect").shadow$(".ui5-select-label-root").getHTML(false);
 
 		assert.ok(selectedOption.getProperty("selected"), "Initially selected item should remain selected");
-		assert.strictEqual(inputResult.getProperty("value"), "5", "Change event should not be fired");
+		assert.strictEqual(inputResult.getProperty("value"), "7", "Change event should not be fired");
 		assert.strictEqual(selectTextAfterEscape, selectText, "Initially selected item should remain selected");
 	});
 
@@ -250,7 +283,7 @@ describe("Select general interaction", () => {
 		// focus out select
 		btn.click();
 
-		assert.strictEqual(inputResult.getProperty("value"), "6", "Change event should be fired");
+		assert.strictEqual(inputResult.getProperty("value"), "8", "Change event should be fired");
 	});
 
 	it("fires change event after selecting a previewed item", () => {
@@ -268,12 +301,12 @@ describe("Select general interaction", () => {
 
 		firstItem.click();
 
-		assert.strictEqual(inputResult.getProperty("value"), "7", "Change event should be fired");
+		assert.strictEqual(inputResult.getProperty("value"), "9", "Change event should be fired");
 	});
 
 	it("tests ESC on closed picker", () => {
 		const select = $("#mySelectEsc");
-		const selectText = browser.$("#mySelectEsc").shadow$("ui5-label");
+		const selectText = browser.$("#mySelectEsc").shadow$(".ui5-select-label-root");
 		const EXPECTED_SELECTION_TEXT = "Cozy";
 		const EXPECTED_SELECTION_TEXT2 = "Condensed";
 
@@ -294,10 +327,9 @@ describe("Select general interaction", () => {
 		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT2) !== -1, "Select label is correct.");
 	});
 
-
 	it("Tests aria-label and aria-labelledby", () => {
-		const select1 = browser.$("#textAreaAriaLabel").shadow$(".ui5-select-root");
-		const select2 = browser.$("#textAreaAriaLabelledBy").shadow$(".ui5-select-root");
+		const select1 = browser.$("#textAreaAriaLabel").shadow$(".ui5-select-label-root");
+		const select2 = browser.$("#textAreaAriaLabelledBy").shadow$(".ui5-select-label-root");
 		const EXPECTED_ARIA_LABEL1 = "Hello World";
 		const EXPECTED_ARIA_LABEL2 = "info text";
 


### PR DESCRIPTION
Role of the ui5-select is changed to combobox which change the speech output near to the default behavior. Issue where role="button" can't be used with aria-required / required attribute is fixed. Overwriting the aria-label speech output with aria-labelledby is fixed.

Fixes: #2485 
Fixes: #2339
Fixes: #2142