### PR TITLE
refactor: simplify ItemNavigation usage in datetime components

### DIFF
--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -340,23 +340,8 @@ class DayPicker extends PickerBase {
 
 		if (dayPressed) {
 			const targetDate = parseInt(target.getAttribute("data-sap-timestamp"));
-
-			// findIndex, give it to item navigation
-			for (let i = 0; i < this._weeks.length; i++) {
-				for (let j = 0; j < this._weeks[i].length; j++) {
-					if (parseInt(this._weeks[i][j].timestamp) === targetDate) {
-						let index = parseInt(target.getAttribute("data-sap-index"));
-						if (this.minDate || this.maxDate) {
-							const focusableItem = this.focusableDays.find(item => parseInt(item._index) === index);
-							index = focusableItem ? this.focusableDays.indexOf(focusableItem) : index;
-						}
-
-						this._itemNav.current = index;
-						this._itemNav.update();
-						break;
-					}
-				}
-			}
+			const selectedDay = this.focusableDays.find(day => parseInt(day.timestamp) === targetDate);
+			this._itemNav.update(selectedDay);
 
 			this.targetDate = targetDate;
 		}
@@ -560,21 +545,12 @@ class DayPicker extends PickerBase {
 	}
 
 	_modifySelectionAndNotifySubscribers(timestamp) {
-		switch (this.selection) {
-		case CalendarSelection.Single:
+		if (this.selection === CalendarSelection.Single) {
 			this.selectedDates = [timestamp];
-			break;
-		case CalendarSelection.Multiple:
-			this.selectedDates = this.selectedDates.includes(timestamp)
-				? this.selectedDates.filter(value => value !== timestamp)
-				: [...this.selectedDates, timestamp];
-			break;
-		case CalendarSelection.Range:
-			this.selectedDates = (this.selectedDates.length === 1)
-				? [...this.selectedDates, timestamp]
-				: [timestamp];
-			break;
-		default:
+		} else if (this.selection === CalendarSelection.Multiple) {
+			this.selectedDates = this.selectedDates.includes(timestamp) ? this.selectedDates.filter(value => value !== timestamp) : [...this.selectedDates, timestamp];
+		} else {
+			this.selectedDates = (this.selectedDates.length === 1) ? [...this.selectedDates, timestamp]	: [timestamp];
 		}
 
 		this.fireEvent("change", { dates: [...this.selectedDates] });

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -339,7 +339,7 @@ class DayPicker extends PickerBase {
 		const dayPressed = this._isDayPressed(target);
 
 		if (dayPressed) {
-			const targetDate = parseInt(target.getAttribute("data-sap-timestamp"));
+			const targetDate = this.getTimestampFromDom(target);
 			const selectedDay = this.focusableDays.find(day => parseInt(day.timestamp) === targetDate);
 			this._itemNav.update(selectedDay);
 

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -75,19 +75,9 @@ class MonthPicker extends PickerBase {
 			pageSize: 12,
 			rowSize: 3,
 			behavior: ItemNavigationBehavior.Paging,
+			getItemsCallback: () => this.focusableMonths,
 			affectedPropertiesNames: ["_quarters"],
 		});
-
-		this._itemNav.getItemsCallback = () => {
-			const focusableMonths = [];
-
-			for (let i = 0; i < this._quarters.length; i++) {
-				const quarter = this._quarters[i].filter(x => !x.disabled);
-				focusableMonths.push(quarter);
-			}
-
-			return [].concat(...focusableMonths);
-		};
 
 		this._itemNav.attachEvent(
 			ItemNavigation.BORDER_REACH,
@@ -150,9 +140,8 @@ class MonthPicker extends PickerBase {
 	_onmousedown(event) {
 		if (event.target.className.indexOf("ui5-mp-item") > -1) {
 			const targetTimestamp = this.getTimestampFromDom(event.target);
-			const focusedItemIndex = this._itemNav._getItems().findIndex(item => parseInt(item.timestamp) === targetTimestamp);
-			this._itemNav.currentIndex = focusedItemIndex;
-			this._itemNav.focusCurrent();
+			const focusedItem = this.focusableMonths.find(item => parseInt(item.timestamp) === targetTimestamp);
+			this._itemNav.update(focusedItem);
 		}
 	}
 
@@ -195,6 +184,17 @@ class MonthPicker extends PickerBase {
 			maxDateCheck = maxDate && ((currentDateYear === maxDate.getFullYear() && monthIndex > maxDate.getMonth()) || (currentDateYear > maxDate.getFullYear()));
 
 		return maxDateCheck || minDateCheck;
+	}
+
+	get focusableMonths() {
+		const focusableMonths = [];
+
+		for (let i = 0; i < this._quarters.length; i++) {
+			const quarter = this._quarters[i].filter(x => !x.disabled);
+			focusableMonths.push(quarter);
+		}
+
+		return [].concat(...focusableMonths);
 	}
 
 	get styles() {

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -83,19 +83,9 @@ class YearPicker extends PickerBase {
 			pageSize: 20,
 			rowSize: 4,
 			behavior: ItemNavigationBehavior.Paging,
+			getItemsCallback: () => this.focusableYears,
 			affectedPropertiesNames: ["_yearIntervals"],
 		});
-
-		this._itemNav.getItemsCallback = () => {
-			const focusableYears = [];
-
-			for (let i = 0; i < this._yearIntervals.length; i++) {
-				const yearInterval = this._yearIntervals[i].filter(x => !x.disabled);
-				focusableYears.push(yearInterval);
-			}
-
-			return [].concat(...focusableYears);
-		};
 
 		this._itemNav.attachEvent(
 			ItemNavigation.BORDER_REACH,
@@ -181,9 +171,8 @@ class YearPicker extends PickerBase {
 	_onmousedown(event) {
 		if (event.target.className.indexOf("ui5-yp-item") > -1) {
 			const targetTimestamp = this.getTimestampFromDom(event.target);
-			const focusedItemIndex = this._itemNav._getItems().findIndex(item => parseInt(item.timestamp) === targetTimestamp);
-			this._itemNav.currentIndex = focusedItemIndex;
-			this._itemNav.focusCurrent();
+			const focusedItem = this.focusableYears.find(item => parseInt(item.timestamp) === targetTimestamp);
+			this._itemNav.update(focusedItem);
 		}
 	}
 
@@ -267,6 +256,17 @@ class YearPicker extends PickerBase {
 			maxDateCheck = maxDate && year > maxDate.getFullYear();
 
 		return minDateCheck || maxDateCheck;
+	}
+
+	get focusableYears() {
+		const focusableYears = [];
+
+		for (let i = 0; i < this._yearIntervals.length; i++) {
+			const yearInterval = this._yearIntervals[i].filter(x => !x.disabled);
+			focusableYears.push(yearInterval);
+		}
+
+		return [].concat(...focusableYears);
 	}
 
 	get styles() {


### PR DESCRIPTION
Changes:
 - create `focusableMonths` and `focusableYears` similarly to `focusableDays`. Use these to search for items intead of querying the ItemNavigation.
 - Use the `update` function and just pass the item instead of doing complex calculations to determine its index.