### PR TITLE
fix(ui5-wizard): correct phone breakpoint size

### DIFF
--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -211,7 +211,7 @@ class Wizard extends UI5Element {
 	}
 
 	static get PHONE_BREAKPOINT() {
-		return 559;
+		return 599;
 	}
 
 	static get SCROLL_DEBOUNCE_RATE() {


### PR DESCRIPTION
The Phone breakpoint used to be wrong, it is updated from 559 to 599 (as defined in the visual design)