### PR TITLE
fix(ui5-bar): display ui5-icon properly inside bar

### DIFF
--- a/packages/fiori/src/themes/Bar.css
+++ b/packages/fiori/src/themes/Bar.css
@@ -56,7 +56,5 @@
 }
 
 ::slotted(*){
-	display: flex;
-	align-items: center;
 	margin: 0 0.25rem;
 }

--- a/packages/fiori/test/pages/Bar.html
+++ b/packages/fiori/test/pages/Bar.html
@@ -13,38 +13,54 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-</head>
-
-<body style="background-color: var(--sapBackgroundColor);">
-	<section>
-		<ui5-bar design="Footer">
-			<ui5-button design="Positive" slot="endContent">Agree</ui5-button>
-			<ui5-button design="Negative" slot="endContent">Decline</ui5-button>
-			<ui5-button design="Transparent" slot="endContent">Cancel</ui5-button>
-		</ui5-bar>
-		<ui5-bar design="Subheader">
-			<ui5-button slot="startContent">Left Button</ui5-button>
-			<ui5-label slot="endContent" id="basic-label">Basic Label</ui5-label>
-			<ui5-button slot="middleContent">Middle Button</ui5-button>
-			<ui5-button slot="middleContent">Middle2 Button</ui5-button>
-			<ui5-button slot="startContent">Middle3 Button</ui5-button>
-			<ui5-button slot="endContent">Right Button</ui5-button>
-		</ui5-bar>
-		<ui5-bar design="FloatingFooter">
-			<ui5-button design="Positive" slot="endContent">Agree</ui5-button>
-			<ui5-button design="Negative" slot="endContent">Decline</ui5-button>
-			<ui5-button design="Transparent" slot="endContent">Cancel</ui5-button>
-		</ui5-bar>
-		<ui5-bar design="Header">
-			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
-			<ui5-label id="basic-label" slot="middleContent">Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
-		</ui5-bar>
-	</section>
 	<style>
 		ui5-bar {
 			margin: 0.25rem 0;
 		}
 	</style>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+	<section>
+		<ui5-title level="3">Header design</ui5-title>
+		<ui5-bar design="Header">
+			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+			<ui5-label slot="middleContent">Title</ui5-label>
+			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+		</ui5-bar>
+		<br>
+
+		<ui5-title level="3">Subheader design</ui5-title>
+		<br>
+		<ui5-bar design="Subheader">
+			<div slot="startContent" style="display: flex; align-items: center;">
+				<ui5-button>Start Button</ui5-button>
+				<ui5-label>Basic Label</ui5-label>
+			</div>
+
+			<ui5-button slot="middleContent">Middle1 Button</ui5-button>
+			<ui5-button slot="middleContent">Middle2 Button</ui5-button>
+
+			<ui5-label slot="endContent">Basic Label</ui5-label>
+			<ui5-button slot="endContent">End Button</ui5-button>
+		</ui5-bar>
+
+		<br>
+		<ui5-title level="3">Footer design</ui5-title>
+		<ui5-bar design="Footer">
+			<ui5-icon name="home" slot="startContent"></ui5-icon>
+			<ui5-button design="Positive" slot="endContent">Agree</ui5-button>
+			<ui5-button design="Negative" slot="endContent">Decline</ui5-button>
+			<ui5-button design="Transparent" slot="endContent">Cancel</ui5-button>
+		</ui5-bar>
+
+		<br>
+		<ui5-title level="3">FloatingFooter design</ui5-title>
+		<ui5-bar design="FloatingFooter">
+			<ui5-button design="Positive" slot="endContent">Agree</ui5-button>
+			<ui5-button design="Negative" slot="endContent">Decline</ui5-button>
+			<ui5-button design="Transparent" slot="endContent">Cancel</ui5-button>
+		</ui5-bar>
+	</section>
 </body>
 </html>


### PR DESCRIPTION
**Background**
Ensure ui5-icon is displayed when used inside ui5-bar. Currently the ui5-icon does not get displayed.
```html
<ui5-bar>
        <ui5-icon name="home" slot="startContent"></ui5-icon>
</ui5-bar>
  ```

**Change**
Remove **"::slotted(*) { display: flex;"** because this  CSS breaks ui5-icon's display.
It was added to provide better support for multi levels of children like:

```html
<ui5-bar>
    <div slot>
        <ui5-button>
     </div>
</ui5-bar>
  ```
  
But now we just let users add do it, instead of us. As shown below, everyone can add **"display: flex; align-items: center;"** to their own slotted elements. Moreover, this is not the main use-case we support.

```html
<ui5-bar>
	<div slot="startContent" style="display: flex; align-items: center;">
		<ui5-button>Start Button</ui5-button>
		<ui5-label>Basic Label</ui5-label>
	</div>
</ui5-bar>
```
