### PR TITLE
fix(ui5-icon): remove vertical icon flip in RTL

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -22,11 +22,6 @@
 	outline: 1px dotted var(--sapContent_FocusColor);
 }
 
-:host(:not([dir="ltr"])) .ui5-icon-root[dir=rtl] {
-	transform: scale(-1, -1);
-	transform-origin: center;
-}
-
 .ui5-icon-root {
 	display:flex;
 	outline: none;


### PR DESCRIPTION
Icons used to have a wrong double vertical flip. This was removed, but
the RTL selectors were missed.

Fixes #2644 


