### PR TITLE
docs(ui5-wizard-step): document content slot

### DIFF
--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -121,6 +121,15 @@ const metadata = {
 		},
 	},
 	slots: /** @lends sap.ui.webcomponents.fiori.WizardStep.prototype */ {
+		/**
+		 * Defines the step content.
+		 * @type {Node[]}
+		 * @slot
+		 * @public
+		 */
+		"default": {
+			type: Node,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.fiori.WizardStep.prototype */ {
 	},


### PR DESCRIPTION
The default slot of ui5-wizard-step was not documented, now it will be part of the API reference.