### PR TITLE
fix(ui5-multi-combobox): fix livechange behaviour

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -468,7 +468,7 @@ class MultiComboBox extends UI5Element {
 			- value of the host and the internal input should be differnt in case of actual input
 			- input is called when a key is pressed => keyup should not be called yet
 		*/
-		const skipFiring = (this._inputDom.value === this.value) && isIE && !this._keyDown && !!this.placeholder;
+		const skipFiring = (this._inputDom.value === this.value) && isIE() && !this._keyDown && !!this.placeholder;
 
 		if (skipFiring) {
 			event.preventDefault();


### PR DESCRIPTION
Prior to this change, if you have a multicombobox with placeholder, the filtration was not working on mobile devices(when dialog is opened)