### PR TITLE
fix(ui5-calendar): Today date is properly calculated

### DIFF
--- a/packages/localization/src/dates/getTodayUTCTimestamp.js
+++ b/packages/localization/src/dates/getTodayUTCTimestamp.js
@@ -1,0 +1,9 @@
+import CalendarDate from "./CalendarDate.js";
+
+/**
+ * Returns a UTC timestamp representing today
+ * @public
+ */
+const getTodayUTCTimestamp = primaryCalendarType => CalendarDate.fromLocalJSDate(new Date(), primaryCalendarType).valueOf() / 1000;
+
+export default getTodayUTCTimestamp;

--- a/packages/main/src/CalendarPart.js
+++ b/packages/main/src/CalendarPart.js
@@ -1,7 +1,7 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
-import getRoundedTimestamp from "@ui5/webcomponents-localization/dist/dates/getRoundedTimestamp.js";
+import getTodayUTCTimestamp from "@ui5/webcomponents-localization/dist/dates/getTodayUTCTimestamp.js";
 import DateComponentBase from "./DateComponentBase.js";
 
 /**
@@ -52,7 +52,7 @@ class CalendarPart extends DateComponentBase {
 	 * @protected
 	 */
 	get _timestamp() {
-		let timestamp = this.timestamp !== undefined ? this.timestamp : getRoundedTimestamp();
+		let timestamp = this.timestamp !== undefined ? this.timestamp : getTodayUTCTimestamp(this._primaryCalendarType);
 		if (timestamp < this._minTimestamp || timestamp > this._maxTimestamp) {
 			timestamp = this._minTimestamp;
 		}

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -2,6 +2,7 @@ import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
 import getRoundedTimestamp from "@ui5/webcomponents-localization/dist/dates/getRoundedTimestamp.js";
+import getTodayUTCTimestamp from "@ui5/webcomponents-localization/dist/dates/getTodayUTCTimestamp.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import {
@@ -373,14 +374,12 @@ class DatePicker extends DateComponentBase {
 	 * @protected
 	 */
 	get _calendarTimestamp() {
-		let millisecondsUTC;
 		if (this.value && this._checkValueValidity(this.value)) {
-			millisecondsUTC = this.dateValueUTC.getTime();
-		} else {
-			millisecondsUTC = new Date().getTime();
+			const millisecondsUTC = this.dateValueUTC.getTime();
+			return getRoundedTimestamp(millisecondsUTC);
 		}
 
-		return getRoundedTimestamp(millisecondsUTC);
+		return getTodayUTCTimestamp(this._primaryCalendarType);
 	}
 
 	/**

--- a/packages/main/src/DateRangePicker.js
+++ b/packages/main/src/DateRangePicker.js
@@ -1,7 +1,7 @@
 import RenderScheduler from "@ui5/webcomponents-base/dist/RenderScheduler.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
-import getRoundedTimestamp from "@ui5/webcomponents-localization/dist/dates/getRoundedTimestamp.js";
+import getTodayUTCTimestamp from "@ui5/webcomponents-localization/dist/dates/getTodayUTCTimestamp.js";
 
 // Styles
 import DateRangePickerCss from "./generated/themes/DateRangePicker.css.js";
@@ -104,7 +104,7 @@ class DateRangePicker extends DatePicker {
 	 * @override
 	 */
 	get _calendarTimestamp() {
-		return this._firstDateTimestamp || getRoundedTimestamp();
+		return this._firstDateTimestamp || getTodayUTCTimestamp(this._primaryCalendarType);
 	}
 
 	/**

--- a/packages/main/test/samples/Calendar.sample.html
+++ b/packages/main/test/samples/Calendar.sample.html
@@ -97,7 +97,7 @@
 	<h3>Buddhist Calendar</h3>
 	<div class="snippet">
 		<div class="datepicker-width">
-			<ui5-calendar primary-calendar-type='Buddhist'></ui5-calendarr>
+			<ui5-calendar primary-calendar-type='Buddhist'></ui5-calendar>
 		</div>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>


### PR DESCRIPTION
For several components the `Today` timestamp was not a UTC timestamp but rather a timestamp, representing the Local date (`new Date().getTime()`) opposed to the UTC Date. Now `new Date()` is never used to get today's timestamp. It is however fine for time-related components, therefore it's not changed there.

closes: https://github.com/SAP/ui5-webcomponents/issues/2655