### PR TITLE
fix(ui5-upload-collection): wrap noDataText/Desc text

### DIFF
--- a/packages/fiori/src/UploadCollection.hbs
+++ b/packages/fiori/src/UploadCollection.hbs
@@ -15,8 +15,8 @@
 				<div class="icon-container">
 					<ui5-icon name="document"></ui5-icon>
 				</div>
-				<ui5-title level="H2">{{_noDataText}}</ui5-title>
-				<ui5-label class="subtitle">{{_noDataDescription}}</ui5-label>
+				<ui5-title level="H2" wrap>{{_noDataText}}</ui5-title>
+				<ui5-label class="subtitle" wrap>{{_noDataDescription}}</ui5-label>
 			</div>
 		{{else if _showDndOverlay}}
 			<div


### PR DESCRIPTION
Now the noDataText and noDateDescription texts will wrap upon overflow. Prior to this change the texts truncate.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2672