### PR TITLE
chore: remove obsolete code

### DIFF
--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -215,14 +215,10 @@ class DateTimePicker extends DatePicker {
 
 	/**
 	 * Opens the picker.
-	 *
-	 * @param {object} options A JSON object with additional configuration.<br>
-	 * <code>{ focusInput: true }</code> By default, the focus goes in the picker after opening it.
-	 * Specify this option to focus the input field.
 	 * @public
 	 */
-	async openPicker(options) {
-		await super.openPicker(options);
+	async openPicker() {
+		await super.openPicker();
 		this._currentTimeSlider = "hours";
 		this._previewValues.timeSelectionValue = this.value || this.getFormat().format(new Date());
 	}

--- a/packages/main/src/TimePickerBase.js
+++ b/packages/main/src/TimePickerBase.js
@@ -295,8 +295,6 @@ class TimePickerBase extends UI5Element {
 
 	/**
 	 * Opens the picker.
-	 * <code>{ focusInput: true }</code> By default, the focus goes in the picker after opening it.
-	 * Specify this option to focus the input field.
 	 * @public
 	 */
 	async openPicker() {


### PR DESCRIPTION
Clean up leftover from the "focusInput" functionality option removal within two date-time components.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2495