### PR TITLE
fix(docs): fix sample for tests

### DIFF
--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -69,9 +69,8 @@ The simplest test would look something like this:
 
 ```js
 describe("ui5-demo rendering", () => {
-	browser.url("http://localhost:8080/test-resources/pages/index.html");
-
 	it("tests if web component is correctly rendered", () => {
+		browser.url("http://localhost:8080/test-resources/pages/index.html");
 		const innerContent = browser.$("#myFirstComponent").shadow$("div");
 		assert.ok(innerContent, "content rendered");
 	});


### PR DESCRIPTION
```browser``` object can only be used inside it() function 