### PR TITLE
fix(ui5-popover): correctly position a popover if dynamically created

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -203,8 +203,8 @@ class Dialog extends Popup {
 		return "flex";
 	}
 
-	async show() {
-		await super.show();
+	show() {
+		super.show();
 		this._center();
 	}
 

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -203,8 +203,8 @@ class Dialog extends Popup {
 		return "flex";
 	}
 
-	show() {
-		super.show();
+	async show() {
+		await super.show();
 		this._center();
 	}
 

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -399,7 +399,7 @@ class Popover extends Popup {
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		return new Promise(resolve => {
+		return async resolve => {
 			window.requestAnimationFrame(() => {
 				rect = this.getBoundingClientRect();
 
@@ -411,7 +411,7 @@ class Popover extends Popup {
 
 				resolve({ width, height });
 			});
-		});
+		};
 	}
 
 	get contentDOM() {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -395,8 +395,8 @@ class Popover extends Popup {
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		return new Promise(function (resolve) {
-			window.requestAnimationFrame(function () {
+		return new Promise((resolve) => {
+			window.requestAnimationFrame(() => {
 				rect = this.getBoundingClientRect();
 
 				width = rect.width;
@@ -406,8 +406,8 @@ class Popover extends Popup {
 				this.style.visibility = "visible";
 
 				resolve({ width, height });
-			}.bind(this));
-		}.bind(this));
+			});
+		});
 	}
 
 	get contentDOM() {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -342,7 +342,7 @@ class Popover extends Popup {
 		const popoverSize = await this._popoverSize;
 
 		if (this.isOpen()) {
-			// update opener rect if it was changed during the popover is opened
+			// update opener rect if it was changed during the popover being opened
 			this._openerRect = this._opener.getBoundingClientRect();
 		}
 

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -336,9 +336,10 @@ class Popover extends Popup {
 		this.show();
 	}
 
-	show() {
+	async show() {
 		let placement;
-		const popoverSize = this.popoverSize;
+		const popoverSize = await this._popoverSize;
+
 		const openerRect = this._opener.getBoundingClientRect();
 
 		if (this.shouldCloseDueToNoOpener(openerRect) && this.isFocusWithin()) {
@@ -379,7 +380,7 @@ class Popover extends Popup {
 		}
 	}
 
-	get popoverSize() {
+	get _popoverSize() {
 		let width,
 			height;
 		let rect = this.getBoundingClientRect();
@@ -388,21 +389,25 @@ class Popover extends Popup {
 			width = rect.width;
 			height = rect.height;
 
-			return { width, height };
+			return Promise.resolve({ width, height });
 		}
 
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		rect = this.getBoundingClientRect();
+		return new Promise(function (resolve) {
+			window.requestAnimationFrame(function () {
+				rect = this.getBoundingClientRect();
 
-		width = rect.width;
-		height = rect.height;
+				width = rect.width;
+				height = rect.height;
 
-		this.hide();
-		this.style.visibility = "visible";
+				this.hide();
+				this.style.visibility = "visible";
 
-		return { width, height };
+				resolve({ width, height });
+			}.bind(this));
+		}.bind(this));
 	}
 
 	get contentDOM() {
@@ -595,6 +600,7 @@ class Popover extends Popup {
 		switch (this.horizontalAlign) {
 		case PopoverHorizontalAlign.Center:
 		case PopoverHorizontalAlign.Stretch:
+
 			left = targetRect.left - (popoverSize.width - targetRect.width) / 2;
 			break;
 		case PopoverHorizontalAlign.Left:

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -277,14 +277,14 @@ class Popover extends Popup {
 	 * @param {boolean} preventInitialFocus prevents applying the focus inside the popover
 	 * @public
 	 */
-	openBy(opener, preventInitialFocus = false) {
+	async openBy(opener, preventInitialFocus = false) {
 		if (!opener || this.opened) {
 			return;
 		}
 
 		this._opener = opener;
 
-		super.open(preventInitialFocus);
+		await super.open(preventInitialFocus);
 	}
 
 	/**
@@ -357,7 +357,7 @@ class Popover extends Popup {
 		}
 
 		if (this._oldPlacement && (this._oldPlacement.left === placement.left) && (this._oldPlacement.top === placement.top) && stretching) {
-			super.show();
+			await super.show();
 			this.style.width = this._width;
 			return;
 		}
@@ -373,7 +373,7 @@ class Popover extends Popup {
 
 		this.style.left = `${popoverOnLeftBorder ? Popover.MIN_OFFSET : this._left}px`;
 		this.style.top = `${popoverOnTopBorder ? Popover.MIN_OFFSET : this._top}px`;
-		super.show();
+		await super.show();
 
 		if (stretching && this._width) {
 			this.style.width = this._width;

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -283,6 +283,7 @@ class Popover extends Popup {
 		}
 
 		this._opener = opener;
+		this._openerRect = opener.getBoundingClientRect()
 
 		await super.open(preventInitialFocus);
 	}
@@ -340,14 +341,17 @@ class Popover extends Popup {
 		let placement;
 		const popoverSize = await this._popoverSize;
 
-		const openerRect = this._opener.getBoundingClientRect();
+		if (this.isOpen()) {
+			// update opener rect if it was changed during the popover is opened
+			this._openerRect = this._opener.getBoundingClientRect();
+		}
 
-		if (this.shouldCloseDueToNoOpener(openerRect) && this.isFocusWithin()) {
+		if (this.shouldCloseDueToNoOpener(this._openerRect) && this.isFocusWithin()) {
 			// reuse the old placement as the opener is not available,
 			// but keep the popover open as the focus is within
 			placement = this._oldPlacement;
 		} else {
-			placement = this.calcPlacement(openerRect, popoverSize);
+			placement = this.calcPlacement(this._openerRect, popoverSize);
 		}
 
 		const stretching = this.horizontalAlign === PopoverHorizontalAlign.Stretch;

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -399,7 +399,7 @@ class Popover extends Popup {
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		return async resolve => {
+		return new Promise((resolve) => {
 			window.requestAnimationFrame(() => {
 				rect = this.getBoundingClientRect();
 
@@ -411,7 +411,7 @@ class Popover extends Popup {
 
 				resolve({ width, height });
 			});
-		};
+		});
 	}
 
 	get contentDOM() {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -283,7 +283,7 @@ class Popover extends Popup {
 		}
 
 		this._opener = opener;
-		this._openerRect = opener.getBoundingClientRect()
+		this._openerRect = opener.getBoundingClientRect();
 
 		await super.open(preventInitialFocus);
 	}

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -395,7 +395,7 @@ class Popover extends Popup {
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		return new Promise((resolve) => {
+		return new Promise(resolve => {
 			window.requestAnimationFrame(() => {
 				rect = this.getBoundingClientRect();
 

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -399,7 +399,7 @@ class Popover extends Popup {
 		this.style.visibility = "hidden";
 		this.style.display = "block";
 
-		return new Promise((resolve) => {
+		return new Promise(resolve => {
 			window.requestAnimationFrame(() => {
 				rect = this.getBoundingClientRect();
 

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -321,7 +321,7 @@ class Popup extends UI5Element {
 	 * @param {boolean} preventInitialFocus prevents applying the focus inside the popup
 	 * @public
 	 */
-	open(preventInitialFocus) {
+	async open(preventInitialFocus) {
 		const prevented = !this.fireEvent("before-open", {}, true, false);
 		if (prevented) {
 			return;
@@ -337,10 +337,11 @@ class Popup extends UI5Element {
 		this._zIndex = getNextZIndex();
 		this.style.zIndex = this._zIndex;
 		this._focusedElementBeforeOpen = getFocusedElement();
-		this.show();
+
+		await this.show();
 
 		if (!this._disableInitialFocus && !preventInitialFocus) {
-			this.applyInitialFocus();
+			await this.applyInitialFocus();
 		}
 
 		this._addOpenedPopup();
@@ -415,7 +416,7 @@ class Popup extends UI5Element {
 	 * Sets "block" display to the popup. The property can be overriden by derivatives of Popup.
 	 * @protected
 	 */
-	show() {
+	async show() {
 		this.style.display = this._displayProp;
 	}
 

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -1,3 +1,4 @@
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
@@ -338,15 +339,17 @@ class Popup extends UI5Element {
 		this.style.zIndex = this._zIndex;
 		this._focusedElementBeforeOpen = getFocusedElement();
 
-		await this.show();
+		this.show();
 
 		if (!this._disableInitialFocus && !preventInitialFocus) {
-			await this.applyInitialFocus();
+			this.applyInitialFocus();
 		}
 
 		this._addOpenedPopup();
 
 		this.opened = true;
+
+		await renderFinished();
 		this.fireEvent("after-open", {}, false, false);
 	}
 
@@ -416,7 +419,7 @@ class Popup extends UI5Element {
 	 * Sets "block" display to the popup. The property can be overriden by derivatives of Popup.
 	 * @protected
 	 */
-	async show() {
+	show() {
 		this.style.display = this._displayProp;
 	}
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -465,12 +465,12 @@
 			popXRight.openBy(targetOpener2);
 		});
 
-		firstBtn.addEventListener("click", (event) => {
+		firstBtn.addEventListener("click", function (event) {
 			popNoFocusableContent.innerHTML = "First button is clicked";
 			popNoFocusableContent.openBy(event.target);
 		});
 
-		secondBtn.addEventListener("click", (event) => {
+		secondBtn.addEventListener("click", function (event) {
 			popNoFocusableContent.innerHTML = "Second button is clicked";
 			popNoFocusableContent.openBy(event.target);
 		});
@@ -479,7 +479,7 @@
 			var popover = document.createElement("ui5-popover"),
 				button = document.createElement("ui5-button");
 
-			button.innerText = "Focusable element";
+			button.textContent = "Focusable element";
 			popover.appendChild(button);
 			popover.setAttribute("placement-type", "Bottom");
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -476,9 +476,12 @@
 		});
 
 		btnOpenDynamic.addEventListener("click", function () {
-			var popover = document.createElement("ui5-popover");
+			var popover = document.createElement("ui5-popover"),
+				button = document.createElement("ui5-button");
+
+			button.innerText = "Focusable element";
+			popover.appendChild(button);
 			popover.setAttribute("placement-type", "Bottom");
-			popover.innerText = "This is a dynamically created popover.";
 
 			document.body.appendChild(popover);
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -376,6 +376,13 @@
 	<ui5-popover id="popNoFocusableContent" placement-type="Bottom">Sample text for the ui5-popover</ui5-popover>
 
 	<br>
+	<br>
+
+	<div style="height: 6rem; text-align: center;">
+		<ui5-button id="btnOpenDynamic" icon="overflow"></ui5-button>
+	</div>
+
+	<br>
 
 	<script>
 		btn.addEventListener("click", function (event) {
@@ -466,6 +473,16 @@
 		secondBtn.addEventListener("click", (event) => {
 			popNoFocusableContent.innerHTML = "Second button is clicked";
 			popNoFocusableContent.openBy(event.target);
+		});
+
+		btnOpenDynamic.addEventListener("click", function () {
+			var popover = document.createElement("ui5-popover");
+			popover.setAttribute("placement-type", "Bottom");
+			popover.innerText = "This is a dynamically created popover.";
+
+			document.body.appendChild(popover);
+
+			popover.openBy(btnOpenDynamic);
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -137,8 +137,8 @@
 
 
 	<ui5-multi-combobox>
-		<ui5-li>Hello</ui5-li>
-		<ui5-li>World</ui5-li>
+		<ui5-cb-item text="Hello"></ui5-cb-item>
+		<ui5-cb-item text="World"></ui5-cb-item>
 	</ui5-multi-combobox>
 
 	<br>
@@ -481,6 +481,7 @@
 
 			button.textContent = "Focusable element";
 			popover.appendChild(button);
+			popover.setAttribute("id", "dynamic-popover");
 			popover.setAttribute("placement-type", "Bottom");
 
 			document.body.appendChild(popover);

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -250,6 +250,24 @@ describe("Popover general interaction", () => {
 
 		assert.ok(activeElementId, popoverId, "Popover remains focused");
 	});
+
+	it("tests that dynamically created popover is opened", () => {
+		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+
+		const btnOpenDynamic = $("#btnOpenDynamic");
+		btnOpenDynamic.click();
+		const popover = $('#dynamic-popover');
+
+		browser.waitUntil(
+			() => popover.getCSSProperty("top").parsed.value > 0 && popover.getCSSProperty("left").parsed.value > 0,
+			{
+				timeout: 500,
+				timeoutMsg: "popover was not opened after a timeout"
+			}
+		);
+
+		assert.ok(true, "popover is opened");
+	});
 });
 
 describe("Acc", () => {


### PR DESCRIPTION
Now when a popover is dynamically created it is shown only after its size can be determined.
This prevents its position to flicker on opening.

BREAKING CHANGE: The methods 'open' for Dialog and 'openBy' for Popover are now async
Fixes: https://github.com/SAP/ui5-webcomponents/issues/1755

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
