### PR TITLE
fix(ui5-select): fix popover opening

### DIFF
--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -5,7 +5,7 @@
 	@click="{{_onclick}}"
 >
 	<div class="ui5-select-label-root"
-		id="{{_id}}-label"
+		data-sap-focus-ref
 		tabindex="{{tabIndex}}"
 		role="combobox"
 		aria-haspopup="listbox"

--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -2,9 +2,10 @@
 	class="ui5-select-root"
 	dir="{{effectiveDir}}"
 	id="{{_id}}-select"
-	@click="{{_toggleRespPopover}}"
+	@click="{{_onclick}}"
 >
 	<div class="ui5-select-label-root"
+		id="{{_id}}-label"
 		tabindex="{{tabIndex}}"
 		role="combobox"
 		aria-haspopup="listbox"

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -456,6 +456,15 @@ class Select extends UI5Element {
 		this._toggleRespPopover();
 	}
 
+	_onclick(event) {
+		this.getFocusDomRef().focus();
+		this._toggleRespPopover();
+	}
+
+	getFocusDomRef() {
+		return this.shadowRoot.querySelector(`#${this.__id}-label`);
+	}
+
 	/**
 	 * The user used arrow up/down on the list
 	 * @private

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -461,10 +461,6 @@ class Select extends UI5Element {
 		this._toggleRespPopover();
 	}
 
-	getFocusDomRef() {
-		return this.shadowRoot.querySelector(`#${this.__id}-label`);
-	}
-
 	/**
 	 * The user used arrow up/down on the list
 	 * @private


### PR DESCRIPTION
When the accessibility refactoring of was done the focus reference was changed. The click event should focus the correct element so the internal rules which controls the visibility of value state could pass.

Fixes: #2682