### PR TITLE
fix(ui5-link): Removed aria-disabled attribute

### DIFF
--- a/packages/main/src/Link.hbs
+++ b/packages/main/src/Link.hbs
@@ -6,7 +6,6 @@
 	rel="{{_rel}}"
 	tabindex="{{tabIndex}}"
 	?disabled="{{disabled}}"
-	aria-disabled="{{ariaDisabled}}"
 	aria-label="{{ariaLabelText}}"
 	@focusin={{_onfocusin}}
 	@click={{_onclick}}

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -234,10 +234,6 @@ class Link extends UI5Element {
 		return (this.disabled || !this.textContent.length) ? "-1" : "0";
 	}
 
-	get ariaDisabled() {
-		return this.disabled ? "true" : undefined;
-	}
-
 	get ariaLabelText() {
 		return getEffectiveAriaLabelText(this);
 	}


### PR DESCRIPTION
aria-disabled attribute is removed, and only the native one is present now.

fixes: https://github.com/SAP/ui5-webcomponents/issues/2673