### PR TITLE
fix(docs) SAP logo not shown in playground and missing start quote in Avatar.js

### DIFF
--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -228,7 +228,7 @@ const metadata = {
  *
  * <h3>ES6 Module Import</h3>
  *
- * <code>import @ui5/webcomponents/dist/Avatar.js";</code>
+ * <code>import "@ui5/webcomponents/dist/Avatar.js";</code>
  *
  * @constructor
  * @author SAP SE

--- a/packages/playground/_layouts/docs.html
+++ b/packages/playground/_layouts/docs.html
@@ -9,7 +9,7 @@ layout: default
         <a class="separator" href="https://www.sap.com/about/legal/privacy.html" target="_blank">Privacy Policy</a>
         <a href="https://www.sap.com/about/legal/impressum.html" target="_blank">Legal</a>
     </div>
-    <img src="{{ "/assets/images/sap-logo-svg.svg" | absolute_url }}" alt="SAP Logo" />
+    <img src="{{ "/ui5-webcomponents/assets/images/sap-logo-svg.svg" | absolute_url }}" alt="SAP Logo" />
 </footer>
 
 <style>


### PR DESCRIPTION
Hey there,

I've adjusted some minor things in the docs/playground as 
- added missing single quote on import statement (copy & paste without the need for manual fix) and
- adjusted the path to the sap logo svg (SAP logo isn't displayed)

I did look at the contribution checklist and hope that everything is in order. I couldn't get the playground running locally but checked the url for the SAP logo myself. Hope it is fine.

## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [X] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)

