### PR TITLE
fix(ui5-multi-combobox): The initial focus is set on the ui5-dialog

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -692,6 +692,11 @@ class MultiComboBox extends UI5Element {
 
 		const filteredItems = this._filterItems(this.value);
 		this._filteredItems = filteredItems;
+
+		if (isPhone() && this.allItemsPopover && this.allItemsPopover.opened) {
+			// Set initial focus to the dialog
+			this.allItemsPopover.focus();
+		}
 	}
 
 	async onAfterRendering() {


### PR DESCRIPTION
When ui5-multi-combobox web component is used on mobile phone and the list with the available options is visualised in a dialog, the initial focus on opening should be set to the dialog according to the specification.

Fixes: #2692 