### PR TITLE
fix(ui5-input): Obsolete accessibility API removed

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -332,10 +332,6 @@ const metadata = {
 			type: Object,
 		},
 
-		_wrapperAccInfo: {
-			type: Object,
-		},
-
 		_inputWidth: {
 			type: Integer,
 		},


### PR DESCRIPTION
The API is deleted, since it is never used.

Fixes: #2605 
