### PR TITLE
fix(ui5-combobox, ui5-multicombobox): center ValueState text

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -814,8 +814,7 @@ class ComboBox extends UI5Element {
 			suggestionPopoverHeader: {
 				"display": this._listWidth === 0 ? "none" : "inline-block",
 				"width": `${this._listWidth}px`,
-				"padding": "0 1rem",
-				"line-height": "2.5rem",
+				"padding": "0.9125rem 1rem",
 			},
 		};
 	}

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -814,7 +814,8 @@ class ComboBox extends UI5Element {
 			suggestionPopoverHeader: {
 				"display": this._listWidth === 0 ? "none" : "inline-block",
 				"width": `${this._listWidth}px`,
-				"padding": "0.5625rem 1rem",
+				"padding": "0 1rem",
+				"line-height": "2.725rem",
 			},
 		};
 	}

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -815,7 +815,7 @@ class ComboBox extends UI5Element {
 				"display": this._listWidth === 0 ? "none" : "inline-block",
 				"width": `${this._listWidth}px`,
 				"padding": "0 1rem",
-				"line-height": "2.725rem",
+				"line-height": "2.5rem",
 			},
 		};
 	}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -872,9 +872,9 @@ class MultiComboBox extends UI5Element {
 		return {
 			popoverValueStateMessage: {
 				"width": `${this._listWidth}px`,
-				"min-height": "2.5rem",
-				"padding": "0.5625rem 1rem",
 				"display": this._listWidth === 0 ? "none" : "inline-block",
+				"padding": "0 1rem",
+				"line-height": "2.725rem",
 			},
 			popoverHeader: {
 				"width": `${this._inputWidth}px`,

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -874,7 +874,7 @@ class MultiComboBox extends UI5Element {
 				"width": `${this._listWidth}px`,
 				"display": this._listWidth === 0 ? "none" : "inline-block",
 				"padding": "0 1rem",
-				"line-height": "2.725rem",
+				"line-height": "2.5rem",
 			},
 			popoverHeader: {
 				"width": `${this._inputWidth}px`,

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -873,8 +873,7 @@ class MultiComboBox extends UI5Element {
 			popoverValueStateMessage: {
 				"width": `${this._listWidth}px`,
 				"display": this._listWidth === 0 ? "none" : "inline-block",
-				"padding": "0 1rem",
-				"line-height": "2.5rem",
+				"padding": "0.9125rem 1rem",
 			},
 			popoverHeader: {
 				"width": `${this._inputWidth}px`,

--- a/packages/main/src/themes/ResponsivePopover.css
+++ b/packages/main/src/themes/ResponsivePopover.css
@@ -13,7 +13,7 @@
 }
 
 .ui5-responsive-popover-header {
-	height: var(--_ui5-responnsive_popover_header_height);
+	height: var(--_ui5-responsive_popover_header_height);
 	display: flex;
 	justify-content: space-between;
 	align-items: center;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -69,6 +69,9 @@
 	/* TextArea */
 	--_ui5_textarea_padding: 0.5625rem 0.6875rem;
 
+	/* Responsive Popover */
+	--_ui5-responsive_popover_header_height: 2.75rem;
+
 	/* Side Navigation */
 	--ui5_side_navigation_item_height: 2.75rem;
 

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -69,9 +69,6 @@
 	/* TextArea */
 	--_ui5_textarea_padding: 0.5625rem 0.6875rem;
 
-	/* Responsive Popover */
-	--_ui5-responnsive_popover_header_height: 2.75rem;
-
 	/* Side Navigation */
 	--ui5_side_navigation_item_height: 2.75rem;
 
@@ -210,7 +207,7 @@
 	--_ui5_radiobutton_min_width: var(--_ui5_radiobutton_min_width_compact);
 
 	/* Responsive Popover */
-	--_ui5-responnsive_popover_header_height: 2.5rem;
+	--_ui5-responsive_popover_header_height: 2.725rem;
 
 	/* Side Navigation */
 	--ui5_side_navigation_item_height: 2rem;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -207,7 +207,7 @@
 	--_ui5_radiobutton_min_width: var(--_ui5_radiobutton_min_width_compact);
 
 	/* Responsive Popover */
-	--_ui5-responsive_popover_header_height: 2.725rem;
+	--_ui5-responsive_popover_header_height: 2.5rem;
 
 	/* Side Navigation */
 	--ui5_side_navigation_item_height: 2rem;


### PR DESCRIPTION
ValueState text is now vertically centered in the Popover's header.

Issue: #2274