### PR TITLE
fix(ui5-input): fire 'change' event before 'submit'

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -693,8 +693,20 @@ class Input extends UI5Element {
 		}
 	}
 
+	/**
+	 * Fire 'change' event only if its triggered by focusout. Otherwise, when triggered
+	 * by press of the 'enter' key - it is fired manually in fireEventByAction() method
+	 * in order to be dispatched before the 'submit' event.
+	 *
+	 * Note: At this point the focused property is still not updated so the
+	 * 'document.activeElement' reference must be used.
+	 *
+	 * @private
+	 */
 	_handleChange(event) {
-		this.fireEvent(this.EVENT_CHANGE);
+		if (document.activeElement !== this) {
+			this.fireEvent(this.EVENT_CHANGE);
+		}
 	}
 
 	_scroll(event) {
@@ -906,7 +918,11 @@ class Input extends UI5Element {
 			return;
 		}
 
+		// Explicitly fire 'change' event before the 'submit' one.
+		// The native 'change' event is being dispatched after this code,
+		// execution, but it should be fired before the 'submit' event.
 		if (isSubmit) { // submit
+			this.fireEvent(this.EVENT_CHANGE);
 			this.fireEvent(this.EVENT_SUBMIT);
 		}
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -694,17 +694,17 @@ class Input extends UI5Element {
 	}
 
 	/**
-	 * Fire 'change' event only if its triggered by focusout. Otherwise, when
-	 * by press of the 'enter' key - it is fired in fireEventByAction() method
-	 * triggered in order to be dispatched before the 'submit' event.
+	 * Fire only 'change' event if it is triggered by focusout.
+	 * Otherwise, fire a "submit" event also.
 	 *
 	 * @private
 	 */
 	_handleChange(event) {
-		if (!this._isChangeFired) {
-			this.fireEvent(this.EVENT_CHANGE);
-		} else {
-			this._isChangeFired = false;
+		this.fireEvent(this.EVENT_CHANGE);
+
+		if (this._isSubmit) {
+			this.fireEvent(this.EVENT_SUBMIT);
+			this._isSubmit = false;
 		}
 	}
 
@@ -892,7 +892,6 @@ class Input extends UI5Element {
 		}
 
 		const inputValue = await this.getInputValue();
-		const isSubmit = action === this.ACTION_ENTER;
 		const isUserInput = action === this.ACTION_USER_INPUT;
 
 		const input = await this.getInputDOMRef();
@@ -901,6 +900,7 @@ class Input extends UI5Element {
 		this.value = inputValue;
 		this.highlightValue = inputValue;
 		this.valueBeforeItemPreview = inputValue;
+		this._isSubmit = action === this.ACTION_ENTER;
 
 		if (isSafari()) {
 			// When setting the value by hand, Safari moves the cursor when typing in the middle of the text (See #1761)
@@ -917,17 +917,9 @@ class Input extends UI5Element {
 			return;
 		}
 
-		// Explicitly fire 'change' event before the 'submit' one.
-		// The native 'change' event is being dispatched after this code,
-		// execution, but it should be fired before the 'submit' event.
-		if (isSubmit) { // submit
-			this._isChangeFired = this.fireEvent(this.EVENT_CHANGE);
-			this.fireEvent(this.EVENT_SUBMIT);
-		}
-
 		// In IE, pressing the ENTER does not fire change
 		const valueChanged = (this.previousValue !== undefined) && (this.previousValue !== this.value);
-		if (isIE() && isSubmit && valueChanged) {
+		if (isIE() && this._isSubmit && valueChanged) {
 			this.fireEvent(this.EVENT_CHANGE);
 		}
 	}

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -704,8 +704,10 @@ class Input extends UI5Element {
 	 * @private
 	 */
 	_handleChange(event) {
-		if (document.activeElement !== this) {
+		if (!this._isChangeFired) {
 			this.fireEvent(this.EVENT_CHANGE);
+		} else {
+			this._isChangeFired = false;
 		}
 	}
 
@@ -922,7 +924,7 @@ class Input extends UI5Element {
 		// The native 'change' event is being dispatched after this code,
 		// execution, but it should be fired before the 'submit' event.
 		if (isSubmit) { // submit
-			this.fireEvent(this.EVENT_CHANGE);
+			this._isChangeFired = this.fireEvent(this.EVENT_CHANGE);
 			this.fireEvent(this.EVENT_SUBMIT);
 		}
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -694,12 +694,9 @@ class Input extends UI5Element {
 	}
 
 	/**
-	 * Fire 'change' event only if its triggered by focusout. Otherwise, when triggered
-	 * by press of the 'enter' key - it is fired manually in fireEventByAction() method
-	 * in order to be dispatched before the 'submit' event.
-	 *
-	 * Note: At this point the focused property is still not updated so the
-	 * 'document.activeElement' reference must be used.
+	 * Fire 'change' event only if its triggered by focusout. Otherwise, when
+	 * by press of the 'enter' key - it is fired in fireEventByAction() method
+	 * triggered in order to be dispatched before the 'submit' event.
 	 *
 	 * @private
 	 */

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -426,7 +426,6 @@
 		});
 
 		inputChangeSubmit.addEventListener("ui5-change", function() {
-
 			inputChangeSubmitResult.value = inputChangeSubmitResult.value + "Change"
 		});
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -134,6 +134,11 @@
 	<h3> Input test change result</h3>
 	<ui5-input id="inputChangeResult"></ui5-input>
 
+	<h3> Input test change is fired before submit on enter</h3>
+	<ui5-input id="inputChangeSubmit">	</ui5-input>
+	<h3> Input test change result</h3>
+	<ui5-input id="inputChangeSubmitResult"></ui5-input>
+
 	<h3>Input test ESC</h3>
 	<ui5-input id="myInputEsc"show-suggestions style="width: 100%">
 		<ui5-suggestion-item text="Chromium"></ui5-suggestion-item>
@@ -326,6 +331,8 @@
 		var labelChange = document.getElementById('myLabelChange');
 		var labelLiveChange = document.getElementById('myLabelLiveChange');
 		var labelSubmit = document.getElementById('myLabelSubmit');
+		var inputChangeSubmit = document.getElementById('inputChangeSubmit');
+		var inputChangeSubmitResult = document.getElementById('inputChangeSubmitResult');
 
 		var suggestionSelectedCounterWithGrouping = 0;
 
@@ -416,6 +423,15 @@
 		scrollInput.addEventListener("ui5-suggestion-scroll", function (event) {
 			scrollResult.value = event.detail.scrollTop;
 			console.log("scroll", { scrolltop: event.detail.scrollTop, container: event.detail.scrollContainer });
+		});
+
+		inputChangeSubmit.addEventListener("ui5-change", function() {
+
+			inputChangeSubmitResult.value = inputChangeSubmitResult.value + "Change"
+		});
+
+		inputChangeSubmit.addEventListener("ui5-submit", function() {
+			inputChangeSubmitResult.value = inputChangeSubmitResult.value + "Submit"
 		});
 	</script>
 </body>

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -103,10 +103,9 @@ describe("Input general interaction", () => {
 		input1.keys("b");
 		input1.keys("c");
 
-		// Click somewhere else to focus out - should fire change event.
 		inputResult.keys("Enter");
 
-		assert.strictEqual(inputResult.getValue(), "ChangeSubmit", "change is before submit");
+		assert.strictEqual(inputResult.getValue(), "ChangeSubmit", "'change' is before 'submit'");
 	});
 
 	it("fires input", () => {

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -93,6 +93,24 @@ describe("Input general interaction", () => {
 		assert.strictEqual(inputResult.getValue(), "2", "change is called twice");
 	});
 
+	it("fires change before 'submit' when ENTER is pressed", () => {
+		const input1 = $("#inputChangeSubmit").shadow$("input");
+		const inputResult = $("#inputChangeSubmitResult").shadow$("input");
+
+		let eventsFired = [];
+
+		// Start typing.
+		input1.click();
+		input1.keys("a");
+		input1.keys("b");
+		input1.keys("c");
+
+		// Click somewhere else to focus out - should fire change event.
+		inputResult.keys("Enter");
+
+		assert.strictEqual(inputResult.getValue(), "ChangeSubmit", "change is before submit");
+	});
+
 	it("fires input", () => {
 		const input2 = $("#input2").shadow$("input");
 		const inputLiveChangeResult = $("#inputLiveChangeResult").shadow$("input");

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -97,8 +97,6 @@ describe("Input general interaction", () => {
 		const input1 = $("#inputChangeSubmit").shadow$("input");
 		const inputResult = $("#inputChangeSubmitResult").shadow$("input");
 
-		let eventsFired = [];
-
 		// Start typing.
 		input1.click();
 		input1.keys("a");


### PR DESCRIPTION
The order of the triggering of the 'change' and 'submit' events when enter key is pressed is now reversed.

Fixes: #2436
