### PR TITLE
fix(ui5-input) center ValueState text

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -1109,7 +1109,7 @@ class Input extends UI5Element {
 			suggestionPopoverHeader: {
 				"display": this._listWidth === 0 ? "none" : "inline-block",
 				"width": `${this._listWidth}px`,
-				"padding": "0.5625rem 1rem",
+				"padding": "0.925rem 1rem",
 			},
 			suggestionsPopover: {
 				"max-width": `${this._inputWidth}px`,


### PR DESCRIPTION
ValueState text is now vertically centered in the Responsive Popover header of the suggestions.

