### PR TITLE
fix(ui5-icon): alignment issue in Safari

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -25,4 +25,5 @@
 .ui5-icon-root {
 	display:flex;
 	outline: none;
+	vertical-align: top;
 }


### PR DESCRIPTION
- ui5-icon-root SVG is now forced with style "vertical-align: top"
which fixes the misalignment.
- No regressions introduced in the rest of the browsers

FIXES: https://github.com/SAP/ui5-webcomponents/issues/913