### PR TITLE
refactor(ui5-input, ui5-textarea, ui5-date-*): allow letter spacing

### DIFF
--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -3,6 +3,9 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
+	line-height: normal;
+	letter-spacing: normal;
+	word-spacing: normal;
 }
 
 :host {
@@ -15,4 +18,7 @@
 	min-width: inherit;
 	color: inherit;
 	background-color: inherit;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -16,6 +16,9 @@
 	border: 1px solid var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
 	box-sizing: border-box;
+	line-height: normal;
+	letter-spacing: normal;
+	word-spacing: normal;
 }
 
 :host([focused]) {
@@ -53,7 +56,6 @@
 	font-style: inherit;
 	-webkit-appearance: none;
 	-moz-appearance: textfield;
-	line-height: normal;
 	padding: var(--_ui5_input_inner_padding);
 	box-sizing: border-box;
 	min-width: 3rem;
@@ -62,6 +64,9 @@
 	outline: none;
 	font-size: inherit;
 	font-family: inherit;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 [inner-input][inner-input-with-icon] {

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -13,6 +13,9 @@
 	border-color: var(--sapField_BorderColor);
 	border-radius: var(--_ui5_input_wrapper_border_radius);
 	box-sizing: border-box;
+	line-height: 1.4;
+	letter-spacing: normal;
+	word-spacing: normal;
 }
 
 :host([disabled]) {
@@ -57,7 +60,6 @@
 	height: 100%;
 	margin: 0;
 	padding: var(--_ui5_textarea_padding);
-	line-height: 1.4;
 	box-sizing: border-box;
 	color: inherit;
 	font-size: inherit;
@@ -72,6 +74,9 @@
 	background-color: var(--sapField_Background);
 	border-width: 1px;
 	border-style: solid;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 :host([growing]) .ui5-textarea-root {


### PR DESCRIPTION
Allow letter spacing in the Input, TextArea, DatePicker, DateTimePicker, DateRangePicker components with common letter spacing tool that is based on three CSS properties - line-height, letter-spacing and word-spacing by setting their default values to the host and inherit them in the native input element.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2755
FIXES: https://github.com/SAP/ui5-webcomponents/issues/2641