### PR TITLE
chore: Deprecate Internet Explorer 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,14 @@ of your application.
 
 ## Browser support
 
-UI5 Web Components are supported by all major modern browsers and can also run on IE11 with a [polyfill](https://www.webcomponents.org/polyfills).
+UI5 Web Components are supported by all major modern browsers.
 
-Browser | Support
+Browser | Supported versions
 --------|--------
-Chrome | Native
-Firefox | Native
-Safari | Native
-Edge | Native
-IE 11 | With Polyfill
-
-If your app needs to support **IE11**, please follow the [instructions](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Public%20Module%20Imports.md#1-old-browser-support-ie11).
+Chrome | Latest
+Firefox | Latest
+Safari | Latest
+Edge | Latest
 
 ## Project structure, development and build
 
@@ -128,8 +125,11 @@ Project | NPM Package | Description
 `base` | [UI5 Web Components Base](https://www.npmjs.com/package/@ui5/webcomponents-base) | The UI5 Web Components framework itself
 `theme-base` | [UI5 Web Components Theme Base](https://www.npmjs.com/package/@ui5/webcomponents-theme-base) | Theming assets (the default theme and additional accessibility themes)
 `localization` | [UI5 Web Components Localization](https://www.npmjs.com/package/@ui5/webcomponents-localization) | `i18n` functionality and `CLDR` assets
-`ie11` | [UI5 Web Components IE11](https://www.npmjs.com/package/@ui5/webcomponents-ie11) | Internet Explorer 11 polyfills and adapter code
+`ie11` * | [UI5 Web Components IE11](https://www.npmjs.com/package/@ui5/webcomponents-ie11) | Internet Explorer 11 polyfills and adapter code
 `playground` | N/A | The playground application
+
+`*` This package is deprecated as Internet Explorer 11 is no longer supported by UI5 Web Components. While the `@ui5/webcomponents-ie11` package allows UI5 Web Components to run on old browsers (IE11, legacy Edge) today,
+future compatibility is not guaranteed and the project may stop working on old browsers even with the aid of this package. Use at your own risk.
 
 ### How to run the project locally:
 

--- a/docs/Public Module Imports.md
+++ b/docs/Public Module Imports.md
@@ -203,45 +203,8 @@ Apart from i18n assets, the above import also provides the JSON, containing all 
 The `base` package provides not only the UI5 Web Components framework, but also some features, relevant to
 all UI5 Web Components.
 
-<a name="oldbrowsersupport"></a>
-### 1. Old browser support ( IE11)
-
-Most modern browsers  - **Chrome, Firefox, Safari, Edge (Chromium-based)**, support Web Components natively.
-
-If your app needs to run on **IE11**, you should import:
-
-```js
-import "@ui5/webcomponents-ie11/dist/features/IE11.js";
-```
-
-In addition, you should load the official Web Components polyfill in your index file, as described
-[here](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs).
-
-Please note that the aforementioned <code>webcomponents-loader.js</code> is not shipped as part of UI5 Web Components,
-but should be imported separately.
-
-Example:
-```html
-<script src="path/to/your/copy/of/webcomponents-loader.js"></script>
-<script src="path/to/your/javasacript/app.js" type="module"></script>
-```
-
-As shown in the example above, it's recommended to load the Web Components Polyfill first, and the web components next.
-
-Finally, there is an alternative to the `IE11.js` import:
-
-```js
-import "@ui5/webcomponents-ie11/dist/features/IE11WithWebComponentsPolyfill.js";
-```
-
-that includes the Web Components Polyfill too, so you don't have to import it manually.
-
-This may be useful in certain use cases when your app has polyfills of its own and you need to guarantee the order of execution.
-
-The three old browser support options are summarized below:
-
 <a name="theming"></a>
-### 2. Theming
+### 1. Theming
 
 UI5 Web Components ship with the default theme only out of the box.
 
@@ -288,7 +251,7 @@ For more general information on assets, click [here](https://sap.github.io/ui5-w
 Find out how you can bundle your themes more efficiently [here](Assets.md#bundling).
 
 <a name="internationalization"></a>
-### 3. Internationalization
+### 2. Internationalization
 
 The `base` project provides i18n support. 
 
@@ -316,7 +279,7 @@ For more general information on assets, click [here](https://sap.github.io/ui5-w
 
 Find out how you can bundle your i18n texts more efficiently [here](Assets.md#bundling).
 
-### 4. Advanced calendar types
+### 3. Advanced calendar types
 
 ```js
 import "@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js";
@@ -331,7 +294,7 @@ In order to be able to use Buddhist, Islamic, Japanese, or Persian calendar with
 (by setting its `primaryCalendarType` property), you should import one or more of the modules above.
 
 <a name="config"></a>
-### 5. Configuration
+### 4. Configuration
 
 ```js
 import { getTheme, setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
@@ -344,7 +307,7 @@ import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSet
 
 For more details, please check [Configuration](https://sap.github.io/ui5-webcomponents/playground/docs/configuration/).
 
-### 6. OpenUI5 integration
+### 5. OpenUI5 integration
 
 ```js
 import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
@@ -363,11 +326,7 @@ When you import the above module:
 Therefore, if you intend to run both frameworks in the same browser window,
 it is highly recommended to enable OpenUI5 support and benefit from these optimizations.
 
-*Note:* In general the order in which OpenUI5 and UI5 Web Components are loaded does not matter.
-However, if your app needs to support Internet Explorer 11, either load OpenUI5 first, or load
-UI5 Web Components deferred.
-
-### 7. Support for registering `i18n` resources in `.properties` format
+### 6. Support for registering `i18n` resources in `.properties` format
 
 ```js
 import "@ui5/webcomponents-base/dist/features/PropertiesFormatSupport.js";
@@ -392,7 +351,7 @@ registerI18nBundle("@ui5/webcomponents", {
 });
 ```
 
-### 8. Custom elements scoping
+### 7. Custom elements scoping
 
 ```js
 import { setCustomElementsScopingSuffix, setCustomElementsScopingRules } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";

--- a/packages/ie11/README.md
+++ b/packages/ie11/README.md
@@ -2,14 +2,51 @@
 
 # UI5 Web Components - IE11
 
+**DEPRECATED!** UI5 Web Components do not officially support Internet Explorer 11. While this package allows the project to
+run on legacy browsers, future compatibility is not guaranteed. Use at your own risk!
+
 [![Travis CI Build Status](https://travis-ci.org/SAP/ui5-webcomponents.svg?branch=master)](https://travis-ci.org/SAP/ui5-webcomponents)
 [![npm Package Version](https://badge.fury.io/js/%40ui5%2Fwebcomponents.svg)](https://www.npmjs.com/package/@ui5/webcomponents)
 
 Contains polyfills and adapter code for Internet Explorer 11
 
-This package transparently integrates Internet Explorer 11 support whenever any of these features is imported:
+This package transparently integrates Internet Explorer 11 support whenever any of these modules is imported:
  - `import "@ui5/webcomponents-ie11/dist/features/IE11.js";`
  - `import "@ui5/webcomponents-ie11/dist/features/IE11WithWebComponentsPolyfill.js";`
+ 
+## Running UI5 Web Components on Internet Explorer 11
+
+Most modern browsers  - **Chrome, Firefox, Safari, Edge (Chromium-based)**, support Web Components natively.
+
+If your app needs to run on **IE11**, you should import:
+
+```js
+import "@ui5/webcomponents-ie11/dist/features/IE11.js";
+```
+
+In addition, you should load the official Web Components polyfill in your index file, as described
+[here](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs).
+
+Please note that the aforementioned <code>webcomponents-loader.js</code> is not shipped as part of UI5 Web Components,
+but should be imported separately.
+
+Example:
+```html
+<script src="path/to/your/copy/of/webcomponents-loader.js"></script>
+<script src="path/to/your/javasacript/app.js" type="module"></script>
+```
+
+As shown in the example above, it's recommended to load the Web Components Polyfill first, and the web components next.
+
+Finally, there is an alternative to the `IE11.js` import:
+
+```js
+import "@ui5/webcomponents-ie11/dist/features/IE11WithWebComponentsPolyfill.js";
+```
+
+that includes the Web Components Polyfill too, so you don't have to import it manually.
+
+This may be useful in certain use cases when your app has polyfills of its own and you need to guarantee the order of execution.
  
 ## Resources
 - [UI5 Web Components - README.md](https://github.com/SAP/ui5-webcomponents/blob/master/README.md)


### PR DESCRIPTION
`UI5 Web Components` will no longer officially support `Internet Explorer 11` starting with `1.0.0-rc12`.

The `@ui5/webcomponents-11` package will continue to work and will be updated to keep the framework going in the near future, but compatibility is not guaranteed and the package might stop working at some point in the furure. 