### PR TITLE
docs: remove IE statement from Playground

### DIFF
--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -147,12 +147,11 @@ redirect_to: ./playground
                     </div>
                     <div class="compatibility-wrapper">
                         <span class="compatibility-header">Browser Compatibility</span>
-                        <p>UI5 Web Components are supported on all modern browsers and even one old-school browser:</p>
+                        <p>UI5 Web Components are supported on all modern browsers:</p>
                         <div class="image-wrapper">
                             <img class="logo-tiny" src="{{ "/assets/images/chrome.svg"| absolute_url }}" alt="Chrome Logo">
                             <img class="logo-tiny" src="{{ "/assets/images/firefox.svg"| absolute_url }}" alt="Firefox Logo">
                             <img class="logo-tiny" src="{{ "/assets/images/edge.svg"| absolute_url }}" alt="Edge Logo">
-                            <img class="logo-tiny" src="{{ "/assets/images/ie.svg"| absolute_url }}" alt="Internet Explorer 11 Logo">
                             <img class="logo-tiny" src="{{ "/assets/images/safari.svg"| absolute_url }}" alt="Safari Logo">
                         </div>
                     </div>


### PR DESCRIPTION
Remove statement for IE support and its logo