### PR TITLE
WorkInProgress - fix(ui5-li-notification): render showMore link without href

### DIFF
--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -81,7 +81,6 @@
 				?hidden="{{hideShowMore}}"
 				@click="{{_onShowMoreClick}}"
 				aria-hidden="true"
-				href="#" {{!--without href ENTER does not trigger click --}}
 				showMore-btn
 			>
 				{{showMoreText}}

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -43,6 +43,7 @@
 	</div>
 
 	<div class="group">
+		<h2>Link with no href or target</h2><ui5-input id="nohrefCounter" value="0"></ui5-input>
 		<ui5-link id="empty-link-1" class="samples-big-margin-right">Link with no href</ui5-link>
 		<ui5-link id="empty-link-2" class="samples-big-margin-right">Link with no target</ui5-link>
 	</div>
@@ -90,11 +91,17 @@
 		var link = document.querySelector("#link");
 		var linkClickPreventDefault = document.querySelector("#link-click-prevent-default");
 		var input = document.querySelector("#helper-input");
+		var emptyLink = document.querySelector("#empty-link-1");
+		var counter = 0;
 
 		[link, disLink].forEach(function(element) {
 			element.addEventListener("click", function(event) {
 				input.value = parseInt(input.value) + 1;
 			});
+		});
+
+		emptyLink.addEventListener("click", function(event) {
+			nohrefCounter.value = ++counter;
 		});
 
 		linkClickPreventDefault.addEventListener("click", function(event) {

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -11,9 +11,13 @@ describe("General API", () => {
 
 	it("tests href attributes", () => {
 		const link = browser.$("#empty-link-1");
+		const input = browser.$("#nohrefCounter");
 		const HREF_ATTRIBUTE = "https://www.sap.com/index.html";
 
 		assert.notOk(link.getAttribute("href"), "Render without 'href' by default");
+
+		link.click();
+		assert.strictEqual(input.getValue(), "1", "Click is fired.");
 
 		link.setAttribute("href", HREF_ATTRIBUTE);
 		assert.strictEqual(link.getAttribute("href"), HREF_ATTRIBUTE, "The href attribute is changed.");
@@ -46,7 +50,6 @@ describe("General API", () => {
 		});
 
 		assert.strictEqual(input.getValue(), "0", "Click should not be fired and value of input should not be changed.");
-
 	});
 
 	it("disabled link should not be enabled", () => {


### PR DESCRIPTION
By clicking on the showMore the location changes to '#' and this is now fixed as the href is removed. The link continues firing "click' and the More/Less functionality works as previously.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2778