### PR TITLE
refactor(ui5-multi-input): Fix DOM structure

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -780,10 +780,17 @@ class UI5Element extends HTMLElement {
 	}
 
 	/**
+	 * @private
+	 */
+	static _needsStaticArea() {
+		return !!this.staticAreaTemplate;
+	}
+
+	/**
 	 * @public
 	 */
 	getStaticAreaItemDomRef() {
-		if (!this.constructor.staticAreaTemplate) {
+		if (!this.constructor._needsStaticArea()) {
 			throw new Error("This component does not use the static area");
 		}
 

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -17,6 +17,7 @@ import isValidPropertyName from "./util/isValidPropertyName.js";
 import { isSlot, getSlotName, getSlottedElementsList } from "./util/SlotsHelper.js";
 import arraysAreEqual from "./util/arraysAreEqual.js";
 import { markAsRtlAware } from "./locale/RTLAwareRegistry.js";
+import isLegacyBrowser from "./isLegacyBrowser.js";
 
 let autoId = 0;
 
@@ -623,8 +624,17 @@ class UI5Element extends HTMLElement {
 			return;
 		}
 
+		this._assertShadowRootStructure();
+
 		return this.shadowRoot.children.length === 1
 			? this.shadowRoot.children[0] : this.shadowRoot.children[1];
+	}
+
+	_assertShadowRootStructure() {
+		const expectedChildrenCount = document.adoptedStyleSheets || isLegacyBrowser() ? 1 : 2;
+		if (this.shadowRoot.children.length !== expectedChildrenCount) {
+			console.warn(`The shadow DOM for ${this.constructor.getMetadata().getTag()} does not have a top level element, the getDomRef() method might not work as expected`); // eslint-disable-line
+		}
 	}
 
 	/**

--- a/packages/main/src/MultiInput.hbs
+++ b/packages/main/src/MultiInput.hbs
@@ -1,6 +1,7 @@
 {{>include "./Input.hbs"}}
-	<span id="{{_id}}-hiddenText-nMore" class="ui5-hidden-text">{{_tokensCountText}}</span>
+
 {{#*inline "preContent"}}
+	<span id="{{_id}}-hiddenText-nMore" class="ui5-hidden-text">{{_tokensCountText}}</span>
 	<ui5-tokenizer
 		class="ui5-multi-input-tokenizer"
 		.morePopoverOpener={{this}}


### PR DESCRIPTION
Each `UI5Element` instance is expected to have a single top-level DOM element, which is considered its `DOM Reference` (and returned by the `getDomRef` method. Usually this means that inside each `.hbs` template you are expected to create a single top-level DOM element, and lay out the component's structure inside it.

Changes:
 - Not having a top-level element in the shadow root produces a warning
 - `ui5-multi-input` DOM structure corrected to get rid of the warning for it.

Additionally, fixed an *unrelated* IE11 bug: the `createComponentStyleTag.js` method in the IE11 adaptor code is calling a non-existent function of `UI5Element.js`. This function was deleted by mistake and is now restored.