### PR TITLE
fix(ui5-multi-combobox): fix JS error on phone

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -81,9 +81,9 @@ const metadata = {
 		* @public
 		* @since 1.0.0-rc.9
 		*/
-	   icon: {
-		   type: HTMLElement,
-	   },
+		icon: {
+			type: HTMLElement,
+		},
 
 		/**
 		 * Defines the value state message that will be displayed as pop up under the <code>ui5-multi-combobox</code>.
@@ -398,6 +398,7 @@ class MultiComboBox extends UI5Element {
 		super();
 
 		this._filteredItems = [];
+		this.selectedValues = [];
 		this._inputLastValue = "";
 		this._deleting = false;
 		this._validationTimeout = null;


### PR DESCRIPTION
Fix JS error thrown on phone (Chrome phone emulator as well). It happens, because the selectedValues array is never declared, but accessed as "this.selectedValues.length" through the "_showAllItemsButtonPressed" getter upon initial rendering. To reproduce the issue you can use Chrome phone emulator and open https://sap.github.io/ui5-webcomponents/master/playground/main/pages/MultiComboBox/ on phone.