### PR TITLE
fix(ui5-popup): hide block layer if popup is closed

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -223,11 +223,15 @@ class Dialog extends Popup {
 	}
 
 	onEnterDOM() {
+		super.onEnterDOM();
+
 		ResizeHandler.register(this, this._screenResizeHandler);
 		ResizeHandler.register(document.body, this._screenResizeHandler);
 	}
 
 	onExitDOM() {
+		super.onExitDOM();
+
 		ResizeHandler.deregister(this, this._screenResizeHandler);
 		ResizeHandler.deregister(document.body, this._screenResizeHandler);
 	}

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -55,7 +55,7 @@ const metadata = {
 		},
 
 		/**
-		 * Indicates if the elements is open
+		 * Indicates if the element is open
 		 * @private
 		 * @type {boolean}
 		 * @defaultvalue false
@@ -204,6 +204,19 @@ class Popup extends UI5Element {
 
 	static get staticAreaStyles() {
 		return staticAreaStyles;
+	}
+
+	onEnterDOM() {
+		if (!this.isOpen()) {
+			this._blockLayerHidden = true;
+		}
+	}
+
+	onExitDOM() {
+		if (this.isOpen()) {
+			Popup.unblockBodyScrolling();
+			this._removeOpenedPopup();
+		}
 	}
 
 	get _displayProp() {
@@ -426,13 +439,6 @@ class Popup extends UI5Element {
 	 */
 	hide() {
 		this.style.display = "none";
-	}
-
-	onExitDOM() {
-		if (this.isOpen()) {
-			Popup.unblockBodyScrolling();
-			this._removeOpenedPopup();
-		}
 	}
 
 	/**

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -127,6 +127,17 @@ describe("Dialog general interaction", () => {
 
 		closeButton.click();
 	});
+
+	it("test dialog overlay when dialog isn't open", () => {
+		const isBlockLayerHidden = browser.executeAsync(async (done) => {
+			const dialog = document.getElementById("dialog");
+			const staticAreaItemDomRef = await dialog.getStaticAreaItemDomRef();
+
+			done(staticAreaItemDomRef.querySelector(".ui5-block-layer").hasAttribute("hidden"));
+		});
+
+		assert.ok(isBlockLayerHidden, "the block layer is hidden");
+	});
 });
 
 


### PR DESCRIPTION
The block layer is created when #getStaticAreaItemDomRef is called, but the attribute "hidden" is not set at that time. Now it's set on onEnterDOM hook, unless the popup is already opened.

Fixes: #2696

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
