### PR TITLE
fix(ui5-popup): prevent focus on elements below block layer

### DIFF
--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -8,6 +8,7 @@
 	dir="{{dir}}"
 	tabindex="-1"
 	@keydown={{_onkeydown}}
+	@focusout={{_onfocusout}}
 >
 
 	<span class="first-fe" data-ui5-focus-trap tabindex="0" @focusin={{forwardToLast}}></span>

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -249,6 +249,13 @@ class Popup extends UI5Element {
 		}
 	}
 
+	_onfocusout(e) {
+		// relatedTarget is the element, which will get focus. If no such element exists, focus the root
+		if (!e.relatedTarget) {
+			this._root.focus();
+		}
+	}
+
 	/**
 	 * Focus trapping
 	 * @private

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -498,7 +498,7 @@
 			popover.openBy(btnOpenDynamic);
 		});
 
-		btnOpenPopoverWithDiv.addEventListener("click", (event) => {
+		btnOpenPopoverWithDiv.addEventListener("click", function (event) {
 			popWithDiv.openBy(event.target);
 		});
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -377,6 +377,15 @@
 
 	<br>
 
+	<ui5-button id="btnOpenPopoverWithDiv">Open Popover with div Inside</ui5-button>
+
+	<ui5-popover id="popWithDiv" header-text="Newsletter subscription" modal>
+		<div id="divContent">I'm a div, which can't get focus. Click me and see where focus goes.</div>
+		<div slot="footer" class="popover-footer">
+			<ui5-button design="Emphasized">Subscribe</ui5-button>
+		</div>
+	</ui5-popover>
+
 	<script>
 		btn.addEventListener("click", function (event) {
 			pop.openBy(btn);
@@ -466,6 +475,10 @@
 		secondBtn.addEventListener("click", (event) => {
 			popNoFocusableContent.innerHTML = "Second button is clicked";
 			popNoFocusableContent.openBy(event.target);
+		});
+
+		btnOpenPopoverWithDiv.addEventListener("click", (event) => {
+			popWithDiv.openBy(event.target);
 		});
 	</script>
 </body>

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -250,6 +250,20 @@ describe("Popover general interaction", () => {
 
 		assert.ok(activeElementId, popoverId, "Popover remains focused");
 	});
+
+	it("tests focus when content, which can't be focused is clicked", () => {
+		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+
+		const popoverId = "popWithDiv";
+
+		$("#btnOpenPopoverWithDiv").click();
+
+		$("#divContent").click();
+
+		let activeElementId = $(browser.getActiveElement()).getAttribute("id");
+
+		assert.strictEqual(activeElementId, popoverId, "Popover is focused");
+	});
 });
 
 describe("Acc", () => {

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -254,13 +254,11 @@ describe("Popover general interaction", () => {
 	it("tests focus when content, which can't be focused is clicked", () => {
 		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
 
-		const popoverId = "popWithDiv";
-
 		$("#btnOpenPopoverWithDiv").click();
-
 		$("#divContent").click();
 
-		let activeElementId = $(browser.getActiveElement()).getAttribute("id");
+		const popoverId = "popWithDiv";
+		const activeElementId = $(browser.getActiveElement()).getAttribute("id");
 
 		assert.strictEqual(activeElementId, popoverId, "Popover is focused");
 	});


### PR DESCRIPTION
Problem:
The body element receives focus when an element inside the popup, which can't get focus (div, span) is clicked.
Then any element below the block layer can be focused.

Solution:
Don't let the focus leave the popup.

Fixes: #2626

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
