### PR TITLE
test: fix failing test on mac

### DIFF
--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -14,10 +14,10 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Custom Validation None", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
 		const daterangepicker = browser.$("#daterange-picker3");
 
 		daterangepicker.click();
-		daterangepicker.keys(["Control", "A"]);
 		daterangepicker.keys("09/09/2020 - 10/10/2020");
 		daterangepicker.keys("Enter");
 
@@ -39,10 +39,10 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("firstDateValue and lastDateValue getter", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
 		const daterangepicker = browser.$("#daterange-picker4");
 
 		daterangepicker.click();
-		browser.keys(["Control", "A"]);
 		browser.keys("27/09/2019 - 10/10/2019");
 		browser.keys("Enter");
 
@@ -149,10 +149,10 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Enter keyboard key confirms the date range in the input field", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
 		const dateRangePicker = browser.$("#daterange-picker5");
 		dateRangePicker.click();
-		
-		browser.keys(["Control", "A"]);
+
 		browser.keys("Jul 17, 2020 @ Jul 16, 2020");
 
 		browser.keys("Enter");
@@ -160,9 +160,9 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Focus out of the input field confirms the date range", () => {
+		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
 		const dateRangePicker = browser.$("#daterange-picker5");
 		dateRangePicker.click();
-		browser.keys(["Control", "A"]);
 		browser.keys("Jul 17, 2020 @ Jul 16, 2020");
 
 		browser.keys("Tab");


### PR DESCRIPTION
- DateRangePicker test is using CTRL-A to reset
the state from the previous test.
- This fails on mac, so a quick fix is to
reopen the page to get a clean state.
- A follow-up fix will use a separate component so that tests do not
depend on the state of the previous test