### PR TITLE
chore: imrpove bundle size reporting

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -30,8 +30,8 @@ const getPlugins = ({ transpile }) => {
 
 	if (!process.env.DEV) {
 		plugins.push(filesize({
-			render : function (options, bundle, { minSize, gzipSize, brotliSize, bundleSize }){
-				return gzipSize;
+			render : function (options, bundle, { minSize, gzipSize, brotliSize, bundleSize, fileName }){
+				return fileName.padEnd(35) + " " + minSize + " / gzipped: " + gzipSize
 			}
 		}));
 	}


### PR DESCRIPTION
dynamic imports of assets introduce many new bundles, this change
improves the output

before:
```
bundle.esm.js → dist/resources...
164.4 KB
4.86 KB
4.61 KB
4.61 KB
```

after:
```
bundle.esm.js → dist/resources...
bundle.esm.js                       732.13 KB / gzipped: 164.37 KB
messagebundle_ar-5a7e48c6.js        55 B / gzipped: 75 B
messagebundle_bg-6490eb0a.js        55 B / gzipped: 75 B
messagebundle_ca-ee9b3967.js        55 B / gzipped: 75 B
```