### PR TITLE
fix(ui5-button): set icon-only attribute (#2567)

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -378,7 +378,7 @@ class Button extends UI5Element {
 	}
 
 	get isIconOnly() {
-		return !Array.from(this.childNodes).filter(node =>{
+		return !Array.from(this.childNodes).filter(node => {
 		    return node.nodeType !== Node.COMMENT_NODE
             && ( node.nodeType !== Node.TEXT_NODE || node.nodeValue.trim().length !== 0)
         }).length;

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -378,7 +378,10 @@ class Button extends UI5Element {
 	}
 
 	get isIconOnly() {
-		return !Array.from(this.childNodes).filter(node => node.nodeType !== Node.COMMENT_NODE).length;
+		return !Array.from(this.childNodes).filter(node =>{
+		    return node.nodeType !== Node.COMMENT_NODE
+            && ( node.nodeType !== Node.TEXT_NODE || node.nodeValue.trim().length !== 0)
+        }).length;
 	}
 
 	get accInfo() {

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -29,7 +29,8 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-	<ui5-button icon="home"><!----><!----></ui5-button>
+	<ui5-button icon="home" id="icon-only-comment"><!----><!----></ui5-button>
+	<ui5-button icon="text" id="icon-only-blank-text"></ui5-button>
 	<ui5-button>
 		<ui5-avatar
 			id="btnImage"

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -30,7 +30,7 @@
 
 <body style="background-color: var(--sapBackgroundColor);">
 	<ui5-button icon="home" id="icon-only-comment"><!----><!----></ui5-button>
-	<ui5-button icon="text" id="icon-only-blank-text"></ui5-button>
+	<ui5-button icon="text" id="icon-only-blank-text"> </ui5-button>
 	<ui5-button>
 		<ui5-avatar
 			id="btnImage"

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -26,6 +26,14 @@ describe("Button general interaction", () => {
 		assert.strictEqual(btnImage.isDisplayed(), true, "Btn image is rendered");
 	});
 
+    it("tests button's icon only rendering", () => {
+        const oButtonIconOnlyComment = browser.$("#icon-only-comment");
+        const oButtonIconOnlyBlankText = browser.$("#icon-only-blank-text");
+
+        assert.strictEqual(oButtonIconOnlyComment.getAttribute("icon-only"), "", "Button comment has attribute icon-only");
+        assert.strictEqual(oButtonIconOnlyBlankText.getAttribute("icon-only"), "", "Button blank text has attribute icon-only");
+    });
+
 	it("tests click event", () => {
 		const button = browser.$("#button1");
 		const field = browser.$("#click-counter");
@@ -92,5 +100,5 @@ describe("Button general interaction", () => {
 		button.removeAttribute("aria-expanded");
 
 		assert.strictEqual(innerButton.getAttribute("aria-expanded"), null, "Attribute is reflected");
-	})
+	});
 });


### PR DESCRIPTION
Issue: When a ui5-button is created with blank text inside the component, for example
 `<ui5-button icon="message-information"> </ui5-button>`, the attribute "icon-only" isn't set correctly. 
Solution: Trim the node value when node is type of "TEXT_NODE" and check the length of the trimmed value.

FIXES: #2567