### PR TITLE
fix(ui5-checkbox): set aria-hidden attribute

### DIFF
--- a/packages/main/src/CheckBox.hbs
+++ b/packages/main/src/CheckBox.hbs
@@ -24,7 +24,7 @@
 				?checked="{{checked}}"
 				?readonly="{{readonly}}"
 				?disabled="{{disabled}}"
-				role="none"
+				aria-hidden="true"
 				data-sap-no-tab-ref
 			/>
 		</div>


### PR DESCRIPTION
Input element now has aria-hidden="true" instead of role="none", to not be mapped to the accessibility tree.

Fixes: #2786