### PR TITLE
chore: fix and improve JSDoc

### DIFF
--- a/packages/fiori/src/Bar.js
+++ b/packages/fiori/src/Bar.js
@@ -29,6 +29,7 @@ const metadata = {
 	},
 	slots: /** @lends sap.ui.webcomponents.fiori.Bar.prototype */ {
 		/**
+		 * Defines the content at the start of the bar
 		 * @type {HTMLElement[]}
 		 * @slot
 		 * @public
@@ -37,6 +38,7 @@ const metadata = {
 			type: HTMLElement,
 		},
 		/**
+		 * Defines the content in the middle of the bar
 		 * @type {HTMLElement[]}
 		 * @slot
 		 * @public
@@ -45,6 +47,7 @@ const metadata = {
 			type: HTMLElement,
 		},
 		/**
+		 * Defines the content at the end of the bar
 		 * @type {HTMLElement[]}
 		 * @slot
 		 * @public

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -64,7 +64,7 @@ const metadata = {
 		 * usually <code>ui5-li-notification</code> items.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -97,7 +97,7 @@ const metadata = {
 		/**
 		 * Defines the elements, dipalyed in the footer of the of the <code>ui5-li-notification</code>.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot footnotes
 		 * @public
 		 */
 		footnotes: {
@@ -111,10 +111,10 @@ const metadata = {
 		 * usually a description of the notification.
 		 *
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
-		 * @slot
+		 * @slot description
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/Page.js
+++ b/packages/fiori/src/Page.js
@@ -93,7 +93,7 @@ const metadata = {
 		 * Defines the content HTML Element.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot content
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/ProductSwitch.js
+++ b/packages/fiori/src/ProductSwitch.js
@@ -29,7 +29,7 @@ const metadata = {
 		 * Defines the items of the <code>ui5-product-switch</code>.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -175,7 +175,7 @@ const metadata = {
 		 * You can use the &nbsp;&lt;ui5-shellbar-item>&lt;/ui5-shellbar-item>.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -43,7 +43,7 @@ const metadata = {
 		 * inside the items.
 		 *
 		 * @public
-		 * @slot
+		 * @slot items
 		 */
 		"default": {
 			propertyName: "items",

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -87,7 +87,7 @@ const metadata = {
 		 *
 		 * @type {HTMLElement[]}
 		 * @public
-		 * @slot
+		 * @slot items
 		 */
 		"default": {
 			propertyName: "items",

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -21,7 +21,7 @@ const metadata = {
 		 * Determines the content of the <code>ui5-timeline</code>.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -105,7 +105,7 @@ const metadata = {
 		 * <br><b>Note:</b> Use <code>ui5-upload-collection-item</code> for the intended design.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -84,7 +84,7 @@ const metadata = {
 		 *
 		 * @type {HTMLElement[]}
 		 * @public
-		 * @slot
+		 * @slot steps
 		 */
 		"default": {
 			propertyName: "steps",

--- a/packages/fiori/src/types/BarDesign.js
+++ b/packages/fiori/src/types/BarDesign.js
@@ -1,7 +1,7 @@
 import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
 
 /**
- * @lends sap.ui.webcomponents.main.types.BarDesign.prototype
+ * @lends sap.ui.webcomponents.fiori.types.BarDesign.prototype
  * @public
  */
 const BarTypes = {
@@ -39,7 +39,7 @@ const BarTypes = {
  * Different types of Bar.
  * @constructor
  * @author SAP SE
- * @alias sap.ui.webcomponents.main.types.BarDesign
+ * @alias sap.ui.webcomponents.fiori.types.BarDesign
  * @public
  * @enum {string}
  */

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -100,7 +100,7 @@ const metadata = {
 		 * @public
 		 */
 		shape: {
-			type: String,
+			type: AvatarShape,
 			defaultValue: AvatarShape.Circle,
 		},
 
@@ -120,7 +120,7 @@ const metadata = {
 		 * @public
 		 */
 		size: {
-			type: String,
+			type: AvatarSize,
 			defaultValue: AvatarSize.S,
 		},
 
@@ -145,7 +145,7 @@ const metadata = {
 		 * @public
 		 */
 		imageFitType: {
-			type: String,
+			type: AvatarFitType,
 			defaultValue: AvatarFitType.Cover,
 		},
 
@@ -171,7 +171,7 @@ const metadata = {
 		 * @public
 		 */
 		backgroundColor: {
-			type: String,
+			type: AvatarBackgroundColor,
 			defaultValue: AvatarBackgroundColor.Accent6,
 		},
 

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -106,7 +106,7 @@ const metadata = {
 		 * Moreover, if you use avatars with "Square" shape, there will be visual inconsistency
 		 * as the built-in overflow action has "Circle" shape.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -37,7 +37,7 @@ const metadata = {
 	slots: /** @lends sap.ui.webcomponents.main.Badge.prototype */ {
 		/**
 		 * Defines the text of the <code>ui5-badge</code>.
-		 * <br><b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <br><b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -222,7 +222,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-button</code>.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -81,7 +81,7 @@ const metadata = {
 		 * Defines the selected date or dates (depending on the <code>selectionMode</code> property) for this calendar as instances of <code>ui5-date</code>
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot dates
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -29,7 +29,7 @@ const metadata = {
 		/**
 		 * Defines the content of the <code>ui5-card</code>.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot content
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -158,7 +158,7 @@ const metadata = {
 		/**
 		 * Defines the content of the <code>ui5-carousel</code>.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot content
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -38,7 +38,7 @@ const metadata = {
 		/**
 		 * Defines the <code>ui5-color-palette-item</code> items.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot colors
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -242,7 +242,7 @@ const metadata = {
 		 * <br> <br>
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -15,7 +15,7 @@ import dialogCSS from "./generated/themes/Dialog.css.js";
  */
 const metadata = {
 	tag: "ui5-dialog",
-	slots: /** @lends  sap.ui.webcomponents.main.Popup.prototype */ {
+	slots: /** @lends  sap.ui.webcomponents.main.Dialog.prototype */ {
 		/**
 		 * Defines the header HTML Element.
 		 *

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -153,7 +153,7 @@ const metadata = {
 		 * By default the <code>ui5-file-uploader</code> contains a single input field. With this slot you can pass any content that you wish to add. See the samples for more information.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot content
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -21,7 +21,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-li-groupheader</code>.
 		 * <br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -87,7 +87,7 @@ const metadata = {
 		 * also automatically imports the &lt;ui5-suggestion-item> for your convenience.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot suggestionItems
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -69,7 +69,7 @@ const metadata = {
 	slots: /** @lends sap.ui.webcomponents.main.Label.prototype */ {
 		/**
 		 * Defines the text of the <code>ui5-label</code>.
-		 * <br><b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <br><b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -126,7 +126,7 @@ const metadata = {
 	slots: /** @lends sap.ui.webcomponents.main.Link.prototype */ {
 		/**
 		 * Defines the text of the <code>ui5-link</code>.
-		 * <br><b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <br><b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -46,7 +46,7 @@ const metadata = {
 		 * <b>Note:</b> Use <code>ui5-li</code>, <code>ui5-li-custom</code>, and <code>ui5-li-groupheader</code> for the intended design.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -66,8 +66,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-messagestrip</code>.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements,
-		 * it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -64,7 +64,7 @@ const metadata = {
 		 * <br> <br>
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Option.js
+++ b/packages/main/src/Option.js
@@ -66,7 +66,16 @@ const metadata = {
 			type: String,
 		},
 	},
-	slots: {
+	slots: /** @lends sap.ui.webcomponents.main.Option.prototype */ {
+		/**
+		 * Defines the text of the <code>ui5-option</code>.
+		 * <br><br>
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 *
+		 * @type {Node[]}
+		 * @slot
+		 * @public
+		 */
 		"default": {
 			type: Node,
 		},

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -31,7 +31,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use the <code>ui5-togglebutton</code> for the intended design.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot buttons
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -63,7 +63,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use the <code>ui5-option</code> component to define the desired options.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot options
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -98,7 +98,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-li</code>.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -49,7 +49,7 @@ const metadata = {
 		 *
 		 * @type {HTMLElement[]}
 		 * @public
-		 * @slot
+		 * @slot items
 		 */
 		"default": {
 			propertyName: "items",

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -35,7 +35,7 @@ const metadata = {
 		 * <b>Note:</b> Use <code>ui5-table-row</code> for the intended design.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot rows
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -18,7 +18,7 @@ const metadata = {
 		 * <b>Note:</b> Use <code>ui5-table-cell</code> for the intended design.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot cells
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -43,7 +43,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-title</code>.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -84,7 +84,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-toast</code> web component.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -107,7 +107,7 @@ const metadata = {
 		 * <b>Note:</b> Use <code>ui5-tree-item</code> for the intended design.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/TreeItem.js
+++ b/packages/main/src/TreeItem.js
@@ -99,7 +99,7 @@ const metadata = {
 		 * Defines the items of this <code>ui5-tree-item</code>.
 		 *
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot items
 		 * @public
 		 */
 		"default": {

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -141,7 +141,7 @@ const metadata = {
 		/**
 		 * Defines the text of the <code>ui5-li-tree</code>.
 		 * <br><br>
-		 * <b>Note:</b> Аlthough this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+		 * <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
 		 *
 		 * @type {Node[]}
 		 * @slot

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -15,7 +15,7 @@ const getScripts = (options) => {
 		lintfix: "eslint . --config config/.eslintrc.js --fix",
 		prepare: "nps clean build.templates build.styles build.i18n build.jsonImports copy build.samples",
 		build: {
-			default: "nps build.samples",
+			default: "nps lint prepare build.bundle",
 			templates: `mkdirp dist/generated/templates && node "${LIB}/hbs2ui5/index.js" -d src/ -o dist/generated/templates`,
 			styles: {
 				default: "nps build.styles.themes build.styles.components",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -15,7 +15,7 @@ const getScripts = (options) => {
 		lintfix: "eslint . --config config/.eslintrc.js --fix",
 		prepare: "nps clean build.templates build.styles build.i18n build.jsonImports copy build.samples",
 		build: {
-			default: "nps lint prepare build.bundle",
+			default: "nps build.samples",
 			templates: `mkdirp dist/generated/templates && node "${LIB}/hbs2ui5/index.js" -d src/ -o dist/generated/templates`,
 			styles: {
 				default: "nps build.styles.themes build.styles.components",

--- a/packages/tools/lib/documentation/index.js
+++ b/packages/tools/lib/documentation/index.js
@@ -10,8 +10,13 @@ const Handlebars = require('handlebars/dist/handlebars.min.js');
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
+const beautify = require("json-beautify");
 
-const api = JSON.parse(fs.readFileSync(path.normalize(process.argv[2])));
+
+const apiJSONPath = path.normalize(process.argv[2]);
+const api = JSON.parse(fs.readFileSync(apiJSONPath));
+
+fs.writeFileSync(apiJSONPath, beautify(api, null, 2, 100));
 
 const entries = api['symbols'];
 const compiledHandlebars = Handlebars.compile(template);

--- a/packages/tools/lib/jsdoc/plugin.js
+++ b/packages/tools/lib/jsdoc/plugin.js
@@ -2060,9 +2060,11 @@ exports.defineTags = function(dictionary) {
 	});
 
 	dictionary.defineTag('slot', {
-		mustNotHaveValue: true,
 		onTagged: function(doclet, tag) {
 			doclet.slot = true;
+			if (tag.value) {
+				doclet.propertyName = tag.value;
+			}
 		}
 	});
 

--- a/packages/tools/lib/jsdoc/template/publish.js
+++ b/packages/tools/lib/jsdoc/template/publish.js
@@ -2838,6 +2838,9 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				if (member.slot) {
 					tag("property");
 					attrib("name", member.name);
+					if (member.propertyName) {
+						attrib("propertyName", member.propertyName);
+					}
 					if (member.__ui5.module && member.__ui5.module !== symbol.__ui5.module) {
 						attrib("module", member.__ui5.module);
 						attrib("export", undefined, '', true);


### PR DESCRIPTION
Tooling changes:
 - the JSDoc plugin now allows the `@slot` annotation to have a value
 - The `documentation/index.js` now also prettifies `api.json` generated by JSDoc (for easier debugging)


Changes:
 - All components: document the `propertyName` in the `@slot` annotation
 - `Bar.js`: document the 3 slots
 - `BarDesign.js`: fix the library in the namespace (main -> fiori)
 - Several components: the word "Although" in the JSDoc of the text slot was with a cyrillic capital A -> changed to latin
 - `Dialog.js`: fixed jsdoc for the slots (did not appear due to wrong namespace)
 - `Option.js`: documented the default slot