### PR TITLE
chore: fix JSDoc for several types

### DIFF
--- a/packages/main/src/types/CalendarSelectionMode.js
+++ b/packages/main/src/types/CalendarSelectionMode.js
@@ -1,11 +1,41 @@
 import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
 
+/**
+ * @lends sap.ui.webcomponents.main.types.CalendarSelectionMode.prototype
+ * @public
+ */
 const CalendarSelectionModes = {
+	/**
+	 * Only one date can be selected at a time
+	 * @public
+	 * @type {Single}
+	 */
 	Single: "Single",
+
+	/**
+	 * Several dates can be selected
+	 * @public
+	 * @type {Multiple}
+	 */
 	Multiple: "Multiple",
+
+	/**
+	 * A range defined by a start date and an end date can be selected
+	 * @public
+	 * @type {Range}
+	 */
 	Range: "Range",
 };
 
+/**
+ * @class
+ * Different date selection modes for <code>ui5-calendar</code>.
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.types.CalendarSelectionMode
+ * @public
+ * @enum {string}
+ */
 class CalendarSelectionMode extends DataType {
 	static isValid(value) {
 		return !!CalendarSelectionModes[value];

--- a/packages/main/src/types/CarouselArrowsPlacement.js
+++ b/packages/main/src/types/CarouselArrowsPlacement.js
@@ -8,14 +8,14 @@ const CarouselArrowsPlacementTypes = {
 	/**
 	 * Carousel arrows are placed on the sides of the current Carousel page.
 	 * @public
-	 * @type {Default}
+	 * @type {Content}
 	 */
 	Content: "Content",
 
 	/**
 	 * Carousel arrows are placed on the sides of the page indicator of the Carousel.
 	 * @public
-	 * @type {Positive}
+	 * @type {Navigation}
 	 */
 	Navigation: "Navigation",
 };

--- a/packages/main/src/types/InputType.js
+++ b/packages/main/src/types/InputType.js
@@ -6,42 +6,42 @@ import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
  */
 const InputTypes = {
 	/**
-	 * <ui5-input type="text"></ui5-input> defines a one-line text input field:
+	 * Defines a one-line text input field:
 	 * @public
 	 * @type {Text}
 	 */
 	Text: "Text",
 
 	/**
-	 * The <ui5-input type="email"></ui5-input> is used for input fields that must contain an e-mail address.
+	 * Used for input fields that must contain an e-mail address.
 	 * @public
 	 * @type {Email}
 	 */
 	Email: "Email",
 
 	/**
-	 * The <ui5-input type="number"></ui5-input> defines a numeric input field.
+	 * Defines a numeric input field.
 	 * @public
 	 * @type {Number}
 	 */
 	Number: "Number",
 
 	/**
-	 * <ui5-input type="password"></ui5-input> defines a password field.
+	 * Defines a password field.
 	 * @public
 	 * @type {Password}
 	 */
 	Password: "Password",
 
 	/**
-	 * The <ui5-input type="url"></ui5-input> is used for input fields that should contain a telephone number.
+	 * Used for input fields that should contain a telephone number.
 	 * @public
 	 * @type {Tel}
 	 */
 	Tel: "Tel",
 
 	/**
-	 * The <i5-input type="url"></ui5-input> is used for input fields that should contain a URL address.
+	 * Used for input fields that should contain a URL address.
 	 * @public
 	 * @type {URL}
 	 */

--- a/packages/main/src/types/PopoverPlacementType.js
+++ b/packages/main/src/types/PopoverPlacementType.js
@@ -22,7 +22,7 @@ const PopoverPlacementTypes = {
 	/**
 	 * Popover will be placed at the top of the reference element.
 	 * @public
-	 * @type {Bottom}
+	 * @type {Top}
 	 */
 	Top: "Top",
 


### PR DESCRIPTION
Changes:
 - `CalendarSelectionMode` was not documented and not parsed by JSDoc at all
 - `CarouselArrowsPlacement` and `PopoverPlacementType` had wrong values
 - `InputTypes` has strange descriptions