### PR TITLE
chore: fix several property types

### DIFF
--- a/packages/main/src/Option.js
+++ b/packages/main/src/Option.js
@@ -60,6 +60,7 @@ const metadata = {
 		/**
 		 * Defines the stable selector that you can use via getStableDomRef method.
 		 * @public
+		 * @type {string}
 		 * @since 1.0.0-rc.11
 		 */
 		stableDomRef: {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -188,7 +188,7 @@ const metadata = {
 		 *
 		 * @event sap.ui.webcomponents.main.TabContainer#tab-select
 		 * @param {HTMLElement} tab The selected <code>tab</code>.
-		 * @param {Number} tabIndex The selected <code>tab</code> index.
+		 * @param {Integer} tabIndex The selected <code>tab</code> index.
 		 * @public
 		 */
 		"tab-select": {

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -31,7 +31,7 @@ const metadata = {
 		 * <br>
 		 * For further responsive design options, see <code>demandPopin</code> property.
 		 *
-		 * @type {number}
+		 * @type {Integer}
 		 * @defaultvalue Infinity
 		 * @public
 		 */

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -128,7 +128,7 @@ const metadata = {
 		 * <li>The CSS <code>height</code> property wins over the <code>rows</code> property, if both are set.</li>
 		 * </ul>
 		 *
-		 * @type {number}
+		 * @type {Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -140,7 +140,7 @@ const metadata = {
 		/**
 		 * Defines the maximum number of characters that the <code>value</code> can have.
 		 *
-		 * @type {number}
+		 * @type {Integer}
 		 * @defaultValue null
 		 * @public
 		 */
@@ -181,7 +181,7 @@ const metadata = {
 		/**
 		 * Defines the maximum number of lines that the Web Component can grow.
 		 *
-		 * @type {number}
+		 * @type {Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */


### PR DESCRIPTION
Fixes:
 - `Option.js`: the type of `stableDomRef` is not documented
 - Several components: use `Integer` instead of `Number` or `number`.