### PR TITLE
fix(ui5-input): remove the 'submit' event

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -373,18 +373,6 @@ const metadata = {
 		input: {},
 
 		/**
-		 * Fired when user presses Enter key on the <code>ui5-input</code>.
-		 * <br><br>
-		 * <b>Note:</b> The event is fired independent of whether there was a change before or not.
-		 * If change was performed, the event is fired after the change event.
-		 * The event is also fired when an item of the select list is selected by pressing Enter.
-		 *
-		 * @event
-		 * @public
-		 */
-		submit: {},
-
-		/**
 		 * Fired when a suggestion item, that is displayed in the suggestion popup, is selected.
 		 *
 		 * @event sap.ui.webcomponents.main.Input#suggestion-item-select
@@ -520,7 +508,6 @@ class Input extends UI5Element {
 		this.highlightValue = "";
 
 		// all sementic events
-		this.EVENT_SUBMIT = "submit";
 		this.EVENT_CHANGE = "change";
 		this.EVENT_INPUT = "input";
 		this.EVENT_SUGGESTION_ITEM_SELECT = "suggestion-item-select";
@@ -884,7 +871,6 @@ class Input extends UI5Element {
 		}
 
 		const inputValue = await this.getInputValue();
-		const isSubmit = action === this.ACTION_ENTER;
 		const isUserInput = action === this.ACTION_USER_INPUT;
 
 		const input = await this.getInputDOMRef();
@@ -909,13 +895,9 @@ class Input extends UI5Element {
 			return;
 		}
 
-		if (isSubmit) { // submit
-			this.fireEvent(this.EVENT_SUBMIT);
-		}
-
 		// In IE, pressing the ENTER does not fire change
 		const valueChanged = (this.previousValue !== undefined) && (this.previousValue !== this.value);
-		if (isIE() && isSubmit && valueChanged) {
+		if (isIE() && action === this.ACTION_ENTER && valueChanged) {
 			this.fireEvent(this.EVENT_CHANGE);
 		}
 	}

--- a/packages/main/src/StepInput.hbs
+++ b/packages/main/src/StepInput.hbs
@@ -42,7 +42,6 @@
 			._inputAccInfo ="{{accInfo}}"
 			._nativeInputAttributes="{{inputAttributes}}"
 			@ui5-change="{{_onInputChange}}"
-			@ui5-submit="{{_onInputChange}}"
 			@focusout="{{_onInputFocusOut}}"
 			@focusin="{{_onInputFocusIn}}"
 	>

--- a/packages/main/src/StepInput.js
+++ b/packages/main/src/StepInput.js
@@ -11,6 +11,7 @@ import {
 	isPageUpShift,
 	isPageDownShift,
 	isEscape,
+	isEnter,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
@@ -563,6 +564,11 @@ class StepInput extends UI5Element {
 	_onkeydown(event) {
 		let preventDefault = true;
 		if (this.disabled || this.readonly) {
+			return;
+		}
+
+		if (isEnter(event)) {
+			this._onInputChange();
 			return;
 		}
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -230,7 +230,7 @@
 		<ui5-li>Compact</ui5-li>
 		<ui5-li>Condensed</ui5-li>
 		<ui5-li>Cozy</ui5-li>
-		<ui5-li>Compact</ui5-li>	
+		<ui5-li>Compact</ui5-li>
 		<ui5-li>Condensed</ui5-li>
 		<ui5-li>Cozy</ui5-li>
 		<ui5-li>Compact</ui5-li>
@@ -326,11 +326,17 @@
 			if (event.key === 'Enter') {
 				var formToSubmit = document.getElementById("submit-form");
 				var submitEvent = new Event('submit');
+				
+				/* The old way - supported by all browsers:
+				The submit method of the form won't trigger
+				a submit event by itself, dispatch it manually */
 
-				// The submit method of the form won't trigger
-				// a submit event by itself, dispatch it manually
-				formToSubmit.dispatchEvent(submitEvent);
-				formToSubmit.submit();
+				// formToSubmit.dispatchEvent(submitEvent);
+				// formToSubmit.submit();
+
+				// Fires submit event and submits
+				// No MS IE11 & Safari support yet
+				formToSubmit.requestSubmit()
 			}
 		});
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -18,7 +18,6 @@
 	<h3> Input with suggestions: type 'a'</h3>
 	<ui5-label id="myLabel">Event [suggestionItemSelect] :: N/A</ui5-label><br/>
 	<ui5-label id="myLabelChange">Event [change] :: N/A</ui5-label><br/>
-	<ui5-label id="myLabelSubmit">Event [submit] :: N/A</ui5-label><br/>
 	<ui5-label id="myLabelLiveChange">Event [input] :: N/A</ui5-label><br/>
 
 	<div>
@@ -335,7 +334,6 @@
 		var label = document.getElementById('myLabel');
 		var labelChange = document.getElementById('myLabelChange');
 		var labelLiveChange = document.getElementById('myLabelLiveChange');
-		var labelSubmit = document.getElementById('myLabelSubmit');
 
 		var suggestionSelectedCounterWithGrouping = 0;
 
@@ -390,10 +388,6 @@
 			labelChange.innerHTML = "Event [change] :: " + event.target.value;
 		});
 
-		input.addEventListener("ui5-submit", function (event) {
-			labelSubmit.innerHTML = "Event [submit] :: " + event.target.value;
-		});
-
 		var changeCounter = 0;
 		var inputCounter = 0;
 		var suggestionSelectedCounter = 0;
@@ -416,9 +410,6 @@
 
 		var inputChangeResultCounter = 0;
 
-		inputChange.addEventListener("ui5-submit", function (event) {
-			inputChange.value = "Changed via API";
-		});
 		inputChange.addEventListener("ui5-change", function (event) {
 			inputChangeResult.value = ++inputChangeResultCounter;
 		});

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -219,13 +219,18 @@
 		<ui5-icon slot="icon" name="decline" style="padding-left: 8px; padding-right: 8px"></ui5-icon>
 	</ui5-input>
 
+	<h3> Input firing submit event and submit action on 'ENTER' in a form</h3>
+	<form id="submit-form">
+		<ui5-input id="submit-input" name="my-submit-input" placeholder="Type something and press 'ENTER' ..."></ui5-input>
+	</form>
+
 	<h3> Test scroll pos</h3>
 	<ui5-input id="scrollInput" show-suggestions>
 		<ui5-li>Cozy</ui5-li>
 		<ui5-li>Compact</ui5-li>
 		<ui5-li>Condensed</ui5-li>
 		<ui5-li>Cozy</ui5-li>
-		<ui5-li>Compact</ui5-li>
+		<ui5-li>Compact</ui5-li>	
 		<ui5-li>Condensed</ui5-li>
 		<ui5-li>Cozy</ui5-li>
 		<ui5-li>Compact</ui5-li>
@@ -317,6 +322,23 @@
 	</style>
 
 	<script>
+		document.getElementById("submit-input").addEventListener("keypress", function(event) {
+			if (event.key === 'Enter') {
+				var formToSubmit = document.getElementById("submit-form");
+				var submitEvent = new Event('submit');
+
+				// The submit method of the form won't trigger
+				// a submit event by itself, dispatch it manually
+				formToSubmit.dispatchEvent(submitEvent);
+				formToSubmit.submit();
+			}
+		});
+
+		document.getElementById("submit-form").addEventListener("submit", function(event) {
+			event.preventDefault();
+			alert("Submitted");
+		});
+
 		btnOpenDialog.addEventListener("click", function () {
 			dialog.open();
 		});


### PR DESCRIPTION
The 'submit' event fired from the `ui5-input` component is now removed as it is an event of the 'form' element and not of the input ones. From now on, the submit (event) must be triggered manually when enter key is pressed.

BREAKING CHANGE: the 'submit' event is now removed. The 'submit' functionality must be added with a custom code -  listen for the standard "keydown" event and check if ENTER is pressed to submit a form containing the input component.


