### PR TITLE
chore: Introduce the notion of interfaces for the purpose of JSDoc

### DIFF
--- a/packages/fiori/src/Interfaces.js
+++ b/packages/fiori/src/Interfaces.js
@@ -1,0 +1,92 @@
+/**
+ * Interface for components that may be slotted as an action inside <code>ui5-li-notification</code> and <code>ui5-li-notification-group</code>
+ *
+ * @name sap.ui.webcomponents.fiori.INotificationAction
+ * @interface
+ * @public
+ */
+const INotificationAction = "sap.ui.webcomponents.fiori.INotificationAction";
+
+/**
+ * Interface for components that may be slotted inside a notification list
+ *
+ * @name sap.ui.webcomponents.fiori.INotificationListItem
+ * @interface
+ * @public
+ */
+const INotificationListItem = "sap.ui.webcomponents.fiori.INotificationListItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-product-switch</code> as items
+ *
+ * @name sap.ui.webcomponents.fiori.IProductSwitchItem
+ * @interface
+ * @public
+ */
+const IProductSwitchItem = "sap.ui.webcomponents.fiori.IProductSwitchItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-shellbar</code> as items
+ *
+ * @name sap.ui.webcomponents.fiori.IShellBarItem
+ * @interface
+ * @public
+ */
+const IShellBarItem = "sap.ui.webcomponents.fiori.IShellBarItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-side-navigation</code> as items
+ *
+ * @name sap.ui.webcomponents.fiori.ISideNavigationItem
+ * @interface
+ * @public
+ */
+const ISideNavigationItem = "sap.ui.webcomponents.fiori.ISideNavigationItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-side-navigation-item</code> as sub-items
+ *
+ * @name sap.ui.webcomponents.fiori.ISideNavigationSubItem
+ * @interface
+ * @public
+ */
+const ISideNavigationSubItem = "sap.ui.webcomponents.fiori.ISideNavigationSubItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-timeline</code> as items
+ *
+ * @name sap.ui.webcomponents.fiori.ITimelineItem
+ * @interface
+ * @public
+ */
+const ITimelineItem = "sap.ui.webcomponents.fiori.ITimelineItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-upload-collection</code> as items
+ *
+ * @name sap.ui.webcomponents.fiori.IUploadCollectionItem
+ * @interface
+ * @public
+ */
+const IUploadCollectionItem = "sap.ui.webcomponents.fiori.IUploadCollectionItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-wizard</code> as wizard steps
+ *
+ * @name sap.ui.webcomponents.fiori.IWizardStep
+ * @interface
+ * @public
+ */
+const IWizardStep = "sap.ui.webcomponents.fiori.IWizardStep";
+
+export {
+	INotificationAction,
+	INotificationListItem,
+	IProductSwitchItem,
+	IShellBarItem,
+	ISideNavigationItem,
+	ISideNavigationSubItem,
+	ITimelineItem,
+	IUploadCollectionItem,
+	IWizardStep,
+};

--- a/packages/fiori/src/NotificationAction.js
+++ b/packages/fiori/src/NotificationAction.js
@@ -78,6 +78,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.fiori.NotificationAction
  * @extends UI5Element
  * @tagname ui5-notification-action
+ * @implements sap.ui.webcomponents.fiori.INotificationAction
  * @public
  */
 class NotificationAction extends UI5Element {

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -63,7 +63,7 @@ const metadata = {
 		 * Defines the items of the <code>ui5-li-notification-group</code>,
 		 * usually <code>ui5-li-notification</code> items.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.INotificationListItem[]}
 		 * @slot items
 		 * @public
 		 */
@@ -116,6 +116,7 @@ const metadata = {
  * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
  * @appenddocs NotificationAction
+ * @implements sap.ui.webcomponents.main.IListItem
  * @public
  */
 class NotificationListGroupItem extends NotificationListItemBase {

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -86,7 +86,7 @@ const metadata = {
 		 * we recommend using avatars with 2rem X 2rem in size (32px X 32px). In case you are using the <code>ui5-avatar</code>
 		 * you can set its <code>size</code><code> property to <code>XS</code> to get the required size - <code><ui5-avatar size="XS"></code>.
 		 *
-		 * @type {HTMLElement}
+		 * @type {sap.ui.webcomponents.main.IAvatar}
 		 * @slot
 		 * @public
 		 */
@@ -161,6 +161,7 @@ const metadata = {
  * @tagname ui5-li-notification
  * @appenddocs NotificationAction
  * @since 1.0.0-rc.8
+ * @implements sap.ui.webcomponents.fiori.INotificationListItem, sap.ui.webcomponents.main.IListItem
  * @public
  */
 class NotificationListItem extends NotificationListItemBase {

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -86,7 +86,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> use the <code>ui5-notification-action</code> component.
 		 *
-		 * @type {HTMLElement}
+		 * @type {sap.ui.webcomponents.fiori.INotificationAction[]}
 		 * @slot
 		 * @public
 		 */

--- a/packages/fiori/src/ProductSwitch.js
+++ b/packages/fiori/src/ProductSwitch.js
@@ -28,7 +28,7 @@ const metadata = {
 		/**
 		 * Defines the items of the <code>ui5-product-switch</code>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.IProductSwitchItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/fiori/src/ProductSwitchItem.js
+++ b/packages/fiori/src/ProductSwitchItem.js
@@ -135,6 +135,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-product-switch-item
  * @public
+ * @implements sap.ui.webcomponents.fiori.IProductSwitchItem
  * @since 1.0.0-rc.5
  */
 class ProductSwitchItem extends UI5Element {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -174,7 +174,7 @@ const metadata = {
 		 * <b>Note:</b>
 		 * You can use the &nbsp;&lt;ui5-shellbar-item>&lt;/ui5-shellbar-item>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.IShellBarItem[]}
 		 * @slot items
 		 * @public
 		 */
@@ -190,7 +190,7 @@ const metadata = {
 		 *
 		 * Note: We recommend not using the <code>size</code> attribute of <code>ui5-avatar</code> because
 		 * it should have specific size by design in the context of <code>ui5-shellbar</code> profile.
-		 * @type {HTMLElement}
+		 * @type {sap.ui.webcomponents.main.IAvatar}
 		 * @slot
 		 * @since 1.0.0-rc.6
 		 * @public
@@ -202,7 +202,7 @@ const metadata = {
 		/**
 		 * Defines the logo of the <code>ui5-shellbar</code>.
 		 * For example, you can use <code>ui5-avatar</code> or <code>img</code> elements as logo.
-		 * @type {HTMLElement}
+		 * @type {sap.ui.webcomponents.main.IAvatar}
 		 * @slot
 		 * @since 1.0.0-rc.8
 		 * @public
@@ -217,7 +217,7 @@ const metadata = {
 		 * <b>Note:</b>
 		 * You can use the &nbsp;&lt;ui5-li>&lt;/ui5-li> and its ancestors.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IListItem[]}
 		 * @slot
 		 * @since 0.10
 		 * @public
@@ -229,7 +229,7 @@ const metadata = {
 		/**
 		 * Defines the <code>ui5-input</code>, that will be used as a search field.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IInput}
 		 * @slot
 		 * @public
 		 */
@@ -242,7 +242,7 @@ const metadata = {
 		 * We encourage this slot to be used for a back or home button.
 		 * It gets overstyled to match ShellBar's styling.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IButton}
 		 * @slot
 		 * @public
 		 */

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -79,6 +79,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.fiori.ShellBarItem
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-shellbar-item
+ * @implements sap.ui.webcomponents.fiori.IShellBarItem
  * @public
  */
 class ShellBarItem extends UI5Element {

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -43,6 +43,7 @@ const metadata = {
 		 * inside the items.
 		 *
 		 * @public
+		 * @type {sap.ui.webcomponents.fiori.ISideNavigationItem[]}
 		 * @slot items
 		 */
 		"default": {
@@ -58,6 +59,7 @@ const metadata = {
 		 * <b>Note:</b> The header is displayed when the component is expanded - the property <code>collapsed</code> is false;
 		 *
 		 * @public
+		 * @type {HTMLElement[]}
 		 * @since 1.0.0-rc.11
 		 * @slot
 		 */
@@ -72,6 +74,7 @@ const metadata = {
 		 * <b>Note:</b> In order to achieve the best user experience, it is recommended that you keep the fixed items "flat" (do not pass sub-items)
 		 *
 		 * @public
+		 * @type {sap.ui.webcomponents.fiori.ISideNavigationItem[]}
 		 * @slot
 		 */
 		fixedItems: {

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -85,7 +85,7 @@ const metadata = {
 		/**
 		 * If you wish to nest menus, you can pass inner menu items to the default slot.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.ISideNavigationSubItem[]}
 		 * @public
 		 * @slot items
 		 */
@@ -116,6 +116,7 @@ const metadata = {
  * @tagname ui5-side-navigation-item
  * @public
  * @since 1.0.0-rc.8
+ * @implements sap.ui.webcomponents.fiori.ISideNavigationItem
  */
 class SideNavigationItem extends UI5Element {
 	static get metadata() {

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -74,6 +74,7 @@ const metadata = {
  * @tagname ui5-side-navigation-sub-item
  * @public
  * @since 1.0.0-rc.8
+ * @implements sap.ui.webcomponents.fiori.ISideNavigationSubItem
  */
 class SideNavigationSubItem extends UI5Element {
 	static get metadata() {

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -20,7 +20,7 @@ const metadata = {
 		/**
 		 * Determines the content of the <code>ui5-timeline</code>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.ITimelineItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/fiori/src/TimelineItem.js
+++ b/packages/fiori/src/TimelineItem.js
@@ -116,6 +116,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.fiori.TimelineItem
  * @extends UI5Element
  * @tagname ui5-timeline-item
+ * @implements sap.ui.webcomponents.fiori.ITimelineItem
  * @public
  */
 class TimelineItem extends UI5Element {

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -104,7 +104,7 @@ const metadata = {
 		 * Defines the items of the <code>ui5-upload-collection</code>.
 		 * <br><b>Note:</b> Use <code>ui5-upload-collection-item</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.IUploadCollectionItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -234,6 +234,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-upload-collection-item
  * @public
+ * @implements sap.ui.webcomponents.fiori.IUploadCollectionItem
  * @since 1.0.0-rc.7
  */
 class UploadCollectionItem extends ListItem {

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -82,7 +82,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use the available <code>ui5-wizard-step</code> component.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.fiori.IWizardStep[]}
 		 * @public
 		 * @slot steps
 		 */

--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -160,6 +160,8 @@ const metadata = {
  * @alias sap.ui.webcomponents.fiori.WizardStep
  * @extends UI5Element
  * @tagname ui5-wizard-step
+ * @since 1.0.0-rc.10
+ * @implements sap.ui.webcomponents.fiori.IWizardStep
  * @public
  */
 class WizardStep extends UI5Element {

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -236,6 +236,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-avatar
  * @since 1.0.0-rc.6
+ * @implements sap.ui.webcomponents.main.IAvatar
  * @public
  */
 class Avatar extends UI5Element {

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -105,7 +105,7 @@ const metadata = {
 		 * <b>Note:</b> The UX guidelines recommends using avatars with "Circle" shape.
 		 * Moreover, if you use avatars with "Square" shape, there will be visual inconsistency
 		 * as the built-in overflow action has "Circle" shape.
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IAvatar[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -50,7 +50,7 @@ const metadata = {
 		/**
 		 * Defines the <code>ui5-icon</code> to be displayed in the <code>ui5-badge</code>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IIcon}
 		 * @slot
 		 * @public
 		 */

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -280,6 +280,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.Button
  * @extends UI5Element
  * @tagname ui5-button
+ * @implements sap.ui.webcomponents.main.IButton
  * @public
  */
 class Button extends UI5Element {

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -80,7 +80,7 @@ const metadata = {
 		/**
 		 * Defines the selected date or dates (depending on the <code>selectionMode</code> property) for this calendar as instances of <code>ui5-date</code>
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ICalendarDate[]}
 		 * @slot dates
 		 * @public
 		 */

--- a/packages/main/src/CalendarDate.js
+++ b/packages/main/src/CalendarDate.js
@@ -31,6 +31,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.CalendarDate
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-date
+ * @implements sap.ui.webcomponents.main.ICalendarDate
  * @public
  */
 class CalendarDate extends UI5Element {

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -37,7 +37,7 @@ const metadata = {
 	slots: /** @lends sap.ui.webcomponents.main.ColorPalette.prototype */ {
 		/**
 		 * Defines the <code>ui5-color-palette-item</code> items.
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IColorPaletteItem[]}
 		 * @slot colors
 		 * @public
 		 */

--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -73,6 +73,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-color-palette-item
  * @since 1.0.0-rc.12
+ * @implements sap.ui.webcomponents.main.IColorPaletteItem
  * @public
  */
 class ColorPaletteItem extends UI5Element {

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -241,7 +241,7 @@ const metadata = {
 		 * &lt;/ui5-combobox>
 		 * <br> <br>
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IComboBoxItem[]}
 		 * @slot items
 		 * @public
 		 */
@@ -271,7 +271,7 @@ const metadata = {
 		/**
 		 * Defines the icon to be displayed in the input field.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IIcon}
 		 * @slot
 		 * @public
 		 * @since 1.0.0-rc.9

--- a/packages/main/src/ComboBoxItem.js
+++ b/packages/main/src/ComboBoxItem.js
@@ -35,6 +35,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.ComboBoxItem
  * @extends UI5Element
  * @tagname ui5-cb-item
+ * @implements sap.ui.webcomponents.main.IComboBoxItem
  * @public
  */
 class ComboBoxItem extends UI5Element {

--- a/packages/main/src/CustomListItem.js
+++ b/packages/main/src/CustomListItem.js
@@ -38,6 +38,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.CustomListItem
  * @extends ListItem
  * @tagname ui5-li-custom
+ * @implements sap.ui.webcomponents.main.IListItem
  * @public
  */
 class CustomListItem extends ListItem {

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -44,6 +44,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.GroupHeaderListItem
  * @extends ListItemBase
  * @tagname ui5-li-groupheader
+ * @implements sap.ui.webcomponents.main.IListItem
  * @public
  */
 class GroupHeaderListItem extends ListItemBase {

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -164,6 +164,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.Icon
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-icon
+ * @implements sap.ui.webcomponents.main.IIcon
  * @public
  */
 class Icon extends UI5Element {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -86,7 +86,7 @@ const metadata = {
 		 * <br>
 		 * also automatically imports the &lt;ui5-suggestion-item> for your convenience.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IInputSuggestionItem[]}
 		 * @slot suggestionItems
 		 * @public
 		 */

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -53,7 +53,7 @@ const metadata = {
 		/**
 		 * Defines the icon to be displayed in the <code>ui5-input</code>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IIcon}
 		 * @slot
 		 * @public
 		 */

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -1,0 +1,162 @@
+/**
+ * Interface for components that may be slotted for components wherever an avatar is expected such as <code>ui5-avatar-group</code>
+ *
+ * @name sap.ui.webcomponents.main.IAvatar
+ * @interface
+ * @public
+ */
+const IAvatar = "sap.ui.webcomponents.main.IAvatar";
+
+/**
+ * Interface for components that may be used as a button inside numerous higher-order components
+ *
+ * @name sap.ui.webcomponents.main.IButton
+ * @interface
+ * @public
+ */
+const IButton = "sap.ui.webcomponents.main.IButton";
+
+/**
+ * Interface for components that may be used as dates inside <code>ui5-calendar</code>
+ *
+ * @name sap.ui.webcomponents.main.ICalendarDate
+ * @interface
+ * @public
+ */
+const ICalendarDate = "sap.ui.webcomponents.main.ICalendarDate";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-combobox</code>
+ *
+ * @name sap.ui.webcomponents.main.IComboBoxItem
+ * @interface
+ * @public
+ */
+const IComboBoxItem = "sap.ui.webcomponents.main.IComboBoxItem";
+
+/**
+ * Interface for components that may be used inside a <code>ui5-color-palette</code>
+ *
+ * @name sap.ui.webcomponents.main.IColorPaletteItem
+ * @interface
+ * @public
+ */
+const IColorPaletteItem = "sap.ui.webcomponents.main.IColorPaletteItem";
+
+/**
+ * Interface for components that represent an icon, usable in numerous higher-order components
+ *
+ * @name sap.ui.webcomponents.main.IIcon
+ * @interface
+ * @public
+ */
+const IIcon = "sap.ui.webcomponents.main.IIcon";
+
+/**
+ * Interface for components that represent an input, usable in numerous higher-order components
+ *
+ * @name sap.ui.webcomponents.main.IInput
+ * @interface
+ * @public
+ */
+const IInput = "sap.ui.webcomponents.main.IInput";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-list</code> as items
+ *
+ * @name sap.ui.webcomponents.main.IListItem
+ * @interface
+ * @public
+ */
+const IListItem = "sap.ui.webcomponents.main.IListItem";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-multi-combobox</code> as items
+ *
+ * @name sap.ui.webcomponents.main.IMultiComboBoxItem
+ * @interface
+ * @public
+ */
+const IMultiComboBoxItem = "sap.ui.webcomponents.main.IMultiComboBoxItem";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-select</code> as options
+ *
+ * @name sap.ui.webcomponents.main.ISelectOption
+ * @interface
+ * @public
+ */
+const ISelectOption = "sap.ui.webcomponents.main.ISelectOption";
+
+/**
+ * Interface for components that may be slotted inside <code>ui5-tabcontainer</code>
+ *
+ * @name sap.ui.webcomponents.main.ITab
+ * @interface
+ * @public
+ */
+const ITab = "sap.ui.webcomponents.main.ITab";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-table</code> as rows
+ *
+ * @name sap.ui.webcomponents.main.ITableRow
+ * @interface
+ * @public
+ */
+const ITableRow = "sap.ui.webcomponents.main.ITableRow";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-table</code> as columns
+ *
+ * @name sap.ui.webcomponents.main.ITableColumn
+ * @interface
+ * @public
+ */
+const ITableColumn = "sap.ui.webcomponents.main.ITableColumn";
+
+/**
+ * Interface for components that may be slotted inside a <code>ui5-table-row</code> as cells
+ *
+ * @name sap.ui.webcomponents.main.ITableCell
+ * @interface
+ * @public
+ */
+const ITableCell = "sap.ui.webcomponents.main.ITableCell";
+
+/**
+ * Interface for components that represent a token and are usable in components such as <code>ui5-multi-input</code>
+ *
+ * @name sap.ui.webcomponents.main.IToken
+ * @interface
+ * @public
+ */
+const IToken = "sap.ui.webcomponents.main.IToken";
+
+/**
+ * Interface for tree items for the purpose of <code>ui5-tree</code>
+ *
+ * @name sap.ui.webcomponents.main.ITreeItem
+ * @interface
+ * @public
+ */
+const ITreeItem = "sap.ui.webcomponents.main.ITreeItem";
+
+export {
+	IAvatar,
+	IButton,
+	ICalendarDate,
+	IColorPaletteItem,
+	IComboBoxItem,
+	IIcon,
+	IInput,
+	IListItem,
+	IMultiComboBoxItem,
+	ISelectOption,
+	ITab,
+	ITableCell,
+	ITableColumn,
+	ITableRow,
+	IToken,
+	ITreeItem,
+};

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -62,6 +62,15 @@ const IIcon = "sap.ui.webcomponents.main.IIcon";
 const IInput = "sap.ui.webcomponents.main.IInput";
 
 /**
+ * Interface for components that represent a suggestion item, usable in <code>ui5-input</code>
+ *
+ * @name sap.ui.webcomponents.main.IInputSuggestionItem
+ * @interface
+ * @public
+ */
+const IInputSuggestionItem = "sap.ui.webcomponents.main.IInputSuggestionItem";
+
+/**
  * Interface for components that may be slotted inside a <code>ui5-list</code> as items
  *
  * @name sap.ui.webcomponents.main.IListItem
@@ -150,6 +159,7 @@ export {
 	IComboBoxItem,
 	IIcon,
 	IInput,
+	IInputSuggestionItem,
 	IListItem,
 	IMultiComboBoxItem,
 	ISelectOption,

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -1,5 +1,5 @@
 /**
- * Interface for components that may be slotted for components wherever an avatar is expected such as <code>ui5-avatar-group</code>
+ * Interface for components that represent an avatar and may be slotted in numerous higher-order components such as <code>ui5-avatar-group</code>
  *
  * @name sap.ui.webcomponents.main.IAvatar
  * @interface

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -45,7 +45,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-li</code>, <code>ui5-li-custom</code>, and <code>ui5-li-groupheader</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IListItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -85,7 +85,7 @@ const metadata = {
 		 *
 		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 *
-		 * @type {HTMLElement}
+		 * @type {sap.ui.webcomponents.main.IIcon}
          * @slot
 		 * @public
 		 */

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -63,7 +63,7 @@ const metadata = {
 		 * &lt;/ui5-multi-combobox>
 		 * <br> <br>
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IMultiComboBoxItem[]}
 		 * @slot items
 		 * @public
 		 */
@@ -76,7 +76,7 @@ const metadata = {
 		/**
 		* Defines the icon to be displayed in the <code>ui5-multi-combobox</code>.
 		*
-		* @type {HTMLElement[]}
+		* @type {sap.ui.webcomponents.main.IIcon}
 		* @slot
 		* @public
 		* @since 1.0.0-rc.9

--- a/packages/main/src/MultiComboBoxItem.js
+++ b/packages/main/src/MultiComboBoxItem.js
@@ -34,6 +34,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.MultiComboBoxItem
  * @extends ComboBoxItem
  * @tagname ui5-mcb-item
+ * @implements sap.ui.webcomponents.main.IMultiComboBoxItem
  * @public
  */
 class MultiComboBoxItem extends ComboBoxItem {

--- a/packages/main/src/MultiInput.js
+++ b/packages/main/src/MultiInput.js
@@ -50,7 +50,7 @@ const metadata = {
 		 * &lt;/ui5-multi-input>
 		 * <br> <br>
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IToken[]}
 		 * @slot
 		 * @public
 		 */

--- a/packages/main/src/Option.js
+++ b/packages/main/src/Option.js
@@ -96,6 +96,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.Option
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-option
+ * @implements sap.ui.webcomponents.main.ISelectOption
  * @public
  */
 class Option extends UI5Element {

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -30,7 +30,7 @@ const metadata = {
 		 * <b>Note:</b> Multiple buttons are allowed.
 		 * <br><br>
 		 * <b>Note:</b> Use the <code>ui5-togglebutton</code> for the intended design.
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IButton[]}
 		 * @slot buttons
 		 * @public
 		 */

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -62,7 +62,7 @@ const metadata = {
 		 *
 		 * <br><br>
 		 * <b>Note:</b> Use the <code>ui5-option</code> component to define the desired options.
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ISelectOption[]}
 		 * @slot options
 		 * @public
 		 */

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -123,6 +123,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.StandardListItem
  * @extends ListItem
  * @tagname ui5-li
+ * @implements sap.ui.webcomponents.main.IListItem
  * @public
  */
 class StandardListItem extends ListItem {

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -139,6 +139,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.SuggestionItem
  * @extends UI5Element
  * @tagname ui5-suggestion-item
+ * @implements sap.ui.webcomponents.main.IInputSuggestionItem
  * @public
  */
 class SuggestionItem extends UI5Element {

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -144,6 +144,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.Tab
  * @extends UI5Element
  * @tagname ui5-tab
+ * @implements sap.ui.webcomponents.main.ITab
  * @public
  */
 class Tab extends UI5Element {

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -47,7 +47,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-tab</code> and <code>ui5-tab-separator</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITab[]}
 		 * @public
 		 * @slot items
 		 */
@@ -64,7 +64,7 @@ const metadata = {
 		/**
 		 * Defines the button which will open the overflow menu. If nothing is provided to this slot, the default button will be used.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IButton}
 		 * @public
 		 * @slot
 		 * @since 1.0.0-rc.9

--- a/packages/main/src/TabSeparator.js
+++ b/packages/main/src/TabSeparator.js
@@ -18,6 +18,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.TabSeparator
  * @extends UI5Element
  * @tagname ui5-tab-separator
+ * @implements sap.ui.webcomponents.main.ITab
  * @public
  */
 class TabSeparator extends UI5Element {

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -34,7 +34,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-table-row</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITableRow[]}
 		 * @slot rows
 		 * @public
 		 */
@@ -49,7 +49,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-table-column</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITableColumn[]}
 		 * @slot
 		 * @public
 		 */

--- a/packages/main/src/TableCell.js
+++ b/packages/main/src/TableCell.js
@@ -61,6 +61,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.TableCell
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-table-cell
+ * @implements sap.ui.webcomponents.main.ITableCell
  * @public
  */
 class TableCell extends UI5Element {

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -101,6 +101,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.TableColumn
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-table-column
+ * @implements sap.ui.webcomponents.main.ITableColumn
  * @public
  */
 class TableColumn extends UI5Element {

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -17,7 +17,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-table-cell</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITableCell[]}
 		 * @slot cells
 		 * @public
 		 */
@@ -58,6 +58,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.TableRow
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-table-row
+ * @implements sap.ui.webcomponents.main.ITableRow
  * @public
  */
 class TableRow extends UI5Element {

--- a/packages/main/src/Token.js
+++ b/packages/main/src/Token.js
@@ -74,7 +74,7 @@ const metadata = {
 		 * Defines the close icon for the token. If nothing is provided to this slot, the default close icon will be used.
 		 * Accepts <code>ui5-icon</code>
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.IIcon}
 		 * @slot
 		 * @public
 		 * @since 1.0.0-rc.9
@@ -127,6 +127,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-token
  * @since 1.0.0-rc.9
+ * @implements sap.ui.webcomponents.main.IToken
  * @public
  */
 class Token extends UI5Element {

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -106,7 +106,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-tree-item</code> for the intended design.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITreeItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/main/src/TreeItem.js
+++ b/packages/main/src/TreeItem.js
@@ -98,7 +98,7 @@ const metadata = {
 		/**
 		 * Defines the items of this <code>ui5-tree-item</code>.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {sap.ui.webcomponents.main.ITreeItem[]}
 		 * @slot items
 		 * @public
 		 */
@@ -131,6 +131,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-tree-item
  * @public
+ * @implements sap.ui.webcomponents.main.ITreeItem
  * @since 1.0.0-rc.8
  */
 class TreeItem extends UI5Element {

--- a/packages/tools/lib/documentation/index.js
+++ b/packages/tools/lib/documentation/index.js
@@ -126,7 +126,7 @@ const generateSamplePage = entry => {
 	if (content) {
 		entry.slots.forEach(slotData => {
 			if (!slotData.type.startsWith("Node") && !slotData.type.startsWith("HTMLElement")) { // interface -> don't show in documentation
-				slotData.type = "HTMLElement" + (slotData.endsWith("[]") ? "[]" : "");
+				slotData.type = "HTMLElement" + (slotData.type.endsWith("[]") ? "[]" : "");
 			}
 		});
 		const APIReference = compiledHandlebars(entry).replace(/\[\]/g, " [0..n]");

--- a/packages/tools/lib/documentation/index.js
+++ b/packages/tools/lib/documentation/index.js
@@ -126,7 +126,7 @@ const generateSamplePage = entry => {
 	if (content) {
 		entry.slots.forEach(slotData => {
 			if (!slotData.type.startsWith("Node") && !slotData.type.startsWith("HTMLElement")) { // interface -> don't show in documentation
-				slotData.type = "HTMLElement[]";
+				slotData.type = "HTMLElement" + (slotData.endsWith("[]") ? "[]" : "");
 			}
 		});
 		const APIReference = compiledHandlebars(entry).replace(/\[\]/g, " [0..n]");

--- a/packages/tools/lib/documentation/index.js
+++ b/packages/tools/lib/documentation/index.js
@@ -124,6 +124,11 @@ const generateSamplePage = entry => {
 	} catch (err) { }
 
 	if (content) {
+		entry.slots.forEach(slotData => {
+			if (!slotData.type.startsWith("Node") && !slotData.type.startsWith("HTMLElement")) { // interface -> don't show in documentation
+				slotData.type = "HTMLElement[]";
+			}
+		});
 		const APIReference = compiledHandlebars(entry).replace(/\[\]/g, " [0..n]");
 		const EntitySince = compiledSinceTemplate(entry).replace(/\[\]/g, " [0..n]");
 


### PR DESCRIPTION
Changes:
 - Components packages get an `Interfaces.js` file. This file documents all interfaces for this package and exports them as strings. They are currently not imported by any module, therefore irrelevant for the runtime.
 - Each component that requires specific components in order to look and work well, now documents the required components via interfaces for each slot separately. The `@type` annotation is used. Additionally, multiple items may be specified via `[]` as for `HTMLElement`.

**Important: the new interfaces are not shown in the Playground. It will continue to show `HTMLElement / HTMLElement[]` instead, like before.**
See the changes to `documentation/index.js`.