### PR TITLE
chore: minor JSDoc fixes

### DIFF
--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -42,7 +42,6 @@ const metadata = {
 		 * for the top-level items, and the <code>ui5-side-navigation-sub-item</code> component for second-level items, nested
 		 * inside the items.
 		 *
-		 * @type {HTMLElement[]}
 		 * @public
 		 * @type {sap.ui.webcomponents.fiori.ISideNavigationItem[]}
 		 * @slot items
@@ -59,7 +58,6 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> The header is displayed when the component is expanded - the property <code>collapsed</code> is false;
 		 *
-		 * @type {HTMLElement[]}
 		 * @public
 		 * @type {HTMLElement[]}
 		 * @since 1.0.0-rc.11
@@ -75,7 +73,6 @@ const metadata = {
 		 *
 		 * <b>Note:</b> In order to achieve the best user experience, it is recommended that you keep the fixed items "flat" (do not pass sub-items)
 		 *
-		 * @type {HTMLElement[]}
 		 * @public
 		 * @type {sap.ui.webcomponents.fiori.ISideNavigationItem[]}
 		 * @slot

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -59,7 +59,7 @@ const metadata = {
 		 * Defines the width of the <code>ui5-wizard</code>.
 		 * @private
 		 */
-		width: {
+		_width: {
 			type: Float,
 		},
 
@@ -413,7 +413,7 @@ class Wizard extends UI5Element {
 	 * @private
 	 */
 	onStepResize() {
-		this.width = this.getBoundingClientRect().width;
+		this._width = this.getBoundingClientRect().width;
 		this.contentHeight = this.getContentHeight();
 
 		if (this.responsivePopover && this.responsivePopover.opened) {
@@ -441,7 +441,7 @@ class Wizard extends UI5Element {
 	_adjustHeaderOverflow() {
 		let counter = 0;
 		let isForward = true;
-		const iWidth = this.width;
+		const iWidth = this._width;
 		const iCurrStep = this.getSelectedStepIndex();
 		const iStepsToShow = this.steps.length ? Math.floor(iWidth / MIN_STEP_WIDTH_WITH_TITLE) : Math.floor(iWidth / MIN_STEP_WIDTH_NO_TITLE);
 
@@ -699,7 +699,7 @@ class Wizard extends UI5Element {
 			return true;
 		}
 
-		return this.width <= Wizard.PHONE_BREAKPOINT;
+		return this._width <= Wizard.PHONE_BREAKPOINT;
 	}
 
 	get navAriaRoleDescription() {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -464,6 +464,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-input
  * @appenddocs SuggestionItem
+ * @implements sap.ui.webcomponents.main.IInput
  * @public
  */
 class Input extends UI5Element {


### PR DESCRIPTION
Changes:
 - some minor JSDoc fixes
 - `Wizard.js`: the private `width` property renamed to `_width` so that `width` is free for the OpenUI5 wrapper and consistent with the rest of the controls.