### PR TITLE
fix(framework): adaprt ie11 package for usage in modern browsers

### DIFF
--- a/packages/base/src/DOMObserver.js
+++ b/packages/base/src/DOMObserver.js
@@ -21,7 +21,9 @@ let _destroyObserver = observer => {
  * @param createFn
  */
 const setCreateObserverCallback = createFn => {
-	_createObserver = createFn;
+	if (typeof createFn === "function") {
+		_createObserver = createFn;
+	}
 };
 
 /**
@@ -29,7 +31,9 @@ const setCreateObserverCallback = createFn => {
  * @param destroyFn
  */
 const setDestroyObserverCallback = destroyFn => {
-	_destroyObserver = destroyFn;
+	if (typeof destroyFn === "function") {
+		_destroyObserver = destroyFn;
+	}
 };
 
 /**

--- a/packages/ie11/src/integrate.js
+++ b/packages/ie11/src/integrate.js
@@ -18,8 +18,10 @@ attachThemeLoaded(runPonyfill);
 attachBeforeComponentRender(createComponentStyleTag);
 
 // Set the custom DOM observer implementation for observe/unobserve
-setCreateObserverCallback(window.ShadyDOM.observeChildren);
-setDestroyObserverCallback(window.ShadyDOM.unobserveChildren);
+const observeChildrenMethod = window.ShadyDOM ? window.ShadyDOM.observeChildren : undefined;
+const unobserveChildrenMethod = window.ShadyDOM ? window.ShadyDOM.unobserveChildren : undefined;
+setCreateObserverCallback(observeChildrenMethod);
+setDestroyObserverCallback(unobserveChildrenMethod);
 
 // Set the custom Resize observer implementation for observe/unobserve
 setResizeHandlerObserveFn(customObserve);


### PR DESCRIPTION
Prior to this change, if you use a bundle with the IE11 support in modern browsers, an error would be thrown