### PR TITLE
fix(ui5-wizard): use CSS vars for navigation bg-color

### DIFF
--- a/packages/fiori/src/themes/Wizard.css
+++ b/packages/fiori/src/themes/Wizard.css
@@ -68,7 +68,7 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	background: #fff;
+	background-color: var(--sapObjectHeader_Background);
 	font-size: .875rem;
 	box-shadow: var(--sapContent_HeaderShadow);
 	outline: none;


### PR DESCRIPTION
We introduced a small degradation with the following [PR](https://github.com/SAP/ui5-webcomponents/pull/2590), using a fixed colors, instead of CSS vars. Now, the Wizard navigation looks fine in all themes:

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2877

Before
<img width="420" alt="Screenshot 2021-03-01 at 5 10 08 PM" src="https://user-images.githubusercontent.com/15702139/109516541-fcdb5f00-7ab0-11eb-8f97-29888a12426e.png">

After

<img width="397" alt="Screenshot 2021-03-01 at 5 09 30 PM" src="https://user-images.githubusercontent.com/15702139/109516470-e92ff880-7ab0-11eb-8313-07e113512acf.png">
