### PR TITLE
chore(framework): Register all themes

### DIFF
--- a/packages/tools/lib/generate-json-imports/themes.js
+++ b/packages/tools/lib/generate-json-imports/themes.js
@@ -8,14 +8,14 @@ const outputFile = path.normalize(`${process.argv[3]}/Themes-static.js`);
 const outputFileDynamic = path.normalize(`${process.argv[3]}/Themes.js`);
 
 // All supported optional themes
-const optionalThemes = assets.themes.all.filter(theme => theme !== assets.themes.default);
+const allThemes = assets.themes.all;
 
 // All themes present in the file system
 const dirs = fs.readdirSync(inputFolder);
 const themesOnFileSystem = dirs.map(dir => {
 	const matches = dir.match(/sap_.*$/);
 	return matches ? dir : undefined;
-}).filter(key => !!key && optionalThemes.includes(key));
+}).filter(key => !!key && allThemes.includes(key));
 
 const packageName = JSON.parse(fs.readFileSync("package.json")).name;
 


### PR DESCRIPTION
Before this change only optional themes were registered with the assumption that each component would register the default theme as part of its CSS.

There are edge-case scenarios where this is not the case. Therefore all themes are now registered. This allows the default theme to be fetched, if necessary, without incurring extra network activity in the usual use-case.