### PR TITLE
docs: describe formSupport slot

### DIFF
--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -163,6 +163,18 @@ const metadata = {
 		 */
 		change: {},
 	},
+	slots: /** @lends sap.ui.webcomponents.main.CheckBox.prototype */ {
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
+	}
 };
 
 /**

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -222,6 +222,17 @@ const metadata = {
 		valueStateMessage: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 
 	events: /** @lends  sap.ui.webcomponents.main.DatePicker.prototype */ {

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -177,6 +177,17 @@ const metadata = {
 		valueStateMessage: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.FileUploader.prototype */ {
 		/**

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -30,7 +30,7 @@ import radioButtonCss from "./generated/themes/RadioButton.css.js";
 const metadata = {
 	tag: "ui5-radiobutton",
 	languageAware: true,
-	properties: /** @lends sap.ui.webcomponents.main.RadioButton.prototype */  {
+	properties: /** @lends sap.ui.webcomponents.main.RadioButton.prototype */ {
 
 		/**
 		 * Determines whether the <code>ui5-radiobutton</code> is disabled.
@@ -166,6 +166,18 @@ const metadata = {
 			type: String,
 			defaultValue: "-1",
 			noAttribute: true,
+		},
+	},
+	slots:  /** @lends sap.ui.webcomponents.main.RadioButton.prototype */ {
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.RadioButton.prototype */ {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -88,6 +88,17 @@ const metadata = {
 		valueStateMessage: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 	properties: /** @lends  sap.ui.webcomponents.main.Select.prototype */  {
 
@@ -410,7 +421,7 @@ class Select extends UI5Element {
 		if (FormSupport) {
 			FormSupport.syncNativeHiddenInput(this, (element, nativeInput) => {
 				nativeInput.disabled = element.disabled;
-				nativeInput.value = element._currentlySelectedOption.value;
+				nativeInput.value = element._currentlySelectedOption ? element._currentlySelectedOption.value : "";
 			});
 		} else if (this.name) {
 			console.warn(`In order for the "name" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line

--- a/packages/main/src/StepInput.js
+++ b/packages/main/src/StepInput.js
@@ -282,6 +282,17 @@ const metadata = {
 		valueStateMessage: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.StepInput.prototype */ {
 		/**

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -292,6 +292,17 @@ const metadata = {
 		valueStateMessage: {
 			type: HTMLElement,
 		},
+
+		/**
+		 * The slot is used to render native <code>input</code> HTML element within Light DOM to enable form submit,
+		 * when <code>name</code> property is set.
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @private
+		 */
+		formSupport: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.TextArea.prototype */ {
 		/**
@@ -390,6 +401,7 @@ class TextArea extends UI5Element {
 			// this should be complex calc between line height and paddings - TODO: make it stable
 			this._maxHeight = `${this.growingMaxLines * 1.4 * 14 + 9}px`;
 		}
+		debugger;
 
 		const FormSupport = getFeature("FormSupport");
 		if (FormSupport) {

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -401,7 +401,6 @@ class TextArea extends UI5Element {
 			// this should be complex calc between line height and paddings - TODO: make it stable
 			this._maxHeight = `${this.growingMaxLines * 1.4 * 14 + 9}px`;
 		}
-		debugger;
 
 		const FormSupport = getFeature("FormSupport");
 		if (FormSupport) {


### PR DESCRIPTION
When some of the components such as FileUploader, Checkbox, Select are used with "name" attribute and FormSupport is enabled, the insertion of the native input with slot="formSupport" throws t warnings as the slot is unknown to component's metadata. 
Minor fix: when the Select has no options, the code that tries to get the value from the selected option used to fail.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2902