### PR TITLE
fix(ui5-popover): calculate offset for all sides of the page

### DIFF
--- a/packages/base/src/util/clamp.js
+++ b/packages/base/src/util/clamp.js
@@ -1,0 +1,12 @@
+/**
+ * Returns a value clamped between an upper bound 'max' and lower bound 'min'.
+ * @param {number} val value
+ * @param {number} min lower bound
+ * @param {number} max upper bound
+ * @returns {number}
+ */
+const clamp = (val, min, max) => {
+	return Math.min(Math.max(val, min), max);
+};
+
+export default clamp;

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -1,4 +1,5 @@
 import { isPhone, isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
+import clamp from "@ui5/webcomponents-base/dist/util/clamp.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import Popup from "./Popup.js";
 import "@ui5/webcomponents-icons/dist/resize-corner.js";
@@ -223,10 +224,6 @@ class Dialog extends Popup {
 		this._center();
 	}
 
-	_clamp(val, min, max) {
-		return Math.min(Math.max(val, min), max);
-	}
-
 	onBeforeRendering() {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
@@ -386,26 +383,26 @@ class Dialog extends Popup {
 		let newLeft;
 
 		if (this._isRTL) {
-			newWidth = this._clamp(
+			newWidth = clamp(
 				this._initialWidth - (clientX - this._initialX),
 				this._minWidth,
 				this._initialLeft + this._initialWidth,
 			);
 
-			newLeft = this._clamp(
+			newLeft = clamp(
 				this._initialLeft + (clientX - this._initialX),
 				0,
 				this._initialX + this._initialWidth - this._minWidth,
 			);
 		} else {
-			newWidth = this._clamp(
+			newWidth = clamp(
 				this._initialWidth + (clientX - this._initialX),
 				this._minWidth,
 				window.innerWidth - this._initialLeft,
 			);
 		}
 
-		const newHeight = this._clamp(
+		const newHeight = clamp(
 			this._initialHeight + (clientY - this._initialY),
 			this._minHeight,
 			window.innerHeight - this._initialTop,

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -402,6 +402,16 @@
 		</div>
 	</ui5-popover>
 
+	<div style="display: flex; justify-content: flex-end;">
+		<ui5-button id="btnRightEdge">Popover on right edge of screen</ui5-button>
+	</div>
+
+	<ui5-popover header-text="Header" id="popoverRightEdge" placement-type="Top">
+		<ui5-label>Input field: </ui5-label>
+		<ui5-input></ui5-input>
+	</ui5-popover>
+
+
 	<script>
 		btn.addEventListener("click", function (event) {
 			pop.openBy(btn);
@@ -513,6 +523,10 @@
 
 		btnOpenXRightWide.addEventListener("click", function () {
 			popXRightWide.openBy(btnOpenXRightWide);
+		});
+
+		btnRightEdge.addEventListener("click", function () {
+			popoverRightEdge.openBy(btnRightEdge);
 		});
 
 	</script>


### PR DESCRIPTION
The popover has a 10px offset from the edges of the screen,
so that its size would not reach the border of the page.

Left and Top positons are now clamped to adjust for that offset on all sides.

Fixes: #2697