### PR TITLE
fix(ui5-popup): position arrows correctly

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -529,9 +529,7 @@ class Popover extends Popup {
 
 		let maxContentHeight = Math.round(maxHeight);
 
-		const hasHeader = this.header.length || this.headerText;
-
-		if (hasHeader) {
+		if (this._displayHeader) {
 			const headerDomRef = this.shadowRoot.querySelector(".ui5-popup-header-root")
 				|| this.shadowRoot.querySelector(".ui5-popup-header-text");
 
@@ -542,7 +540,33 @@ class Popover extends Popup {
 
 		this._maxContentHeight = maxContentHeight;
 
-		let arrowXCentered = (this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch);
+		let arrowPos = this.getArrowPosition();
+
+		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {
+			this._left = Math.round(left);
+		}
+
+		if (this._top === undefined || Math.abs(this._top - top) > 1.5) {
+			this._top = Math.round(top);
+		}
+
+		return {
+			arrowX: arrowPos.x,
+			arrowY: arrowPos.y,
+			top: this._top,
+			left: this._left,
+			placementType,
+		};
+	}
+
+	/**
+	 * Calculates the position for the arrow.
+	 * @private
+	 * @returns {{x: number, y: number}} Arrow's coordinates
+	 */
+	getArrowPosition() {
+		let arrowXCentered = this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch;
+
 		if (this.horizontalAlign === PopoverHorizontalAlign.Right && left <= targetRect.left) {
 			arrowXCentered = true;
 		}
@@ -561,20 +585,9 @@ class Popover extends Popup {
 			arrowTranslateY = targetRect.top + targetRect.height / 2 - top - popoverSize.height / 2;
 		}
 
-		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {
-			this._left = Math.round(left);
-		}
-
-		if (this._top === undefined || Math.abs(this._top - top) > 1.5) {
-			this._top = Math.round(top);
-		}
-
 		return {
-			arrowX: Math.round(arrowTranslateX),
-			arrowY: Math.round(arrowTranslateY),
-			top: this._top,
-			left: this._left,
-			placementType,
+			x: Math.round(arrowTranslateX),
+			y: Math.round(arrowTranslateY),
 		};
 	}
 

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -542,9 +542,24 @@ class Popover extends Popup {
 
 		this._maxContentHeight = maxContentHeight;
 
-		const arrowXCentered = this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch;
-		const arrowTranslateX = isVertical && arrowXCentered ? targetRect.left + targetRect.width / 2 - left - popoverSize.width / 2 : 0;
-		const arrowTranslateY = !isVertical ? targetRect.top + targetRect.height / 2 - top - popoverSize.height / 2 : 0;
+		let arrowXCentered = (this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch);
+		if (this.horizontalAlign === PopoverHorizontalAlign.Right && left <= targetRect.left) {
+			arrowXCentered = true;
+		}
+
+		if (this.horizontalAlign === PopoverHorizontalAlign.Left && left + popoverSize.width >= targetRect.left + targetRect.width) {
+			arrowXCentered = true;
+		}
+
+		let arrowTranslateX = 0;
+		if (isVertical && arrowXCentered) {
+			arrowTranslateX = targetRect.left + targetRect.width / 2 - left - popoverSize.width / 2;
+		}
+
+		let arrowTranslateY = 0;
+		if (!isVertical) {
+			arrowTranslateY = targetRect.top + targetRect.height / 2 - top - popoverSize.height / 2;
+		}
 
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {
 			this._left = Math.round(left);

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -540,7 +540,7 @@ class Popover extends Popup {
 
 		this._maxContentHeight = maxContentHeight;
 
-		let arrowPos = this.getArrowPosition();
+		let arrowPos = this.getArrowPosition(targetRect, popoverSize, left, isVertical);
 
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {
 			this._left = Math.round(left);
@@ -562,9 +562,13 @@ class Popover extends Popup {
 	/**
 	 * Calculates the position for the arrow.
 	 * @private
+	 * @param targetRect BoundingClientRect of the target element
+	 * @param popoverSize Width and height of the popover
+	 * @param left Left offset of the popover
+	 * @param isVertical if the popover is positioned vertically to the target element
 	 * @returns {{x: number, y: number}} Arrow's coordinates
 	 */
-	getArrowPosition() {
+	getArrowPosition(targetRect, popoverSize, left, isVertical) {
 		let arrowXCentered = this.horizontalAlign === PopoverHorizontalAlign.Center || this.horizontalAlign === PopoverHorizontalAlign.Stretch;
 
 		if (this.horizontalAlign === PopoverHorizontalAlign.Right && left <= targetRect.left) {

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -511,10 +511,6 @@
 			popWithDiv.openBy(event.target);
 		});
 
-		btnRightEdge.addEventListener("click", function () {
-			popoverRightEdge.openBy(btnRightEdge);
-		});
-
 		btnOpenXRightWide.addEventListener("click", function () {
 			popXRightWide.openBy(btnOpenXRightWide);
 		});

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -368,6 +368,15 @@
 		</div>
 	</ui5-popover>
 
+	<div style="text-align: right;">
+		<p>Right-aligned Popover, wider than button, arrow should be centered on the button</p>
+		<ui5-button id="btnOpenXRightWide">Open</ui5-button>
+	</div>
+
+	<ui5-popover id="popXRightWide" placement-type="Bottom" horizontal-align="Right">
+		Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni architecto tenetur quia nam reprehenderit quas eveniet possimus similique quisquam culpa distinctio ex doloremque molestiae maxime sed harum, in exercitationem! Incidunt?
+	</ui5-popover>
+
 	<br>
 	<br>
 
@@ -500,6 +509,14 @@
 
 		btnOpenPopoverWithDiv.addEventListener("click", function (event) {
 			popWithDiv.openBy(event.target);
+		});
+
+		btnRightEdge.addEventListener("click", function () {
+			popoverRightEdge.openBy(btnRightEdge);
+		});
+
+		btnOpenXRightWide.addEventListener("click", function () {
+			popXRightWide.openBy(btnOpenXRightWide);
 		});
 
 	</script>


### PR DESCRIPTION
When the Popover is aligned horizontally against the opener,
but it is wider than the opener, the arrows will be centered to the middle of the opener element.

Fixes: #2758
Fixes: #2401