### PR TITLE
refactor(framework): Allow passing strings for Float and Integer types

### DIFF
--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -1,4 +1,6 @@
 import DataType from "./types/DataType.js";
+import Integer from "./types/Integer.js";
+import Float from "./types/Float.js";
 import isDescendantOf from "./util/isDescendantOf.js";
 import { camelToKebabCase } from "./util/StringHelper.js";
 import { getSlottedElements } from "./util/SlotsHelper.js";
@@ -283,6 +285,10 @@ class UI5ElementMetadata {
 
 const validateSingleProperty = (value, propData) => {
 	const propertyType = propData.type;
+
+	if ([Integer, Float].includes(propertyType) && typeof value === "string") { // Allow passing strings that contain a number to Integer and Float types
+		value = Number(value);
+	}
 
 	if (propertyType === Boolean) {
 		return typeof value === "boolean" ? value : false;

--- a/packages/base/src/types/Float.js
+++ b/packages/base/src/types/Float.js
@@ -2,7 +2,6 @@ import DataType from "./DataType.js";
 
 class Float extends DataType {
 	static isValid(value) {
-		// Assuming that integers are floats as well!
 		return Number(value) === value;
 	}
 }


### PR DESCRIPTION
Before this change passing a `String` instead of a `Number` for properties of types `Float` and `Integer` used to set the default value. Now it's possible to pass a string containing a number, as for attributes.