### PR TITLE
chore: do not distribute the webcomponentsjs polyfill's src dir

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -3,7 +3,7 @@ const path = require("path");
 const LIB = path.join(__dirname, `../lib/`);
 const serveConfig = path.join(__dirname, `serve.json`);
 const polyfillDir = path.dirname(require.resolve("@webcomponents/webcomponentsjs"));
-const polyfillPath = path.join(polyfillDir, "/**/*.*");
+const polyfillPath = path.join(polyfillDir, "{*.js,*.md,bundles/**/*.js}");
 
 const getScripts = (options) => {
 

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -3,7 +3,7 @@ const path = require("path");
 const LIB = path.join(__dirname, `../lib/`);
 const serveConfig = path.join(__dirname, `serve.json`);
 const polyfillDir = path.dirname(require.resolve("@webcomponents/webcomponentsjs"));
-const polyfillPath = path.join(polyfillDir, "{*.js,*.md,bundles/**/*.js}");
+const polyfillPath = path.join(polyfillDir, "{*.js,*.map,*.md,bundles/**/*.*}");
 
 const getScripts = (options) => {
 


### PR DESCRIPTION
The `package.json` and `src/` directory of the `webcomponentjs` polyfill are not necessary for the runtime, but may confuse some build tools.

Before:
![image](https://user-images.githubusercontent.com/15844574/110595374-9b894f00-8186-11eb-8698-c713d2b6df16.png)

After:
![image](https://user-images.githubusercontent.com/15844574/110595893-4994f900-8187-11eb-903e-4c9f70b3e0da.png)

