### PR TITLE
fix(ui5-calendar): re-render header on lang change

### DIFF
--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -22,6 +22,7 @@ import styles from "./generated/themes/CalendarHeader.css.js";
 
 const metadata = {
 	tag: "ui5-calendar-header",
+	languageAware: true,
 	properties: {
 		/**
 		 * Already normalized by Calendar


### PR DESCRIPTION
The CalendarHeader is not language aware, because unlike the Calendar, DatePicker and the rest Date* components, the CalendarHeader is not derived by DateComponentBase class (which is language aware) and thus never re-renders on language change, triggered by the setLanguage API - the week days get translated, but the month text in the CalendarHeader - not.

Before
https://user-images.githubusercontent.com/15702139/110925172-88fc4a80-832b-11eb-9072-891f0dad05bf.mov

After
https://user-images.githubusercontent.com/15702139/110925305-b1844480-832b-11eb-9011-f25c6d783964.mov




