### PR TITLE
chore: Define ui5-static-area

### DIFF
--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -77,4 +77,8 @@ if (!customElements.get("ui5-static-area-item")) {
 	customElements.define("ui5-static-area-item", StaticAreaItem);
 }
 
+if (!customElements.get("ui5-static-area")) {
+	customElements.define("ui5-static-area", class extends HTMLElement {});
+}
+
 export default StaticAreaItem;


### PR DESCRIPTION
Some test pages such as `kitchen.html` have the following CSS:

```html
	<style>
		*:not(:defined) {
			visibility: hidden;
		}
	</style>
```

This makes the `ui5-static-area` tag invisible. The solution is to define `ui5-static-area` as we do it for `ui5-static-area-item`. It used to be so, but this was removed in a recent update to static area functionality.