### PR TITLE
chore: improve build responsiveness OLD

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -64,7 +64,7 @@ const getScripts = (options) => {
 			styles: {
 				default: 'concurrently "nps watch.styles.themes" "nps watch.styles.components"',
 				themes: 'nps "build.styles.themes -w"',
-				components: 'chokidar "src/themes/*.css" -c "nps build.styles.components"',
+				components: `node "${LIB}/watch-components-css/index.js" "src/themes/*.css"`,
 			},
 			templates: 'chokidar "src/**/*.hbs" -c "nps build.templates"',
 			samples: 'chokidar "test/**/*.sample.html" -c "nps build.samples"',

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -52,8 +52,8 @@ const getScripts = (options) => {
 			"webcomponents-polyfill-placeholder": `node ${LIB}/polyfill-placeholder/index.js`
 		},
 		watch: {
-			default: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle" "nps watch.styles"',
-			es5: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle.es5" "nps watch.styles"',
+			default: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle" "nps watch.styles" "nps watch.i18n"',
+			es5: 'concurrently "nps watch.templates" "nps watch.samples" "nps watch.test" "nps watch.src" "nps watch.bundle.es5" "nps watch.styles" "nps watch.i18n"',
 			src: 'nps "copy.src --watch --safe --skip-initial-copy"',
 			props: 'nps "copy.props --watch --safe --skip-initial-copy"',
 			test: 'nps "copy.test --watch --safe --skip-initial-copy"',
@@ -64,10 +64,11 @@ const getScripts = (options) => {
 			styles: {
 				default: 'concurrently "nps watch.styles.themes" "nps watch.styles.components"',
 				themes: 'nps "build.styles.themes -w"',
-				components: 'nps "build.styles.components -w"',
+				components: 'chokidar "src/themes/*.css" -c "nps build.styles.components"',
 			},
-			templates: "chokidar \"src/**/*.hbs\" -c \"nps build.templates\"",
-			samples: "chokidar \"test/**/*.sample.html\" -c \"nps build.samples\"",
+			templates: 'chokidar "src/**/*.hbs" -c "nps build.templates"',
+			samples: 'chokidar "test/**/*.sample.html" -c "nps build.samples"',
+			i18n: 'chokidar "src/i18n/messagebundle.properties" -c "nps build.i18n.defaultsjs"'
 		},
 		dev: {
 			default: 'concurrently "nps serve" "nps watch"',

--- a/packages/tools/lib/watch-components-css/index.js
+++ b/packages/tools/lib/watch-components-css/index.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const chokidar = require("chokidar");
+const postcss = require("postcss");
+const postcssComponents = require("../../components-package/postcss.components");
+
+const srcFiles = process.argv[2];
+
+const run = path => {
+	fs.readFile(path, (err, css) => {
+		postcss(postcssComponents.plugins)
+			.process(css, { from: path })
+			.then(result => {
+				console.log("Processed: ", path);
+			});
+	});
+};
+
+let ready = false; // Do nothing until the ready event has been fired (we don't want to recompile all files initially)
+
+const watcher = chokidar.watch(srcFiles);
+
+watcher.on("ready", () => {
+	ready = true; // Initial scan is over -> waiting for changes or new files
+});
+watcher.on("add", path => {
+	if (ready) {
+		run(path);
+	}
+});
+watcher.on("change", path => {
+	if (ready) {
+		run(path);
+	}
+});

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -38,6 +38,7 @@
     "@wdio/sync": "^7.2.0",
     "@webcomponents/webcomponentsjs": "^2.5.0",
     "chai": "^4.3.4",
+    "chokidar": "^3.5.1",
     "chokidar-cli": "^2.1.0",
     "clean-css": "^5.1.1",
     "colors": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,7 +2522,7 @@ chokidar@3.4.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
-chokidar@3.5.1, chokidar@^3.0.0, chokidar@^3.2.3, chokidar@^3.3.0, chokidar@^3.4.0, chokidar@^3.5.0:
+chokidar@3.5.1, chokidar@^3.0.0, chokidar@^3.2.3, chokidar@^3.3.0, chokidar@^3.4.0, chokidar@^3.5.0, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==


### PR DESCRIPTION
This change fixes 2 bugs of the `yarn start` command:
 - Newly created `.css` files are not usable unless `yarn start` is killed and re-run. The reason is a known `postcss` bug in `--watch` mode: newly created files are not detected, only existing files are re-compiled (https://github.com/postcss/postcss-cli/issues/161).
 - Newly added entries to `messagebundle.properties` are not automatically available in `i18n-defaults.js` and if you try to use them - the bundle breaks. This is due to the fact that there is no watch mode for `i18n`.

Changes:
 - Use `chokidar` for watching the `themes/` directory instead of `postcss --watch`. Note: this is only necessary for component css files. Themes css files are fine with `postcss --watch`, because new ones are never created.
 - Create a `watch` task for `i18n` too: it only needs to watch the `messagebundle.properties` file and regenerate the defaults file (not the `.json`s).

After the change it's possible to create a new component with all needed files and resources without restarting `yarn start`.