### PR TITLE
feat(framework): Maintain a common z-index for all UI5 Web Components instances and OpenUI5

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-MUfM5wQo+eUhgUm/wAfVuvW4G7E=
+LnA57prVpk1aAMvC39RJd6Yc7Kg=

--- a/packages/base/src/util/PopupUtils.js
+++ b/packages/base/src/util/PopupUtils.js
@@ -1,5 +1,6 @@
-import getSharedResource from "@ui5/webcomponents-base/dist/getSharedResource.js";
-import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
+import getSharedResource from "../getSharedResource.js";
+import { getFeature } from "../FeaturesRegistry.js";
+import getActiveElement from "./getActiveElement.js";
 
 const PopupUtilsData = getSharedResource("PopupUtilsData", {});
 PopupUtilsData.currentZIndex = PopupUtilsData.currentZIndex || 100;
@@ -69,7 +70,16 @@ const getClosedPopupParent = el => {
 };
 
 const getNextZIndex = () => {
+	const OpenUI5Support = getFeature("OpenUI5Support");
+	if (OpenUI5Support && OpenUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
+		return OpenUI5Support.getNextZIndex();
+	}
+
 	PopupUtilsData.currentZIndex += 2;
+	return PopupUtilsData.currentZIndex;
+};
+
+const getCurrentZIndex = () => {
 	return PopupUtilsData.currentZIndex;
 };
 
@@ -78,5 +88,6 @@ export {
 	isClickInRect,
 	getClosedPopupParent,
 	getNextZIndex,
+	getCurrentZIndex,
 	isFocusedElementWithinNode,
 };

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -1,11 +1,11 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import { getClosedPopupParent } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import Popup from "./Popup.js";
 import PopoverPlacementType from "./types/PopoverPlacementType.js";
 import PopoverVerticalAlign from "./types/PopoverVerticalAlign.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 import { addOpenedPopover, removeOpenedPopover } from "./popup-utils/PopoverRegistry.js";
-import { getClosedPopupParent } from "./popup-utils/PopupUtils.js";
 
 // Template
 import PopoverTemplate from "./generated/templates/PopoverTemplate.lit.js";

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -5,9 +5,9 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { getFirstFocusableElement, getLastFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 import createStyleInHead from "@ui5/webcomponents-base/dist/util/createStyleInHead.js";
 import { isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
+import { getNextZIndex, getFocusedElement, isFocusedElementWithinNode } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import PopupTemplate from "./generated/templates/PopupTemplate.lit.js";
 import PopupBlockLayer from "./generated/templates/PopupBlockLayerTemplate.lit.js";
-import { getNextZIndex, getFocusedElement, isFocusedElementWithinNode } from "./popup-utils/PopupUtils.js";
 import { addOpenedPopup, removeOpenedPopup } from "./popup-utils/OpenedPopupsRegistry.js";
 
 // Styles

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -1,7 +1,7 @@
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getNextZIndex } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import { RESPONSIVE_POPOVER_CLOSE_DIALOG_BUTTON } from "./generated/i18n/i18n-defaults.js";
-import { getNextZIndex } from "./popup-utils/PopupUtils.js";
 import ResponsivePopoverTemplate from "./generated/templates/ResponsivePopoverTemplate.lit.js";
 import Popover from "./Popover.js";
 import Dialog from "./Dialog.js";

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -1,8 +1,8 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import { getNextZIndex } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import ToastPlacement from "./types/ToastPlacement.js";
-import { getNextZIndex } from "./popup-utils/PopupUtils.js";
 
 // Template
 import ToastTemplate from "./generated/templates/ToastTemplate.lit.js";

--- a/packages/main/src/popup-utils/PopoverRegistry.js
+++ b/packages/main/src/popup-utils/PopoverRegistry.js
@@ -1,4 +1,4 @@
-import { isClickInRect } from "./PopupUtils.js";
+import { isClickInRect } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import { getOpenedPopups, addOpenedPopup, removeOpenedPopup } from "./OpenedPopupsRegistry.js";
 
 let updateInterval = null;

--- a/packages/main/src/popup-utils/PopupUtils.js
+++ b/packages/main/src/popup-utils/PopupUtils.js
@@ -1,6 +1,8 @@
+import getSharedResource from "@ui5/webcomponents-base/dist/getSharedResource.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 
-let currentZIndex = 100;
+const PopupUtilsData = getSharedResource("PopupUtilsData", {});
+PopupUtilsData.currentZIndex = PopupUtilsData.currentZIndex || 100;
 
 const getFocusedElement = () => {
 	const element = getActiveElement();
@@ -67,8 +69,8 @@ const getClosedPopupParent = el => {
 };
 
 const getNextZIndex = () => {
-	currentZIndex += 2;
-	return currentZIndex;
+	PopupUtilsData.currentZIndex += 2;
+	return PopupUtilsData.currentZIndex;
 };
 
 export {


### PR DESCRIPTION
# Introduce Common Popup Registry

## 1. Between different UI5 Web Components runtimes

A new Shared Resources entity was introduced: `PopupUtilsData`. You can test this in your browser as follows:
```js
document.head.querySelector("ui5-shared-resources").PopupUtilsData.currentZIndex
```
Thus all UI5 Web Components runtimes will use the same `currentZIndex` value, stored on the global `ui5-shared-resources` tag in the `head`.

## 2. Between UI5 Web Components runtimes and OpenUI5

Whenever the `OpenUI5Support` feature is imported by an application:
```js
import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
```
the OpenUI5 popup registry will be used as a source of truth for each popup, opened by UI5 Web Components. This would allow UI5 Web Components popups to stack correctly with OpenUI5 popups.

There are 2 possible scenarios regarding which framework is loaded first:
 - `OpenUI5` is loaded first: when this is the case, nothing special needs to be done. The first UI5 Web Components popup to be opened will require a new `z-index` value from OpenUI5 and will get the next eligible OpenUI5 `z-index`.
 - `OpenUI5` is loaded lazily after 1 or more popups have already been opened by UI5 Web Components. In this case, OpenUI5 will need to start from the last `z-index` value, used by UI5 Web Components, although it will still be the source of truth for future popups. In this case, after the application has loaded OpenUI5 on demand, it would need to explicitly synchronize its initial `z-index` with the one from the UI5 Web Components shared registry.

```js
import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
const OpenUI5Support = getFeature("OpenUI5Support");

sap.ui.getCore().attachInit(() => {
  sap.ui.require(["sap/ui/core/Popup"], () => {
    OpenUI5Support.setInitialZIndex();
  }
});
```
This will set OpenUI5's initial `z-index` value to whatever the current one for UI5 Web Components is. From then on, OpenUI5 will be used as a source of truth.

Misc changes:
 - `PopupUtils.js` moved to the `base` project as now the framework itself will be concerned with `z-index` management.
 - The `OpenUI5Support` feature will no longer assume that OpenUI5 is already loaded. Therefore the code that gets a reference to the core is moved from the module to a function (`getCore`) and this function is called every time the presence of OpenUI5 needs to be re-evaluated. This is needed in order to support the OpenUI5 lazy-load scenario.

BREAKING CHANGES:
 - **Important for developers** The `@ui5/webcomponents/dist/popup-utils/PopupUtils.js` has been moved to the `base` package.  Change your imports from:
 ```js
 import PopupUtils from "@ui5/webcomponents/dist/popup-utils/PopupUtils.js";
 ``` 
to:
```js
import PopupUtils from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
```

closes: https://github.com/SAP/ui5-webcomponents/issues/2973