### PR TITLE
fix(ui5-rangeslider): fix handles opacity for IE11

### DIFF
--- a/packages/main/src/themes/base/SliderBase-parameters.css
+++ b/packages/main/src/themes/base/SliderBase-parameters.css
@@ -9,6 +9,7 @@
 	--_ui5_slider_handle_width: 1.625rem;
 	--_ui5_slider_handle_border: solid 0.125rem var(--sapField_BorderColor);
 	--_ui5_slider_handle_background: var(--sapButton_Background);
+	/* --_ui5_range_slider_handle_background: rgba(var(--sapButton_Background), 0.25); - doesn't work on IE */
 	--_ui5_range_slider_handle_background: rgba(255, 255, 255, 0.25);
 	--_ui5_slider_handle_top: -0.825rem;
 	--_ui5_slider_handle_margin_left: -0.9725rem;
@@ -16,6 +17,7 @@
 	--_ui5_slider_handle_hover_border: var(--sapButton_Hover_BorderColor);
 	--_ui5_slider_handle_outline: 1px dotted var(--sapContent_FocusColor);
 	--_ui5_slider_handle_outline_offset: 0.075rem;
+	/* --_ui5_range_slider_handle_hover_background: rgba(var(--sapButton_Background), 0.25); - doesn't work on IE */
 	--_ui5_range_slider_handle_hover_background: rgba(255, 255, 255, 0.25);
 	--_ui5_slider_progress_outline: 0.0625rem dotted var(--sapContent_FocusColor);
 	--_ui5_slider_progress_outline_offset: 0.525rem;

--- a/packages/main/src/themes/base/SliderBase-parameters.css
+++ b/packages/main/src/themes/base/SliderBase-parameters.css
@@ -9,14 +9,14 @@
 	--_ui5_slider_handle_width: 1.625rem;
 	--_ui5_slider_handle_border: solid 0.125rem var(--sapField_BorderColor);
 	--_ui5_slider_handle_background: var(--sapButton_Background);
-	--_ui5_range_slider_handle_background: rgba(var(--sapButton_Background), 0.25);
+	--_ui5_range_slider_handle_background: rgba(255, 255, 255, 0.25);
 	--_ui5_slider_handle_top: -0.825rem;
 	--_ui5_slider_handle_margin_left: -0.9725rem;
 	--_ui5_slider_handle_hover_background: var(--sapButton_Hover_Background);
 	--_ui5_slider_handle_hover_border: var(--sapButton_Hover_BorderColor);
 	--_ui5_slider_handle_outline: 1px dotted var(--sapContent_FocusColor);
 	--_ui5_slider_handle_outline_offset: 0.075rem;
-	--_ui5_range_slider_handle_hover_background: rgba(var(--sapButton_Background), 0.25);
+	--_ui5_range_slider_handle_hover_background: rgba(255, 255, 255, 0.25);
 	--_ui5_slider_progress_outline: 0.0625rem dotted var(--sapContent_FocusColor);
 	--_ui5_slider_progress_outline_offset: 0.525rem;
 	--_ui5_slider_tickmark_color: #89919a;


### PR DESCRIPTION
Range Slider's handles' background is now fixed to be consistent across all browsers, as previously their opacity was not correct in IE11.