### PR TITLE
fix(ui5-select): set aria-expanded initially

### DIFF
--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -341,7 +341,7 @@ class Select extends UI5Element {
 	}
 
 	get _isPickerOpen() {
-		return this.responsivePopover && this.responsivePopover.opened;
+		return !!this.responsivePopover && this.responsivePopover.opened;
 	}
 
 	async _respPopover() {

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -341,12 +341,12 @@ describe("Select general interaction", () => {
 		assert.strictEqual(select1.getAttribute("aria-label"), EXPECTED_ARIA_LABEL1,
 			"The aria-label is correctly set internally.");
 		assert.strictEqual(select1.getAttribute("aria-expanded"), "false",
-			"The aria-expanded is false by defaualt.");
+			"The aria-expanded is false by default.");
 	
 		assert.strictEqual(select2.getAttribute("aria-label"), EXPECTED_ARIA_LABEL2,
 			"The aria-label is correctly set internally.");
 		assert.strictEqual(select2.getAttribute("aria-expanded"), "false",
-			"The aria-expanded is false by defaualt.");
+			"The aria-expanded is false by default.");
 	});
 
 	it('selected options are correctly disabled', () => {

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -332,7 +332,7 @@ describe("Select general interaction", () => {
 		assert.ok(selectText.getHTML(false).indexOf(EXPECTED_SELECTION_TEXT2) !== -1, "Select label is correct.");
 	});
 
-	it("Tests aria-label and aria-labelledby", () => {
+	it("Tests aria-label, aria-labelledby and aria-expanded", () => {
 		const select1 = browser.$("#textAreaAriaLabel").shadow$(".ui5-select-label-root");
 		const select2 = browser.$("#textAreaAriaLabelledBy").shadow$(".ui5-select-label-root");
 		const EXPECTED_ARIA_LABEL1 = "Hello World";
@@ -340,8 +340,13 @@ describe("Select general interaction", () => {
 
 		assert.strictEqual(select1.getAttribute("aria-label"), EXPECTED_ARIA_LABEL1,
 			"The aria-label is correctly set internally.");
+		assert.strictEqual(select1.getAttribute("aria-expanded"), "false",
+			"The aria-expanded is false by defaualt.");
+	
 		assert.strictEqual(select2.getAttribute("aria-label"), EXPECTED_ARIA_LABEL2,
 			"The aria-label is correctly set internally.");
+		assert.strictEqual(select2.getAttribute("aria-expanded"), "false",
+			"The aria-expanded is false by defaualt.");
 	});
 
 	it('selected options are correctly disabled', () => {


### PR DESCRIPTION
We used to return undefined for aria-expanded upon initial rendering, causing the attribute to not render at all, now we always return boolean and the attribute is added with "false" on initial rendering.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/2987