### PR TITLE
chore: fix the hash for the base package

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-LnA57prVpk1aAMvC39RJd6Yc7Kg=
+8tu7HnyfNvd2n6yTlNh6ErjOoSI=


### PR DESCRIPTION
A change to the `@ui5/webcomponents-base` package was merged without recalculating the hash for this package: https://github.com/SAP/ui5-webcomponents/pull/2916/files

If any of the following packages is changed:
 - `@ui5/webcomponents-base`
 - `@ui5/webcomponents-localization`
 - `@ui5/webcomponents-theme-base`
 - `@ui5/webcomponents-icons`
 - `@ui5/webcomponents-icons-tnt`
 - `@ui5/webcomponents-ie11`

, please run `yarn hash` afterwards in order to generate the new hash. For more info, see: https://github.com/SAP/ui5-webcomponents/pull/2933