### PR TITLE
chore: read ports from configuration for tests

### DIFF
--- a/packages/fiori/test/specs/Components.spec.js
+++ b/packages/fiori/test/specs/Components.spec.js
@@ -11,7 +11,7 @@ const assertHidden = component => {
 
 describe("General assertions", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/Components.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Components.html`);
 	});
 
 	it("tests components with 'hidden' property are not visible", () => {

--- a/packages/fiori/test/specs/Components.spec.js
+++ b/packages/fiori/test/specs/Components.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 const assertBooleanProperty = (el, prop) => {
 	assert.strictEqual(el.getProperty(prop), false, "the value should be false by default.");

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -5,7 +5,7 @@ const PORT = require("./_port.js");
 
 describe("FlexibleColumnLayout Behavior", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/FCL.html?sap-ui-animationMode=none");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/FCL.html?sap-ui-animationMode=none`);
 	});
 
 	it("tests Desktop size 1400px", () => {

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -1,5 +1,6 @@
 
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("FlexibleColumnLayout Behavior", () => {

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Notification List Item Tests", () => {
 	before(() => {

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Notification List Item Tests", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/NotificationList_test_page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/NotificationList_test_page.html`);
 	});
 
 	it("tests itemClick fired", () => {

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Page general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/Page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Page.html`);
 	});
 
 	it("tests initial rendering", () => {

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -1,4 +1,5 @@
-const assert = require('chai').assert;
+const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Page general interaction", () => {
 	before(() => {

--- a/packages/fiori/test/specs/ProductSwitch.spec.js
+++ b/packages/fiori/test/specs/ProductSwitch.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("ProductSwitch general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/ProductSwitch.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ProductSwitch.html`);
 	});
 
 	it("tests desktopColumns attribute", () => {

--- a/packages/fiori/test/specs/ProductSwitch.spec.js
+++ b/packages/fiori/test/specs/ProductSwitch.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("ProductSwitch general interaction", () => {
 	before(() => {

--- a/packages/fiori/test/specs/ProductSwitchItem.spec.js
+++ b/packages/fiori/test/specs/ProductSwitchItem.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("ProductSwitchItem general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/ProductSwitchItem.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ProductSwitchItem.html`);
 	});
 
 	it("tests rendering", () => {

--- a/packages/fiori/test/specs/ProductSwitchItem.spec.js
+++ b/packages/fiori/test/specs/ProductSwitchItem.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("ProductSwitchItem general interaction", () => {
 	before(() => {

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -25,7 +25,7 @@ const getCustomActionProp = (id, pos, prop) => {
 
 describe("Component Behavior", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/ShellBar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ShellBar.html`);
 	});
 
 	describe("ui5-shellbar-item", () => {

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -1,5 +1,6 @@
 
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 const getOverflowPopover = id => {
 	const staticAreaItemClassName = browser.getStaticAreaItemClassName(`#${id}`);

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Component Behavior", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/SideNavigation.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/SideNavigation.html`);
 	});
 
 	describe("Main functionality", () => {

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -1,5 +1,6 @@
 
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Component Behavior", () => {
 	before(() => {

--- a/packages/fiori/test/specs/Timeline.spec.js
+++ b/packages/fiori/test/specs/Timeline.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Timeline general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/Timeline.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Timeline.html`);
 	});
 
 	it("should fire itemNameClick event on a normal item name", () => {

--- a/packages/fiori/test/specs/Timeline.spec.js
+++ b/packages/fiori/test/specs/Timeline.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Timeline general interaction", () => {
 	before(() => {

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("UploadCollection", () => {
 	describe("Rendering", () => {

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("UploadCollection", () => {
 	describe("Rendering", () => {
 		before(() => {
-			browser.url("http://localhost:8081/test-resources/pages/UploadCollection.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/UploadCollection.html`);
 		});
 
 		it("should show Link when 'fileNameClickable'", () => {

--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Wizard general interaction", () => {
 	before(() => {
@@ -218,7 +219,7 @@ describe("Wizard general interaction", () => {
 		const wizardDisabled = browser.$("#wizTest2");
 		const groupedStep = wizard.shadow$(`[data-ui5-index="3"]`);
 		const groupedStepDisabled = wizardDisabled.shadow$(`[data-ui5-index="3"]`);
-		
+
 		// act - click on the stack of steps
 		groupedStep.shadow$(`.ui5-wiz-step-root`).click();
 

--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Wizard general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8081/test-resources/pages/Wizard_test.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Wizard_test.html`);
 	});
 
 	it("test initial selection", () => {
@@ -180,7 +180,7 @@ describe("Wizard general interaction", () => {
 	});
 
 	it("tests no scrolling to selected step, if the selection was not changed", ()=>{
-		browser.url("http://localhost:8081/test-resources/pages/Wizard_test.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Wizard_test.html`);
 
 		const wizard = browser.$("#wizTest");
 		const wizardContentDOM = wizard.shadow$(".ui5-wiz-content");
@@ -213,7 +213,7 @@ describe("Wizard general interaction", () => {
 	});
 
 	it("tests small screen", ()=>{
-		browser.url("http://localhost:8081/test-resources/pages/Wizard_test_mobile.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Wizard_test_mobile.html`);
 
 		const wizard = browser.$("#wizTest");
 		const wizardDisabled = browser.$("#wizTest2");

--- a/packages/fiori/test/specs/_port.js
+++ b/packages/fiori/test/specs/_port.js
@@ -1,0 +1,3 @@
+const fs = require("fs");
+const PORT = JSON.parse(fs.readFileSync("../../package.json")).ui5.port;
+export default PORT;

--- a/packages/fiori/test/specs/_port.js
+++ b/packages/fiori/test/specs/_port.js
@@ -1,3 +1,3 @@
 const fs = require("fs");
-const PORT = JSON.parse(fs.readFileSync("../../package.json")).ui5.port;
-export default PORT;
+const packageFile = JSON.parse(fs.readFileSync(require.resolve("@ui5/webcomponents-fiori/package.json")));
+module.exports = packageFile.ui5.port;

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Avatar", () => {
@@ -78,7 +79,7 @@ describe("Avatar", () => {
 		browser.execute(function() {
 			window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(false);
 		});
-		
+
 		const avatar = browser.$("#myInteractiveAvatar");
 		const input = browser.$("#click-event-2");
 

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Avatar", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Avatar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Avatar.html`);
 	});
 
 	it("tests rendering of image", () => {

--- a/packages/main/test/specs/AvatarGroup.spec.js
+++ b/packages/main/test/specs/AvatarGroup.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("avatar-group rendering", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/AvatarGroup.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/AvatarGroup.html`);
 	});
 
 	it("tests if web component is correctly rendered", () => {

--- a/packages/main/test/specs/AvatarGroup.spec.js
+++ b/packages/main/test/specs/AvatarGroup.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("avatar-group rendering", () => {
 	before(() => {

--- a/packages/main/test/specs/Badge.spec.js
+++ b/packages/main/test/specs/Badge.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Badge rendering", () => {
 	before(() => {

--- a/packages/main/test/specs/Badge.spec.js
+++ b/packages/main/test/specs/Badge.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Badge rendering", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Badge.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Badge.html`);
 	});
 
 	it("tests label not rendered if not text content", () => {

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("BusyIndicator general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/BusyIndicator.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/BusyIndicator.html`);
 	});
 
 	it("tests event propagation", () => {

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("BusyIndicator general interaction", () => {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Button general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Button.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Button.html`);
 	});
 
 	it("tests button's text rendering", () => {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Button general interaction", () => {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Calendar general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 	});
 
 	it("Calendar is rendered", () => {
@@ -65,7 +65,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Calendar focuses the selected year when yearpicker is opened", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		const yearPicker = calendar.shadow$("ui5-yearpicker");
 		const YEAR = 1997;
@@ -76,7 +76,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Calendar doesn't mark year as selected when there are no selected dates", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 10, 1, 0, 0, 0)).valueOf() / 1000);
 		calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`).click();
@@ -87,7 +87,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Calendar doesn't mark month as selected when there are no selected dates", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 10, 1, 0, 0, 0)).valueOf() / 1000);
 		calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-month]`).click();
@@ -98,7 +98,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Page up/down increments/decrements the month value", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 10, 1, 0, 0, 0)).valueOf() / 1000);
@@ -157,7 +157,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Page up/down increments/decrements the year range in the year picker", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 9, 1, 0, 0, 0)).valueOf() / 1000);
 
@@ -173,7 +173,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("When month picker is shown the month button is hidden", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		const calendarHeader = calendar.shadow$("ui5-calendar-header");
 
@@ -186,7 +186,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Calendar with 'Multiple' selection type", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("selection-mode", "Multiple");
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 9, 10, 0, 0, 0)).valueOf() / 1000);
@@ -208,7 +208,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Keyboard navigation works properly, when calendar selection type is set to 'Multiple'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const toggleButton = browser.$("#weekNumbersButton");
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("selection-mode", "Multiple");
@@ -228,7 +228,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Calendar with 'Range' selection type", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Calendar.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
 		const calendar = browser.$("#calendar1");
 		calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 9, 10, 0, 0, 0)).valueOf() / 1000);
 		calendar.setAttribute("selection-mode", "Range");

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Calendar general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -1,4 +1,5 @@
-const assert = require('chai').assert;
+const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Card general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Card general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Card.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Card.html`);
 	});
 
 	it("tests initial rendering", () => {

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Carousel general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Carousel.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Carousel.html`);
 	});
 
 	it("Carousel is rendered", () => {

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Carousel general interaction", () => {

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("CheckBox general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("CheckBox general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/CheckBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/CheckBox.html`);
 	});
 
 	it("tests checked default value is false", () => {

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("ColorPalette interactions", () => {
 	before(() => {

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -3,11 +3,11 @@ const PORT = require("./_port.js");
 
 describe("ColorPalette interactions", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 	});
 
 	it("Test if selecting element works", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 		const colorPalette = browser.$("#cp1");
 		const colorPaletteEntries = colorPalette.$$("[ui5-color-palette-item]");
 
@@ -17,7 +17,7 @@ describe("ColorPalette interactions", () => {
 	});
 
 	it("Test if keyboard navigation on elements works", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 		const colorPalette = browser.$("#cp1");
 		const colorPaletteEntries = colorPalette.$$("[ui5-color-palette-item]");
 		const item = colorPaletteEntries[0];
@@ -31,7 +31,7 @@ describe("ColorPalette interactions", () => {
 	});
 
 	it("Test if keyboard navigation on elements works", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 		const colorPalette = browser.$("#cp1");
 		const colorPaletteEntries = colorPalette.$$("[ui5-color-palette-item]");
 		const item = colorPaletteEntries[0];
@@ -47,7 +47,7 @@ describe("ColorPalette interactions", () => {
 	});
 
 	it("Test if keyboard navigation on elements works", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 		const colorPalette = browser.$("#cp1");
 		const colorPaletteEntries = colorPalette.$$("[ui5-color-palette-item]");
 		const item = colorPaletteEntries[0];
@@ -61,7 +61,7 @@ describe("ColorPalette interactions", () => {
 	});
 
 	it("Test if keyboard navigation on elements works", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPalette.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPalette.html`);
 		const colorPalette = browser.$("#cp1");
 		const colorPaletteEntries = colorPalette.$$("[ui5-color-palette-item]");
 		const item = colorPaletteEntries[9];

--- a/packages/main/test/specs/ColorPicker.spec.js
+++ b/packages/main/test/specs/ColorPicker.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Color Picker general interaction", () => {

--- a/packages/main/test/specs/ColorPicker.spec.js
+++ b/packages/main/test/specs/ColorPicker.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Color Picker general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ColorPicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ColorPicker.html`);
 	});
 
 	it("tests color picker rendering", () => {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("General interaction", () => {
 
@@ -315,7 +316,7 @@ describe("General interaction", () => {
 
 		assert.ok(combo.getProperty("focused"), "property focused should be true");
 	});
-	
+
 	it ("Tests Combo with two-column layout", () => {
 		const combo = $("#combobox-two-column-layout");
 		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#combobox-two-column-layout");

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("General interaction", () => {
 
 	it ("Should open the popover when clicking on the arrow", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo");
 		const arrow = combo.shadow$("[input-icon]");
@@ -19,7 +19,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Items filtration", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo");
 		const arrow = combo.shadow$("[input-icon]");
@@ -45,7 +45,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Should open the popover when typing a value", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo");
 		const lazy = $("#lazy");
@@ -75,7 +75,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Should filter items based on input", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo2");
 		const arrow = combo.shadow$("[input-icon]");
@@ -114,7 +114,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Should close popover on item click / change event", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo2");
 		const arrow = combo.shadow$("[input-icon]");
@@ -174,7 +174,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Tests change event", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const counter = $("#change-count");
 		const combo = $("#change-cb");
@@ -193,7 +193,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Tests input event", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const counter = $("#input-count");
 		const combo = $("#input-cb");
@@ -292,7 +292,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Tests focused property when clicking on the arrow", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo");
 		const arrow = combo.shadow$("[input-icon]");
@@ -305,7 +305,7 @@ describe("General interaction", () => {
 	});
 
 	it ("Tests focused property when clicking on the input", () => {
-		browser.url("http://localhost:8080/test-resources/pages/ComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
 		const combo = $("#combo");
 		const input = combo.shadow$("#ui5-combobox-input");

--- a/packages/main/test/specs/Components.spec.js
+++ b/packages/main/test/specs/Components.spec.js
@@ -11,7 +11,7 @@ const assertHidden = component => {
 
 describe("General assertions", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Components.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Components.html`);
 	});
 
 	it("tests boolean props default", () => {

--- a/packages/main/test/specs/Components.spec.js
+++ b/packages/main/test/specs/Components.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 const assertBooleanProperty = (el, prop) => {
 	assert.strictEqual(el.getProperty(prop), false, "the value should be false by default.");

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -26,7 +26,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("input receives value in format pattern depending on the set language", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DatePicker_test_page.html?sap-ui-language=bg");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=bg`);
 		datepicker.id = "#dp16";
 
 		const setDateButton = browser.$("#b1");
@@ -203,7 +203,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("respect first day of the week - monday", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DatePicker_test_page.html?sap-ui-language=bg");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=bg`);
 		datepicker.id = "#dp7_1";
 
 		datepicker.root.setProperty("value", "фев 6, 2019");
@@ -771,7 +771,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("DayPicker day name attribute", ()=>{
-		// browser.url("http://localhost:8080/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en");
+		// browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en`);
 		// datepicker.root.setAttribute("primary-calendar-type", "Gregorian");
 		// datepicker.id = "#dp13";
 		// datepicker.openPicker();
@@ -787,7 +787,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("DayPiker day number attribute", ()=>{
-		browser.url("http://localhost:8080/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en`);
 		datepicker.root.setAttribute("primary-calendar-type", "Gregorian");
 		datepicker.id = "#dp13";
 		datepicker.openPicker();
@@ -808,7 +808,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("DatePicker dates and week number", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=en`);
 		datepicker.root.setAttribute("primary-calendar-type", "Gregorian");
 		datepicker.id = "#dp13";
 		datepicker.input.click();

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1,5 +1,6 @@
 const datepicker = require("../pageobjects/DatePickerTestPage");
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Date Picker Tests", () => {
 	before(() => {

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("DateRangePicker general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("DateRangePicker general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 	});
 
 	it("Custom Validation Error", () => {
@@ -17,7 +17,7 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Custom Validation None", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 		const daterangepicker = browser.$("#daterange-picker3");
 
 		daterangepicker.click();
@@ -42,7 +42,7 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("firstDateValue and lastDateValue getter", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 		const daterangepicker = browser.$("#daterange-picker4");
 
 		daterangepicker.click();
@@ -152,7 +152,7 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Enter keyboard key confirms the date range in the input field", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 		const dateRangePicker = browser.$("#daterange-picker5");
 		dateRangePicker.click();
 
@@ -163,7 +163,7 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Focus out of the input field confirms the date range", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 		const dateRangePicker = browser.$("#daterange-picker5");
 		dateRangePicker.click();
 		browser.keys("Jul 17, 2020 @ Jul 16, 2020");
@@ -173,7 +173,7 @@ describe("DateRangePicker general interaction", () => {
 	});
 
 	it("Delimiter is part of the format pattern", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DateRangePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateRangePicker.html`);
 		const daterangepicker = browser.$("#daterange-picker6");
 
 		daterangepicker.click();

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 const openPickerById = (id, options) => {
 	const res = browser.execute((id, options) => {

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -46,7 +46,7 @@ const getTimeSlidersCount = id => {
 
 describe("DateTimePicker general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/DateTimePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DateTimePicker.html`);
 	});
 
 	it("tests picker opens/closes programmatically", () => {

--- a/packages/main/test/specs/DayPicker.spec.js
+++ b/packages/main/test/specs/DayPicker.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Day Picker Tests", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/DayPicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DayPicker.html`);
 	});
 
 	it("Day Picker Renders", () => {

--- a/packages/main/test/specs/DayPicker.spec.js
+++ b/packages/main/test/specs/DayPicker.spec.js
@@ -1,5 +1,6 @@
 const daypicker = require("../pageobjects/DayPickerTestPage");
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Day Picker Tests", () => {
 	before(() => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Dialog general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Dialog.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Dialog.html`);
 	});
 
 	it("tests dialog toggling", () => {
@@ -36,7 +36,7 @@ describe("Dialog general interaction", () => {
 	});
 
 	it("tests dialog lifecycle", () => {
-		browser.url("http://localhost:8080/test-resources/pages/DialogLifecycle.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DialogLifecycle.html`);
 
 		assert.ok(!browser.$("ui5-static-area").length, "No static area.");
 
@@ -52,7 +52,7 @@ describe("Dialog general interaction", () => {
 	});
 
 	it("draggable", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Dialog.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Dialog.html`);
 
 		const openDraggableDialogButton = browser.$("#draggable-open");
 		openDraggableDialogButton.click();
@@ -146,7 +146,7 @@ describe("Dialog general interaction", () => {
 
 describe("Acc", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Dialog.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Dialog.html`);
 	});
 
 	it("tests aria-labelledby and aria-label", () => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Dialog general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/DurationPicker.spec.js
+++ b/packages/main/test/specs/DurationPicker.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Duration Picker general interaction", () => {

--- a/packages/main/test/specs/DurationPicker.spec.js
+++ b/packages/main/test/specs/DurationPicker.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Duration Picker general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/DurationPicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/DurationPicker.html`);
 	});
 
 	it("Tests opening and closing of popover", () => {

--- a/packages/main/test/specs/Eventing.spec.js
+++ b/packages/main/test/specs/Eventing.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Eventing", () => {
 

--- a/packages/main/test/specs/Eventing.spec.js
+++ b/packages/main/test/specs/Eventing.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("Eventing", () => {
 
 	it("Default prevented", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Eventing.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Eventing.html`);
 
 		const innerLink = browser.$("#defaultPreventedLink");
 		innerLink.click();
@@ -16,7 +16,7 @@ describe("Eventing", () => {
 	});
 
 	it("Default not prevented", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Eventing.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Eventing.html`);
 
 		const innerLink = browser.$("#normalLink");
 		innerLink.click();

--- a/packages/main/test/specs/FileUploader.spec.js
+++ b/packages/main/test/specs/FileUploader.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("API", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/FileUploader.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/FileUploader.html`);
 	});
 
 	it("Files property", () => {

--- a/packages/main/test/specs/FileUploader.spec.js
+++ b/packages/main/test/specs/FileUploader.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("API", () => {
 	before(() => {

--- a/packages/main/test/specs/FormSupport.spec.js
+++ b/packages/main/test/specs/FormSupport.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Form support", () => {
 

--- a/packages/main/test/specs/FormSupport.spec.js
+++ b/packages/main/test/specs/FormSupport.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("Form support", () => {
 
 	it("Normal button does not submit forms", () => {
-		browser.url("http://localhost:8080/test-resources/pages/FormSupport.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/FormSupport.html`);
 
 		const noSubmitButton = browser.$("#b1");
 		noSubmitButton.click();
@@ -16,7 +16,7 @@ describe("Form support", () => {
 	});
 
 	it("Submit button does submit forms", () => {
-		browser.url("http://localhost:8080/test-resources/pages/FormSupport.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/FormSupport.html`);
 
 		const submitButton = browser.$("#b2");
 		submitButton.click();

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Icon general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Icon general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Icon.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Icon.html`);
 	});
 
 	it("Tests icon rendering", () => {

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Input.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input.html`);
 	});
 
 	it("Should change the placeholder of the inner input", () => {
@@ -59,7 +59,7 @@ describe("Attributes propagation", () => {
 
 describe("Input general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Input.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input.html`);
 	});
 
 	it("Should open suggestions popover when focused", () => {
@@ -164,7 +164,7 @@ describe("Input general interaction", () => {
 	});
 
 	it("handles suggestions", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Input.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input.html`);
 
 		let item;
 		const suggestionsInput = $("#myInput").shadow$("input");
@@ -197,7 +197,7 @@ describe("Input general interaction", () => {
 	});
 
 	it("handles suggestions via keyboard", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Input.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input.html`);
 
 		const suggestionsInput = $("#myInput2").shadow$("input");
 		const inputResult = $("#inputResult").shadow$("input");
@@ -351,7 +351,7 @@ describe("Input general interaction", () => {
 	});
 
 	it("fires suggestion-item-preview", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Input_quickview.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input_quickview.html`);
 
 		const inputItemPreview = $("#inputPreview2").shadow$("input");
 		const suggestionItemPreviewRes = $("#suggestionItemPreviewRes");
@@ -382,7 +382,7 @@ describe("Input general interaction", () => {
 	});
 
 	it("Should open suggestions popover when ui5-input is the first focusable element within a dialog", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Input.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Input.html`);
 		const input = $("#inputInDialog");
 		const button = browser.$("#btnOpenDialog");
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Item Navigation Tests", () => {
 	before(() => {

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Item Navigation Tests", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ItemNavigation.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ItemNavigation.html`);
 	});
 
 	it("focus does not cycle", () => {

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("General API", () => {
 	before(() => {

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("General API", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Label.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Label.html`);
 	});
 
 	it("tests initial rendering", () => {

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -1,4 +1,5 @@
-const assert = require('chai').assert;
+const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("General API", () => {
 	before(() => {

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("General API", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Link.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Link.html`);
 	});
 
 	it("render initially", () => {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -1,5 +1,6 @@
 const list = require("../pageobjects/ListTestPage");
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("List Tests", () => {
 	before(() => {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("List Tests", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/List_test_page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/List_test_page.html`);
 	});
 
 	it("List is rendered", () => {
@@ -139,7 +139,7 @@ describe("List Tests", () => {
 	});
 
 	it("mode: multiselect. clicking every item selects it independently from the other items", () => {
-		browser.url("http://localhost:8080/test-resources/pages/List_test_page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/List_test_page.html`);
 		list.root.setProperty("mode", "MultiSelect");
 
 		const firstItem = list.getItem(0);
@@ -157,7 +157,7 @@ describe("List Tests", () => {
 	});
 
 	it("mode: delete. items have X buttons which delete them", () => {
-		browser.url("http://localhost:8080/test-resources/pages/List_test_page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/List_test_page.html`);
 		list.root.setProperty("mode", "Delete");
 
 		const firstItem = list.getItem(0);

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Lit HTML key function for #each", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/LitKeyFunction.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/LitKeyFunction.html`);
 	});
 
 	it("LIT HTML does not mess up keys when looping over lists", () => {

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Lit HTML key function for #each", () => {
 	before(() => {

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("MessageStrip general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("MessageStrip general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/MessageStrip.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/MessageStrip.html`);
 	});
 
 	it("tests close event", () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("MultiComboBox general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("MultiComboBox general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 	});
 
 	describe("toggling", () => {
@@ -61,7 +61,7 @@ describe("MultiComboBox general interaction", () => {
 		});
 
 		it("Opens selected items Popover", () => {
-			browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 
 			browser.setWindowSize(400, 1250);
 			const staticAreaItemClassName = browser.getStaticAreaItemClassName("#multi1")
@@ -76,7 +76,7 @@ describe("MultiComboBox general interaction", () => {
 
 	describe("selection and filtering", () => {
 		before(() => {
-			browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 			browser.setWindowSize(1920, 1080);
 		});
 
@@ -222,7 +222,7 @@ describe("MultiComboBox general interaction", () => {
 
 	describe("keyboard handling", () => {
 		before(() => {
-			browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 		});
 
 		it("tests backspace when combobox has an empty value", () => {
@@ -244,7 +244,7 @@ describe("MultiComboBox general interaction", () => {
 
 	describe("General", () => {
 		before(() => {
-			browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 		});
 
 		it ("tests two-column layout", () => {
@@ -270,7 +270,7 @@ describe("MultiComboBox general interaction", () => {
 
 	describe("ARIA attributes", () => {
 		before(() => {
-			browser.url("http://localhost:8080/test-resources/pages/MultiComboBox.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 		});
 
 		it ("aria-describedby value according to the tokens count and the value state", () => {

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 const getTokenizerPopoverId = (inputId) => {
 	return browser.execute(async (inputId) => {

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -12,7 +12,7 @@ const getTokenizerPopoverId = (inputId) => {
 
 describe("MultiInput general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/MultiInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/MultiInput.html`);
 	});
 
 	it("tests expanding of tokenizer", () => {

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Panel general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Panel general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Panel.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Panel.html`);
 	});
 
 	it("Changing the header text is reflected", () => {

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 	});
 
 	it("Header text attribute is propagated", () => {
@@ -33,7 +33,7 @@ describe("Attributes propagation", () => {
 
 describe("Popover general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 	});
 
 	it("tests popover toggling", () => {
@@ -178,7 +178,7 @@ describe("Popover general interaction", () => {
 	});
 
 	it("tests focus trapping using TAB", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 
 		const btn = $("#btn");
 		const ff = $("#first-focusable");
@@ -210,7 +210,7 @@ describe("Popover general interaction", () => {
 	});
 
 	it("tests focus trapping using SHIFT TAB", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 
 		const btn = $("#btn");
 		const ff = $("#first-focusable");
@@ -238,7 +238,7 @@ describe("Popover general interaction", () => {
 	});
 
 	it("tests focus when there is no focusable content", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 
 		const firstBtn = $("#firstBtn");
 		const popoverId = "popNoFocusableContent";
@@ -257,7 +257,7 @@ describe("Popover general interaction", () => {
 	});
 
 	it("tests focus when content, which can't be focused is clicked", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 
 		$("#btnOpenPopoverWithDiv").click();
 		$("#divContent").click();
@@ -269,7 +269,7 @@ describe("Popover general interaction", () => {
 	});
 
 	it("tests that dynamically created popover is opened", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 
 		const btnOpenDynamic = $("#btnOpenDynamic");
 		btnOpenDynamic.click();
@@ -289,7 +289,7 @@ describe("Popover general interaction", () => {
 
 describe("Acc", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Popover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Popover.html`);
 	});
 
 	it("tests aria-labelledby and aria-label", () => {

--- a/packages/main/test/specs/ProgressIndicator.spec.js
+++ b/packages/main/test/specs/ProgressIndicator.spec.js
@@ -10,7 +10,7 @@ const getValidatedValue = (pi) => {
 
 describe("API", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ProgressIndicator.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ProgressIndicator.html`);
 	});
 
 	it("tests value validation", () => {

--- a/packages/main/test/specs/ProgressIndicator.spec.js
+++ b/packages/main/test/specs/ProgressIndicator.spec.js
@@ -1,4 +1,6 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
+
 
 const getValidatedValue = (pi) => {
 	return browser.execute((pi) => {

--- a/packages/main/test/specs/RTL.spec.js
+++ b/packages/main/test/specs/RTL.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("RTL", () => {
 	it("language forces RTL, if RTL not specified", () => {

--- a/packages/main/test/specs/RTL.spec.js
+++ b/packages/main/test/specs/RTL.spec.js
@@ -3,21 +3,21 @@ const PORT = require("./_port.js");
 
 describe("RTL", () => {
 	it("language forces RTL, if RTL not specified", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-language=he");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Button.html?sap-ui-language=he`);
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
 		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
 	});
 
 	it("config forces RTL", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=true");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Button.html?sap-ui-rtl=true`);
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
 		assert.strictEqual(buttonRoot.getProperty("dir"), "rtl", "dir is correctly set");
 	});
 
 	it("config unsets RTL, although rtl language is used", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Button.html?sap-ui-rtl=false&sap-ui-language=he");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Button.html?sap-ui-rtl=false&sap-ui-language=he`);
 
 		const buttonRoot = browser.$("#button1").shadow$(".ui5-button-root");
 		assert.notOk(buttonRoot.getProperty("dir"), "dir is not present");

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("RadioButton general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/RadioButton.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RadioButton.html`);
 	});
 
 	it("tests select event", () => {

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("RadioButton general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("Testing Range Slider interactions", () => {
 
 	it("Changing the current startValue is reflected", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 		browser.setWindowSize(1257, 2000);
 
 		const rangeSlider = browser.$("#range-slider-tickmarks");
@@ -325,7 +325,7 @@ describe("Accessibility", () => {
 	});
 
 	it("Click anywhere in the  Range Slider should focus the closest handle", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 
 		const rangeSlider = browser.$("#basic-range-slider");
 		const rangeSliderStartHandle = rangeSlider.shadow$(".ui5-slider-handle--start");
@@ -350,7 +350,7 @@ describe("Accessibility", () => {
 	});
 
 	it("Click currently selected range should focus it", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 
 		const rangeSlider = browser.$("#basic-range-slider");
 		const rangeSliderSelection = rangeSlider.shadow$(".ui5-slider-progress");
@@ -367,7 +367,7 @@ describe("Accessibility", () => {
 
 
 	it("When not yet focused, 'Tab' should focus the Range Slider and move the focus to the progress bar", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 
 		const rangeSlider = browser.$("#basic-range-slider");
 		const rangeSliderSelection = rangeSlider.shadow$(".ui5-slider-progress");
@@ -493,7 +493,7 @@ describe("Accessibility", () => {
 
 describe("Accessibility: Testing keyboard handling", () => {
 	it("When progress bar is focused 'Right Arrow' key should increase both values of the Range Slider with a small increment step", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 		const rangeSlider = browser.$("#basic-range-slider");
 
 		browser.keys("Tab");
@@ -645,7 +645,7 @@ describe("Accessibility: Testing keyboard handling", () => {
 	});
 
 	it("When a handle is focused 'Right Arrow' key should increase its value with a small increment step", () => {
-		browser.url("http://localhost:8080/test-resources/pages/RangeSlider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RangeSlider.html`);
 
 		const rangeSlider = browser.$("#basic-range-slider");
 

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Testing Range Slider interactions", () => {
 

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Rating Indicator general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/RatingIndicator.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/RatingIndicator.html`);
 	});
 
 	it("Tests basic rating indicator rendering", () => {

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Rating Indicator general interaction", () => {

--- a/packages/main/test/specs/ResponsivePopover.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("ResponsivePopover general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ResponsivePopover.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ResponsivePopover.html`);
 	});
 
 	it("header and footer are displayed by default", () => {

--- a/packages/main/test/specs/ResponsivePopover.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("ResponsivePopover general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("SegmentedButton general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/SegmentedButton.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/SegmentedButton.html`);
 	});
 
 	it("tests if pressed attribute is applied", () => {

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("SegmentedButton general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Select general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Select.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Select.html`);
 	});
 
 	it("fires change on selection", () => {

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Select general interaction", () => {
 	before(() => {
@@ -344,7 +345,7 @@ describe("Select general interaction", () => {
 			"The aria-label is correctly set internally.");
 		assert.strictEqual(select1.getAttribute("aria-expanded"), "false",
 			"The aria-expanded is false by default.");
-	
+
 		assert.strictEqual(select2.getAttribute("aria-label"), EXPECTED_ARIA_LABEL2,
 			"The aria-label is correctly set internally.");
 		assert.strictEqual(select2.getAttribute("aria-expanded"), "false",

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Slider basic interactions", () => {
 

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("Slider basic interactions", () => {
 
 	it("Changing the current value is reflected", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Slider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Slider.html`);
 
 		const slider = browser.$("#basic-slider");
 		const sliderHandle = slider.shadow$(".ui5-slider-handle");
@@ -203,7 +203,7 @@ describe("Accessibility", () => {
 	});
 
 	it("Click anywhere in the Slider should focus the Slider's handle", () => {
-		browser.url("http://localhost:8080/test-resources/pages/Slider.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Slider.html`);
 
 		const slider = browser.$("#basic-slider");
 		const sliderHandle = slider.shadow$(".ui5-slider-handle");

--- a/packages/main/test/specs/StepInput.spec.js
+++ b/packages/main/test/specs/StepInput.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 

--- a/packages/main/test/specs/StepInput.spec.js
+++ b/packages/main/test/specs/StepInput.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 describe("Attributes propagation", () => {
 
 	it("'placeholder' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const sExpected = "New placeholder text";
 
@@ -15,7 +15,7 @@ describe("Attributes propagation", () => {
 	});
 
 	it("'min' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const sExpected = "0";
 
@@ -26,7 +26,7 @@ describe("Attributes propagation", () => {
 	});
 
 	it("'max' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const sExpected = "10";
 
@@ -37,7 +37,7 @@ describe("Attributes propagation", () => {
 	});
 
 	it("'step' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const sExpected = "2";
 
@@ -48,17 +48,17 @@ describe("Attributes propagation", () => {
 	});
 
 	it("'disabled' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		assert.ok(browser.$("#stepInputDisabled").shadow$('.ui5-step-input-input').shadow$("input").getAttribute("disabled"), "The 'disabled' property was propagated");
 	});
 
 	it("'redonly' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		assert.ok(browser.$("#stepInputReadOnly").shadow$('.ui5-step-input-input').shadow$("input").getAttribute("readonly"), "The 'readonly' property was propagated");
 	});
 
 	it("'value' attribute is propagated properly", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const sExpectedValue = "5";
 
 		browser.execute(() => {
@@ -73,7 +73,7 @@ describe("Attributes propagation", () => {
 describe("Keyboard interactions", () => {
 
 	it("'ArrowUp' increases the value if it is less than 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const initValue = siMinMax.getProperty("value");
 
@@ -90,7 +90,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'ArrowUp' does not increase the value if it is greater than 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 
@@ -105,7 +105,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'ArrowDown' decreases the value if it is greater than 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 		const minValue = siMinMax.getProperty("min");
@@ -125,7 +125,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'ArrowDown' does not decrease the value if it is less than 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 		const minValue = siMinMax.getProperty("min");
@@ -141,7 +141,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'Shift+PageUp' sets the value to the 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 
@@ -152,7 +152,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'Shift+PageDown' sets the value to the 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 		const minValue = siMinMax.getProperty("min");
@@ -166,7 +166,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'Ctrl+Shift+ArrowUp' sets the value to the 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 
@@ -177,7 +177,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'Ctrl+Shift+ArrowDown' sets the value to the 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const maxValue = siMinMax.getProperty("max");
 		const minValue = siMinMax.getProperty("min");
@@ -191,7 +191,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("'Escape' restores the previous value", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const initValue = siMinMax.getProperty("value");
 
@@ -207,7 +207,7 @@ describe("Keyboard interactions", () => {
 	});
 
 	it("Manual input changes the value", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 
 		// focus the step input field
@@ -222,7 +222,7 @@ describe("Keyboard interactions", () => {
 describe("Inc/Dec buttons interactions", () => {
 
 	it("'Increase' button increases the value if it is less than 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const incButton = siMinMax.shadow$(".ui5-step-inc");
 		const initValue = siMinMax.getProperty("value");
@@ -237,7 +237,7 @@ describe("Inc/Dec buttons interactions", () => {
 	});
 
 	it("'Increase' button does not increase the value if it is greater than 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const incButton = siMinMax.shadow$(".ui5-step-inc");
 		const initValue = siMinMax.getProperty("value");
@@ -252,7 +252,7 @@ describe("Inc/Dec buttons interactions", () => {
 	});
 
 	it("'Decrease' button decreases the value if it is greater than 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const decButton = siMinMax.shadow$(".ui5-step-dec");
 		const maxValue = siMinMax.getProperty("max");
@@ -270,7 +270,7 @@ describe("Inc/Dec buttons interactions", () => {
 	});
 
 	it("'Decrease' button does not decrease the value if it is less than 'min'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const decButton = siMinMax.shadow$(".ui5-step-dec");
 		const minValue = siMinMax.getProperty("min");
@@ -288,7 +288,7 @@ describe("Inc/Dec buttons interactions", () => {
 describe("'change' event firing", () => {
 
 	it("'Increase' and 'Decrease' buttons should fire 'change' event on each click only if value is between 'min' and 'max'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const incButton = siMinMax.shadow$(".ui5-step-inc");
 		const decButton = siMinMax.shadow$(".ui5-step-dec");
@@ -334,7 +334,7 @@ describe("'change' event firing", () => {
 	});
 
 	it("'change' event should not be fired when 'ArrowUp'/'ArrowDown' are pressed without 'Enter' after that", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const changeResult = $("#changeResult");
 
@@ -352,7 +352,7 @@ describe("'change' event firing", () => {
 	});
 
 	it("'change' event should not be fired when previous value is restored with 'Escape'", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const changeResult = $("#changeResult");
 
@@ -368,7 +368,7 @@ describe("'change' event firing", () => {
 	});
 
 	it("'change' event should be fired when 'ArrowUp'/'ArrowDown' are pressed with 'Enter' after that", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const changeResult = $("#changeResult");
 
@@ -388,7 +388,7 @@ describe("'change' event firing", () => {
 	});
 
 	it("'change' event should be fired after manual entry and 'Enter' pressed after that", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siMinMax = $("#stepInputMinMax");
 		const changeResult = $("#changeResult");
 
@@ -405,7 +405,7 @@ describe("'change' event firing", () => {
 	});
 
 	it("'change' event should be fired after focus out", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const siMinMax = $("#stepInputMinMax");
 		const changeResult = $("#changeResult");
@@ -429,7 +429,7 @@ describe("'change' event firing", () => {
 describe("Accessibility related parameters", () => {
 
 	it("'step', 'min', 'max', 'aria-required' and 'aria-label' attributes presence", () => {
-		browser.url("http://localhost:8080/test-resources/pages/StepInput.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/StepInput.html`);
 		const siCozy = $("#stepInputCozy");
 		const siInner = siCozy.shadow$('.ui5-step-input-input').shadow$("input");
 

--- a/packages/main/test/specs/Switch.spec.js
+++ b/packages/main/test/specs/Switch.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Switch general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Switch.spec.js
+++ b/packages/main/test/specs/Switch.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Switch general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Switch.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Switch.html`);
 	});
 
 	it("tests change event", () => {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("TabContainer general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/TabContainer.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TabContainer.html`);
 	});
 
 	it("tests initially selected tab", () => {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("TabContainer general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Table general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Table general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Table.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Table.html`);
 	});
 
 	it("tests if column disapears when min-width is reacted (650px)", () => {
@@ -77,7 +77,7 @@ describe("Table general interaction", () => {
 
 	describe("Growing Table on 'More' button press", () => {
 		it("tests the 'load-more' event", () => {
-			browser.url("http://localhost:8080/test-resources/pages/TableLoadMore.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/TableLoadMore.html`);
 
 			const inputResult = browser.$("#inputLoadMoreCounter");
 			const loadMoreTrigger = browser.$("#tbl").shadow$("[load-more-inner]");
@@ -104,7 +104,7 @@ describe("Table general interaction", () => {
 
 	describe("Growing Table on Scroll", () => {
 		it("tests the 'load-more' event", () => {
-			browser.url("http://localhost:8080/test-resources/pages/TableGrowingWithScroll.html");
+			browser.url(`http://localhost:${PORT}/test-resources/pages/TableGrowingWithScroll.html`);
 
 			const inputResult = browser.$("#inputLoadMoreCounter");
 			const btnScroll = browser.$("#btnScroll");

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Attributes propagation", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/TextArea.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TextArea.html`);
 	});
 
 	it("Should change the placeholder of the inner textarea", () => {
@@ -55,7 +55,7 @@ describe("Attributes propagation", () => {
 
 describe("disabled and readonly textarea", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/TextArea.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TextArea.html`);
 	});
 
 	it("can not be edited when disabled", () => {
@@ -78,7 +78,7 @@ describe("disabled and readonly textarea", () => {
 
 describe("when enabled", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/TextArea.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TextArea.html`);
 	});
 
 	it("shows value state message", () => {

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("TimePicker general interaction", () => {
 	it("input receives value in format pattern depending on the set language", () => {
-		browser.url("http://localhost:8080/test-resources/pages/TimePicker.html?sap-ui-language=bg");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html?sap-ui-language=bg`);
 
 		const timepicker = browser.$("#timepickerSetTime");
 		const setTimeButton = browser.$("#setTimeButton");
@@ -14,7 +14,7 @@ describe("TimePicker general interaction", () => {
 	});
 
 	it("tests sliders value", () => {
-		browser.url("http://localhost:8080/test-resources/pages/TimePicker.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html`);
 		const timepicker = browser.$("#timepicker");
 		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#timepicker");
 		const timepickerPopover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("TimePicker general interaction", () => {
 	it("input receives value in format pattern depending on the set language", () => {

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Rendering", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Title.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Title.html`);
 	});
 
 	it("h{n} tags rendered correctly", () => {

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Rendering", () => {
 	before(() => {

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 
 describe("Toast general interaction", () => {

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -4,7 +4,7 @@ const PORT = require("./_port.js");
 
 describe("Toast general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Toast.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Toast.html`);
 	});
 
 	it("tests open attribute before show", () => {

--- a/packages/main/test/specs/ToggleButton.spec.js
+++ b/packages/main/test/specs/ToggleButton.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("ToggleButton general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/ToggleButton.spec.js
+++ b/packages/main/test/specs/ToggleButton.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("ToggleButton general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/ToggleButton.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ToggleButton.html`);
 	});
 
 	it("should fire click event on a normal togglebutton", () => {

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Tree general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Tree.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Tree.html`);
 	});
 
 	it("Tree is rendered", () => {
@@ -35,7 +35,7 @@ describe("Tree general interaction", () => {
 
 describe("Tree proxies properties to list", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Tree.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Tree.html`);
 	});
 
 	it("Mode works", () => {
@@ -66,7 +66,7 @@ describe("Tree proxies properties to list", () => {
 
 describe("Tree has screen reader support", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/Tree.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Tree.html`);
 	});
 
 	it("List role is correct", () => {

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Tree general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/WheelSlider.spec.js
+++ b/packages/main/test/specs/WheelSlider.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("./_port.js");
 
 describe("Wheel Slider general interaction", () => {
 	before(() => {

--- a/packages/main/test/specs/WheelSlider.spec.js
+++ b/packages/main/test/specs/WheelSlider.spec.js
@@ -3,7 +3,7 @@ const PORT = require("./_port.js");
 
 describe("Wheel Slider general interaction", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/WheelSlider_Test_Page.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/WheelSlider_Test_Page.html`);
 	});
 
 	before(() => {

--- a/packages/main/test/specs/_port.js
+++ b/packages/main/test/specs/_port.js
@@ -1,0 +1,3 @@
+const fs = require("fs");
+const packageFile = JSON.parse(fs.readFileSync(require.resolve("@ui5/webcomponents/package.json")));
+module.exports = packageFile.ui5.port;

--- a/packages/main/test/specs/base/DOMObserver.spec.js
+++ b/packages/main/test/specs/base/DOMObserver.spec.js
@@ -3,7 +3,7 @@ const PORT = require("../_port.js");
 
 describe("DOMObserver", () => {
 	before(() => {
-		browser.url("http://localhost:8080/test-resources/pages/base/DOMObserver.html");
+		browser.url(`http://localhost:${PORT}/test-resources/pages/base/DOMObserver.html`);
 	});
 
 	it("insertion order still fires DOMObserver", () => {

--- a/packages/main/test/specs/base/DOMObserver.spec.js
+++ b/packages/main/test/specs/base/DOMObserver.spec.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const PORT = require("../_port.js");
 
 describe("DOMObserver", () => {
 	before(() => {


### PR DESCRIPTION
This is a preparation for another change, related to ports management.

Changes:
 - for all tests, read the port from the `package.json` files