### PR TITLE
refactor(ui5-wizard): configure step change threshold

### DIFF
--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -63,6 +63,28 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the threshold to switch between steps upon user scrolling.
+		 * <br><br>
+		 *
+		 * <b>For Example:</b>
+		 * <br>
+		 * (1) To switch to the next step, when half of the step is scrolled out - set <code>step-switch-threshold="0.5"</code>.
+		 * (2) To switch to the next step, when the entire current step is scrolled out - set <code>step-switch-threshold="1"</code>.
+		 *
+		 * <br><br>
+		 * <b>Note:</b> Supported values are between 0.5 and 1
+		 * and values out of the range will be normalized to 0.5 and 1 respectively.
+		 * @private
+		 * @type {Float}
+		 * @defaultvalue 0.7
+		 * @since 1.0.0-rc.13
+		 */
+		 stepSwitchThreshold: {
+			type: Float,
+			defaultValue: 0.7,
+		},
+
+		/**
 		 * Defines the height of the <code>ui5-wizard</code> content.
 		 * @private
 		 */
@@ -731,6 +753,18 @@ class Wizard extends UI5Element {
 		return this.ariaLabel || this.i18nBundle.getText(WIZARD_NAV_ARIA_ROLE_DESCRIPTION);
 	}
 
+	get effectivestepSwitchThreshold() {
+		if (this.stepSwitchThreshold < 0.5) {
+			return 0.5;
+		}
+
+		if (this.stepSwitchThreshold > 1) {
+			return 1;
+		}
+
+		return this.stepSwitchThreshold;
+	}
+
 	/**
 	 * Returns an array of data objects, based on the user defined steps
 	 * to later build the steps (tabs) within the header.
@@ -813,9 +847,12 @@ class Wizard extends UI5Element {
 		return this.shadowRoot.querySelector(`[data-ui5-content-item-ref-id=${refId}]`);
 	}
 
+	getStepWrapperByIdx(idx) {
+		return this.getStepWrapperByRefId(this.steps[idx]._id);
+	}
+
 	/**
-	 * Scrolls to the content of the selected step
-	 * and it is used in <code>onAfteRendering</cod>.
+	 * Scrolls to the content of the selected step, used in <code>onAfterRendering</cod>.
 	 * @private
 	 */
 	scrollToSelectedStep() {
@@ -838,7 +875,6 @@ class Wizard extends UI5Element {
 
 	/**
 	 * Returns to closest scroll position for the given step index.
-	 * by given step index.
 	 *
 	 * @private
 	 * @param {Integer} stepIndex the index of a step
@@ -862,16 +898,20 @@ class Wizard extends UI5Element {
 
 	/**
 	 * Returns the closest step index by given scroll position.
-	 *
-	 * @param {Integer} scrollPos scroll position
-	 * @returns {Integer} closestStepIndex the closest step index
 	 * @private
+	 * @param {Integer} scrollPos the scroll position
 	 */
 	getClosestStepIndexByScrollPos(scrollPos) {
 		for (let closestStepIndex = 0; closestStepIndex <= this.stepScrollOffsets.length - 1; closestStepIndex++) {
-			const stepOffset = this.stepScrollOffsets[closestStepIndex];
+			const stepScrollOffset = this.stepScrollOffsets[closestStepIndex];
+			const step = this.getStepWrapperByIdx(closestStepIndex);
+			const switchStepBoundary = step.offsetTop + (step.offsetHeight * this.effectivestepSwitchThreshold);
 
-			if (stepOffset > 0 && scrollPos < stepOffset) {
+			if (stepScrollOffset > 0 && scrollPos < stepScrollOffset) {
+				if (scrollPos > switchStepBoundary) {
+					return closestStepIndex + 1;
+				}
+
 				return closestStepIndex;
 			}
 		}

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -753,7 +753,7 @@ class Wizard extends UI5Element {
 		return this.ariaLabel || this.i18nBundle.getText(WIZARD_NAV_ARIA_ROLE_DESCRIPTION);
 	}
 
-	get effectivestepSwitchThreshold() {
+	get effectiveStepSwitchThreshold() {
 		if (this.stepSwitchThreshold < 0.5) {
 			return 0.5;
 		}
@@ -905,7 +905,7 @@ class Wizard extends UI5Element {
 		for (let closestStepIndex = 0; closestStepIndex <= this.stepScrollOffsets.length - 1; closestStepIndex++) {
 			const stepScrollOffset = this.stepScrollOffsets[closestStepIndex];
 			const step = this.getStepWrapperByIdx(closestStepIndex);
-			const switchStepBoundary = step.offsetTop + (step.offsetHeight * this.effectivestepSwitchThreshold);
+			const switchStepBoundary = step.offsetTop + (step.offsetHeight * this.effectiveStepSwitchThreshold);
 
 			if (stepScrollOffset > 0 && scrollPos < stepScrollOffset) {
 				if (scrollPos > switchStepBoundary) {

--- a/packages/fiori/test/pages/Wizard_test.html
+++ b/packages/fiori/test/pages/Wizard_test.html
@@ -43,6 +43,16 @@
 
 					<ui5-input id="inpSelectionChangeCounter"></ui5-input>
 					<ui5-button id="btnOpenDialog" style="width: 150px; align-self: flex-end;">Open Wizard Dialog</ui5-button>
+
+					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+						<ui5-label>Configure step-switch-threshold</ui5-label>
+						<ui5-segmentedbutton id="setting">
+							<ui5-togglebutton threshold="0.3">0.5</ui5-togglebutton>
+							<ui5-togglebutton threshold="0.7" pressed>default (0.7)</ui5-togglebutton>
+							<ui5-togglebutton threshold="1">1</ui5-togglebutton>
+						</ui5-segmentedbutton>
+					</div>
+					
 				</div>
 
 				<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
@@ -350,6 +360,10 @@
 
 		btnOpenDialog.addEventListener("click", function () {
 			dialog.open();
+		});
+
+		setting.addEventListener("selection-change", function (event) {
+			wiz.setAttribute("step-switch-threshold", event.detail.selectedButton.getAttribute("threshold"));
 		});
 	</script>
 </body>


### PR DESCRIPTION
**Background**
There are complains that if the user is at the very beginning of a step and scrolls a bit upwards, the selection switches to the previous step, although most of the viewport is taken by the first one.

This has been raised with https://github.com/SAP/ui5-webcomponents/issues/2883:
"5. scroll up a little bit of the cascading goal dialog, and you can see the fact that although the most of dialog is step two, but the wizard will highlight the step one button. this is an issue, because the current step is still step two"

**Solution**
Add private/protected API, called step-switch-threshold
to give more control of the point the switch happens.
It support float values between 0.5 and 1, where 0.5 means the step will be switched after the user scrolls half of the current step, and 1 - when the current step is entirely scrolled out. The default value is 0.7, which is very close to the behaviour of the sap.m.Wizard.

**Usage**
```html
<ui5-wizard step-switch-threshold="0.5">
<ui5-wizard step-switch-threshold="0.6">
<ui5-wizard step-switch-threshold="1">
```

Related to: https://github.com/SAP/ui5-webcomponents/issues/2883
