### PR TITLE
fix(ui5-input): inner input padding is correctly updated

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -1101,7 +1101,7 @@ class Input extends UI5Element {
 	}
 
 	get styles() {
-		return {
+		const stylesObject = {
 			popoverHeader: {
 				"max-width": `${this._inputWidth}px`,
 			},
@@ -1113,10 +1113,14 @@ class Input extends UI5Element {
 			suggestionsPopover: {
 				"max-width": `${this._inputWidth}px`,
 			},
-			innerInput: {
-				padding: this.nativeInputWidth < 48 ? "0" : undefined,
-			},
+			innerInput: {},
 		};
+
+		if (this.nativeInputWidth < 48) {
+			stylesObject.innerInput.padding = "0";
+		}
+
+		return stylesObject;
 	}
 
 	get suggestionSeparators() {


### PR DESCRIPTION
Prevously, after padding: 0 was applied when the condition is false, it remained 0. That could be easily reproduced with native HTML as well. Setting 'undefined' as a value does not change the padding to the one specified in the component's css styles.
https://snippix.only.sap/snippets/52143
Now, when the padding should not be 0, the inline style is removed, instead of setting 'undefined' as a value

FIXES: #2940 
