### PR TITLE
docs: document native metadata events

### DIFF
--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -71,15 +71,6 @@ const metadata = {
 	},
 
 	events: /** @lends sap.ui.webcomponents.fiori.SideNavigationItem.prototype */ {
-		/**
-		 * @public
-		 * @event
-		 * @since 1.0.0-rc.9
-		 * @native
-		 */
-		click: {
-
-		},
 	},
 
 	slots: /** @lends sap.ui.webcomponents.fiori.SideNavigationItem.prototype */ {

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -75,6 +75,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 * @since 1.0.0-rc.9
+		 * @native
 		 */
 		click: {
 

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -49,6 +49,7 @@ const metadata = {
 		 * @public
 		 * @event
 		 * @since 1.0.0-rc.9
+		 * @native
 		 */
 		click: {
 

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -45,15 +45,6 @@ const metadata = {
 	},
 
 	events: /** @lends sap.ui.webcomponents.fiori.SideNavigationSubItem.prototype */ {
-		/**
-		 * @public
-		 * @event
-		 * @since 1.0.0-rc.9
-		 * @native
-		 */
-		click: {
-
-		},
 	},
 };
 

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -135,6 +135,7 @@ const metadata = {
 		 * @readonly
 		 * @param {DataTransfer} dataTransfer The <code>drop</code> event operation data.
 		 * @public
+		 * @native
 		 */
 		drop: {},
 

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -252,6 +252,7 @@ const metadata = {
 		 *
 		 * @event
 		 * @public
+		 * @native
 		 */
 		click: {},
 	},

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -143,6 +143,7 @@ const metadata = {
 		 *
 		 * @event
 		 * @public
+		 * @native
 		 */
 		click: {},
 	},

--- a/packages/tools/lib/jsdoc/plugin.js
+++ b/packages/tools/lib/jsdoc/plugin.js
@@ -31,6 +31,8 @@
  *
  *   tagname
  *
+ *   native
+ *
  *   allowPreventDefault
  *
  * It furthermore listens to the following JSDoc3 events to implement additional functionality
@@ -2088,6 +2090,13 @@ exports.defineTags = function(dictionary) {
 		mustHaveValue: false,
 		onTagged: function(doclet, tag) {
 			doclet.allowPreventDefault = true;
+		}
+	});
+
+	dictionary.defineTag('native', {
+		mustHaveValue: false,
+		onTagged: function(doclet, tag) {
+			doclet.native = true;
 		}
 	});
 };

--- a/packages/tools/lib/jsdoc/template/publish.js
+++ b/packages/tools/lib/jsdoc/template/publish.js
@@ -2885,6 +2885,9 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				if (member.allowPreventDefault) {
 					attrib("allowPreventDefault", true);
 				}
+				if (member.native) {
+					attrib("native", true);
+				}
 				attrib("visibility", visibility(member), 'public');
 				if ( member.scope === 'static' ) {
 					attrib("static", true, false, /* raw = */true);


### PR DESCRIPTION
Most `event`s described in `metadata` are instances of `CustomEvent`, but some are native browser events. They are however described in the events metadata to give developers extra information.

It is however important to know which events are native and which are custom for several reasons:
 - native events are not fired by the framework, therefore they don't have a `ui5-` version. In practice this means that when they are bound in `.hbs` files, they are without the `ui5-` prefix. 
 - for the purpose of documentation

These events get a new `native` field in `API.json` :
```
"events": [
        {
          "name": "click",
          "native": "true",
          "visibility": "public",
          "description": "Fired when the <code>ui5-button</code> is activated either with a mouse/tap or by using the Enter or Space key. <br><br> <b>Note:</b> The event will not be fired if the <code>disabled</code> property is set to <code>true</code>."
        }
      ]
```