### PR TITLE
fix(ui5-icon): RTL mirroring

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -28,3 +28,8 @@
 	outline: none;
 	vertical-align: top;
 }
+
+:host(:not([dir="ltr"])) .ui5-icon-root[dir=rtl] {
+	transform: scale(-1, -1);
+	transform-origin: center;
+}

--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -30,6 +30,6 @@
 }
 
 :host(:not([dir="ltr"])) .ui5-icon-root[dir=rtl] {
-	transform: scale(-1, -1);
+	transform: scale(-1, 1);
 	transform-origin: center;
 }


### PR DESCRIPTION
The vertical flip fix in #2645 also removeд the horizontal mirroring. This returns the normal RTL mirroring.

Fixes: #3029