### PR TITLE
docs: Explain how to make the tests run on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ yarn start:playground
 
 *Note: If you wish to manually install dependencies & run the Playground you can check out our [in depth tutorial](/docs/dev/Playground.md)*
 
+If you want to locally run the tests on a Windows machine, you must also manually install Windows Build Tools 2015 and Python 2.7.
+See the [instructions](/docs/dev/Testing%20Web%20Components.md#24-getting-the-tests-to-run-on-windows) on how to do this. 
+
 ### Production Build
 To build the UI5 Web Components project, run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ yarn start:playground
 
 *Note: If you wish to manually install dependencies & run the Playground you can check out our [in depth tutorial](/docs/dev/Playground.md)*
 
-If you want to locally run the tests on a Windows machine, you must also manually install Windows Build Tools 2015 and Python 2.7.
+If you wish to run the tests locally on a Windows machine, you must also manually install `Windows Build Tools 2015` and `Python 2.7`.
 See the [instructions](/docs/dev/Testing%20Web%20Components.md#24-getting-the-tests-to-run-on-windows) on how to do this. 
 
 ### Production Build

--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -63,6 +63,32 @@ or
 Make sure you're running the `start` command while running single test specs, as it provides a server and the ability to change
 files, and test the changes on the fly.
 
+## 2.4 Getting the tests to run on Windows
+
+Certain modules, required by the test setup, have a dependency to [Node gyp](https://github.com/nodejs/node-gyp). 
+Normally it is installed along with the other dependencies from NPM, but for a `Windows` environment specifically, this is not enough, and
+some manual steps must be performed:
+ 1. Install Windows build tools:
+```shell
+npm install --global --production windows-build-tools --vs2015
+```
+Note the `--vs2015` flag.
+
+Also note that this might take some time to complete as several GB might be downloaded in the process.
+ 2. Configure the right version of Windows build tools for Node.js:
+```shell
+npm config set msvs_version 2015 -–global
+```
+ 3. Install Python `2.7` if you don't already have it: https://www.python.org/download/releases/2.7/
+
+ 4. Set the version of Python to `2.7`
+```shell
+npm config set python python2.7
+```
+
+This should be enough to be able to run `yarn test` successfully. If you still get an error about `node-gyp`,
+you should install `Windows build tools 2015` (from step 1) manually: https://www.microsoft.com/en-us/download/details.aspx?id=48159 .
+
 ## 3. Writing tests
 
 The simplest test would look something like this:

--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -65,6 +65,8 @@ files, and test the changes on the fly.
 
 ## 2.4 Getting the tests to run on Windows
 
+When you first try to run the tests on a Windows machine, you're most likely to get an error saying `node-gyp` is not installed.
+
 Certain modules, required by the test setup, have a dependency to [Node gyp](https://github.com/nodejs/node-gyp). 
 Normally it is installed along with the other dependencies from NPM, but for a `Windows` environment specifically, this is not enough, and
 some manual steps must be performed:

--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -77,10 +77,12 @@ npm install --global --production windows-build-tools --vs2015
 Note the `--vs2015` flag.
 
 Also note that this might take some time to complete as several GB might be downloaded in the process.
+
  2. Configure the right version of Windows build tools for Node.js:
 ```shell
 npm config set msvs_version 2015 -–global
 ```
+
  3. Install Python `2.7` if you don't already have it: https://www.python.org/download/releases/2.7/
 
  4. Set the version of Python to `2.7`


### PR DESCRIPTION
Getting the tests to run on Windows locally is quite complicated.
 - Windows build tools 2015 is required
 - Python 2.7 is required
 - node-gyp is required
These must be installed and configured manually for `yarn test` to run successfully.
