### PR TITLE
feat(ui5-avatar-group): new slot overflowButton

### DIFF
--- a/packages/main/src/AvatarGroup.hbs
+++ b/packages/main/src/AvatarGroup.hbs
@@ -13,7 +13,7 @@
 		{{#if _customOverflowButton}}
 			<slot name="overflowButton"></slot>
 		{{else}}
-			<ui5-button ?hidden="{{_overflowBtnHidden}}" tabindex="{{_overflowButtonTabIndex}}" class="ui5-avatar-group-overflow-btn">
+			<ui5-button ?hidden="{{_overflowBtnHidden}}" ?non-interactive={{_isGroup}} class="ui5-avatar-group-overflow-btn">
 				{{_overflowButtonText}}
 			</ui5-button>
 		{{/if}}

--- a/packages/main/src/AvatarGroup.hbs
+++ b/packages/main/src/AvatarGroup.hbs
@@ -10,8 +10,12 @@
 	>
 		<slot></slot>
 
-		<ui5-button ?hidden="{{_overflowBtnHidden}}" tabindex="{{_overflowButtonTabIndex}}" class="ui5-avatar-group-overflow-btn">
-			{{_overflowButtonText}}
-		</ui5-button>
+		{{#if _hasSlottedOverflowBtn}}
+			<slot name="overflowButton"></slot>
+		{{else}}
+			<ui5-button ?hidden="{{_overflowBtnHidden}}" tabindex="{{_overflowButtonTabIndex}}" class="ui5-avatar-group-overflow-btn">
+				{{_overflowButtonText}}
+			</ui5-button>
+		{{/if}}
 	</div>
 </div>

--- a/packages/main/src/AvatarGroup.hbs
+++ b/packages/main/src/AvatarGroup.hbs
@@ -10,7 +10,7 @@
 	>
 		<slot></slot>
 
-		{{#if _hasSlottedOverflowBtn}}
+		{{#if _customOverflowButton}}
 			<slot name="overflowButton"></slot>
 		{{else}}
 			<ui5-button ?hidden="{{_overflowBtnHidden}}" tabindex="{{_overflowButtonTabIndex}}" class="ui5-avatar-group-overflow-btn">

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -263,7 +263,7 @@ class AvatarGroup extends UI5Element {
 		return this.items.map(avatar => avatar._effectiveBackgroundColor);
 	}
 
-	get _customOverflowButton () {
+	get _customOverflowButton() {
 		return this.overflowButton[0];
 	}
 

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -113,6 +113,20 @@ const metadata = {
 			type: HTMLElement,
 			propertyName: "items",
 		},
+		/**
+		 * Defines the overflow button of <code>ui5-avatar-group</code>.
+		 * <b>Note:</b> We recommend using the <code>ui5-button</code> component.
+		 * <br><br>
+		 * <b>Note:</b> If this slot is not used, the <code>ui5-avatar-group</code> will
+		 * display the built-in overflow button.
+		 * @type {sap.ui.webcomponents.main.Button}
+		 * @slot overflowButton
+		 * @public
+		 * @since 1.0.0-rc.13
+		 */
+		 overflowButton: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.AvatarGroup.prototype */ {
 		/**
@@ -130,6 +144,14 @@ const metadata = {
 				overflowButtonClicked: { type: Boolean },
 			},
 		},
+		/**
+		* Fired when the count of visible <code>ui5-avatar</code> elements in the
+		* <code>ui5-avatar-group</code> has changed
+		* @event
+		* @public
+		* @since 1.0.0-rc.13
+		*/
+		overflow: {},
 	},
 };
 
@@ -241,6 +263,10 @@ class AvatarGroup extends UI5Element {
 		return this.items.map(avatar => avatar._effectiveBackgroundColor);
 	}
 
+	get _hasSlottedOverflowBtn() {
+		return !!this.overflowButton.length;
+	}
+
 	get _hiddenStartIndex() {
 		return this._itemsCount - this._hiddenItems;
 	}
@@ -278,19 +304,20 @@ class AvatarGroup extends UI5Element {
 	 * @private
 	 */
 	get _overflowButtonEffectiveWidth() {
+		const button = this.overflowButton.length ? this.overflowButton[0] : this._overflowButton;
 		// if in "Group" mode overflow button size is equal to the offset from second item
 		if (this._isGroup) {
 			let item = this.items[1];
 
 			// in some cases when second avatar is overflowed the offset of the button is the right one
 			if (!item || item.hidden) {
-				item = this._overflowButton;
+				item = button;
 			}
 
 			return this.effectiveDir === "rtl" ? this._getWidthToItem(item) : item.offsetLeft;
 		}
 
-		return this._overflowButton.offsetWidth;
+		return button.offsetWidth;
 	}
 
 	onAfterRendering() {
@@ -298,6 +325,10 @@ class AvatarGroup extends UI5Element {
 	}
 
 	onBeforeRendering() {
+		if (this._hasSlottedOverflowBtn) {
+			this.overflowButton[0].nonInteractive = this._isGroup;
+		}
+
 		this._prepareAvatars();
 	}
 
@@ -332,7 +363,7 @@ class AvatarGroup extends UI5Element {
 	}
 
 	_fireGroupEvent(targetRef) {
-		const isOverflowButtonClicked = targetRef.classList.contains(OVERFLOW_BTN_CLASS);
+		const isOverflowButtonClicked = targetRef.classList.contains(OVERFLOW_BTN_CLASS) || targetRef === this.overflowButton[0];
 
 		this.fireEvent("click", {
 			targetRef,
@@ -384,7 +415,7 @@ class AvatarGroup extends UI5Element {
 			}
 
 			// last avatar should not be offset as it breaks the container width and focus styles are no set correctly
-			if (index !== this._itemsCount - 1) {
+			if (index !== this._itemsCount - 1 || this._hasSlottedOverflowBtn) {
 				// based on RTL margin left or right is set to avatars
 				avatar.style[`margin-${RTL ? "left" : "right"}`] = offsets[avatar._effectiveSize][this.type];
 			}
@@ -437,7 +468,7 @@ class AvatarGroup extends UI5Element {
 			// used to determine whether the following items will fit the container or not
 			let totalWidth = this._getWidthToItem(item) + item.offsetWidth;
 
-			if (index !== this._itemsCount - 1) {
+			if (index !== this._itemsCount - 1 || this._hasSlottedOverflowBtn) {
 				totalWidth += this._overflowButtonEffectiveWidth;
 			}
 
@@ -460,6 +491,8 @@ class AvatarGroup extends UI5Element {
 	}
 
 	_setHiddenItems(hiddenItems) {
+		const shouldFireEvent = this._hiddenItems !== hiddenItems;
+
 		this._hiddenItems = hiddenItems;
 
 		this.items.forEach((item, index) => {
@@ -467,6 +500,10 @@ class AvatarGroup extends UI5Element {
 		});
 
 		this._overflowButtonText = `+${hiddenItems > 99 ? 99 : hiddenItems}`;
+
+		if (shouldFireEvent) {
+			this.fireEvent("overflow");
+		}
 	}
 }
 

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -263,8 +263,8 @@ class AvatarGroup extends UI5Element {
 		return this.items.map(avatar => avatar._effectiveBackgroundColor);
 	}
 
-	get _hasSlottedOverflowBtn() {
-		return !!this.overflowButton.length;
+	get _customOverflowButton () {
+		return this.overflowButton[0];
 	}
 
 	get _hiddenStartIndex() {
@@ -325,8 +325,8 @@ class AvatarGroup extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		if (this._hasSlottedOverflowBtn) {
-			this.overflowButton[0].nonInteractive = this._isGroup;
+		if (this._customOverflowButton) {
+			this._customOverflowButton.nonInteractive = this._isGroup;
 		}
 
 		this._prepareAvatars();
@@ -415,7 +415,7 @@ class AvatarGroup extends UI5Element {
 			}
 
 			// last avatar should not be offset as it breaks the container width and focus styles are no set correctly
-			if (index !== this._itemsCount - 1 || this._hasSlottedOverflowBtn) {
+			if (index !== this._itemsCount - 1 || this._customOverflowButton) {
 				// based on RTL margin left or right is set to avatars
 				avatar.style[`margin-${RTL ? "left" : "right"}`] = offsets[avatar._effectiveSize][this.type];
 			}
@@ -468,7 +468,7 @@ class AvatarGroup extends UI5Element {
 			// used to determine whether the following items will fit the container or not
 			let totalWidth = this._getWidthToItem(item) + item.offsetWidth;
 
-			if (index !== this._itemsCount - 1 || this._hasSlottedOverflowBtn) {
+			if (index !== this._itemsCount - 1 || this._customOverflowButton) {
 				totalWidth += this._overflowButtonEffectiveWidth;
 			}
 

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -119,7 +119,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> If this slot is not used, the <code>ui5-avatar-group</code> will
 		 * display the built-in overflow button.
-		 * @type {sap.ui.webcomponents.main.Button}
+		 * @type {HTMLElement}
 		 * @slot overflowButton
 		 * @public
 		 * @since 1.0.0-rc.13
@@ -264,7 +264,7 @@ class AvatarGroup extends UI5Element {
 	}
 
 	get _customOverflowButton() {
-		return this.overflowButton[0];
+		return this.overflowButton.length ? this.overflowButton[0] : undefined;
 	}
 
 	get _hiddenStartIndex() {
@@ -287,10 +287,6 @@ class AvatarGroup extends UI5Element {
 		return this._isGroup ? "0" : "-1";
 	}
 
-	get _overflowButtonTabIndex() {
-		return this._isGroup ? "-1" : false;
-	}
-
 	get _overflowButton() {
 		return this.shadowRoot.querySelector(AVATAR_GROUP_OVERFLOW_BTN_SELECTOR);
 	}
@@ -304,7 +300,7 @@ class AvatarGroup extends UI5Element {
 	 * @private
 	 */
 	get _overflowButtonEffectiveWidth() {
-		const button = this.overflowButton.length ? this.overflowButton[0] : this._overflowButton;
+		const button = this._customOverflowButton ? this._customOverflowButton : this._overflowButton;
 		// if in "Group" mode overflow button size is equal to the offset from second item
 		if (this._isGroup) {
 			let item = this.items[1];
@@ -363,7 +359,7 @@ class AvatarGroup extends UI5Element {
 	}
 
 	_fireGroupEvent(targetRef) {
-		const isOverflowButtonClicked = targetRef.classList.contains(OVERFLOW_BTN_CLASS) || targetRef === this.overflowButton[0];
+		const isOverflowButtonClicked = targetRef.classList.contains(OVERFLOW_BTN_CLASS) || targetRef === this._customOverflowButton;
 
 		this.fireEvent("click", {
 			targetRef,

--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -26,21 +26,25 @@
 	cursor: pointer;
 }
 
+:host([type="Group"]) ::slotted([ui5-button]),
 :host([type="Group"]) ::slotted([ui5-avatar]) {
 	pointer-events: none;
 }
 
+::slotted([ui5-button]),
 .ui5-avatar-group-overflow-btn:not([hidden]) {
 	border-radius: 50%;
 	display: inline-flex;
 	text-overflow: unset;
 }
 
+::slotted([ui5-button][focused]),
 .ui5-avatar-group-overflow-btn[focused] {
 	outline: var(--_ui5_button_outline);
 	outline-offset: var(--_ui5_avatar_group_overflow_button_focus_offset);
 }
 
+:host([avatar-size="XS"]) ::slotted([ui5-button]),
 :host([avatar-size="XS"]) .ui5-avatar-group-overflow-btn {
 	height: 2rem;
 	width: 2rem;
@@ -48,6 +52,8 @@
 	font-size: .75rem;
 }
 
+::slotted([ui5-button]),
+:host([avatar-size="S"]) ::slotted([ui5-button]),
 :host([avatar-size="S"]) .ui5-avatar-group-overflow-btn {
 	height: 3rem;
 	width: 3rem;
@@ -55,6 +61,7 @@
 	font-size: 1.125rem;
 }
 
+:host([avatar-size="M"]) ::slotted([ui5-button]),
 :host([avatar-size="M"]) .ui5-avatar-group-overflow-btn {
 	height: 4rem;
 	width: 4rem;
@@ -62,6 +69,7 @@
 	font-size: 1.625rem;
 }
 
+:host([avatar-size="L"]) ::slotted([ui5-button]),
 :host([avatar-size="L"]) .ui5-avatar-group-overflow-btn {
 	height: 5rem;
 	width: 5rem;
@@ -69,6 +77,7 @@
 	font-size: 2rem;
 }
 
+:host([avatar-size="XL"]) ::slotted([ui5-button]),
 :host([avatar-size="XL"]) .ui5-avatar-group-overflow-btn {
 	height: 7rem;
 	width: 7rem;

--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -31,11 +31,11 @@
 	pointer-events: none;
 }
 
-::slotted([ui5-button]),
+::slotted([ui5-button]:not([hidden])),
 .ui5-avatar-group-overflow-btn:not([hidden]) {
 	border-radius: 50%;
 	display: inline-flex;
-	text-overflow: unset;
+	text-overflow: initial;
 }
 
 ::slotted([ui5-button][focused]),

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -213,6 +213,21 @@
 			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
 			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
 		</ui5-avatar-group>
+
+		<h3>Slotted overflow button</h3>
+		<ui5-avatar-group type="Individual" id="group-with-overflow-btn">
+			<ui5-avatar size="XS" interactive initials="XS"></ui5-avatar>
+			<ui5-avatar size="S" interactive initials="S"></ui5-avatar>
+			<ui5-avatar size="M" interactive initials="M"></ui5-avatar>
+			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
+			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
+			<ui5-avatar size="XS" interactive initials="XS"></ui5-avatar>
+			<ui5-avatar size="S" interactive initials="S"></ui5-avatar>
+			<ui5-avatar size="M" interactive initials="M"></ui5-avatar>
+			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
+			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
+			<ui5-button slot="overflowButton" id="overflowButton">+99</ui5-button>
+		</ui5-avatar-group>
 	</div>
 
 <script>
@@ -230,6 +245,7 @@
 	var resetBtn = document.getElementById("reset-btn")
 	var slider = document.getElementById("slider");
 	var avGrWrapper = document.getElementById("avatar-group-wrapper");
+	var customOBtn = document.getElementById("overflowButton");
 
 	slider.style.width = '100%';
 	avGrWrapper.style.width = slider.getAttribute("value") + '%';
@@ -299,6 +315,17 @@
 		eventName.value = "";
 		eventTargetRef.value = "";
 		eventOverflowButtonClicked.value = "";
+	});
+
+	function formatBtnText(group) {
+		var totalAvatars = 90 - group.items.length + group.hiddenItems.length;
+
+		customOBtn.innerHTML = totalAvatars > 99 ? "+99" : "+" + totalAvatars;
+	};
+
+
+	groupWithBtn.addEventListener("ui5-overflow", function (event) {
+		formatBtnText(event.target);
 	});
 </script>
 

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -214,7 +214,7 @@
 			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
 		</ui5-avatar-group>
 
-		<h3>Slotted overflow button</h3>
+		<h3>AvatarGroup with user defined overflow button</h3>
 		<ui5-avatar-group type="Individual" id="group-with-overflow-btn">
 			<ui5-avatar size="XS" interactive initials="XS"></ui5-avatar>
 			<ui5-avatar size="S" interactive initials="S"></ui5-avatar>
@@ -324,7 +324,6 @@
 		customOBtn.innerHTML = totalAvatars > 99 ? "+99" : "+" + totalAvatars;
 		customOBtn.ariaLabel = totalAvatars > 99 ? "+99 avatars" : "+" + totalAvatars + " avatars";
 	};
-
 
 	groupWithBtn.addEventListener("ui5-overflow", function (event) {
 		formatBtnText(event.target);

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -226,7 +226,7 @@
 			<ui5-avatar size="M" interactive initials="M"></ui5-avatar>
 			<ui5-avatar size="L" interactive initials="L"></ui5-avatar>
 			<ui5-avatar size="XL" interactive initials="XL"></ui5-avatar>
-			<ui5-button slot="overflowButton" id="overflowButton">+99</ui5-button>
+			<ui5-button slot="overflowButton" id="overflowButton" aria-label="+99 avatars">+99</ui5-button>
 		</ui5-avatar-group>
 	</div>
 
@@ -245,6 +245,7 @@
 	var resetBtn = document.getElementById("reset-btn")
 	var slider = document.getElementById("slider");
 	var avGrWrapper = document.getElementById("avatar-group-wrapper");
+	var groupWithBtn = document.getElementById("group-with-overflow-btn");
 	var customOBtn = document.getElementById("overflowButton");
 
 	slider.style.width = '100%';
@@ -321,6 +322,7 @@
 		var totalAvatars = 90 - group.items.length + group.hiddenItems.length;
 
 		customOBtn.innerHTML = totalAvatars > 99 ? "+99" : "+" + totalAvatars;
+		customOBtn.ariaLabel = totalAvatars > 99 ? "+99 avatars" : "+" + totalAvatars + " avatars";
 	};
 
 


### PR DESCRIPTION
Added new slot which allows to add custom overflow button and "overflow" event to let you know when avatars 
hide/show in order to update the overflow button text. If not provided, the AvatarGroup will display the built-in overflow button. The slot is provided to allow you defining the text of the overflow button  and let you set additional aria attributes, such as aria-label.  

```html
<ui5-avatar-group>
    <ui5-button slot="overflowButton"  aria-label="your text">+99</ui5-button>
</ui5-avatar-group>
```

Fixes: #2912 