### PR TITLE
fix(ui5-input): Prevent dialog closing on Escape

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -649,9 +649,6 @@ class Input extends UI5Element {
 			// Mark that the selection has been canceled, so the popover can close
 			// and not reopen, due to receiving focus.
 			this.suggestionSelectionCanceled = true;
-
-			// Close suggestion popover
-			this._closeRespPopover(true);
 		}
 	}
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -445,8 +445,17 @@ describe("Input general interaction", () => {
 
 		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#inputInDialog");
 		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const dialog = browser.$("#inputInDialog");
 
 		//assert
 		assert.ok(popover.isDisplayedInViewport(), "The popover is visible");
+
+		// act
+		input.keys("ArrowDown");
+		browser.keys("Escape");
+
+		// assert
+		assert.notOk(popover.isDisplayedInViewport(), "The popover is not visible");
+		assert.ok(dialog.isDisplayedInViewport(), "The dialog is opened.");
 	});
 });


### PR DESCRIPTION
When a ui5-input with suggestions is positioned within a dialog a popover, closing the suggestions popover does not close the outer dialog/popover.

FIXES: #3028 