### PR TITLE
refactor(ui5-button, ui5-li): make touch events handlers passive

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -364,7 +364,7 @@ class Button extends UI5Element {
 		activeButton = this; // eslint-disable-line
 	}
 
-	_ontouchstart(event) {
+	_touchStartPassiveHandler(event) {
 		event.isMarked = "button";
 		if (this.nonInteractive) {
 			return;
@@ -373,12 +373,30 @@ class Button extends UI5Element {
 		this.active = true;
 	}
 
-	_ontouchend(event) {
+	get _ontouchstart() {
+		return {
+			handleEvent(event) {
+			  this._touchStartPassiveHandler(event);
+			},
+			passive: true,
+		};
+	}
+
+	_touchEndPassiveHandler(event) {
 		this.active = false;
 
 		if (activeButton) {
 			activeButton.active = false;
 		}
+	}
+
+	get _ontouchend() {
+		return {
+			handleEvent(event) {
+			  this._touchEndPassiveHandler(event);
+			},
+			passive: true,
+		};
 	}
 
 	_onmouseup(event) {

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -193,12 +193,30 @@ class ListItem extends ListItemBase {
 		this.deactivate();
 	}
 
-	_ontouchstart(event) {
+	_touchStartPassiveHandler(event) {
 		this._onmousedown(event);
 	}
 
-	_ontouchend(event) {
+	get _ontouchstart() {
+		return {
+			handleEvent(event) {
+			  this._touchStartPassiveHandler(event);
+			},
+			passive: true,
+		};
+	}
+
+	_touchEndPassiveHandler(event) {
 		this._onmouseup(event);
+	}
+
+	get _ontouchend() {
+		return {
+			handleEvent(event) {
+			  this._touchEndPassiveHandler(event);
+			},
+			passive: true,
+		};
 	}
 
 	_onfocusout() {


### PR DESCRIPTION
Fixes: #2995

There is one non ```passive``` event handler left in the code. It is in the ```SliderBase.hbs``` file. It is left because the behaviour of the slider depends on preventing the native event.