### PR TITLE
fix(ui5-dialog): fix content stretching on Safari

### DIFF
--- a/packages/fiori/test/pages/Wizard_test.html
+++ b/packages/fiori/test/pages/Wizard_test.html
@@ -175,7 +175,7 @@
 		</ui5-wizard>
 
 		<ui5-dialog id="dialog" stretch header-heading="Wizard">
-				<ui5-wizard>
+				<ui5-wizard id="wizInDialog">
 					<ui5-wizard-step icon="sap-icon://product" selected heading="Product type">
 						<div style="display: flex; min-height: 200px; flex-direction: column;">
 							<ui5-title>1. Product Type</ui5-title><br>
@@ -190,7 +190,7 @@
 							<ui5-input></ui5-input>
 						</div>
 
-						<ui5-button design="Emphasized">Step 2</ui5-button>
+						<ui5-button id="toStep2InDialog" design="Emphasized">Step 2</ui5-button>
 					</ui5-wizard-step>
 
 					<ui5-wizard-step heading="Product Information">
@@ -231,7 +231,7 @@
 							</div>
 						</div>
 
-						<ui5-button design="Emphasized">Step 3</ui5-button>
+						<ui5-button id="toStep3InDialog" design="Emphasized">Step 3</ui5-button>
 					</ui5-wizard-step>
 
 					<ui5-wizard-step heading="Options">
@@ -272,7 +272,7 @@
 							</div>
 						</div>
 
-						<ui5-button design="Emphasized">Step 4</ui5-button>
+						<ui5-button id="toStep4InDialog" design="Emphasized">Step 4</ui5-button>
 					</ui5-wizard-step>
 
 					<ui5-wizard-step heading="Pricing">
@@ -311,6 +311,7 @@
 
 	<script>
 		var wiz = document.getElementById("wizTest");
+		var wizInDialog = document.getElementById("wizInDialog");
 		var counter = 0;
 		wiz.addEventListener("ui5-selection-change", function (event) {
 			console.log(event.detail.selectedStep);
@@ -319,37 +320,53 @@
 		});
 
 		toStep2.addEventListener("click", function () {
-			deselectAll();
-			setStep(1);
+			deselectAll(wiz);
+			setStep(1, wiz);
 		});
+
 		toStep22.addEventListener("click", function () {
-			deselectAll();
-			setStep(1);
+			deselectAll(wiz);
+			setStep(1, wiz);
 		});
 
 		toStep3.addEventListener("click", function () {
-			deselectAll();
-			setStep(2);
+			deselectAll(wiz);
+			setStep(2, wiz);
 		});
 
 		toStep4.addEventListener("click", function () {
-			deselectAll();
-			setStep(3);
+			deselectAll(wiz);
+			setStep(3, wiz);
 		});
 
-		function deselectAll() {
+		toStep2InDialog.addEventListener("click", function () {
+			deselectAll(wizInDialog);
+			setStep(1, wizInDialog);
+		});
+
+		toStep3InDialog.addEventListener("click", function () {
+			deselectAll(wizInDialog);
+			setStep(2, wizInDialog);
+		});
+
+		toStep4InDialog.addEventListener("click", function () {
+			deselectAll(wizInDialog);
+			setStep(3, wizInDialog);
+		});
+
+		function deselectAll(wiz) {
 			Array.from(wiz.children).forEach(function(step) {
 				step.selected = false;
 			});
 		}
 
-		function setStep(idx) {
-			const step = getStep(idx);
+		function setStep(idx, wiz) {
+			const step = getStep(idx, wiz);
 			step.selected = true;
 			step.disabled = false;
 		}
 
-		function getStep(idx) {
+		function getStep(idx, wiz) {
 			return Array.from(wiz.children)[idx];
 		}
 

--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -34,6 +34,11 @@
 	max-width: 100vw;
 }
 
+:host([stretch]) .ui5-popup-content {
+	width: 100%;
+	height: 100%;
+}
+
 .ui5-popup-content {
 	min-height: var(--_ui5_dialog_content_min_height);
 	flex: 1 1 auto;

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -131,6 +131,82 @@
 		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
 		</ui5-textarea>
 
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
+
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
+
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
+
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
+
+		<div style="padding: 1rem;text-align: center;">
+			<ui5-title level="H2">Hello World!</ui5-title>
+		</div>
+
+		<ui5-select id="mySelect">
+			<ui5-option>Hello</ui5-option>
+			<ui5-option>World</ui5-option>
+		</ui5-select>
+
+		<ui5-textarea id="area" placeholder="Type some text" max-length="2" show-exceeded-text>
+		</ui5-textarea>
+
 		<div slot="footer" style="display: flex; align-items: center;padding: 0.25rem 0.5rem; width: 100%">
 			<div style="flex: 1;"></div>
 			<ui5-button id="btnCloseDialog">Close</ui5-button>


### PR DESCRIPTION
On Safari the style that stretches the content `flex: 1 1 auto` is not working the same way as in the rest of the browsers. Two issues has been observed. (1) One with the Wizard, the navigation header used to not remaining at the top, but could have been scrolled together with the content, which breaks the scrolling/navigation of the Wizard 
+ (2) one of the Dialog itself - the header and the footer are not displayed correctly (see below), because of the content not stretched correctly.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/3064

### First, Wizard is scrolling between steps on Safari, inside a Dialog

https://user-images.githubusercontent.com/15702139/113152593-f3bfe800-923e-11eb-8e2a-38c1c43d4538.mov

### And, the Dialog itself is improved on Safari,  previously the footer and the header were not displayed correctly, when the content overflows

Before (Safari)
<img width="751" alt="Screenshot 2021-03-31 at 16 19 54" src="https://user-images.githubusercontent.com/15702139/113152414-c8d59400-923e-11eb-87d2-b1d62e0a32a9.png">

After (Safari)
<img width="733" alt="Screenshot 2021-03-31 at 16 20 06" src="https://user-images.githubusercontent.com/15702139/113152381-be1aff00-923e-11eb-857f-82b0d7bcc637.png">




