### PR TITLE
fix(ui5-li-tree): fixed incorrect background of selected item

### DIFF
--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -41,7 +41,6 @@
     padding-left: 0;
 }
 
-:host([selected][has-border]:not([level="1"])),
 :host(:not([level="1"])) {
     border-bottom: none;
 }

--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -55,7 +55,7 @@
     cursor: pointer;
 }
 
-:host(:not([level="1"])) .ui5-li-root-tree {
+:host(:not([level="1"]):not([selected])) .ui5-li-root-tree {
     background: var(--sapList_AlternatingBackground);
 }
 


### PR DESCRIPTION
The background of the selected items on level 2 and higher was wrong.
Now it's aligned with specification.

Fixes: #2978

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
