### PR TITLE
fix(ui5-li-tree): fixed incorrect tree items alignment

### DIFF
--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -68,8 +68,8 @@
 }
 
 .ui5-li-tree-toggle-box {
-    width: var(--_ui5-tree-toggle-box-width);
-    height: var(--_ui5-tree-toggle-box-height);
+    min-width: var(--_ui5-tree-toggle-box-width);
+    min-height: var(--_ui5-tree-toggle-box-height);
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
When there was ellipsis of the text of the tree items, the ones
which got truncated were misaligned with the ones which weren't.
Now they are correctly aligned.

Fixes: #3069

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
