### PR TITLE
fix(ui5-li-tree): fixed incorrect display of the text

### DIFF
--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -7,7 +7,8 @@
 }
 
 :host([_minimal]) .ui5-li-tree-toggle-box {
-    width: 0;
+	width: 0;
+	min-width: 0;
 }
 
 :host([_minimal]) .ui5-li-icon {


### PR DESCRIPTION
While the TreeListItem is in its _minimal state (with no visible
text), the text was still taking space, causing incorrect alignment
of the icons. Now the text is not rendered when we are in _minimal state
which results in proper alignment of the icons.

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
