### PR TITLE
chore: show a deprecation warning for old tags

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-EpEv8ewlNPY90ULIm8etkaS9plo=
+WeIr8BhWti5PEgIpG30j/drpLD4=

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -999,7 +999,9 @@ class UI5Element extends HTMLElement {
 
 			if (altTag && !customElements.get(altTag)) {
 				registerTag(altTag);
-				window.customElements.define(altTag, getClassCopy(this));
+				window.customElements.define(altTag, getClassCopy(this, () => {
+					console.log(`The ${altTag} tag is deprecated and will be removed in the next release, please use ${tag} instead.`); // eslint-disable-line
+				}));
 			}
 		}
 		return this;

--- a/packages/base/src/util/getClassCopy.js
+++ b/packages/base/src/util/getClassCopy.js
@@ -1,5 +1,10 @@
-const getClassCopy = klass => {
-	return class classCopy extends klass {};
+const getClassCopy = (klass, constructorCallback) => {
+	return class classCopy extends klass {
+		constructor() {
+			super();
+			constructorCallback();
+		}
+	};
 };
 
 export default getClassCopy;

--- a/packages/base/src/util/getClassCopy.js
+++ b/packages/base/src/util/getClassCopy.js
@@ -2,7 +2,7 @@ const getClassCopy = (klass, constructorCallback) => {
 	return class classCopy extends klass {
 		constructor() {
 			super();
-			constructorCallback();
+			constructorCallback && constructorCallback();
 		}
 	};
 };

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -20,8 +20,8 @@
 
 	</head>
 	<body style="background-color: var(--sapBackgroundColor);">
-		<ui5-timepicker id="timepicker" format-pattern="HH:mm:ss"></ui5-timepicker>
-		<ui5-timepicker></ui5-timepicker>
+		<ui5-time-picker id="timepicker" format-pattern="HH:mm:ss"></ui5-time-picker>
+		<ui5-time-picker></ui5-time-picker>
 		<ui5-time-picker id="timepicker2" format-pattern="hh:mm:ss" value=""></ui5-time-picker>
 		<ui5-time-picker id="timepicker3" format-pattern="hh:mm:ss a"></ui5-time-picker>
 		<ui5-time-picker id="timepicker4" format-pattern="HH:mm" value="12:05"></ui5-time-picker>

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -20,8 +20,8 @@
 
 	</head>
 	<body style="background-color: var(--sapBackgroundColor);">
-		<ui5-time-picker id="timepicker" format-pattern="HH:mm:ss"></ui5-time-picker>
-		<ui5-time-picker></ui5-time-picker>
+		<ui5-timepicker id="timepicker" format-pattern="HH:mm:ss"></ui5-timepicker>
+		<ui5-timepicker></ui5-timepicker>
 		<ui5-time-picker id="timepicker2" format-pattern="hh:mm:ss" value=""></ui5-time-picker>
 		<ui5-time-picker id="timepicker3" format-pattern="hh:mm:ss a"></ui5-time-picker>
 		<ui5-time-picker id="timepicker4" format-pattern="HH:mm" value="12:05"></ui5-time-picker>


### PR DESCRIPTION
The `getClassCopy` util, used for registering the `altTag` (old tag) for some components, gets a new callback parameter that executes in the constructor.

The following warning is shown: "The ui5-timepicker tag is deprecated and will be removed in the next release, please use ui5-time-picker instead."
 