### PR TITLE
chore(ui5-wizard): make use of base util mehtod

### DIFF
--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -5,6 +5,7 @@ import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/Ari
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
+import clamp from "@ui5/webcomponents-base/dist/util/clamp.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import debounce from "@ui5/webcomponents-base/dist/util/debounce.js";
@@ -34,6 +35,13 @@ const EXPANDED_STEP = "data-ui5-wizard-expanded-tab";
 const AFTER_EXPANDED_STEP = "data-ui5-wizard-expanded-tab-next";
 const AFTER_CURRENT_STEP = "data-ui5-wizard-after-current-tab";
 const BEFORE_EXPANDED_STEP = "data-ui5-wizard-expanded-tab-prev";
+
+
+const STEP_SWITCH_THRESHOLDS = {
+	MIN: 0.5,
+	DEFAULT: 0.7,
+	MAX: 1, 
+};
 
 /**
  * @public
@@ -81,7 +89,7 @@ const metadata = {
 		 */
 		 stepSwitchThreshold: {
 			type: Float,
-			defaultValue: 0.7,
+			defaultValue: STEP_SWITCH_THRESHOLDS.DEFAULT,
 		},
 
 		/**
@@ -757,15 +765,7 @@ class Wizard extends UI5Element {
 	}
 
 	get effectiveStepSwitchThreshold() {
-		if (this.stepSwitchThreshold < 0.5) {
-			return 0.5;
-		}
-
-		if (this.stepSwitchThreshold > 1) {
-			return 1;
-		}
-
-		return this.stepSwitchThreshold;
+		return clamp(this.stepSwitchThreshold, STEP_SWITCH_THRESHOLDS.MIN, STEP_SWITCH_THRESHOLDS.MAX);
 	}
 
 	/**

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -36,11 +36,10 @@ const AFTER_EXPANDED_STEP = "data-ui5-wizard-expanded-tab-next";
 const AFTER_CURRENT_STEP = "data-ui5-wizard-after-current-tab";
 const BEFORE_EXPANDED_STEP = "data-ui5-wizard-expanded-tab-prev";
 
-
 const STEP_SWITCH_THRESHOLDS = {
 	MIN: 0.5,
 	DEFAULT: 0.7,
-	MAX: 1, 
+	MAX: 1,
 };
 
 /**


### PR DESCRIPTION
This is a follow up of a review comment from https://github.com/SAP/ui5-webcomponents/pull/3009
to make us of an existing method instead of local implementation.
