### PR TITLE
fix(ui5-date-picker): calibrate the width and alignment of day names

### DIFF
--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -307,6 +307,10 @@ class DayPicker extends CalendarPart {
 		}
 
 		this._dayNames[1].classes += " ui5-dp-firstday";
+		
+		if (this.shouldHideWeekNumbers) {
+			this._dayNames.shift();
+		}
 	}
 
 	onAfterRendering() {
@@ -700,6 +704,7 @@ class DayPicker extends CalendarPart {
 		return {
 			wrapper: {
 				display: this._hidden ? "none" : "flex",
+				"justify-content": "center"
 			},
 			main: {
 				width: "100%",

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -307,7 +307,7 @@ class DayPicker extends CalendarPart {
 		}
 
 		this._dayNames[1].classes += " ui5-dp-firstday";
-		
+
 		if (this.shouldHideWeekNumbers) {
 			this._dayNames.shift();
 		}
@@ -704,7 +704,7 @@ class DayPicker extends CalendarPart {
 		return {
 			wrapper: {
 				display: this._hidden ? "none" : "flex",
-				"justify-content": "center"
+				"justify-content": "center",
 			},
 			main: {
 				width: "100%",

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -5,6 +5,7 @@
 :host {
 	height: 100%;
 	width: 100%;
+	
 }
 
 :host([_hide-week-numbers]) .ui5-dp-content {

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -5,7 +5,6 @@
 :host {
 	height: 100%;
 	width: 100%;
-	
 }
 
 :host([_hide-week-numbers]) .ui5-dp-content {


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/3059

As the weekday names and the weeks themselves are build in different blocks and arrays, when removing the week numbers( not presenting them) we don't remove the 'filler' block which we insert in the header row where the names are. Now we remove the first block, if the property for hiding weeks is set to true, and then we place the DayPicker content block in the center.