### PR TITLE
docs: add docs for css parts

### DIFF
--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -110,7 +110,7 @@ const metadata = {
  * <br>
  * The <code>ui5-li-notification-group</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>heading</code> - Used to style the heading of the notification list group item</li>
+ * <li>heading - Used to style the heading of the notification list group item</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -104,6 +104,15 @@ const metadata = {
  * <h3>Usage</h3>
  * The component can be used in a standard <code>ui5-list</code>.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-li-notification-group</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>heading</code> - Used to style the heading of the notification list group item</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import @ui5/webcomponents/dist/NotificationListGroupItem.js";</code>

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -149,6 +149,15 @@ const metadata = {
  * <h3>Usage</h3>
  * The component can be used in a standard <code>ui5-list</code>.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-li-notification</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>heading</code> - Used to style the heading of the notification list item</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import @ui5/webcomponents/dist/NotificationListItem.js";</code>

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -155,7 +155,7 @@ const metadata = {
  * <br>
  * The <code>ui5-li-notification</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>heading</code> - Used to style the heading of the notification list item</li>
+ * <li>heading - Used to style the heading of the notification list item</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -372,7 +372,7 @@ const metadata = {
  * <br>
  * The <code>ui5-shellbar</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>root</code> - Used to style the outermost wrapper of the <code>ui5-shellbar</code></li>
+ * <li>root - Used to style the outermost wrapper of the <code>ui5-shellbar</code></li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -366,6 +366,15 @@ const metadata = {
  * Example: <code><ui5-shellbar-item stable-dom-ref="messages"></ui5-shellbar-item></code></li>
  * </ul>
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-shellbar</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>root</code> - Used to style the outermost wrapper of the <code>ui5-shellbar</code></li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  * <code>import "@ui5/webcomponents-fiori/dist/ShellBar";</code>
  *

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -281,6 +281,15 @@ const metadata = {
  * its style to provide visual feedback to the user that it is pressed or hovered over with
  * the mouse cursor. A disabled <code>ui5-button</code> appears inactive and cannot be pressed.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-button</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>button</code> - Used to style the native button element</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Button";</code>

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -287,7 +287,7 @@ const metadata = {
  * <br>
  * The <code>ui5-button</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>button</code> - Used to style the native button element</li>
+ * <li>button - Used to style the native button element</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -170,6 +170,17 @@ const metadata = {
  * <h3>Keyboard handling</h3>
  * In case you enable <code>headerInteractive</code> property, you can press the <code>ui5-card</code> header by Space and Enter keys.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-card</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>heading</code> - Used to style the heading of the card</li>
+ * <li><code>subheading</code> - Used to style the subheading of the card</li>
+ * <li><code>status</code> - Used to style the status of the card</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Card";</code>

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -176,9 +176,9 @@ const metadata = {
  * <br>
  * The <code>ui5-card</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>heading</code> - Used to style the heading of the card</li>
- * <li><code>subheading</code> - Used to style the subheading of the card</li>
- * <li><code>status</code> - Used to style the status of the card</li>
+ * <li>heading - Used to style the heading of the card</li>
+ * <li>subheading - Used to style the subheading of the card</li>
+ * <li>status - Used to style the status of the card</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -340,6 +340,15 @@ const metadata = {
  * Example: <code><ui5-mcb-item stable-dom-ref="item1"></ui5-mcb-item></code></li>
  * </ul>
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-multi-combobox</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>token-{index}</code> - Used to style each token(where <code>token-0</code> corresponds to the first item)</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/MultiComboBox";</code>

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -346,7 +346,7 @@ const metadata = {
  * <br>
  * The <code>ui5-multi-combobox</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>token-{index}</code> - Used to style each token(where <code>token-0</code> corresponds to the first item)</li>
+ * <li>token-{index} - Used to style each token(where <code>token-0</code> corresponds to the first item)</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/Slider.hbs
+++ b/packages/main/src/Slider.hbs
@@ -11,7 +11,7 @@
 			@focusout="{{_onfocusout}}"
 			@focusin="{{_onfocusin}}"
 			tabindex="-1"
-			part="slider-progress"
+			part="progress-bar"
 		></div>
 	</div>
 {{/inline}}
@@ -30,7 +30,7 @@
 		aria-labelledby="{{_id}}-sliderDesc"
 		aria-disabled="{{_ariaDisabled}}"
 		data-sap-focus-ref
-		part="slider-handle"
+		part="handle"
 	>
 		{{#if showTooltip}}
 			<div class="ui5-slider-tooltip" style="{{styles.tooltip}}">

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -70,9 +70,9 @@ const metadata = {
  * <br>
  * The <code>ui5-slider</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>progress-container</code> - Used to style the progress container(the thin line) of the <code>ui5-slider</code></li>
- * <li><code>progress-bar</code> - Used to style the progress bar, which shows the progress of the <code>ui5-slider</code></li>
- * <li><code>handle</code> - Used to style the handle of the <code>ui5-slider</code></li>
+ * <li>progress-container - Used to style the progress container(the thin line) of the <code>ui5-slider</code></li>
+ * <li>progress-bar - Used to style the progress bar, which shows the progress of the <code>ui5-slider</code></li>
+ * <li>handle - Used to style the handle of the <code>ui5-slider</code></li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -64,6 +64,17 @@ const metadata = {
  * <li>Click/tap on the range bar to move the handle to that location</li>
  * </ul>
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-slider</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>progress-container</code> - Used to style the progress container(the thin line) of the <code>ui5-slider</code></li>
+ * <li><code>progress-bar</code> - Used to style the progress bar, which shows the progress of the <code>ui5-slider</code></li>
+ * <li><code>handle</code> - Used to style the handle of the <code>ui5-slider</code></li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Slider";</code>

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -118,6 +118,18 @@ const metadata = {
  * providing the most common use cases such as <code>text</code>,
  * <code>image</code> and <code>icon</code>.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-switch</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>title</code> - Used to style the title of the list item</li>
+ * <li><code>description</code> - Used to style the description of the list item</li>
+ * <li><code>info</code> - Used to style the info of the list item</li>
+ * <li><code>icon</code> - Used to style the icon of the list item</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.StandardListItem

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -122,12 +122,12 @@ const metadata = {
  *
  * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
  * <br>
- * The <code>ui5-switch</code> exposes the following CSS Shadow Parts:
+ * The <code>ui5-li</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>title</code> - Used to style the title of the list item</li>
- * <li><code>description</code> - Used to style the description of the list item</li>
- * <li><code>info</code> - Used to style the info of the list item</li>
- * <li><code>icon</code> - Used to style the icon of the list item</li>
+ * <li>title - Used to style the title of the list item</li>
+ * <li>description - Used to style the description of the list item</li>
+ * <li>info - Used to style the info of the list item</li>
+ * <li>icon - Used to style the icon of the list item</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/SuggestionListItem.js
+++ b/packages/main/src/SuggestionListItem.js
@@ -31,6 +31,17 @@ const metadata = {
  * The <code>ui5-li-suggestion-item</code> represents the suggestion item in the <code>ui5-input</code>
  * suggestion popover.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-li-suggestion-item</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>title</code> - Used to style the title of the suggestion list item</li>
+ * <li><code>description</code> - Used to style the description of the suggestion list item</li>
+ * <li><code>info</code> - Used to style the info of the suggestion list item</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SuggestionListItem

--- a/packages/main/src/SuggestionListItem.js
+++ b/packages/main/src/SuggestionListItem.js
@@ -37,9 +37,9 @@ const metadata = {
  * <br>
  * The <code>ui5-li-suggestion-item</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>title</code> - Used to style the title of the suggestion list item</li>
- * <li><code>description</code> - Used to style the description of the suggestion list item</li>
- * <li><code>info</code> - Used to style the info of the suggestion list item</li>
+ * <li>title - Used to style the title of the suggestion list item</li>
+ * <li>description - Used to style the description of the suggestion list item</li>
+ * <li>info - Used to style the info of the suggestion list item</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -126,10 +126,10 @@ const metadata = {
  * <br>
  * The <code>ui5-switch</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>slider</code> - Used to style the track, where the handle is being slid</li>
- * <li><code>text-on</code> - Used to style the onText</li>
- * <li><code>text-off</code> - Used to style the offText</li>
- * <li><code>handle</code> - Used to style the handle of the switch</li>
+ * <li>slider - Used to style the track, where the handle is being slid</li>
+ * <li>text-on - Used to style the onText</li>
+ * <li>text-off - Used to style the offText</li>
+ * <li>handle - Used to style the handle of the switch</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -113,12 +113,24 @@ const metadata = {
  * The component can display texts, that will be switched, based on the component state, via the <code>textOn</code> and <code>textOff</code> properties,
  * but texts longer than 3 letters will be cutted off.
  * <br>
- * However, users are able to customize the width of <code>ui5-switch</code> with pure CSS (&lt;ui5-switch style="width: 200px">), and set widths, depending on the texts they would use.
+ * However, users are able to customize the width of <code>ui5-switch</code> with pure CSS (<code>&lt;ui5-switch style="width: 200px"></code>), and set widths, depending on the texts they would use.
  * <br>
  * Note: the component would not automatically stretch to fit the whole text width.
  *
  * <h3>Keyboard Handling</h3>
  * The state can be changed by pressing the Space and Enter keys.
+ *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-switch</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>slider</code> - Used to style the track, where the handle is being slid</li>
+ * <li><code>text-on</code> - Used to style the onText</li>
+ * <li><code>text-off</code> - Used to style the offText</li>
+ * <li><code>handle</code> - Used to style the handle of the switch</li>
+ * </ul>
  *
  * <h3>ES6 Module Import</h3>
  *

--- a/packages/main/src/TableCell.js
+++ b/packages/main/src/TableCell.js
@@ -56,6 +56,15 @@ const metadata = {
  *
  * The <code>ui5-table-cell</code> component defines the structure of the data in a single <code>ui5-table</code> cell.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-table-cell</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>cell</code> - Used to style the native <code>td</code> element</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TableCell

--- a/packages/main/src/TableCell.js
+++ b/packages/main/src/TableCell.js
@@ -62,7 +62,7 @@ const metadata = {
  * <br>
  * The <code>ui5-table-cell</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>cell</code> - Used to style the native <code>td</code> element</li>
+ * <li>cell - Used to style the native <code>td</code> element</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -102,7 +102,7 @@ const metadata = {
  * <br>
  * The <code>ui5-table-column</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>column</code> - Used to style the native <code>th</code> element</li>
+ * <li>column - Used to style the native <code>th</code> element</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -96,6 +96,15 @@ const metadata = {
  * The <code>ui5-table-column</code> component allows to define column specific properties that are applied
  * when rendering the <code>ui5-table</code> component.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-table-column</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>column</code> - Used to style the native <code>th</code> element</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TableColumn

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -56,6 +56,16 @@ const metadata = {
  *
  * The <code>ui5-table-row</code> component represents a row in the <code>ui5-table</code>.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-table-row</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>row</code> - Used to style the native <code>tr</code> element</li>
+ * <li><code>popin-row</code> - Used to style the <code>tr</code> element</li> when a row pops in
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TableRow

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -62,8 +62,8 @@ const metadata = {
  * <br>
  * The <code>ui5-table-row</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>row</code> - Used to style the native <code>tr</code> element</li>
- * <li><code>popin-row</code> - Used to style the <code>tr</code> element</li> when a row pops in
+ * <li>row - Used to style the native <code>tr</code> element</li>
+ * <li>popin-row - Used to style the <code>tr</code> element</li> when a row pops in
  * </ul>
  *
  * @constructor

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -343,7 +343,7 @@ const metadata = {
  * <br>
  * The <code>ui5-textarea</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>textarea</code> - Used to style the native textarea</li>
+ * <li>textarea - Used to style the native textarea</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -337,6 +337,15 @@ const metadata = {
  * When empty, it can hold a placeholder similar to a <code>ui5-input</code>.
  * You can define the rows of the <code>ui5-textarea</code> and also determine specific behavior when handling long texts.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-textarea</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>textarea</code> - Used to style the native textarea</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/TextArea";</code>

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -200,6 +200,17 @@ const metadata = {
  * <i>Note:</i> Do not use <code>ui5-li-tree</code> directly in your apps. Use <code>ui5-tree-item</code> instead, as it can be nested inside a <code>ui5-tree</code>.
  * On the other hand, <code>ui5-li-tree</code> can only be slotted inside a <code>ui5-list</code>, being a list item. It may be useful if you want to build a custom tree component, for example.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-li-tree</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li><code>title</code> - Used to style the title of the tree list item</li>
+ * <li><code>info</code> - Used to style the info of the tree list item</li>
+ * <li><code>icon</code> - Used to style the icon of the tree list item</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TreeListItem

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -206,9 +206,9 @@ const metadata = {
  * <br>
  * The <code>ui5-li-tree</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li><code>title</code> - Used to style the title of the tree list item</li>
- * <li><code>info</code> - Used to style the info of the tree list item</li>
- * <li><code>icon</code> - Used to style the icon of the tree list item</li>
+ * <li>title - Used to style the title of the tree list item</li>
+ * <li>info - Used to style the info of the tree list item</li>
+ * <li>icon - Used to style the icon of the tree list item</li>
  * </ul>
  *
  * @constructor


### PR DESCRIPTION
Fixes #3082

BREAKING_CHANGE: The following Slider CSS parts have been renamed:

- ```slider-progress``` -> ```progress-bar```
- ```slider-handle``` -> ```handle```