### PR TITLE
chore(ui5-page): offset content top when header exists

### DIFF
--- a/packages/fiori/src/Page.js
+++ b/packages/fiori/src/Page.js
@@ -168,11 +168,16 @@ class Page extends UI5Element {
 		return this.floatingFooter && !this.hideFooter ? "3.5rem" : "0";
 	}
 
+	get _contentTop() {
+		return !!this.header.length ? "2.75rem" : "0rem";
+	}
+
 	get styles() {
 		return {
 			content: {
 				"padding-bottom": this.footer.length && this._contentPaddingBottom,
 				"bottom": this.footer.length && this._contentBottom,
+				"top": this._contentTop,
 			},
 		};
 	}


### PR DESCRIPTION
We had feedback in one of the Slack channels that the content will start with an offset even when the "header" slot is not present. And this is what we address here - setting "2.75rem" top offset to the content in case the Page has a header.
