### PR TITLE
fix(ui5-li-tree): fixed incorrect expanding on Safari

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -251,7 +251,7 @@ class UI5Element extends HTMLElement {
 						}
 						await Promise.race([whenDefinedPromise, timeoutPromise]);
 					}
-					window.customElements.upgrade(child);
+					await window.customElements.upgrade(child);
 				}
 			}
 


### PR DESCRIPTION
The branches/leaves couldn't be toggled/expanded on Safari browser.
Now they are correctly toggled/expanded.

Fixes: #2752

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
