### PR TITLE
fix(ui5-date-picker): changing month on previous button pressed 

### DIFF
--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -568,8 +568,7 @@ class Calendar extends PickerBase {
 
 		// focus first day of the month
 		const currentMonthDate = this.dayPicker._calendarDate.setMonth(this.dayPicker._calendarDate.getMonth());
-		let lastMonthDate = this.dayPicker._calendarDate.setDate(1);
-		lastMonthDate = this.dayPicker._calendarDate.setDate(0);
+		let lastMonthDate = this.dayPicker._calendarDate.setDate(0); // Last day of previous month
 
 		// set the date to last day of last month
 		currentMonthDate.setDate(-1);

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -568,7 +568,7 @@ class Calendar extends PickerBase {
 
 		// focus first day of the month
 		const currentMonthDate = this.dayPicker._calendarDate.setMonth(this.dayPicker._calendarDate.getMonth());
-		let lastMonthDate = this.dayPicker._calendarDate.setDate(0); // Last day of previous month
+		const lastMonthDate = this.dayPicker._calendarDate.setDate(0); // Last day of previous month
 
 		// set the date to last day of last month
 		currentMonthDate.setDate(-1);

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -568,7 +568,8 @@ class Calendar extends PickerBase {
 
 		// focus first day of the month
 		const currentMonthDate = this.dayPicker._calendarDate.setMonth(this.dayPicker._calendarDate.getMonth());
-		const lastMonthDate = this.dayPicker._calendarDate.setMonth(this.dayPicker._calendarDate.getMonth() - 1);
+		let lastMonthDate = this.dayPicker._calendarDate.setDate(1);
+		lastMonthDate = this.dayPicker._calendarDate.setDate(0);
 
 		// set the date to last day of last month
 		currentMonthDate.setDate(-1);
@@ -576,7 +577,7 @@ class Calendar extends PickerBase {
 		// find the index of the last day
 		let lastDayOfMonthIndex = -1;
 
-		if (!this.isInValidRange(currentMonthDate.toLocalJSDate().valueOf())) {
+		if (!this.isInValidRange(lastMonthDate.toLocalJSDate().valueOf())) {
 			return;
 		}
 
@@ -614,6 +615,9 @@ class Calendar extends PickerBase {
 		oNewDate.setYear(iNewYear);
 		oNewDate.setMonth(iNewMonth);
 
+		if (this._calendarDate.getMonth() === oNewDate.getMonth()) {
+			oNewDate.setDate(0);
+		}
 
 		if (oNewDate.getYear() < minCalendarDateYear) {
 			return;

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -568,7 +568,7 @@ class Calendar extends PickerBase {
 
 		// focus first day of the month
 		const currentMonthDate = this.dayPicker._calendarDate.setMonth(this.dayPicker._calendarDate.getMonth());
-		const lastMonthDate = this.dayPicker._calendarDate.setDate(0); // Last day of previous month
+		const lastMonthDate = this.dayPicker._calendarDate.setDate(0); // last day of previous month
 
 		// set the date to last day of last month
 		currentMonthDate.setDate(-1);

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -615,7 +615,7 @@ class Calendar extends PickerBase {
 		oNewDate.setMonth(iNewMonth);
 
 		if (this._calendarDate.getMonth() === oNewDate.getMonth()) {
-			oNewDate.setDate(0);
+			oNewDate.setDate(0); // If we're still in the same month we set the date to the last day of previous month
 		}
 
 		if (oNewDate.getYear() < minCalendarDateYear) {

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -112,6 +112,9 @@
 		<h3>1 year range</h3>
 		<ui5-date-picker id="minMax4" value="Feb 5, 2020" min-date="Jan 5, 2020" max-date="Jan 5, 2021"></ui5-date-picker>
 
+		<h3>December edge case example with min and max</h3>
+		<ui5-date-picker max-date="Dec 31, 2022" min-date="Oct 31, 2022" format-pattern="MMM d, yyyy" placeholder="MMM d, yyyy" value="Dec 31, 2022"></ui5-date-picker>
+
 		<section>
 			<h3>Test ariaLabel and ariaLabelledBy</h3>
 			<ui5-date-picker id="dpAriaLabel" aria-label="Hello World"></ui5-date-picker>


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/3083

In an edge case, when the current month has more days than the previous month and we focus last day of the current month and press the previous month button in the days view of date picker, the month wasn't initially changed.

Example: Focus 31th of December and try to go back.

This is fixed in upper versions. Currently the small fix is related to checking if we are still in the same month and then focusing the last day of the previous month if we are.

