### PR TITLE
refactor(ui5-color-palette): refactor rendering of items

### DIFF
--- a/packages/main/src/ColorPalette.hbs
+++ b/packages/main/src/ColorPalette.hbs
@@ -1,10 +1,13 @@
-<div class="ui5-cp-root">
+<div
+	class="ui5-cp-root"
+	@click={{_onclick}}
+	@keyup={{_onkeyup}}
+	@keydown={{_onkeydown}}
+>
 	<div class="ui5-cp-item-container" 
 		role="region"
 		aria-label="{{colorContainerLabel}}"
-		@click={{_onclick}}
-		@keyup={{_onkeyup}}
-		@keydown={{_onkeydown}}>
+	>
 		{{#each this.displayedColors}}
 			<slot
 				name="{{this._individualSlot}}"

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -179,7 +179,10 @@ class ColorPalette extends UI5Element {
 
 	selectColor(item) {
 		item.focus();
-		this._itemNavigation.setCurrentItem(item);
+
+		if (this.displayedColors.includes(item)) {
+			this._itemNavigation.setCurrentItem(item);
+		}
 
 		this._setColor(item.value);
 	}
@@ -187,7 +190,11 @@ class ColorPalette extends UI5Element {
 	_setColor(color) {
 		this.value = color;
 		if (this._recentColors[0] !== this.value) {
-			this._recentColors.unshift(this.value);
+			if (this._recentColors.includes(this.value)) {
+				this._recentColors.unshift(this._recentColors.splice(this._recentColors.indexOf(this.value), 1)[0]);
+			} else {
+				this._recentColors.unshift(this.value);
+			}
 		}
 
 		this.fireEvent("change", {

--- a/packages/main/src/ColorPaletteItem.hbs
+++ b/packages/main/src/ColorPaletteItem.hbs
@@ -6,5 +6,6 @@
 	role="button"
 	aria-label="{{colorLabel}} - {{index}}: {{this.value}}"
 	title="{{colorLabel}} - {{index}}: {{this.value}}"
+	?disabled="{{_disabled}}"
 >
 </div>

--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -37,6 +37,7 @@ const metadata = {
 		stableDomRef: {
 			type: String,
 		},
+
 		/**
 		 * Defines the tab-index of the element, helper information for the ItemNavigation.
 		 * @private
@@ -46,6 +47,7 @@ const metadata = {
 			defaultValue: "-1",
 			noAttribute: true,
 		},
+
 		/**
 		 * Defines the index of the item inside of the ColorPalette.
 		 * @private
@@ -53,6 +55,15 @@ const metadata = {
 		 */
 		index: {
 			type: String,
+		},
+
+		/**
+		 * @private
+		 * @type {boolean}
+		 * @since 1.0.0-rc.15
+		 */
+		_disabled: {
+			type: Boolean,
 		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.ColorPaletteItem.prototype */ {
@@ -101,6 +112,10 @@ class ColorPaletteItem extends UI5Element {
 	constructor() {
 		super();
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
+	}
+
+	onBeforeRendering() {
+		this._disabled = !this.value;
 	}
 
 	get colorLabel() {

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -22,6 +22,7 @@
 
 .ui5-cp-more-colors {
 	width: 100%;
+	height: 2rem;
 	text-align: center;
 	border: none;
 }

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -1,4 +1,4 @@
-.ui5-cp-item {
+:host(:not([hidden])) {
 	height: var(--_ui5_color-palette-item-height);
 	width: var(--_ui5_color-palette-item-height);
 	border: 1px solid var(--sapContent_ForegroundBorderColor);
@@ -7,23 +7,24 @@
 	margin: var(--_ui5_color-palette-item-margin);
 }
 
-.ui5-cp-item:focus:before {
-	content: "";
-	width: var(--_ui5_color-palette-item-focus-height);
-	height: var(--_ui5_color-palette-item-focus-height);
-	margin: 2px;
-	position: absolute;
-	outline: rgb(0, 0, 0) dotted 0.0625rem;
+:host(:not([_disabled])) .ui5-cp-item:focus{
+	outline: white dotted 0.0625rem;
+	outline-offset: -2px;
 }
 
-.ui5-cp-item:focus {
+:host(:not([_disabled]):focus) .ui5-cp-item {
 	pointer-events: none;
 	outline: white solid 0.0625rem;
 	outline-offset: -3px;
 }
 
-.ui5-cp-item:hover {
+:host(:not([_disabled]):hover) {
 	height: var(--_ui5_color-palette-item-hover-height);
 	width: var(--_ui5_color-palette-item-hover-height);
 	margin: var(--_ui5_color-palette-item-hover-margin);
+}
+
+.ui5-cp-item {
+	width: 100%;
+    height: 100%;
 }

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -125,7 +125,7 @@
 	--_ui5_color-palette-item-hover-height: 1.65rem;
 	--_ui5_color-palette-item-hover-margin: 0.3125rem;
 	--_ui5_color-palette-row-width: 12rem;
-	--_ui5_color-palette-row-height: 7.25rem;
+	--_ui5_color-palette-row-height: 7.5rem;
 
 	/* Custom List Item */
 	--_ui5_custom_list_item_height: 2rem;


### PR DESCRIPTION
This PR fixes the following issues:

-  Color Picker height in Compact size
-  Focus & hover handling of ```ui5-color-picker-item```
-  Clicking on recent colors affects their order now 