### PR TITLE
fix(ui5-shellbar): hide notification bubble if empty str

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -326,7 +326,7 @@ slot[name="profile"] {
 	position: relative;
 }
 
-:host([notification-count]) .ui5-shellbar-bell-button::before,
+:host([notification-count]:not([notification-count=""])) .ui5-shellbar-bell-button::before,
 .ui5-shellbar-button[data-count]::before {
 	position: absolute;
 	width: auto;
@@ -347,7 +347,7 @@ slot[name="profile"] {
 	box-sizing: border-box;
 }
 
-:host([notification-count]) .ui5-shellbar-bell-button::before {
+:host([notification-count]:not([notification-count=""])) .ui5-shellbar-bell-button::before {
 	content: attr(data-ui5-notification-count);
 }
 


### PR DESCRIPTION
The notification bubble used to remain displayed when notification-count is an empty string
<img width="126" alt="Screenshot 2021-04-09 at 09 53 02" src="https://user-images.githubusercontent.com/15702139/114140782-643ec700-9919-11eb-9557-713fbdc52faf.png">

Fixes: https://github.com/SAP/ui5-webcomponents/issues/3121