### PR TITLE
chore(ui5-table): forward focus correctly to row element

### DIFF
--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -236,7 +236,7 @@ class TableRow extends UI5Element {
 			return;
 		}
 
-		if (this._getActiveElementTagName() === "body") {
+		if (!this.contains(document.activeElement)) {
 			// If the user clickes on non-focusable element within the ui5-table-cell,
 			// the focus goes to the body, se we have to bring it back to the row.
 			// If the user clicks on input, button or similar clickable element,


### PR DESCRIPTION
If the user clicks on a non-focusable element within the ui5-table-cell, the focus goes to the body or to the first focusable element above, so we have to bring it back to the row. If the user clicks on input, button or a similar clickable element, the focus remains on that element.