### PR TITLE
refactor(ui5-icon): Show not-imported icons warning

### DIFF
--- a/docs/Assets.md
+++ b/docs/Assets.md
@@ -59,11 +59,26 @@ package are also imported since the `fiori` package internally uses features of 
 
 ### `icons` package
 
-`import "@ui5/webcomponents-fiori/dist/Assets.js";`
+The assets file for the `@ui5/webcomponents-icons` package provides i18n assets for some icons: 
+
+`import "@ui5/webcomponents-icons/dist/Assets.js";`
 
 Normally applications are expected to import only the individual icons that are going to be used, for example:
 
 `import "@ui5/webcomponents-icons/dist/add.js`";`
 
-However, sometimes it makes sense to import all icons, hence the `import "@ui5/webcomponents-fiori/dist/Assets.js";` JSON import.
-Along with the icons, it also includes all translatable texts.
+However, sometimes it makes sense to import all icons. To do so, use the following import:
+
+`import "@ui5/webcomponents-icons/dist/AllIcons.js";`
+
+### `icons-tnt` package
+
+The assets file for the `@ui5/webcomponents-icons-tnt` package is currently empty, but it may provide i18n assets in the future:
+
+`import "@ui5/webcomponents-icons/dist/Assets.js";`
+
+Therefore, we recommend importing it to be future-proof.
+
+To import all `tnt` icons:
+
+`import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";`

--- a/docs/Public Module Imports.md
+++ b/docs/Public Module Imports.md
@@ -205,7 +205,7 @@ For additional `icons` package assets (i18n), use:
 `import "@ui5/webcomponents-icons/dist/Assets.js";`
 
 ## Icons-TNT package (```@ui5/webcomponents-icons-tnt```)
-<a name="icons"></a>
+<a name="icons-tnt"></a>
 
 The `icons-tnt` package provides assets for the rich `SAP-icons-TNT` icon collection.
 

--- a/docs/Public Module Imports.md
+++ b/docs/Public Module Imports.md
@@ -10,6 +10,7 @@ Table of contents:
  - [Main package - @ui5/webcomponents](#main)
  - [Fiori package - @ui5/webcomponents-fiori](#fiori)
  - [Icons package - @ui5/webcomponents-icons](#icons)
+ - [Icons-TNT package - @ui5/webcomponents-icons-tnt](#icons-tnt)
  - [Base package - @ui5/webcomponents-base](#base)
 
 <a name="main"></a>
@@ -189,15 +190,52 @@ just the ones that your app will actually use.
 
 For a complete list of the icons in the `SAP-icons` collection, click [here](https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons).
 
-### 2. Assets
+### 2. All icons
 
-For additional `icons` package assets (i18n, all icons JSON), use:
+To import all icons, use:
+
+`import "@ui5/webcomponents-icons/dist/AllIcons.js";`
+
+*Note: if you use an icon which you did not import individually, the JSON, containing all icons definitions, will be fetched.*
+
+### 3. Assets
+
+For additional `icons` package assets (i18n), use:
 
 `import "@ui5/webcomponents-icons/dist/Assets.js";`
 
-*Note:*
-Apart from i18n assets, the above import also provides the JSON, containing all icons definitions (~115KB zipped).
-**Therefore, if you use an icon which you did not import individually, the JSON will be fetched.**
+## Icons-TNT package (```@ui5/webcomponents-icons-tnt```)
+<a name="icons"></a>
+
+The `icons-tnt` package provides assets for the rich `SAP-icons-TNT` icon collection.
+
+*Note:* The `@ui5/webcomponents-icons-tnt` package does not provide any web components per se, but rather icon assets,
+usable by other web components such as `ui5-icon`. You could import all icons, but it's recommended to import
+just the ones that your app will actually use.
+
+### 1. Individual icon imports
+
+|    Icon asset    |                      Module import                       |
+| ---------------- | -------------------------------------------------------- |
+| Actor icon       | `import "@ui5/webcomponents-icons-tnt/dist/actor.js";` |
+| ...              | ...                                                      |
+| Workflow editor icon    | `import "@ui5/webcomponents-icons-tnt/dist/workflow-editor.js";`    |
+
+For a complete list of the icons in the `SAP-icons-TNT` collection, click [here](https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT).
+
+### 2. All icons
+
+To import all icons, use:
+
+`import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";`
+
+*Note: if you use an icon which you did not import individually, the JSON, containing all icons definitions, will be fetched.*
+
+### 3. Assets
+
+Currently, the `icons-tnt` package assets file does not provide any assets, but still it's recommended to import it to be future proof:
+
+`import "@ui5/webcomponents-icons/dist/Assets.js";`
 
 ## Base package (```@ui5/webcomponents-base```)
 

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-b+/Y1CiDnS64nQ6x9g7Olwl1dkY=
+Ypwf1pcj/tFLkCFKDb5OPtwjd5A=

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-WeIr8BhWti5PEgIpG30j/drpLD4=
+b+/Y1CiDnS64nQ6x9g7Olwl1dkY=

--- a/packages/base/src/asset-registries/Icons.js
+++ b/packages/base/src/asset-registries/Icons.js
@@ -21,6 +21,9 @@ const registerIconLoader = async (collectionName, loader) => {
 const _loadIconCollectionOnce = async collectionName => {
 	if (!iconCollectionPromises.has(collectionName)) {
 		const loadIcons = loaders.get(collectionName);
+		if (typeof loadIcons !== "function") {
+			throw new Error(`No loader registered for the ${collectionName} icons collection. Probably you forgot to import the "AllIcons.js" module for the respective package.`);
+		}
 		iconCollectionPromises.set(collectionName, loadIcons(collectionName));
 	}
 

--- a/packages/base/src/asset-registries/Icons.js
+++ b/packages/base/src/asset-registries/Icons.js
@@ -20,10 +20,10 @@ const registerIconLoader = async (collectionName, loader) => {
 
 const _loadIconCollectionOnce = async collectionName => {
 	if (!iconCollectionPromises.has(collectionName)) {
-		const loadIcons = loaders.get(collectionName);
-		if (typeof loadIcons !== "function") {
+		if (!loaders.has(collectionName)) {
 			throw new Error(`No loader registered for the ${collectionName} icons collection. Probably you forgot to import the "AllIcons.js" module for the respective package.`);
 		}
+		const loadIcons = loaders.get(collectionName);
 		iconCollectionPromises.set(collectionName, loadIcons(collectionName));
 	}
 

--- a/packages/icons-tnt/hash.txt
+++ b/packages/icons-tnt/hash.txt
@@ -1,1 +1,1 @@
-PQjj0bSpADeSU9nZ1ReSswKaEJA=
+hPfm+eMQ4XIW8c+KBg7bFx+0LpE=

--- a/packages/icons-tnt/src/AllIcons-static.js
+++ b/packages/icons-tnt/src/AllIcons-static.js
@@ -1,0 +1,1 @@
+import "./json-imports/Icons-static.js";

--- a/packages/icons-tnt/src/AllIcons.js
+++ b/packages/icons-tnt/src/AllIcons.js
@@ -1,0 +1,1 @@
+import "./json-imports/Icons.js";

--- a/packages/icons-tnt/src/Assets-static.js
+++ b/packages/icons-tnt/src/Assets-static.js
@@ -1,1 +1,0 @@
-import "./json-imports/Icons-static.js";

--- a/packages/icons-tnt/src/Assets.js
+++ b/packages/icons-tnt/src/Assets.js
@@ -1,1 +1,0 @@
-import "./json-imports/Icons.js";

--- a/packages/icons/hash.txt
+++ b/packages/icons/hash.txt
@@ -1,1 +1,1 @@
-HT9cm9Sk2rTO2pXVrqEzJGLkBdA=
+ELfgGQJ2bDyU1wIrwyHrbcJYr3o=

--- a/packages/icons/src/AllIcons-static.js
+++ b/packages/icons/src/AllIcons-static.js
@@ -1,0 +1,1 @@
+import "./json-imports/Icons-static.js";

--- a/packages/icons/src/AllIcons.js
+++ b/packages/icons/src/AllIcons.js
@@ -1,0 +1,1 @@
+import "./json-imports/Icons.js";

--- a/packages/icons/src/Assets-static.js
+++ b/packages/icons/src/Assets-static.js
@@ -1,2 +1,1 @@
 import "./generated/json-imports/i18n-static.js";
-import "./json-imports/Icons-static.js";

--- a/packages/icons/src/Assets.js
+++ b/packages/icons/src/Assets.js
@@ -1,2 +1,1 @@
 import "./generated/json-imports/i18n.js";
-import "./json-imports/Icons.js";

--- a/packages/main/bundle.es5.js
+++ b/packages/main/bundle.es5.js
@@ -6,8 +6,13 @@ import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
 
 // Assets
 import "./dist/Assets-static.js";
+
+// Icons
 import "@ui5/webcomponents-icons/dist/Assets-static.js";
+import "@ui5/webcomponents-icons/dist/AllIcons-static.js";
+
 import "@ui5/webcomponents-icons-tnt/dist/Assets-static.js";
+import "@ui5/webcomponents-icons-tnt/dist/AllIcons-static.js";
 
 import testAssets from "./bundle.common.js";
 

--- a/packages/main/bundle.esm.js
+++ b/packages/main/bundle.esm.js
@@ -3,8 +3,13 @@ import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
 
 // Assets
 import "./dist/Assets.js";
+
+// Icons
 import "@ui5/webcomponents-icons/dist/Assets.js";
+import "@ui5/webcomponents-icons/dist/AllIcons.js";
+
 import "@ui5/webcomponents-icons-tnt/dist/Assets.js";
+import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";
 
 import testAssets from "./bundle.common.js";
 

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -282,7 +282,7 @@ class Icon extends UI5Element {
 		if (iconData === ICON_NOT_FOUND) {
 			this.invalid = true;
 			/* eslint-disable-next-line */
-			return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents-icons/dist/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/Assets.js".`);
+			return console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents-icons/dist/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/AllIcons.js".`);
 		}
 
 		if (!iconData) {


### PR DESCRIPTION
❗❗❗ **IMPORTANT - BREAKING CHANGE** ❗❗❗

When developing apps, if an icon was not imported, the whole icon bundle is silently fetched and the developers have no easy way of finding out which icon caused that fetch.

**After this change, it will no longer be possible to use an icon you did not import, unless you explicitly import all icons**:
`import "@ui5/webcomponents-icons/dist/AllIcons.js";`
`import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";`

Additional changes:
 - the icons registry module now throws a more specific error (used to be `loadIcons is not a function` which sounds more like a runtime error than lack of setup), because after the change all apps that use not-imported icons are expected to see this error.
 - The documentation was updated
 - Documentation was added for the `@ui5/webcomponents-icons-tnt` package wherever there was information about `@ui5/webcomponents-icons`.

BREAKING CHANGE:
If your app was using icons that you did not explicitly import, it will no longer silently fetch the JSON in order to find them. An error will be logged in the console instead.

In that case you should consider what to use:
1. import individual icons (if the app uses only a few icons)
2. import all icons as before this change (a bigger download, only helpful if a lot of icons are used, main bundle will become smaller)

To continue using all icons, add the following imports:
`import "@ui5/webcomponents-icons/dist/AllIcons.js";`

and

`import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";`

if you're also using  the `tnt` package..