### PR TITLE
refactor(framework): Add interactsWithChildren metadata entity

### DIFF
--- a/docs/dev/Metadata.md
+++ b/docs/dev/Metadata.md
@@ -220,7 +220,7 @@ Notes:
  Node | Accepts both Text nodes and HTML Elements
  HTMLElement | Accepts HTML Elements only
 
-## Managed slots
+## The `managedSlots` setting
 
 Determines whether the framework should manage the slots of this UI5 Web Component. 
 
@@ -235,8 +235,6 @@ rendering on the presence/absence/type of children.
 
 When `managedSlots` is set to `true`:
  - The framework will invalidate this UI5 Web Component, whenever its children are added/removed/rearranged (and additionally when invalidated, if `invalidateOnChildChange` is set).
- - If any of this UI5 Web Component's children are custom elements, the framework will await until they are all
- defined and upgraded, before rendering the component for the first time.
  - The framework will create properties for each slot on this UI5 Web Component's instances for easier access
  to the slotted children. For example, if there are `header`, `content` and `footer` slots, there will be
  respectively `header`, `content` and `footer` properties of type `Array` holding the slotted children for each slot.
@@ -248,3 +246,30 @@ When `managedSlots` is set to `true`:
  An example of a component that would benefit from `managedSlots` is a Tab Container that monitors its children (Tabs)
  in order to display a link on its Tab Strip for each Tab child. Therefore it would need to be invalidated whenever
  Tabs are added/removed, in order to update its own state and visualization.
+
+## The `interactsWithChildren` setting
+
+Determines whether the framework should await for the children of this UI5 Web Component to be defined and upgraded, before rendering
+the component itself.
+
+This setting is useful for UI5 Web Components that not only base their rendering on the presence/absence of its children, but also
+read/set properties or attributes of their children.
+
+```json
+{
+	"interactsWithChildren": true
+}
+```
+
+An example of a component that would benefit from `interactsWithChildren` is a List that determines the characteristics 
+of its children (list items), based on its own properties (list type, inset, etc...). In such use cases, the component
+will need its children to be fully functional before interacting with them
+
+## Summary of slot control levels
+
+Setting | Level of involvement | Description | Use-case
+ -----|-------------|------------|---------
+*None* | None | The component does not know anything of its children | A generic container that looks the same way regardless of whether empty or with children
+`managedSlots: true` | Some | The component needs to know if, or how many, children it has, and must be invalidated when children change, but does not interact with them directly (does not read/write their properties). | Component that needs to hide some of its HTML, if there are no children in a particular slot, or in general bases its design on the presence/number of children. 
+`intractsWithChildren: true` | High | The component will read/write the state of its children, therefore needs them to be defined and upgraded before being rendered | A component that bases its design/functionality not only on the presence/number of children, but also on their properties/attributes, etc...; a component that sets properties on its children. Usually such components expect their children to be of a specific type. 
+

--- a/docs/dev/Metadata.md
+++ b/docs/dev/Metadata.md
@@ -267,9 +267,9 @@ will need its children to be fully functional before interacting with them
 
 ## Summary of slot control levels
 
-Setting | Level of involvement | Description | Use-case
- -----|-------------|------------|---------
-*None* | None | The component does not know anything of its children | A generic container that looks the same way regardless of whether empty or with children
-`managedSlots: true` | Some | The component needs to know if, or how many, children it has, and must be invalidated when children change, but does not interact with them directly (does not read/write their properties). | Component that needs to hide some of its HTML, if there are no children in a particular slot, or in general bases its design on the presence/number of children. 
-`intractsWithChildren: true` | High | The component will read/write the state of its children, therefore needs them to be defined and upgraded before being rendered | A component that bases its design/functionality not only on the presence/number of children, but also on their properties/attributes, etc...; a component that sets properties on its children. Usually such components expect their children to be of a specific type. 
+Setting | Level of involvement | Description | Use-case | Technical implications
+ -----|-------------|------------|---------|-----------
+*None* | None | The component does not need to know anything of its children | A generic container that looks the same way regardless of whether empty or with children | None - the component only renders `slot` tags in its shadow root and lets the browser do the rest
+`managedSlots: true` | Some | The component needs to know if, or how many, children it has, and must be invalidated when its children change, but does not interact with them directly (does not read/write their properties). | Component that needs to hide some of its HTML (or set specific CSS such as paddings/margins), if there are no children in a particular slot, or in general bases its design on the presence/number of children, but does not care about its children's type or properties. | The component will use a mutation observer to be invalidated whenever its children change. 
+`intractsWithChildren: true` | High | The component will read/write the state of its children, therefore needs them to be defined and upgraded before the component itself can be rendered | A component that bases its design/functionality not only on the presence/number of children, but also on their properties/attributes, etc..., or a component that directly sets properties/calls methods on its children. Such components expect their children to be of a specific type or at least have some assumptions about their children's API. | The component will not only use a mutation observer to monitor its children, but it will also await for all its children to be defined and upgraded, so it can safely start interacting with them.
 

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-WeIr8BhWti5PEgIpG30j/drpLD4=
+IpkLvJPq/iByibBevD9r/s9/8UI=

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -201,6 +201,7 @@ class UI5Element extends HTMLElement {
 	async _updateSlots() {
 		const slotsMap = this.constructor.getMetadata().getSlots();
 		const canSlotText = this.constructor.getMetadata().canSlotText();
+		const shouldAwaitChildren = this.constructor.getMetadata().shouldAwaitChildren();
 		const domChildren = Array.from(canSlotText ? this.childNodes : this.children);
 
 		const slotsCachedContentMap = new Map(); // Store here the content of each slot before the mutation occurred
@@ -237,7 +238,7 @@ class UI5Element extends HTMLElement {
 			}
 
 			// Await for not-yet-defined custom elements
-			if (child instanceof HTMLElement) {
+			if (shouldAwaitChildren && child instanceof HTMLElement) {
 				const localName = child.localName;
 				const isCustomElement = localName.includes("-");
 				if (isCustomElement) {

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -189,6 +189,14 @@ class UI5ElementMetadata {
 	}
 
 	/**
+	 * Determines whether this component should await until its slotted custom elements are defined, before being rendered
+	 * @public
+	 */
+	shouldAwaitChildren() {
+		return !!this.metadata.awaitChildren;
+	}
+
+	/**
 	 * Returns an object with key-value pairs of properties and their metadata definitions
 	 * @public
 	 */

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -201,7 +201,7 @@ class UI5ElementMetadata {
 	 * @public
 	 */
 	shouldAwaitChildren() {
-		return !!this.metadata.awaitChildren || this.usesInvalidateOnChildChange();
+		return !!this.metadata.interactsWithChildren || this.usesInvalidateOnChildChange();
 	}
 
 	/**

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -189,11 +189,19 @@ class UI5ElementMetadata {
 	}
 
 	/**
+	 * Determines whether this UI5 Element supports any slots with "invalidateOnChildChange"
+	 * @public
+	 */
+	usesInvalidateOnChildChange() {
+		return this.slotsAreManaged() && Object.entries(this.getSlots()).some(([_slotName, slotData]) => !!slotData.invalidateOnChildChange);
+	}
+
+	/**
 	 * Determines whether this component should await until its slotted custom elements are defined, before being rendered
 	 * @public
 	 */
 	shouldAwaitChildren() {
-		return !!this.metadata.awaitChildren;
+		return !!this.metadata.awaitChildren || this.usesInvalidateOnChildChange();
 	}
 
 	/**

--- a/packages/base/test/elements/Parent.js
+++ b/packages/base/test/elements/Parent.js
@@ -4,6 +4,7 @@ import litRender, { html } from "../../renderer/LitRenderer.js";
 const metadata = {
 	tag: "ui5-test-parent",
 	managedSlots: true,
+	awaitChildren: true,
 	slots: {
 		default: {
 			type: Node,

--- a/packages/base/test/elements/Parent.js
+++ b/packages/base/test/elements/Parent.js
@@ -4,7 +4,6 @@ import litRender, { html } from "../../renderer/LitRenderer.js";
 const metadata = {
 	tag: "ui5-test-parent",
 	managedSlots: true,
-	awaitChildren: true,
 	slots: {
 		default: {
 			type: Node,

--- a/packages/fiori/src/Bar.js
+++ b/packages/fiori/src/Bar.js
@@ -11,7 +11,6 @@ import BarCss from "./generated/themes/Bar.css.js";
  */
 const metadata = {
 	tag: "ui5-bar",
-	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.Bar.prototype */ {
 		/**
 		 * Defines the <code>ui5-bar</code> design.

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -34,7 +34,6 @@ import NotificationListGroupItemCss from "./generated/themes/NotificationListGro
 const metadata = {
 	tag: "ui5-li-notification-group",
 	languageAware: true,
-	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListGroupItem.prototype */ {
 
 		/**

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -39,7 +39,6 @@ const MAX_WRAP_HEIGHT = 32; // px.
 const metadata = {
 	tag: "ui5-li-notification",
 	languageAware: true,
-	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListItem.prototype */ {
 
 		/**

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -22,7 +22,7 @@ import NotifactionOverflowActionsPopoverCss from "./generated/themes/Notifaction
  */
 const metadata = {
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListItemBase.prototype */ {
 
 		/**

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -22,6 +22,7 @@ import NotifactionOverflowActionsPopoverCss from "./generated/themes/Notifaction
  */
 const metadata = {
 	managedSlots: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListItemBase.prototype */ {
 
 		/**

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -167,7 +167,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 		/**
 		 * Defines the <code>ui5-shellbar</code> aditional items.

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -167,6 +167,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.ShellBar.prototype */ {
 		/**
 		 * Defines the <code>ui5-shellbar</code> aditional items.

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -17,6 +17,7 @@ import SideNavigationCss from "./generated/themes/SideNavigation.css.js";
 const metadata = {
 	tag: "ui5-side-navigation",
 	managedSlots: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.SideNavigation.prototype */ {
 		/**
 		 * Defines whether the <code>ui5-side-navigation</code> is expanded or collapsed.

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -17,7 +17,7 @@ import SideNavigationCss from "./generated/themes/SideNavigation.css.js";
 const metadata = {
 	tag: "ui5-side-navigation",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.SideNavigation.prototype */ {
 		/**
 		 * Defines whether the <code>ui5-side-navigation</code> is expanded or collapsed.

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -16,6 +16,7 @@ const metadata = {
 	tag: "ui5-timeline",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.Timeline.prototype */ {
 		/**
 		 * Determines the content of the <code>ui5-timeline</code>.

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -16,7 +16,7 @@ const metadata = {
 	tag: "ui5-timeline",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.fiori.Timeline.prototype */ {
 		/**
 		 * Determines the content of the <code>ui5-timeline</code>.

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -52,6 +52,7 @@ const STEP_SWITCH_THRESHOLDS = {
 const metadata = {
 	tag: "ui5-wizard",
 	managedSlots: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.Wizard.prototype */ {
 		/**
 		 * Defines the aria-label text of the <code>ui5-wizard</code>.

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -52,7 +52,7 @@ const STEP_SWITCH_THRESHOLDS = {
 const metadata = {
 	tag: "ui5-wizard",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.Wizard.prototype */ {
 		/**
 		 * Defines the aria-label text of the <code>ui5-wizard</code>.

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -50,7 +50,7 @@ const offsets = {
 const metadata = {
 	tag: "ui5-avatar-group",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.AvatarGroup.prototype */  {
 
 		/**

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -50,6 +50,7 @@ const offsets = {
 const metadata = {
 	tag: "ui5-avatar-group",
 	managedSlots: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.AvatarGroup.prototype */  {
 
 		/**

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -76,7 +76,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends  sap.ui.webcomponents.main.Calendar.prototype */ {
 		/**
 		 * Defines the selected date or dates (depending on the <code>selectionMode</code> property) for this calendar as instances of <code>ui5-date</code>

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -76,6 +76,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends  sap.ui.webcomponents.main.Calendar.prototype */ {
 		/**
 		 * Defines the selected date or dates (depending on the <code>selectionMode</code> property) for this calendar as instances of <code>ui5-date</code>

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -27,6 +27,7 @@ import ColorPaletteStaticAreaCss from "./generated/themes/ColorPaletteStaticArea
 const metadata = {
 	tag: "ui5-color-palette",
 	managedSlots: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.ColorPalette.prototype */ {
 
 		/**

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -27,7 +27,7 @@ import ColorPaletteStaticAreaCss from "./generated/themes/ColorPaletteStaticArea
 const metadata = {
 	tag: "ui5-color-palette",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.ColorPalette.prototype */ {
 
 		/**

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -230,6 +230,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.ComboBox.prototype */ {
 		/**
 		 * Defines the <code>ui5-combobox</code> items.

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -230,7 +230,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.ComboBox.prototype */ {
 		/**
 		 * Defines the <code>ui5-combobox</code> items.

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -50,6 +50,7 @@ const metadata = {
 	tag: "ui5-input",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Input.prototype */ {
 
 		/**

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -50,7 +50,7 @@ const metadata = {
 	tag: "ui5-input",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Input.prototype */ {
 
 		/**

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -33,6 +33,7 @@ const INFINITE_SCROLL_DEBOUNCE_RATE = 250; // ms
 const metadata = {
 	tag: "ui5-list",
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.List.prototype */ {
 
 		/**

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -33,7 +33,7 @@ const INFINITE_SCROLL_DEBOUNCE_RATE = 250; // ms
 const metadata = {
 	tag: "ui5-list",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.List.prototype */ {
 
 		/**

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -52,7 +52,7 @@ const metadata = {
 	tag: "ui5-multi-combobox",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.MultiComboBox.prototype */ {
 		/**
 		 * Defines the <code>ui5-multi-combobox</code> items.

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -52,6 +52,7 @@ const metadata = {
 	tag: "ui5-multi-combobox",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.MultiComboBox.prototype */ {
 		/**
 		 * Defines the <code>ui5-multi-combobox</code> items.

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -21,7 +21,6 @@ import {
 const metadata = {
 	tag: "ui5-range-slider",
 	languageAware: true,
-	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.main.RangeSlider.prototype */  {
 		/**
 		 * Defines start point of a selection - position of a first handle on the slider.

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -20,6 +20,7 @@ import SegmentedButtonCss from "./generated/themes/SegmentedButton.css.js";
 const metadata = {
 	tag: "ui5-segmentedbutton",
 	languageAware: true,
+	awaitChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */  {},
 	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */ {

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -20,7 +20,7 @@ import SegmentedButtonCss from "./generated/themes/SegmentedButton.css.js";
 const metadata = {
 	tag: "ui5-segmentedbutton",
 	languageAware: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	properties: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */  {},
 	managedSlots: true,
 	slots: /** @lends sap.ui.webcomponents.main.SegmentedButton.prototype */ {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -51,7 +51,7 @@ const metadata = {
 	tag: "ui5-select",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Select.prototype */ {
 
 		/**

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -51,6 +51,7 @@ const metadata = {
 	tag: "ui5-select",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Select.prototype */ {
 
 		/**

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -17,7 +17,6 @@ import {
 const metadata = {
 	tag: "ui5-slider",
 	languageAware: true,
-	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.main.Slider.prototype */  {
 		/**
 		 * Current value of the slider

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -42,6 +42,7 @@ const metadata = {
 	tag: "ui5-tabcontainer",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends  sap.ui.webcomponents.main.TabContainer.prototype */ {
 		/**
 		 * Defines the tabs.

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -42,7 +42,7 @@ const metadata = {
 	tag: "ui5-tabcontainer",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends  sap.ui.webcomponents.main.TabContainer.prototype */ {
 		/**
 		 * Defines the tabs.

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -33,7 +33,7 @@ const GROWING_WITH_SCROLL_DEBOUNCE_RATE = 250; // ms
 const metadata = {
 	tag: "ui5-table",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Table.prototype */ {
 
 		/**

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -33,6 +33,7 @@ const GROWING_WITH_SCROLL_DEBOUNCE_RATE = 250; // ms
 const metadata = {
 	tag: "ui5-table",
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Table.prototype */ {
 
 		/**

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -16,7 +16,7 @@ import styles from "./generated/themes/TableRow.css.js";
 const metadata = {
 	tag: "ui5-table-row",
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.TableRow.prototype */ {
 		/**
 		 * Defines the cells of the <code>ui5-table-row</code>.

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -16,6 +16,7 @@ import styles from "./generated/themes/TableRow.css.js";
 const metadata = {
 	tag: "ui5-table-row",
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.TableRow.prototype */ {
 		/**
 		 * Defines the cells of the <code>ui5-table-row</code>.

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -34,6 +34,7 @@ const metadata = {
 	tag: "ui5-tokenizer",
 	languageAware: true,
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Tokenizer.prototype */ {
 		"default": {
 			propertyName: "tokens",

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -34,7 +34,7 @@ const metadata = {
 	tag: "ui5-tokenizer",
 	languageAware: true,
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Tokenizer.prototype */ {
 		"default": {
 			propertyName: "tokens",

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -108,7 +108,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
-	awaitChildren: true,
+	interactsWithChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Tree.prototype */ {
 
 		/**

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -108,6 +108,7 @@ const metadata = {
 		},
 	},
 	managedSlots: true,
+	awaitChildren: true,
 	slots: /** @lends sap.ui.webcomponents.main.Tree.prototype */ {
 
 		/**


### PR DESCRIPTION
WIP

# `intaractsWithChildren` slot setting

## Problem

If a component with `managedSlots: true` has children, which are just custom tags, but not web components (do not define a class for the particular tag), it will wait for 1 second before being rendered to give its children the chance to get upgraded. This is a performance problem.

Example:

```html
<ui5-page>
  <my-article>Hello world</my-article>
</ui5-page>
```

and `my-article` is never defined, only used for CSS or semantics:

```css
my-article {
 width: 500px;
 height: 500px;
 background: green;
}
```

However, `my-article` will trigger the following code in `UI5Element.js`:

```js
if (isCustomElement) {
    const isDefined = window.customElements.get(localName);
    if (!isDefined) {
        const whenDefinedPromise = window.customElements.whenDefined(localName); // Class registered, but instances not upgraded yet
        let timeoutPromise = elementTimeouts.get(localName);
        if (!timeoutPromise) {
            timeoutPromise = new Promise(resolve => setTimeout(resolve, 1000));
            elementTimeouts.set(localName, timeoutPromise);
        }
        await Promise.race([whenDefinedPromise, timeoutPromise]);
    }
    window.customElements.upgrade(child);
}
```
and the promise will resolve after a whole 1 second.

## Goal
The aim is to give developers more control over how the framework manages their compnents' slots.

`managedSlots: true` is too engaging in a sense that it awaits for all children to be defined and upgraded before rendering the component. This is an overkill for some components, because they only need to know whether they have children (or how many) for each particular slot, but don't interact with them and don't really need to await for them to be functional in order to work.

## The new setting

The new `interactsWithChildren` setting takes away the "await for children" behavior from `managedSlots: true` and developers must set it explicitly only for the components that really need to interact with their children.

## Summary of slot control levels

Setting | Level of involvement | Description | Use-case | Technical implications
 -----|-------------|------------|---------|-----------
*None* | None | The component does not need to know anything of its children | A generic container that looks the same way regardless of whether empty or with children | None - the component only renders `slot` tags in its shadow root and lets the browser do the rest
`managedSlots: true` | Some | The component needs to know if, or how many, children it has, and must be invalidated when its children change, but does not interact with them directly (does not read/write their properties). | Component that needs to hide some of its HTML (or set specific CSS such as paddings/margins), if there are no children in a particular slot, or in general bases its design on the presence/number of children, but does not care about its children's type or properties. | The component will use a mutation observer to be invalidated whenever its children change. 
`intractsWithChildren: true` | High | The component will read/write the state of its children, therefore needs them to be defined and upgraded before the component itself can be rendered | A component that bases its design/functionality not only on the presence/number of children, but also on their properties/attributes, etc..., or a component that directly sets properties/calls methods on its children. Such components expect their children to be of a specific type or at least have some assumptions about their children's API. | The component will not only use a mutation observer to monitor its children, but it will also await for all its children to be defined and upgraded, so it can safely start interacting with them.
