### PR TITLE
fix(ui5-responsive-popover): fix header styles

### DIFF
--- a/packages/main/src/ResponsivePopover.hbs
+++ b/packages/main/src/ResponsivePopover.hbs
@@ -13,7 +13,7 @@
 			{{#if header.length}}
 				<slot slot="header" name="header"></slot>
 			{{else}}
-				<header class="{{dialogClasses.header}}">
+				<header class="{{classes.header}}">
 					{{#if headerText }}
 						<ui5-title level="H2" class="ui5-popup-header-text ui5-responsive-popover-header-text">{{headerText}}</ui5-title>
 					{{/if}}

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -90,7 +90,7 @@ class ResponsivePopover extends Popover {
 		return [Popover.styles, ResponsivePopoverCss];
 	}
 
-	get dialogClasses() {
+	get classes() {
 		return {
 			header: {
 				"ui5-responsive-popover-header": true,

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -91,12 +91,14 @@ class ResponsivePopover extends Popover {
 	}
 
 	get classes() {
-		return {
-			header: {
-				"ui5-responsive-popover-header": true,
-				"ui5-responsive-popover-header-no-title": !this.headerText,
-			},
+		const allClasses = super.classes;
+
+		allClasses.header = {
+			"ui5-responsive-popover-header": true,
+			"ui5-responsive-popover-header-no-title": !this.headerText,
 		};
+
+		return allClasses;
 	}
 
 	static get template() {

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -94,6 +94,11 @@
 		<ui5-date-picker></ui5-date-picker>
 	</ui5-dialog>
 
+	<ui5-button id="btnSimpleRP">Open Simple RP</ui5-button>
+	<ui5-responsive-popover id="simpleRP">
+		Content
+	</ui5-responsive-popover>
+
 	<script>
 		btnOpen.addEventListener("click", function(event) {
 			respPopover.open(btnOpen);
@@ -117,6 +122,10 @@
 		});
 		btnOpenDialog.addEventListener('click', function (event) {
 			dialog.open(btnOpenDialog);
+		});
+
+		btnSimpleRP.addEventListener("click", function(event) {
+			simpleRP.open(btnSimpleRP);
 		});
 	</script>
 </body>


### PR DESCRIPTION
We use lit-html [classMaps](https://lit-html.polymer-project.org/guide/template-reference#classmap) to render classes out of objects , but it works with this getter "get classes()". Previously instead of having a class, the header element got this:
 ```html
<header class="[object Object]"
```

FIXES: https://github.com/SAP/ui5-webcomponents/issues/3173