### PR TITLE
chore: make serve an optional dependency

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-KJ0tn0Kg8EEEQiQ6XKfqbAsP3eQ=
+52riaJNf3/W5XsbYKCniEmwezbc=

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -77,8 +77,10 @@
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^4.2.0",
-    "serve": "github:vercel/serve#a85bd9d03ae267a492aac683616e028c0bfc6447",
     "wdio-chromedriver-service": "^7.0.0"
+  },
+  "optionalDependencies": {
+    "serve": "git://github.com/vercel/serve.git#a85bd9d03ae267a492aac683616e028c0bfc6447"
   },
   "peerDependencies": {
     "chromedriver": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8691,9 +8691,9 @@ serve-handler@6.1.3:
     path-to-regexp "2.2.1"
     range-parser "1.2.0"
 
-"serve@github:vercel/serve#a85bd9d03ae267a492aac683616e028c0bfc6447":
+"serve@git://github.com/vercel/serve.git#a85bd9d03ae267a492aac683616e028c0bfc6447":
   version "11.3.2"
-  resolved "https://codeload.github.com/vercel/serve/tar.gz/a85bd9d03ae267a492aac683616e028c0bfc6447"
+  resolved "git://github.com/vercel/serve.git#a85bd9d03ae267a492aac683616e028c0bfc6447"
   dependencies:
     "@zeit/schemas" "2.6.0"
     ajv "6.12.6"


### PR DESCRIPTION
Changes:
 - `serve` is now an optional dependency
 - the used protocol is now `git` instead of `github`