### PR TITLE
chore: add links to the docs on the landing page of the playground

### DIFF
--- a/packages/playground/_layouts/default.html
+++ b/packages/playground/_layouts/default.html
@@ -10,6 +10,11 @@
           <img src="{{ "/assets/images/logo.png" | absolute_url }}" alt="Logo" class="logo">
           <div class="heading">UI5 Web Components</div>
         </a>
+        <div class="links-wrapper">
+          <a class="wrapper-links" href="{{ page.docs | absolute_url }}">Docs</a>
+          <a class="wrapper-links" href="{{ page.tutorials | absolute_url }}">Tutorials</a>
+          <a class="wrapper-links" href="{{ page.samples | absolute_url }}">Samples</a>
+        </div>
         <div class="search js-search">
           <div class="search-input-wrap">
             <input type="text" class="js-search-input search-input" tabindex="0" placeholder="Search" aria-label="Search {{ site.title }} docs" autocomplete="off">

--- a/packages/playground/_sass/layout.scss
+++ b/packages/playground/_sass/layout.scss
@@ -89,6 +89,7 @@
 }
 
 .page-header {
+  position: relative;
   width: 100%;
   height: 3rem;
   display: flex;
@@ -118,6 +119,33 @@
   width: 2.4rem;
   height: 2.4rem;
   margin: 0 .5rem;
+}
+
+.links-wrapper {
+  position: absolute;
+  height: 100%;
+  display: flex;
+  left: 250px;
+}
+
+@media only screen and (max-width: 1100px) {
+  .links-wrapper {
+    display: none;
+  }
+}
+
+.wrapper-links {
+  display: flex;
+  align-items: center;
+	font-size: 16px;
+	font-family: "72-Regular", "72-Light";
+	color: #fff;
+	text-decoration: none;
+	margin-right: .5rem;
+}
+
+.wrapper-links:hover {
+	color: #A2A2A2;
 }
 
 .heading {

--- a/packages/playground/assets/css/landing-page.css
+++ b/packages/playground/assets/css/landing-page.css
@@ -482,6 +482,10 @@ body {
 }
 
 @media only screen and (max-width: 600px) {
+	.wrapper.header-links {
+		margin-top: -2rem;
+	}
+
 	.sub-header {
 		font-size: 20px;
 		width: auto;

--- a/packages/playground/assets/css/landing-page.css
+++ b/packages/playground/assets/css/landing-page.css
@@ -42,6 +42,11 @@ body {
     font-family: "72-Bold", "72-Regular";
 }
 
+.wrapper.header-links {
+	margin-top: -5rem;
+    margin-bottom: 5rem;
+}
+
 .header-wrapper {
 	width: 100%;
 	height: 33.19rem;
@@ -170,6 +175,20 @@ body {
 	max-width: 1000px;
 	margin: 0 auto;
 	box-sizing: border-box;
+}
+
+
+.wrapper-links {
+	margin-top: 1rem;
+	font-size: 16px;
+	font-family: "72-Regular", "72-Light";
+	color: #fff;
+	text-decoration: none;
+	margin-right: .5rem;
+}
+
+.wrapper-links:hover {
+	color: #A2A2A2;
 }
 
 .flex-center {

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -4,6 +4,9 @@ permalink: /
 nav_order: 4
 nav_exclude: true
 redirect_to: ./playground
+docs: ./playground/docs
+tutorials: ./playground/tutorials
+samples: ./playground/components
 ---
 
 <!DOCTYPE html>
@@ -39,6 +42,11 @@ redirect_to: ./playground
         <div class="content">
 
             <header class="header-wrapper section-container">
+                <div class="wrapper header-links">
+                    <a class="wrapper-links" href="{{ page.docs | absolute_url }}">Docs</a>
+                    <a class="wrapper-links" href="{{ page.tutorials | absolute_url }}">Tutorials</a>
+                    <a class="wrapper-links" href="{{ page.samples | absolute_url }}">Samples</a>
+                </div>
                 <div class="wrapper header-inside-wrapper">
                         <div class="header-text-wrapper">
                             <h2 class="ui5-header bold-font">UI5 Web Components</h2>


### PR DESCRIPTION
Changes on the landing page:
- Desktop:
![image](https://user-images.githubusercontent.com/16850339/116520122-f9126000-a8da-11eb-8fb6-3e071b9efafe.png)

- Mobile:
![image](https://user-images.githubusercontent.com/16850339/116520200-11827a80-a8db-11eb-86b2-b07176f32100.png)

In the documentation pages:
- Desktop:
![image](https://user-images.githubusercontent.com/16850339/116520307-3aa30b00-a8db-11eb-95ac-1888e06acaf7.png)
- Mobile: Links are hidden on devices with width < 1100px
