### PR TITLE
fix(ui5-busyindicator): focus handling improvements

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-52riaJNf3/W5XsbYKCniEmwezbc=
+VtcT3O0SUP+WFCXL1txQutIxxPY=

--- a/packages/base/src/util/FocusableElements.js
+++ b/packages/base/src/util/FocusableElements.js
@@ -21,6 +21,10 @@ const getLastFocusableElement = async container => {
 	return findFocusableElement(container, false);
 };
 
+const isElemFocusable = el => {
+	return el.hasAttribute("data-ui5-focus-redirect") || !isNodeHidden(el);
+};
+
 const findFocusableElement = async (container, forward) => {
 	let child;
 
@@ -48,7 +52,7 @@ const findFocusableElement = async (container, forward) => {
 			return null;
 		}
 
-		if (child.nodeType === 1 && !isNodeHidden(child) && !isFocusTrap(child)) {
+		if (child.nodeType === 1 && isElemFocusable(child) && !isFocusTrap(child)) {
 			if (isNodeClickable(child)) {
 				return (child && typeof child.focus === "function") ? child : null;
 			}

--- a/packages/main/src/BusyIndicator.hbs
+++ b/packages/main/src/BusyIndicator.hbs
@@ -23,5 +23,9 @@
 		</div>
 	{{/if}}
 
-	<slot tabindex="{{slotTabIndex}}"></slot>
+	<slot></slot>
+
+	{{#if active}}
+		<span data-ui5-focus-redirect tabindex="0" @focusin="{{_redirectFocus}}"></span>
+	{{/if}}
 </div>

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -188,7 +188,7 @@ class BusyIndicator extends UI5Element {
 			return;
 		}
 
-		event.stopImmediatePropagation()
+		event.stopImmediatePropagation();
 
 		// move the focus to the last element in this DOM and let TAB continue to the next focusable element
 		if (isTabNext(event)) {

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -2,6 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { isTabNext } from "@ui5/webcomponents-base/dist/Keys.js";
 import BusyIndicatorSize from "./types/BusyIndicatorSize.js";
 import Label from "./Label.js";
 
@@ -12,7 +13,6 @@ import { BUSY_INDICATOR_TITLE } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
 import busyIndicatorCss from "./generated/themes/BusyIndicator.css.js";
-import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 
 /**
  * @public

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -12,6 +12,7 @@ import { BUSY_INDICATOR_TITLE } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
 import busyIndicatorCss from "./generated/themes/BusyIndicator.css.js";
+import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 
 /**
  * @public
@@ -131,7 +132,7 @@ class BusyIndicator extends UI5Element {
 	}
 
 	onEnterDOM() {
-		this.addEventListener("keyup", this._preventHandler, {
+		this.addEventListener("focusin", this._preventHandler, {
 			capture: true,
 		});
 
@@ -141,7 +142,7 @@ class BusyIndicator extends UI5Element {
 	}
 
 	onExitDOM() {
-		this.removeEventListener("keyup", this._preventHandler, true);
+		this.removeEventListener("focusin", this._preventHandler, true);
 		this.removeEventListener("keydown", this._preventHandler, true);
 	}
 
@@ -183,13 +184,32 @@ class BusyIndicator extends UI5Element {
 	}
 
 	get slotTabIndex() {
-		return this.active ? -1 : 0;
+		return this.active ? -1 : "";
 	}
 
 	_preventEvent(event) {
-		if (this.active) {
-			event.stopImmediatePropagation();
+		if (!this.active) {
+			return;
 		}
+
+		if (isTabNext(event)) {
+			this.bIgnore = true;
+			this.shadowRoot.querySelector("[data-ui5-focus-redirect]").tabIndex = -1;
+			this.shadowRoot.querySelector("[data-ui5-focus-redirect]").focus();
+			this.shadowRoot.querySelector("[data-ui5-focus-redirect]").tabIndex = 0;
+			event.stopImmediatePropagation();
+			this.bIgnore = false;
+		}
+	}
+
+	_redirectFocus(e) {
+		if (this.bIgnore) {
+			return;
+		}
+
+		const busyArea = this.shadowRoot.querySelector(".ui5-busyindicator-busy-area");
+		e.preventDefault();
+		busyArea.focus();
 	}
 }
 

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -188,15 +188,10 @@ class BusyIndicator extends UI5Element {
 			return;
 		}
 
-		event.stopImmediatePropagation();
-
-		// use the helper span to move the focus out of ui5-busyindicator
+		// move the focus to the last element in this DOM and let TAB continue to the next focusable element
 		if (isTabNext(event)) {
-			const focusRedirectSpan = this.shadowRoot.querySelector("[data-ui5-focus-redirect]");
 			this.focusForward = true;
-			focusRedirectSpan.tabIndex = -1;
-			focusRedirectSpan.focus();
-			focusRedirectSpan.tabIndex = 0;
+			this.shadowRoot.querySelector("[data-ui5-focus-redirect]").focus();
 			this.focusForward = false;
 		}
 	}

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -129,16 +129,21 @@ class BusyIndicator extends UI5Element {
 
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 		this._keydownHandler = this._handleKeydown.bind(this);
+		this._preventEventHandler = this._preventEvent.bind(this);
 	}
 
 	onEnterDOM() {
 		this.addEventListener("keydown", this._keydownHandler, {
 			capture: true,
 		});
+		this.addEventListener("keyup", this._preventEventHandler, {
+			capture: true,
+		});
 	}
 
 	onExitDOM() {
 		this.removeEventListener("keydown", this._keydownHandler, true);
+		this.removeEventListener("keyup",this. _preventEventHandler, true);
 	}
 
 	static get metadata() {
@@ -193,6 +198,12 @@ class BusyIndicator extends UI5Element {
 			focusRedirectSpan.focus();
 			focusRedirectSpan.tabIndex = 0;
 			this.focusForward = false;
+		}
+	}
+
+	_preventEvent(event) {
+		if (this.active) {
+			event.stopImmediatePropagation();
 		}
 	}
 

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -188,6 +188,8 @@ class BusyIndicator extends UI5Element {
 			return;
 		}
 
+		event.stopImmediatePropagation()
+
 		// move the focus to the last element in this DOM and let TAB continue to the next focusable element
 		if (isTabNext(event)) {
 			this.focusForward = true;

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -143,7 +143,7 @@ class BusyIndicator extends UI5Element {
 
 	onExitDOM() {
 		this.removeEventListener("keydown", this._keydownHandler, true);
-		this.removeEventListener("keyup",this. _preventEventHandler, true);
+		this.removeEventListener("keyup", this._preventEventHandler, true);
 	}
 
 	static get metadata() {

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -142,8 +142,24 @@
 	<br>
 	<br>
 
-	<ui5-button id="open-dialog">Open Dialog</ui5-button>
-	<ui5-dialog id="dialog">
+	<ui5-button id="open-dialog-inactive-indicator">Open Dialog with Inactive Indicator</ui5-button>
+	<ui5-dialog id="dialog-inactive-indicator">
+		<div slot="header">Dialog with focus issue</div>
+		<div>
+			<div>
+				these buttons do not get initial focus and once they do, the focus is
+				allowed to leave the dialog
+			</div>
+			<ui5-busyindicator>
+				<ui5-button>button 1</ui5-button>
+				<ui5-button>button 2</ui5-button>
+				<ui5-button>button 3</ui5-button>
+			</ui5-busyindicator>
+		</div>
+	</ui5-dialog>
+
+	<ui5-button id="open-dialog-active-indicator">Open Dialog with Active Indicator</ui5-button>
+	<ui5-dialog id="dialog-active-indicator">
 		<div slot="header">Dialog with focus issue</div>
 		<div>
 			<div>
@@ -208,11 +224,12 @@
 			}
 		});
 
-		document.getElementById("open-dialog").addEventListener("click", function () {
-			document.getElementById("dialog").open();
-			setTimeout(function () {
-				document.getElementById("dialog").querySelector("ui5-busyindicator").active = false;
-			}, 2000)
+		document.getElementById("open-dialog-inactive-indicator").addEventListener("click", function () {
+			document.getElementById("dialog-inactive-indicator").open();
+		});
+
+		document.getElementById("open-dialog-active-indicator").addEventListener("click", function () {
+			document.getElementById("dialog-active-indicator").open();
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -45,9 +45,13 @@
 	<br />
 	<br />
 
-	<ui5-busyindicator id="indicatorWithBtn" size="Medium" active>
-		<ui5-button>Hello World</ui5-button>
-	</ui5-busyindicator>
+	<div>
+		<ui5-button id="beforeIndicatorWithBtn">focus stop before</ui5-button>
+		<ui5-busyindicator id="indicatorWithBtn" size="Medium" active>
+			<ui5-button>Hello World</ui5-button>
+		</ui5-busyindicator>
+		<ui5-button id="afterIndicatorWithBtn" >focus stop after</ui5-button>
+	</div>
 
 	<br />
 	<br />
@@ -151,7 +155,7 @@
 				allowed to leave the dialog
 			</div>
 			<ui5-busyindicator>
-				<ui5-button>button 1</ui5-button>
+				<ui5-button id="dialog-inactive-indicator-focused-button">button 1</ui5-button>
 				<ui5-button>button 2</ui5-button>
 				<ui5-button>button 3</ui5-button>
 			</ui5-busyindicator>

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -139,6 +139,24 @@
 
 	<ui5-input value="0" id="tree-input"></ui5-input>
 
+	<br>
+	<br>
+
+	<ui5-button id="open-dialog">Open Dialog</ui5-button>
+	<ui5-dialog id="dialog">
+		<div slot="header">Dialog with focus issue</div>
+		<div>
+			<div>
+				these buttons do not get initial focus and once they do, the focus is
+				allowed to leave the dialog
+			</div>
+			<ui5-busyindicator active>
+				<ui5-button>button 1</ui5-button>
+				<ui5-button>button 2</ui5-button>
+				<ui5-button>button 3</ui5-button>
+			</ui5-busyindicator>
+		</div>
+	</ui5-dialog>
 	<script>
 		var busyIndocator = document.getElementById("busy-container");
 		var list = document.getElementById("fetch-list");
@@ -188,6 +206,13 @@
 			if (item.id === "dynamicNode") {
 				input.value = ++inputValue;
 			}
+		});
+
+		document.getElementById("open-dialog").addEventListener("click", function () {
+			document.getElementById("dialog").open();
+			setTimeout(function () {
+				document.getElementById("dialog").querySelector("ui5-busyindicator").active = false;
+			}, 2000)
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -150,10 +150,7 @@
 	<ui5-dialog id="dialog-inactive-indicator">
 		<div slot="header">Dialog with focus issue</div>
 		<div>
-			<div>
-				these buttons do not get initial focus and once they do, the focus is
-				allowed to leave the dialog
-			</div>
+			<div>Buttons are wrapped in busy indicator, which is inactive.</div>
 			<ui5-busyindicator>
 				<ui5-button id="dialog-inactive-indicator-focused-button">button 1</ui5-button>
 				<ui5-button>button 2</ui5-button>
@@ -166,10 +163,7 @@
 	<ui5-dialog id="dialog-active-indicator">
 		<div slot="header">Dialog with focus issue</div>
 		<div>
-			<div>
-				these buttons do not get initial focus and once they do, the focus is
-				allowed to leave the dialog
-			</div>
+			<div>Buttons are wrapped in busy indicator, which is active.</div>
 			<ui5-busyindicator active>
 				<ui5-button>button 1</ui5-button>
 				<ui5-button>button 2</ui5-button>

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -43,10 +43,32 @@ describe("BusyIndicator general interaction", () => {
 		assert.strictEqual(innerFocusElement.getAttribute("aria-valuetext"), "Busy", "Correct 'aria-valuetext' is set");
 	});
 
-	it("tests content is not reachable with keyboard when active", () => {
+	it("tests content is not reachable with keyboard when active in both directions", () => {
+		const beforeBusyIndicator = browser.$("#beforeIndicatorWithBtn");
 		const busyIndicator = browser.$("#indicatorWithBtn");
-		const defaultSLot = busyIndicator.shadow$("slot");
+		const afterBusyIndicator = browser.$("#afterIndicatorWithBtn");
 
-		assert.strictEqual(defaultSLot.getAttribute("tabindex"), "-1", "Slot is not reachable via keyboard");
+		beforeBusyIndicator.click();
+		browser.keys("Tab");
+		assert.strictEqual($(browser.getActiveElement()).getAttribute("id"), busyIndicator.getAttribute("id"), "Correct element is focused with TAB");
+
+		browser.keys("Tab");
+		assert.strictEqual($(browser.getActiveElement()).getAttribute("id"), afterBusyIndicator.getAttribute("id"), "Correct element is focused with TAB");
+
+		browser.keys(["Shift", "Tab"]);
+		assert.strictEqual($(browser.getActiveElement()).getAttribute("id"), busyIndicator.getAttribute("id"), "Correct element is focused with SHIFT + TAB");
+
+		browser.keys(["Shift", "Tab"]);
+		assert.strictEqual($(browser.getActiveElement()).getAttribute("id"), beforeBusyIndicator.getAttribute("id"), "Correct element is focused with SHIFT + TAB");
+	});
+
+	it("test inactive indicator in dialog - correct element from default slot is focused", () => {
+		browser.$("#open-dialog-inactive-indicator").click();
+
+		assert.strictEqual(
+			$(browser.getActiveElement()).getAttribute("id"),
+			browser.$("#dialog-inactive-indicator-focused-button").getAttribute("id"),
+			"Correct element from default slot is focused"
+		);
 	});
 });


### PR DESCRIPTION
Removed "tabIndex" attribute from default \<slot\> of ui5-busyindicator, because it breaks `findFirstFocusableElement` and `findLastFocusableElement` . Instead focus redirecting is now done with `span` helper

Fixes #3181 