### PR TITLE
fix(ui5-rating-indicator): Aria-readonly attribute added

### DIFF
--- a/packages/main/src/RatingIndicator.hbs
+++ b/packages/main/src/RatingIndicator.hbs
@@ -6,7 +6,7 @@
 	aria-valuemax="{{maxValue}}"
 	aria-orientation="horizontal"
 	aria-disabled="{{_ariaDisabled}}"
-	?aria-readonly="{{readOnly}}"
+	aria-readonly="{{ariaReadonly}}"
 	tabindex="{{tabIndex}}"
 	@focusin="{{_onfocusin}}"
 	@focusout="{{_onfocusout}}"

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -291,6 +291,10 @@ class RatingIndicator extends UI5Element {
 	get _ariaDisabled() {
 		return this.disabled || undefined;
 	}
+
+	get ariaReadonly() {
+		return this.readonly ? "true" : undefined;
+	}
 }
 
 RatingIndicator.define();

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -47,7 +47,7 @@
 	<br>
 
 	<h3>readonly</h3>
-	<ui5-rating-indicator value="1" max-value="3" readonly></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-indicator-readonly" value="1" max-value="3" readonly></ui5-rating-indicator>
 	<br>
 	<br>
 	<br>

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -69,6 +69,8 @@ describe("Rating Indicator general interaction", () => {
 
 	it("Tests ACC attrs", () => {
 		const ratingIndicator = browser.$("#rating-indicator1").shadow$(".ui5-rating-indicator-root");
+		const ratingIndicatorReadOnly = browser.$("#rating-indicator-readonly").shadow$(".ui5-rating-indicator-root");
+
 		const TOOLTIP = "Rating";
 		const ARIA_LABEL = "Hello World";
 
@@ -77,5 +79,8 @@ describe("Rating Indicator general interaction", () => {
 
 		assert.strictEqual(ratingIndicator.getAttribute("title"), TOOLTIP,
 			"The default tooltip is displayed");
+
+		assert.notOk(ratingIndicator.getAttribute("aria-readonly"), "The aria-readonly attribute is not presented");
+		assert.strictEqual(ratingIndicatorReadOnly.getAttribute("aria-readonly"), 'true', "The aria-readonly attribute is presented");
 	});
 });


### PR DESCRIPTION
When a Rating Indicator is not editable, aria-readonly attribute is added to the root element.

FIXES: #3203 