### PR TITLE
refactor(ui5-rating-indicator): remove private property "title"

### DIFF
--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -265,7 +265,7 @@ class RatingIndicator extends UI5Element {
 	}
 
 	get tooltip() {
-		return this.getAttribute('title') || this.defaultTooltip;
+		return this.getAttribute("title") || this.defaultTooltip;
 	}
 
 	get defaultTooltip() {

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -97,18 +97,6 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the tooltip for the rating indicator.
-		 * @type {String}
-		 * @defaultvalue: undefined
-		 * @private
-		 * @since 1.0.0-rc.8
-		 */
-		title: {
-			type: String,
-			defaultValue: undefined,
-		},
-
-		/**
 		 * @private
 		 */
 		_stars: {
@@ -277,7 +265,7 @@ class RatingIndicator extends UI5Element {
 	}
 
 	get tooltip() {
-		return this.title || this.defaultTooltip;
+		return this.getAttribute('title') || this.defaultTooltip;
 	}
 
 	get defaultTooltip() {

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -62,6 +62,12 @@
 	<br>
 	<br>
 
+	<h3>RatingIndicator with title</h3>
+	<ui5-rating-indicator id="rating-indicator-title" title="Test" aria-label="Hello World"></ui5-rating-indicator>
+	<br>
+	<br>
+	<br>
+
 	<h3>sizes</h3>
 	<section>
 		<ui5-rating-indicator style="font-size: 1rem;"></ui5-rating-indicator>

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -16,7 +16,7 @@ describe("Rating Indicator general interaction", () => {
 	it("Tests max-value property", () => {
 		const ratingIndicator = browser.$("#rating-indicator2");
 
-		assert.strictEqual(ratingIndicator.shadow$$(".ui5-rating-indicator-icon").length, 10, "Basic rating indicator renders 5 stars");
+		assert.strictEqual(ratingIndicator.shadow$$(".ui5-rating-indicator-icon").length, 10, "Basic rating indicator renders 10 stars");
 	});
 
 	it("Tests clicking on star", () => {
@@ -77,5 +77,12 @@ describe("Rating Indicator general interaction", () => {
 
 		assert.strictEqual(ratingIndicator.getAttribute("title"), TOOLTIP,
 			"The default tooltip is displayed");
+	});
+
+	it("Tests ACC attrs - title attribute provided", () => {
+		const ratingIndicator = browser.$("#rating-indicator-title").shadow$(".ui5-rating-indicator-root");
+		const TOOLTIP = "Test";
+
+		assert.strictEqual(ratingIndicator.getAttribute("title"), TOOLTIP, "The title attribute is rendered in the inner div as well.");
 	});
 });


### PR DESCRIPTION
We have decided that we do not need to have private property on the web component level, as all HTML elements have 'title' attribute by default. 
The 'title' property of the inner div will be synced with the provided one.
In case no title is provided - the default from the internationalisation bundle will be taken. 
