### PR TITLE
refactor(ui5-color-palette): rename moreColors to showMoreColors

### DIFF
--- a/packages/main/src/ColorPalette.hbs
+++ b/packages/main/src/ColorPalette.hbs
@@ -16,7 +16,7 @@
 		{{/each}}
 	</div>
 
-	{{#if showMoreColors}}
+	{{#if _showMoreColors}}
 		<div class="ui5-cp-more-colors-wrapper">
 			<div class="ui5-cp-separator"></div>
 			<ui5-button

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -44,9 +44,9 @@ const metadata = {
 		 * <b>Note:</b> In order to use this property you need to import the following module: <code>"@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js"</code>
 		 * @type {boolean}
 		 * @public
-		 * @since 1.0.0-rc.12
+		 * @since 1.0.0-rc.15
 		 */
-		moreColors: {
+		showMoreColors: {
 			type: Boolean,
 		},
 
@@ -101,7 +101,7 @@ const metadata = {
  *
  * <h3>Usage</h3>
  * The Colorpalette is intended for users that needs to select a color from a predefined set of colors.
- * To allow users select any color from a color picker, enable the <code>more-colors</code> property.
+ * To allow users select any color from a color picker, enable the <code>show-more-colors</code> property.
  * And, to display the most recent color selection, enable the <code>show-recent-colors</code> property.
  *
  * <h3>ES6 Module Import</h3>
@@ -168,7 +168,7 @@ class ColorPalette extends UI5Element {
 			item.index = index + 1;
 		});
 
-		if (this.moreColors) {
+		if (this.showMoreColors) {
 			const ColorPaletteMoreColors = getFeature("ColorPaletteMoreColors");
 			if (ColorPaletteMoreColors) {
 				this.moreColorsFeature = new ColorPaletteMoreColors();
@@ -250,8 +250,8 @@ class ColorPalette extends UI5Element {
 		return this.i18nBundle.getText(COLOR_PALETTE_MORE_COLORS_TEXT);
 	}
 
-	get showMoreColors() {
-		return this.moreColors && this.moreColorsFeature;
+	get _showMoreColors() {
+		return this.showMoreColors && this.moreColorsFeature;
 	}
 
 	get recentColors() {

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -37,7 +37,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 
 </body>
-	<ui5-color-palette id="cp1" more-colors>
+	<ui5-color-palette id="cp1" show-more-colors>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -94,7 +94,7 @@
 	<br/>
 	<br/>
 
-	<ui5-color-palette id="cp3" more-colors show-recent-colors>
+	<ui5-color-palette id="cp3" show-more-colors show-recent-colors>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -109,7 +109,7 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette>
 
-	<ui5-color-palette id="cp4" more-colors show-recent-colors>
+	<ui5-color-palette id="cp4" show-more-colors show-recent-colors>
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>

--- a/packages/main/test/samples/ColorPalette.sample.html
+++ b/packages/main/test/samples/ColorPalette.sample.html
@@ -45,7 +45,7 @@
 <section>
 	<h3>ColorPalette With More Colors & Recent Colours Functionality</h3>
 	<div class="snippet">
-		<ui5-color-palette more-colors show-recent-colors>
+		<ui5-color-palette show-more-colors show-recent-colors>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 			<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -61,7 +61,7 @@
 		</ui5-color-palette>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-color-palette more-colors show-recent-colors>
+<ui5-color-palette show-more-colors show-recent-colors>
 	<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 	<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 	<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -92,7 +92,7 @@
 			placement-type="Bottom"
 			horizontal-align="Left"
 			no-arrow>
-				<ui5-color-palette id="colorPaletteInPopover" more-colors>
+				<ui5-color-palette id="colorPaletteInPopover" show-more-colors>
 					<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 					<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 					<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -124,7 +124,7 @@
 </section>
 
 <ui5-popover id="palettePopover" header-text="Pick a color" placement-type="Bottom">
-		<ui5-color-palette id="colorPaletteInPopover" more-colors>
+		<ui5-color-palette id="colorPaletteInPopover" show-more-colors>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 			<ui5-color-palette-item value="#444444"></ui5-color-palette-item>

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -74,7 +74,7 @@ describe("ColorPalette interactions", () => {
 		assert.strictEqual(colorPalette.getProperty("value"), "darkblue", "Check if selected value is darkblue");
 	});
 
-	it("Tests more-colors functionality", () => {
+	it("Tests show-more-colors functionality", () => {
 		const colorPalette = browser.$("#cp3");
 		const colorPaletteMoreColorsButton = colorPalette.shadow$(".ui5-cp-more-colors");
 


### PR DESCRIPTION
Rename moreColors to showMoreColors to make it sound like boolean and consistent with showRecentColors.
Related to: https://github.com/SAP/ui5-webcomponents/issues/3107

BREAKING_CHANGE: the property `"moreColors"` has been renamed to `"showMoreColors"`