### PR TITLE
fix(ui5-button): remove iconSize property

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -24,9 +24,9 @@
 >
 	{{#if icon}}
 		<ui5-icon
-			style="{{styles.icon}}"
 			class="ui5-button-icon"
 			name="{{icon}}"
+			part="icon"
 			?show-tooltip={{showIconTooltip}}
 		></ui5-icon>
 	{{/if}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -94,19 +94,6 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the size of the icon inside the <code>ui5-button</code>.
-		 *
-		 * @type {string}
-		 * @defaultvalue undefined
-		 * @public
-		 * @since 1.0.0-rc.8
-		 */
-		iconSize: {
-			type: String,
-			defaultValue: undefined,
-		},
-
-		/**
 		 * When set to <code>true</code>, the <code>ui5-button</code> will
 		 * automatically submit the nearest form element upon <code>press</code>.
 		 * <br><br>
@@ -484,15 +471,6 @@ class Button extends UI5Element {
 
 	get showIconTooltip() {
 		return this.iconOnly && !this.title;
-	}
-
-	get styles() {
-		return {
-			icon: {
-				width: this.iconSize,
-				height: this.iconSize,
-			},
-		};
 	}
 
 	static async onDefine() {

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -24,12 +24,11 @@
 
 	{{#unless noCloseButton}}
 		<ui5-button
-				icon="decline"
-				icon-size=".75rem"
-				design="Transparent"
-				class="ui5-messagestrip-close-button"
-				title="{{_closeButtonText}}"
-				@click={{_closeClick}}
+			icon="decline"
+			design="Transparent"
+			class="ui5-messagestrip-close-button"
+			title="{{_closeButtonText}}"
+			@click={{_closeClick}}
 		></ui5-button>
 	{{/unless}}
 </div>

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -91,8 +91,14 @@
 	top: 0.125rem;
 	color: var(--sapTextColor);
 }
+
 .ui5-messagestrip-close-button[active] {
 	color: var(--sapButton_Active_TextColor);
+}
+
+.ui5-messagestrip-close-button::part(icon) {
+	width: .75rem;
+	height: .75rem;
 }
 
 /* RTL */


### PR DESCRIPTION
iconSize is a public property that is used only for the purpose of the MessageStrip close button. Remove the property and add a Shadow Part so the MessageStrip can re-style the button. Part of #3107

BREAKING_CHANGE: ```iconSize``` property of ```ui5-button``` has been deprecated