### PR TITLE
refactor(ui5-slider): show tooltips on focus

### DIFF
--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -87,7 +87,7 @@ const metadata = {
  * <li><code>Home</code> - Moves the <code>ui5-slider</code> handle to the beginning of the range;</li>
  * <li><code>End</code> - Moves the <code>ui5-slider</code> handle to the end of the range;</li>
  * <li><code>Page Up</code> - Same as <code>Right/Up + Ctrl/Cmd</code></li>
- * <li><code>Page Down</code> - Same as <code>Left/Down + Ctrl/Cmd<code></li>
+ * <li><code>Page Down</code> - Same as <code>Left/Down + Ctrl/Cmd</code></li>
  * <li><code>Escape</code> - Resets the value after interaction, to the position prior the <ui5-slider> focusing;</li>
  * </ul>
  *

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -160,7 +160,7 @@ class Slider extends SliderBase {
 		}
 
 		if (this.showTooltip) {
-			this._tooltipVisibility = "visible";
+			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
 		}
 	}
 
@@ -177,7 +177,7 @@ class Slider extends SliderBase {
 		this._setInitialValue("value", null);
 
 		if (this.showTooltip) {
-			this._tooltipVisibility = "hidden";
+			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
 		}
 	}
 

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -75,6 +75,22 @@ const metadata = {
  * <li>handle - Used to style the handle of the <code>ui5-slider</code></li>
  * </ul>
  *
+ * <h3>Keyboard Handling</h3>
+ *
+ * <ul>
+ * <li><code>Left/Down Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the left, effectively decreasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
+ * <li><code>Right/Up Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the right, effectively increasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
+ * <li><code>Left/Down Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the left with step equal to 1/10th of the entire range, effectively decreasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
+ * <li><code>Right/Up Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the right with step equal to 1/10th of the entire range, effectively increasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
+ * <li><code>Plus</code> - Same as <code>Right/Up Arrow</code></li>
+ * <li><code>Minus</code> - Same as <code>Left/Down Arrow</code></li>
+ * <li><code>Home</code> - Moves the <code>ui5-slider</code> handle to the beginning of the range;</li>
+ * <li><code>End</code> - Moves the <code>ui5-slider</code> handle to the end of the range;</li>
+ * <li><code>Page Up</code> - Same as <code>Right/Up + Ctrl/Cmd</code></li>
+ * <li><code>Page Down</code> - Same as <code>Left/Down + Ctrl/Cmd<code></li>
+ * <li><code>Escape</code> - Resets the value after interaction, to the position prior the <ui5-slider> focusing;</li>
+ * </ul>
+ *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Slider";</code>

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -158,6 +158,10 @@ class Slider extends SliderBase {
 		if (this._getInitialValue("value") === null) {
 			this._setInitialValue("value", this.value);
 		}
+
+		if (this.showTooltip) {
+			this._tooltipVisibility = "visible";
+		}
 	}
 
 	_onfocusout(event) {
@@ -171,6 +175,10 @@ class Slider extends SliderBase {
 		// Reset focus state and the stored Slider's initial
 		// value that was saved when it was first focused in
 		this._setInitialValue("value", null);
+
+		if (this.showTooltip) {
+			this._tooltipVisibility = "hidden";
+		}
 	}
 
 	/**

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -78,16 +78,16 @@ const metadata = {
  * <h3>Keyboard Handling</h3>
  *
  * <ul>
- * <li><code>Left/Down Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the left, effectively decreasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
- * <li><code>Right/Up Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the right, effectively increasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
- * <li><code>Left/Down Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the left with step equal to 1/10th of the entire range, effectively decreasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
- * <li><code>Right/Up Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the right with step equal to 1/10th of the entire range, effectively increasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
- * <li><code>Plus</code> - Same as <code>Right/Up Arrow</code></li>
- * <li><code>Minus</code> - Same as <code>Left/Down Arrow</code></li>
+ * <li><code>Left or Down Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the left, effectively decreasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
+ * <li><code>Right or Up Arrow</code> - Moves the <code>ui5-slider</code> handle one step to the right, effectively increasing the <code>ui5-slider</code>'s value by <code>step</code> amount;</li>
+ * <li><code>Left or Down Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the left with step equal to 1/10th of the entire range, effectively decreasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
+ * <li><code>Right or Up Arrow + Ctrl/Cmd</code> - Moves the <code>ui5-slider</code> handle to the right with step equal to 1/10th of the entire range, effectively increasing the <code>ui5-slider</code>'s value by 1/10th of the range;</li>
+ * <li><code>Plus</code> - Same as <code>Right or Up Arrow</code></li>
+ * <li><code>Minus</code> - Same as <code>Left or Down Arrow</code></li>
  * <li><code>Home</code> - Moves the <code>ui5-slider</code> handle to the beginning of the range;</li>
  * <li><code>End</code> - Moves the <code>ui5-slider</code> handle to the end of the range;</li>
- * <li><code>Page Up</code> - Same as <code>Right/Up + Ctrl/Cmd</code></li>
- * <li><code>Page Down</code> - Same as <code>Left/Down + Ctrl/Cmd</code></li>
+ * <li><code>Page Up</code> - Same as <code>Right or Up + Ctrl/Cmd</code></li>
+ * <li><code>Page Down</code> - Same as <code>Left or Down + Ctrl/Cmd</code></li>
  * <li><code>Escape</code> - Resets the value after interaction, to the position prior the <ui5-slider> focusing;</li>
  * </ul>
  *

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -160,7 +160,7 @@ class Slider extends SliderBase {
 		}
 
 		if (this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
+			this._tooltipVisibility = this._constants().TOOLTIP_VISIBLE;
 		}
 	}
 
@@ -177,7 +177,7 @@ class Slider extends SliderBase {
 		this._setInitialValue("value", null);
 
 		if (this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
+			this._tooltipVisibility = this._constants().TOOLTIP_HIDDEN;
 		}
 	}
 

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -261,7 +261,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseover(event) {
 		if (this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;;
+			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
 		}
 	}
 
@@ -272,7 +272,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseout(event) {
 		if (this.showTooltip && !this.shadowRoot.activeElement) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;;
+			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
 		}
 	}
 
@@ -417,7 +417,7 @@ class SliderBase extends UI5Element {
 		const newValue = SliderBase.getValueFromInteraction(event, step, min, max, domRect, directionStart);
 
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;;
+			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
 		}
 
 		// Mark start of a user interaction
@@ -454,7 +454,7 @@ class SliderBase extends UI5Element {
 	 */
 	handleUpBase(valueType) {
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;;
+			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
 		}
 
 		SliderBase.UP_EVENTS.forEach(upEventType => window.removeEventListener(upEventType, this._upHandler));

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -132,6 +132,11 @@ const metadata = {
 	},
 };
 
+const CONSTANTS = {
+	TOOLTIP_VISIBLE: "visible",
+	TOOLTIP_HIDDEN: "hidden"
+};
+
 /**
  * @class
  *
@@ -261,7 +266,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseover(event) {
 		if (this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
+			this._tooltipVisibility = this._constants().TOOLTIP_VISIBLE;
 		}
 	}
 
@@ -272,7 +277,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseout(event) {
 		if (this.showTooltip && !this.shadowRoot.activeElement) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
+			this._tooltipVisibility = this._constants().TOOLTIP_HIDDEN;
 		}
 	}
 
@@ -417,7 +422,7 @@ class SliderBase extends UI5Element {
 		const newValue = SliderBase.getValueFromInteraction(event, step, min, max, domRect, directionStart);
 
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;
+			this._tooltipVisibility = this._constants().TOOLTIP_VISIBLE;
 		}
 
 		// Mark start of a user interaction
@@ -454,7 +459,7 @@ class SliderBase extends UI5Element {
 	 */
 	handleUpBase(valueType) {
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;
+			this._tooltipVisibility = this._constants().TOOLTIP_HIDDEN;
 		}
 
 		SliderBase.UP_EVENTS.forEach(upEventType => window.removeEventListener(upEventType, this._upHandler));
@@ -841,6 +846,15 @@ class SliderBase extends UI5Element {
 
 	get tabIndex() {
 		return this.disabled ? "-1" : "0";
+	}
+
+	/**
+	 * Gets stored constants for internal use.
+	 *
+	 * @private
+	 */
+	_constants() {
+		return CONSTANTS;
 	}
 }
 

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -224,14 +224,6 @@ class SliderBase extends UI5Element {
 		return 8;
 	}
 
-	static get TOOLTIP_VISIBLE() {
-		return "visible";
-	}
-
-	static get TOOLTIP_HIDDEN() {
-		return "hidden";
-	}
-
 	get classes() {
 		return {
 			labelContainer: {

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -134,7 +134,7 @@ const metadata = {
 
 const CONSTANTS = {
 	TOOLTIP_VISIBLE: "visible",
-	TOOLTIP_HIDDEN: "hidden"
+	TOOLTIP_HIDDEN: "hidden",
 };
 
 /**

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -219,6 +219,14 @@ class SliderBase extends UI5Element {
 		return 8;
 	}
 
+	static get TOOLTIP_VISIBLE() {
+		return "visible";
+	}
+
+	static get TOOLTIP_HIDDEN() {
+		return "hidden";
+	}
+
 	get classes() {
 		return {
 			labelContainer: {
@@ -253,7 +261,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseover(event) {
 		if (this.showTooltip) {
-			this._tooltipVisibility = "visible";
+			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;;
 		}
 	}
 
@@ -264,7 +272,7 @@ class SliderBase extends UI5Element {
 	 */
 	_onmouseout(event) {
 		if (this.showTooltip && !this.shadowRoot.activeElement) {
-			this._tooltipVisibility = "hidden";
+			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;;
 		}
 	}
 
@@ -409,7 +417,7 @@ class SliderBase extends UI5Element {
 		const newValue = SliderBase.getValueFromInteraction(event, step, min, max, domRect, directionStart);
 
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = "visible";
+			this._tooltipVisibility = SliderBase.TOOLTIP_VISIBLE;;
 		}
 
 		// Mark start of a user interaction
@@ -446,7 +454,7 @@ class SliderBase extends UI5Element {
 	 */
 	handleUpBase(valueType) {
 		if (isPhone() && this.showTooltip) {
-			this._tooltipVisibility = "hidden";
+			this._tooltipVisibility = SliderBase.TOOLTIP_HIDDEN;;
 		}
 
 		SliderBase.UP_EVENTS.forEach(upEventType => window.removeEventListener(upEventType, this._upHandler));

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -263,7 +263,7 @@ class SliderBase extends UI5Element {
 	 * @private
 	 */
 	_onmouseout(event) {
-		if (this.showTooltip) {
+		if (this.showTooltip && !this.shadowRoot.activeElement) {
 			this._tooltipVisibility = "hidden";
 		}
 	}

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -201,7 +201,7 @@ describe("Slider elements - tooltip, step, tickmarks, labels", () => {
 		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: hidden;", "Slider tooltip should be shown");
 	});
 
-	/* it("Slider have correct number of labels and tickmarks based on the defined step and labelInterval properties", () => {
+	it("Slider have correct number of labels and tickmarks based on the defined step and labelInterval properties", () => {
 		const slider = browser.$("#slider-tickmarks-tooltips-labels");
 		const labelsContainer = slider.shadow$(".ui5-slider-labels");
 		const numberOfLabels = labelsContainer.$$("li").length;
@@ -215,7 +215,7 @@ describe("Slider elements - tooltip, step, tickmarks, labels", () => {
 		slider.setProperty("value", 13);
 
 		assert.strictEqual(slider.getProperty("value"), 13, "current value should not be stepped to the next step (14)");
-	}); */
+	});
 });
 
 describe("Testing events", () => {

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -148,7 +148,60 @@ describe("Slider elements - tooltip, step, tickmarks, labels", () => {
 		assert.strictEqual(sliderTooltipValue.getText(), "2", "Slider tooltip should display value of 2");
 	});
 
-	it("Slider have correct number of labels and tickmarks based on the defined step and labelInterval properties", () => {
+	it("Slider Tooltip should become visible when slider is focused", () => {
+		const slider = browser.$("#basic-slider-with-tooltip");
+		const sliderTooltip = slider.shadow$(".ui5-slider-tooltip");
+		const basicSlider = browser.$("#basic-slider");
+
+		basicSlider.click();
+
+		// initial state
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "hidden", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: hidden;", "Slider tooltip should be shown");
+
+		slider.click();
+
+		// slider is focused
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "visible", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: visible;", "Slider tooltip should be shown");
+	});
+
+	it("Slider Tooltip should stay visible when slider is focused and mouse moves away", () => {
+		const slider = browser.$("#basic-slider-with-tooltip");
+		const sliderTooltip = slider.shadow$(".ui5-slider-tooltip");
+
+		slider.click();
+
+		// slider is focused
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "visible", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: visible;", "Slider tooltip should be shown");
+
+		// move mouse away - fires mouseout
+		slider.moveTo(0, -100);
+
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "visible", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: visible;", "Slider tooltip should be shown");
+	});
+
+	it("Slider Tooltip should become hidden when slider is looses focus", () => {
+		const slider = browser.$("#basic-slider-with-tooltip");
+		const anotherSlider = browser.$("#basic-slider");
+		const sliderTooltip = slider.shadow$(".ui5-slider-tooltip");
+
+		slider.click();
+
+		// slider is focused
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "visible", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: visible;", "Slider tooltip should be shown");
+
+		// move mouse away - fires mouseout
+		anotherSlider.click();
+
+		assert.strictEqual(slider.getProperty("_tooltipVisibility"), "hidden", "Slider tooltip visibility property should be 'visible'");
+		assert.strictEqual(sliderTooltip.getAttribute("style"), "visibility: hidden;", "Slider tooltip should be shown");
+	});
+
+	/* it("Slider have correct number of labels and tickmarks based on the defined step and labelInterval properties", () => {
 		const slider = browser.$("#slider-tickmarks-tooltips-labels");
 		const labelsContainer = slider.shadow$(".ui5-slider-labels");
 		const numberOfLabels = labelsContainer.$$("li").length;
@@ -162,7 +215,7 @@ describe("Slider elements - tooltip, step, tickmarks, labels", () => {
 		slider.setProperty("value", 13);
 
 		assert.strictEqual(slider.getProperty("value"), 13, "current value should not be stepped to the next step (14)");
-	});
+	}); */
 });
 
 describe("Testing events", () => {


### PR DESCRIPTION
- Tooltips will become and remain visible when the focus is
on the slider/handle.
- In case the slider looses the focus and the mouse is not
over it, the tooltip will be hidden.
