### PR TITLE
fix(ui5-list): rename inset property to indent

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -96,7 +96,7 @@ const metadata = {
 		 * @defaultvalue false
 		 * @public
 		 */
-		inset: {
+		indent: {
 			type: Boolean,
 		},
 

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -6,7 +6,7 @@
 	width: 100%;
 }
 
-:host([inset]) .ui5-list-root {
+:host([indent]) .ui5-list-root {
 	padding: 2rem;
 }
 

--- a/packages/main/test/pages/List_keyboard_support.html
+++ b/packages/main/test/pages/List_keyboard_support.html
@@ -41,7 +41,7 @@
 
 	<div class="focusable" tabindex="0"></div>
 
-	<ui5-list id="myList" inset separators="Inner"
+	<ui5-list id="myList" indent separators="Inner"
 		mode="MultiSelect"
 		header-text="Text when no header provided"
 		footer-text="Copyright"
@@ -72,7 +72,7 @@
 
 	<div class="focusable" tabindex="0"></div>
 
-	<ui5-list id="myList" inset separators="Inner"
+	<ui5-list id="myList" indent separators="Inner"
 		mode="MultiSelect"
 		header-text="Text when no header provided"
 		footer-text="Copyright"

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -63,7 +63,7 @@
 	</div>
 
 	<ui5-popover placement-type="Bottom" horizontal-align="Stretch" no-arrow initial-focus="input1" class="wcPopoverWithList">
-		<ui5-list id="myList" inset separators="Inner" mode="MultiSelect" footer-text="Copyright" no-data-text="No data">
+		<ui5-list id="myList" indent separators="Inner" mode="MultiSelect" footer-text="Copyright" no-data-text="No data">
 			<!-- Header -->
 			<div style="display: flex; align-items: center;" slot="header">
 				<ui5-title>Countries:</ui5-title>


### PR DESCRIPTION
Part of #3107

BREAKING_CHANGE: ```inset``` property of ```ui5-list``` is deprecated in favour of ```indent``` property