### PR TITLE
fix(ui5-calendar): correct enable/disable of prev and next buttons

### DIFF
--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -138,11 +138,11 @@ class CalendarHeader extends UI5Element {
 		return {
 			prevButton: {
 				"ui5-calheader-arrowbtn": true,
-				"ui5-calheader-arrowbtn-disabled": this._isPrevButtonDisabled,
+				"ui5-calheader-arrowbtn-disabled": this.isPrevButtonDisabled,
 			},
 			nextButton: {
 				"ui5-calheader-arrowbtn": true,
-				"ui5-calheader-arrowbtn-disabled": this._isNextButtonDisabled,
+				"ui5-calheader-arrowbtn-disabled": this.isNextButtonDisabled,
 			},
 		};
 	}

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -64,6 +64,11 @@
 		</ui5-calendar>
 	</section>
 
+	<section>
+		<ui5-title>Calendar with Minimum and Maximum Date & Format Pattern</ui5-title>
+		<ui5-calendar id="calendar4" data-ui5-compact-size min-date="7/7/2020" max-date="20/10/2020" timestamp="1594080000" format-pattern="dd/MM/yyyy"></ui5-calendar>
+	</section>
+
 </body>
 
 <script>

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -250,4 +250,26 @@ describe("Calendar general interaction", () => {
 
 		assert.deepEqual(selectedDates, [971740800, 971913600], "Change event is fired with proper data");
 	});
+
+	it("Previous and next buttons are disabled when necessary", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Calendar.html`);
+		const calendarHeader = browser.$("#calendar4").shadow$("ui5-calendar-header");
+		const prevButton = calendarHeader.shadow$(`[data-ui5-cal-header-btn-prev]`);
+		const nextButton = calendarHeader.shadow$(`[data-ui5-cal-header-btn-next]`);
+
+		assert.ok(prevButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Previous Button is disabled");
+		assert.notOk(nextButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Next Button is enabled");
+
+		nextButton.click();
+
+		assert.notOk(prevButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Previous Button is enabled");
+		assert.notOk(nextButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Next Button is enabled");
+
+		nextButton.click();
+		nextButton.click();
+
+		assert.notOk(prevButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Previous Button is enabled");
+		assert.ok(nextButton.hasClass("ui5-calheader-arrowbtn-disabled"), "Next Button is disabled");
+	});
+
 });


### PR DESCRIPTION
Prev and next buttons should be disabled when there is min and max dates set

Fixes #3201