### PR TITLE
fix(ui5-avatar-group): visual design deviations

### DIFF
--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -32,7 +32,7 @@ const offsets = {
 	},
 	[AvatarSize.M]: {
 		[AvatarGroupType.Individual]: "0.125rem",
-		[AvatarGroupType.Group]: "-1.62rem",
+		[AvatarGroupType.Group]: "-1.625rem",
 	},
 	[AvatarSize.L]: {
 		[AvatarGroupType.Individual]: "0.125rem",
@@ -40,7 +40,7 @@ const offsets = {
 	},
 	[AvatarSize.XL]: {
 		[AvatarGroupType.Individual]: "0.25rem",
-		[AvatarGroupType.Group]: "-2.7rem",
+		[AvatarGroupType.Group]: "-2.75rem",
 	},
 };
 

--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -33,6 +33,7 @@
 
 ::slotted([ui5-button]:not([hidden])),
 .ui5-avatar-group-overflow-btn:not([hidden]) {
+	--_ui5_button_base_padding: 0;
 	border-radius: 50%;
 	display: inline-flex;
 	text-overflow: initial;


### PR DESCRIPTION
First and second deviations were cause because IE11 support. It was rounding incorrectly floated values.
The Third issue comes from base padding of **ui5-button** which is now removed in the context of overflow button in **ui5-avatar-group**

Fixes: #3197 