### PR TITLE
feat(ui5-carousel): add property hide-page-indicator

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -7,7 +7,7 @@
     @mouseout="{{_onmouseout}}"
     @mouseover="{{_onmouseover}}"
 >
-    <div class="ui5-carousel-viewport {{classes.viewport}}">
+    <div class="{{classes.viewport}}">
         <div class="{{classes.content}}" style="{{styles.content}}">
             {{#each items}}
                  <div id="{{id}}"
@@ -30,25 +30,27 @@
             </div>
         {{/if}}
 
-        {{#if hasManyPages}}
+        {{#if renderNavigation}}
             <div class="{{classes.navigation}}">
                 {{#if arrows.navigation}}
                     {{> arrow-back}}
                 {{/if}}
 
                 <div class="ui5-carousel-navigation">
-                    {{#if isPageTypeDots}}
-                        {{#each dots}}
-                            <div
-                                role="img"
-                                aria-label="{{ariaLabel}}"
-                                ?active="{{active}}"
-                                class="ui5-carousel-navigation-dot"
-                            ></div>
-                        {{/each}}
-                    {{else}}
-                        <ui5-label>{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pagesCount}}</ui5-label>
-                    {{/if}}
+                    {{#unless hidePageIndicator}}
+                        {{#if isPageTypeDots}}
+                            {{#each dots}}
+                                <div
+                                    role="img"
+                                    aria-label="{{ariaLabel}}"
+                                    ?active="{{active}}"
+                                    class="ui5-carousel-navigation-dot"
+                                ></div>
+                            {{/each}}
+                        {{else}}
+                            <ui5-label>{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pagesCount}}</ui5-label>
+                        {{/if}}
+                    {{/unless}}
                 </div>
 
                 {{#if arrows.navigation}}

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -466,10 +466,6 @@ class Carousel extends UI5Element {
 			return true;
 		}
 
-		if (this.hidePageIndicator && this.hideNavigationArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation) {
-			return false;
-		}
-
 		if (this.hidePageIndicator) {
 			return false;
 		}

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -95,6 +95,17 @@ const metadata = {
 		},
 
 		/**
+		 * If set to true the page indicator is hidden.
+		 * @type {boolean}
+		 * @since 1.0.0-rc.15
+		 * @defaultvalue false
+		 * @public
+		 */
+		hidePageIndicator: {
+			type: Boolean,
+		},
+
+		/**
 		 * Defines the index of the initially selected item.
 		 * @type {Integer}
 		 * @defaultvalue 0
@@ -277,6 +288,10 @@ class Carousel extends UI5Element {
 	}
 
 	onBeforeRendering() {
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation) {
+			this._visibleNavigationArrows = true;
+		}
+
 		this.validateSelectedIndex();
 	}
 
@@ -347,17 +362,21 @@ class Carousel extends UI5Element {
 	}
 
 	_onmouseout() {
-		this._visibleNavigationArrows = false;
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Content) {
+			this._visibleNavigationArrows = false;
+		}
 	}
 
 	_onmouseover() {
-		this._visibleNavigationArrows = true;
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Content) {
+			this._visibleNavigationArrows = true;
+		}
 	}
 
 	navigateLeft() {
 		this._resizing = false;
 
-		const peviousSelectedIndex = this.selectedIndex;
+		const previousSelectedIndex = this.selectedIndex;
 
 		if (this.selectedIndex - 1 < 0) {
 			if (this.cyclic) {
@@ -367,7 +386,7 @@ class Carousel extends UI5Element {
 			--this.selectedIndex;
 		}
 
-		if (peviousSelectedIndex !== this.selectedIndex) {
+		if (previousSelectedIndex !== this.selectedIndex) {
 			this.fireEvent("navigate", { selectedIndex: this.selectedIndex });
 		}
 	}
@@ -375,7 +394,7 @@ class Carousel extends UI5Element {
 	navigateRight() {
 		this._resizing = false;
 
-		const peviousSelectedIndex = this.selectedIndex;
+		const previousSelectedIndex = this.selectedIndex;
 
 		if (this.selectedIndex + 1 > this.pagesCount - 1) {
 			if (this.cyclic) {
@@ -387,7 +406,7 @@ class Carousel extends UI5Element {
 			++this.selectedIndex;
 		}
 
-		if (peviousSelectedIndex !== this.selectedIndex) {
+		if (previousSelectedIndex !== this.selectedIndex) {
 			this.fireEvent("navigate", { selectedIndex: this.selectedIndex });
 		}
 
@@ -435,6 +454,29 @@ class Carousel extends UI5Element {
 		return index >= 0 && index <= this.pagesCount - 1;
 	}
 
+	/**
+	 * @private
+	 */
+	get renderNavigation() {
+		if (!this.hasManyPages) {
+			return false;
+		}
+
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows) {
+			return true;
+		}
+
+		if (this.hidePageIndicator && this.hideNavigationArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation) {
+			return false;
+		}
+
+		if (this.hidePageIndicator) {
+			return false;
+		}
+
+		return true;
+	}
+
 	get hasManyPages() {
 		return this.pagesCount > 1;
 	}
@@ -450,17 +492,18 @@ class Carousel extends UI5Element {
 	get classes() {
 		return {
 			viewport: {
+				"ui5-carousel-viewport": true,
 				"ui5-carousel-viewport--single": this.pagesCount === 1,
 			},
 			content: {
 				"ui5-carousel-content": true,
-				"ui5-carousel-content-no-animation": this.supressAimation,
-				"ui5-carousel-content-has-navigation": this.hasManyPages,
-				"ui5-carousel-content-has-navigation-and-buttons": this.hasManyPages && this.arrowsPlacement === CarouselArrowsPlacement.Navigation,
+				"ui5-carousel-content-no-animation": this.suppressAnimation,
+				"ui5-carousel-content-has-navigation": this.renderNavigation,
+				"ui5-carousel-content-has-navigation-and-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows,
 			},
 			navigation: {
 				"ui5-carousel-navigation-wrapper": true,
-				"ui5-carousel-navigation-with-buttons": this.hasManyPages && (this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows),
+				"ui5-carousel-navigation-with-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows,
 			},
 			navPrevButton: {
 				"ui5-carousel-navigation-button--hidden": !this.hasPrev,
@@ -511,7 +554,7 @@ class Carousel extends UI5Element {
 		return this.cyclic || this.selectedIndex + 1 <= this.pagesCount - 1;
 	}
 
-	get supressAimation() {
+	get suppressAnimation() {
 		return this._resizing || getAnimationMode() === AnimationMode.None;
 	}
 

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -50,11 +50,7 @@
 }
 
 .ui5-carousel-content.ui5-carousel-content-has-navigation {
-    height: calc(100% - 2.75rem);
-}
-
-.ui5-carousel-content.ui5-carousel-content-has-navigation.ui5-carousel-content-has-navigation-and-buttons {
-    height: calc(100% - 3.5rem);
+    height: calc(100% - 1rem);
 }
 
 .ui5-carousel-item {
@@ -137,7 +133,7 @@
 
 .ui5-carousel-navigation-dot[active] {
     width: .5rem;
-    height: .5rem;;
+    height: .5rem;
     margin: 0 .25rem;
     background-color: var(--sapSelectedColor);
     border: var(--ui5_carousel_dot_border);

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -413,6 +413,22 @@
     </ui5-carousel>
     <ui5-input id="loadmore-result" value="0"></ui5-input>
 
+    <ui5-title style="margin-top: 2rem;">Carousel with hidden page indicator</ui5-title>
+    <ui5-label>arrows-placement="Navigation"</ui5-label>
+    <ui5-carousel id="carouselHiddenPageIndicator" arrows-placement="Navigation" hide-page-indicator>
+        <ui5-button>Button 1</ui5-button>
+        <ui5-button>Button 2</ui5-button>
+        <ui5-button>Button 3</ui5-button>
+    </ui5-carousel>
+
+    <ui5-title style="margin-top: 2rem;">Carousel with hidden page indicator and hidden navigation arrows</ui5-title>
+    <ui5-label>arrows-placement="Navigation"</ui5-label>
+    <ui5-carousel id="carouselHiddenPageIndicatorHiddenArrows" arrows-placement="Navigation" hide-page-indicator hide-navigation-arrows>
+        <ui5-button>Button 1</ui5-button>
+        <ui5-button>Button 2</ui5-button>
+        <ui5-button>Button 3</ui5-button>
+    </ui5-carousel>
+
 </body>
 
 <script>

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -312,7 +312,7 @@
         <ui5-button>Button 9</ui5-button>
     </ui5-carousel>
 
-    <ui5-carousel id="carousel3" arrows-placement="Navigation">
+    <ui5-carousel id="carousel3" selected-index="1" arrows-placement="Navigation">
         <ui5-button>Button 1</ui5-button>
         <ui5-button>Button 2</ui5-button>
         <ui5-button>Button 3</ui5-button>

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -51,10 +51,22 @@ describe("Carousel general interaction", () => {
 		assert.ok(navigation.isExisting(), "Navigation is rendered");
 	});
 
-	it("Buttons are rendered in the navigation(arrows-placement)", () => {
+	it("Buttons are rendered in the content only when hovering (arrows-placement)", () => {
+		const carousel = browser.$("#carousel2");
+		carousel.scrollIntoView();
+
+		// show both arrows by navigating to the right and focus the button
+		const carouselNextButton = carousel.shadow$(".ui5-carousel-navigation-button[arrow-forward]");
+		carouselNextButton.click();
+		carousel.moveTo();
+
+		const buttons = carousel.shadow$$(".ui5-carousel-navigation-arrows .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
+		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
+	});
+
+	it("Buttons are rendered in the navigation without hovering (arrows-placement)", () => {
 		const carousel = browser.$("#carousel3");
 		carousel.scrollIntoView();
-		carousel.moveTo();
 		const buttons = carousel.shadow$$(".ui5-carousel-navigation-wrapper ui5-button");
 
 		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
@@ -149,7 +161,7 @@ describe("Carousel general interaction", () => {
 		const navigationArrowForward = carousel.shadow$("ui5-button[arrow-forward]");
 		const navigationArrowsBack = carousel.shadow$("ui5-button[arrow-back]");
 
-		// using the navigtion arrows
+		// using the navigation arrows
 		navigationArrowForward.click(); // forward
 		assert.strictEqual(selectedIndex.getProperty("value"), "1", "The selectedIndex is correct.");
 		assert.strictEqual(eventCounter.getProperty("value"), "1", "The navigate event is fired.");
@@ -181,7 +193,7 @@ describe("Carousel general interaction", () => {
 		assert.strictEqual(eventCounter.getProperty("value"), "6", "The navigate event is not fired as no previous item.");
 	});
 
-	it("loadMore event is fired only when neccessary", () => {
+	it("loadMore event is fired only when necessary", () => {
 		const carousel = browser.$("#carousel9");
 		const eventCounter = browser.$("#loadmore-result");
 		carousel.scrollIntoView();
@@ -203,4 +215,11 @@ describe("Carousel general interaction", () => {
 
 		assert.strictEqual(eventCounter.getProperty("value"), "3", "loadMore event is fired 3 times");
 	});
+
+	it("hide-page-indicator property", () => {
+		const carousel = browser.$("#carouselHiddenPageIndicator");
+		carousel.scrollIntoView();
+
+		assert.strictEqual(carousel.shadow$$(".ui5-carousel-navigation > *").length, 0, "carousel has not rendered a page indicator")
+	})
 });

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -67,7 +67,7 @@ describe("Carousel general interaction", () => {
 	it("Buttons are rendered in the navigation without hovering (arrows-placement)", () => {
 		const carousel = browser.$("#carousel3");
 		carousel.scrollIntoView();
-		const buttons = carousel.shadow$$(".ui5-carousel-navigation-wrapper ui5-button");
+		const buttons = carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
 
 		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
 	});


### PR DESCRIPTION
The page indicator can now be hidden by setting the property
hide-page-indicator on the ui5-carousel element.

- the arrows are always visible when `arrowsPlacement` is set to `Navigation`
- fixed typos
- changed height reduction of the carousel viewport to 1rem

Closes: #3158