### PR TITLE
refactor(ui5-panel): use heading and headingLevel

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -4,7 +4,7 @@
 	role="{{accRole}}"
 	aria-label="{{effectiveAccessibleName}}"
 >
-	<!-- header: either header or h1 with header text -->
+	<!-- header: either header or h1 with heading -->
 	<div
 		@click="{{_headerClick}}"
 		@keydown="{{_headerKeyDown}}"
@@ -40,12 +40,12 @@
 			<slot name="header"></slot>
 		{{else}}
 			<div
-				id="{{_id}}-header-title"
+				id="{{_id}}-heading"
 				role="heading"
-				aria-level="{{headerAriaLevel}}"
-				class="ui5-panel-header-title"
+				aria-level="{{ariaHeadingLevel}}"
+				class="ui5-panel-heading"
 			>
-				{{headerText}}
+				{{heading}}
 			</div>
 		{{/if}}
 	</div>

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -29,7 +29,7 @@ const metadata = {
 		/**
 		 * Defines the <code>ui5-panel</code> header area.
 		 * <br><br>
-		 * <b>Note:</b> When a header is provided, the <code>headerText</code> property is ignored.
+		 * <b>Note:</b> When a header is provided, the <code>heading</code> property is ignored.
 		 *
 		 * @type {HTMLElement[]}
 		 * @slot
@@ -54,8 +54,8 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.Panel.prototype */ {
 
 		/**
-		 * This property is used to set the header text of the <code>ui5-panel</code>.
-		 * The text is visible in both expanded and collapsed states.
+		 * This property is used to set the heading of the <code>ui5-panel</code>.
+		 * The heading is visible in both expanded and collapsed states.
 		 * <br><br>
 		 * <b>Note:</b> This property is overridden by the <code>header</code> slot.
 		 *
@@ -63,7 +63,7 @@ const metadata = {
 		 * @defaultvalue ""
 		 * @public
 		 */
-		headerText: {
+		heading: {
 			type: String,
 		},
 
@@ -106,14 +106,14 @@ const metadata = {
 
 		/**
 		 * Defines the "aria-level" of <code>ui5-panel</code> heading,
-		 * set by the <code>headerText</code>.
+		 * set by the <code>heading</code>.
 		 * <br><br>
 		 * Available options are: <code>"H6"</code> to <code>"H1"</code>.
 		 * @type {TitleLevel}
 		 * @defaultvalue "H2"
 		 * @public
 		*/
-		headerLevel: {
+		headingLevel: {
 			type: TitleLevel,
 			defaultValue: TitleLevel.H2,
 		},
@@ -400,15 +400,15 @@ class Panel extends UI5Element {
 	}
 
 	get ariaLabelledbyReference() {
-		return (this.nonFocusableButton && this.headerText) ? `${this._id}-header-title` : undefined;
+		return (this.nonFocusableButton && this.heading) ? `${this._id}-heading` : undefined;
 	}
 
 	get header() {
-		return this.getDomRef().querySelector(`#${this._id}-header-title`);
+		return this.getDomRef().querySelector(`#${this._id}-heading`);
 	}
 
-	get headerAriaLevel() {
-		return this.headerLevel.slice(1);
+	get ariaHeadingLevel() {
+		return this.headingLevel.slice(1);
 	}
 
 	get headerTabIndex() {
@@ -424,7 +424,7 @@ class Panel extends UI5Element {
 	}
 
 	get shouldRenderH1() {
-		return !this.header.length && (this.headerText || !this.fixed);
+		return !this.header.length && (this.heading || !this.fixed);
 	}
 
 	get styles() {

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -52,11 +52,11 @@
 	transform: rotate(90deg);
 }
 
-:host([fixed]) .ui5-panel-header-title {
+:host([fixed]) .ui5-panel-heading {
 	width: 100%;
 }
 
-.ui5-panel-header-title {
+.ui5-panel-heading {
 	width: calc(100% - var(--_ui5_panel_button_root_width));
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/main/test/pages/AnimanitionOff.html
+++ b/packages/main/test/pages/AnimanitionOff.html
@@ -32,7 +32,7 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-	<ui5-panel id="panel1" collapsed header-text="Click to expand!" class="panel">
+	<ui5-panel id="panel1" collapsed heading="Click to expand!" class="panel">
 		<ui5-title>This is a demo how to use the &quot;expand&quot; event.</ui5-title><br>
 		<ui5-label>Some short text.</ui5-label>
 	</ui5-panel>

--- a/packages/main/test/pages/Components.html
+++ b/packages/main/test/pages/Components.html
@@ -39,7 +39,7 @@
 	<ui5-busyindicator id="busyIndicator2" hidden></ui5-busyindicator>
 	<ui5-badge id="badge2" hidden>Required</ui5-badge>
 	<ui5-button id="btn2" hidden>Primary button</ui5-button>
-	<ui5-card id="card2" hidden header-text="Primary card"></ui5-card>
+	<ui5-card id="card2" hidden heading="Primary card"></ui5-card>
 	<ui5-checkbox id="cb2" text="I agree" hidden></ui5-checkbox>
 	<ui5-date-picker id="dp2" hidden></ui5-date-picker>
 	<ui5-icon id="icon2" name="add-equipment" hidden></ui5-icon>
@@ -59,7 +59,7 @@
 		<ui5-li selected>UI5</ui5-li>
 	</ui5-multi-combobox>
 
-	<ui5-panel id="p2" width="100%" hidden header-text="Both expandable and expanded">
+	<ui5-panel id="p2" width="100%" hidden heading="Both expandable and expanded">
 		<h1 class="content-color">I am a native heading!</h1>
 	</ui5-panel>
 

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -279,7 +279,7 @@
 		</section>
 
 		<section class="row">
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 				<div slot="header" class="panel-header">
 					<ui5-title level="H5">Countries</ui5-title>
 					<ui5-button id="button1" icon="refresh">Reset</ui5-button>
@@ -291,7 +291,7 @@
 					<ui5-li id="ch1">China</ui5-li>
 				</ui5-list>
 			</ui5-panel>
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 				<div slot="header" class="panel-header">
 					<ui5-title level="H5">Quarks</ui5-title>
 					<ui5-button id="button2" icon="add">Add</ui5-button>
@@ -303,7 +303,7 @@
 					<ui5-li id="ch2">Charm</ui5-li>
 				</ui5-list>
 			</ui5-panel>
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 					<div slot="header" class="panel-header">
 						<ui5-title level="H5">Employees</ui5-title>
 						<ui5-button id="button3" icon="add">Add</ui5-button>

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -252,7 +252,7 @@
 		</section>
 
 		<section class="row">
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 				<div style="display: flex;" slot="header">
 					<ui5-title level="H5">Countries</ui5-title>
 					<ui5-button id="button1" icon="refresh">Reset</ui5-button>
@@ -265,7 +265,7 @@
 					<ui5-li type="Active" id="ch1">China</ui5-li>
 				</ui5-list>
 			</ui5-panel>
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 				<div style="display: flex;" slot="header">
 					<ui5-title level="H5">Quarks</ui5-title>
 					<ui5-button id="button2" icon="add">Add</ui5-button>
@@ -278,7 +278,7 @@
 					<ui5-li type="Active" id="ch2">Charm</ui5-li>
 				</ui5-list>
 			</ui5-panel>
-			<ui5-panel header-text="Panel">
+			<ui5-panel heading="Panel">
 				<div style="display: flex;" slot="header">
 						<ui5-title level="H5">Employees</ui5-title>
 						<ui5-button id="button3" icon="add">Add</ui5-button>

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -97,7 +97,7 @@
 
 	<br>
 
-	<ui5-panel id="panel-expandable" accessible-role="Complementary" header-text="Both expandable and expanded" header-level="H4">
+	<ui5-panel id="panel-expandable" accessible-role="Complementary" heading="Both expandable and expanded" heading-level="H4">
 
 
 		<!-- Content -->
@@ -127,7 +127,7 @@
 
 	<br>
 
-	<ui5-panel id="panel-fixed" fixed accessible-role="Complementary" header-text="Expanded, but not expandable">
+	<ui5-panel id="panel-fixed" fixed accessible-role="Complementary" heading="Expanded, but not expandable">
 
 		<!-- Content -->
 		<ui5-title>Lorem ipsum!</ui5-title>
@@ -140,7 +140,7 @@
 
 	<br>
 
-	<ui5-panel collapsed fixed accessible-role="Complementary" header-text="Neither expandable, nor expanded">
+	<ui5-panel collapsed fixed accessible-role="Complementary" heading="Neither expandable, nor expanded">
 
 		<!-- Content -->
 		<ui5-title>Lorem ipsum!</ui5-title>
@@ -153,7 +153,7 @@
 
 	<br>
 
-	<ui5-panel id="panel1" collapsed header-text="Click to expand!" header-level="H3" accessible-role="Form">
+	<ui5-panel id="panel1" collapsed heading="Click to expand!" heading-level="H3" accessible-role="Form">
 
 		<!-- Content -->
 		<ui5-title>This is a demo how to use the &quot;expand&quot; event.</ui5-title>
@@ -186,14 +186,14 @@
 
 	<section>
 		<!-- accessibleName, useAccessibleNameForToggleButton and header text -->
-		<ui5-panel accessible-role="Complementary" accessible-name="My new panel with header text and button" use-accessible-name-for-toggle-button header-text="Accessible name test 1">
+		<ui5-panel accessible-role="Complementary" accessible-name="My new panel with header text and button" use-accessible-name-for-toggle-button heading="Accessible name test 1">
 			<ui5-title>Lorem ipsum!</ui5-title>
 		</ui5-panel>
 
 		<br><br>
 
 		<!-- accessibleName and header text -->
-		<ui5-panel accessible-role="Complementary" accessible-name="My new panel with header text" header-text="Accessible name test 2">
+		<ui5-panel accessible-role="Complementary" accessible-name="My new panel with header text" heading="Accessible name test 2">
 			<ui5-title>Lorem ipsum!</ui5-title>
 		</ui5-panel>
 

--- a/packages/main/test/samples/Panel.sample.html
+++ b/packages/main/test/samples/Panel.sample.html
@@ -23,7 +23,7 @@
 	<h3>Basic Panel</h3>
 	<div class="snippet">
 		<ui5-panel width="100%" accessible-role="Complementary"
-			header-text="Both expandable and expanded" class="full-width">
+			heading="Both expandable and expanded" class="full-width">
 			<h1 class="content-color">I am a native heading!</h1>
 			<ui5-label wrap>Short text.</ui5-label>
 			<br>
@@ -35,7 +35,7 @@
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-panel width="100%" accessible-role="Complementary"
-	header-text="Both expandable and expanded" class="full-width">
+	heading="Both expandable and expanded" class="full-width">
 	<h1 class="content-color">I am a native heading!</h1>
 	<ui5-label wrap>Short text.</ui5-label>
 	<br>
@@ -51,7 +51,7 @@
 	<h3>Panel with List</h3>
 	<div class="snippet">
 		<ui5-panel accessible-role="Complementary"
-			header-text="Select your country" class="full-width">
+			heading="Select your country" class="full-width">
 			<ui5-list id="myList1" mode="MultiSelect">
 				<ui5-li key="country1">Argentina</ui5-li>
 				<ui5-li key="country2">Bulgaria</ui5-li>
@@ -66,7 +66,7 @@
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-panel accessible-role="Complementary"
-	header-text="Select your country" class="full-width">
+	heading="Select your country" class="full-width">
 	<ui5-list id="myList1" mode="MultiSelect">
 		<ui5-li key="country1">Argentina</ui5-li>
 		<ui5-li key="country2">Bulgaria</ui5-li>
@@ -84,7 +84,7 @@
 <section>
 	<h3>Fixed Panel (Can't be Collapsed/Expanded)</h3>
 	<div class="snippet panel-snippet">
-		<ui5-panel class="full-width" fixed accessible-role="Complementary" header-text="Country Of Birth" class="panel-width">
+		<ui5-panel class="full-width" fixed accessible-role="Complementary" heading="Country Of Birth" class="panel-width">
 			<ui5-list id="myList2" mode="SingleSelectBegin" >
 				<ui5-li key="country1">Argentina</ui5-li>
 				<ui5-li key="country2">Bulgaria</ui5-li>
@@ -96,7 +96,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-panel
 	fixed accessible-role="Complementary"
-	header-text="Country Of Birth"
+	heading="Country Of Birth"
 	class="panel-width">
 	<ui5-list id="myList2" mode="SingleSelectBegin" >
 		<ui5-li key="country1">Argentina</ui5-li>

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -8,7 +8,7 @@ describe("Panel general interaction", () => {
 
 	it("Changing the header text is reflected", () => {
 		const panel = browser.$( "#panel-fixed");
-		const title = panel.shadow$(".ui5-panel-header-title");
+		const title = panel.shadow$(".ui5-panel-heading");
 		const sExpected = "Expanded, but not expandable";
 		const sNew = "New text";
 
@@ -105,7 +105,7 @@ describe("Panel general interaction", () => {
 		it("tests whether aria attributes are set correctly with native header", () => {
 			const panelRoot = browser.$("#panel1").shadow$(".ui5-panel-root");
 			const header = browser.$("#panel1").shadow$(".ui5-panel-header");
-			const title = browser.$("#panel1").shadow$(".ui5-panel-header-title");
+			const title = browser.$("#panel1").shadow$(".ui5-panel-heading");
 			const button = browser.$("#panel1").shadow$(".ui5-panel-header-button");
 
 			assert.strictEqual(panelRoot.getAttribute("role"), "form", "The correct accessible role is applied");
@@ -125,7 +125,7 @@ describe("Panel general interaction", () => {
 			const panelWithNativeHeaderId = panelWithNativeHeader.getProperty("_id");
 
 			assert.strictEqual(nativeHeader.getAttribute("aria-labelledby"),
-				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");
+				`${panelWithNativeHeaderId}-heading`, "aria-labelledby is correct");
 
 			browser.execute(() => {
 				document.getElementById("panel-expandable").setAttribute("accessible-name", "New accessible name");

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -15,7 +15,7 @@ describe("Panel general interaction", () => {
 		assert.strictEqual(title.getText(), sExpected, "Initially the text is the expected one");
 
 		browser.execute(() => {
-			document.getElementById("panel-fixed").setAttribute("header-text", "New text");
+			document.getElementById("panel-fixed").setAttribute("heading", "New text");
 		});
 		browser.pause(500);
 


### PR DESCRIPTION
Change "headerText" and "headerLevel" properties have been removed, use "heading"  and "headingLevel" properties instead. Part of: https://github.com/SAP/ui5-webcomponents/issues/3107

BREAKING_CHANGE: the "headerText" and "headerLevel" properties have been removed, use "heading"  and "headingLevel" properties instead.