### PR TITLE
fix(ui5-list): prevent scrolling with space

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -672,6 +672,9 @@ class List extends UI5Element {
 	}
 
 	_onkeydown(event) {
+		if (isSpace(event)) {
+			event.preventDefault(); // prevent scroll
+		}
 		if (isTabNext(event)) {
 			this._handleTabNext(event);
 		}


### PR DESCRIPTION
Part of: #3089 

Prevent default behavior of the keydown event when `SPACE` key is pressed, to avoid scrolling of the page.