### PR TITLE
fix(ui5-li-tree): fix info text visual appearance

### DIFF
--- a/packages/main/src/TreeListItem.hbs
+++ b/packages/main/src/TreeListItem.hbs
@@ -24,7 +24,7 @@
 		{{/if}}
 
 		{{#if info}}
-			<span part="info" class="ui5-li-tree-info">{{info}}</span>
+			<span part="info" class="ui5-li-info">{{info}}</span>
 		{{/if}}
 	</div>
 {{/inline}}

--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -89,35 +89,6 @@
     color: var(--sapList_Active_TextColor);
 }
 
-/* [ui5-li]: infoState */
-:host([info-state="Warning"]) .ui5-li-tree-info {
-	color: var(--sapCriticalTextColor);
-}
-
-:host([info-state="Success"]) .ui5-li-tree-info {
-	color: var(--sapPositiveTextColor);
-}
-
-:host([info-state="Error"]) .ui5-li-tree-info {
-	color: var(--sapNegativeTextColor);
-}
-
-:host([info-state="Information"]) .ui5-li-tree-info {
-	color: var(--sapInformativeTextColor);
-}
-
-/* [ui5-li]: info */
-.ui5-li-tree-info {
-	margin: 0 0.25rem;
-	color: var(--sapNeutralTextColor);
-	font-size: 0.875rem;
-	min-width: 6rem;
-	max-width: 40%;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 .ui5-li-tree-text-wrapper {
 	display:flex;
 	justify-content:space-between;


### PR DESCRIPTION
There was a separate CSS class `.ui5-li-tree-info` which add the same styles as `.ui5-li-info`. Now, `ui5-tree-item` uses `.ui5-li-info` CSS class.

Fixes: #3130