### PR TITLE
refactor(ui5-messagestrip): update icons for better contrast ratio

### DIFF
--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -2,10 +2,10 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
-import "@ui5/webcomponents-icons/dist/message-information.js";
-import "@ui5/webcomponents-icons/dist/message-success.js";
-import "@ui5/webcomponents-icons/dist/message-error.js";
-import "@ui5/webcomponents-icons/dist/message-warning.js";
+import "@ui5/webcomponents-icons/dist/information.js";
+import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
+import "@ui5/webcomponents-icons/dist/error.js";
+import "@ui5/webcomponents-icons/dist/alert.js";
 import MessageStripType from "./types/MessageStripType.js";
 import MessageStripTemplate from "./generated/templates/MessageStripTemplate.lit.js";
 import Icon from "./Icon.js";
@@ -181,10 +181,10 @@ class MessageStrip extends UI5Element {
 
 	static iconMappings() {
 		return {
-			"Information": "message-information",
-			"Positive": "message-success",
-			"Negative": "message-error",
-			"Warning": "message-warning",
+			"Information": "information",
+			"Positive": "sys-enter-2",
+			"Negative": "error",
+			"Warning": "alert",
 		};
 	}
 


### PR DESCRIPTION
This is to full-fill global requirement of the VD team. It turns out that the currently used message/value state icons do not cover the contrast ratio criteria. The change replaces the icons in the MessageStrip component with the[ recommended icons](https://wiki.wdf.sap.corp/wiki/pages/viewpage.action?pageId=2036840833):
message-information -> information
message-success -> sys-enter-2
message-error -> error
message-warning -> alert

Old ones
<img width="130" alt="Screenshot 2021-05-20 at 12 45 21" src="https://user-images.githubusercontent.com/15702139/118957508-40838d80-b969-11eb-8579-54a36b6f8c34.png">

New ones
<img width="138" alt="Screenshot 2021-05-20 at 12 45 15" src="https://user-images.githubusercontent.com/15702139/118957535-47120500-b969-11eb-995d-8e5a994dc6b0.png">

Fixes: https://github.com/SAP/ui5-webcomponents/issues/3287