### PR TITLE
fix(ui5-li-tree): arrow flickering

### DIFF
--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -43,7 +43,7 @@
 }
 
 :host(:not([level="1"])) {
-    border-bottom: none;
+    border-color: var(--sapList_AlternatingBackground);
 }
 
 :host([_toggle-button-end][selected]:not([level="1"])){


### PR DESCRIPTION
Nested items should have border only when they are selected which has the same border and background colorsas `ui5-li`.

Changing the border color to be the same as background color for nested items so we can reuse the rest CSS styles from `ui5-li`.

Fixes #3238