### PR TITLE
fix(ui5-table): introduce hide-no-data property

### DIFF
--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -29,7 +29,7 @@
 			{{/each}}
 
 			{{#unless rows.length}}
-				{{#if hideNoData}}
+				{{#unless hideNoData}}
 					<tr class="ui5-table-no-data-row-root" role="row">
 						<td colspan="{{visibleColumnsCount}}" role="cell">
 
@@ -38,7 +38,7 @@
 							</div>
 						</td>
 					</tr>
-				{{/if}}
+				{{/unless}}
 			{{/unless}}
 
 			{{#if growsWithButton}}

--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -29,7 +29,7 @@
 			{{/each}}
 
 			{{#unless rows.length}}
-				{{#if showNoData}}
+				{{#if hideNoData}}
 					<tr class="ui5-table-no-data-row-root" role="row">
 						<td colspan="{{visibleColumnsCount}}" role="cell">
 

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -71,7 +71,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.Table.prototype */ {
 
 		/**
-		 * Defines the text that will be displayed when there is no data and <code>hideNoData</code> is present.
+		 * Defines the text that will be displayed when there is no data and <code>hideNoData</code> is not present.
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
@@ -438,7 +438,7 @@ class Table extends UI5Element {
 			return !this._hiddenColumns[index];
 		});
 
-		this._noDataDisplayed = !this.rows.length && this.hideNoData;
+		this._noDataDisplayed = !this.rows.length && !this.hideNoData;
 		this.visibleColumnsCount = this.visibleColumns.length;
 	}
 

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -71,7 +71,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.Table.prototype */ {
 
 		/**
-		 * Defines the text that will be displayed when there is no data and <code>showNoData</code> is present.
+		 * Defines the text that will be displayed when there is no data and <code>hideNoData</code> is present.
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
@@ -120,8 +120,9 @@ const metadata = {
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
+		 * @since 1.0.0-rc.15
 		 */
-		showNoData: {
+		hideNoData: {
 			type: Boolean,
 		},
 
@@ -437,7 +438,7 @@ class Table extends UI5Element {
 			return !this._hiddenColumns[index];
 		});
 
-		this._noDataDisplayed = !this.rows.length && this.showNoData;
+		this._noDataDisplayed = !this.rows.length && this.hideNoData;
 		this.visibleColumnsCount = this.visibleColumns.length;
 	}
 

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -146,6 +146,9 @@
 		</thead>
 	</table>
 
+	<br>
+	<br>
+	<br>
 
 	<ui5-table class="no-data-table" id="tableNoData" no-data-text="No Data" busy>
 		<ui5-table-column id="column-1" slot="columns">

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -147,7 +147,7 @@
 	</table>
 
 
-	<ui5-table class="no-data-table" id="tableNoData" no-data-text="No Data" show-no-data busy>
+	<ui5-table class="no-data-table" id="tableNoData" no-data-text="No Data" busy>
 		<ui5-table-column id="column-1" slot="columns">
 			<div class="column-content">
 				<ui5-label>Product</ui5-label>

--- a/packages/main/test/samples/Table.sample.html
+++ b/packages/main/test/samples/Table.sample.html
@@ -164,7 +164,7 @@
 	<section>
 		<h3>Table with No Data</h3>
 		<div class="snippet flex-column">
-			<ui5-table class="demo-table" no-data-text="No Data" show-no-data>
+			<ui5-table class="demo-table" no-data-text="No Data">
 				<!-- Columns -->
 				<ui5-table-column slot="columns" style="width: 12rem">
 					<span style="line-height: 1.4rem">Product</span>
@@ -189,7 +189,7 @@
 		</div>
 
 		<pre class="prettyprint lang-html"><xmp>
-<ui5-table class="demo-table" no-data-text="No Data" show-no-data>
+<ui5-table class="demo-table" no-data-text="No Data">
 	<ui5-table-column slot="columns" style="width: 12rem">
 		<span style="line-height: 1.4rem">Product</span>
 	</ui5-table-column>


### PR DESCRIPTION
Part of #3107 

BREAKING_CHANGE: ```show-no-data``` property is deprecated in favour of ```hide-no-data``` property