### PR TITLE
fix(ui5-list): fixed keyboard navigation when a list is inside a list

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -773,6 +773,7 @@ class List extends UI5Element {
 			}
 
 			event.stopImmediatePropagation();
+			event.stopPropagation();
 			return;
 		}
 
@@ -785,6 +786,8 @@ class List extends UI5Element {
 				this.focusPreviouslyFocusedItem();
 			}
 		}
+
+		event.stopPropagation();
 
 		this.setForwardingFocus(false);
 	}
@@ -852,6 +855,7 @@ class List extends UI5Element {
 	onForwardBefore(event) {
 		this.setPreviouslyFocusedItem(event.target);
 		this.focusBeforeElement();
+		event.stopPropagation();
 	}
 
 	onForwardAfter(event) {

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -773,7 +773,6 @@ class List extends UI5Element {
 			}
 
 			event.stopImmediatePropagation();
-			event.stopPropagation();
 			return;
 		}
 
@@ -785,9 +784,9 @@ class List extends UI5Element {
 			} else {
 				this.focusPreviouslyFocusedItem();
 			}
-		}
 
-		event.stopPropagation();
+			event.stopImmediatePropagation();
+		}
 
 		this.setForwardingFocus(false);
 	}
@@ -855,7 +854,7 @@ class List extends UI5Element {
 	onForwardBefore(event) {
 		this.setPreviouslyFocusedItem(event.target);
 		this.focusBeforeElement();
-		event.stopPropagation();
+		event.stopImmediatePropagation();
 	}
 
 	onForwardAfter(event) {


### PR DESCRIPTION
ui5-li-notification-group uses a list inside a list

The issue:
The issue can be reproduced on
https://sap.github.io/ui5-webcomponents/playground/components/NotificationListGroupItem

When the focus is on the list item and shif+tab is pressed, the focus doesn't go to the notification group item header buttons.

The error:
When ListItemBase fires "_forward-before" event, the event is handled from each ui5-list above it, but it should be handled only from the parent list. 

The solution:
Bubbling of the "_forward-before" event is now prevented