### PR TITLE
fix(ui5-popover, ui5-dialog, ui5-responsive-popover): rename headerText property to titleText

### DIFF
--- a/packages/main/src/ColorPaletteDialog.hbs
+++ b/packages/main/src/ColorPaletteDialog.hbs
@@ -1,5 +1,5 @@
 <ui5-dialog
-    header-text="{{moreColorsFeature.colorPaletteDialogTitle}}"
+    title-text="{{moreColorsFeature.colorPaletteDialogTitle}}"
 >
     <div class="ui5-cp-dialog-content">
         <ui5-color-picker></ui5-color-picker>

--- a/packages/main/src/Dialog.hbs
+++ b/packages/main/src/Dialog.hbs
@@ -9,7 +9,7 @@
 			{{#if header.length }}
 				<slot name="header"></slot>
 			{{else}}
-				<h2 id="ui5-popup-header-text" class="ui5-popup-header-text">{{headerText}}</h2>
+				<h2 id="ui5-popup-title-text" class="ui5-popup-title-text">{{titleText}}</h2>
 			{{/if}}
 		</header>
 	{{/if}}

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -47,13 +47,13 @@ const metadata = {
 		/**
 		 * Defines the header text.
 		 * <br><br>
-		 * <b>Note:</b> If <code>header</code> slot is provided, the <code>headerText</code> is ignored.
+		 * <b>Note:</b> If <code>header</code> slot is provided, the <code>titleText</code> is ignored.
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */
-		headerText: {
+		titleText: {
 			type: String,
 		},
 
@@ -224,8 +224,8 @@ class Dialog extends Popup {
 	get _ariaLabelledBy() { // Required by Popup.js
 		let ariaLabelledById;
 
-		if (this.headerText !== "" && !this.ariaLabel) {
-			ariaLabelledById = "ui5-popup-header-text";
+		if (this.titleText !== "" && !this.ariaLabel) {
+			ariaLabelledById = "ui5-popup-title-text";
 		}
 
 		return ariaLabelledById;
@@ -249,7 +249,7 @@ class Dialog extends Popup {
 	}
 
 	get _displayHeader() {
-		return this.header.length || this.headerText;
+		return this.header.length || this.titleText;
 	}
 
 	show() {

--- a/packages/main/src/Popover.hbs
+++ b/packages/main/src/Popover.hbs
@@ -8,7 +8,7 @@
 			{{#if header.length }}
 				<slot name="header"></slot>
 			{{else}}
-				<h2 class="ui5-popup-header-text">{{headerText}}</h2>
+				<h2 class="ui5-popup-title-text">{{titleText}}</h2>
 			{{/if}}
 		</header>
 	{{/if}}

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -26,13 +26,13 @@ const metadata = {
 		/**
 		 * Defines the header text.
 		 * <br><br>
-		 * <b>Note:</b> If <code>header</code> slot is provided, the <code>headerText</code> is ignored.
+		 * <b>Note:</b> If <code>header</code> slot is provided, the <code>titleText</code> is ignored.
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */
-		headerText: {
+		titleText: {
 			type: String,
 		},
 
@@ -554,7 +554,7 @@ class Popover extends Popup {
 
 		if (this._displayHeader) {
 			const headerDomRef = this.shadowRoot.querySelector(".ui5-popup-header-root")
-				|| this.shadowRoot.querySelector(".ui5-popup-header-text");
+				|| this.shadowRoot.querySelector(".ui5-popup-title-text");
 
 			if (headerDomRef) {
 				maxContentHeight = Math.round(maxHeight - headerDomRef.offsetHeight);
@@ -747,7 +747,7 @@ class Popover extends Popup {
 	 * Hook for descendants to hide header.
 	 */
 	get _displayHeader() {
-		return this.header.length || this.headerText;
+		return this.header.length || this.titleText;
 	}
 
 	/**

--- a/packages/main/src/ResponsivePopover.hbs
+++ b/packages/main/src/ResponsivePopover.hbs
@@ -14,8 +14,8 @@
 				<slot slot="header" name="header"></slot>
 			{{else}}
 				<header class="{{classes.header}}">
-					{{#if headerText }}
-						<ui5-title level="H2" class="ui5-popup-header-text ui5-responsive-popover-header-text">{{headerText}}</ui5-title>
+					{{#if titleText }}
+						<ui5-title level="H2" class="ui5-popup-title-text ui5-responsive-popover-title-text">{{titleText}}</ui5-title>
 					{{/if}}
 					<ui5-button
 						icon="decline"

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -95,7 +95,7 @@ class ResponsivePopover extends Popover {
 
 		allClasses.header = {
 			"ui5-responsive-popover-header": true,
-			"ui5-responsive-popover-header-no-title": !this.headerText,
+			"ui5-responsive-popover-header-no-title": !this.titleText,
 		};
 
 		return allClasses;

--- a/packages/main/src/TokenizerPopover.hbs
+++ b/packages/main/src/TokenizerPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	tokenizer-popover="true"
 	style={{styles.popover}}
-	header-text={{morePopoverTitle}}
+	title-text={{morePopoverTitle}}
 	?content-only-on-desktop="{{hasValueState}}"
 	no-arrow
 	placement-type="Bottom"
@@ -11,7 +11,7 @@
 		<div slot="header" class="ui5-responsive-popover-header" style="{{styles.popoverHeader}}">
 			{{#if _isPhone}}
 				<div class="row" style="{{styles.popoverHeaderTitle}}">
-					<ui5-title level="H5" class="ui5-responsive-popover-header-text">Remove</ui5-title>
+					<ui5-title level="H5" class="ui5-responsive-popover-title-text">Remove</ui5-title>
 					<ui5-button
 						class="ui5-responsive-popover-close-btn"
 						icon="decline"

--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -42,7 +42,7 @@
 
 .ui5-popup-header-root,
 .ui5-popup-footer-root,
-:host([header-text]) .ui5-popup-header-text {
+:host([title-text]) .ui5-popup-title-text {
     margin: 0;
     color: var(--sapPageHeader_TextColor);
     font-size: 1rem;
@@ -65,7 +65,7 @@
     padding: 0;
 }
 
-:host([header-text]) .ui5-popup-header-text {
+:host([title-text]) .ui5-popup-title-text {
     padding: 0 0.25rem;
     text-align: center;
     min-height: 3rem;
@@ -78,7 +78,7 @@
     display: inline-block;
 }
 
-:host(:not([header-text])) .ui5-popup-header-text {
+:host(:not([title-text])) .ui5-popup-title-text {
     display: none;
 }
 

--- a/packages/main/src/themes/ResponsivePopover.css
+++ b/packages/main/src/themes/ResponsivePopover.css
@@ -25,7 +25,7 @@
 	padding: 0 1rem 0 0;
 }
 
-.ui5-responsive-popover-header-text {
+.ui5-responsive-popover-title-text {
 	width: calc(100% - var(--_ui5_button_base_min_width));
 }
 

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -119,7 +119,7 @@
 	flex-direction: column;
 }
 
-.ui5-responsive-popover-header-text {
+.ui5-responsive-popover-title-text {
 	width: calc(100% - var(--_ui5_button_base_min_width));
 }
 

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -76,7 +76,7 @@
 
 	<div id="avatar-group-wrapper">
 
-		<ui5-popover header-text="My Heading" id="group-pop" style="width: 400px" placement-type="Bottom" aria-label="This popover is important">
+		<ui5-popover title-text="My Heading" id="group-pop" style="width: 400px" placement-type="Bottom" aria-label="This popover is important">
 			<div slot="header">
 				<h5>Business card</h5>
 			</div>
@@ -90,7 +90,7 @@
 			</div>
 		</ui5-popover>
 
-		<ui5-popover header-text="My Heading" id="individual-pop" style="width: 300px" placement-type="Bottom" aria-label="This popover is important" prevent-focus-restore>
+		<ui5-popover title-text="My Heading" id="individual-pop" style="width: 300px" placement-type="Bottom" aria-label="This popover is important" prevent-focus-restore>
 			<div slot="header">
 				<h5>Business card</h5>
 			</div>

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -56,7 +56,7 @@
 
 	<ui5-block-layer></ui5-block-layer>
 
-	<ui5-dialog id="msg-dialog" header-text="Message dialog" style="--sapScrollBar_Dimension: 20px">
+	<ui5-dialog id="msg-dialog" title-text="Message dialog" style="--sapScrollBar_Dimension: 20px">
 		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
 			That´s OpenUI5.</p>
 		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
@@ -217,7 +217,7 @@
 
 
 
-	<ui5-dialog id="prevent-dialog" header-text="Message dialog">
+	<ui5-dialog id="prevent-dialog" title-text="Message dialog">
 		<p>Prevent closing the dialog.</p>
 
 		<div slot="footer" style="display: flex; justify-content: flex-end; width: 100%; padding: .25rem 1rem;">
@@ -233,7 +233,7 @@
 		</div>
 	</ui5-dialog>
 
-	<ui5-dialog id="wide-dialog" header-text="Wide dialog" style="width: 100%">
+	<ui5-dialog id="wide-dialog" title-text="Wide dialog" style="width: 100%">
 		<p>That´s OpenUI5.</p>
 		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
 			That´s OpenUI5.</p>
@@ -253,7 +253,7 @@
 		</div>
 	</ui5-dialog>
 
-	<ui5-dialog id="wide-dialog2" header-text="Wide dialog" stretch style="width: 100%">
+	<ui5-dialog id="wide-dialog2" title-text="Wide dialog" stretch style="width: 100%">
 		<p>That´s OpenUI5.</p>
 		<p>Build enterprise-ready web applications, responsive to all devices and running on the browser of your choice.
 			That´s OpenUI5.</p>
@@ -284,7 +284,7 @@
 		</div>
 	</ui5-dialog>
 
-	<ui5-dialog id="resizable-dialog" header-text="Resizable dialog" resizable>
+	<ui5-dialog id="resizable-dialog" title-text="Resizable dialog" resizable>
 		<p>Resize this dialog by dragging it by its resize handle.</p>
 		<p>This feature available only on Desktop.</p>
 
@@ -293,7 +293,7 @@
 		</div>
 	</ui5-dialog>
 
-	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top">
+	<ui5-popover title-text="My Heading" id="pop" style="width: 300px" placement-type="Top">
 		<!-- <div slot="header">
 			Hello World
 		</div> -->

--- a/packages/main/test/pages/DialogLifecycle.html
+++ b/packages/main/test/pages/DialogLifecycle.html
@@ -29,7 +29,7 @@
 <br />
 
 <template id="dt">
-	<ui5-dialog id="hello-dialog" header-text="Dialogs are easy!">
+	<ui5-dialog id="hello-dialog" title-text="Dialogs are easy!">
 		<div style="padding: 2rem; display:flex; justify-content: center;">
 			Hello World!
 			<ui5-button id="closeDialogButton">Dismiss</ui5-button>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -188,7 +188,7 @@
 			<ui5-togglebutton design="Positive">On/Off</ui5-togglebutton>
 			<ui5-togglebutton pressed design="Negative" icon="menu">Menu</ui5-togglebutton>
 			<ui5-button id="openPopoverButton">Open Popover</ui5-button>
-			<ui5-popover header-text="Popover" id="hello-popover">
+			<ui5-popover title-text="Popover" id="hello-popover">
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>
@@ -204,7 +204,7 @@
 			</ui5-popover>
 
 			<ui5-button id="openDialogButton">Open Dialog</ui5-button>
-			<ui5-dialog id="hello-dialog" header-text="Dialog">
+			<ui5-dialog id="hello-dialog" title-text="Dialog">
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>
@@ -219,7 +219,7 @@
 				</div>
 			</ui5-dialog>
 			<ui5-button id="openDialogStretched">Open Dialog Stretched</ui5-button>
-			<ui5-dialog id="hello-dialog2" header-text="Dialog" stretch>
+			<ui5-dialog id="hello-dialog2" title-text="Dialog" stretch>
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -161,7 +161,7 @@
 			<ui5-togglebutton type="Positive">On/Off</ui5-togglebutton>
 			<ui5-togglebutton pressed type="Negative" icon="menu">Menu</ui5-togglebutton>
 			<ui5-button id="openPopoverButton">Open Popover</ui5-button>
-			<ui5-popover header-text="Popover" id="hello-popover">
+			<ui5-popover title-text="Popover" id="hello-popover">
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>
@@ -177,7 +177,7 @@
 			</ui5-popover>
 
 			<ui5-button id="openDialogButton">Open Dialog</ui5-button>
-			<ui5-dialog id="hello-dialog" header-text="Dialog">
+			<ui5-dialog id="hello-dialog" title-text="Dialog">
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>
@@ -192,7 +192,7 @@
 				</div>
 			</ui5-dialog>
 			<ui5-button id="openDialogStretched">Open Dialog Stretched</ui5-button>
-			<ui5-dialog id="hello-dialog2" header-text="Dialog" stretch>
+			<ui5-dialog id="hello-dialog2" title-text="Dialog" stretch>
 				<div style="padding: 1rem;text-align: center;">
 					<ui5-title level="H2">Hello World!</ui5-title>
 				</div>

--- a/packages/main/test/pages/MultiInput.html
+++ b/packages/main/test/pages/MultiInput.html
@@ -256,7 +256,7 @@
 			<ui5-suggestion-item text="excepteur"></ui5-suggestion-item>
 		</ui5-multi-input>
 
-		<ui5-dialog id="dialog" header-text="Add Competency">
+		<ui5-dialog id="dialog" title-text="Add Competency">
 
 			<ui5-list id="tokens-list">
 

--- a/packages/main/test/pages/MultiInput_Suggestions.html
+++ b/packages/main/test/pages/MultiInput_Suggestions.html
@@ -64,7 +64,7 @@
 			<ui5-suggestion-item text="excepteur"></ui5-suggestion-item>
 		</ui5-multi-input>
 
-		<ui5-dialog id="dialog" header-text="Add Competency">
+		<ui5-dialog id="dialog" title-text="Add Competency">
 
 			<ui5-list id="tokens-list">
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -35,7 +35,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 	<!-- <ui5-button id="btnOpenPopover" design="Emphasized" icon="employee">Open Popover</ui5-button>
 
-	<ui5-popover id="popoverToOpen" header-text="Popover">
+	<ui5-popover id="popoverToOpen" title-text="Popover">
 		<div style="padding: 1rem;text-align: center;">
 			<ui5-title level="H2">Hello World!</ui5-title>
 		</div>
@@ -60,7 +60,7 @@
 
 	<ui5-button id="btn">Click me !</ui5-button>
 
-	<ui5-popover header-text="My Heading" id="pop" style="width: 300px" placement-type="Top" aria-label="This popover is important">
+	<ui5-popover title-text="My Heading" id="pop" style="width: 300px" placement-type="Top" aria-label="This popover is important">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -153,13 +153,13 @@
 		Open Big Popover
 	</ui5-button>
 
-	<ui5-popover placement-type="Bottom" id="big-popover" header-text="hello world">
+	<ui5-popover placement-type="Bottom" id="big-popover" title-text="hello world">
 		<ui5-list id="bigList"></ui5-list>
 	</ui5-popover>
 
 	<ui5-button id="btnPopModal">Opens modal popover!</ui5-button>
 
-	<ui5-popover id="modalPopover" modal header-text="Modal popover">
+	<ui5-popover id="modalPopover" modal title-text="Modal popover">
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>Again</ui5-li>
@@ -173,7 +173,7 @@
 
 	<ui5-button id="btnPopModalNoLayer">Opens modal popover with no block layer!</ui5-button>
 
-	<ui5-popover id="modalPopoverNoLayer" modal header-text="Modal popover" hide-backdrop>
+	<ui5-popover id="modalPopoverNoLayer" modal title-text="Modal popover" hide-backdrop>
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>Again</ui5-li>
@@ -187,7 +187,7 @@
 
 	<ui5-button id="btnPopFocus">Opens popover with initial focus!</ui5-button>
 
-	<ui5-popover id="popFocus" initial-focus="focusMe" header-text="Popover header">
+	<ui5-popover id="popFocus" initial-focus="focusMe" title-text="Popover header">
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>Again</ui5-li>
@@ -237,7 +237,7 @@
 	<ui5-title>placement-type="Bottom"</ui5-title>
 	<ui5-button id="btnFullWidthBottom" style="width: 100%">Click me !</ui5-button>
 
-	<ui5-popover header-text="My Heading" id="popFullWidth" style="width: 300px" >
+	<ui5-popover title-text="My Heading" id="popFullWidth" style="width: 300px" >
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -249,32 +249,7 @@
 		</ui5-list>
 	</ui5-popover>
 
-	<ui5-popover allow-target-overlap header-text="My Heading" id="popFullWidthTargetOverlap" style="width: 300px" >
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-
-		<ui5-list>
-			<ui5-li>Hello</ui5-li>
-			<ui5-li>World</ui5-li>
-			<ui5-li>Again</ui5-li>
-		</ui5-list>
-	</ui5-popover>
-
-
-	<ui5-popover header-text="My Heading" id="popFullWidthLeft" style="width: 300px" placement-type="Left">
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-
-		<ui5-list>
-			<ui5-li>Hello</ui5-li>
-			<ui5-li>World</ui5-li>
-			<ui5-li>Again</ui5-li>
-		</ui5-list>
-	</ui5-popover>
-
-	<ui5-popover header-text="My Heading" id="popFullWidthLeftTargetOverlap" style="width: 300px" placement-type="Left" allow-target-overlap>
+	<ui5-popover allow-target-overlap title-text="My Heading" id="popFullWidthTargetOverlap" style="width: 300px" >
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -287,7 +262,7 @@
 	</ui5-popover>
 
 
-	<ui5-popover header-text="My Heading" id="popFullWidthTop" style="width: 300px" placement-type="Top">
+	<ui5-popover title-text="My Heading" id="popFullWidthLeft" style="width: 300px" placement-type="Left">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -299,7 +274,32 @@
 		</ui5-list>
 	</ui5-popover>
 
-	<ui5-popover header-text="My Heading" id="popFullWidthBottom" style="width: 300px" placement-type="Bottom">
+	<ui5-popover title-text="My Heading" id="popFullWidthLeftTargetOverlap" style="width: 300px" placement-type="Left" allow-target-overlap>
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+
+		<ui5-list>
+			<ui5-li>Hello</ui5-li>
+			<ui5-li>World</ui5-li>
+			<ui5-li>Again</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
+
+	<ui5-popover title-text="My Heading" id="popFullWidthTop" style="width: 300px" placement-type="Top">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+
+		<ui5-list>
+			<ui5-li>Hello</ui5-li>
+			<ui5-li>World</ui5-li>
+			<ui5-li>Again</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
+	<ui5-popover title-text="My Heading" id="popFullWidthBottom" style="width: 300px" placement-type="Bottom">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -335,7 +335,7 @@
 	<ui5-button id="btnOpenXLeft">Open Popup Left aligned</ui5-button>
 
 	<ui5-popover
-		header-text="My Heading"
+		title-text="My Heading"
 		id="popXLeft" horizontal-align="Left"
 		style="width: 300px">
 		<div slot="header">
@@ -354,7 +354,7 @@
 	<ui5-button id="btnOpenXRight">Open Popup Right aligned</ui5-button>
 
 	<ui5-popover
-		header-text="My Heading"
+		title-text="My Heading"
 		id="popXRight" horizontal-align="Right"
 		style="width: 300px">
 		<div slot="header">
@@ -395,7 +395,7 @@
 
 	<ui5-button id="btnOpenPopoverWithDiv">Open Popover with div Inside</ui5-button>
 
-	<ui5-popover id="popWithDiv" header-text="Newsletter subscription" modal>
+	<ui5-popover id="popWithDiv" title-text="Newsletter subscription" modal>
 		<div id="divContent">I'm a div, which can't get focus. Click me and see where focus goes.</div>
 		<div slot="footer" class="popover-footer">
 			<ui5-button design="Emphasized">Subscribe</ui5-button>
@@ -406,7 +406,7 @@
 		<ui5-button id="btnRightEdge">Popover on right edge of screen</ui5-button>
 	</div>
 
-	<ui5-popover header-text="Header" id="popoverRightEdge" placement-type="Top">
+	<ui5-popover title-text="Header" id="popoverRightEdge" placement-type="Top">
 		<ui5-label>Input field: </ui5-label>
 		<ui5-input></ui5-input>
 	</ui5-popover>

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -100,7 +100,7 @@
 
 		<ui5-button class="wcBtnOpenDialog">Open Dialog</ui5-button>
 
-			<ui5-dialog class="wcDialog" initial-focus="focusButton" header-text="Web Component Dialog">
+			<ui5-dialog class="wcDialog" initial-focus="focusButton" title-text="Web Component Dialog">
 
 				<div slot="header" id="head1" style="display: flex; align-items: center;padding: 0 0.5rem">
 					<div style="flex: 1; text-align: center">Custom Header</div>
@@ -115,12 +115,12 @@
 				<ui5-button class="wcBtnOpenNewDialog">Open New Dialog</ui5-button>
 				<ui5-button class="wcBtnCloseDialog">Close Dialog</ui5-button>
 
-				<ui5-popover placement-type="Right" class="wcNewDialogPopover" header-text="Second Popover">
+				<ui5-popover placement-type="Right" class="wcNewDialogPopover" title-text="Second Popover">
 					<ui5-button class="wcBtnOpenNewPopoverDialog1">Open New Popover </ui5-button>
 					<ui5-button class="wcBtnClosePopoverDialog1">Popover Button</ui5-button>
 				</ui5-popover>
 				<ui5-button class="wcBtnOpenNewDialogPopover">Open New Popover</ui5-button>
-				<ui5-dialog class="wcNewDialog" header-text="Second Dialog">
+				<ui5-dialog class="wcNewDialog" title-text="Second Dialog">
 					<ui5-button class="wcNewDialog1">Open New Dialog</ui5-button>
 					<ui5-button class="wcBtnCloseDialog1">Dialog Button</ui5-button>
 				</ui5-dialog>
@@ -135,7 +135,7 @@
 		<!--</div>-->
 		<h5>Web Component</h5>
 		<ui5-button class="wcBtnOpenPopover">Open Popover</ui5-button>
-		<ui5-popover placement-type="Top" class="wcPopover" header-text="Web Component Popover">
+		<ui5-popover placement-type="Top" class="wcPopover" title-text="Web Component Popover">
 			<div slot="header" style="display: flex; align-items: center;padding: 0 0.5rem">
 				<div style="flex: 1; text-align: center">Custom Header</div>
 				<ui5-button icon="decline"></ui5-button>
@@ -145,14 +145,14 @@
 				<ui5-button>Accept</ui5-button>
 			</div>
 			<ui5-date-picker></ui5-date-picker>
-			<ui5-popover placement-type="Right" class="wcNewPopover" header-text="Second Popover">
+			<ui5-popover placement-type="Right" class="wcNewPopover" title-text="Second Popover">
 				<ui5-button class="wcBtnOpenNewPopover1">Open New Popover </ui5-button>
 				<ui5-button class="wcBtnClosePopover1">Popover Button</ui5-button>
 			</ui5-popover>
 			<ui5-button class="wcBtnOpenNewPopover">Open New Popover </ui5-button>
 			<ui5-button class="wcBtnClosePopover">Close Popover</ui5-button>
 			<ui5-button class="wcBtnOpenNewPopoverDialog11">Open New Dialog</ui5-button>
-			<ui5-dialog class="wcNewPopoverDialog11" header-text="Second Dialog">
+			<ui5-dialog class="wcNewPopoverDialog11" title-text="Second Dialog">
 				<ui5-button class="wcNewPopoverDialog1">Open New Dialog</ui5-button>
 				<ui5-button class="wcBtnClosePopoverDialog1">Dialog Button</ui5-button>
 			</ui5-dialog>

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -44,8 +44,8 @@
 		</div>
 	</ui5-responsive-popover>
 
-	<!-- with header-text and footer slot-->
-	<ui5-responsive-popover id="respPopover2" header-text="Newsletter subscription for very long period of time">
+	<!-- with title-text and footer slot-->
+	<ui5-responsive-popover id="respPopover2" title-text="Newsletter subscription for very long period of time">
 		<div class="popover-content">
 			<ui5-label for="emailInput" required>Email: </ui5-label>
 			<ui5-input id="emailInput" class="samples-margin-top" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
@@ -74,7 +74,7 @@
 
 	<h2> Inputs based component that opens popover/dialog within dialog</h2>
 	<ui5-button id="btnOpenDialog" design="Emphasized" icon="employee">Open Dialog</ui5-button>
-	<ui5-dialog id="dialog" header-text="Dialog" stretch>
+	<ui5-dialog id="dialog" title-text="Dialog" stretch>
 		<ui5-select id="mySelect">
 			<ui5-option >Cozy</ui5-option>
 			<ui5-option >Compact</ui5-option>

--- a/packages/main/test/samples/AvatarGroup.sample.html
+++ b/packages/main/test/samples/AvatarGroup.sample.html
@@ -12,7 +12,7 @@
 <section>
 	<h4>Avatar Group - type "Individual"</h4> 
 	<div class="snippet individual">
-		<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
+		<ui5-popover title-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
 			<div class="avatar-slot" style="display: inline-block;">
 				<ui5-avatar id="popAvatar"></ui5-avatar>
 			</div>
@@ -23,7 +23,7 @@
 			</div>
 		</ui5-popover>
 	
-		<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+		<ui5-popover title-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
 			<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 		</ui5-popover>
 	
@@ -108,13 +108,13 @@
 		</script>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
+<ui5-popover title-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
 	...
 	<ui5-avatar id="popAvatar"></ui5-avatar>
 	...
 </ui5-popover>
 
-<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+<ui5-popover title-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
 	...
 	<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 	...
@@ -165,7 +165,7 @@
 <section>
 	<h4>Avatar Group - type "Group"</h4>
 	<div class="snippet group">
-	    <ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+	    <ui5-popover title-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
 			<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 		</ui5-popover>
 	
@@ -228,7 +228,7 @@
 		</script>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+<ui5-popover title-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
 	...
 	<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 	...

--- a/packages/main/test/samples/ColorPalette.sample.html
+++ b/packages/main/test/samples/ColorPalette.sample.html
@@ -88,7 +88,7 @@
 
 		<ui5-popover
 			id="palettePopover"
-			header-text="Pick a color"
+			title-text="Pick a color"
 			placement-type="Bottom"
 			horizontal-align="Left"
 			no-arrow>
@@ -123,7 +123,7 @@
 	<ui5-input id="inpSelectedColor" placeholder="Selected color..."></ui5-input>
 </section>
 
-<ui5-popover id="palettePopover" header-text="Pick a color" placement-type="Bottom">
+<ui5-popover id="palettePopover" title-text="Pick a color" placement-type="Bottom">
 		<ui5-color-palette id="colorPaletteInPopover" show-more-colors>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>

--- a/packages/main/test/samples/Dialog.sample.html
+++ b/packages/main/test/samples/Dialog.sample.html
@@ -11,7 +11,7 @@
 	<div class="snippet">
 		<ui5-button id="openDialogButton" design="Emphasized">Open Dialog</ui5-button>
 
-		<ui5-dialog id="hello-dialog" header-text="Register Form">
+		<ui5-dialog id="hello-dialog" title-text="Register Form">
 			<section class="login-form">
 				<div>
 					<ui5-label for="username" required>Username: </ui5-label>
@@ -57,7 +57,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="openDialogButton" design="Emphasized">Open Dialog</ui5-button>
 
-<ui5-dialog id="hello-dialog" header-text="Register Form">
+<ui5-dialog id="hello-dialog" title-text="Register Form">
 	<section class="login-form">
 		<div>
 			<ui5-label for="username" required>Username: </ui5-label>
@@ -109,7 +109,7 @@
 
 		<ui5-dialog
 			id="resize-draggable-dialog"
-			header-text="Draggable/Resizable dialog"
+			title-text="Draggable/Resizable dialog"
 			resizable
 			draggable
 		>

--- a/packages/main/test/samples/Popover.sample.html
+++ b/packages/main/test/samples/Popover.sample.html
@@ -11,7 +11,7 @@
 	<div class="snippet">
 		<ui5-button id="openPopoverButton" design="Emphasized">Open Popover</ui5-button>
 
-		<ui5-popover id="hello-popover" header-text="Newsletter subscription">
+		<ui5-popover id="hello-popover" title-text="Newsletter subscription">
 			<div class="popover-content">
 				<div class="flex-column">
 					<ui5-label for="emailInput" required>Email: </ui5-label>
@@ -41,7 +41,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="openPopoverButton" design="Emphasized">Open Popover</ui5-button>
 
-<ui5-popover id="hello-popover" header-text="Newsletter subscription">
+<ui5-popover id="hello-popover" title-text="Newsletter subscription">
 	<div class="popover-content">
 		<div class="flex-column">
 			<ui5-label for="emailInput" required>Email: </ui5-label>

--- a/packages/main/test/samples/ResponsivePopover.sample.html
+++ b/packages/main/test/samples/ResponsivePopover.sample.html
@@ -14,7 +14,7 @@
 	<div class="snippet">
 		<ui5-button id="openBtn" design="Emphasized">Open ResponsivePopover</ui5-button>
 
-		<ui5-responsive-popover id="hello-popover" header-text="Newsletter subscription">
+		<ui5-responsive-popover id="hello-popover" title-text="Newsletter subscription">
 			<div style="width: auto;padding: 2rem;display: flex;flex-direction: column;justify-content: center;">
 				<ui5-label for="emailInput" required>Email: </ui5-label>
 				<ui5-input id="emailInput" class="samples-margin-top" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
@@ -41,7 +41,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="openBtn" design="Emphasized">Open Popover</ui5-button>
 
-<ui5-responsive-popover id="hello-popover" header-text="Newsletter subscription">
+<ui5-responsive-popover id="hello-popover" title-text="Newsletter subscription">
 	<div class="popover-content">
 		<div class="flex-column">
 			<ui5-label for="emailInput" required>Email: </ui5-label>

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -10,7 +10,7 @@ describe("Attributes propagation", () => {
 		const popover = $("#pop");
 		const selector = "h2=New text";
 
-		popover.setAttribute("header-text", "New text");
+		popover.setAttribute("title-text", "New text");
 		assert.ok($(selector), "The new header text was set correctly");
 	});
 

--- a/packages/playground/_layouts/sample.html
+++ b/packages/playground/_layouts/sample.html
@@ -20,7 +20,7 @@ layout: default
         C229.552,202.287,202.902,228.474,170.128,228.474z"></path>
     </svg>
 </div>
-<ui5-dialog id="settings-dialog" header-text="Settings">
+<ui5-dialog id="settings-dialog" title-text="Settings">
     <section class="settings-form">
         <div class="settings-content">
             <div class="setting">


### PR DESCRIPTION
Part of #3107

BREAKING_CHANGE: rename ```headerText``` property to ```titleText```