### PR TITLE
fix(ui5-flexible-column-layout): column borders in high contrast themes

### DIFF
--- a/packages/fiori/src/themes/sap_fiori_3_hcb/FlexibleColumnLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/FlexibleColumnLayout-parameters.css
@@ -1,0 +1,6 @@
+:root {
+	--_ui5_fcl_solid_bg: var(--sapBackgroundColor);
+	--_ui5_fcl_column_border: solid 0.0625rem var(--sapGroup_ContentBorderColor);
+	--_ui5_fcl_decoration_top: linear-gradient(to top, var(--sapObjectHeader_BorderColor), #000); 
+	--_ui5_fcl_decoration_bottom: linear-gradient(to bottom, var(--sapObjectHeader_BorderColor), #000); 
+}

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -1,4 +1,5 @@
 @import "../base/Bar-parameters.css";
+@import "./FlexibleColumnLayout-parameters.css";
 @import "./Page-parameters.css";
 @import "./ProductSwitchItem-parameters.css";
 @import "./TimelineItem-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/FlexibleColumnLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/FlexibleColumnLayout-parameters.css
@@ -1,0 +1,6 @@
+:root {
+	--_ui5_fcl_solid_bg: var(--sapBackgroundColor);
+	--_ui5_fcl_column_border: solid 0.0625rem var(--sapGroup_ContentBorderColor);
+	--_ui5_fcl_decoration_top: linear-gradient(to top, var(--sapObjectHeader_BorderColor), #fff); 
+	--_ui5_fcl_decoration_bottom: linear-gradient(to bottom, var(--sapObjectHeader_BorderColor), #fff); 
+}

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -1,4 +1,5 @@
 @import "../base/Bar-parameters.css";
+@import "./FlexibleColumnLayout-parameters.css";
 @import "./Page-parameters.css";
 @import "./ProductSwitchItem-parameters.css";
 @import "./TimelineItem-parameters.css";


### PR DESCRIPTION
CSS parameters points to wrong values. Now, they are aligned to correct values for high contrast Fiori 3 themes.

Fixes: #3320
