### PR TITLE
fix(ui5-wizard-step): rename properties

### DIFF
--- a/packages/fiori/src/Wizard.hbs
+++ b/packages/fiori/src/Wizard.hbs
@@ -3,8 +3,8 @@
 		<div class="ui5-wiz-nav-list" role="list" aria-label="{{listAriaLabelText}}" aria-controls="{{_id}}-wiz-content">
 			{{#each _stepsInHeader}}
 				<ui5-wizard-tab
-					titleText="{{heading}}"
-					subtitleText="{{subheading}}"
+					title-text="{{titleText}}"
+					subtitle-text="{{subtitleText}}"
 					icon="{{icon}}"
 					number="{{number}}"
 					?disabled="{{disabled}}"

--- a/packages/fiori/src/Wizard.hbs
+++ b/packages/fiori/src/Wizard.hbs
@@ -3,8 +3,8 @@
 		<div class="ui5-wiz-nav-list" role="list" aria-label="{{listAriaLabelText}}" aria-controls="{{_id}}-wiz-content">
 			{{#each _stepsInHeader}}
 				<ui5-wizard-tab
-					heading="{{heading}}"
-					subheading="{{subheading}}"
+					titleText="{{heading}}"
+					subtitleText="{{subheading}}"
 					icon="{{icon}}"
 					number="{{number}}"
 					?disabled="{{disabled}}"

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -205,7 +205,7 @@ const metadata = {
  * When the task has less than 3 steps.
  *
  * <h3>Responsive Behavior</h3>
- * On small widths the step's heading, subheading and separators in the navigation area
+ * On small widths the step's heading, subtitleText and separators in the navigation area
  * will start truncate and shrink and from particular point they will hide to free as much space as possible.
  *
  * <h3>ES6 Module Import</h3>
@@ -818,8 +818,8 @@ class Wizard extends UI5Element {
 			// Hide separator if it's the last step and it's not a branching one
 			const hideSeparator = (idx === stepsCount - 1) && !step.branching;
 
-			const isOptional = step.subheading ? this.optionalStepText : "";
-			const ariaLabel = (step.heading ? `${pos} ${step.heading} ${isOptional}` : `${this.navStepDefaultHeading} ${pos} ${isOptional}`).trim();
+			const isOptional = step.subtitleText ? this.optionalStepText : "";
+			const ariaLabel = (step.titleText ? `${pos} ${step.titleText} ${isOptional}` : `${this.navStepDefaultHeading} ${pos} ${isOptional}`).trim();
 			const isAfterCurrent = (idx > selectedStepIndex);
 
 			accInfo = {
@@ -830,8 +830,8 @@ class Wizard extends UI5Element {
 
 			return {
 				icon: step.icon,
-				heading: step.heading,
-				subheading: step.subheading,
+				titleText: step.titleText,
+				subtitleText: step.subtitleText,
 				number: pos,
 				selected: step.selected,
 				disabled: step.disabled,

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -161,7 +161,7 @@ const metadata = {
  * It shows the sequence of steps, where the recommended number of steps is between 3 and 8 steps.
  * <ul>
  * <li> Steps can have different visual representations - numbers or icons.
- * <li> Steps might have labels for better readability - heading and subheding.</li>
+ * <li> Steps might have labels for better readability - titleText and subTitleText.</li>
  * <li> Steps are defined by using the <code>ui5-wizard-step</code> as slotted element within the <code>ui5-wizard</code></li>
  * </ul>
  *
@@ -205,7 +205,7 @@ const metadata = {
  * When the task has less than 3 steps.
  *
  * <h3>Responsive Behavior</h3>
- * On small widths the step's heading, subtitleText and separators in the navigation area
+ * On small widths the step's titleText, subtitleText and separators in the navigation area
  * will start truncate and shrink and from particular point they will hide to free as much space as possible.
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -7,7 +7,7 @@ const metadata = {
 	tag: "ui5-wizard-step",
 	properties: /** @lends sap.ui.webcomponents.fiori.WizardStep.prototype */ {
 		/**
-		 * Defines the <code>heading</code> of the step.
+		 * Defines the <code>titleText</code> of the step.
 		 * <br><br>
 		 *
 		 * <b>Note:</b> the text is displayed in the <code>ui5-wizard</code> navigation header.
@@ -16,13 +16,14 @@ const metadata = {
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @public
+		 * @since 1.0.0-rc.15
 		 */
-		heading: {
+		titleText: {
 			type: String,
 		},
 
 		/**
-		 * Defines the <code>subheading</code> of the step.
+		 * Defines the <code>subtitleText</code> of the step.
 		 * <br><br>
 		 *
 		 * <b>Note:</b> the text is displayed in the <code>ui5-wizard</code> navigation header.
@@ -31,8 +32,9 @@ const metadata = {
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @public
+		 * @since 1.0.0-rc.15
 		 */
-		subheading: {
+		subtitleText: {
 			type: String,
 		},
 
@@ -146,7 +148,7 @@ const metadata = {
  * <h3>Structure</h3>
  * <ul>
  * <li>Each wizard step has arbitrary content</li>
- * <li>Each wizard step might have texts - defined by the <code>heading</code> and <code>subheading</code> properties</li>
+ * <li>Each wizard step might have texts - defined by the <code>titleText</code> and <code>subtitleText</code> properties</li>
  * <li>Each wizard step might have an icon - defined by the <code>icon</code> property</li>
  * <li>Each wizard step might display a number in place of the <code>icon</code>, when it's missing</li>
  * </ul>

--- a/packages/fiori/src/WizardTab.hbs
+++ b/packages/fiori/src/WizardTab.hbs
@@ -21,8 +21,8 @@
 		</div>
 		{{#if hasTexts}}
 			<div class="ui5-wiz-step-texts">
-				<div class="ui5-wiz-step-heading">{{heading}}</div>
-				<div class="ui5-wiz-step-subheading">{{subheading}}</div>
+				<div class="ui5-wiz-step-title-text">{{titleText}}</div>
+				<div class="ui5-wiz-step-subtitle-text">{{subtitleText}}</div>
 			</div>
 		{{/if}}
 	</div>

--- a/packages/fiori/src/WizardTab.js
+++ b/packages/fiori/src/WizardTab.js
@@ -24,6 +24,7 @@ const metadata = {
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @private
+		 * @since 1.0.0-rc.15
 		 */
 		titleText: {
 			type: String,
@@ -34,6 +35,7 @@ const metadata = {
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @private
+		 * @since 1.0.0-rc.15
 		 */
 		subtitleText: {
 			type: String,

--- a/packages/fiori/src/WizardTab.js
+++ b/packages/fiori/src/WizardTab.js
@@ -20,22 +20,22 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the <code>heading</code> of the step.
+		 * Defines the <code>titleText</code> of the step.
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @private
 		 */
-		heading: {
+		titleText: {
 			type: String,
 		},
 
 		/**
-		 * Defines the <code>subheading</code> of the step.
+		 * Defines the <code>subtitleText</code> of the step.
 		 * @type {String}
 		 * @defaultvalue ""
 		 * @private
 		 */
-		subheading: {
+		subtitleText: {
 			type: String,
 		},
 
@@ -210,7 +210,7 @@ class WizardTab extends UI5Element {
 	}
 
 	get hasTexts() {
-		return this.heading || this.subheading;
+		return this.titleText || this.subtitleText;
 	}
 
 	get accInfo() {

--- a/packages/fiori/src/themes/WizardTab.css
+++ b/packages/fiori/src/themes/WizardTab.css
@@ -106,23 +106,23 @@
 	background: var(--sapObjectHeader_Background);
 }
 
-.ui5-wiz-step-heading,
-.ui5-wiz-step-subheading {
+.ui5-wiz-step-title-text,
+.ui5-wiz-step-subtitle-text {
 	color: var(--sapContent_LabelColor);
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
 
-:host([data-ui5-wizard-expanded-tab-prev="true"]) .ui5-wiz-step-heading,
-:host([data-ui5-wizard-expanded-tab-prev="true"]) .ui5-wiz-step-subheading,
+:host([data-ui5-wizard-expanded-tab-prev="true"]) .ui5-wiz-step-title-text,
+:host([data-ui5-wizard-expanded-tab-prev="true"]) .ui5-wiz-step-subtitle-text,
 :host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-texts,
-:host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-heading,
-:host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-subheading {
+:host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-title-text,
+:host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-subtitle-text {
 	display: none;
 }
 
-.ui5-wiz-step-subheading {
+.ui5-wiz-step-subtitle-text {
 	font-size: var(--sapFontSmallSize);
 }
 

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -84,7 +84,7 @@
 		<!-- mid column -->
 		<div style="box-sizing: border-box; height: 100%" slot="midColumn">
 			<ui5-wizard id="wiz">
-				<ui5-wizard-step icon="sap-icon://home" heading="Product type">
+				<ui5-wizard-step icon="sap-icon://home" title-text="Product type">
 					<div style="display: flex; min-height: 200px; flex-direction: column;">
 						<ui5-title>1. Product Type</ui5-title><br>
 
@@ -100,7 +100,7 @@
 					<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 				</ui5-wizard-step>
 
-				<ui5-wizard-step heading="Product Information">
+				<ui5-wizard-step title-text="Product Information">
 					<div style="display: flex;flex-direction: column">
 						<ui5-title>2. Product Information</ui5-title><br>
 						<ui5-label wrap>
@@ -137,7 +137,7 @@
 					<ui5-button id="toStep3" design="Emphasized" hidden>Step 3</ui5-button>
 				</ui5-wizard-step>
 
-				<ui5-wizard-step heading="Options">
+				<ui5-wizard-step title-text="Options">
 					<div style="display: flex; flex-direction: column;">
 						<ui5-title>3. Options</ui5-title><br>
 
@@ -178,7 +178,7 @@
 					<ui5-button id="toStep4" design="Emphasized" hidden>Step 4</ui5-button>
 				</ui5-wizard-step>
 
-				<ui5-wizard-step heading="Pricing">
+				<ui5-wizard-step title-text="Pricing">
 					<div style="display: flex; flex-direction: column;">
 						<ui5-title>4. Pricing</ui5-title><br>
 						<ui5-label wrap>

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -32,7 +32,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 	<h2>Wizard</h2>
 	<ui5-wizard id="wiz" style="height: 700px">
-		<ui5-wizard-step heading="Product type" icon="sap-icon://product" disabled>
+		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" disabled>
 			<div style="display: flex; min-height: 200px; flex-direction: column;">
 				<ui5-title>1. Product Type</ui5-title><br>
 
@@ -48,7 +48,7 @@
 			<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" disabled>
+		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -85,7 +85,7 @@
 			<ui5-button id="toStep3" design="Emphasized" hidden>Step 3</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Options" disabled>
+		<ui5-wizard-step title-text="Options" disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>3. Options</ui5-title><br>
 
@@ -126,7 +126,7 @@
 			<ui5-button id="toStep4" design="Emphasized" hidden>Step 4</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Pricing" selected>
+		<ui5-wizard-step title-text="Pricing" selected>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrap>
@@ -160,7 +160,7 @@
 
 	<h2>Wizard non-standard</h2>
 	<ui5-wizard style="height: 700px">
-		<ui5-wizard-step heading="Product type" icon="sap-icon://product" selected>
+		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected>
 			<div style="display: flex; min-height: 200px; flex-direction: column;">
 				<ui5-title>1. Product Type</ui5-title><br>
 
@@ -174,7 +174,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" disabled>
+		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -210,7 +210,7 @@
 
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Options" selected>
+		<ui5-wizard-step title-text="Options" selected>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>3. Options</ui5-title><br>
 
@@ -251,7 +251,7 @@
 			<ui5-button design="Emphasized" hidden>Step 4</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Pricing" disabled>
+		<ui5-wizard-step title-text="Pricing" disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrap>
@@ -281,7 +281,7 @@
 
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Final" selected disabled>
+		<ui5-wizard-step title-text="Final" selected disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>5. Final</ui5-title><br>
 				<ui5-label wrap>
@@ -314,7 +314,7 @@
 
 	<h2>Wizard non-standard 2</h2>
 	<ui5-wizard style="height: 700px">
-		<ui5-wizard-step heading="Product type" icon="sap-icon://product" selected disabled>
+		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected disabled>
 			<div style="display: flex; min-height: 200px; flex-direction: column;">
 				<ui5-title>1. Product Type</ui5-title><br>
 
@@ -328,7 +328,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" selected disabled>
+		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -365,7 +365,7 @@
 			<ui5-button design="Emphasized" hidden>Step 3</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Options" selected>
+		<ui5-wizard-step title-text="Options" selected>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>3. Options</ui5-title><br>
 
@@ -403,7 +403,7 @@
 			<ui5-button design="Emphasized" hidden>Step 4</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Pricing" selected disabled>
+		<ui5-wizard-step title-text="Pricing" selected disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrap>
@@ -436,7 +436,7 @@
 
 	<h2>Wizard non-standard 3</h2>
 	<ui5-wizard style="height: 700px">
-		<ui5-wizard-step heading="Product type" icon="sap-icon://product" selected disabled>
+		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected disabled>
 			<div style="display: flex; min-height: 200px; flex-direction: column;">
 				<ui5-title>1. Product Type</ui5-title><br>
 
@@ -449,7 +449,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" selected>
+		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -486,7 +486,7 @@
 			<ui5-button design="Emphasized" hidden>Step 3</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Options" selected disabled>
+		<ui5-wizard-step title-text="Options" selected disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>3. Options</ui5-title><br>
 
@@ -524,7 +524,7 @@
 			<ui5-button design="Emphasized" hidden>Step 4</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Pricing" selected disabled>
+		<ui5-wizard-step title-text="Pricing" selected disabled>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrap>
@@ -554,7 +554,7 @@
 
 	<ui5-dialog id="dialog" stretch header-heading="Wizard">
 		<ui5-wizard id="wiz2">
-			<ui5-wizard-step icon="sap-icon://home" heading="Product type">
+			<ui5-wizard-step icon="sap-icon://home" title-text="Product type">
 				<div style="display: flex; min-height: 200px; flex-direction: column;">
 					<ui5-title>1. Product Type</ui5-title><br>
 
@@ -569,7 +569,7 @@
 				<ui5-button id="toStep22" design="Emphasized">Step 2</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step heading="Product Information" selected>
+			<ui5-wizard-step title-text="Product Information" selected>
 				<div style="display: flex;flex-direction: column">
 					<ui5-title>2. Product Information</ui5-title><br>
 					<ui5-label wrap>
@@ -606,7 +606,7 @@
 				<ui5-button id="toStep32" design="Emphasized" hidden>Step 3</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step heading="Options" disabled>
+			<ui5-wizard-step title-text="Options" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>3. Options</ui5-title><br>
 
@@ -647,7 +647,7 @@
 				<ui5-button id="toStep42" design="Emphasized" hidden>Step 4</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step heading="Pricing" disabled>
+			<ui5-wizard-step title-text="Pricing" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>4. Pricing</ui5-title><br>
 					<ui5-label wrap>

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -48,7 +48,7 @@
 			<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subheading="(Optional)" disabled>
+		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -174,7 +174,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subheading="(Optional)" disabled>
+		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -328,7 +328,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subheading="(Optional)" selected disabled>
+		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" selected disabled>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>
@@ -449,7 +449,7 @@
 			</div>
 		</ui5-wizard-step>
 
-		<ui5-wizard-step heading="Product Information" subheading="(Optional)" selected>
+		<ui5-wizard-step heading="Product Information" subtitle-text="(Optional)" selected>
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrap>

--- a/packages/fiori/test/pages/Wizard_test.html
+++ b/packages/fiori/test/pages/Wizard_test.html
@@ -30,7 +30,7 @@
 
 	<div class="stretch">
 		<ui5-wizard id="wizTest">
-			<ui5-wizard-step id="st1" icon="sap-icon://product" selected heading="Product type">
+			<ui5-wizard-step id="st1" icon="sap-icon://product" selected title-text="Product type">
 				<div style="display: flex; min-height: 200px; flex-direction: column;">
 					<ui5-title>1. Product Type</ui5-title><br>
 
@@ -58,7 +58,7 @@
 				<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step  id="st2" heading="Product Information" disabled>
+			<ui5-wizard-step  id="st2" title-text="Product Information" disabled>
 				<div style="display: flex;flex-direction: column">
 					<ui5-title>2. Product Information</ui5-title><br>
 					<ui5-label wrap>
@@ -101,7 +101,7 @@
 				<ui5-button id="toStep3" design="Emphasized">Step 3</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step  id="st3" heading="Options" disabled>
+			<ui5-wizard-step  id="st3" title-text="Options" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>3. Options</ui5-title><br>
 
@@ -145,7 +145,7 @@
 				<ui5-button id="toStep4" design="Emphasized">Step 4</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step  id="st4" heading="Pricing" disabled>
+			<ui5-wizard-step  id="st4" title-text="Pricing" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>4. Pricing</ui5-title><br>
 					<ui5-label wrap>
@@ -179,7 +179,7 @@
 
 		<ui5-dialog id="dialog" stretch header-heading="Wizard">
 				<ui5-wizard id="wizInDialog">
-					<ui5-wizard-step icon="sap-icon://product" selected heading="Product type">
+					<ui5-wizard-step icon="sap-icon://product" selected title-text="Product type">
 						<div style="display: flex; min-height: 200px; flex-direction: column;">
 							<ui5-title>1. Product Type</ui5-title><br>
 
@@ -196,7 +196,7 @@
 						<ui5-button id="toStep2InDialog" design="Emphasized">Step 2</ui5-button>
 					</ui5-wizard-step>
 
-					<ui5-wizard-step heading="Product Information">
+					<ui5-wizard-step title-text="Product Information">
 						<div style="display: flex;flex-direction: column">
 							<ui5-title>2. Product Information</ui5-title><br>
 							<ui5-label wrap>
@@ -237,7 +237,7 @@
 						<ui5-button id="toStep3InDialog" design="Emphasized">Step 3</ui5-button>
 					</ui5-wizard-step>
 
-					<ui5-wizard-step heading="Options">
+					<ui5-wizard-step title-text="Options">
 						<div style="display: flex; flex-direction: column;">
 							<ui5-title>3. Options</ui5-title><br>
 
@@ -278,7 +278,7 @@
 						<ui5-button id="toStep4InDialog" design="Emphasized">Step 4</ui5-button>
 					</ui5-wizard-step>
 
-					<ui5-wizard-step heading="Pricing">
+					<ui5-wizard-step title-text="Pricing">
 						<div style="display: flex; flex-direction: column;">
 							<ui5-title>4. Pricing</ui5-title><br>
 							<ui5-label wrap>

--- a/packages/fiori/test/pages/Wizard_test_mobile.html
+++ b/packages/fiori/test/pages/Wizard_test_mobile.html
@@ -29,7 +29,7 @@
 	<div class="stretch" style="width: 400px;">
 		<div style="display: flex; flex-direction: row;">
 			<ui5-wizard id="wizTest">
-				<ui5-wizard-step icon="sap-icon://product" heading="Product type">
+				<ui5-wizard-step icon="sap-icon://product" title-text="Product type">
 					<div style="display: flex; min-height: 200px; flex-direction: column;">
 						<ui5-title>1. Product Type</ui5-title><br>
 						<ui5-messagestrip>
@@ -38,7 +38,7 @@
 					</div>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Product Information">
+				<ui5-wizard-step title-text="Product Information">
 					<div style="display: flex;flex-direction: column">
 						<ui5-title>2. Product Information</ui5-title><br>
 						<ui5-label wrap>
@@ -47,7 +47,7 @@
 					</div>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Options">
+				<ui5-wizard-step title-text="Options">
 						<ui5-title>3. Options</ui5-title><br>
 						<ui5-label wrap>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -57,7 +57,7 @@
 						</ui5-messagestrip><br>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Pricing" selected>
+				<ui5-wizard-step title-text="Pricing" selected>
 						<ui5-title>4. Pricing</ui5-title><br>
 						<ui5-label wrap>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -69,7 +69,7 @@
 			</ui5-wizard>
 
 			<ui5-wizard id="wizTest2">
-				<ui5-wizard-step icon="sap-icon://product" heading="Product type" disabled>
+				<ui5-wizard-step icon="sap-icon://product" title-text="Product type" disabled>
 					<div style="display: flex; min-height: 200px; flex-direction: column;">
 						<ui5-title>1. Product Type</ui5-title><br>
 						<ui5-messagestrip>
@@ -78,7 +78,7 @@
 					</div>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Product Information" disabled>
+				<ui5-wizard-step title-text="Product Information" disabled>
 					<div style="display: flex;flex-direction: column">
 						<ui5-title>2. Product Information</ui5-title><br>
 						<ui5-label wrap>
@@ -87,7 +87,7 @@
 					</div>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Options" disabled>
+				<ui5-wizard-step title-text="Options" disabled>
 						<ui5-title>3. Options</ui5-title><br>
 						<ui5-label wrap>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -97,7 +97,7 @@
 						</ui5-messagestrip><br>
 				</ui5-wizard-step>
 	
-				<ui5-wizard-step heading="Pricing" selected>
+				<ui5-wizard-step title-text="Pricing" selected>
 						<ui5-title>4. Pricing</ui5-title><br>
 						<ui5-label wrap>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien

--- a/packages/fiori/test/samples/Wizard.sample.html
+++ b/packages/fiori/test/samples/Wizard.sample.html
@@ -27,7 +27,7 @@
 
 	<div class="snippet">
 		<ui5-wizard id="wiz">
-			<ui5-wizard-step icon="product" heading="Product type" selected>
+			<ui5-wizard-step icon="product" title-text="Product type" selected>
 				<div style="display: flex; min-height: 200px; flex-direction: column;">
 					<ui5-title>1. Product Type</ui5-title><br>
 
@@ -42,7 +42,7 @@
 				<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="hint" heading="Product Information" disabled>
+			<ui5-wizard-step icon="hint" title-text="Product Information" disabled>
 				<div style="display: flex;flex-direction: column">
 					<ui5-title>2. Product Information</ui5-title><br>
 					<ui5-label wrap>
@@ -79,7 +79,7 @@
 				<ui5-button id="toStep3" design="Emphasized" hidden>Step 3</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="action-settings" heading="Options" disabled>
+			<ui5-wizard-step icon="action-settings" title-text="Options" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>3. Options</ui5-title><br>
 
@@ -120,7 +120,7 @@
 				<ui5-button id="toStep4" design="Emphasized" hidden>Step 4</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="lead" heading="Pricing" disabled>
+			<ui5-wizard-step icon="lead" title-text="Pricing" disabled>
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>4. Pricing</ui5-title><br>
 					<ui5-label wrap>
@@ -209,14 +209,14 @@
 
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-wizard id="wiz">
-	<ui5-wizard-step icon="product" heading="Product type" selected>
+	<ui5-wizard-step icon="product" title-text="Product type" selected>
 		<ui5-title>1. Product Type</ui5-title>
 
 		<!-- Move to step 2 -->
 		<ui5-button id="toStep2">Step 2</ui5-button>
 	</ui5-wizard-step>
 
-	<ui5-wizard-step icon="hint" heading="Product Information" disabled>
+	<ui5-wizard-step icon="hint" title-text="Product Information" disabled>
 		<ui5-title>2. Product Information</ui5-title>
 
 		<div>
@@ -228,7 +228,7 @@
 		<ui5-button id="toStep3" hidden>Step 3</ui5-button>
 	</ui5-wizard-step>
 
-	<ui5-wizard-step icon="action-settings" heading="Options" disabled>
+	<ui5-wizard-step icon="action-settings" title-text="Options" disabled>
 		<ui5-title>3. Options</ui5-title><br>
 
 		<ui5-segmentedbutton id="sb">
@@ -241,7 +241,7 @@
 		<ui5-button id="toStep4" hidden>Step 4</ui5-button>
 	</ui5-wizard-step>
 
-	<ui5-wizard-step icon="lead" heading="Pricing" disabled>
+	<ui5-wizard-step icon="lead" title-text="Pricing" disabled>
 		<ui5-title>4. Pricing</ui5-title><br>
 		<ui5-button id="finalize">Finalize</ui5-button>
 	</ui5-wizard-step>


### PR DESCRIPTION
Part of #3107

BREAKING_CHANGE: heading/subheading properties of WizardStep are renamed to titleText/subtitleText
