### PR TITLE
refactor(ui5-tabcontainer): deprecate tabsPlacement

### DIFF
--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -115,7 +115,7 @@ const metadata = {
 		 * @type {TabContainerTabsPlacement}
 		 * @defaultvalue "Top"
 		 * @since 1.0.0-rc.7
-		 * @public
+		 * @private
 		 */
 		tabsPlacement: {
 			type: TabContainerTabsPlacement,

--- a/packages/main/src/types/TabContainerTabsPlacement.js
+++ b/packages/main/src/types/TabContainerTabsPlacement.js
@@ -2,19 +2,19 @@ import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
 
 /**
  * @lends sap.ui.webcomponents.main.types.TabContainerTabsPlacement.prototype
- * @public
+ * @private
  */
 const TabContainerTabsPlacements = {
 	/**
 	 * The tab strip is displayed above the tab content (Default)
-	 * @public
+	 * @private
 	 * @type {Top}
 	 */
 	Top: "Top",
 
 	/**
 	 * The tab strip is displayed below the tab content
-	 * @public
+	 * @private
 	 * @type {Bottom}
 	 */
 	Bottom: "Bottom",
@@ -26,7 +26,7 @@ const TabContainerTabsPlacements = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.types.TabContainerTabsPlacement
- * @public
+ * @private
  * @enum {string}
  */
 class TabContainerTabsPlacement extends DataType {

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -362,53 +362,6 @@
 		</div>
 	</section>
 
-
-    <section>
-        <h2>tabs-placement=Bottom</h2>
-        <ui5-tabcontainer show-overflow tabs-placement="Bottom">
-            <ui5-tab icon="sap-icon://card" selected>
-                <ui5-button>Button 11</ui5-button>
-                <ui5-button>Button 12</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://menu2">
-                <ui5-button>Button 2</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://menu2">
-                <ui5-button>Button 2</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://menu2">
-                <ui5-button>Button 2</ui5-button>
-            </ui5-tab>
-            <ui5-tab icon="sap-icon://employee">
-                <ui5-button>Button 3</ui5-button>
-            </ui5-tab>
-        </ui5-tabcontainer>
-	</section>
-	
 	<section>
 		<h2>Tab Container With Custom Menu Button</h2>
 		<ui5-tabcontainer id="tabContainer-custom-icon" fixed collapsed show-overflow>


### PR DESCRIPTION
Hide the tabsPlacement, but keep it working for some time as it is consumed in production, until we introduce the feature  on stakeholder's side. Part of: https://github.com/SAP/ui5-webcomponents/issues/3107

BREAKING_CHANGE: tabsPlacement has been removed as it is not specified in SAP Fiori 3 design system