### PR TITLE
fix: build error on MacOS 11 from rollup-plugin-terser

### DIFF
--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -106,7 +106,9 @@ const getPlugins = ({ transpile }) => {
 	plugins.push(nodeResolve());
 
 	if (!process.env.DEV) {
-		plugins.push(terser());
+		plugins.push(terser({
+			numWorkers: 1,
+		}));
 	}
 
 	if (process.env.DEV) {


### PR DESCRIPTION
revert of revert of https://github.com/SAP/ui5-webcomponents/pull/2515 :D 