### PR TITLE
refactor(ui5-input): remove highlight property

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -138,7 +138,7 @@ const metadata = {
 		 *
 		 * @type {boolean}
 		 * @defaultvalue false
-		 * @public
+		 * @private
 		 * @sicne 1.0.0-rc.8
 		 */
 		highlight: {
@@ -814,13 +814,13 @@ class Input extends UI5Element {
 
 	enableSuggestions() {
 		if (this.Suggestions) {
-			this.Suggestions.highlight = this.highlight;
 			return;
 		}
 
 		const Suggestions = getFeature("InputSuggestions");
+
 		if (Suggestions) {
-			this.Suggestions = new Suggestions(this, "suggestionItems", this.highlight);
+			this.Suggestions = new Suggestions(this, "suggestionItems", true);
 		} else {
 			throw new Error(`You have to import "@ui5/webcomponents/dist/features/InputSuggestions.js" module to use ui5-input suggestions`);
 		}

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -26,7 +26,7 @@
 			style="width: 500px"
 			show-suggestions
 			placeholder="Search for a country ..."
-			highlight>
+		>
 		</ui5-input>
 	</div>
 
@@ -63,7 +63,7 @@
 	</ui5-input>
 
 	<h3>Input suggestions with highlighing</h3>
-	<ui5-input id="myInputHighlighted" highlight show-suggestions style="width: 100%">
+	<ui5-input id="myInputHighlighted" show-suggestions style="width: 100%">
 		<ui5-suggestion-item text="Adam D" description="Administrative Support"></ui5-suggestion-item>
 		<ui5-suggestion-item text="Aanya Sing" description="Administrative Support"></ui5-suggestion-item>
 		<ui5-suggestion-item text="Allen K" description="Technical Support"></ui5-suggestion-item>
@@ -288,7 +288,7 @@
 	<ui5-input aria-labelledby="enterNameLabel"></ui5-input>
 
 	<h3>Input suggestions with highlighing and XSS test</h3>
-	<ui5-input highlight show-suggestions style="width: 100%">
+	<ui5-input show-suggestions style="width: 100%">
 		<ui5-suggestion-item text="<script>alert('XSS')</script>" description="Administrative Support"></ui5-suggestion-item>
 		<ui5-suggestion-item text="Aanya Sing" description="<b onmouseover=alert('XSS')></b>">
 		</ui5-suggestion-item>


### PR DESCRIPTION
All inputs by Fiori Specification should highlight
matching suggestions.

BREAKING CHANGE: highlight property is removed and the feature is enabled by default
