### PR TITLE
fix(ui5-popover): rename noArrow property to hideArrow

### DIFF
--- a/packages/fiori/src/NotifactionOverflowActionsPopover.hbs
+++ b/packages/fiori/src/NotifactionOverflowActionsPopover.hbs
@@ -2,7 +2,7 @@
 	class="ui5-notification-overflow-popover"
 	placement-type="Bottom"
 	horizontal-align="Right"
-	no-arrow
+	hide-arrow
 >
 	<div class="ui5-notification-overflow-list">
 		{{#each overflowActions}}

--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -13,7 +13,7 @@
 <ui5-popover class="ui5-shellbar-overflow-popover"
 	placement-type="Bottom"
 	horizontal-align="{{popoverHorizontalAlign}}"
-	no-arrow
+	hide-arrow
 	@ui5-before-open={{_overflowPopoverBeforeOpen}}
 	@ui5-after-close={{_overflowPopoverAfterClose}}
 >

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -1,5 +1,5 @@
 <ui5-responsive-popover
-	no-arrow
+	hide-arrow
 	content-only-on-desktop
 	_disable-initial-focus
 	placement-type="Bottom"
@@ -95,7 +95,7 @@
 		_disable-initial-focus
 		prevent-focus-restore
 		no-padding
-		no-arrow
+		hide-arrow
 		class="ui5-valuestatemessage-popover"
 		placement-type="Bottom"
 	>

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -5,7 +5,7 @@
 	placement-type="Bottom"
 	horizontal-align="Left"
 	?disable-scrolling="{{_isIE}}"
-	no-arrow
+	hide-arrow
 	with-padding
 	no-stretch
 	?_hide-header={{_shouldHideHeader}}

--- a/packages/main/src/FileUploaderPopover.hbs
+++ b/packages/main/src/FileUploaderPopover.hbs
@@ -3,7 +3,7 @@
 	_disable-initial-focus
 	prevent-focus-restore
 	no-padding
-	no-arrow
+	hide-arrow
 	class="ui5-valuestatemessage-popover"
 	placement-type="Bottom"
 	horizontal-align="Left"

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -1,6 +1,6 @@
 {{#if showSuggestions}}
 	<ui5-responsive-popover
-		no-arrow
+		hide-arrow
 		_disable-initial-focus
 		placement-type="Bottom"
 		horizontal-align="Left"
@@ -68,7 +68,7 @@
 			_disable-initial-focus
 			prevent-focus-restore
 			no-padding
-			no-arrow
+			hide-arrow
 			class="ui5-valuestatemessage-popover"
 			placement-type="Bottom"
 			horizontal-align="Left"

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -2,7 +2,7 @@
 	placement-type="Bottom"
 	horizontal-align="Left"
 	class="ui5-multi-combobox-all-items-responsive-popover"
-	no-arrow
+	hide-arrow
 	_disable-initial-focus
 	@ui5-selection-change={{_listSelectionChange}}
 	@ui5-after-close={{_toggle}}
@@ -95,7 +95,7 @@
 		_disable-initial-focus
 		prevent-focus-restore
 		no-padding
-		no-arrow
+		hide-arrow
 		class="ui5-valuestatemessage-popover"
 		placement-type="Bottom"
 		horizontal-align="Left"

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -127,7 +127,7 @@ const metadata = {
 		 * @defaultvalue false
 		 * @public
 		 */
-		noArrow: {
+		hideArrow: {
 			type: Boolean,
 		},
 
@@ -498,7 +498,7 @@ class Popover extends Popup {
 		this._width = width;
 		this._height = height;
 
-		const arrowOffset = this.noArrow ? 0 : arrowSize;
+		const arrowOffset = this.hideArrow ? 0 : arrowSize;
 
 		// calc popover positions
 		switch (placementType) {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -126,6 +126,7 @@ const metadata = {
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
+		 * @since 1.0.0-rc.15
 		 */
 		hideArrow: {
 			type: Boolean,

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -1,6 +1,6 @@
 {{#if options}}
 	<ui5-responsive-popover
-		no-arrow
+		hide-arrow
 		_disable-initial-focus
 		content-only-on-desktop
 		placement-type="Bottom"
@@ -67,7 +67,7 @@
 		_disable-initial-focus
 		prevent-focus-restore
 		no-padding
-		no-arrow
+		hide-arrow
 		class="ui5-valuestatemessage-popover"
 		placement-type="Bottom"
 	>

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -4,7 +4,7 @@
 	placement-type="Bottom"
 	content-only-on-desktop
 	with-padding
-	no-arrow
+	hide-arrow
 	_hide-header
 >
 	<ui5-list @ui5-item-press="{{_onOverflowListItemSelect}}">

--- a/packages/main/src/TextAreaPopover.hbs
+++ b/packages/main/src/TextAreaPopover.hbs
@@ -3,7 +3,7 @@
 		skip-registry-update
 		prevent-focus-restore
 		no-padding
-		no-arrow
+		hide-arrow
 		_disable-initial-focus
 		class="ui5-valuestatemessage-popover"
 		style="{{styles.valueStateMsgPopover}}"

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -5,7 +5,7 @@
 	horizontal-align="Left"
 	allow-target-overlap
 	_hide-header
-	no-arrow
+	hide-arrow
 	no-stretch
 	stay-open-on-scroll
 	@ui5-after-close="{{onResponsivePopoverAfterClose}}"

--- a/packages/main/src/TokenizerPopover.hbs
+++ b/packages/main/src/TokenizerPopover.hbs
@@ -3,7 +3,7 @@
 	style={{styles.popover}}
 	header-text={{morePopoverTitle}}
 	?content-only-on-desktop="{{hasValueState}}"
-	no-arrow
+	hide-arrow
 	placement-type="Bottom"
 	horizontal-align="Left"
 >

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -81,6 +81,6 @@
 	margin: .1875rem -.375rem 0 0;
 }
 
-:host([no-arrow]) .ui5-popover-arrow {
+:host([hide-arrow]) .ui5-popover-arrow {
 	display: none;
 }

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -329,7 +329,7 @@
 		</div>
 	</ui5-popover>
 
-	<ui5-dialog placement-type="Bottom" no-arrow id='danger'>
+	<ui5-dialog placement-type="Bottom" id='danger'>
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>World</ui5-li>

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -33,7 +33,7 @@
 		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
 	</ui5-input>
 
-	<ui5-popover id="quickViewCard" no-arrow placement-type="Right" height="500px" prevent-focus-restore>
+	<ui5-popover id="quickViewCard" hide-arrow placement-type="Right" height="500px" prevent-focus-restore>
 		<button>hello</button>
 		<ui5-input id="searchInput" style="width: 300px">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
@@ -78,7 +78,7 @@
 	<div style="width: 200px">Test mouseover on item</div>
 	<ui5-input id="mouseoverResult" style="width: 100%"></ui5-input>
 
-	<ui5-popover id="quickViewCard2" no-arrow placement-type="Right" height="500px">
+	<ui5-popover id="quickViewCard2" hide-arrow placement-type="Right" height="500px">
 		<ui5-input id="searchInput2" style="width: 300px">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -76,7 +76,7 @@
 
 		<ui5-button id="popbtn">Open Popover</ui5-button>
 
-		<ui5-popover placement-type="Bottom" no-arrow id="danger">
+		<ui5-popover placement-type="Bottom" hide-arrow id="danger">
 
 
 			<ui5-list>

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -62,7 +62,7 @@
 		<content id="popover"></content>
 	</div>
 
-	<ui5-popover placement-type="Bottom" horizontal-align="Stretch" no-arrow initial-focus="input1" class="wcPopoverWithList">
+	<ui5-popover placement-type="Bottom" horizontal-align="Stretch" hide-arrow initial-focus="input1" class="wcPopoverWithList">
 		<ui5-list id="myList" indent separators="Inner" mode="MultiSelect" footer-text="Copyright" no-data-text="No data">
 			<!-- Header -->
 			<div style="display: flex; align-items: center;" slot="header">

--- a/packages/main/test/samples/ColorPalette.sample.html
+++ b/packages/main/test/samples/ColorPalette.sample.html
@@ -91,7 +91,7 @@
 			header-text="Pick a color"
 			placement-type="Bottom"
 			horizontal-align="Left"
-			no-arrow>
+			hide-arrow>
 				<ui5-color-palette id="colorPaletteInPopover" show-more-colors>
 					<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 					<ui5-color-palette-item value="pink"></ui5-color-palette-item>

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -23,7 +23,7 @@ describe("Attributes propagation", () => {
 		assert.ok(popover.shadow$(".ui5-popover-arrow").isDisplayedInViewport(), "Initially popover has arrow.");
 
 		browser.execute(() => {
-			document.getElementById("pop").toggleAttribute("no-arrow");
+			document.getElementById("pop").toggleAttribute("hide-arrow");
 		});
 
 		assert.ok(!popover.shadow$(".ui5-popover-arrow").isDisplayedInViewport(), "The arrow was hidden.");


### PR DESCRIPTION
Part of #3107 

BREAKING_CHANGE: rename ```noArrow``` property to ```hideArrow```