### PR TITLE
fix(ui5-flexible-column-layout): rename noArrows property to hideArrows

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -77,6 +77,7 @@ const metadata = {
 		* @type {boolean}
 		* @defaultvalue false
 		* @public
+		* @since 1.0.0-rc.15
 		*/
 		hideArrows: {
 			type: Boolean,

--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -78,7 +78,7 @@ const metadata = {
 		* @defaultvalue false
 		* @public
 		*/
-		noArrows: {
+		hideArrows: {
 			type: Boolean,
 		},
 
@@ -592,11 +592,11 @@ class FlexibleColumnLayout extends UI5Element {
 	}
 
 	get showStartArrow() {
-		return this.noArrows ? false : this.startArrowVisibility;
+		return this.hideArrows ? false : this.startArrowVisibility;
 	}
 
 	get showEndArrow() {
-		return this.noArrows ? false : this.endArrowVisibility;
+		return this.hideArrows ? false : this.endArrowVisibility;
 	}
 
 	get startArrowVisibility() {

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -227,11 +227,11 @@
 
 	<!-- ex2 -->
 	<br><br>
-	<ui5-title class="sectionTitle">Master-Detail: Detail expanded + no-arrows</ui5-title>
+	<ui5-title class="sectionTitle">Master-Detail: Detail expanded + hide-arrows</ui5-title>
 	<ui5-toggle-button id="switchBtn2" class="testButton">Set to TwoColumnsMidExpanded</ui5-toggle-button>
 	<br><br>
 
-	<ui5-flexible-column-layout id="fcl2" layout="TwoColumnsMidExpanded" no-arrows>
+	<ui5-flexible-column-layout id="fcl2" layout="TwoColumnsMidExpanded" hide-arrows>
 			<!-- start column -->
 			<div style="box-sizing: border-box;" slot="startColumn">
 				<div style="padding: 1rem">


### PR DESCRIPTION
Part of #3107 

BREAKING_CHANGE: rename ```noArrows``` property to ```hideArrows```