### PR TITLE
fix(ui5-popover): Calculate max content height

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -562,7 +562,7 @@ class Popover extends Popup {
 			}
 		}
 
-		this._maxContentHeight = maxContentHeight;
+		this._maxContentHeight = maxContentHeight - Popover.MIN_OFFSET;
 
 		const arrowPos = this.getArrowPosition(targetRect, popoverSize, left, top, isVertical);
 


### PR DESCRIPTION
Resolves https://github.com/SAP/ui5-webcomponents/issues/3131

This fix steps on the following commit: https://github.com/SAP/ui5-webcomponents/commit/e35cc1ae9f3830fa137b3d683dc10481e13743f4

It enhances it in a way that Popover.MIN_OFFSET is taken into account into Popover's maxContentHeight. Popover.MIN_OFFSET is used when calculating the offset of the Popover from the top but has never been extracted from the content's height.