### PR TITLE
fix(ui5-responsive-popover): fix public methods

### DIFF
--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -120,7 +120,7 @@ class ResponsivePopover extends Popover {
 	 * @async
 	 * @returns {Promise} Resolves when the responsive popover is open
 	 */
-	async open(opener) {
+	async openBy(opener) {
 		this.style.display = this._isPhone ? "contents" : "";
 
 		if (this.isOpen() || (this._dialog && this._dialog.isOpen())) {
@@ -133,7 +133,7 @@ class ResponsivePopover extends Popover {
 				this._minWidth = Math.max(POPOVER_MIN_WIDTH, opener.getBoundingClientRect().width);
 			}
 
-			await this.openBy(opener);
+			await super.openBy(opener);
 		} else {
 			this.style.zIndex = getNextZIndex();
 			await this._dialog.open();

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -101,21 +101,21 @@
 
 	<script>
 		btnOpen.addEventListener("click", function(event) {
-			respPopover.open(btnOpen);
+			respPopover.openBy(btnOpen);
 		});
 		btnClose.addEventListener("click", function(event) {
 			respPopover.close();
 		});
 
 		btnOpen2.addEventListener("click", function(event) {
-			respPopover2.open(btnOpen2);
+			respPopover2.openBy(btnOpen2);
 		});
 		btnClose2.addEventListener("click", function(event) {
 			respPopover2.close();
 		});
 
 		btnOpen3.addEventListener("click", function(event) {
-			respPopover3.open(btnOpen3);
+			respPopover3.openBy(btnOpen3);
 		});
 		btnClose3.addEventListener("click", function(event) {
 			respPopover3.close();
@@ -125,7 +125,7 @@
 		});
 
 		btnSimpleRP.addEventListener("click", function(event) {
-			simpleRP.open(btnSimpleRP);
+			simpleRP.openBy(btnSimpleRP);
 		});
 	</script>
 </body>

--- a/packages/main/test/samples/ResponsivePopover.sample.html
+++ b/packages/main/test/samples/ResponsivePopover.sample.html
@@ -31,7 +31,7 @@
 			var popoverCloser = document.getElementById("closePopoverButton");
 
 			popoverOpener.addEventListener("click", function() {
-				popover.open(popoverOpener);
+				popover.openBy(popoverOpener);
 			});
 			popoverCloser.addEventListener("click", function() {
 				popover.close();
@@ -61,7 +61,7 @@
 	var popoverCloser = document.getElementById("closePopoverButton");
 
 	popoverOpener.addEventListener("click", function() {
-		popover.open(popoverOpener);
+		popover.openBy(popoverOpener);
 	});
 	popoverCloser.addEventListener("click", function() {
 		popover.close();


### PR DESCRIPTION
Part of #3107

BREAKING_CHANGE: ```open``` method of ui5-responsive-popover is depreacted in favour of ```openBy```method