### PR TITLE
refactor(ui5-checkbox): replace `wrap` with `wrappingType`

### DIFF
--- a/packages/main/src/CheckBox.hbs
+++ b/packages/main/src/CheckBox.hbs
@@ -29,8 +29,8 @@
 			/>
 		</div>
 
-		{{#if _label.text}}
-			<ui5-label id="{{_id}}-label" class="ui5-checkbox-label" wrapping-type="{{_label.wrappingType}}">{{_label.text}}</ui5-label>
+		{{#if text}}
+			<ui5-label id="{{_id}}-label" class="ui5-checkbox-label" wrapping-type="{{wrappingType}}">{{text}}</ui5-label>
 		{{/if}}
 
 		{{#if hasValueState}}

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -130,14 +130,19 @@ const metadata = {
 		/**
 		 * Defines whether the component text wraps when there is not enough space.
 		 * <br><br>
-		 * <b>Note:</b> By default, the text truncates when there is not enough space.
+		 * Available options are:
+		 * <ul>
+		 * <li><code>None</code> - The text will be truncated with an ellipsis.</li>
+		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
+		 * </ul>
 		 *
-		 * @type {boolean}
-		 * @defaultvalue false
+		 * @type {WrappingType}
+		 * @defaultvalue "None"
 		 * @public
 		 */
-		wrap: {
-			type: Boolean,
+		 wrappingType: {
+			type: WrappingType,
+			defaultValue: WrappingType.None,
 		},
 
 		/**
@@ -183,10 +188,6 @@ const metadata = {
 			type: String,
 			defaultValue: "",
 		},
-
-		_label: {
-			type: Object,
-		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.CheckBox.prototype */ {
 
@@ -230,7 +231,7 @@ const metadata = {
  * <h3>Usage</h3>
  *
  * You can define the checkbox text with via the <code>text</code> property. If the text exceeds the available width, it is truncated by default.
- * In case you prefer text to wrap, use the <code>wrap</code> property.
+ * In case you prefer text to wrap, set the <code>wrappingType</code> property to "Normal".
  * The touchable area for toggling the <code>ui5-checkbox</code> ends where the text ends.
  * <br><br>
  * You can disable the <code>ui5-checkbox</code> by setting the <code>disabled</code> property to
@@ -278,23 +279,11 @@ class CheckBox extends UI5Element {
 	constructor() {
 		super();
 
-		this._label = {};
 		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
 	}
 
 	onBeforeRendering() {
-		this.syncLabel();
-
 		this._enableFormSupport();
-	}
-
-	syncLabel() {
-		this._label = { ...this._label };
-		this._label.text = this.text;
-		/* temporary workaround. remove after all wrap properties in the relevant components are renamed to wrappingType */
-		this._label.wrappingType = this.wrap ? WrappingType.Normal : WrappingType.None;
-		/* end */
-		this._label.textDirection = this.textDirection;
 	}
 
 	_enableFormSupport() {

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -23,7 +23,7 @@
 }
 
 /* wrap */
-:host([wrap][text]) .ui5-checkbox-root {
+:host([wrapping-type="Normal"][text]) .ui5-checkbox-root {
 	min-height: auto;
 	box-sizing: border-box;
 	align-items: flex-start;
@@ -31,17 +31,17 @@
 	padding-bottom: var(--_ui5_checkbox_root_side_padding);
 }
 
-:host([wrap][text]) .ui5-checkbox-root .ui5-checkbox-inner,
-:host([wrap][text]) .ui5-checkbox-root .ui5-checkbox-label {
+:host([wrapping-type="Normal"][text]) .ui5-checkbox-root .ui5-checkbox-inner,
+:host([wrapping-type="Normal"][text]) .ui5-checkbox-root .ui5-checkbox-label {
 	margin-top: var(--_ui5_checkbox_wrapped_content_margin_top);
 }
 
-:host([wrap][text]) .ui5-checkbox-root .ui5-checkbox-label {
+:host([wrapping-type="Normal"][text]) .ui5-checkbox-root .ui5-checkbox-label {
 	word-break: break-all;
 	align-self: center;
 }
 
-:host([wrap]) .ui5-checkbox-root:focus::before {
+:host([wrapping-type="Normal"]) .ui5-checkbox-root:focus::before {
 	bottom: var(--_ui5_checkbox_wrapped_focus_left_top_bottom_position);
 }
 

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -21,19 +21,24 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-	<ui5-checkbox id="cb1" text="Long long long text"></ui5-checkbox>
+	<ui5-checkbox></ui5-checkbox>
 	<ui5-checkbox id="cbError" value-state="Error"></ui5-checkbox>
-	<ui5-checkbox id="cb2" disabled></ui5-checkbox>
 	<ui5-checkbox id="truncatingCb" text="Long long long text that should truncate at some point" style="width: 300px"></ui5-checkbox>
-	<ui5-checkbox id="wrappingCb" wrap class="ui5-cb-testing-wrap" text="Longest ever text written in English that have to truncate immediately because it is so long of course!" style="width: 300px"></ui5-checkbox>
+	<ui5-checkbox text="Long long long text that should truncate at some point"></ui5-checkbox>
+
+	<br><br>
+	<ui5-title>Text Wrapping</ui5-title>
+	<ui5-checkbox id="wrappingCb" wrapping-type="Normal" class="ui5-cb-testing-wrap" text="Longest ever text written in English that have to wraps because it is so long of course!" style="width: 300px"></ui5-checkbox>
+	<ui5-checkbox wrapping-type="Normal" text="Longest ever text written in English that wraps because it's too long of course!" style="width: 300px"></ui5-checkbox>
+
+	<br><br>
+	<ui5-title>Change Event Test</ui5-title>
+	<ui5-checkbox id="cb1" text="Long long long text"></ui5-checkbox>
+	<ui5-checkbox id="cb2" disabled></ui5-checkbox>
 	<ui5-input id="field"></ui5-input>
 
-	<ui5-checkbox></ui5-checkbox>
-	<ui5-checkbox text="Long long long text that should truncate at some point"></ui5-checkbox>
-	<ui5-checkbox wrap text="Longest ever text written in English that have to truncate immediately because it is so long of course!"></ui5-checkbox>
-
 	<br>
-	<ui5-title>ACC test - aria-label</ui5-title>
+	<ui5-title>ACC Test - aria-label</ui5-title>
 	<ui5-checkbox id="accCb" aria-label="Hello world"></ui5-checkbox>
 	<br />
 	<ui5-checkbox value-state="Warning" text="Long long long text" indeterminate checked></ui5-checkbox>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -254,7 +254,7 @@
 		<section class="row row-centered">
 			<ui5-checkbox id="myCb1" checked text="Default"></ui5-checkbox>
 			<ui5-checkbox id="myCb2" read-only text="read only"></ui5-checkbox>
-			<ui5-checkbox id="myCb3" disabled wrap text="disabled long text might also wrap"></ui5-checkbox>
+			<ui5-checkbox id="myCb3" disabled wrapping-type="Normal" text="disabled long text might also wrap"></ui5-checkbox>
 			<ui5-checkbox id="myCb4" read-only text="read only" checked></ui5-checkbox>
 			<ui5-checkbox id="myCb5" disabled text="disabled" checked></ui5-checkbox>
 			<ui5-checkbox id="myCb6" value-state="Warning" checked text="warning"></ui5-checkbox>

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -227,7 +227,7 @@
 		<section class="row row-centered">
 			<ui5-checkbox id="myCb1" checked text="Default"></ui5-checkbox>
 			<ui5-checkbox id="myCb2" read-only text="read only"></ui5-checkbox>
-			<ui5-checkbox id="myCb3" disabled wrap text="disabled long text might also wrap"></ui5-checkbox>
+			<ui5-checkbox id="myCb3" disabled wrapping-type="Normal" text="disabled long text might also wrap"></ui5-checkbox>
 			<ui5-checkbox id="myCb4" read-only text="read only" checked></ui5-checkbox>
 			<ui5-checkbox id="myCb5" disabled text="disabled" checked></ui5-checkbox>
 			<ui5-checkbox id="myCb6" value-state="Warning" checked text="warning"></ui5-checkbox>

--- a/packages/main/test/samples/CheckBox.sample.html
+++ b/packages/main/test/samples/CheckBox.sample.html
@@ -70,12 +70,12 @@
 <section>
 	<h3>CheckBox with Text Wrapping</h3>
 	<div class="snippet">
-		<ui5-checkbox text="ui5-checkbox with 'wrap' set and some long text." wrap style="width:200px"></ui5-checkbox>
-		<ui5-checkbox text="Another ui5-checkbox with very long text here" wrap style="width:200px"></ui5-checkbox>
+		<ui5-checkbox text="ui5-checkbox with 'wrapping-type=Normal' set and some long text." wrapping-type="Normal" style="width:200px"></ui5-checkbox>
+		<ui5-checkbox text="Another ui5-checkbox with very long text here" wrapping-type="Normal" style="width:200px"></ui5-checkbox>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-checkbox text="ui5-checkbox with 'wrap' set and some long text." wrap style="width:200px"></ui5-checkbox>
-<ui5-checkbox text="Another ui5-checkbox with very long text here" wrap style="width:200px"></ui5-checkbox>
+<ui5-checkbox text="ui5-checkbox with 'wrapping-type=Normal' set and some long text." wrapping-type="Normal" style="width:200px"></ui5-checkbox>
+<ui5-checkbox text="Another ui5-checkbox with very long text here" wrapping-type="Normal" style="width:200px"></ui5-checkbox>
 	</xmp></pre>
 </section>
 

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -20,7 +20,7 @@ describe("CheckBox general interaction", () => {
 		checkBox.keys("Space");
 		checkBox.keys("Enter");
 
-		assert.strictEqual(field.getProperty("value"), "3", "Select event should be fired 3 times");
+		assert.strictEqual(field.getProperty("value"), "3", "Change event should be fired 3 times");
 	});
 
 	it("tests change event not fired, when disabled", () => {
@@ -31,7 +31,7 @@ describe("CheckBox general interaction", () => {
 		checkBox.keys("Space");
 		checkBox.keys("Enter");
 
-		assert.strictEqual(field.getProperty("value"), "3", "Select event should not be called any more");
+		assert.strictEqual(field.getProperty("value"), "3", "Change event should not be called any more");
 	});
 
 	it("tests truncating and wrapping", () => {


### PR DESCRIPTION
As part of https://github.com/SAP/ui5-webcomponents/issues/3107 we decided to replace the boolean property `wrap` as we expect to add a new type of wrapping (Hyphenated) and for this the string property from enum type is more suitable.

BREAKING_CHANGE: The boolean property `wrap` has been removed in favour of string prop `wrappingType`. If you previously used `wrap`, now set `wrappingType="Normal"` instead.
