### PR TITLE
fix(CheckBox): Prevent shifting of elements aligned with baseline when checking/unchecking

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -175,6 +175,7 @@ https://github.com/philipwalton/flexbugs/issues/231
 	height: var(--_ui5_checkbox_icon_size);
 	color: currentColor;
 	cursor: default;
+    position: absolute;
 }
 
 /* RTL */


### PR DESCRIPTION
This PR moves the icon inside the CheckBox outside of the flow, so it doesn't affect elements aligned with `baseline`.

See this codeSandbox for reference:
https://codesandbox.io/s/ui5-webcomponents-forked-fnmzi