### PR TITLE
fix(ui5-popup): scroll handle is now working for input controls

### DIFF
--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -6,7 +6,6 @@
 	aria-label="{{_ariaLabel}}"
 	aria-labelledby="{{_ariaLabelledBy}}"
 	dir="{{effectiveDir}}"
-	tabindex="-1"
 	@keydown={{_onkeydown}}
 	@focusout={{_onfocusout}}
 >

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -278,6 +278,7 @@ class Popup extends UI5Element {
 	_onfocusout(e) {
 		// relatedTarget is the element, which will get focus. If no such element exists, focus the root
 		if (!e.relatedTarget) {
+			this._root.tabIndex = -1;
 			this._root.focus();
 		}
 	}
@@ -334,6 +335,9 @@ class Popup extends UI5Element {
 			|| this._root; // in case of no focusable content focus the root
 
 		if (element) {
+			if(element === this._root) {
+				element.tabIndex = -1
+			}
 			element.focus();
 		}
 	}

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -335,8 +335,8 @@ class Popup extends UI5Element {
 			|| this._root; // in case of no focusable content focus the root
 
 		if (element) {
-			if(element === this._root) {
-				element.tabIndex = -1
+			if (element === this._root) {
+				element.tabIndex = -1;
 			}
 			element.focus();
 		}


### PR DESCRIPTION
tabIndex on the root element is set to "-1" if there are no focusable elements

Fixes #3330
