### PR TITLE
fix(inputs): use base CSS param for border-radius

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -14,7 +14,7 @@
 	font-style: normal;
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
-	border-radius: var(--_ui5_input_wrapper_border_radius);
+	border-radius: var(--sapField_BorderCornerRadius);
 	box-sizing: border-box;
 	line-height: normal;
 	letter-spacing: normal;

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -7,7 +7,7 @@
 	font-family: "72override", var(--sapFontFamily);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
-	border-radius: var(--_ui5_input_wrapper_border_radius);
+	border-radius: var(--sapField_BorderCornerRadius);
 	box-sizing: border-box;
 }
 

--- a/packages/main/src/themes/StepInput.css
+++ b/packages/main/src/themes/StepInput.css
@@ -10,7 +10,7 @@
 	color: var(--sapField_TextColor);
 	background-color: var(--sapField_Background);
 	border: 1px solid var(--sapField_BorderColor);
-	border-radius: var(--_ui5_input_wrapper_border_radius);
+	border-radius: var(--sapField_BorderCornerRadius);
 	box-sizing: border-box;
 	height: var(--_ui5_input_height);
 	position: relative;
@@ -39,7 +39,7 @@
 	left: -1px;
 	outline: none;
 	pointer-events: none;
-	border-radius: var(--_ui5_input_wrapper_border_radius);
+	border-radius: var(--sapField_BorderCornerRadius);
 	border-style: var(--_ui5_input_error_warning_border_style);
 	z-index: 3;
 	border-width: 0px;

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -11,7 +11,7 @@
 	font-family: "72override", var(--sapFontFamily);
 	font-style: normal;
 	border-color: var(--sapField_BorderColor);
-	border-radius: var(--_ui5_input_wrapper_border_radius);
+	border-radius: var(--sapField_BorderCornerRadius);
 	box-sizing: border-box;
 	line-height: 1.4;
 	letter-spacing: normal;

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -2,7 +2,6 @@
 	--_ui5_input_width: 13.125rem;
 	--_ui5_input_height: 2.5rem;
 	--_ui5_input_compact_height: 1.625rem;
-	--_ui5_input_wrapper_border_radius: 0;
 	--_ui5_input_state_border_width: 0.125rem;
 	--_ui5-input-information_border_width: 0.125rem;
 	--_ui5_input_error_font_weight: normal;

--- a/packages/main/src/themes/sap_fiori_3/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/Input-parameters.css
@@ -3,5 +3,4 @@
 :root {
 	--_ui5_input_height: 2.25rem;
 	--_ui5_input_disabled_opacity: 0.4;
-	--_ui5_input_wrapper_border_radius: 0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_dark/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/Input-parameters.css
@@ -3,5 +3,4 @@
 :root {
 	--_ui5_input_height: 2.25rem;
 	--_ui5_input_disabled_opacity: 0.4;
-	--_ui5_input_wrapper_border_radius: 0.125rem;
 }

--- a/packages/theme-base/css-vars-usage.json
+++ b/packages/theme-base/css-vars-usage.json
@@ -94,6 +94,7 @@
   "--sapField_Active_BorderColor",
   "--sapField_Background",
   "--sapField_BorderColor",
+  "--sapField_BorderCornerRadius",
   "--sapField_BorderWidth",
   "--sapField_Hover_Background",
   "--sapField_Hover_BorderColor",


### PR DESCRIPTION
There is a standard css variable `--sapField_BorderCornerRadius` meant to be used for Input's border radius. It is 0.125rem in sap_fiori_3 and sap_fiori_3_dark and 0 in all other themes. This allows changing the border radius of all inputs via the Theme Designer