### PR TITLE
feat(ui5-breadcrumbs): Initial implementation

### DIFF
--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -33,6 +33,7 @@ import "./dist/features/ColorPaletteMoreColors.js";
 import Avatar from "./dist/Avatar.js";
 import AvatarGroup from "./dist/AvatarGroup.js";
 import Badge from "./dist/Badge.js";
+import Breadcrumbs from "./dist/Breadcrumbs.js";
 import BusyIndicator from "./dist/BusyIndicator.js";
 import Button from "./dist/Button.js";
 import Card from "./dist/Card.js";

--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -1,0 +1,41 @@
+<nav class="ui5-breadcrumbs-root"
+    aria-label="{{_accessibleNameText}}"
+    aria-haspopup="{{_ariaHasPopup}}">
+    <ol @focusin="{{_onfocusin}}" 
+        @keydown="{{_onkeydown}}"
+		@keyup="{{_onkeyup}}">
+
+        <li class="ui5-breadcrumbs-overflow-opener"
+            ?hidden="{{_isOverflowEmpty}}">
+            <ui5-link @click="{{_toggleRespPopover}}"
+                aria-label="{{_overflowAccessibleNameText}}">
+                <ui5-icon name="slim-arrow-down"
+                    title="{{_overflowAccessibleNameText}}"></ui5-icon>
+            </ui5-link>
+        </li>
+
+        {{#each _nonOverflowingLinks}}
+            <li class="ui5-breadcrumbs-link-wrapper" @click="{{../_onLinkClick}}">
+                <slot name="{{this._individualSlot}}"></slot>
+            </li>
+        {{/each}}
+
+        {{#if _endsWithCurrentLocationLabel}}
+        <li class="ui5-breadcrumbs-current-location">
+            <ui5-label id="{{id}}-current-location"
+                wrapping-type="Normal"
+                aria-current="page">{{_endingLabelText}}
+            </ui5-label>
+        </li>
+        {{/if}}
+    </ol>
+    <!-- we still render the slots for the overflowing links in a hidden area
+    => we are able this way to monitor changes in their size and visibility  -->
+    <ol class="ui5-breadcrumbs-hidden-overflow">
+        {{#each _overflowingLinks}}
+            <li class="ui5-breadcrumbs-link-wrapper">
+                <slot name="{{this._individualSlot}}"></slot>
+            </li>
+        {{/each}}
+    </ol>
+</nav>

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -1,0 +1,520 @@
+import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import {
+	isSpace,
+	isShow,
+} from "@ui5/webcomponents-base/dist/Keys.js";
+import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
+import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import BreadcrumbsDesign from "./types/BreadcrumbsDesign.js";
+import BreadcrumbsSeparatorStyle from "./types/BreadcrumbsSeparatorStyle.js";
+
+// Template
+import BreadcrumbsTemplate from "./generated/templates/BreadcrumbsTemplate.lit.js";
+import BreadcrumbsPopoverTemplate from "./generated/templates/BreadcrumbsPopoverTemplate.lit.js";
+
+import {
+	BREADCRUMBS_ARIA_LABEL,
+	BREADCRUMBS_OVERFLOW_ARIA_LABEL,
+	BREADCRUMBS_CANCEL_BUTTON,
+} from "./generated/i18n/i18n-defaults.js";
+
+// Styles
+import breadcrumbsCss from "./generated/themes/Breadcrumbs.css.js";
+import breadcrumbsPopoverCss from "./generated/themes/BreadcrumbsPopover.css.js";
+
+/**
+ * @public
+ */
+const metadata = {
+	tag: "ui5-breadcrumbs",
+	managedSlots: true,
+	languageAware: true,
+	slots: /** @lends sap.ui.webcomponents.main.Breadcrumbs.prototype */ {
+
+		/**
+		 * Defines the links of the <code>ui5-breadcrumbs</code>.
+		 * <br><br>
+		 * <b>Note:</b> Use <code>ui5-link</code> component to define the required anchors.
+		 *
+		 * @type {HTMLElement[]}
+		 * @slot
+		 * @public
+		 */
+		"default": {
+			propertyName: "links",
+			type: HTMLElement,
+			individualSlots: true,
+			invalidateOnChildChange: {
+				properties: false,
+				slots: true,
+			},
+		},
+	},
+	properties: /** @lends  sap.ui.webcomponents.main.Breadcrumbs.prototype */ {
+
+		/**
+		 * Defines the visual indication and behavior of the breadcrumbs.
+		 * Available options are <code>Standard</code> (by default) and <code>NoCurrentPage</code>.
+		 * <br><br>
+		 * <b>Note:</b> The <code>Standard</code> breadcrumbs show the current page as the last item in the trail.
+		 * The last item contains only plain text and not a link.
+		 *
+		 * @type {BreadcrumbsDesign}
+		 * @defaultvalue "Standard"
+		 * @public
+		*/
+		design: {
+			type: BreadcrumbsDesign,
+			defaultValue: BreadcrumbsDesign.Standard,
+		},
+
+		/**
+		 * Determines the visual style of the separator between the Breadcrumbs elements.
+		 *
+		 * @type {BreadcrumbsSeparatorStyle}
+		 * @defaultvalue "Slash"
+		 * @public
+		 */
+		separatorStyle: {
+			type: BreadcrumbsSeparatorStyle,
+			defaultValue: BreadcrumbsSeparatorStyle.Slash,
+		},
+
+		/**
+		 * Defines the <code>ui5-breadcrumbs</code> current location text.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @private
+		 */
+		_endingLabelText: {
+			type: String,
+			noAttribute: true,
+			defaultValue: "",
+		},
+
+		/**
+		 * Holds the number of link-items in the overflow
+		 *
+		 * @type {string}
+		 * @defaultvalue "0"
+		 * @private
+		 */
+		_countLinksInOverflow: {
+			type: Integer,
+			noAttribute: true,
+			defaultValue: 0,
+		},
+
+	},
+	events: /** @lends  sap.ui.webcomponents.main.Breadcrumbs.prototype */ {
+
+		/**
+		 * Fired when a link is activated.
+		 *
+		 * @event sap.ui.webcomponents.main.Breadcrumbs#item-click
+		 * @param {HTMLElement} item The clicked item.
+		 * @public
+		 */
+		"link-click": {
+			detail: {
+				link: { type: HTMLElement },
+			},
+		},
+	},
+};
+
+/**
+ * @class
+ *
+ * <h3 class="comment-api-title">Overview</h3>
+ *
+ *
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.Breadcrumbs
+ * @extends UI5Element
+ * @tagname ui5-breadcrumbs
+ * @public
+ */
+class Breadcrumbs extends UI5Element {
+	static get metadata() {
+		return metadata;
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	static get template() {
+		return BreadcrumbsTemplate;
+	}
+
+	static get staticAreaTemplate() {
+		return BreadcrumbsPopoverTemplate;
+	}
+
+	static get styles() {
+		return breadcrumbsCss;
+	}
+
+	static get staticAreaStyles() {
+		return breadcrumbsPopoverCss;
+	}
+
+	constructor() {
+		super();
+		this.i18nBundle = getI18nBundle("@ui5/webcomponents");
+		this.initItemNavigation();
+
+		this._onContainerResizeHandler = this._onContainerResize.bind(this);
+		this._onContentResizeHandler = this._onContentResize.bind(this);
+
+		// maps links to their widths
+		this._linkWidths = new WeakMap();
+		// the width of the interactive element that opens the overflow
+		this._overflowBtnWidth = 0;
+		// a list of the two elements that wrap the breadcrumps content
+		// and allow to monitor content-resize
+		this._contentWrappers = null;
+	}
+
+	onAfterRendering() {
+		this._endingLabelText = this._parseEndingLabelText();
+		this._contentWrappers = this.shadowRoot.querySelectorAll(".ui5-breadcrumbs-root > ol");
+		this._cacheWidths();
+		this._updateOverflow();
+	}
+
+	onEnterDOM() {
+		ResizeHandler.register(this, this._onContainerResizeHandler);
+		this._contentWrappers.forEach(el => ResizeHandler.register(el, this._onContentResizeHandler));
+	}
+
+	onExitDOM() {
+		ResizeHandler.deregister(this, this._onContainerResizeHandler);
+		if (this._contentWrappers) {
+			this._contentWrappers.forEach(el => ResizeHandler.deregister(el, this._onContentResizeHandler));
+		}
+	}
+
+	initItemNavigation() {
+		if (!this._itemNavigation) {
+			this._itemNavigation = new ItemNavigation(this, {
+				navigationMode: NavigationMode.Horizontal,
+				getItemsCallback: () => this._getFocusableItems(),
+			});
+		}
+	}
+
+	/**
+	 * Obtains the items for navigation via keyboard
+	 * @private
+	 */
+	_getFocusableItems() {
+		const items = this._nonOverflowingLinks;
+
+		if (this._hasLinksInOverflow) {
+			items.unshift(this._overflowBtn);
+		}
+		if (this._endingLabelComponent) {
+			items.push(this._endingLabelComponent);
+		}
+		return items;
+	}
+
+	_onfocusin(event) {
+		this._itemNavigation.setCurrentItem(event.target);
+	}
+
+	_onkeydown(event) {
+		if (isShow(event)) {
+			event.preventDefault();
+			this._toggleRespPopover();
+		}
+		if (isSpace(event) && !this._isPickerOpen) {
+			event.preventDefault();
+		}
+	}
+
+	_onkeyup(event) {
+		if (isSpace(event) && !this._isPickerOpen) {
+			this._toggleRespPopover();
+		}
+	}
+
+	_onContainerResize() {
+		this._updateOverflow();
+	}
+
+	_onContentResize() {
+		this._endingLabelText = this._parseEndingLabelText();
+		this._cacheWidths();
+		this._updateOverflow();
+	}
+
+	/**
+	 * Caches the space required to render the content
+	 * @private
+	 */
+	_cacheWidths() {
+		const map = this._linkWidths;
+		const linkItems = this.shadowRoot.querySelectorAll(".ui5-breadcrumbs-link-wrapper");
+
+		for (let i = 0; i < linkItems.length; i++) {
+			const link = linkItems[i].querySelector("slot").assignedElements()[0];
+			map.set(link, this._getElementWidth(linkItems[i]));
+		}
+
+		if (this._hasLinksInOverflow) {
+			const overflow = this.shadowRoot.querySelector(".ui5-breadcrumbs-overflow-opener");
+			this._overflowBtnWidth = this._getElementWidth(overflow);
+		}
+	}
+
+	_updateOverflow() {
+		const links = this._interactiveLinks.filter(link => !link.hidden),
+			availableWidth = this.shadowRoot.querySelector(".ui5-breadcrumbs-root").offsetWidth;
+		let requiredWidth = this._getTotalContentWidth(),
+			countLinksInOverflow = 0;
+
+		if (requiredWidth > availableWidth) {
+			// need to show the overflow button as well
+			requiredWidth += this._overflowBtnWidth;
+		}
+
+		while ((requiredWidth > availableWidth) && (countLinksInOverflow < this._maxCountLinksInOverflow)) {
+			const linkToOverflow = links[countLinksInOverflow],
+				linkWidth = this._linkWidths.get(linkToOverflow) || 0;
+
+			// move the link to the overflow
+			requiredWidth -= linkWidth;
+			countLinksInOverflow++;
+		}
+
+		this._countLinksInOverflow = countLinksInOverflow;
+
+		// if overflow was emptied while picker was open => close redundant view
+		if (this._countLinksInOverflow === 0 && this._isPickerOpen) {
+			this._toggleRespPopover();
+		}
+
+		// if the last focused link has done into the overflow =>
+		// ensure the first visible link is focusable
+		const focusableItems = this._getFocusableItems();
+		if (!focusableItems.some(x => x._tabIndex === "0")) {
+			this._itemNavigation.setCurrentItem(focusableItems[0]);
+		}
+
+		links.forEach(link => link.classList.toggle("ui5-breadcrumbs-empty-link", !link.innerHTML));
+	}
+
+	_getElementWidth(element) {
+		return Math.ceil(element.getBoundingClientRect().width);
+	}
+
+	_getTotalContentWidth() {
+		const links = this._interactiveLinks,
+			map = this._linkWidths,
+			totalLinksWidth = links.reduce((sum, link) => sum + map.get(link), 0),
+			currentLocationWidth = this._endingLabelComponent ? this._getElementWidth(this._endingLabelComponent) : 0;
+
+		return totalLinksWidth + currentLocationWidth;
+	}
+
+	_parseEndingLabelText() {
+		const link = this._endingLabelLink;
+		return (link) ? link.innerText : "";
+	}
+
+	_onLinkClick(event) {
+		const link = event.target;
+		this.fireEvent("link-click", { link });
+	}
+
+	_getSelectedItemIndex(item) {
+		return [].indexOf.call(item.parentElement.children, item);
+	}
+
+	_onOverflowListItemSelect(event) {
+		const item = event.detail.item,
+			selectedItemIndex = this._getSelectedItemIndex(item),
+			selectedLink = this._overflowingLinks[selectedItemIndex],
+			selectedLinkTarget = selectedLink.target || "_self",
+			windowFeatures = (selectedLinkTarget !== "_self") ? "noopener,noreferrer" : "";
+
+		window.open(selectedLink.href, selectedLinkTarget, windowFeatures);
+		this._toggleRespPopover();
+		this.fireEvent("link-click", { link: selectedLink });
+	}
+
+	/**
+	 * Returns all slotted links except the link that represents the ending label
+	 */
+	get _interactiveLinks() {
+		const links = this.getSlottedNodes("links");
+		if (this._endsWithCurrentLocationLabel) {
+			links.pop();
+		}
+		return links;
+	}
+
+	get _endsWithCurrentLocationLabel() {
+		return this.design === BreadcrumbsDesign.Standard;
+	}
+
+	get _endingLabelComponent() {
+		return this.shadowRoot.querySelector(".ui5-breadcrumbs-current-location ui5-label");
+	}
+
+	/**
+	 * Returns the maximum allowed count of links in the overflow
+	 */
+	get _maxCountLinksInOverflow() {
+		const interactiveLinks = this._interactiveLinks.filter(link => !link.hidden);
+		// UX requirement: the last visible breadcrumbs item should never overflow
+		// so all items before the last visible are allowed to overflow
+		if (this.design === BreadcrumbsDesign.Standard) {
+			// the last visible item is the label 
+			// => all interactive links are allowed to overflow
+			return interactiveLinks.length;
+		}
+		return interactiveLinks.length - 1;
+	}
+
+	async _respPopover() {
+		const staticAreaItem = await this.getStaticAreaItemDomRef();
+		return staticAreaItem.querySelector("[ui5-responsive-popover]");
+	}
+
+	async _toggleRespPopover() {
+		this.responsivePopover = await this._respPopover();
+
+		if (this._isPickerOpen) {
+			this.responsivePopover.close();
+		} else {
+			this.responsivePopover.openBy(this);
+		}
+	}
+
+	get _endingLabelLink() {
+		let lastLink;
+		if (this._endsWithCurrentLocationLabel) {
+			const links = this.getSlottedNodes("links");
+			lastLink = links[links.length - 1];
+		}
+		return lastLink;
+	}
+
+	get _endingLabelLinkIndividualSlot() {
+		const link = this._endingLabelLink;
+		if (link) {
+			return link._individualSlot;
+		}
+		return null;
+	}
+
+	/**
+	 * Getter for the interactive element that opens the overflow
+	 * @private
+	 */
+	get _overflowBtn() {
+		return this.shadowRoot.querySelector(".ui5-breadcrumbs-overflow-opener ui5-link");
+	}
+
+	/**
+	 * Getter for the list of links to be rendered outside the overflow
+	 */
+	get _nonOverflowingLinks() {
+		const links = this._interactiveLinks,
+			indexOfLastOveflowingLink = this._indexOfLastOveflowingLink;
+
+		// if there is at least one overflowing link
+		// => extract the remaining and return as non-overflowing
+		if (indexOfLastOveflowingLink > -1) {
+			return links.slice(indexOfLastOveflowingLink + 1);
+		}
+		return links;
+	}
+
+	/**
+	 * Getter for the list of links to be rendered inside the overflow
+	 */
+	get _overflowingLinks() {
+		const indexOfLastOveflowingLink = this._indexOfLastOveflowingLink;
+
+		if (indexOfLastOveflowingLink > -1) {
+			return this._interactiveLinks
+				.slice(0, indexOfLastOveflowingLink + 1)
+				.reverse();
+		}
+		return [];
+	}
+
+	/**
+	 * Getter for the list of non-hidden links to be rendered inside the overflow
+	 */
+	get _visibleOverflowingLinks() {
+		return this._interactiveLinks
+			.filter(link => !link.hidden)
+			.slice(0, this._countLinksInOverflow)
+			.reverse();
+	}
+
+	get _indexOfLastOveflowingLink() {
+		const visibleOverflowingLinks = this._visibleOverflowingLinks;
+		let lastVisibleOverflowingLink;
+
+		if (visibleOverflowingLinks.length) {
+			// visible links appear in reverse order in the dropdown
+			// => we obtain the first item
+			lastVisibleOverflowingLink = visibleOverflowingLinks[0];
+			return this._getSelectedItemIndex(lastVisibleOverflowingLink);
+		}
+
+		return -1;
+	}
+
+	get _ariaHasPopup() {
+		if (this._hasLinksInOverflow) {
+			return "listbox";
+		}
+		return undefined;
+	}
+
+	get _isPickerOpen() {
+		return !!this.responsivePopover && this.responsivePopover.opened;
+	}
+
+	get _hasLinksInOverflow() {
+		return this._countLinksInOverflow > 0;
+	}
+
+	get _isOverflowEmpty() {
+		return !this._countLinksInOverflow;
+	}
+
+	get _accessibleNameText() {
+		return this.i18nBundle.getText(BREADCRUMBS_ARIA_LABEL);
+	}
+
+	get _overflowAccessibleNameText() {
+		return this.i18nBundle.getText(BREADCRUMBS_OVERFLOW_ARIA_LABEL);
+	}
+
+	get _cancelButtonText() {
+		return this.i18nBundle.getText(BREADCRUMBS_CANCEL_BUTTON);
+	}
+
+	static get dependencies() {
+		return [];
+	}
+}
+
+Breadcrumbs.define();
+
+export default Breadcrumbs;

--- a/packages/main/src/BreadcrumbsPopover.hbs
+++ b/packages/main/src/BreadcrumbsPopover.hbs
@@ -1,0 +1,26 @@
+<ui5-responsive-popover
+	no-arrow
+	content-only-on-desktop
+	placement-type="Bottom"
+	horizontal-align="Left"
+	with-padding
+	_hide-header
+	@keydown="{{_onkeydown}}">
+	<ui5-list mode="SingleSelectAuto"
+		separators="None"
+		@ui5-item-press="{{_onOverflowListItemSelect}}">
+
+		{{#each _visibleOverflowingLinks}}
+			<ui5-li
+				id="{{this.id}}-li">
+				{{this.textContent}}
+			</ui5-li>
+		{{/each}}
+	</ui5-list>
+	<div slot="footer" class="ui5-breadcrumbs-popover-footer">
+		<ui5-button
+			design="Transparent"
+			@click="{{_toggleRespPopover}}"
+		>{{_cancelButtonText}}</ui5-button>
+	</div>
+</ui5-responsive-popover>

--- a/packages/main/src/Label.hbs
+++ b/packages/main/src/Label.hbs
@@ -3,6 +3,7 @@
 		dir="{{effectiveDir}}"
 		@click={{_onclick}}
 		for="{{for}}"
+		tabindex={{tabIndex}}
 	>
 	<span class="{{classes.textWrapper}}">
 		<bdi id="{{_id}}-bdi">

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -71,6 +71,11 @@ const metadata = {
 		"for": {
 			type: String,
 		},
+
+		_tabIndex: {
+			type: String,
+			noAttribute: true,
+		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.Label.prototype */ {
 		/**
@@ -137,6 +142,13 @@ class Label extends UI5Element {
 				"ui5-label-text-wrapper-safari": isSafari(),
 			},
 		};
+	}
+
+	get tabIndex() {
+		if (this._tabIndex.length) {
+			return this._tabIndex;
+		}
+		return undefined;
 	}
 
 	_onclick() {

--- a/packages/main/src/Link.hbs
+++ b/packages/main/src/Link.hbs
@@ -8,6 +8,7 @@
 	?disabled="{{disabled}}"
 	aria-label="{{ariaLabelText}}"
 	@focusin={{_onfocusin}}
+	@focusout={{_onfocusout}}
 	@click={{_onclick}}
 	@keydown={{_onkeydown}}
 	@keyup={{_onkeyup}}>

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -19,6 +19,7 @@ import linkCss from "./generated/themes/Link.css.js";
  */
 const metadata = {
 	tag: "ui5-link",
+	managedSlots: true,
 	languageAware: true,
 	properties: /** @lends  sap.ui.webcomponents.main.Link.prototype */  {
 
@@ -131,6 +132,19 @@ const metadata = {
 			type: String,
 			noAttribute: true,
 		},
+
+		_tabIndex: {
+			type: String,
+			noAttribute: true,
+		},
+
+		/**
+		 * Indicates if the elements is on focus
+		 * @private
+		 */
+		 focused: {
+			type: Boolean,
+		},
 	},
 	slots: /** @lends sap.ui.webcomponents.main.Link.prototype */ {
 		/**
@@ -241,6 +255,9 @@ class Link extends UI5Element {
 	}
 
 	get tabIndex() {
+		if (this._tabIndex.length) {
+			return this._tabIndex;
+		}
 		return (this.disabled || !this.textContent.length) ? "-1" : "0";
 	}
 
@@ -277,6 +294,11 @@ class Link extends UI5Element {
 
 	_onfocusin(event) {
 		event.isMarked = "link";
+		this.focused = true;
+	}
+
+	_onfocusout(event) {
+		this.focused = false;
 	}
 
 	_onkeydown(event) {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -34,6 +34,15 @@ AVATAR_GROUP_MOVE=Press ARROW keys to move.
 #XACT: ARIA announcement for the badge
 BADGE_DESCRIPTION=Badge
 
+#XACT: ARIA announcement for the breadcrumbs
+BREADCRUMBS_ARIA_LABEL=Breadcrumb Trail
+
+#XACT: ARIA announcement for the breadcrumbs overflow button
+BREADCRUMBS_OVERFLOW_ARIA_LABEL=More
+
+#XFLD: Breadcrumbs popover cancel button
+BREADCRUMBS_CANCEL_BUTTON=Cancel
+
 #XTOL: text that could be show if BusyIndicator is active
 BUSY_INDICATOR_TITLE=Please wait
 

--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -1,0 +1,102 @@
+.ui5-breadcrumbs-root {
+    white-space: nowrap;
+    outline: none;
+    margin: 0 0 0.5rem 0;
+}
+
+.ui5-breadcrumbs-root > ol {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+.ui5-breadcrumbs-root > ol,
+.ui5-breadcrumbs-root > ol > li {
+    display: inline-block;
+}
+
+.ui5-breadcrumbs-overflow-opener[hidden] {
+    display: none
+}
+
+.ui5-breadcrumbs-hidden-overflow {
+    position: absolute;
+    top: -10000px;
+    left: -10000px;
+}
+
+.ui5-breadcrumbs-overflow-opener ui5-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+    padding-left: .675rem;
+    vertical-align: text-top;
+    color: var(--sapLinkColor);
+}
+
+.ui5-breadcrumbs-overflow-opener ui5-icon::before {
+    content: "...";
+    vertical-align: middle;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+}
+
+/* icon-decoration on hover */
+.ui5-breadcrumbs-overflow-opener ui5-link[focused] ui5-icon::after,
+.ui5-breadcrumbs-overflow-opener:hover ui5-icon::after {
+    content: "";
+    position: absolute;
+    border-bottom: 0.0625rem solid;
+    top: 0;
+    left: 0;
+    bottom: 1px;
+    right: 0;
+}
+
+/* links separator */
+ui5-link::after,
+::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after  {
+    content: "";
+    padding: 0 .25rem;
+    cursor: auto;
+    color: var(--sapContent_LabelColor);
+    display: flex;
+    align-items: flex-end;
+}
+
+.ui5-breadcrumbs-popover-footer {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+}
+
+/* separator styles */
+:host([separator-style="Slash"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="Slash"]) ui5-link::after {
+    content: "/";
+}
+
+:host([separator-style="BackSlash"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="BackSlash"]) ui5-link::after {
+    content: "\\";
+}
+
+:host([separator-style="DoubleBackSlash"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="DoubleBackSlash"]) ui5-link::after {
+    content: "\\\\";
+}
+
+:host([separator-style="DoubleGreaterThan"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="DoubleGreaterThan"]) ui5-link::after {
+    content: ">>";
+}
+
+:host([separator-style="DoubleSlash"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="DoubleSlash"]) ui5-link::after {
+    content: "//";
+}
+
+:host([separator-style="GreaterThan"]) ::slotted([ui5-link]:not(.ui5-breadcrumbs-empty-link))::after,
+:host([separator-style="GreaterThan"]) ui5-link::after {
+    content: ">";
+}

--- a/packages/main/src/themes/BreadcrumbsPopover.css
+++ b/packages/main/src/themes/BreadcrumbsPopover.css
@@ -1,0 +1,6 @@
+.ui5-breadcrumbs-popover-footer {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    padding-right: 0.5rem;
+}

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -77,3 +77,9 @@ bdi {
 	margin-right: .125rem;
 	margin-left: 0;
 }
+
+.ui5-label-root:focus {
+	outline-offset: -1px;
+	outline: 1px dotted var(--sapContent_FocusColor);
+	text-decoration: underline;
+}

--- a/packages/main/src/types/BreadcrumbsDesign.js
+++ b/packages/main/src/types/BreadcrumbsDesign.js
@@ -1,0 +1,42 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * @lends sap.ui.webcomponents.main.types.BreadcrumbsDesign.prototype
+ * @public
+ */
+const BreadcrumbsTypes = {
+	/**
+	 * Shows the current page as the last item in the trail.
+	 * The last item contains only plain text and not a link.
+	 *
+	 * @public
+	 * @type {Standard}
+	 */
+	Standard: "Standard",
+
+	/**
+	 * All items in the breadcrumb are links.
+	 * @public
+	 * @type {NoCurrentPage}
+	 */
+	NoCurrentPage: "NoCurrentPage",
+};
+
+/**
+ * @class
+ * Different types of Breadcrumbs.
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.types.BreadcrumbsDesign
+ * @public
+ * @enum {string}
+ */
+class BreadcrumbsDesign extends DataType {
+	static isValid(value) {
+		return !!BreadcrumbsTypes[value];
+	}
+}
+
+BreadcrumbsDesign.generateTypeAccessors(BreadcrumbsTypes);
+
+export default BreadcrumbsDesign;

--- a/packages/main/src/types/BreadcrumbsSeparatorStyle.js
+++ b/packages/main/src/types/BreadcrumbsSeparatorStyle.js
@@ -1,0 +1,69 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * @lends sap.ui.webcomponents.main.types.BreadcrumbsSeparatorStyle.prototype
+ * @public
+ */
+const SeparatorTypes = {
+
+	/**
+	 * The separator will appear as "/"
+	 * @public
+	 * @type {Slash}
+	 */
+	Slash: "Slash",
+
+	/**
+	 * The separator will appear as "\"
+	 * @public
+	 * @type {BackSlash}
+	 */
+	BackSlash: "BackSlash",
+
+	/**
+	 * The separator will appear as "\\"
+	 * @public
+	 * @type {DoubleBackSlash}
+	 */
+	DoubleBackSlash: "DoubleBackSlash",
+
+	/**
+	 * The separator will appear as ">>"
+	 * @public
+	 * @type {DoubleGreaterThan}
+	 */
+	DoubleGreaterThan: "DoubleGreaterThan",
+
+	/**
+	 * The separator will appear as "//"
+	 * @public
+	 * @type {DoubleSlash}
+	 */
+	DoubleSlash: "DoubleSlash",
+
+	/**
+	 * The separator will appear as ">"
+	 * @public
+	 * @type {GreaterThan}
+	 */
+	GreaterThan: "GreaterThan",
+};
+
+/**
+ * @class
+ * Different types of Breadcrumbs separator.
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.types.BreadcrumbsSeparatorStyle
+ * @public
+ * @enum {string}
+ */
+class BreadcrumbsSeparatorStyle extends DataType {
+	static isValid(value) {
+		return !!SeparatorTypes[value];
+	}
+}
+
+BreadcrumbsSeparatorStyle.generateTypeAccessors(SeparatorTypes);
+
+export default BreadcrumbsSeparatorStyle;

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<title>Breadcrumbs</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+
+	<script data-ui5-config type="application/json">
+		{
+			"language": "EN"
+		}
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);">
+
+	<ui5-togglebutton id="myBtn">turn lights</ui5-togglebutton>
+	<div style="display:inline-block;margin-left:0.5rem"><label for="size">Resize last container: </label>
+		<div style="width:2rem;display:inline-block">
+
+			<ui5-button id="extendSizeBtn"
+			style="width:1rem;height:1rem"
+			icon="slim-arrow-up" ></ui5-button>
+
+			<ui5-button id="shrinkSizeBtn"
+			style="width:1rem;height:1rem"
+			icon="slim-arrow-down"></ui5-button>
+		</div>
+		
+	</div>
+	<div style="display:inline-block;margin-left:0.5rem">
+		<label for="size">Resize last link: </label>
+		<div style="width:1rem;display:inline-block">
+
+			<ui5-button id="extendLinkTextBtn"
+			style="width:1rem;height:1rem"
+			icon="slim-arrow-up"></ui5-button>
+
+			<ui5-button id="shortenLinkTextBtn"
+			style="width:1rem;height:1rem"
+			icon="slim-arrow-down"></ui5-button>
+		</div>
+	</div>
+	
+	<h2>Breadcrumbs with current location</h2>
+
+	<ui5-breadcrumbs id="breadcrumbs2" separator-style="Slash">
+		<ui5-link href="https://www.sap.com">Link1 </ui5-link>
+		<ui5-link href="https://www.sap.com" target="_blank">Link2</ui5-link>
+		<ui5-link href="#" >Link3</ui5-link>
+		<ui5-link>Location</ui5-link>
+	</ui5-breadcrumbs>
+
+	<h2>Breadcrumbs with no current location</h2>
+
+	<ui5-breadcrumbs id="breadcrumbs3" design="NoCurrentPage" separator-style="Slash">
+		<ui5-link href="https://www.sap.com">Link1 </ui5-link>
+		<ui5-link href="https://www.sap.com" target="_blank">Link2</ui5-link>
+		<ui5-link href="#" >Link3</ui5-link>
+	</ui5-breadcrumbs>
+
+	<div id="wrapper" style="width: 200px;border: 1px solid lightgray;padding-top: 0.5rem;">
+
+	<h2>Breadcrumbs with overflowing links</h2>
+
+		<ui5-breadcrumbs id="breadcrumbs1" separator-style="Slash">
+			<ui5-link href="https://www.sap.com" target="_blank">Link1 </ui5-link>
+			<ui5-link href="https://www.sap.com" target="_blank">Link2</ui5-link>
+			<ui5-link href="#" >Link3</ui5-link>
+			<ui5-link href="#" >Link4</ui5-link>
+			<ui5-link href="#" >Link5</ui5-link>
+			<ui5-link href="#" >Link6</ui5-link>
+			<ui5-link id="link7" href="#" >aaaaa</ui5-link>
+			<ui5-link>Location</ui5-link>
+		</ui5-breadcrumbs>
+	</div>
+	
+	Last pressed link: <span id="result"></span>
+
+
+	<script>
+		// HCB button
+		var btn = document.getElementById('myBtn');
+		btn.addEventListener("click", function(event) {
+			var hcb = event.target.pressed;
+			var styles = hcb ? "background:#333;color:palegoldenrod;" : "background:#fff;color:#333;";
+			var theme = hcb ? "sap_belize_hcb" : "sap_fiori_3";
+
+			document.body.setAttribute("style", styles);
+			var Conf = window["sap-ui-webcomponents-bundle"].configuration;
+			Conf.setTheme(theme);
+		});
+
+		// log events
+		breadcrumbs1.addEventListener("link-click", (event) => {result.innerText = event.detail.link.innerText});
+
+		extendSizeBtn.addEventListener("click", () => resizeContainer(true));
+		shrinkSizeBtn.addEventListener("click", () => resizeContainer());
+
+		extendLinkTextBtn.addEventListener("click", () => updateLinkContent(true));
+		shortenLinkTextBtn.addEventListener("click", () => updateLinkContent());
+
+		// resize breadcrumbs container
+		function resizeContainer(extendSize) {
+			let wrapperWidth = wrapper.clientWidth,
+				step = 50,
+				amount = extendSize ?  step: -step,
+				newWidth = Math.max(wrapperWidth + amount, 0);
+				wrapper.style.width = newWidth + "px";
+		}
+
+		// cause resize of the breadcrumbs last link
+		function updateLinkContent(extendSize) {
+			let link = link7,
+				step = 10,
+				content = link.innerText,
+				newContent;
+
+			if (extendSize) {
+				newContent = content + new Array(step + 1).join( "a" );
+			} else {
+				newContent = content.substring(step);
+			}
+
+			link.innerText = newContent;
+		}
+
+	</script>
+
+</body>
+
+</html>

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -1,0 +1,255 @@
+const assert = require("chai").assert;
+const PORT = require("./_port.js");
+
+describe("Breadcrumbs general interaction", () => {
+	before(() => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
+	});
+
+	it("fires link-click event", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			link = breadcrumbs.$$("ui5-link")[6];
+
+		// Act
+		link.click();
+
+		// Check
+		const eventResult = browser.$("#result");
+		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
+	});
+
+	it("fires link-click event when link in overflow", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			overflowArrowLink = breadcrumbs.shadow$$("ui5-link")[0];
+			link = breadcrumbs.$$("ui5-link")[5];
+
+
+		// Act
+		overflowArrowLink.click(); // open the overflow
+
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#breadcrumbs1");
+		const firstItem = browser.$(`.${staticAreaItemClassName}`).shadow$$("ui5-li")[0];
+
+		firstItem.click();
+
+		// Check
+		const eventResult = browser.$("#result");
+		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
+	});
+
+	it("updates layout on container resize", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			shrinkSizeBtn = $("#shrinkSizeBtn"),
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow"),
+			expectedCountLinksInOverflowAfter = countLinksInOverflowBefore + 1;
+
+		// Act: shrink the breadcrumbs container
+		// to cause one more item to overflow
+		shrinkSizeBtn.click();
+
+		// Check links inside overflow
+		assert.strictEqual(breadcrumbs.getProperty("_countLinksInOverflow"), expectedCountLinksInOverflowAfter, "one link is added to the overflow");
+	});
+
+	it("updates layout on resize of content outside overflow", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			extendLinkTextBtn = $("#extendLinkTextBtn"),
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow"),
+			expectedCountLinksInOverflowAfter = countLinksInOverflowBefore + 1;
+
+		// Act:
+		// extend the length of the last link,
+		// so that it becomes too big to be rendered outside the overflow
+		extendLinkTextBtn.click();
+
+		// Check
+		assert.strictEqual(breadcrumbs.getProperty("_countLinksInOverflow"), expectedCountLinksInOverflowAfter, "the link is added to the overflow");
+	});
+
+	it("updates layout on resize of content inside overflow", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			shortenLinkTextBtn = $("#shortenLinkTextBtn"),
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow"),
+			expectedCountLinksInOverflowAfter = countLinksInOverflowBefore - 1;
+
+		// Act: 
+		// shrink the length of the last link from the overflow,
+		// to make it small enough => eligible to be moved outside the overflow
+		shortenLinkTextBtn.click();
+
+		// Check
+		assert.strictEqual(breadcrumbs.getProperty("_countLinksInOverflow"), expectedCountLinksInOverflowAfter, "the link is taken out of the overflow");
+	});
+
+	it("updates layout when link content removed", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			shortenLinkTextBtn = $("#shortenLinkTextBtn"),
+			link = breadcrumbs.$$("ui5-link")[6];
+
+		// Check initial state
+		assert.ok(link.getText().length, "the link has text");
+
+		// Act: 
+		// shrink the length of the last link to make it empty
+		shortenLinkTextBtn.click();
+
+		// verify result => the link is now empty
+		assert.strictEqual(link.getText(), "", "the link is empty");
+
+		// Check
+		assert.strictEqual(breadcrumbs.$("ui5-link.ui5-breadcrumbs-empty-link").id, link.id, "the link is marked as empty");
+	});
+
+	it("updates layout when content added to empty link", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			extendLinkTextBtn = $("#extendLinkTextBtn"),
+			link = breadcrumbs.$$("ui5-link")[6];
+
+		// Check initial state
+		assert.strictEqual(link.getText(), "", "the link is empty");
+
+		// Act: 
+		// add content to the empty link
+		extendLinkTextBtn.click();
+
+		// verify result => the link is now empty
+		assert.ok(link.getText().length, "the link has text");
+
+		// Check
+		assert.strictEqual(breadcrumbs.$$("ui5-link.ui5-breadcrumbs-empty-link").length, 0, "the link is no longer marked as empty");
+	});
+
+	it("updates layout when a non-overflowing link is hidden", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			link = breadcrumbs.$$("ui5-link")[6],
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow");
+
+		// Check initial state
+		assert.strictEqual(link.getProperty("hidden"), false, "the link is visible");
+
+		// Act: 
+		// hide the first link
+		browser.execute(() => {
+			document.querySelector("#breadcrumbs1 ui5-link:nth-child(7)").hidden = true;
+		});
+
+		// verify result => the link is now hidden
+		assert.strictEqual(link.getProperty("hidden"), true, "the link is hidden");
+
+		// Check
+		assert.ok(breadcrumbs.getProperty("_countLinksInOverflow") < countLinksInOverflowBefore, "a link-item is taken out of the overflow");
+	});
+
+	it("updates layout when a hidden non-overflowing link is made visible", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			link = breadcrumbs.$$("ui5-link")[6],
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow");
+
+		// Check initial state
+		assert.strictEqual(link.getProperty("hidden"), true, "the link is hidden");
+
+		// Act: 
+		// show the first link
+		browser.execute(() => {
+			document.querySelector("#breadcrumbs1 ui5-link:nth-child(7)").hidden = false;
+		});
+
+		// verify result => the link is now visible
+		assert.strictEqual(link.getProperty("hidden"), false, "the link is visible");
+
+		// Check
+		assert.ok(breadcrumbs.getProperty("_countLinksInOverflow") > countLinksInOverflowBefore, "a new link-item is added to the overflow");
+	});
+
+	it("updates layout when an overflowing link is hidden", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			link = breadcrumbs.$$("ui5-link")[0],
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow"),
+			expectedCountLinksInOverflowAfter = countLinksInOverflowBefore - 1;
+
+		// Check initial state
+		assert.strictEqual(link.getProperty("hidden"), false, "the link is visible");
+
+		// Act: 
+		// hide the first link
+		browser.execute(() => {
+			document.querySelector("#breadcrumbs1 ui5-link:nth-child(1)").hidden = true;
+		});
+
+		// verify result => the link is now hidden
+		assert.strictEqual(link.getProperty("hidden"), true, "the link is hidden");
+
+		// Check
+		assert.strictEqual(breadcrumbs.getProperty("_countLinksInOverflow"), expectedCountLinksInOverflowAfter, "the link-item is taken out of the overflow");
+	});
+
+	it("updates layout when a hidden overflowing link is made visible", () => {
+		const breadcrumbs = $("#breadcrumbs1"),
+			link = breadcrumbs.$$("ui5-link")[0],
+			countLinksInOverflowBefore = breadcrumbs.getProperty("_countLinksInOverflow"),
+			expectedCountLinksInOverflowAfter = countLinksInOverflowBefore + 1;
+
+		// Check initial state
+		assert.strictEqual(link.getProperty("hidden"), true, "the link is hidden");
+
+		// Act: 
+		// show the first link
+		browser.execute(() => {
+			document.querySelector("#breadcrumbs1 ui5-link:nth-child(1)").hidden = false;
+		});
+
+		// verify result => the link is now visible
+		assert.strictEqual(link.getProperty("hidden"), false, "the link is visible");
+
+		// Check
+		assert.strictEqual(breadcrumbs.getProperty("_countLinksInOverflow"), expectedCountLinksInOverflowAfter, "the link-item is added to the overflow");
+	});
+
+	it("opens upon space", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
+
+		const externalElement = $("#breadcrumbs3").$$("ui5-link")[2];
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#breadcrumbs1");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		externalElement.click();
+		externalElement.keys("Tab");
+
+		browser.keys("Space");
+		assert.ok(popover.getProperty("opened"), "Dropdown is opened.");
+	});
+
+	it("toggles upon F4", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
+
+		const externalElement = $("#breadcrumbs3").$$("ui5-link")[2];
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#breadcrumbs1");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		externalElement.click();
+		externalElement.keys("Tab");
+
+		browser.keys("F4");
+		assert.ok(popover.getProperty("opened"), "Dropdown is opened.");
+
+		browser.keys("F4");
+		assert.ok(!popover.getProperty("opened"), "Dropdown is closed.");
+	});
+
+	it("toggles upon ALT + DOWN", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
+
+		const externalElement = $("#breadcrumbs3").$$("ui5-link")[2];
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#breadcrumbs1");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		externalElement.click();
+		externalElement.keys("Tab");
+
+		browser.keys(["Alt", "ArrowDown", "NULL"]);
+		assert.ok(popover.getProperty("opened"), "Dropdown is opened.");
+
+		browser.keys(["Alt", "ArrowDown", "NULL"]);
+		assert.ok(!popover.getProperty("opened"), "Dropdown is closed.");
+	});
+});


### PR DESCRIPTION
Fixes #3166

Two implementations are available:

1) ui5-breadcrumbs **with "current-location" property** e.g.:
`<ui5-breadcrumbs current-location="Laptop">
  <ui5-link>Products</ui5-link>
  <ui5-link>Suppliers</ui5-link>
  <ui5-link>Titanium</ui5-link>
</ui5-breadcrumbs>`
Code: https://github.com/kineticjs/ui5-webcomponents/tree/breadcrumbs

2) ui5-breadcrumbs **with links only** e.g.:
`<ui5-breadcrumbs>
  <ui5-link>Products</ui5-link>
  <ui5-link>Suppliers</ui5-link>
  <ui5-link>Titanium</ui5-link>
  <ui5-link>Current</ui5-link>
</ui5-breadcrumbs>`
Code: https://github.com/kineticjs/ui5-webcomponents/tree/breadcrumbs1

THIS PR IS FOR THE 2nd INPLEMENTATION (links only), because its API seemed to be preferred 
However, both versions are proposed, esp. as the 1st seem better to me from performance perspective)

Note:
The 2nd implementation (links only) seemed to require some extra performance cost.
This is because the last slotted link is used to indicate the current location
   => the text of the last slotted link is **rendered as ui5-label**
   => I had to **ensure we are notified for changes in the text of the last link**
   => I had to additionally declare:
       -- ui5-link declared to have managedSlots = true
       -- ui5-breadcrumbs declared to invalidateOnChildChange: {
				properties: false,
				slots: true,
			}
     **No such need detected for implementation 1** (with "current-location" property) as it only listens for resize of its content.

Feel free to propose improvements. I will complete the version (1 or 2) that we eventually choose.
