### PR TITLE
refactor: apply styles in a CSP-compliant way

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-zTRXVc9BSmjH0NfY+gYM/Dk+gBs=
+wnRpeaAOGe7uQ7X/8hgQjNn/u18=

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-qIoCWcnUsXXyku4AAXsM1nFtY+s=
+zTRXVc9BSmjH0NfY+gYM/Dk+gBs=

--- a/packages/base/src/FontFace.js
+++ b/packages/base/src/FontFace.js
@@ -111,7 +111,7 @@ const insertMainFontFace = () => {
 
 const insertOverrideFontFace = () => {
 	if (!hasStyle("data-ui5-font-face-override")) {
-		createStyle(fontFaceCSS, "data-ui5-font-face-override");
+		createStyle(overrideFontFaceCSS, "data-ui5-font-face-override");
 	}
 };
 

--- a/packages/base/src/FontFace.js
+++ b/packages/base/src/FontFace.js
@@ -1,7 +1,7 @@
 /**
  * CSS font face used for the texts provided by SAP.
  */
-import createStyleInHead from "./util/createStyleInHead.js";
+import { hasStyle, createStyle } from "./ManagedStyles.js";
 import { getFeature } from "./FeaturesRegistry.js";
 
 /* CDN Locations */
@@ -26,7 +26,7 @@ const fontFaceCSS = `
 			url(${font72RegularWoff2}) format("woff2"),
 			url(${font72RegularWoff}) format("woff");
 	}
-	
+
 	@font-face {
 		font-family: "72full";
 		font-style: normal;
@@ -34,9 +34,9 @@ const fontFaceCSS = `
 		src: local('72-full'),
 			url(${font72RegularFullWoff2}) format("woff2"),
 			url(${font72RegularFullWoff}) format("woff");
-		
+
 	}
-	
+
 	@font-face {
 		font-family: "72";
 		font-style: normal;
@@ -45,7 +45,7 @@ const fontFaceCSS = `
 			url(${font72BoldWoff2}) format("woff2"),
 			url(${font72BoldWoff}) format("woff");
 	}
-	
+
 	@font-face {
 		font-family: "72full";
 		font-style: normal;
@@ -104,14 +104,14 @@ const insertFontFace = () => {
 };
 
 const insertMainFontFace = () => {
-	if (!document.querySelector(`head>style[data-ui5-font-face]`)) {
-		createStyleInHead(fontFaceCSS, { "data-ui5-font-face": "" });
+	if (!hasStyle("data-ui5-font-face")) {
+		createStyle(fontFaceCSS, "data-ui5-font-face");
 	}
 };
 
 const insertOverrideFontFace = () => {
-	if (!document.querySelector(`head>style[data-ui5-font-face-override]`)) {
-		createStyleInHead(overrideFontFaceCSS, { "data-ui5-font-face-override": "" });
+	if (!hasStyle("data-ui5-font-face-override")) {
+		createStyle(fontFaceCSS, "data-ui5-font-face-override");
 	}
 };
 

--- a/packages/base/src/ManagedStyles.js
+++ b/packages/base/src/ManagedStyles.js
@@ -1,7 +1,8 @@
+import getSharedResource from "./getSharedResource.js";
 import createStyleInHead from "./util/createStyleInHead.js";
 import setToArray from "./util/setToArray.js";
 
-const allAdopted = new Map();
+const allAdopted = getSharedResource("ManagedStyles.allAdopted", new Map());
 
 const createStyle = (content, name, value = "") => {
 	if (document.adoptedStyleSheets) {

--- a/packages/base/src/ManagedStyles.js
+++ b/packages/base/src/ManagedStyles.js
@@ -32,12 +32,17 @@ const updateStyle = (content, name, value = "") => {
 };
 
 const hasStyle = (name, value) => {
+	const hasStyleTag = !!document.querySelector(`head>style[${name}="${value}"]`);
+	if (hasStyleTag) {
+		return true; // If another runtime has created the style tag, even if adoptedStyleSheets are supported, use this tag
+	}
+
 	if (document.adoptedStyleSheets) {
 		const key = `${name}|${value}`;
 		return allAdopted.has(key);
 	}
 
-	return !!document.querySelector(`head>style[${name}="${value}"]`);
+	return hasStyleTag;
 };
 
 export { createStyle, hasStyle, updateStyle };

--- a/packages/base/src/ManagedStyles.js
+++ b/packages/base/src/ManagedStyles.js
@@ -1,0 +1,42 @@
+import createStyleInHead from "./util/createStyleInHead.js";
+import setToArray from "./util/setToArray.js";
+
+const allAdopted = new Map();
+
+const createStyle = (content, name, value = "") => {
+	if (document.adoptedStyleSheets) {
+		const key = `${name}|${value}`;
+		if (!allAdopted.has(key)) {
+			const stylesheet = new CSSStyleSheet();
+			stylesheet.replaceSync(content);
+			allAdopted.set(key, stylesheet);
+			document.adoptedStyleSheets = setToArray(allAdopted); // works for a map too -> returns an array of the values
+		}
+	} else {
+		const attributes = {};
+		attributes[name] = value;
+		createStyleInHead(content, attributes);
+	}
+};
+
+const updateStyle = (content, name, value = "") => {
+	if (document.adoptedStyleSheets) {
+		const key = `${name}|${value}`;
+		const stylesheet = allAdopted.get(key);
+		stylesheet.replaceSync(content);
+		document.adoptedStyleSheets = setToArray(allAdopted); // works for a map too -> returns an array of the values
+	} else {
+		document.querySelector(`head>style[${name}="${value}"]`).textContent = content || "";
+	}
+};
+
+const hasStyle = (name, value) => {
+	if (document.adoptedStyleSheets) {
+		const key = `${name}|${value}`;
+		return allAdopted.has(key);
+	}
+
+	return !!document.querySelector(`head>style[${name}="${value}"]`);
+};
+
+export { createStyle, hasStyle, updateStyle };

--- a/packages/base/src/SystemCSSVars.js
+++ b/packages/base/src/SystemCSSVars.js
@@ -1,31 +1,29 @@
-import createStyleInHead from "./util/createStyleInHead.js";
+import { hasStyle, createStyle } from "./ManagedStyles.js";
 
 const systemCSSVars = `
 	:root {
 		--_ui5_content_density:cozy;
 	}
-	
+
 	[data-ui5-compact-size],
 	.ui5-content-density-compact,
 	.sapUiSizeCompact {
 		--_ui5_content_density:compact;
 	}
-	
+
 	[dir="rtl"] {
 		--_ui5_dir:rtl;
 	}
-	
+
 	[dir="ltr"] {
 		--_ui5_dir:ltr;
 	}
 `;
 
 const insertSystemCSSVars = () => {
-	if (document.querySelector(`head>style[data-ui5-system-css-vars]`)) {
-		return;
+	if (!hasStyle("data-ui5-system-css-vars")) {
+		createStyle(systemCSSVars, "data-ui5-system-css-vars");
 	}
-
-	createStyleInHead(systemCSSVars, { "data-ui5-system-css-vars": "" });
 };
 
 export default insertSystemCSSVars;

--- a/packages/base/src/theming/createThemePropertiesStyleTag.js
+++ b/packages/base/src/theming/createThemePropertiesStyleTag.js
@@ -1,4 +1,4 @@
-import createStyleInHead from "../util/createStyleInHead.js";
+import { hasStyle, createStyle, updateStyle } from "../ManagedStyles.js";
 
 /**
  * Creates/updates a style element holding all CSS Custom Properties
@@ -6,14 +6,10 @@ import createStyleInHead from "../util/createStyleInHead.js";
  * @param packageName
  */
 const createThemePropertiesStyleTag = (cssText, packageName) => {
-	const styleElement = document.head.querySelector(`style[data-ui5-theme-properties="${packageName}"]`);
-	if (styleElement) {
-		styleElement.textContent = cssText || "";	// in case of undefined
+	if (hasStyle("data-ui5-theme-properties", packageName)) {
+		updateStyle(cssText, "data-ui5-theme-properties", packageName);
 	} else {
-		const attributes = {
-			"data-ui5-theme-properties": packageName,
-		};
-		createStyleInHead(cssText, attributes);
+		createStyle(cssText, "data-ui5-theme-properties", packageName);
 	}
 };
 

--- a/packages/base/src/updateShadowRoot.js
+++ b/packages/base/src/updateShadowRoot.js
@@ -24,15 +24,45 @@ const updateShadowRoot = (element, forStaticArea = false) => {
 
 	// Apply styles with imperative APIs
 	if (typeof element.styles === "object") {
-		for (const [selector, styles] of Object.entries(element.styles)) { // eslint-disable-line
-			for (const [name, value] of Object.entries(styles)) { // eslint-disable-line
-				const el = shadowRoot.querySelector(selector);
-				if (el) {
-					el.style[name] = value;
+		applyStyles(shadowRoot, element.styles);
+	}
+};
+
+/**
+ * Applies styles to one or more DOM nodes in the shadow root of the component with imperative APIs instead of rendering "style" attributes for CSP compliance
+ *
+ * @param shadowRoot The normal or static area shadow root where styles must be applied
+ * @param styles The object, returned by "get styles()" in the component class
+ * @param path The current path in the object keys (for when "get styles()" has several nested levels such as arrows.right / arrows.left)
+ */
+const applyStyles = (shadowRoot, styles, path = "") => {
+	for (const key in styles) { // eslint-disable-line
+		const obj = styles[key];
+		if (isStylesObject(obj)) { // top-level object (containing the styles themselves) in "get styles"
+			const styleRefValue = `${path}${key}`; // path is something like "root", "content" or "arrows.left"
+			const el = shadowRoot.querySelector(`[data-ui5-style-ref="${styleRefValue}"]`); // the element from the .hbs where the styles must be applied
+			if (el) {
+				for (const styleName in obj) { // eslint-disable-line
+					const styleValue = obj[styleName];
+					if (!Number.isNaN(styleValue) && styleValue !== undefined) {
+						el.style[styleName] = styleValue;
+					}
 				}
 			}
+		} else {
+			applyStyles(shadowRoot, obj, `${path}${key}.`); // set the path to f.e. "arrows." and continue walking the object
 		}
 	}
+};
+
+/**
+ * Determines whether obj is a top-level object in "get styles" (one containing the styles definitions themselves).
+ * Otherwise, it is a nested object and the styles definitions are on some of the next levels.
+ * @param obj
+ * @returns {boolean}
+ */
+const isStylesObject = obj => {
+	return !Object.values(obj).some(value => value !== null && typeof value === "object"); // if one or more of the values in this object are objects, this is not a styles object
 };
 
 export default updateShadowRoot;

--- a/packages/base/src/updateShadowRoot.js
+++ b/packages/base/src/updateShadowRoot.js
@@ -21,6 +21,18 @@ const updateShadowRoot = (element, forStaticArea = false) => {
 	}
 
 	element.constructor.render(renderResult, shadowRoot, styleToPrepend, { eventContext: element });
+
+	// Apply styles with imperative APIs
+	if (typeof element.styles === "object") {
+		for (const [selector, styles] of Object.entries(element.styles)) { // eslint-disable-line
+			for (const [name, value] of Object.entries(styles)) { // eslint-disable-line
+				const el = shadowRoot.querySelector(selector);
+				if (el) {
+					el.style[name] = value;
+				}
+			}
+		}
+	}
 };
 
 export default updateShadowRoot;

--- a/packages/base/src/util/createStyleInHead.js
+++ b/packages/base/src/util/createStyleInHead.js
@@ -9,7 +9,7 @@ const createStyleInHead = (cssText, attributes = {}) => {
 	style.type = "text/css";
 
 	Object.entries(attributes).forEach(pair => style.setAttribute(...pair));
-	
+
 	style.textContent = cssText;
 	document.head.appendChild(style);
 	return style;

--- a/packages/base/src/util/createStyleInHead.js
+++ b/packages/base/src/util/createStyleInHead.js
@@ -9,15 +9,8 @@ const createStyleInHead = (cssText, attributes = {}) => {
 	style.type = "text/css";
 
 	Object.entries(attributes).forEach(pair => style.setAttribute(...pair));
-
-	if (document.adoptedStyleSheets) { // Chrome
-		const stylesheet = new CSSStyleSheet();
-		stylesheet.replaceSync(cssText);
-		document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
-	} else {
-		style.textContent = cssText;
-	}
-
+	
+	style.textContent = cssText;
 	document.head.appendChild(style);
 	return style;
 };

--- a/packages/base/src/util/createStyleInHead.js
+++ b/packages/base/src/util/createStyleInHead.js
@@ -5,19 +5,19 @@
  * @returns {HTMLElement}
  */
 const createStyleInHead = (cssText, attributes = {}) => {
-	if (document.adoptedStyleSheets) { // Chrome
-		const style = new CSSStyleSheet();
-		style.replaceSync(cssText);
-		document.adoptedStyleSheets = [...document.adoptedStyleSheets, style];
-		return style;
-	}
-
 	const style = document.createElement("style");
 	style.type = "text/css";
 
 	Object.entries(attributes).forEach(pair => style.setAttribute(...pair));
 
-	style.textContent = cssText;
+	if (document.adoptedStyleSheets) { // Chrome
+		const stylesheet = new CSSStyleSheet();
+		stylesheet.replaceSync(cssText);
+		document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
+	} else {
+		style.textContent = cssText;
+	}
+
 	document.head.appendChild(style);
 	return style;
 };

--- a/packages/base/src/util/createStyleInHead.js
+++ b/packages/base/src/util/createStyleInHead.js
@@ -5,6 +5,13 @@
  * @returns {HTMLElement}
  */
 const createStyleInHead = (cssText, attributes = {}) => {
+	if (document.adoptedStyleSheets) { // Chrome
+		const style = new CSSStyleSheet();
+		style.replaceSync(cssText);
+		document.adoptedStyleSheets = [...document.adoptedStyleSheets, style];
+		return style;
+	}
+
 	const style = document.createElement("style");
 	style.type = "text/css";
 

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -8,7 +8,6 @@
 	dir="{{effectiveDir}}"
 	aria-expanded="{{ariaExpanded}}"
 	aria-labelledby="{{ariaLabelledBy}}"
-	style="list-style-type: none;"
 >
 	<div class="ui5-nli-group-header">
 		<ui5-button

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -9,7 +9,6 @@
 	tabindex="{{_tabIndex}}"
 	dir="{{effectiveDir}}"
 	aria-labelledby="{{ariaLabelledBy}}"
-	style="list-style-type: none;"
 >
 	<div class="ui5-nli-actions">
 		{{#if showOverflow}}

--- a/packages/fiori/src/Timeline.hbs
+++ b/packages/fiori/src/Timeline.hbs
@@ -1,7 +1,7 @@
 <div class="ui5-timeline-root" @focusin={{_onfocusin}}>
 	<ul class="ui5-timeline-list" role="listbox" aria-live="polite" aria-label="{{ariaLabel}}">
 		{{#each items}}
-			<li class="ui5-timeline-list-item" style="list-style-type: none;">
+			<li class="ui5-timeline-list-item">
 				<slot name="{{this._individualSlot}}"></slot>
 			</li>
 		{{/each}}

--- a/packages/fiori/src/Wizard.hbs
+++ b/packages/fiori/src/Wizard.hbs
@@ -19,7 +19,6 @@
 					@ui5-selection-change-requested="{{../onSelectionChangeRequested}}"
 					@ui5-focused="{{../onStepInHeaderFocused}}"
 					@click="{{../_onGroupedTabClick}}"
-					style={{styles}}
 				></ui5-wizard-tab>
 			{{/each}}
 		</div>

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -329,6 +329,9 @@ class Wizard extends UI5Element {
 	}
 
 	onAfterRendering() {
+		this._stepsInHeader.forEach(step => {
+			this.getDomRef().querySelector(`[data-ui5-content-ref-id="${step.refStepId}"]`).style.zIndex = step.zIndex;
+		});
 		this.storeStepScrollOffsets();
 
 		if (this.previouslySelectedStepIndex !== this.selectedStepIndex) {
@@ -842,7 +845,7 @@ class Wizard extends UI5Element {
 				accInfo,
 				refStepId: step._id,
 				tabIndex: this.selectedStepIndex === idx ? "0" : "-1",
-				styles: `z-index: ${isAfterCurrent ? --inintialZIndex : 1}`,
+				zIndex: isAfterCurrent ? --inintialZIndex : 1,
 			};
 		});
 	}

--- a/packages/fiori/test/pages/Components.html
+++ b/packages/fiori/test/pages/Components.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
 
     <title>Default values test page</title>
-    <script>delete Document.prototype.adoptedStyleSheets</script>
+    <script>// delete document.prototype.adoptedStyleSheets</script>
 
     <script data-ui5-config type="application/json">
         {

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -7,7 +7,7 @@
 
 	<title>Flexible Column Layout</title>
 
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>

--- a/packages/fiori/test/pages/FCLApp.html
+++ b/packages/fiori/test/pages/FCLApp.html
@@ -7,7 +7,7 @@
 
 	<title>Flexible Column Layout</title>
 
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>

--- a/packages/fiori/test/pages/FCLCustom.html
+++ b/packages/fiori/test/pages/FCLCustom.html
@@ -7,7 +7,7 @@
 
 	<title>Flexible Column Layout</title>
 
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/fiori/test/pages/NotificationList_test_page.html
+++ b/packages/fiori/test/pages/NotificationList_test_page.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		.test-section {

--- a/packages/fiori/test/pages/ProductSwitch.html
+++ b/packages/fiori/test/pages/ProductSwitch.html
@@ -18,7 +18,7 @@
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 </head>

--- a/packages/fiori/test/pages/ProductSwitchItem.html
+++ b/packages/fiori/test/pages/ProductSwitchItem.html
@@ -18,7 +18,7 @@
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 </head>

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Side Navigation</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/fiori/test/pages/UploadCollection.html
+++ b/packages/fiori/test/pages/UploadCollection.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<title>UploadCollection</title>
     <script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
     </script>
 
 

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -18,7 +18,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		html, body {

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -26,6 +26,18 @@
 			padding: 0;
 			height: 100%;
 		}
+		.step-wrapper {
+			display: flex; min-height: 200px; flex-direction: column;
+		}
+		.step-body {
+			display: flex; flex-direction: column;
+		}
+		.block1 {
+			display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem;
+		}
+		.block2 {
+			display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;
+		}
 	</style>
 </head>
 
@@ -33,7 +45,7 @@
 	<h2>Wizard</h2>
 	<ui5-wizard id="wiz" style="height: 700px">
 		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" disabled>
-			<div style="display: flex; min-height: 200px; flex-direction: column;">
+			<div class="step-wrapper">
 				<ui5-title>1. Product Type</ui5-title><br>
 
 				<ui5-messagestrip>
@@ -49,24 +61,24 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
-			<div style="display: flex;flex-direction: column">
+			<div class="step-body">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Name</ui5-label>
 						<ui5-input placeholder="product name..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Weight</ui5-label>
 						<ui5-input value="3.65"></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Manifacturer</ui5-label>
 						<ui5-select>
 							<ui5-option selected>Apple</ui5-option>
@@ -75,7 +87,7 @@
 						</ui5-select>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>5 years guarantee included</ui5-label>
 						<ui5-switch id="sw"></ui5-switch>
 					</div>
@@ -86,7 +98,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Options" disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>3. Options</ui5-title><br>
 
 				<ui5-label wrapping-type="Normal">
@@ -96,13 +108,13 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Manifacture date</ui5-label>
 						<ui5-date-picker></ui5-date-picker>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Availability</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>In stock</ui5-toggle-button>
@@ -112,7 +124,7 @@
 						</ui5-segmented-button>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Size</ui5-label>
 						<ui5-segmented-button id="sb">
 							<ui5-toggle-button icon="employee" pressed>Small</ui5-toggle-button>
@@ -127,7 +139,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Pricing" selected>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -136,18 +148,18 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Price</ui5-label>
 						<ui5-input placeholder="product price..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Quantity</ui5-label>
 						<ui5-input placeholder="product quantity..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Vat included</ui5-label>
 						<ui5-switch checked></ui5-switch>
 					</div>
@@ -161,7 +173,7 @@
 	<h2>Wizard non-standard</h2>
 	<ui5-wizard style="height: 700px">
 		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected>
-			<div style="display: flex; min-height: 200px; flex-direction: column;">
+			<div class="step-wrapper">
 				<ui5-title>1. Product Type</ui5-title><br>
 
 				<ui5-messagestrip>
@@ -175,24 +187,24 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
-			<div style="display: flex;flex-direction: column">
+			<div class="step-body">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Name</ui5-label>
 						<ui5-input placeholder="product name..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Weight</ui5-label>
 						<ui5-input value="3.65"></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Manifacturer</ui5-label>
 						<ui5-select>
 							<ui5-option selected>Apple</ui5-option>
@@ -201,7 +213,7 @@
 						</ui5-select>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>5 years guarantee included</ui5-label>
 						<ui5-switch></ui5-switch>
 					</div>
@@ -211,7 +223,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Options" selected>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>3. Options</ui5-title><br>
 
 				<ui5-label wrapping-type="Normal">
@@ -221,13 +233,13 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Manifacture date</ui5-label>
 						<ui5-date-picker></ui5-date-picker>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Availability</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>In stock</ui5-toggle-button>
@@ -237,7 +249,7 @@
 						</ui5-segmented-button>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Size</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>Small</ui5-toggle-button>
@@ -252,7 +264,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Pricing" disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -261,18 +273,18 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Price</ui5-label>
 						<ui5-input placeholder="product price..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Quantity</ui5-label>
 						<ui5-input placeholder="product quantity..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Vat included</ui5-label>
 						<ui5-switch checked></ui5-switch>
 					</div>
@@ -282,7 +294,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Final" selected disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>5. Final</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -291,18 +303,18 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Price</ui5-label>
 						<ui5-input placeholder="product price..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Quantity</ui5-label>
 						<ui5-input placeholder="product quantity..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Vat included</ui5-label>
 						<ui5-switch checked></ui5-switch>
 					</div>
@@ -315,7 +327,7 @@
 	<h2>Wizard non-standard 2</h2>
 	<ui5-wizard style="height: 700px">
 		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected disabled>
-			<div style="display: flex; min-height: 200px; flex-direction: column;">
+			<div class="step-wrapper">
 				<ui5-title>1. Product Type</ui5-title><br>
 
 				<ui5-messagestrip>
@@ -329,24 +341,24 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected disabled>
-			<div style="display: flex;flex-direction: column">
+			<div class="step-body">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Name</ui5-label>
 						<ui5-input placeholder="product name..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Weight</ui5-label>
 						<ui5-input value="3.65"></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Manifacturer</ui5-label>
 						<ui5-select>
 							<ui5-option selected>Apple</ui5-option>
@@ -355,7 +367,7 @@
 						</ui5-select>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>5 years guarantee included</ui5-label>
 						<ui5-switch></ui5-switch>
 					</div>
@@ -366,20 +378,20 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Options" selected>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>3. Options</ui5-title><br>
 
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Manifacture date</ui5-label>
 						<ui5-date-picker></ui5-date-picker>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Availability</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>In stock</ui5-toggle-button>
@@ -389,7 +401,7 @@
 						</ui5-segmented-button>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Size</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>Small</ui5-toggle-button>
@@ -404,7 +416,7 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Pricing" selected disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -413,18 +425,18 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-messagestrip><br>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Price</ui5-label>
 						<ui5-input placeholder="product price..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Quantity</ui5-label>
 						<ui5-input placeholder="product quantity..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Vat included</ui5-label>
 						<ui5-switch checked></ui5-switch>
 					</div>
@@ -437,7 +449,7 @@
 	<h2>Wizard non-standard 3</h2>
 	<ui5-wizard style="height: 700px">
 		<ui5-wizard-step title-text="Product type" icon="sap-icon://product" selected disabled>
-			<div style="display: flex; min-height: 200px; flex-direction: column;">
+			<div class="step-wrapper">
 				<ui5-title>1. Product Type</ui5-title><br>
 
 				<ui5-messagestrip>
@@ -450,24 +462,24 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected>
-			<div style="display: flex;flex-direction: column">
+			<div class="step-body">
 				<ui5-title>2. Product Information</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Name</ui5-label>
 						<ui5-input placeholder="product name..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Weight</ui5-label>
 						<ui5-input value="3.65"></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Manifacturer</ui5-label>
 						<ui5-select>
 							<ui5-option selected>Apple</ui5-option>
@@ -476,7 +488,7 @@
 						</ui5-select>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>5 years guarantee included</ui5-label>
 						<ui5-switch></ui5-switch>
 					</div>
@@ -487,20 +499,20 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Options" selected disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>3. Options</ui5-title><br>
 
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Manifacture date</ui5-label>
 						<ui5-date-picker></ui5-date-picker>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Availability</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>In stock</ui5-toggle-button>
@@ -510,7 +522,7 @@
 						</ui5-segmented-button>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Size</ui5-label>
 						<ui5-segmented-button>
 							<ui5-toggle-button icon="employee" pressed>Small</ui5-toggle-button>
@@ -525,24 +537,24 @@
 		</ui5-wizard-step>
 
 		<ui5-wizard-step title-text="Pricing" selected disabled>
-			<div style="display: flex; flex-direction: column;">
+			<div class="step-body">
 				<ui5-title>4. Pricing</ui5-title><br>
 				<ui5-label wrapping-type="Normal">
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
-				<div style="display: flex; flex-direction: column;">
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+				<div class="step-body">
+					<div class="block1">
 						<ui5-label>Price</ui5-label>
 						<ui5-input placeholder="product price..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="block1">
 						<ui5-label>Quantity</ui5-label>
 						<ui5-input placeholder="product quantity..."></ui5-input>
 					</div>
 
-					<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+					<div class="block2">
 						<ui5-label>Vat included</ui5-label>
 						<ui5-switch checked></ui5-switch>
 					</div>
@@ -555,7 +567,7 @@
 	<ui5-dialog id="dialog" stretch header-heading="Wizard">
 		<ui5-wizard id="wiz2">
 			<ui5-wizard-step icon="sap-icon://home" title-text="Product type">
-				<div style="display: flex; min-height: 200px; flex-direction: column;">
+				<div class="step-wrapper">
 					<ui5-title>1. Product Type</ui5-title><br>
 
 					<ui5-messagestrip>
@@ -570,24 +582,24 @@
 			</ui5-wizard-step>
 
 			<ui5-wizard-step title-text="Product Information" selected>
-				<div style="display: flex;flex-direction: column">
+				<div class="step-body">
 					<ui5-title>2. Product Information</ui5-title><br>
 					<ui5-label wrapping-type="Normal">
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 
-					<div style="display: flex; flex-direction: column;">
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="step-body">
+						<div class="block1">
 							<ui5-label>Name</ui5-label>
 							<ui5-input placeholder="product name..."></ui5-input>
 						</div>
 
-						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+						<div class="block2">
 							<ui5-label>Weight</ui5-label>
 							<ui5-input value="3.65"></ui5-input>
 						</div>
 
-						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+						<div class="block2">
 							<ui5-label>Manifacturer</ui5-label>
 							<ui5-select>
 								<ui5-option selected>Apple</ui5-option>
@@ -596,7 +608,7 @@
 							</ui5-select>
 						</div>
 
-						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+						<div class="block2">
 							<ui5-label>5 years guarantee included</ui5-label>
 							<ui5-switch id="sw2"></ui5-switch>
 						</div>
@@ -607,7 +619,7 @@
 			</ui5-wizard-step>
 
 			<ui5-wizard-step title-text="Options" disabled>
-				<div style="display: flex; flex-direction: column;">
+				<div class="step-body">
 					<ui5-title>3. Options</ui5-title><br>
 
 					<ui5-label wrapping-type="Normal">
@@ -617,13 +629,13 @@
 						The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 					</ui5-messagestrip><br>
 
-					<div style="display: flex; flex-direction: column;">
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="step-body">
+						<div class="block1">
 							<ui5-label>Manifacture date</ui5-label>
 							<ui5-date-picker></ui5-date-picker>
 						</div>
 
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+						<div class="block1">
 							<ui5-label>Availability</ui5-label>
 							<ui5-segmented-button>
 								<ui5-toggle-button icon="employee" pressed>In stock</ui5-toggle-button>
@@ -633,7 +645,7 @@
 							</ui5-segmented-button>
 						</div>
 
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+						<div class="block1">
 							<ui5-label>Size</ui5-label>
 							<ui5-segmented-button id="sb2">
 								<ui5-toggle-button icon="employee" pressed>Small</ui5-toggle-button>
@@ -648,7 +660,7 @@
 			</ui5-wizard-step>
 
 			<ui5-wizard-step title-text="Pricing" disabled>
-				<div style="display: flex; flex-direction: column;">
+				<div class="step-body">
 					<ui5-title>4. Pricing</ui5-title><br>
 					<ui5-label wrapping-type="Normal">
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
@@ -657,18 +669,18 @@
 						The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 					</ui5-messagestrip><br>
 
-					<div style="display: flex; flex-direction: column;">
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+					<div class="step-body">
+						<div class="block1">
 							<ui5-label>Price</ui5-label>
 							<ui5-input placeholder="product price..."></ui5-input>
 						</div>
 
-						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
+						<div class="block1">
 							<ui5-label>Quantity</ui5-label>
 							<ui5-input placeholder="product quantity..."></ui5-input>
 						</div>
 
-						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
+						<div class="block2">
 							<ui5-label>Vat included</ui5-label>
 							<ui5-switch checked></ui5-switch>
 						</div>

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -12,7 +12,6 @@
             {{#each items}}
                  <div id="{{id}}"
                     class="ui5-carousel-item {{classes}}"
-                    style="width: {{this.width}}px;"
                     role="option"
                     aria-posinset="{{posinset}}"
                     aria-setsize="{{setsize}}"

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -319,6 +319,9 @@ class Carousel extends UI5Element {
 	onAfterRendering() {
 		this._scrollEnablement.scrollContainer = this.getDomRef();
 		this._resizing = false; // not invalidating
+		this.items.forEach(item => {
+			this.getDomRef().querySelector(`#${item.id}`).style.width = `${item.width}px`;
+		});
 	}
 
 	onEnterDOM() {

--- a/packages/main/src/ColorPaletteItem.hbs
+++ b/packages/main/src/ColorPaletteItem.hbs
@@ -1,6 +1,6 @@
 <div
 	class="ui5-cp-item"
-	style="background-color: {{value}}"
+	style="{{styles.root}}"
 	value="{{value}}"
 	tabindex="{{_tabIndex}}"
 	role="button"

--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -121,6 +121,14 @@ class ColorPaletteItem extends UI5Element {
 	get colorLabel() {
 		return this.i18nBundle.getText(COLORPALETTE_COLOR_LABEL);
 	}
+
+	get styles() {
+		return {
+			root: {
+				"background-color": this.value,
+			},
+		};
+	}
 }
 
 ColorPaletteItem.define();

--- a/packages/main/src/DateTimePickerPopover.hbs
+++ b/packages/main/src/DateTimePickerPopover.hbs
@@ -4,7 +4,7 @@
 {{#*inline "header"}}
 	{{#if phone}}
 		<div class="ui5-dt-picker-header">
-			<ui5-segmented-button style="width: 8rem">
+			<ui5-segmented-button class="ui5-dt-picker-toggle-button">
 				<ui5-toggle-button key="Date" ?pressed="{{showDateView}}" @click="{{_dateTimeSwitchChange}}">{{btnDateLabel}}</ui5-toggle-button>
 				<ui5-toggle-button key="Time" ?pressed="{{showTimeView}}" @click="{{_dateTimeSwitchChange}}">{{btnTimeLabel}}</ui5-toggle-button>
 			</ui5-segmented-button>

--- a/packages/main/src/DayPicker.hbs
+++ b/packages/main/src/DayPicker.hbs
@@ -22,7 +22,7 @@
 		</div>
 		{{#each _weeks}}
 			{{#if this.length}}
-				<div style="display: flex;" role="row">
+				<div class="ui5-dp-weeks-row" role="row">
 					{{#each this}}
 						{{#if this.timestamp}}
 							<div

--- a/packages/main/src/GroupHeaderListItem.hbs
+++ b/packages/main/src/GroupHeaderListItem.hbs
@@ -5,7 +5,6 @@
 	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	role="option"
-	style="list-style-type: none;"
 >
 	<span class="ui5-hidden-text">{{groupHeaderText}} {{accessibleName}}</span>
 

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -28,7 +28,7 @@
 			<slot></slot>
 
 			{{#if showNoDataText}}
-				<li id="{{_id}}-nodata" class="ui5-list-nodata" tabindex="{{noDataTabIndex}}" style="list-style-type: none;">
+				<li id="{{_id}}-nodata" class="ui5-list-nodata" tabindex="{{noDataTabIndex}}">
 					<div id="{{_id}}-nodata-text" class="ui5-list-nodata-text">
 						{{noDataText}}
 					</div>

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -19,7 +19,6 @@
 	aria-setsize="{{_accInfo.setsize}}"
 	aria-labelledby="{{_id}}-invisibleText {{_id}}-content"
 	aria-disabled="{{ariaDisabled}}"
-	style="list-style-type: none;"
 >
 		{{> listItemPreContent}}
 

--- a/packages/main/src/Popover.hbs
+++ b/packages/main/src/Popover.hbs
@@ -1,7 +1,7 @@
 {{>include "./Popup.hbs"}}
 
 {{#*inline "beforeContent"}}
-	<span class="ui5-popover-arrow"></span>
+	<span class="ui5-popover-arrow" style="{{styles.arrow}}"></span>
 
 	{{#if _displayHeader}}
 		<header class="ui5-popup-header-root" id="ui5-popup-header">

--- a/packages/main/src/Popover.hbs
+++ b/packages/main/src/Popover.hbs
@@ -1,7 +1,7 @@
 {{>include "./Popup.hbs"}}
 
 {{#*inline "beforeContent"}}
-	<span class="ui5-popover-arrow" style="{{styles.arrow}}"></span>
+	<span class="ui5-popover-arrow"></span>
 
 	{{#if _displayHeader}}
 		<header class="ui5-popup-header-root" id="ui5-popup-header">

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -735,10 +735,10 @@ class Popover extends Popup {
 	get styles() {
 		return {
 			...super.styles,
-			content: {
+			".ui5-popup-content": {
 				"max-height": `${this._maxContentHeight}px`,
 			},
-			arrow: {
+			".ui5-popover-arrow": {
 				transform: `translate(${this.arrowTranslateX}px, ${this.arrowTranslateY}px)`,
 			},
 		};

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -735,10 +735,10 @@ class Popover extends Popup {
 	get styles() {
 		return {
 			...super.styles,
-			".ui5-popup-content": {
+			content: {
 				"max-height": `${this._maxContentHeight}px`,
 			},
-			".ui5-popover-arrow": {
+			arrow: {
 				transform: `translate(${this.arrowTranslateX}px, ${this.arrowTranslateY}px)`,
 			},
 		};

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,4 +1,5 @@
 <section
+	style="{{styles.root}}"
 	class="{{classes.root}}"
 	role="dialog"
 	aria-modal="{{_ariaModal}}"
@@ -13,7 +14,7 @@
 
 	{{> beforeContent}}
 
-	<div class="{{classes.content}}"  @scroll="{{_scroll}}">
+	<div style="{{styles.content}}" class="{{classes.content}}"  @scroll="{{_scroll}}">
 		<slot></slot>
 	</div>
 

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -1,5 +1,4 @@
 <section
-	style="{{styles.root}}"
 	class="{{classes.root}}"
 	role="dialog"
 	aria-modal="{{_ariaModal}}"
@@ -14,7 +13,7 @@
 
 	{{> beforeContent}}
 
-	<div style="{{styles.content}}" class="{{classes.content}}"  @scroll="{{_scroll}}">
+	<div class="{{classes.content}}"  @scroll="{{_scroll}}">
 		<slot></slot>
 	</div>
 

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -2,7 +2,7 @@ import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { getFirstFocusableElement, getLastFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
-import createStyleInHead from "@ui5/webcomponents-base/dist/util/createStyleInHead.js";
+import { hasStyle, createStyle } from "@ui5/webcomponents-base/dist/ManagedStyles.js";
 import { isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getNextZIndex, getFocusedElement, isFocusedElementWithinNode } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import PopupTemplate from "./generated/templates/PopupTemplate.lit.js";
@@ -140,23 +140,17 @@ const metadata = {
 	},
 };
 
-let customBlockingStyleInserted = false;
-
 const createBlockingStyle = () => {
-	if (customBlockingStyleInserted) {
-		return;
-	}
-
-	createStyleInHead(`
+	if (!hasStyle("data-ui5-popup-scroll-blocker")) {
+		createStyle(`
 		.ui5-popup-scroll-blocker {
 			width: 100%;
 			height: 100%;
 			position: fixed;
 			overflow: hidden;
 		}
-	`, { "data-ui5-popup-scroll-blocker": "" });
-
-	customBlockingStyleInserted = true;
+	`, "data-ui5-popup-scroll-blocker");
+	}
 };
 
 createBlockingStyle();

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -519,9 +519,9 @@ class Popup extends UI5Element {
 
 	get styles() {
 		return {
-			root: {},
-			content: {},
-			blockLayer: {
+			".ui5-popup-root": {},
+			".ui5-popup-content": {},
+			".ui5-block-layer": {
 				"zIndex": (this._zIndex - 1),
 			},
 		};

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -513,9 +513,9 @@ class Popup extends UI5Element {
 
 	get styles() {
 		return {
-			".ui5-popup-root": {},
-			".ui5-popup-content": {},
-			".ui5-block-layer": {
+			root: {},
+			content: {},
+			blockLayer: {
 				"zIndex": (this._zIndex - 1),
 			},
 		};

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -30,7 +30,7 @@
 							{{this.stripPresentation}}
 						{{/unless}}
 						{{#if this.isSeparator}}
-							<li id="{{this._id}}" role="separator" class="{{../classes.separator}}" style="list-style-type: none;"></li>
+							<li id="{{this._id}}" role="separator" class="{{../classes.separator}}"></li>
 						{{/if}}
 					{{/each}}
 				</ul>

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -10,7 +10,6 @@
 	?disabled="{{this.effectiveDisabled}}"
 	aria-labelledby="{{this.ariaLabelledBy}}"
 	data-ui5-stable="{{this.stableDomRef}}"
-	style="list-style-type: none;"
 >
 
 	{{#if this.icon}}

--- a/packages/main/src/TabSeparator.hbs
+++ b/packages/main/src/TabSeparator.hbs
@@ -1,1 +1,1 @@
-<li id="{{_id}}" role="separator" style="list-style-type: none;"></li>
+<li id="{{_id}}" role="separator"></li>

--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -5,7 +5,7 @@
 
 	<table border="0" cellspacing="0" cellpadding="0" @keydown="{{_onkeydown}}" role="table">
 		<thead>
-			<tr id="{{_columnHeader.id}}" role="row" class="ui5-table-header-row" aria-label="{{ariaLabelText}}" tabindex="{{_columnHeader._tabIndex}}" style="height: 48px" @click="{{_onColumnHeaderClick}}">
+			<tr id="{{_columnHeader.id}}" role="row" class="ui5-table-header-row" aria-label="{{ariaLabelText}}" tabindex="{{_columnHeader._tabIndex}}" @click="{{_onColumnHeaderClick}}">
 				{{#if isMultiSelect}}
 					<th class="ui5-table-select-all-column" role="presentation" aria-hidden="true">
 						<ui5-checkbox class="ui5-table-select-all-checkbox"

--- a/packages/main/src/TreeListItem.hbs
+++ b/packages/main/src/TreeListItem.hbs
@@ -3,7 +3,7 @@
 {{#*inline "listItemPreContent"}}
 	<div
 		class="ui5-li-tree-toggle-box"
-		style="padding-left: {{effectiveLevel}}rem; padding-left: calc(var(--_ui5-tree-indent-step) * {{effectiveLevel}});"
+		style="{{styles.preContent}}"
 	>
 		{{#if _showToggleButtonBeginning}}
 			<ui5-icon

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -2,6 +2,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isLeft, isRight } from "@ui5/webcomponents-base/dist/Keys.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
+import { isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import ListItem from "./ListItem.js";
 import Icon from "./Icon.js";
 import "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";
@@ -253,6 +254,14 @@ class TreeListItem extends ListItem {
 		const allClasses = super.classes;
 		allClasses.main["ui5-li-root-tree"] = true;
 		return allClasses;
+	}
+
+	get styles() {
+		return {
+			preContent: {
+				"padding-left": isIE() ? `${this.effectiveLevel}rem` : `calc(var(--_ui5-tree-indent-step) * ${this.effectiveLevel})`,
+			},
+		};
 	}
 
 	get effectiveLevel() {

--- a/packages/main/src/WheelSlider.hbs
+++ b/packages/main/src/WheelSlider.hbs
@@ -25,7 +25,6 @@
 							data-item-index="{{@index}}"
 							role="option"
 							aria-selected="{{this.selected}}"
-							style="list-style-type: none;">
 							{{this.value}}
 						</li>
 					{{/each}}
@@ -35,7 +34,7 @@
 					<li class="ui5-wheelslider-item"
 						role="option"
 						aria-selected="true"
-						style="list-style-type: none;">
+					>
 						{{value}}
 					</li>
 				</ul>

--- a/packages/main/src/WheelSlider.hbs
+++ b/packages/main/src/WheelSlider.hbs
@@ -25,6 +25,7 @@
 							data-item-index="{{@index}}"
 							role="option"
 							aria-selected="{{this.selected}}"
+						>
 							{{this.value}}
 						</li>
 					{{/each}}

--- a/packages/main/src/themes/DateTimePickerPopover.css
+++ b/packages/main/src/themes/DateTimePickerPopover.css
@@ -7,6 +7,10 @@
 	justify-content: center;
 }
 
+.ui5-dt-picker-toggle-button {
+    width: 8rem;
+}
+
 .ui5-dt-cal {
 	width: auto;
 	padding: 0.5rem 0.25rem 0 0.25rem; /* both cozy and compact */

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -26,6 +26,10 @@
 	color: var(--_ui5_daypicker_weekname_color);
 }
 
+.ui5-dp-weeks-row {
+    display: flex;
+}
+
 .ui5-dp-content {
 	display: flex;
 	flex-basis: 87.5%;

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -14,7 +14,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -8,7 +8,7 @@
 
 	<title>Busy Indicator</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -7,7 +7,7 @@
 
 	<title>Button</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -8,7 +8,7 @@
 	<title>Calendar Playground</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -11,7 +11,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		ui5-checkbox:not(.ui5-cb-testing-wrap) {

--- a/packages/main/test/pages/ColorPicker.html
+++ b/packages/main/test/pages/ColorPicker.html
@@ -8,7 +8,7 @@
 	<title>ColorPicker Playground</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -7,7 +7,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ComboBox test page</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Components.html
+++ b/packages/main/test/pages/Components.html
@@ -6,7 +6,7 @@
 	<meta charset="utf-8">
 
 	<title>Default values test page</title>
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 
 	<script data-ui5-config type="application/json">
 		{

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -7,7 +7,7 @@
 	<title>DatePicker test page</title>
 
 	<script>
-		// delete Document.prototype.adoptedStyleSheets;
+		// // delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/DateRangePicker.html
+++ b/packages/main/test/pages/DateRangePicker.html
@@ -7,7 +7,7 @@
 	<title>DateRangePicker test page</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/DateTimePicker.html
+++ b/packages/main/test/pages/DateTimePicker.html
@@ -8,7 +8,7 @@
 	<title>DateTimePicker Test Page</title>
 
     <script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
     </script>
 
     <script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/DayPicker.html
+++ b/packages/main/test/pages/DayPicker.html
@@ -6,7 +6,7 @@
 	<meta charset="utf-8">
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -16,7 +16,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/DialogSemantic.html
+++ b/packages/main/test/pages/DialogSemantic.html
@@ -16,7 +16,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/DurationPicker.html
+++ b/packages/main/test/pages/DurationPicker.html
@@ -7,7 +7,7 @@
 
 	<title>DurationPicker</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/FileUploader.html
+++ b/packages/main/test/pages/FileUploader.html
@@ -15,7 +15,7 @@
 		}
 	</style>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 </head>
 <body>

--- a/packages/main/test/pages/Icon.html
+++ b/packages/main/test/pages/Icon.html
@@ -7,7 +7,7 @@
 
 	<title>Icon</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 	<script data-id="sap-ui-config" type="application/json">
 		{

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 </head>
 
@@ -335,7 +335,7 @@
 			if (event.key === 'Enter') {
 				var formToSubmit = document.getElementById("submit-form");
 				var submitEvent = new Event('submit');
-				
+
 				/* The old way - supported by all browsers:
 				The submit method of the form won't trigger
 				a submit event by itself, dispatch it manually */

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -8,7 +8,7 @@
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/main/test/pages/InputsAlignment.html
+++ b/packages/main/test/pages/InputsAlignment.html
@@ -9,7 +9,7 @@
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -42,7 +42,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete Document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body class="body-bg">

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -42,7 +42,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>// delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// // delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body class="body-bg">

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -16,7 +16,7 @@
 		}
 	</script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
@@ -75,7 +75,7 @@
 			<ui5-label style="width: 600px; text-align: right;" id="wrapping-label-4" wrapping-type="Normal">Must be right-aligned using `text-align: right` and wrapping-type="Normal".</ui5-label>
 		</div>
 	</section>
-	
+
 	<h2>Test show-colon not forcing truncation</h2>
 	<ui5-label id="showColon-false">Basic Label</ui5-label>
 	<ui5-label show-colon id="showColon-true">Basic Label</ui5-label>

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -10,7 +10,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<script data-ui5-config type="application/json">
 		{

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/main/test/pages/ListGrowing_Button.html
+++ b/packages/main/test/pages/ListGrowing_Button.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">

--- a/packages/main/test/pages/ListGrowing_Scroll.html
+++ b/packages/main/test/pages/ListGrowing_Scroll.html
@@ -10,7 +10,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
@@ -29,7 +29,7 @@
 			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 		</ui5-list>
 	</section>
-	
+
 
 	<br><br><br>
 	<ui5-title>List growing="Scroll" max-height: 8rem;</ui5-title>

--- a/packages/main/test/pages/LitKeyFunction.html
+++ b/packages/main/test/pages/LitKeyFunction.html
@@ -7,7 +7,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>LitHTML key function test page</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/MessageStrip.html
+++ b/packages/main/test/pages/MessageStrip.html
@@ -13,7 +13,7 @@
 		}
 	</script>
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/MultiComboBox.html
+++ b/packages/main/test/pages/MultiComboBox.html
@@ -7,7 +7,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>MultiComboBox test page</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/MultiInput.html
+++ b/packages/main/test/pages/MultiInput.html
@@ -11,7 +11,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		ui5-multi-input {

--- a/packages/main/test/pages/MultiInput_Suggestions.html
+++ b/packages/main/test/pages/MultiInput_Suggestions.html
@@ -11,7 +11,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		ui5-multi-input {

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -14,7 +14,7 @@
 		}
 	</script>
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -28,7 +28,7 @@
 	</style>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 </head>
 

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -7,7 +7,7 @@
 	<title>Popups</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/ProgressIndicator.html
+++ b/packages/main/test/pages/ProgressIndicator.html
@@ -8,7 +8,7 @@
 
 	<title>Progress Indicator</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/RTL.html
+++ b/packages/main/test/pages/RTL.html
@@ -7,7 +7,7 @@
 
 	<title>RTL and Language</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/RadioButton.html
+++ b/packages/main/test/pages/RadioButton.html
@@ -11,7 +11,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		.radio-section {

--- a/packages/main/test/pages/RangeSlider.html
+++ b/packages/main/test/pages/RangeSlider.html
@@ -20,7 +20,7 @@
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		html,
@@ -70,7 +70,7 @@
 		<script>
 			const eventTargetSlider = document.getElementById("test-slider");
 			const eventResultSlider = document.getElementById("test-result-slider");
-		
+
 			eventTargetSlider.addEventListener("ui5-input", () => {
 				eventResultSlider.setAttribute("end-value", parseInt(eventResultSlider.getAttribute("end-value")) + 1);
 			});

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -8,7 +8,7 @@
 
 	<title>Rating Indicator</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -12,7 +12,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 </head>
 

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -7,7 +7,7 @@
 	<title>ui5-select</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Simple.html
+++ b/packages/main/test/pages/Simple.html
@@ -15,16 +15,20 @@
 
 </head>
 
-<body style="background-color: var(--sapBackgroundColor);">
+<body>
 
-<ui5-datepicker></ui5-datepicker>
+<ui5-button id="btn">test</ui5-button>
 
-<ui5-button id="b">test</ui5-button>
+<ui5-popover header-text="Header" id="pop">
+	Hello world
+</ui5-popover>
 
-<ui5-select id="mySelect">
-	<ui5-option selected id="o1">Cozy</ui5-option>
-	<ui5-option selected id="o2">Compact</ui5-option>
-</ui5-select>
+
+<script>
+	btn.addEventListener("click", function (event) {
+		pop.openBy(btn);
+	});
+</script>
 
 </body>
 </html>

--- a/packages/main/test/pages/Slider.html
+++ b/packages/main/test/pages/Slider.html
@@ -16,7 +16,7 @@
 		}
 	</script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
@@ -62,10 +62,10 @@
 
 			<h2 style="text-align: center;">Slider with steps, tooltips, tickmarks and labels</h2>
 			<ui5-slider id="slider-tickmarks-labels" min="-20" max="20" step="2" value="12" show-tooltip label-interval="2" show-tickmarks style="width: 60%; margin-left: 20%; margin-top: 50px;"></ui5-slider>
-			
+
 			<h2>Slider with float number step (1.25), tooltips, tickmarks and labels between 3 steps (3.75 value)</h2>
 			<ui5-slider id="slider-tickmarks-tooltips-labels" min="-12.5" max="47.5" step="1.25" value="10" show-tooltip label-interval="3" show-tickmarks></ui5-slider>
-			
+
 			<h2>Basic RTL Slider</h2>
 			<ui5-slider id="basic-slider-rtl" min="0" max="10" dir="rtl"></ui5-slider>
 		</section>
@@ -80,7 +80,7 @@
 		<script>
 			const eventTargetSlider = document.getElementById("test-slider");
 			const eventResultSlider = document.getElementById("test-result-slider");
-		
+
 			eventTargetSlider.addEventListener("ui5-input", () => {
 				eventResultSlider.setAttribute("value", parseInt(eventResultSlider.getAttribute("value")) + 1);
 			});

--- a/packages/main/test/pages/StepInput.html
+++ b/packages/main/test/pages/StepInput.html
@@ -7,7 +7,7 @@
 	<title>StepInput test page</title>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets;
+		// delete document.prototype.adoptedStyleSheets;
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Switch.html
+++ b/packages/main/test/pages/Switch.html
@@ -11,7 +11,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 </head>
 
 <style>

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -18,7 +18,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		html,

--- a/packages/main/test/pages/Table-perf-pure.html
+++ b/packages/main/test/pages/Table-perf-pure.html
@@ -13,7 +13,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Table-perf.html
+++ b/packages/main/test/pages/Table-perf.html
@@ -13,7 +13,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -13,7 +13,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/TableAllPopin.html
+++ b/packages/main/test/pages/TableAllPopin.html
@@ -13,7 +13,7 @@
     </script>
 
     <script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
     </script>
 
     <script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/TableCustomStyling.html
+++ b/packages/main/test/pages/TableCustomStyling.html
@@ -13,7 +13,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/TableGrowingWithButton.html
+++ b/packages/main/test/pages/TableGrowingWithButton.html
@@ -6,7 +6,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>

--- a/packages/main/test/pages/TableGrowingWithScroll.html
+++ b/packages/main/test/pages/TableGrowingWithScroll.html
@@ -6,7 +6,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<script>delete Document.prototype.adoptedStyleSheets</script>
+	<script>// delete document.prototype.adoptedStyleSheets</script>
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -17,7 +17,7 @@
 	</script>
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -6,7 +6,7 @@
 		<meta charset="utf-8">
 
 		<script>
-			delete Document.prototype.adoptedStyleSheets;
+			// delete document.prototype.adoptedStyleSheets;
 		</script>
 		<style>
 			html,body {

--- a/packages/main/test/pages/TimeSelection.html
+++ b/packages/main/test/pages/TimeSelection.html
@@ -6,7 +6,7 @@
 		<meta charset="utf-8">
 
 		<script>
-			delete Document.prototype.adoptedStyleSheets;
+			// delete document.prototype.adoptedStyleSheets;
 		</script>
 		<style>
 			html,body {

--- a/packages/main/test/pages/Toast.html
+++ b/packages/main/test/pages/Toast.html
@@ -9,7 +9,7 @@
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<style>
 		ui5-button, ui5-title {

--- a/packages/main/test/pages/ToggleButton.html
+++ b/packages/main/test/pages/ToggleButton.html
@@ -11,7 +11,7 @@
 	<meta charset="utf-8">
 
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete document.prototype.adoptedStyleSheets
 	</script>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -10,7 +10,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 	<script data-ui5-config type="application/json">
 		{

--- a/packages/main/test/pages/WheelSlider_Test_Page.html
+++ b/packages/main/test/pages/WheelSlider_Test_Page.html
@@ -6,7 +6,7 @@
 		<meta charset="utf-8">
 
 		<script>
-			delete Document.prototype.adoptedStyleSheets;
+			// delete document.prototype.adoptedStyleSheets;
 		</script>
 
 		<script src="../../webcomponentsjs/webcomponents-loader.js"></script>

--- a/packages/main/test/pages/i18n-demo.html
+++ b/packages/main/test/pages/i18n-demo.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
@@ -12,7 +12,7 @@
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
 
-	<script>delete Document.prototype.adoptedStyleSheets;</script>
+	<script>// delete document.prototype.adoptedStyleSheets;</script>
 
 </head>
 

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -54,7 +54,10 @@ HTMLLitVisitor.prototype.ContentStatement = function(content) {
 	Visitor.prototype.ContentStatement.call(this, content);
 	// let content = content.orgiinal; // attribute="__ attribute = "__  attribute ="__
 
-	const contentStatement = content.original;
+	let contentStatement = content.original;
+	if (contentStatement.match(/style="?$/)) {
+		contentStatement = contentStatement.replace(/style=("?)$/, `data-ui5-style-ref=$1`);
+	}
 	skipIfDefined = !!dynamicAttributeRgx.exec(contentStatement);
 
 	const closingIndex = contentStatement.lastIndexOf(">");
@@ -83,7 +86,7 @@ HTMLLitVisitor.prototype.MustacheStatement = function(mustache) {
 		} else if (hasCalculatingClasses) {
 			parsedCode = `\${classMap(${path})}`;
 		} else if (hasStylesCalculation) {
-			parsedCode = `\${styleMap(${path})}`;
+			parsedCode = path.replace(/^context\.styles\./, "");
 		} else if (skipIfDefined){
 			parsedCode = `\${${path}}`;
 		} else {

--- a/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
+++ b/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
@@ -2,7 +2,7 @@ const buildRenderer = (controlName, litTemplate) => {
 	return `
 /* eslint no-unused-vars: 0 */
 import ifDefined from '@ui5/webcomponents-base/dist/renderer/ifDefined.js';
-import { html, svg, repeat, classMap, styleMap, unsafeHTML, setTags, setSuffix } from '@ui5/webcomponents-base/dist/renderer/LitRenderer.js';
+import { html, svg, repeat, classMap, unsafeHTML, setTags, setSuffix } from '@ui5/webcomponents-base/dist/renderer/LitRenderer.js';
 ${litTemplate}
 
 const main = (context, tags, suffix) => {
@@ -10,7 +10,7 @@ const main = (context, tags, suffix) => {
 	setSuffix(suffix);
 	return block0(context);
 };
- 
+
 export default main;`
 };
 

--- a/packages/tools/lib/serve/serve.json
+++ b/packages/tools/lib/serve/serve.json
@@ -1,3 +1,12 @@
 {
-  "cleanUrls": false
+  "cleanUrls": false,
+  "headers": [
+	{
+	  "source" : "**/*.*",
+	  "headers" : [{
+		"key" : "Content-Security-Policy",
+		"value" : "style-src 'self'"
+	  }]
+	}
+  ]
 }


### PR DESCRIPTION
⚠️ **WIP - for initial feedback**

# Make UI5 Web Components CSP Compliant

## Summary for component developers

 - Allowed:
 ✅  style="{{styles.content}}"
 ✅  style="{{styles.arrows.left}}"

 - Forbidden:
 🚫  style="width: {{someWidth}}px"
 🚫  style="{{myStyleString}}"

_The only way to set CSP-compliant styles in `.hbs` templates will be by binding the `get styles()` CSS rules._

## Setup

The feature is tested with the following `serve.json` configuration :
```
{
  "cleanUrls": false,
  "headers": [
	{
	  "source" : "**/*.*",
	  "headers" : [{
		"key" : "Content-Security-Policy",
		"value" : "style-src 'self'"
	  }]
	}
  ]
}
```

## Requirement

In order to achieve CSP compliance, there should be:
 - no `style` tags, generated by the framework 
 - no `style` attributes, rendered by the components.

## Changes

The current change achieves full CSP compliance for **Google Chrome**.
 - `document.adoptedStyleSheets` **seems to be CSP-compliant** and we use it in place of the previously used `style` tags - for fonts, system CSS Vars, themes' CSS Vars, Popup block layer, etc... See the new `ManagedStyles.js` module, which is used wherever `createStyleTagInHead` was used.
 - The `.hbs` compiler now finds  bound `style` attributes and generates `data-ui5-` marker attributes for the respective DOM nodes. We no longer use `lit-html`s `styleMap` feature. 
 
 Example:
 `style="{{styles.arrows.left}}"`
 used to compile to a `lit-html` *styleMap(context.arrows.left)* expression, but now compiles to:
 `data-ui5-style-ref="arrows.left"` and  `lit-html` is no longer responsible for rendering the `style` tag.
 
 Then `updateShadowRoot.js` automatically applies the styles to all DOM nodes inside the shadow root, to which `style` was bound in the `.hbs`, imperatively.
 
 For example, if we have:
 ```
 get styles() {
   return {
     arrows: {
       left: {
         padding: `${this.padding}px`,
       },
     },
   };
 }
```
the *arrows -> left* path in this object will provide the styles for  the`data-ui5-style-ref="arrows.left"` attribute.

 - Static inline styles have been replaced with classes or removed where unnecessary
 - Static inline styles for IE11 only (applied to `<li>` elements) have been removed completely
 - Components that render strings inside `style` attributes without using the `get styles()` feature, and were already thus bypassing the framework, have been slightly reworked to use `get styles()` instead.
 - 2 components used to render respectively `z-index` and `width` to their children in loops by `style` attributes. These have been reworked to use `onAfterRendering` to set them imperatively instead.