### PR TITLE
refactor(ui5-color-palette-item): remove `stableDomRef` as not needed

### DIFF
--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -30,15 +30,6 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the stable selector that you can use via getStableDomRef method.
-		 * @type {String}
-		 * @public
-		 */
-		stableDomRef: {
-			type: String,
-		},
-
-		/**
 		 * Defines the tab-index of the element, helper information for the ItemNavigation.
 		 * @private
 		 */


### PR DESCRIPTION
The  `stableDomRef` is meant for components that don't have a template on their own, but are pure elements, that the parent component renders (for example Select and Options). In this case the ColorPaletteItem is a component with own template and does not need to expose a special property like this to app developers to get its DOM ref as there is already `getDomRef` method that is sufficient.

BREAKING_CHANGE: `stableDomRef` is removed, if you need to get the item's DOM ref, use `getDomRef` on the item instance.