### PR TITLE
fix(ui5-card): correct content html tag

### DIFF
--- a/packages/main/src/Card.hbs
+++ b/packages/main/src/Card.hbs
@@ -39,8 +39,8 @@
 		</div>
 	{{/if}}
 
-	<section role="group" aria-label="{{ariaCardContentLabel}}">
+	<div role="group" aria-label="{{ariaCardContentLabel}}">
 		<slot></slot>
-	</section>
+	</div>
 	<span id="{{_id}}-desc" class="ui5-hidden-text">{{ariaCardRoleDescription}}</span>
 </div>


### PR DESCRIPTION

<section> does not support role='group'

Fixes: #3439