### PR TITLE
docs(ui5-dialog): Documentation is updated referencing z-index

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -163,6 +163,9 @@ const metadata = {
  * <b>Note:</b> We don't recommend nesting popup-like components (<code>ui5-dialog</code>, <code>ui5-popover</code>) inside <code>ui5-dialog</code>.
  * Ideally you should create all popups on the same level inside your HTML page and just open them from one another, rather than nesting them.
  *
+ * <b>Note:</b> We don't recommend nesting popup-like components (<code>ui5-dialog</code>, <code>ui5-popover</code>) inside other components containing z-index.
+ * This might break z-index management.
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Dialog


### PR DESCRIPTION
When dialog is nested inside an element containing z-index, this might break the z-index management of the ui5-dialog.

Related to:  #3426
