### PR TITLE
fix(ui5-sideNavigation): Items in popup fire click event

### DIFF
--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -227,6 +227,7 @@ class SideNavigation extends UI5Element {
 		const listItem = event.detail.item;
 		const item = listItem.associatedItem;
 
+		item.fireEvent("click");
 		if (item.selected) {
 			return;
 		}

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -50,18 +50,30 @@ describe("Component Behavior", () => {
 
 			items[0].click();
 
-			assert.strictEqual(input.getProperty("value"), "6", "Event is fired");
+			assert.strictEqual(input.getProperty("value"), "7", "Event is fired");
 
 			items[3].click();
 
-			assert.strictEqual(input.getProperty("value"), "6", "Event is not fired");
+			assert.strictEqual(input.getProperty("value"), "7", "Event is not fired");
 			assert.strictEqual(items[3].getAttribute("expanded"), "true", "Expanded is toggled");
 
 			items[3].click();
 
-			assert.strictEqual(input.getProperty("value"), "6", "Event is not fired");
+			assert.strictEqual(input.getProperty("value"), "7", "Event is not fired");
 			assert.strictEqual(items[3].getAttribute("expanded"), "false", "Expanded is toggled");
-		});
+
+            items[1].click();
+            assert.strictEqual(input.getProperty("value"), "8", "Event is fired");
+
+            const staticAreaItemClassName = browser.getStaticAreaItemClassName("#sn1");
+            const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+            items = popover.$("ui5-list").$$("ui5-li");
+
+            items[1].click();
+
+            assert.strictEqual(input.getProperty("value"), "9", "Event is fired");
+
+        });
 
 		it("Tests header visibility", () => {
 			let showHeader = null;


### PR DESCRIPTION
When sideNavigation is collapsed, subitems in popup did not fire "click" event. Test are adapted, because the issue was giving wrong values.

Fixes: #3333
