### PR TITLE
fix(ui5-popup): adjust default header height

### DIFF
--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -68,9 +68,9 @@
 :host([header-text]) .ui5-popup-header-text {
     padding: 0 0.25rem;
     text-align: center;
-    min-height: 3rem;
-    max-height: 3rem;
-    line-height: 3rem;
+    min-height: var(--_ui5_popup_default_header_height);
+    max-height: var(--_ui5_popup_default_header_height);
+    line-height: var(--_ui5_popup_default_header_height);
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -39,6 +39,10 @@
 	--_ui5_list_item_selection_btn_margin_top: calc(-1 * var(--_ui5_checkbox_wrapper_padding));
 	--_ui5_list_busy_row_height: 3rem;
 	--_ui5_month_picker_item_height: 3rem;
+
+	/* Popup subclasses */
+	--_ui5_popup_default_header_height: 2.75rem;
+
 	--_ui5_year_picker_item_height: 3rem;
 	--_ui5_tokenizer_root_padding: 0.1875rem;
 	--_ui5_token_height: 1.625rem;
@@ -157,6 +161,9 @@
 	--_ui5_input_icon_min_width: var(--_ui5_input_compact_min_width);
 	--_ui5_input_icon_padding: .25rem .5rem;
 	--_ui5_input_value_state_icon_padding: .1875rem .5rem;
+
+	/* Popup subclasses */
+	--_ui5_popup_default_header_height: 2.5rem;
 
 	/* TextArea */
 	--_ui5_textarea_padding: .1875rem .5rem;

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -25,6 +25,8 @@
 </head>
 
 <body>
+	<ui5-checkbox text="Compact size" id="cbCompact"></ui5-checkbox>
+	<br>
 	<ui5-button id="btnOpenDialog">Open Streched Dialog</ui5-button>
 	<br>
 	<br>
@@ -368,6 +370,10 @@
 	<ui5-dialog id="empty-dialog">Empty</ui5-dialog>
 
 	<script>
+		cbCompact.addEventListener("change", function () {
+			document.body.classList.toggle("ui5-content-density-compact", cbCompact.checked);
+		});
+
 		let preventClosing = true;
 
 		btnOpenDialog.addEventListener("click", function () {

--- a/packages/theme-base/hash.txt
+++ b/packages/theme-base/hash.txt
@@ -1,1 +1,1 @@
-uvoNQhv6oafzulJZx8BIAfGhmME=
+ldK1ja/5Q2Vh5wwiveJGYLCZDSA=


### PR DESCRIPTION
The header height is defined as 44px in Cozy and 40px in compact.

This change affects the Dialog and Popover components only when the property headerText is used.
This doesn't change the height of the slot `header`.

Fixes #3497

