### PR TITLE
refactor(ui5-popover, ui5-responsive-popover): rename "openBy" to "showAt"

### DIFF
--- a/packages/base/src/util/PopupUtils.js
+++ b/packages/base/src/util/PopupUtils.js
@@ -62,7 +62,7 @@ const isClickInRect = (event, rect) => {
 const getClosedPopupParent = el => {
 	const parent = el.parentElement || (el.getRootNode && el.getRootNode().host);
 
-	if (parent && ((parent.openBy && parent.isUI5Element) || (parent.open && parent.isUI5Element) || parent === document.documentElement)) {
+	if (parent && ((parent.showAt && parent.isUI5Element) || (parent.open && parent.isUI5Element) || parent === document.documentElement)) {
 		return parent;
 	}
 

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -257,7 +257,7 @@ class NotificationListItemBase extends ListItemBase {
 
 	async openOverflow() {
 		const overflowPopover = await this.getOverflowPopover();
-		overflowPopover.openBy(this.overflowButtonDOM);
+		overflowPopover.showAt(this.overflowButtonDOM);
 	}
 
 	async closeOverflow() {

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -460,7 +460,7 @@ class ShellBar extends UI5Element {
 
 				if (this.hasMenuItems) {
 					const menuPopover = await this._getMenuPopover();
-					menuPopover.openBy(this.shadowRoot.querySelector(".ui5-shellbar-menu-button"));
+					menuPopover.showAt(this.shadowRoot.querySelector(".ui5-shellbar-menu-button"));
 				}
 			},
 		};
@@ -688,7 +688,7 @@ class ShellBar extends UI5Element {
 
 	_toggleActionPopover() {
 		const overflowButton = this.shadowRoot.querySelector(".ui5-shellbar-overflow-button");
-		this.overflowPopover.openBy(overflowButton);
+		this.overflowPopover.showAt(overflowButton);
 	}
 
 	onEnterDOM() {

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -242,7 +242,7 @@ class SideNavigation extends UI5Element {
 
 	async openPicker(opener) {
 		const responsivePopover = await this.getPicker();
-		responsivePopover.openBy(opener);
+		responsivePopover.showAt(opener);
 	}
 
 	async closePicker(opener) {

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -592,7 +592,7 @@ class Wizard extends UI5Element {
 		}
 
 		const responsivePopover = await this._respPopover();
-		responsivePopover.openBy(oDomTarget);
+		responsivePopover.showAt(oDomTarget);
 	}
 
 	async _onGroupedTabClick(event) {

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -315,7 +315,7 @@
 		});
 
 		openNotifications.addEventListener("click", function(event) {
-			notificationsPopover.openBy(openNotifications);
+			notificationsPopover.showAt(openNotifications);
 		});
 
 		btnMakeGroupBusy.addEventListener("click", function(event) {
@@ -330,7 +330,7 @@
 
 		shellbar.addEventListener("ui5-notificationsClick", function(event) {
 			event.preventDefault();
-			notificationsPopover.openBy(event.detail.targetRef);
+			notificationsPopover.showAt(event.detail.targetRef);
 		});
 	</script>
 </body>

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -286,12 +286,12 @@
 		});
 
 		openNotifications.addEventListener("click", function(event) {
-			notificationsPopover.openBy(openNotifications);
+			notificationsPopover.showAt(openNotifications);
 		});
 
 		shellbar.addEventListener("ui5-notificationsClick", function(event) {
 			event.preventDefault();
-			notificationsPopover.openBy(event.detail.targetRef);
+			notificationsPopover.showAt(event.detail.targetRef);
 		});
 	</script>
 </body>

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -231,14 +231,14 @@
 		});
 
 		shellbar.addEventListener("ui5-profileClick", function(event) {
-			popover.openBy(event.detail.targetRef);
+			popover.showAt(event.detail.targetRef);
 			window["press-input"].value = "Profile";
 		});
 
 		shellbar.addEventListener("ui5-notificationsClick", function(event) {
 			window["press-input"].value = "Notifications";
 			event.preventDefault();
-			popover.openBy(event.detail.targetRef);
+			popover.showAt(event.detail.targetRef);
 		});
 
 		shellbar.addEventListener("ui5-productSwitchClick", function(event) {
@@ -266,12 +266,12 @@
 
 		shelbarCompact.addEventListener("ui5-notificationsClick", function(event) {
 			event.preventDefault();
-			popover.openBy(event.detail.targetRef);
+			popover.showAt(event.detail.targetRef);
 		});
 
 		shelbarCompact.addEventListener("ui5-productSwitchClick", function(event) {
 			event.preventDefault();
-			popover.openBy(event.detail.targetRef);
+			popover.showAt(event.detail.targetRef);
 		});
 
 		menuItemsSB.addEventListener("ui5-menuItemClick", function(event) {
@@ -285,7 +285,7 @@
 			currenItem.addEventListener("ui5-itemClick", function(event) {
 				event.preventDefault();
 				window["press-input"].value = event.target.id;
-				window["custom-item-popover"].openBy(event.detail.targetRef);
+				window["custom-item-popover"].showAt(event.detail.targetRef);
 			});
 		});
 	</script>

--- a/packages/fiori/test/samples/NotificationListGroupItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListGroupItem.sample.html
@@ -301,7 +301,7 @@
 		<script>
 			shellbar.addEventListener("ui5-notifications-click", function(event) {
 				event.preventDefault();
-				notificationsPopover.openBy(event.detail.targetRef);
+				notificationsPopover.showAt(event.detail.targetRef);
 			});
 		</script>
 	</div>
@@ -347,7 +347,7 @@
 
 <script>
 	shellbar.addEventListener("ui5-notifications-click", function(event) {
-		notificationsPopover.openBy(event.detail.targetRef);
+		notificationsPopover.showAt(event.detail.targetRef);
 	});
 </script>
 	

--- a/packages/fiori/test/samples/NotificationListItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListItem.sample.html
@@ -221,7 +221,7 @@
 		<script>
 			shellbar.addEventListener("ui5-notifications-click", function(event) {
 				event.preventDefault();
-				notificationsPopover.openBy(event.detail.targetRef);
+				notificationsPopover.showAt(event.detail.targetRef);
 			});
 		</script>
 	</div>
@@ -260,7 +260,7 @@
 
 <script>
 	shellbar.addEventListener("ui5-notifications-click", function(event) {
-		notificationsPopover.openBy(event.detail.targetRef);
+		notificationsPopover.showAt(event.detail.targetRef);
 	});
 </script>
 	

--- a/packages/fiori/test/samples/ProductSwitch.sample.html
+++ b/packages/fiori/test/samples/ProductSwitch.sample.html
@@ -68,7 +68,7 @@
 					popover.close();
 				} else {
 					event.preventDefault();
-					popover.openBy(event.detail.targetRef);
+					popover.showAt(event.detail.targetRef);
 				}
 			});
 		</script>
@@ -109,7 +109,7 @@
 		if (popover.opened) {
 			popover.close();
 		} else {
-			popover.openBy(event.detail.targetRef);
+			popover.showAt(event.detail.targetRef);
 		}
 	});
 </script>

--- a/packages/fiori/test/samples/ShellBar.sample.html
+++ b/packages/fiori/test/samples/ShellBar.sample.html
@@ -57,7 +57,7 @@
 
 	<script>
 		shellbar.addEventListener("profile-click", function(event) {
-			window["action-popover"].openBy(event.detail.targetRef);
+			window["action-popover"].showAt(event.detail.targetRef);
 		});
 	</script>
 	</div>
@@ -107,7 +107,7 @@
 
 <script>
 	shellbar.addEventListener("profile-click", function(event) {
-		popover.openBy(event.detail.targetRef);
+		popover.showAt(event.detail.targetRef);
 	});
 </script>
 	</xmp></pre>

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -479,7 +479,7 @@ class ComboBox extends UI5Element {
 
 	async openValueStatePopover() {
 		this.popover = await this._getPopover();
-		this.popover && this.popover.openBy(this);
+		this.popover && this.popover.showAt(this);
 	}
 
 	async closeValueStatePopover() {
@@ -648,7 +648,7 @@ class ComboBox extends UI5Element {
 	}
 
 	_openRespPopover() {
-		this.responsivePopover.openBy(this);
+		this.responsivePopover.showAt(this);
 	}
 
 	_filterItems(str) {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -550,7 +550,7 @@ class DatePicker extends DateComponentBase {
 
 	_click(event) {
 		if (isPhone()) {
-			this.responsivePopover.openBy(this);
+			this.responsivePopover.showAt(this);
 			event.preventDefault(); // prevent immediate selection of any item
 		}
 	}
@@ -712,7 +712,7 @@ class DatePicker extends DateComponentBase {
 		this._calendarCurrentPicker = "day";
 		this.responsivePopover = await this._respPopover();
 
-		this.responsivePopover.openBy(this);
+		this.responsivePopover.showAt(this);
 	}
 
 	togglePicker() {

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -386,7 +386,7 @@ class FileUploader extends UI5Element {
 		const popover = await this._getPopover();
 
 		if (popover) {
-			popover.openBy(this);
+			popover.showAt(this);
 		}
 	}
 

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -691,7 +691,7 @@ class Input extends UI5Element {
 
 	_click(event) {
 		if (isPhone() && !this.readonly && this.Suggestions) {
-			this.Suggestions.openBy(this);
+			this.Suggestions.showAt(this);
 			this.isRespPopoverOpen = true;
 		}
 	}
@@ -813,7 +813,7 @@ class Input extends UI5Element {
 
 		if (popover) {
 			this._isPopoverOpen = true;
-			popover.openBy(this);
+			popover.showAt(this);
 		}
 	}
 

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -503,7 +503,7 @@ class MultiComboBox extends UI5Element {
 			if (filteredItems.length === 0) {
 				this.allItemsPopover.close();
 			} else {
-				this.allItemsPopover.openBy(this);
+				this.allItemsPopover.showAt(this);
 			}
 		}
 
@@ -664,7 +664,7 @@ class MultiComboBox extends UI5Element {
 
 	_click(event) {
 		if (isPhone() && !this.readonly && !this._showMorePressed) {
-			this.allItemsPopover.openBy(this);
+			this.allItemsPopover.showAt(this);
 		}
 
 		this._showMorePressed = false;
@@ -731,7 +731,7 @@ class MultiComboBox extends UI5Element {
 		const popover = await this._getPopover();
 
 		if (popover) {
-			popover.openBy(this);
+			popover.showAt(this);
 		}
 	}
 

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -290,14 +290,14 @@ class Popover extends Popup {
 	}
 
 	/**
-	 * Opens the popover.
-	 * @param {HTMLElement} opener the element that the popover is opened by
+	 * Shows the popover.
+	 * @param {HTMLElement} opener the element that the popover is shown at
 	 * @param {boolean} preventInitialFocus prevents applying the focus inside the popover
 	 * @public
 	 * @async
 	 * @returns {Promise} Resolved when the popover is open
 	 */
-	async openBy(opener, preventInitialFocus = false) {
+	async showAt(opener, preventInitialFocus = false) {
 		if (!opener || this.opened) {
 			return;
 		}
@@ -337,7 +337,7 @@ class Popover extends Popup {
 		let overflowsBottom = false;
 		let overflowsTop = false;
 
-		if (closedPopupParent.openBy) {
+		if (closedPopupParent.showAt) {
 			const contentRect = closedPopupParent.contentDOM.getBoundingClientRect();
 			overflowsBottom = openerRect.top > (contentRect.top + contentRect.height);
 			overflowsTop = (openerRect.top + openerRect.height) < contentRect.top;

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -114,13 +114,13 @@ class ResponsivePopover extends Popover {
 	}
 
 	/**
-	 * Opens popover on desktop and dialog on mobile.
-	 * @param {HTMLElement} opener the element that the popover is opened by
+	 * Shows popover on desktop and dialog on mobile.
+	 * @param {HTMLElement} opener the element that the popover is shown at
 	 * @public
 	 * @async
 	 * @returns {Promise} Resolves when the responsive popover is open
 	 */
-	async openBy(opener) {
+	async showAt(opener) {
 		this.style.display = this._isPhone ? "contents" : "";
 
 		if (this.isOpen() || (this._dialog && this._dialog.isOpen())) {
@@ -132,7 +132,7 @@ class ResponsivePopover extends Popover {
 			if (!this.noStretch) {
 				this._minWidth = Math.max(POPOVER_MIN_WIDTH, opener.getBoundingClientRect().width);
 			}
-			await super.openBy(opener);
+			await super.showAt(opener);
 		} else {
 			this.style.zIndex = getNextZIndex();
 			await this._dialog.show();
@@ -156,7 +156,7 @@ class ResponsivePopover extends Popover {
 			return this.close();
 		}
 
-		this.openBy(opener);
+		this.showAt(opener);
 	}
 
 	/**

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -372,7 +372,7 @@ class Select extends UI5Element {
 		if (this._isPickerOpen) {
 			this.responsivePopover.close();
 		} else {
-			this.responsivePopover.openBy(this);
+			this.responsivePopover.showAt(this);
 		}
 	}
 
@@ -712,7 +712,7 @@ class Select extends UI5Element {
 	async openValueStatePopover() {
 		this.popover = await this._getPopover();
 		if (this.popover) {
-			this.popover.openBy(this);
+			this.popover.showAt(this);
 		}
 	}
 

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -497,7 +497,7 @@ class TabContainer extends UI5Element {
 		if (this.responsivePopover.opened) {
 			this.responsivePopover.close();
 		} else {
-			this.responsivePopover.openBy(button);
+			this.responsivePopover.showAt(button);
 		}
 	}
 

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -498,7 +498,7 @@ class TextArea extends UI5Element {
 
 	async openPopover() {
 		this.popover = await this._getPopover();
-		this.popover && this.popover.openBy(this.shadowRoot.querySelector(".ui5-textarea-inner"));
+		this.popover && this.popover.showAt(this.shadowRoot.querySelector(".ui5-textarea-inner"));
 	}
 
 	async closePopover() {

--- a/packages/main/src/TimePickerBase.js
+++ b/packages/main/src/TimePickerBase.js
@@ -302,7 +302,7 @@ class TimePickerBase extends UI5Element {
 	async openPicker() {
 		this.tempValue = this.value && this.isValid(this.value) ? this.value : this.getFormat().format(new Date());
 		const responsivePopover = await this._getPopover();
-		responsivePopover.openBy(this);
+		responsivePopover.showAt(this);
 		this._isPickerOpen = true;
 	}
 

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -169,7 +169,7 @@ class Tokenizer extends UI5Element {
 		if (this.showPopover) {
 			const popover = await this.getPopover();
 
-			popover.openBy(this.morePopoverOpener || this);
+			popover.showAt(this.morePopoverOpener || this);
 		}
 
 		this.fireEvent("show-more-items-press");

--- a/packages/main/src/features/InputSuggestions.js
+++ b/packages/main/src/features/InputSuggestions.js
@@ -124,7 +124,7 @@ class Suggestions {
 		this._beforeOpen();
 
 		if (this._getItems().length) {
-			this.responsivePopover.openBy(this._getComponent());
+			this.responsivePopover.showAt(this._getComponent());
 		}
 	}
 

--- a/packages/main/src/popup-utils/PopoverRegistry.js
+++ b/packages/main/src/popup-utils/PopoverRegistry.js
@@ -39,7 +39,7 @@ const detachGlobalClickHandler = () => {
 
 const clickHandler = event => {
 	const openedPopups = getOpenedPopups();
-	const isTopPopupPopover = openedPopups[openedPopups.length - 1].instance.openBy;
+	const isTopPopupPopover = openedPopups[openedPopups.length - 1].instance.showAt;
 
 	if (openedPopups.length === 0 || !isTopPopupPopover) {
 		return;

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -324,7 +324,7 @@
 		placeholder.innerHTML = html;
 
 		groupPop.close();
-		groupPop.openBy(event.detail.targetRef);
+		groupPop.showAt(event.detail.targetRef);
 	}
 
 	function onAvatarClicked(avatarGroup, avatarRef) {
@@ -333,7 +333,7 @@
 		popAvatar.colorScheme = avatarGroup.colorScheme[avatarGroup.items.indexOf(avatarRef)];
 
 		individualPop.close();
-		individualPop.openBy(avatarRef);
+		individualPop.showAt(avatarRef);
 	}
 
 	avatarGroupGroupEvents.addEventListener("ui5-click", function (event) {

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -130,7 +130,7 @@
 		});
 
 		colorPaletteBtn.addEventListener("click", function(event) {
-			respPopover.openBy(colorPaletteBtn);
+			respPopover.showAt(colorPaletteBtn);
 		});
 
 		btnClose.addEventListener("click", function(event) {

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -413,14 +413,14 @@
 			preventClosing = true;
 		});
 
-		window["modals-open"].addEventListener("click", function (event) { pop.openBy(event.target) });
+		window["modals-open"].addEventListener("click", function (event) { pop.showAt(event.target) });
 
 		popbtn.addEventListener('click', function (event) {
 			danger.show();
 		});
 
 		bigDanger.addEventListener('click', function (event) {
-			bigDangerPop.openBy(bigDanger);
+			bigDangerPop.showAt(bigDanger);
 		});
 
 		window["empty-open"].addEventListener("click", function () { window["empty-dialog"].show(); });

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -107,7 +107,7 @@
 			const targetRef = event.detail.targetRef;
 
 			quickViewCard.close();
-			quickViewCard.openBy(targetRef, true /* preventInitialFocus */);
+			quickViewCard.showAt(targetRef, true /* preventInitialFocus */);
 		});
 
 		/*
@@ -118,7 +118,7 @@
 				const targetRef = event.detail.targetRef;
 
 				quickViewCard.close();
-				quickViewCard.openBy(targetRef, true /* preventInitialFocus */);
+				quickViewCard.showAt(targetRef, true /* preventInitialFocus */);
 			});
 
 			el.addEventListener("mouseout", function (event) {
@@ -158,7 +158,7 @@
 		inputPreview2.addEventListener("ui5-suggestion-item-preview", function (event) {
 			var item = event.detail.targetRef;
 			quickViewCard2.close();
-			quickViewCard2.openBy(item, true /* preventInitialFocus */);
+			quickViewCard2.showAt(item, true /* preventInitialFocus */);
 
 			// log info
 			suggestionItemPreviewRes.value = item.textContent;
@@ -182,7 +182,7 @@
 			el.addEventListener("mouseover", function (event) {
 				const targetRef = event.detail.targetRef;
 				quickViewCard2.close();
-				quickViewCard2.openBy(targetRef, true /* preventInitialFocus */);
+				quickViewCard2.showAt(targetRef, true /* preventInitialFocus */);
 
 				// log info
 				mouseoverResult.value = targetRef.textContent;

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -299,7 +299,7 @@
 		});
 
 		btnOpenPopup.addEventListener("click", function() {
-			popup.openBy(btnOpenPopup);
+			popup.showAt(btnOpenPopup);
 		});
 
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -414,23 +414,23 @@
 
 	<script>
 		btn.addEventListener("click", function (event) {
-			pop.openBy(btn);
+			pop.showAt(btn);
 		});
 
 		popbtn.addEventListener("click", function (event) {
-			danger.openBy(popbtn);
+			danger.showAt(popbtn);
 		});
 
 		bigDanger.addEventListener("click", function (event) {
-			bigDangerPop.openBy(bigDanger);
+			bigDangerPop.showAt(bigDanger);
 		});
 
 		btnPopModal.addEventListener("click", function (event) {
-			modalPopover.openBy(btnPopModal);
+			modalPopover.showAt(btnPopModal);
 		});
 
 		btnPopModalNoLayer.addEventListener("click", function() {
-			modalPopoverNoLayer.openBy(btnPopModalNoLayer);
+			modalPopoverNoLayer.showAt(btnPopModalNoLayer);
 		});
 
 		modalPopoverNoLayerClose.addEventListener("click", function() {
@@ -442,7 +442,7 @@
 		});
 
 		btnPopFocus.addEventListener("click", function (event) {
-			popFocus.openBy(btnPopFocus);
+			popFocus.showAt(btnPopFocus);
 		});
 
 		document.getElementById("many-items").innerHTML = [].map.call("Ullamco ea ad fugiat enim elit dolore ullamco ad magna excepteur cupidatat.", function (item, index) {
@@ -454,53 +454,53 @@
 		}).join("");
 
 		document.getElementById("big-popover-button").addEventListener("click", function (event) {
-			document.getElementById("big-popover").openBy(event.target);
+			document.getElementById("big-popover").showAt(event.target);
 		});
 
 		btnFullWidth.addEventListener("click", function (event) {
-			popFullWidth.openBy(btnFullWidth);
+			popFullWidth.showAt(btnFullWidth);
 		});
 
 		btnFullWidthTargetOverlap.addEventListener("click", function (event) {
-			popFullWidthTargetOverlap.openBy(btnFullWidthTargetOverlap);
+			popFullWidthTargetOverlap.showAt(btnFullWidthTargetOverlap);
 		});
 
 		btnFullWidthLeft.addEventListener("click", function (event) {
-			popFullWidthLeft.openBy(btnFullWidthLeft);
+			popFullWidthLeft.showAt(btnFullWidthLeft);
 		});
 
 		btnFullWidthLeftTargetOverlap.addEventListener("click", function (event) {
-			popFullWidthLeftTargetOverlap.openBy(btnFullWidthLeftTargetOverlap);
+			popFullWidthLeftTargetOverlap.showAt(btnFullWidthLeftTargetOverlap);
 		});
 
 		btnFullWidthTop.addEventListener("click", function (event) {
-			popFullWidthTop.openBy(btnFullWidthTop);
+			popFullWidthTop.showAt(btnFullWidthTop);
 		});
 
 		btnFullWidthBottom.addEventListener("click", function (event) {
-			popFullWidthBottom.openBy(btnFullWidthBottom);
+			popFullWidthBottom.showAt(btnFullWidthBottom);
 		});
 
 		btnQuickViewCardOpener.addEventListener("click", function (event) {
-			quickViewCard.openBy(btnQuickViewCardOpener);
+			quickViewCard.showAt(btnQuickViewCardOpener);
 
 			btnQuickViewCardOpener.setAttribute("hidden", true);
 		})
 		btnOpenXLeft.addEventListener("click", function (event) {
-			popXLeft.openBy(targetOpener);
+			popXLeft.showAt(targetOpener);
 		});
 		btnOpenXRight.addEventListener("click", function (event) {
-			popXRight.openBy(targetOpener2);
+			popXRight.showAt(targetOpener2);
 		});
 
 		firstBtn.addEventListener("click", function (event) {
 			popNoFocusableContent.innerHTML = "First button is clicked";
-			popNoFocusableContent.openBy(event.target);
+			popNoFocusableContent.showAt(event.target);
 		});
 
 		secondBtn.addEventListener("click", function (event) {
 			popNoFocusableContent.innerHTML = "Second button is clicked";
-			popNoFocusableContent.openBy(event.target);
+			popNoFocusableContent.showAt(event.target);
 		});
 
 		btnOpenDynamic.addEventListener("click", function () {
@@ -514,19 +514,19 @@
 
 			document.body.appendChild(popover);
 
-			popover.openBy(btnOpenDynamic);
+			popover.showAt(btnOpenDynamic);
 		});
 
 		btnOpenPopoverWithDiv.addEventListener("click", function (event) {
-			popWithDiv.openBy(event.target);
+			popWithDiv.showAt(event.target);
 		});
 
 		btnOpenXRightWide.addEventListener("click", function () {
-			popXRightWide.openBy(btnOpenXRightWide);
+			popXRightWide.showAt(btnOpenXRightWide);
 		});
 
 		btnRightEdge.addEventListener("click", function () {
-			popoverRightEdge.openBy(btnRightEdge);
+			popoverRightEdge.showAt(btnRightEdge);
 		});
 
 	</script>

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -106,21 +106,21 @@
 
 	<script>
 		btnOpen.addEventListener("click", function(event) {
-			respPopover.openBy(btnOpen);
+			respPopover.showAt(btnOpen);
 		});
 		btnClose.addEventListener("click", function(event) {
 			respPopover.close();
 		});
 
 		btnOpen2.addEventListener("click", function(event) {
-			respPopover2.openBy(btnOpen2);
+			respPopover2.showAt(btnOpen2);
 		});
 		btnClose2.addEventListener("click", function(event) {
 			respPopover2.close();
 		});
 
 		btnOpen3.addEventListener("click", function(event) {
-			respPopover3.openBy(btnOpen3);
+			respPopover3.showAt(btnOpen3);
 		});
 		btnClose3.addEventListener("click", function(event) {
 			respPopover3.close();
@@ -130,11 +130,11 @@
 		});
 
 		btnSimpleRP.addEventListener("click", function(event) {
-			simpleRP.openBy(btnSimpleRP);
+			simpleRP.showAt(btnSimpleRP);
 		});
 
 		btnRpTopWithArrow.addEventListener("click", function(event) {
-			rpTopWithArrow.openBy(btnRpTopWithArrow);
+			rpTopWithArrow.showAt(btnRpTopWithArrow);
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/kitchen-scripts.js
+++ b/packages/main/test/pages/kitchen-scripts.js
@@ -81,7 +81,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	var popoverCloser = document.getElementById("closePopoverButton");
 
 	popoverOpener.addEventListener("click", function() {
-		popover.openBy(popoverOpener);
+		popover.showAt(popoverOpener);
 	});
 	popoverCloser.addEventListener("click", function() {
 		popover.close();

--- a/packages/main/test/pages/modules/Popups.js
+++ b/packages/main/test/pages/modules/Popups.js
@@ -21,14 +21,14 @@ function onload() {
 	var wcBtnOpenNewDialogPopover = document.querySelector('.wcBtnOpenNewDialogPopover');
 	wcBtnOpenNewDialogPopover.addEventListener('click', function () {
 		var wcNewDialogPopover = document.querySelector('.wcNewDialogPopover');
-		wcNewDialogPopover.openBy(wcBtnOpenNewDialogPopover);
+		wcNewDialogPopover.showAt(wcBtnOpenNewDialogPopover);
 	});
 
 	// web component popover
 	var wcBtnOpenPopover = document.querySelector('.wcBtnOpenPopover');
 	wcBtnOpenPopover.addEventListener('click', function () {
 		var wcPopover = document.querySelector('.wcPopover');
-		wcPopover.openBy(wcBtnOpenPopover);
+		wcPopover.showAt(wcBtnOpenPopover);
 	});
 
 	var wcBtnClosePopover = document.querySelector('.wcBtnClosePopover');
@@ -40,7 +40,7 @@ function onload() {
 	var wcBtnOpenNewPopover = document.querySelector('.wcBtnOpenNewPopover');
 	wcBtnOpenNewPopover.addEventListener('click', function () {
 		var wcNewPopover = document.querySelector('.wcNewPopover');
-		wcNewPopover.openBy(wcBtnOpenNewPopover);
+		wcNewPopover.showAt(wcBtnOpenNewPopover);
 	});
 
 	var wcBtnOpenNewPopoverDialog11 = document.querySelector('.wcBtnOpenNewPopoverDialog11');

--- a/packages/main/test/samples/AvatarGroup.sample.html
+++ b/packages/main/test/samples/AvatarGroup.sample.html
@@ -79,7 +79,7 @@
 					popAvatar.image = avatarRef.image;
 					popAvatar.icon = avatarRef.icon;
 	
-					personPopover.openBy(avatarRef);
+					personPopover.showAt(avatarRef);
 				}
 	
 				function onButtonClicked(targetRef) {
@@ -103,7 +103,7 @@
 					placeholder.innerHTML = html;
 	
 					peoplePopover.close();
-					peoplePopover.openBy(targetRef);
+					peoplePopover.showAt(targetRef);
 				}
 	
 				avatarGroup.addEventListener("click", function (event) {
@@ -150,7 +150,7 @@
 	const personPopover = document.querySelector(".personPopover");
 
 	function onAvatarClicked(avatarRef) {
-		personPopover.openBy(avatarRef);
+		personPopover.showAt(avatarRef);
 	}
 
 	function onButtonClicked(targetRef) {
@@ -165,7 +165,7 @@
 		});
 
 		placeholder.innerHTML = html;
-		peoplePopover.openBy(targetRef);
+		peoplePopover.showAt(targetRef);
 	}
 
 	avatarGroup.addEventListener("click", function (event) {
@@ -245,7 +245,7 @@
 					placeholder.innerHTML = html;
 	
 					peoplePopover.close();
-					peoplePopover.openBy(targetRef);
+					peoplePopover.showAt(targetRef);
 				}
 	
 				avatarGroup.addEventListener("click", function (event) {
@@ -282,7 +282,7 @@
 	const peoplePopover = document.querySelector(".peoplePopover");
 
 	function onAvatarGroupClick(targetRef) {
-		peoplePopover.openBy(targetRef);
+		peoplePopover.showAt(targetRef);
 	}
 
 	avatarGroup.addEventListener("click", function (event) {

--- a/packages/main/test/samples/Popover.sample.html
+++ b/packages/main/test/samples/Popover.sample.html
@@ -30,7 +30,7 @@
 			var popoverCloser = document.getElementById("closePopoverButton");
 
 			popoverOpener.addEventListener("click", function() {
-				popover.openBy(popoverOpener);
+				popover.showAt(popoverOpener);
 			});
 
 			popoverCloser.addEventListener("click", function() {
@@ -60,7 +60,7 @@
 	var popoverCloser = document.getElementById("closePopoverButton");
 
 	popoverOpener.addEventListener("click", function() {
-		popover.openBy(popoverOpener);
+		popover.showAt(popoverOpener);
 	});
 
 	popoverCloser.addEventListener("click", function() {

--- a/packages/main/test/samples/ResponsivePopover.sample.html
+++ b/packages/main/test/samples/ResponsivePopover.sample.html
@@ -31,7 +31,7 @@
 			var popoverCloser = document.getElementById("closePopoverButton");
 
 			popoverOpener.addEventListener("click", function() {
-				popover.openBy(popoverOpener);
+				popover.showAt(popoverOpener);
 			});
 			popoverCloser.addEventListener("click", function() {
 				popover.close();
@@ -61,7 +61,7 @@
 	var popoverCloser = document.getElementById("closePopoverButton");
 
 	popoverOpener.addEventListener("click", function() {
-		popover.openBy(popoverOpener);
+		popover.showAt(popoverOpener);
 	});
 	popoverCloser.addEventListener("click", function() {
 		popover.close();


### PR DESCRIPTION
Rename the Popover's and ResponsivePopover's "openBy" method  to "showAt" to have more consistent API with the Toast and Dialog components, which have "show" method.  The name "showBy" has been also discussed, but from English language perspective to "show" something "at" some place is more accurate to say and this why we picked up "showAt".

BREAKING CHANGE: Popover's and ResponsivePopover's "openBy" method has been renamed to "showAt".