### PR TITLE
refactor(ui5-card-header): rename "headerInteractive" to "interactive"

### DIFF
--- a/packages/main/src/CardHeader.js
+++ b/packages/main/src/CardHeader.js
@@ -83,13 +83,13 @@ const metadata = {
 		},
 
 		/**
-		 * Defines if the component header would be interactive,
+		 * Defines if the component would be interactive,
 		 * e.g gets hover effect, gets focused and <code>headerPress</code> event is fired, when it is pressed.
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
 		 */
-		headerInteractive: {
+		interactive: {
 			type: Boolean,
 		},
 
@@ -124,11 +124,10 @@ const metadata = {
 	events: /** @lends sap.ui.webcomponents.main.CardHeader.prototype */ {
 
 		/**
-		 * Fired when the header is activated
-		 * by mouse/tap or by using the Enter or Space key.
+		 * Fired when the component is activated by mouse/tap or by using the Enter or Space key.
 		 * <br><br>
-		 * <b>Note:</b> The event would be fired only if the <code>headerInteractive</code> property is set to true.
-		 * @event sap.ui.webcomponents.main.CarHeader#header-click
+		 * <b>Note:</b> The event would be fired only if the <code>interactive</code> property is set to true.
+		 * @event sap.ui.webcomponents.main.CardHeader#click
 		 * @public
 		 */
 		"click": {},
@@ -145,7 +144,7 @@ const metadata = {
  * and two slots: <code>avatar</code> and <code>action</code>.
  *
  * <h3>Keyboard handling</h3>
- * In case you enable <code>headerInteractive</code> property, you can press the <code>ui5-card</code> header by Space and Enter keys.
+ * In case you enable <code>interactive</code> property, you can press the <code>ui5-card-header</code> by Space and Enter keys.
  *
  * <h3>CSS Shadow Parts</h3>
  *
@@ -153,9 +152,9 @@ const metadata = {
  * <br>
  * The <code>ui5-card</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li>title - Used to style the title of the card</li>
- * <li>subtitle - Used to style the subtitle of the card</li>
- * <li>status - Used to style the status of the card</li>
+ * <li>title - Used to style the title of the CardHeader</li>
+ * <li>subtitle - Used to style the subtitle of the CardHeader</li>
+ * <li>status - Used to style the status of the CardHeader</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>
@@ -197,17 +196,17 @@ class CardHeader extends UI5Element {
 	get classes() {
 		return {
 			"ui5-card-header": true,
-			"ui5-card-header--interactive": this.headerInteractive,
-			"ui5-card-header--active": this.headerInteractive && this._headerActive,
+			"ui5-card-header--interactive": this.interactive,
+			"ui5-card-header--active": this.interactive && this._headerActive,
 		};
 	}
 
 	get ariaHeaderRole() {
-		return this.headerInteractive ? "button" : "heading";
+		return this.interactive ? "button" : "heading";
 	}
 
 	get ariaLevel() {
-		return this.headerInteractive ? undefined : "3";
+		return this.interactive ? undefined : "3";
 	}
 
 	get ariaLabelText() {
@@ -215,7 +214,7 @@ class CardHeader extends UI5Element {
 	}
 
 	get ariaCardHeaderRoleDescription() {
-		return this.headerInteractive ? this.i18nBundle.getText(ARIA_ROLEDESCRIPTION_INTERACTIVE_CARD_HEADER) : this.i18nBundle.getText(ARIA_ROLEDESCRIPTION_CARD_HEADER);
+		return this.interactive ? this.i18nBundle.getText(ARIA_ROLEDESCRIPTION_INTERACTIVE_CARD_HEADER) : this.i18nBundle.getText(ARIA_ROLEDESCRIPTION_CARD_HEADER);
 	}
 
 	get ariaCardAvatarLabel() {
@@ -257,13 +256,13 @@ class CardHeader extends UI5Element {
 	}
 
 	_headerClick() {
-		if (this.headerInteractive) {
+		if (this.interactive) {
 			this.fireEvent("click");
 		}
 	}
 
 	_headerKeydown(event) {
-		if (!this.headerInteractive) {
+		if (!this.interactive) {
 			return;
 		}
 
@@ -283,7 +282,7 @@ class CardHeader extends UI5Element {
 	}
 
 	_headerKeyup(event) {
-		if (!this.headerInteractive) {
+		if (!this.interactive) {
 			return;
 		}
 

--- a/packages/main/src/CardHeader.js
+++ b/packages/main/src/CardHeader.js
@@ -50,7 +50,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.CardHeader.prototype */ {
 
 		/**
-		 * Defines the title displayed in the component header.
+		 * Defines the title text.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
@@ -60,7 +60,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the subtitle displayed in the component header.
+		 * Defines the subtitle text.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
@@ -70,7 +70,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the status displayed in the component header.
+		 * Defines the status text.
 		 * <br><br>
 		 * <b>Note:</b> If the <code>action</code> slot is set, the <code>status</code> will not be displayed,
 		 * you can either have <code>action</code>, or <code>status</code>.
@@ -84,7 +84,7 @@ const metadata = {
 
 		/**
 		 * Defines if the component would be interactive,
-		 * e.g gets hover effect, gets focused and <code>headerPress</code> event is fired, when it is pressed.
+		 * e.g gets hover effect, gets focus outline and <code>click</code> event is fired, when pressed.
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
@@ -138,9 +138,8 @@ const metadata = {
  * @class
  * <h3 class="comment-api-title">Overview</h3>
  *
- * The <code>ui5-card-header</code> is a component that represents information in the header slot
- * of the <code>ui5-card</code> component.
- * The header can be used through several properties, such as: <code>titleText</code>, <code>subtitleText</code>, <code>status</code>
+ * The <code>ui5-card-header</code> is a component, meant to be used as a header of the <code>ui5-card</code> component.
+ * It displays valuable information, that can be defined with several properties, such as: <code>titleText</code>, <code>subtitleText</code>, <code>status</code>
  * and two slots: <code>avatar</code> and <code>action</code>.
  *
  * <h3>Keyboard handling</h3>

--- a/packages/main/test/pages/Card.html
+++ b/packages/main/test/pages/Card.html
@@ -29,7 +29,7 @@
 		status="4 of 10"
 		title-text="Quick Links"
 		subtitle-text="quick links"
-		header-interactive>
+		interactive>
 	</ui5-card-header>
 	<ui5-list id="myList3" separators="Inner">
 		<ui5-li icon="horizontal-bullet-chart" >Template Based Segmentation</ui5-li>

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -29,7 +29,7 @@
 	<ui5-carousel id="carouselCards" items-per-page-s="3" items-per-page-m="3" items-per-page-l="3">
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="1 of 11" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="1 of 11" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -61,7 +61,7 @@
 
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="4 of 11" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="4 of 11" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -93,7 +93,7 @@
 
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="7 of 11" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="7 of 11" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -148,7 +148,7 @@
 	<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="Item 1" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="Item 1" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -180,7 +180,7 @@
 
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="Item 4" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="Item 4" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -212,7 +212,7 @@
 
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="Item 7" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="Item 7" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -264,9 +264,8 @@
 	</ui5-carousel>
 
 	<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="3">
-		<ui5-card id="card" header-interactive
-			class="myCard">
-			<ui5-card-header slot="header" status="1 of 8" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+		<ui5-card id="card" class="myCard">
+			<ui5-card-header slot="header" status="1 of 8" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -296,9 +295,8 @@
 			</ui5-list>
 		</ui5-card>
 
-		<ui5-card id="card"
-			class="myCard">
-			<ui5-card-header slot="header" status="4 of 8" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+		<ui5-card id="card" class="myCard">
+			<ui5-card-header slot="header" status="4 of 8" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -328,9 +326,8 @@
 			</ui5-list>
 		</ui5-card>
 
-		<ui5-card id="card"
-			class="myCard">
-			<ui5-card-header slot="header" status="7 of 8" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+		<ui5-card id="card" class="myCard">
+			<ui5-card-header slot="header" status="7 of 8" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>
@@ -381,7 +378,7 @@
 	<ui5-carousel id="carousel4" arrows-placement="Navigation">
 		<ui5-card id="card"
 			class="myCard">
-			<ui5-card-header slot="header" status="1 of 3" title-text="Quick Links" subtitle-text="quick links" header-interactive>
+			<ui5-card-header slot="header" status="1 of 3" title-text="Quick Links" subtitle-text="quick links" interactive>
 			</ui5-card-header>
 			<ui5-list id="myList3" separators="Inner">
 				<ui5-li icon="horizontal-bullet-chart">Template Based Segmentation</ui5-li>

--- a/packages/main/test/samples/Card.sample.html
+++ b/packages/main/test/samples/Card.sample.html
@@ -86,7 +86,7 @@
 			</div>
 		</ui5-card>
 		<ui5-card class="medium">
-			<ui5-card-header slot="header" title-text="This header is interactive" header-interactive subtitle-text="Click, press Enter or Space" status="3 of 6">
+			<ui5-card-header slot="header" title-text="This header is interactive" interactive subtitle-text="Click, press Enter or Space" status="3 of 6">
 				<ui5-icon name="group" slot="avatar"></ui5-icon>
 			</ui5-card-header>
 
@@ -124,7 +124,7 @@
 	</div>
 </ui5-card>
 <ui5-card class="medium">
-		<ui5-card-header slot="header" title-text="This header is interactive" header-interactive subtitle-text="Click, press Enter or Space" status="3 of 6">
+		<ui5-card-header slot="header" title-text="This header is interactive" interactive subtitle-text="Click, press Enter or Space" status="3 of 6">
 				<ui5-icon name="group" slot="avatar"></ui5-icon>
 		</ui5-card-header>
 	<div class="card-content">

--- a/packages/main/test/samples/Carousel.sample.html
+++ b/packages/main/test/samples/Carousel.sample.html
@@ -54,7 +54,13 @@
 
 	<div class="snippet">
 		<ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="2">
-			<ui5-card title-text="Activities" subtitle-text="For Today" class="medium">
+			<ui5-card class="medium">
+				<ui5-card-header
+					slot="header"
+					title-text="Activities"
+					subtitle-text="For Today"
+				></ui5-card-header>
+
 				<ui5-timeline>
 					<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
 					<ui5-timeline-item title-text="Weekly Sync - CP Design" timestamp="1517349600000" icon="calendar">
@@ -66,8 +72,14 @@
 				</ui5-timeline>
 			</ui5-card>
 
-			<ui5-card title-text="David Willams" subtitle-text="Sales Manager" class="small">
-				<img src="../../../assets/images/avatars/man_avatar_1.png" slot="avatar" />
+			<ui5-card class="small">
+				<ui5-card-header
+					slot="header"
+					title-text="David Willams"
+					subtitle-text="Sales Manager"
+				>
+					<img src="../../../assets/images/avatars/man_avatar_1.png" slot="avatar" />
+				</ui5-card-header>
 
 				<ui5-list separators="Inner" class="content-padding">
 					<ui5-li icon="competitor" icon-end>Personal Development</ui5-li>
@@ -76,8 +88,15 @@
 				</ui5-list>
 			</ui5-card>
 
-			<ui5-card title-text="Team Dolphins" subtitle-text="Direct Reports" status="1 of 2" class="medium">
-				<ui5-icon name="group" slot="avatar"></ui5-icon>
+			<ui5-card class="medium">
+				<ui5-card-header
+					slot="header"
+					title-text="Team Dolphins"
+					subtitle-text="Direct Reports"
+					status="1 of 2"
+				>
+					<ui5-icon name="group" slot="avatar"></ui5-icon>
+				</ui5-card-header>
 
 				<div class="card-content">
 					<ui5-list separators="None" class="card-content-child" style="width: 100%">
@@ -85,12 +104,18 @@
 						<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
 						<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Michael Adams</ui5-li>
 					</ui5-list>
-
 				</div>
 			</ui5-card>
 
-			<ui5-card title-text="Team Bears" header-interactive subtitle-text="Direct Reports" status="2 of 2" class="medium">
-				<ui5-icon name="group" slot="avatar"></ui5-icon>
+			<ui5-card class="medium">
+				<ui5-card-header
+					slot="header"
+					title-text="Team Bears"
+					subtitle-text="Direct Reports"
+					interactive
+					status="2 of 2">
+						<ui5-icon name="group" slot="avatar"></ui5-icon>
+				</ui5-card-header>
 
 				<div class="card-content">
 					<ui5-list separators="None" class="card-content-child" style="width: 100%">
@@ -104,52 +129,77 @@
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-carousel items-per-page-s="1" items-per-page-m="2" items-per-page-l="2">
-		<ui5-card title-text="Activities" subtitle-text="For Today" class="medium">
-			<ui5-timeline>
-				<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
-				<ui5-timeline-item title-text="Weekly Sync - CP Design" timestamp="1517349600000" icon="calendar">
-					MR SOF02 2.43
-				</ui5-timeline-item>
-				<ui5-timeline-item title-text="Video Converence Call - UI5" timestamp="1485813600000" icon="calendar">
-					Online meeting
-				</ui5-timeline-item>
-			</ui5-timeline>
-		</ui5-card>
+	<ui5-card class="medium">
+		<ui5-card-header
+			slot="header"
+			title-text="Activities"
+			subtitle-text="For Today"
+		></ui5-card-header>
 
-		<ui5-card title-text="David Willams" subtitle-text="Sales Manager" class="small">
+		<ui5-timeline>
+			<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
+			<ui5-timeline-item title-text="Weekly Sync - CP Design" timestamp="1517349600000" icon="calendar">
+				MR SOF02 2.43
+			</ui5-timeline-item>
+			<ui5-timeline-item title-text="Video Converence Call - UI5" timestamp="1485813600000" icon="calendar">
+				Online meeting
+			</ui5-timeline-item>
+		</ui5-timeline>
+	</ui5-card>
+
+	<ui5-card class="small">
+		<ui5-card-header
+			slot="header"
+			title-text="David Willams"
+			subtitle-text="Sales Manager"
+		>
 			<img src="../../../assets/images/avatars/man_avatar_1.png" slot="avatar" />
+		</ui5-card-header>
 
-			<ui5-list separators="Inner" class="content-padding">
-				<ui5-li icon="competitor" icon-end>Personal Development</ui5-li>
-				<ui5-li icon="wallet" icon-end>Finance</ui5-li>
-				<ui5-li icon="collaborate" icon-end>Communications Skills</ui5-li>
+		<ui5-list separators="Inner" class="content-padding">
+			<ui5-li icon="competitor" icon-end>Personal Development</ui5-li>
+			<ui5-li icon="wallet" icon-end>Finance</ui5-li>
+			<ui5-li icon="collaborate" icon-end>Communications Skills</ui5-li>
+		</ui5-list>
+	</ui5-card>
+
+	<ui5-card class="medium">
+		<ui5-card-header
+			slot="header"
+			title-text="Team Dolphins"
+			subtitle-text="Direct Reports"
+			status="1 of 2"
+		>
+			<ui5-icon name="group" slot="avatar"></ui5-icon>
+		</ui5-card-header>
+
+		<div class="card-content">
+			<ui5-list separators="None" class="card-content-child" style="width: 100%">
+				<ui5-li image="../../../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain Chevalier</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Michael Adams</ui5-li>
 			</ui5-list>
-		</ui5-card>
+		</div>
+	</ui5-card>
 
-		<ui5-card title-text="Team Dolphins" subtitle-text="Direct Reports" status="1 of 2" class="medium">
-			<ui5-icon name="group" slot="avatar"></ui5-icon>
+	<ui5-card class="medium">
+		<ui5-card-header
+			slot="header"
+			title-text="Team Bears"
+			subtitle-text="Direct Reports"
+			interactive
+			status="2 of 2">
+				<ui5-icon name="group" slot="avatar"></ui5-icon>
+		</ui5-card-header>
 
-			<div class="card-content">
-				<ui5-list separators="None" class="card-content-child" style="width: 100%">
-					<ui5-li image="../../../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain Chevalier</ui5-li>
-					<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
-					<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Michael Adams</ui5-li>
-				</ui5-list>
-
-			</div>
-		</ui5-card>
-
-		<ui5-card title-text="Team Bears" header-interactive subtitle-text="Direct Reports" status="2 of 2" class="medium">
-			<ui5-icon name="group" slot="avatar"></ui5-icon>
-
-			<div class="card-content">
-				<ui5-list separators="None" class="card-content-child" style="width: 100%">
-					<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard Wilson</ui5-li>
-					<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena Petrova</ui5-li>
-					<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John Miller</ui5-li>
-				</ui5-list>
-			</div>
-		</ui5-card>
+		<div class="card-content">
+			<ui5-list separators="None" class="card-content-child" style="width: 100%">
+				<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard Wilson</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena Petrova</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John Miller</ui5-li>
+			</ui5-list>
+		</div>
+	</ui5-card>
 </ui5-carousel>
 	</xmp></pre>
 </section>


### PR DESCRIPTION
As we extracted all header related properties from the Card component to a new CardHeader and the "headerInteractive" property now belongs to CardHeader component, we no longer have to use "header" in the name, but call it just "interactive" - same as we did with the "header-click" event, that is now called "click".

Changes:
- rename "headerInteractive" to "interactive"
- fix Carousel sample to use the CardHeader

BREAKING CHANGE: The CardHeader's property "headerInteractive" has been renamed to "interactive"