### PR TITLE
fix(ui5-li-notification, ui5-li-notification-group): rename heading property to titleText

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-L4iGj2puGZcQfMJ02grqW31YqrU=
+4ww8NXNfQEKz/jKz4fx9NcfWBUE=

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -27,8 +27,8 @@
 			</ui5-icon>
 		{{/if}}
 
-		<div id="{{_id}}-heading" class="ui5-nli-group-heading" part="heading">
-			{{heading}}
+		<div id="{{_id}}-title-text" class="ui5-nli-group-title-text" part="title-text">
+			{{titleText}}
 		</div>
 
 		{{#if showCounter}}

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -96,7 +96,7 @@ const metadata = {
  * <ul>
  * <li><code>Toggle</code> button to expand and collapse the group</li>
  * <li><code>Priority</code> icon to display the priority of the group</li>
- * <li><code>titleText</code> to entitle the group</li>
+ * <li><code>TitleText</code> to entitle the group</li>
  * <li>Custom actions - with the use of <code>ui5-notification-action</code></li>
  * <li>Items of the group</li>
  * </ul>

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -96,7 +96,7 @@ const metadata = {
  * <ul>
  * <li><code>Toggle</code> button to expand and collapse the group</li>
  * <li><code>Priority</code> icon to display the priority of the group</li>
- * <li><code>Heading</code> to entitle the group</li>
+ * <li><code>titleText</code> to entitle the group</li>
  * <li>Custom actions - with the use of <code>ui5-notification-action</code></li>
  * <li>Items of the group</li>
  * </ul>
@@ -110,7 +110,7 @@ const metadata = {
  * <br>
  * The <code>ui5-li-notification-group</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li>heading - Used to style the heading of the notification list group item</li>
+ * <li>title-text - Used to style the titleText of the notification list group item</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>
@@ -232,8 +232,8 @@ class NotificationListGroupItem extends NotificationListItemBase {
 		const id = this._id;
 		const ids = [];
 
-		if (this.hasHeading) {
-			ids.push(`${id}-heading`);
+		if (this.hasTitleText) {
+			ids.push(`${id}-title-text`);
 		}
 
 		ids.push(`${id}-invisibleText`);

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -49,7 +49,7 @@
 	</div>
 
 	<div class="ui5-nli-content {{classes.content}}">
-		<div class="ui5-nli-heading-wrapper">
+		<div class="ui5-nli-title-text-wrapper">
 			{{#if hasPriority}}
 				<ui5-icon
 					class="ui5-prio-icon ui5-prio-icon--{{priorityIcon}}"
@@ -57,8 +57,8 @@
 				</ui5-icon>
 			{{/if}}
 
-			<div id="{{_id}}-heading" class="ui5-nli-heading" part="heading">
-				{{heading}}
+			<div id="{{_id}}-title-text" class="ui5-nli-title-text" part="title-text">
+				{{titleText}}
 			</div>
 		</div>
 

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -44,11 +44,11 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListItem.prototype */ {
 
 		/**
-		 * Defines if the <code>heading</code> and <code>description</code> should wrap,
+		 * Defines if the <code>titleText</code> and <code>description</code> should wrap,
 		 * they truncate by default.
 		 *
 		 * <br><br>
-		 * <b>Note:</b> by default the <code>heading</code> and <code>decription</code>,
+		 * <b>Note:</b> by default the <code>titleText</code> and <code>decription</code>,
 		 * and a <code>ShowMore/Less</code> button would be displayed.
 		 * @type {WrappingType}
 		 * @defaultvalue "None"
@@ -61,7 +61,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the state of the <code>heading</code> and <code>description</code>,
+		 * Defines the state of the <code>titleText</code> and <code>description</code>,
 		 * if less or more information is displayed.
 		 * @private
 		 */
@@ -137,14 +137,14 @@ const metadata = {
  * The <code>ui5-li-notification</code> is a type of list item, meant to display notifications.
  * <br>
  *
- * The component has a rich set of various properties that allows the user to set <code>avatar</code>, <code>heading</code>, descriptive <code>content</code>
+ * The component has a rich set of various properties that allows the user to set <code>avatar</code>, <code>titleText</code>, descriptive <code>content</code>
  * and <code>footnotes</code> to fully describe a notification.
  * <br>
  *
  * The user can:
  * <ul>
  * <li>display a <code>Close</code> button</li>
- * <li>can control whether the <code>heading</code> and <code>description</code> should wrap or truncate
+ * <li>can control whether the <code>titleText</code> and <code>description</code> should wrap or truncate
  * and display a <code>ShowMore</code> button to switch between less and more information</li>
  * <li>add custom actions by using the <code>ui5-notification-action</code> component</li>
  * </ul>
@@ -158,7 +158,7 @@ const metadata = {
  * <br>
  * The <code>ui5-li-notification</code> exposes the following CSS Shadow Parts:
  * <ul>
- * <li>heading - Used to style the heading of the notification list item</li>
+ * <li>title-text - Used to style the titleText of the notification list item</li>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>
@@ -180,8 +180,8 @@ class NotificationListItem extends NotificationListItemBase {
 	constructor() {
 		super();
 
-		// the heading overflow height
-		this._headingOverflowHeight = 0;
+		// the titleText overflow height
+		this._titleTextOverflowHeight = 0;
 
 		// the description overflow height
 		this._descOverflowHeight = 0;
@@ -260,30 +260,30 @@ class NotificationListItem extends NotificationListItemBase {
 		return this.shadowRoot.querySelector(".ui5-nli-description");
 	}
 
-	get headingDOM() {
-		return this.shadowRoot.querySelector(".ui5-nli-heading");
+	get titleTextDOM() {
+		return this.shadowRoot.querySelector(".ui5-nli-title-text");
 	}
 
-	get headingHeight() {
-		return this.headingDOM.offsetHeight;
+	get titleTextHeight() {
+		return this.titleTextDOM.offsetHeight;
 	}
 
 	get descriptionHeight() {
 		return this.descriptionDOM.offsetHeight;
 	}
 
-	get headingOverflows() {
-		const heading = this.headingDOM;
+	get titleTextOverflows() {
+		const titleText = this.titleTextDOM;
 
-		if (!heading) {
+		if (!titleText) {
 			return false;
 		}
 
 		if (isIE()) {
-			return heading.scrollHeight > MAX_WRAP_HEIGHT;
+			return titleText.scrollHeight > MAX_WRAP_HEIGHT;
 		}
 
-		return heading.offsetHeight < heading.scrollHeight;
+		return titleText.offsetHeight < titleText.scrollHeight;
 	}
 
 	get descriptionOverflows() {
@@ -313,8 +313,8 @@ class NotificationListItem extends NotificationListItemBase {
 		const id = this._id;
 		const ids = [];
 
-		if (this.hasHeading) {
-			ids.push(`${id}-heading`);
+		if (this.hasTitleText) {
+			ids.push(`${id}-title-text`);
 		}
 		if (this.hasDesc) {
 			ids.push(`${id}-description`);
@@ -413,17 +413,17 @@ class NotificationListItem extends NotificationListItemBase {
 			return;
 		}
 
-		const headingWouldOverflow = this.headingHeight > this._headingOverflowHeight;
+		const titleTextWouldOverflow = this.titleTextHeight > this._titleTextOverflowHeight;
 		const descWouldOverflow = this.hasDesc && this.descriptionHeight > this._descOverflowHeight;
-		const overflows = headingWouldOverflow || descWouldOverflow;
+		const overflows = titleTextWouldOverflow || descWouldOverflow;
 
 		if (this._showMorePressed && overflows) {
 			this._showMore = true;
 			return;
 		}
 
-		if (this.headingOverflows || this.descriptionOverflows) {
-			this._headingOverflowHeight = this.headingHeight;
+		if (this.titleTextOverflows || this.descriptionOverflows) {
+			this._titleTextOverflowHeight = this.titleTextHeight;
 			this._descOverflowHeight = this.hasDesc ? this.descriptionHeight : 0;
 			this._showMore = true;
 			return;

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -26,12 +26,12 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.fiori.NotificationListItemBase.prototype */ {
 
 		/**
-		 * Defines the <code>heading</code> of the item.
+		 * Defines the <code>titleText</code> of the item.
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */
-		heading: {
+		titleText: {
 			type: String,
 		},
 
@@ -66,7 +66,7 @@ const metadata = {
 		/**
 		 * Defines if the <code>notification</code> is new or has been already read.
 		 * <br><br>
-		 * <b>Note:</b> if set to <code>false</code> the <code>heading</code> has bold font,
+		 * <b>Note:</b> if set to <code>false</code> the <code>titleText</code> has bold font,
 		 * if set to true - it has a normal font.
 		 * @type {boolean}
 		 * @defaultvalue false
@@ -167,8 +167,8 @@ class NotificationListItemBase extends ListItemBase {
 		};
 	}
 
-	get hasHeading() {
-		return !!this.heading.length;
+	get hasTitleText() {
+		return !!this.titleText.length;
 	}
 
 	get hasPriority() {

--- a/packages/fiori/src/themes/NotificationListGroupItem.css
+++ b/packages/fiori/src/themes/NotificationListGroupItem.css
@@ -9,7 +9,7 @@
 	display: none;
 }
 
-:host([read]) .ui5-nli-group-heading {
+:host([read]) .ui5-nli-group-title-text {
 	font-weight: normal;
 }
 
@@ -36,7 +36,7 @@
 	cursor: pointer;
 }
 
-.ui5-nli-group-heading {
+.ui5-nli-group-title-text {
 	color: var(--sapGroup_TitleTextColor);
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontHeader6Size);

--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -1,7 +1,7 @@
 @import "./NotificationListItemBase.css";
 @import "./NotificationPrioIcon.css";
 
-:host([wrapping-type="None"]) .ui5-nli-heading {
+:host([wrapping-type="None"]) .ui5-nli-title-text {
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
@@ -15,7 +15,7 @@
 	overflow: hidden;
 }
 
-:host([_show-more-pressed]) .ui5-nli-heading {
+:host([_show-more-pressed]) .ui5-nli-title-text {
 	-webkit-line-clamp: unset;
 }
 
@@ -23,7 +23,7 @@
 	-webkit-line-clamp: unset;
 }
 
-:host([read]) .ui5-nli-heading {
+:host([read]) .ui5-nli-title-text {
 	font-weight: normal;
 }
 
@@ -32,11 +32,11 @@
 	max-height: 32px;
 }
 
-:host([wrapping-type="None"]) .ui5-nli-content--ie .ui5-nli-heading {
+:host([wrapping-type="None"]) .ui5-nli-content--ie .ui5-nli-title-text {
 	max-height: 32px;
 }
 
-:host([_show-more-pressed]) .ui5-nli-content--ie .ui5-nli-heading {
+:host([_show-more-pressed]) .ui5-nli-content--ie .ui5-nli-title-text {
 	max-height: inherit;
 }
 
@@ -66,18 +66,18 @@
 	box-sizing: border-box;
 }
 
-.ui5-nli-heading-wrapper {
+.ui5-nli-title-text-wrapper {
 	display: flex;
 	flex-direction: row;
 }
 
-.ui5-nli-heading {
+.ui5-nli-title-text {
 	display: flex;
 	margin-bottom: 0.25rem;
 	box-sizing: border-box;
 }
 
-.ui5-nli-heading {
+.ui5-nli-title-text {
 	color: var(--sapGroup_TitleTextColor);
 	font-weight: bold;
 	font-size: var(--sapFontHeader6Size);

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -22,7 +22,7 @@
 
 	<h3>Properties</h3>
 	<ul>
-		<li>heading</li>
+		<li>titleText</li>
 		<li>priority (default: "None")</li>
 		<li>collapsed (default: "false")</li>
 		<li>show-close (default: "false")</li>
@@ -52,12 +52,12 @@
 		<ui5-li-notification-group
 			show-close
 			show-counter
-			heading="Orders"
+			title-text="Orders"
 			priority="High"
 		>
 			<ui5-li-notification
 				show-close
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -72,7 +72,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -86,7 +86,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#252) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#252) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -105,13 +105,13 @@
 		<ui5-li-notification-group
 			show-close
 			show-counter
-			heading="Payments"
+			title-text="Payments"
 			priority="High"
 		>
 			<ui5-li-notification
 				busy
 				show-close
-				heading="New order (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -125,7 +125,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -139,7 +139,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#29003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#29003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -158,12 +158,12 @@
 			show-counter
 			read
 			priority="High"
-			heading="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		>
 			<ui5-li-notification
 				busy
 				show-close
-				heading="New order (#35001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#35001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 				read
 			>
@@ -176,7 +176,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#35002) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#35002) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 				read
 			>
@@ -189,7 +189,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#35003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#35003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 				read
 			>
@@ -209,17 +209,17 @@
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
 	<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="Right">
-		<ui5-list id="notificationListTop" header-text="Notifications heading and content 'truncates'" accessible-role="list">
+		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'" accessible-role="list">
 			<ui5-li-notification-group
 				show-close
 				show-counter
-				heading="Orders"
+				title-text="Orders"
 				priority="Medium"
 			>
 				<ui5-li-notification
 					show-close
 					priority="Medium"
-					heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 
@@ -238,7 +238,7 @@
 				<ui5-li-notification
 					show-close
 					show-counter
-					heading="Orders"
+					title-text="Orders"
 					priority="Medium"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -255,11 +255,11 @@
 			<ui5-li-notification-group
 				show-close
 				show-counter
-				heading="Calls"
+				title-text="Calls"
 				priority="Low"
 			>
 				<ui5-li-notification
-					heading="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="Low"
 				>
 					Short description
@@ -273,7 +273,7 @@
 				</ui5-li-notification>
 
 				<ui5-li-notification
-					heading="New order (#2523)"
+					title-text="New order (#2523)"
 					priority="Low"
 				>
 					<div>. With a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
@@ -293,18 +293,18 @@
 
 	<script>
 		notificationList.addEventListener("itemClick", function(event) {
-			wcToastBS.textContent = event.detail.item.heading;
+			wcToastBS.textContent = event.detail.item.titleText;
 			wcToastBS.show();
 		});
 
 		notificationList.addEventListener("itemClose", function(event) {
-			wcToastBS.textContent = event.detail.item.heading;
+			wcToastBS.textContent = event.detail.item.titleText;
 			wcToastBS.show();
 		});
 
 		notificationList.addEventListener("itemToggle", function(event) {
 			var item = event.detail.item;
-			wcToastBS.textContent = item.heading + " has been " + (item.collapsed ? "collapsed" : "expanded");
+			wcToastBS.textContent = item.titleText + " has been " + (item.collapsed ? "collapsed" : "expanded");
 			wcToastBS.show();
 		});
 

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -28,7 +28,7 @@
 
 	<h3>Properties</h3>
 	<ul>
-		<li>heading</li>
+		<li>titleText</li>
 		<li>wrappingType (default: "None")</li>
 		<li>priority (default: "None")</li>
 		<li>read (default: "false")</li>
@@ -55,12 +55,12 @@
 		<li>itemClose</li>
 	</ul>
 
-	<ui5-list id="notificationList" header-text="Notifications heading and content 'truncates'" accessible-role="list">
+	<ui5-list id="notificationList" header-text="Notifications titleText and content 'truncates'" accessible-role="list">
 
 		<ui5-li-notification
 			busy
 			show-close
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 
@@ -84,7 +84,7 @@
 
 		<ui5-li-notification
 			show-close
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			priority="High"
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -97,7 +97,7 @@
 		</ui5-li-notification>
 
 		<ui5-li-notification
-			heading="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			priority="Medium"
 			>
 				Short description
@@ -110,7 +110,7 @@
 			<ui5-notification-action icon="decline" design="Negative" text="Reject All Requested Information" slot="actions"></ui5-notification-action>
 		</ui5-li-notification>
 
-		<ui5-li-notification heading="New order (#2523)">
+		<ui5-li-notification title-text="New order (#2523)">
 			<div>And with a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
 
 			<span slot="footnotes">John SMith</span>
@@ -129,12 +129,12 @@
 
 	<br><br>
 
-	<ui5-list id="notificationList2" header-text="Notifications heading and content 'wraps'" accessible-role="list">
+	<ui5-list id="notificationList2" header-text="Notifications titleText and content 'wraps'" accessible-role="list">
 
 		<ui5-li-notification
 			show-close
 			wrapping-type="Normal"
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 			<ui5-avatar size="XS" slot="avatar">
@@ -148,7 +148,7 @@
 		<ui5-li-notification
 			show-close
 			wrapping-type="Normal"
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			priority="High"
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -160,7 +160,7 @@
 
 		<ui5-li-notification
 			wrapping-type="Normal"
-			heading="New order (#2522)"
+			title-text="New order (#2522)"
 			priority="Low"
 		>
 			And short description
@@ -171,7 +171,7 @@
 		</ui5-li-notification>
 
 		<ui5-li-notification
-			heading="New order (#2523)"
+			title-text="New order (#2523)"
 			wrapping-type="Normal"
 		>
 			<div>With a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
@@ -184,10 +184,10 @@
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
 	<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="Right">
-		<ui5-list id="notificationListTop" header-text="Notifications heading and content 'truncates'" accessible-role="list">
+		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'" accessible-role="list">
 			<ui5-li-notification
 				show-close
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -209,7 +209,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -222,7 +222,7 @@
 			</ui5-li-notification>
 
 			<ui5-li-notification
-				heading="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="Medium"
 			>
 					Short description
@@ -235,7 +235,7 @@
 				<ui5-notification-action icon="decline" design="Negative" text="Reject All Requested Information" slot="actions"></ui5-notification-action>
 			</ui5-li-notification>
 
-			<ui5-li-notification heading="New order (#2523)">
+			<ui5-li-notification title-text="New order (#2523)">
 				<div>. With a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
 
 				<span slot="footnotes">John SMith</span>
@@ -252,12 +252,12 @@
 
 	<script>
 		notificationList.addEventListener("itemClick", function(event) {
-			wcToastBS.textContent = event.detail.item.heading;
+			wcToastBS.textContent = event.detail.item.titleText;
 			wcToastBS.show();
 		});
 
 		notificationList.addEventListener("itemClose", function(event) {
-			wcToastBS.textContent = event.detail.item.heading;
+			wcToastBS.textContent = event.detail.item.titleText;
 			wcToastBS.show();
 		});
 
@@ -270,12 +270,12 @@
 			}, 1000);
 
 			item.busy = true;
-			wcToastBS.textContent = item.heading;
+			wcToastBS.textContent = item.titleText;
 			wcToastBS.show();
 		});
 
 		notificationList2.addEventListener("itemClose", function(event) {
-			wcToastBS.textContent = event.detail.item.heading;
+			wcToastBS.textContent = event.detail.item.titleText;
 			wcToastBS.show();
 		});
 

--- a/packages/fiori/test/pages/NotificationList_test_page.html
+++ b/packages/fiori/test/pages/NotificationList_test_page.html
@@ -61,13 +61,13 @@
 				id="nlgi1"
 				show-close
 				show-counter
-				heading="Orders"
+				title-text="Orders"
 				priority="High"
 			>
 				<ui5-li-notification
 					id="nli1"
 					show-close
-					heading="New order #2201"
+					title-text="New order #2201"
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -83,7 +83,7 @@
 				<ui5-li-notification
 					id="nli2"
 					show-close
-					heading="New order #2202"
+					title-text="New order #2202"
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -102,14 +102,14 @@
 			<ui5-li-notification-group
 				show-close
 				show-counter
-				heading="Payments"
+				title-text="Payments"
 				priority="High"
 			>
 				<ui5-li-notification
 					id="nli3"
 					show-close
 					wrapping-type="Normal"
-					heading="New payment #2900"
+					title-text="New payment #2900"
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -127,7 +127,7 @@
 					busy
 					wrapping-type="Normal"
 					show-close
-					heading="New payment #2901"
+					title-text="New payment #2901"
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -144,7 +144,7 @@
 				id="nlgi3"
 				show-close
 				show-counter
-				heading="Collapsed"
+				title-text="Collapsed"
 				priority="High"
 				collapsed
 			>
@@ -152,7 +152,7 @@
 				id="nli5"
 				wrapping-type="Normal"
 				show-close
-				heading="New payment #2900"
+				title-text="New payment #2900"
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -173,15 +173,15 @@
 
 	<script>
 		notificationList.addEventListener("ui5-itemClick", function(event) {
-			clickInput.value = event.detail.item.heading;
+			clickInput.value = event.detail.item.titleText;
 		});
 
 		notificationList.addEventListener("ui5-itemClose", function(event) {
-			closeInput.value = event.detail.item.heading;
+			closeInput.value = event.detail.item.titleText;
 		});
 
 		notificationList.addEventListener("ui5-itemToggle", function(event) {
-			toggleInput.value = event.detail.item.heading;
+			toggleInput.value = event.detail.item.titleText;
 		});
 
 		var counter = 0;

--- a/packages/fiori/test/pages/ProductSwitchItem.html
+++ b/packages/fiori/test/pages/ProductSwitchItem.html
@@ -24,7 +24,7 @@
 </head>
 
 <body style="background-color: var(--sapBackgroundColor);">
-		<ui5-product-switch-item id="productSwitchItem" heading="Home" subtitle-text="Central Home" icon="home"></ui5-product-switch-item>
+	<ui5-product-switch-item id="productSwitchItem" title-text="Home" subtitle-text="Central Home" icon="home"></ui5-product-switch-item>
 </body>
 
 </html>

--- a/packages/fiori/test/samples/NotificationListGroupItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListGroupItem.sample.html
@@ -23,12 +23,12 @@
 			<ui5-li-notification-group
 				show-close
 				show-counter
-				heading="Orders"
+				title-text="Orders"
 				priority="High"
 			>
 				<ui5-li-notification
 					show-close
-					heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -43,7 +43,7 @@
 	
 				<ui5-li-notification
 					show-close
-					heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -63,13 +63,13 @@
 			<ui5-li-notification-group
 				show-close
 				show-counter
-				heading="Deliveries"
+				title-text="Deliveries"
 				priority="Medium"
 				collapsed
 			>
 				<ui5-li-notification
 					show-close
-					heading="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="Medium"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -83,7 +83,7 @@
 	
 				<ui5-li-notification
 					show-close
-					heading="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="Medium"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -104,11 +104,11 @@
 				show-counter
 				priority="Low"
 				collapsed
-				heading="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			>
 				<ui5-li-notification
 					show-close
-					heading="New meeting at Building (#35001)"
+					title-text="New meeting at Building (#35001)"
 					priority="Low"
 					read
 				>
@@ -121,7 +121,7 @@
 	
 				<ui5-li-notification
 					show-close
-					heading="New meeting at Building (#35001)"
+					title-text="New meeting at Building (#35001)"
 					priority="Low"
 					read
 				>
@@ -146,12 +146,12 @@
 	<ui5-li-notification-group
 		show-close
 		show-counter
-		heading="Orders"
+		title-text="Orders"
 		priority="High"
 	>
 		<ui5-li-notification
 			show-close
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			priority="High"
 		>
 		...
@@ -159,7 +159,7 @@
 
 		<ui5-li-notification
 			show-close
-			heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			priority="High"
 		>
 		...
@@ -191,12 +191,12 @@
 				<ui5-li-notification-group
 					show-close
 					show-counter
-					heading="Orders"
+					title-text="Orders"
 					priority="High"
 				>
 					<ui5-li-notification
 						show-close
-						heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+						title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 						priority="High"
 					>
 						And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -211,7 +211,7 @@
 		
 					<ui5-li-notification
 						show-close
-						heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+						title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 						priority="High"
 					>
 						And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -231,13 +231,13 @@
 				<ui5-li-notification-group
 					show-close
 					show-counter
-					heading="Deliveries"
+					title-text="Deliveries"
 					priority="Medium"
 					collapsed
 				>
 					<ui5-li-notification
 						show-close
-						heading="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+						title-text="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 						priority="Medium"
 					>
 						And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -251,7 +251,7 @@
 		
 					<ui5-li-notification
 						show-close
-						heading="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+						title-text="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 						priority="Medium"
 					>
 						And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -272,11 +272,11 @@
 					show-counter
 					priority="High"
 					collapsed
-					heading="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				>
 					<ui5-li-notification
 						show-close
-						heading="New meeting at Building (#35001)"
+						title-text="New meeting at Building (#35001)"
 						priority="High"
 						read
 					>
@@ -289,7 +289,7 @@
 		
 					<ui5-li-notification
 						show-close
-						heading="New meeting at Building (#35001)"
+						title-text="New meeting at Building (#35001)"
 						priority="High"
 						read
 					>
@@ -331,12 +331,12 @@
 		<ui5-li-notification-group
 			show-close
 			show-counter
-			heading="Orders"
+			title-text="Orders"
 			priority="High"
 		>
 			<ui5-li-notification
 				show-close
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar slot="avatar" size="XS">

--- a/packages/fiori/test/samples/NotificationListItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListItem.sample.html
@@ -22,7 +22,7 @@
 		<ui5-list id="myList" class="full-width" header-text="Notifications">
 			<ui5-li-notification
 				show-close
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -36,7 +36,7 @@
 
 			<ui5-li-notification
 				show-close
-				heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				priority="High"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -50,7 +50,7 @@
 			<ui5-li-notification
 				show-close
 				priority="High"
-				heading="New order (#2525) With a short title"
+				title-text="New order (#2525) With a short title"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -72,7 +72,7 @@
 <ui5-list header-text="Notifications">
 	<ui5-li-notification
 		show-close
-		heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+		title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		priority="High"
 	>
 		And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -85,7 +85,7 @@
 
 	<ui5-li-notification
 		show-close
-		heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+		title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		priority="High"
 	>
 		And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -113,7 +113,7 @@
 			<ui5-li-notification
 				show-close
 				priority="Low"
-				heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -129,7 +129,7 @@
 			<ui5-li-notification
 				show-close
 				priority="Low"
-				heading="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+				title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -144,7 +144,7 @@
 			<ui5-li-notification
 				show-close
 				priority="Low"
-				heading="New order (#2525) With a short title"
+				title-text="New order (#2525) With a short title"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -163,7 +163,7 @@
 	<ui5-li-notification
 		show-close
 		priority="Low"
-		heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+		title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 	>
 		And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 		<ui5-avatar size="XS" slot="avatar">
@@ -194,7 +194,7 @@
 			<ui5-list id="notificationListTop" header-text="Notifications">
 				<ui5-li-notification
 					show-close
-					heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 					<ui5-avatar initials="JD" size="XS" slot="avatar"></ui5-avatar>
@@ -207,7 +207,7 @@
 		
 				<ui5-li-notification
 					show-close
-					heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="High"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
@@ -220,7 +220,7 @@
 				</ui5-li-notification>
 		
 				<ui5-li-notification
-					heading="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+					title-text="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 					priority="Medium"
 				>
 						Short description
@@ -233,7 +233,7 @@
 					<ui5-notification-action icon="decline" text="Reject All Requested Information" slot="actions"></ui5-notification-action>
 				</ui5-li-notification>
 		
-				<ui5-li-notification heading="New order (#2523)">
+				<ui5-li-notification title-text="New order (#2523)">
 					<div>. With a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
 		
 					<span slot="footnotes">John SMith</span>
@@ -270,7 +270,7 @@
 	<ui5-list header-text="Notifications">
 		<ui5-li-notification
 			show-close
-			heading="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 			<ui5-avatar size="XS" slot="avatar">

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -149,9 +149,9 @@ describe("Notification List Item Tests", () => {
 	it("tests List Group Item ACC ariaLabelledBy", () => {
 		const firstGroupItem = $("#nlgi1");
 		const firstGroupItemRoot = firstGroupItem.shadow$(".ui5-nli-group-root");
-		const headingId = `${firstGroupItem.getProperty("_id")}-heading`;
+		const titleTextId = `${firstGroupItem.getProperty("_id")}-title-text`;
 		const inivisbleTextId = `${firstGroupItem.getProperty("_id")}-invisibleText`;
-		const EXPECTED_ARIA_LABELLED_BY = `${headingId} ${inivisbleTextId}`;
+		const EXPECTED_ARIA_LABELLED_BY = `${titleTextId} ${inivisbleTextId}`;
 
 		// assert
 		assert.strictEqual(firstGroupItemRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY,
@@ -162,11 +162,11 @@ describe("Notification List Item Tests", () => {
 		const firstItem = $("#nli1");
 		const firstItemRoot = firstItem.shadow$(".ui5-nli-root");
 
-		const headingId = `${firstItem.getProperty("_id")}-heading`;
+		const titleTextId = `${firstItem.getProperty("_id")}-title-text`;
 		const descriptionId = `${firstItem.getProperty("_id")}-description`;
 		const footerId = `${firstItem.getProperty("_id")}-footer`;
 		const inivisbleTextId = `${firstItem.getProperty("_id")}-invisibleText`;
-		const EXPECTED_ARIA_LABELLED_BY = `${headingId} ${descriptionId} ${footerId} ${inivisbleTextId}`;
+		const EXPECTED_ARIA_LABELLED_BY = `${titleTextId} ${descriptionId} ${footerId} ${inivisbleTextId}`;
 
 		// assert
 		assert.strictEqual(firstItemRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY,


### PR DESCRIPTION
BREAKING CHANGE

For ```ui5-li-notification``` and ```ui5-li-notification-group```, ```heading``` property has been renamed to ```titleText```