### PR TITLE
chore(ui5-vsd): rename "open" to show"

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -2,8 +2,8 @@ import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import Dialog from "@ui5/webcomponents/Dialog.js";
-import Button from "@ui5/webcomponents/Button.js";
+import Dialog from "@ui5/webcomponents/dist/Dialog.js";
+import Button from "@ui5/webcomponents/dist/Button.js";
 import GroupHeaderListItem from "@ui5/webcomponents/dist/GroupHeaderListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
@@ -254,9 +254,10 @@ class ViewSettingsDialog extends UI5Element {
 	}
 
 	/**
-	 * Opens the dialog. On first call does initialization of the control.
+	 * Shows the dialog.
+	 * @public
 	 */
-	open() {
+	show() {
 		if (!this._dialog) {
 			this._sortOrder = this.shadowRoot.querySelector("[ui5-list][sort-order]");
 			this._sortBy = this.shadowRoot.querySelector("[ui5-list][sort-by]");

--- a/packages/fiori/test/pages/ViewSettingsDialog.html
+++ b/packages/fiori/test/pages/ViewSettingsDialog.html
@@ -22,7 +22,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 
 	<h3> ViewSettingsDialog</h3>
-	<ui5-button id="btnOpenDialog">Open ViewSettingsDialog</ui5-button>
+	<ui5-button id="btnOpenDialog">Show ViewSettingsDialog</ui5-button>
 	<br>
 	<br>
 	<ui5-view-settings-dialog id="vsd">
@@ -34,7 +34,7 @@
 
 	<script>
 		btnOpenDialog.addEventListener("click", function () {
-			vsd.open();
+			vsd.show();
 		});
 		vsd.addEventListener("confirm", function(evt) {
 			alert("OK button clicked, returned info is: " + JSON.stringify(evt.detail));

--- a/packages/fiori/test/samples/ViewSettingsDialog.sample.html
+++ b/packages/fiori/test/samples/ViewSettingsDialog.sample.html
@@ -33,7 +33,7 @@
 			let vsdResults = document.getElementById("vsdResults");
 			btnOpenDialog1.addEventListener("click", ()=> {
 				vsdResults.innerHTML = "";
-				vsd1.open();
+				vsd1.show();
 			});
 
 			vsd1.addEventListener("confirm", function(evt) {
@@ -45,7 +45,7 @@
 		var vsdResults = document.getElementById("vsdResults");
 		btnOpenDialog1.addEventListener("click", function () {
 			vsdResults.innerHTML = "";
-			vsd1.open();
+			vsd1.show();
 		});
 		vsd1.addEventListener("confirm", function(evt) {
 			vsdResults.innerHTML = JSON.stringify(evt.detail);


### PR DESCRIPTION
The Dialog's and Popup's public methods have been recently renamed to show (previously open), showAt (previously openBy) and  we have to use "show" here as well to keep the convention. Also, the public method should be documented.