### PR TITLE
chore(framework): Generate better lit templates

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-etgGZCy+pX2kcY3oXrk2gwC/3OM=
+i/EAJKfy3rFVnl0L6WScWC/Sd3w=

--- a/packages/base/src/renderer/LitRenderer.js
+++ b/packages/base/src/renderer/LitRenderer.js
@@ -26,6 +26,7 @@ export { scopeTag };
 export { repeat } from "lit-html/directives/repeat.js";
 export { classMap } from "lit-html/directives/class-map.js";
 export { styleMap } from "lit-html/directives/style-map.js";
+export { ifDefined } from "lit-html/directives/if-defined.js";
 export { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 
 export default litRender;

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -32,7 +32,7 @@ function HTMLLitVisitor(debug) {
 	this.result = "";
 	this.mainBlock = "";
 	this.blockPath = "context";
-	this.blockParameters = ["context"];
+	this.blockParameters = ["context", "tags", "suffix"];
 	this.paths = []; //contains all normalized relative paths
 	this.debug = debug;
 	if (this.debug) {
@@ -48,7 +48,7 @@ HTMLLitVisitor.prototype.Program = function(program) {
 	this.keys.push(key);
 	this.debug && this.blockByNumber.push(key);
 
-	this.blocks[this.currentKey()] = "const " + this.currentKey() + " = (" + this.blockParameters.join(", ") + ") => { return ";
+	this.blocks[this.currentKey()] = "const " + this.currentKey() + " = (" + this.blockParameters.join(", ") + ") => ";
 
 	if (this.keys.length > 1) { //it's a nested block
 		this.blocks[this.prevKey()] += this.currentKey() + "(" + this.blockParameters.join(", ") + ")";
@@ -59,7 +59,7 @@ HTMLLitVisitor.prototype.Program = function(program) {
 
 	this.blocks[this.currentKey()] += "html`";
 	Visitor.prototype.Program.call(this, program);
-	this.blocks[this.currentKey()] += "`; };";
+	this.blocks[this.currentKey()] += "`;";
 
 	this.keys.pop(key);
 };

--- a/packages/tools/lib/hbs2lit/src/svgProcessor.js
+++ b/packages/tools/lib/hbs2lit/src/svgProcessor.js
@@ -55,7 +55,7 @@ function replaceInternalBlocks(template, svgContent) {
 	const internalBlocks = svgContent.match(blockrx) || [];
 
 	internalBlocks.forEach(blockName => {
-		const rx = new RegExp(`const ${blockName}.*(html\`).*};`);
+		const rx = new RegExp(`const ${blockName}.*(html\`).*;`);
 		template = template.replace(rx, (match, p1) => {
 			return match.replace(p1, "svg\`");
 		});

--- a/packages/tools/lib/hbs2lit/src/svgProcessor.js
+++ b/packages/tools/lib/hbs2lit/src/svgProcessor.js
@@ -46,8 +46,8 @@ function getSVGMatches(template) {
 
 function getSVGBlock(input, blockCounter) {
 	return {
-		usage: `\${blockSVG${blockCounter}(context)}`,
-		definition: `\nconst blockSVG${blockCounter} = (context) => {return svg\`${input}\`};`,
+		usage: `\${blockSVG${blockCounter}(context, tags, suffix)}`,
+		definition: `\nconst blockSVG${blockCounter} = (context, tags, suffix) => svg\`${input}\`;`,
 	};
 }
 

--- a/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
+++ b/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
@@ -1,16 +1,10 @@
 const buildRenderer = (controlName, litTemplate) => {
-	return `
-/* eslint no-unused-vars: 0 */
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { html, svg, repeat, classMap, styleMap, unsafeHTML, scopeTag } from '@ui5/webcomponents-base/dist/renderer/LitRenderer.js';
+	return `/* eslint no-unused-vars: 0 */
+import { html, svg, repeat, classMap, styleMap, ifDefined, unsafeHTML, scopeTag } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 
-const main = (context, tags, suffix) => {
-	${litTemplate}
+${litTemplate}
 
-	return block0(context);
-};
-
-export default main;`;
+export default block0;`;
 };
 
 module.exports = {

--- a/packages/tools/lib/scoping/lint-src.js
+++ b/packages/tools/lib/scoping/lint-src.js
@@ -10,7 +10,7 @@ const errors = [];
 glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
 	let content = String(fs.readFileSync(file));
 	tags.forEach(tag => {
-		if (content.match(new RegExp(`(^|[^\-_A-Za-z0-9"\[])(${tag})([^\-_A-Za-z0-9]|$)`, "g"))) {
+		if (content.match(new RegExp(`(^|[^\.\-_A-Za-z0-9"\[])(${tag})([^\-_A-Za-z0-9]|$)`, "g"))) {
 			errors.push(`Warning! ${tag} found in ${file}`);
 		}
 	});


### PR DESCRIPTION
`lit-html 2.0` has optimizations that require creating lit templates only once. 

Our current code generates templates like this:

```js
const main = (context, tags, suffix) => {
	const block0 = (context) => { return html`<div class="ui5-badge-root" dir="${ifDefined(context.effectiveDir)}"><slot name="icon"></slot>${ context.hasText ? block1(context) : undefined }<span class="ui5-hidden-text">${ifDefined(context.badgeDescription)}</span></div>`; };
	const block1 = (context) => { return html`<label class="ui5-badge-text"><bdi><slot></slot></bdi></label>`; };


	return block0(context);
};

export default main;
```

Every time the `main` function is executed, `block0`, etc... are created again.

The new code creates templates like this:
```js
const block0 = (context, tags, suffix) => html`<div class="ui5-badge-root" dir="${ifDefined(context.effectiveDir)}"><slot name="icon"></slot>${ context.hasText ? block1(context, tags, suffix) : undefined }<span class="ui5-hidden-text">${ifDefined(context.badgeDescription)}</span></div>`;
const block1 = (context, tags, suffix) => html`<label class="ui5-badge-text"><bdi><slot></slot></bdi></label>`;


export default block0;
```

Now each template function is created only once, on module level, which allows lit optimizations to work correctly.

Additional cosmetic changes:
 - `ifDefined` is no longer imported by each template directly from `lit-html`, but rather from our wrapper like the rest of the required directives (`styleMap`, `classMap`, etc...). This makes it possible to centrally control lit dependencies.
 - Blocks are now generated without the `return { }`, but directly `const block0 = (context, tags, suffix) => html`...`;
 - A bug fixed in the tool that checks `.css` files for not-scoping-friendly selectors (the tool used to get confused whenever you have a CSS class with the same name as the component's tag)