### PR TITLE
refactor(framework): Improve types handling

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-i/EAJKfy3rFVnl0L6WScWC/Sd3w=
+3yJSCm+cqLixKMQYnH6qhQ6Ivxk=

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-3yJSCm+cqLixKMQYnH6qhQ6Ivxk=
+2BIvhMbm2vGFJMqg6BzuGcn5EMs=

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -891,6 +891,8 @@ class UI5Element extends HTMLElement {
 							oldValue: oldState,
 						});
 						this._updateAttribute(prop, value);
+					} else {
+						this._attributeInSync.delete(camelToKebabCase(prop));
 					}
 				},
 			});

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -377,11 +377,10 @@ class UI5Element extends HTMLElement {
 	 * @private
 	 */
 	attributeChangedCallback(name, oldValue, newValue) {
-		if (this._attributeInSync) {
-			this._attributeInSync = false;
-			return;
-		}
-
+		// if (this._attributeInSync) {
+		// 	this._attributeInSync = false;
+		// 	return;
+		// }
 		const properties = this.constructor.getMetadata().getProperties();
 		const realName = name.replace(/^ui5-/, "");
 		const nameInCamelCase = kebabToCamelCase(realName);
@@ -403,11 +402,10 @@ class UI5Element extends HTMLElement {
 	 * @private
 	 */
 	_updateAttribute(name, newValue) {
-		if (this._attributeInSync) {
-			this._attributeInSync = false;
-			return;
-		}
-
+		// if (this._attributeInSync) {
+		// 	this._attributeInSync = false;
+		// 	return;
+		// }
 		if (!this.constructor.getMetadata().hasAttribute(name)) {
 			return;
 		}

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -391,7 +391,7 @@ class UI5Element extends HTMLElement {
 			if (propertyTypeClass === Boolean) {
 				newValue = newValue !== null;
 			} else if (isDescendantOf(propertyTypeClass, DataType)) {
-				newValue = propertyTypeClass.attributeToValue(newValue);
+				newValue = propertyTypeClass.attributeToProperty(newValue);
 			}
 
 			this._attributeInSync = true;
@@ -412,11 +412,14 @@ class UI5Element extends HTMLElement {
 			return;
 		}
 
+		const attrName = camelToKebabCase(name);
+
 		if (typeof newValue === "object") {
+			this._attributeInSync = true;
+			this.removeAttribute(attrName); // If the type allows both primitive and object values, and there was an attribute set, remove it when setting an object value
 			return;
 		}
 
-		const attrName = camelToKebabCase(name);
 		const attrValue = this.getAttribute(attrName);
 		if (typeof newValue === "boolean") {
 			if (newValue === true && attrValue === null) {

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -60,6 +60,7 @@ class UI5Element extends HTMLElement {
 	constructor() {
 		super();
 
+		this._attributeInSync = new Set();
 		this._changedState = []; // Filled on each invalidation, cleared on re-render (used for debugging)
 		this._suppressInvalidation = true; // A flag telling whether all invalidations should be ignored. Initialized with "true" because a UI5Element can not be invalidated until it is rendered for the first time
 		this._inDOM = false; // A flag telling whether the UI5Element is currently in the DOM tree of the document or not
@@ -79,8 +80,6 @@ class UI5Element extends HTMLElement {
 		if (this.constructor._needsShadowDOM()) {
 			this.attachShadow({ mode: "open" });
 		}
-
-		this._attributeInSync = new Set();
 	}
 
 	/**

--- a/packages/base/src/types/DataType.js
+++ b/packages/base/src/types/DataType.js
@@ -11,6 +11,10 @@ class DataType {
 	static isValid(value) {
 	}
 
+	static attributeToProperty(attributeValue) {
+		return attributeValue;
+	}
+
 	static generateTypeAccessors(types) {
 		Object.keys(types).forEach(type => {
 			Object.defineProperty(this, type, {

--- a/packages/base/src/types/Float.js
+++ b/packages/base/src/types/Float.js
@@ -5,6 +5,10 @@ class Float extends DataType {
 		// Assuming that integers are floats as well!
 		return Number(value) === value;
 	}
+
+	static attributeToProperty(attributeValue) {
+		return parseFloat(attributeValue);
+	}
 }
 
 export default Float;

--- a/packages/base/src/types/Integer.js
+++ b/packages/base/src/types/Integer.js
@@ -4,6 +4,10 @@ class Integer extends DataType {
 	static isValid(value) {
 		return Number.isInteger(value);
 	}
+
+	static attributeToProperty(attributeValue) {
+		return parseInt(attributeValue);
+	}
 }
 
 export default Integer;


### PR DESCRIPTION
Changes:
 - Optimization: use the `_attributesInSyncSet` set to cut the "attribute -> property -> attribute" update cycle sooner.
 
 The `attributeChangedCallback` lifecycle hook is called by the browser for each `setAttribute`/`removeAttribute` call. This is welcome when the attribute was changed by the user, as we want to be notified, but is redundant whenever we manually call `setAttribute`/`removeAttribute` when the property value changes and we want to synchronize the attribute. To address this, we use a set to mark each attribute as "already in sync" before invoking code that is about to trigger `attributeChangedCallback`.
 
 **Important:** The property setter *must* unflag the attribute as "in-sync" if it does not call `_udpateAttribute`. For example `attributeChangedCallback` is executed for `design="Default"`, but then the property setter finds out that the property `design` is already with `Default` value (this is the default value) and does not trigger a property update, hence no `_updateAttribute`. But `attributeChangedCallback` can't know this in advance, so it marked `design` as "in sync" to avoid the next `_updateAttribute`. If the property `design` stays in the set, this will prevent the next `attributeChangedCallback` or `_updateAttribute`, when `design` might be set to some other value.
 
 - `UI5Element.js` no longer has specific knowledge of custom types such as `Integer` and `Float` - instead it asks them to parse the attribute values themselves. 

For this purpose `DataType.js` introduces a new `attributeToProperty` static method. `Float` and `Integer` implement it.

 - The framework now assumes that there might be types that accept both primitive values and object (Object or Array) values. If a primitive value is set for a property, the framework will set an attribute as well. But if an object value is set, the framework will not only not set an attribute, but it will also remove an existing attribute (set due to a previous primitive-type value).
 
 Example:

Assuming that `specialColor` is of a type that accepts both strings and objects, for example:

```js
import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";

class SpecialColor extends DataType {
	static isValid(value) {
		return typeof value === "string" || (typeof value === "object" && !!value.from && !!value.to);
	}
}

export default SpecialColor;
```

and the property `specialColor` is of type `SpecialColor`:

 ```js
myComponent.specialColor = "blue"; // will set special-color="blue" attribute
myComponent.specialColor = {
  from: "blue",
  to: "red"
}; // will remove the special-color attribute
myComponent.specialColor = "green"; // will once again set the special-color attribute
```