### PR TITLE
fix(ui5-date-picker): keyboard handling now compliant with the specification

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -394,9 +394,8 @@ class DatePicker extends DateComponentBase {
 		this._isPickerOpen = false;
 		if (isPhone()) {
 			this.blur(); // close device's keyboard and prevent further typing
-		} else if (this._focusInputAfterClose) {
+		} else {
 			this._getInput().focus();
-			this._focusInputAfterClose = false;
 		}
 	}
 
@@ -710,7 +709,6 @@ class DatePicker extends DateComponentBase {
 		const newValue = event.detail.values && event.detail.values[0];
 		this._updateValueAndFireEvents(newValue, true, ["change", "value-changed"]);
 
-		this._focusInputAfterClose = true;
 		this.closePicker();
 	}
 

--- a/packages/main/src/DateRangePicker.js
+++ b/packages/main/src/DateRangePicker.js
@@ -223,7 +223,6 @@ class DateRangePicker extends DatePicker {
 
 		const newValue = this._buildValue(...event.detail.dates); // the value will be normalized so we don't need to order them here
 		this._updateValueAndFireEvents(newValue, true, ["change", "value-changed"]);
-		this._focusInputAfterClose = true;
 		this.closePicker();
 	}
 

--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -369,7 +369,6 @@ class DateTimePicker extends DatePicker {
 			this.fireEvent("value-changed", { value: this.value, valid });
 		}
 
-		this._focusInputAfterClose = true;
 		this._updateValueState();
 		this.closePicker();
 	}


### PR DESCRIPTION
- Focus is moved on the component input field after closing
the corresponding popover via Escape keyboard key.

related to: #3091