### PR TITLE
fix(ui5-date-picker): internal calendar component state managed properly

### DIFF
--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -108,6 +108,9 @@ const metadata = {
 				values: { type: Array },
 			},
 		},
+
+		"show-month-press": {},
+		"show-year-press": {},
 	},
 };
 
@@ -271,15 +274,17 @@ class Calendar extends CalendarPart {
 	/**
 	 * The user clicked the "month" button in the header
 	 */
-	onHeaderShowMonthPress() {
+	onHeaderShowMonthPress(event) {
 		this._currentPicker = "month";
+		this.fireEvent("show-month-press", event);
 	}
 
 	/**
 	 * The user clicked the "year" button in the header
 	 */
-	onHeaderShowYearPress() {
+	onHeaderShowYearPress(event) {
 		this._currentPicker = "year";
+		this.fireEvent("show-year-press", event);
 	}
 
 	get _currentPickerDOM() {

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -715,6 +715,20 @@ class DatePicker extends DateComponentBase {
 	}
 
 	/**
+	 * The user clicked the "month" button in the header
+	 */
+	onHeaderShowMonthPress() {
+		this._calendarCurrentPicker = "month";
+	}
+
+	/**
+	 * The user clicked the "year" button in the header
+	 */
+	onHeaderShowYearPress() {
+		this._calendarCurrentPicker = "year";
+	}
+
+	/**
 	 * Formats a Java Script date object into a string representing a locale date
 	 * according to the <code>formatPattern</code> property of the DatePicker instance
 	 * @param {object} date A Java Script date object to be formatted as string

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -48,6 +48,8 @@
 		.minDate="{{minDate}}"
 		.maxDate="{{maxDate}}"
 		@ui5-selected-dates-change="{{onSelectedDatesChange}}"
+		@ui5-show-month-press="{{onHeaderShowMonthPress}}"
+		@ui5-show-year-press="{{onHeaderShowYearPress}}"
 		?hide-week-numbers="{{hideWeekNumbers}}"
 		._currentPicker="{{_calendarCurrentPicker}}"
 	>
@@ -58,3 +60,4 @@
 {{/inline}}
 
 {{#*inline "footer"}}{{/inline}}
+

--- a/packages/main/src/DateTimePickerPopover.hbs
+++ b/packages/main/src/DateTimePickerPopover.hbs
@@ -24,6 +24,8 @@
 			.minDate="{{minDate}}"
 			.maxDate="{{maxDate}}"
 			@ui5-selected-dates-change="{{onSelectedDatesChange}}"
+			@ui5-show-month-press="{{onHeaderShowMonthPress}}"
+			@ui5-show-year-press="{{onHeaderShowYearPress}}"
 			?hide-week-numbers="{{hideWeekNumbers}}"
 			._currentPicker="{{_calendarCurrentPicker}}"
 		>

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -394,6 +394,24 @@ describe("Date Picker Tests", () => {
 		datepicker.valueHelpIcon.click(); // close the datepicker
 	});
 
+	it("DatePicker popover when initially opened displays a day picker", () => {
+		datepicker.id = "#dp11";
+
+		datepicker.valueHelpIcon.click() // open the datepicker
+		browser.keys('F4'); // show month picker
+		datepicker.valueHelpIcon.click(); // close the datepicker
+
+		assert.notOk(datepicker.calendar.shadow$("ui5-daypicker")._hidden, "Day picker is open");
+
+		browser.keys(['Shift', 'F4']); // show year picker
+		datepicker.valueHelpIcon.click(); // close the datepicker
+
+		datepicker.valueHelpIcon.click() // open the datepicker
+		assert.notOk(datepicker.calendar.shadow$("ui5-daypicker")._hidden, "Day picker is open");
+
+		datepicker.valueHelpIcon.click(); // close the datepicker
+	});
+
 
 	it("[F4] on year picker doesn't close the date picker", () => {
 		datepicker.id = "#dp11";


### PR DESCRIPTION
- Day picker is always shown when the corresponding ui5-date-picker,
ui5-datetime-picker or ui5-daterange-picker component popover is opened.

