### PR TITLE
chore: create type definitions for @ui5/webcomponents-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "npm-run-all": "^4.1.3",
     "nps": "^5.10.0",
     "rimraf": "^3.0.2",
+    "typescript": "^4.3.5",
     "wsrun": "^5.2.4"
   },
   "workspaces": [

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-XfwM5Q5x9CyXTd3ewO6fAuUW9Hs=
+9bQqfTusGs3xO7HVLl9F25bmb/M=

--- a/packages/base/package-scripts.js
+++ b/packages/base/package-scripts.js
@@ -30,8 +30,9 @@ const scripts = {
 		},
 	},
 	build: {
-		default: `${UP_TO_DATE} || nps lint prepare build.bundle hash`,
+		default: `${UP_TO_DATE} || nps lint prepare build.bundle build.types hash`,
 		bundle: "rollup --config config/rollup.config.js",
+        types: "tsc"
 	},
 	copy: {
 		default: "nps copy.src copy.test",

--- a/packages/base/src/config/AnimationMode.js
+++ b/packages/base/src/config/AnimationMode.js
@@ -3,6 +3,10 @@ import AnimationMode from "../types/AnimationMode.js";
 
 let animationMode;
 
+/**
+ * Getter for the currently active animation mode
+ * @return {"full"|"basic"|"minimal"|"none"}
+ */
 const getAnimationMode = () => {
 	if (animationMode === undefined) {
 		animationMode = getConfiguredAnimationMode();
@@ -11,6 +15,10 @@ const getAnimationMode = () => {
 	return animationMode;
 };
 
+/**
+ * Sets the animation mode
+ * @param {"full"|"basic"|"minimal"|"none"} newAnimationMode
+ */
 const setAnimationMode = newAnimationMode => {
 	if (Object.values(AnimationMode).includes(newAnimationMode)) {
 		animationMode = newAnimationMode;

--- a/packages/base/src/config/CalendarType.js
+++ b/packages/base/src/config/CalendarType.js
@@ -3,6 +3,10 @@ import { getCalendarType as getConfiguredCalendarType } from "../InitialConfigur
 
 let calendarType;
 
+/**
+ * Getter for the currently active calendar type
+ * @return {string|null}
+ */
 const getCalendarType = () => {
 	if (calendarType === undefined) {
 		calendarType = getConfiguredCalendarType();

--- a/packages/base/src/config/FormatSettings.js
+++ b/packages/base/src/config/FormatSettings.js
@@ -2,6 +2,10 @@ import { getFormatSettings } from "../InitialConfiguration.js";
 
 let formatSettings;
 
+/**
+ * Getter for the first day of the week
+ * @return {string}
+ */
 const getFirstDayOfWeek = () => {
 	if (formatSettings === undefined) {
 		formatSettings = getFormatSettings();

--- a/packages/base/src/config/NoConflict.js
+++ b/packages/base/src/config/NoConflict.js
@@ -16,6 +16,10 @@ const shouldNotFireOriginalEvent = eventName => {
 	return !(nc.events && nc.events.includes && nc.events.includes(eventName));
 };
 
+/**
+ * Returns true when events are fired in the `non-conflict` mode.
+ * @return {boolean}
+ */
 const getNoConflict = () => {
 	if (noConflict === undefined) {
 		noConflict = getConfiguredNoConflict();
@@ -40,6 +44,10 @@ const skipOriginalEvent = eventName => {
 	return !shouldNotFireOriginalEvent(eventName);
 };
 
+/**
+ * Sets whether events should be fired in a non-conflict mode
+ * @param {boolean} noConflictData
+ */
 const setNoConflict = noConflictData => {
 	noConflict = noConflictData;
 };

--- a/packages/base/src/config/Theme.js
+++ b/packages/base/src/config/Theme.js
@@ -3,6 +3,10 @@ import applyTheme from "../theming/applyTheme.js";
 
 let theme;
 
+/**
+ *
+ * @return {string} currently applied theme
+ */
 const getTheme = () => {
 	if (theme === undefined) {
 		theme = getConfiguredTheme();
@@ -11,6 +15,11 @@ const getTheme = () => {
 	return theme;
 };
 
+/**
+ * Sets the new theme
+ * @param {"sap_fiori_3"|"sap_fiori_3_dark"|"sap_belize"|"sap_belize_hcb"|"sap_belize_hcw"|"sap_fiori_3_hcb"|"sap_fiori_3_hcw"} newTheme
+ * @return {Promise<void>}
+ */
 const setTheme = async newTheme => {
 	if (theme === newTheme) {
 		return;

--- a/packages/base/src/theming/CustomStyle.js
+++ b/packages/base/src/theming/CustomStyle.js
@@ -18,6 +18,12 @@ const fireCustomCSSChange = tag => {
 
 const customCSSFor = {};
 
+/**
+ *
+ * @param {string} tag tag-name where the custom css should be added, e.g. `ui5-button`
+ * @param {string} css
+ * @return {Promise<void>}
+ */
 const addCustomCSS = (tag, css) => {
 	if (!customCSSFor[tag]) {
 		customCSSFor[tag] = [];

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    // This compiler run should only output d.ts files
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9750,6 +9750,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
 typical@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"


### PR DESCRIPTION
In the Web Components for React project we get the same questions about TypeDefinitions for UI5 Web Components over and over again, and instead of writing them manually in our repo I tried to integrate them here as part of the build script:

## What I Did

I've added `typescript` as a global dev dependency and added a basic `tsconfig.json` to the `base` package so that only the `.d.ts` files are emited during the `build` script. The type definitions are now infered from the JSDoc comments and the JavaScript files (https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html).

I tried to add some more jsdoc comments for the public methods of the base package (documented [here](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Configuration.md)).

## Open Topics
- [ ] Do you want the `.d.ts` files to be part of your npm package? or would you prefer to have them in the `DefinitelyTyped` repo?
- [ ] Which methods should be documented as well?
- [ ] Add types for `main`, `fiori` and both `icons` packages as well?

cc @ilhan007 @pskelin 