### PR TITLE
fix(framework): apply RTL for components with popovers

### DIFF
--- a/packages/base/bundle.esm.js
+++ b/packages/base/bundle.esm.js
@@ -34,6 +34,8 @@ import { getNoConflict, setNoConflict } from "./dist/config/NoConflict.js";
 import { getRTL } from "./dist/config/RTL.js";
 import { getFirstDayOfWeek } from "./dist/config/FormatSettings.js";
 import { _getRegisteredNames as getIconNames } from  "./dist/asset-registries/Icons.js"
+import applyDirection from "./dist/locale/applyDirection.js";
+
 window["sap-ui-webcomponents-bundle"] = {
 	configuration : {
 		getAnimationMode,
@@ -51,4 +53,5 @@ window["sap-ui-webcomponents-bundle"] = {
 	fetchI18nBundle,
 	getI18nBundle,
 	renderFinished,
+	applyDirection,
 };

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-qSOA4ADi9kCKJzq4u55stvBOMMA=
+EDyKy0JUgyCZ34E/jIs5Wgbb/2g=

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-zeUeeqLt7DMMy68aroBUHAyxLAA=
+qSOA4ADi9kCKJzq4u55stvBOMMA=

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-XfwM5Q5x9CyXTd3ewO6fAuUW9Hs=
+zeUeeqLt7DMMy68aroBUHAyxLAA=

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -3,6 +3,7 @@ import updateShadowRoot from "./updateShadowRoot.js";
 import { renderFinished } from "./Render.js";
 import getEffectiveContentDensity from "./util/getEffectiveContentDensity.js";
 import { getEffectiveScopingSuffixForTag } from "./CustomElementsScope.js";
+import getEffectiveDir from "./locale/getEffectiveDir.js";
 
 /**
  *
@@ -33,6 +34,7 @@ class StaticAreaItem extends HTMLElement {
 	update() {
 		if (this._rendered) {
 			this._updateContentDensity();
+			this._updateDirection();
 			updateShadowRoot(this.ownerElement, true);
 		}
 	}
@@ -48,6 +50,13 @@ class StaticAreaItem extends HTMLElement {
 		} else {
 			this.classList.remove("sapUiSizeCompact");
 			this.classList.remove("ui5-content-density-compact");
+		}
+	}
+
+	_updateDirection() {
+		const dir = getEffectiveDir(this.ownerElement);
+		if (dir) {
+			this.dir = dir;
 		}
 	}
 

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -57,6 +57,8 @@ class StaticAreaItem extends HTMLElement {
 		const dir = getEffectiveDir(this.ownerElement);
 		if (dir) {
 			this.dir = dir;
+		} else {
+			delete this.dir;
 		}
 	}
 

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -56,9 +56,9 @@ class StaticAreaItem extends HTMLElement {
 	_updateDirection() {
 		const dir = getEffectiveDir(this.ownerElement);
 		if (dir) {
-			this.dir = dir;
+			this.setAttribute("dir", dir);
 		} else {
-			delete this.dir;
+			this.removeAttribute("dir");
 		}
 	}
 

--- a/packages/base/test/elements/WithStaticArea.js
+++ b/packages/base/test/elements/WithStaticArea.js
@@ -27,8 +27,9 @@ class WithStaticArea extends UI5Element {
 
 	static get template() {
 		return element => {
+			// access effectiveDir getter to mark control as RTL-aware (test changes dir attribute and expects rerender)
 			return html`
-				<div>
+				<div dir=${element.effectiveDir}>
 					WithStaticArea works!
 				</div>`;
 		};

--- a/packages/base/test/pages/AllTestElements.html
+++ b/packages/base/test/pages/AllTestElements.html
@@ -35,5 +35,8 @@
 
     <ui5-with-static-area id="no-static-area"></ui5-with-static-area>
     <ui5-with-static-area id="with-static-area" static-content></ui5-with-static-area>
+    <div dir="rtl">
+        <ui5-with-static-area id="with-static-area-rtl" static-content></ui5-with-static-area>
+    </div>
 </body>
 </html>

--- a/packages/base/test/pages/AllTestElements.html
+++ b/packages/base/test/pages/AllTestElements.html
@@ -35,7 +35,7 @@
 
     <ui5-with-static-area id="no-static-area"></ui5-with-static-area>
     <ui5-with-static-area id="with-static-area" static-content></ui5-with-static-area>
-    <div dir="rtl">
+    <div id="with-static-area-rtl-container" dir="rtl">
         <ui5-with-static-area id="with-static-area-rtl" static-content></ui5-with-static-area>
     </div>
 </body>

--- a/packages/base/test/specs/StaticArea.spec.js
+++ b/packages/base/test/specs/StaticArea.spec.js
@@ -33,4 +33,18 @@ describe("Some configuration options can be changed at runtime", () => {
 
 		assert.ok(result, "Static area removed from DOM successfully");
 	});
+
+	it("Test RTL not set for static area items", () => {
+		const componentId = browser.$("#with-static-area").getProperty("_id");
+		const staticArea = browser.$("ui5-static-area");
+
+		assert.notOk(staticArea.$(`.${componentId}`).getProperty("rtl"), "dir attribute not set for static area item");
+	});
+
+	it("Test RTL set for static area items", () => {
+		const componentId = browser.$("#with-static-area-rtl").getProperty("_id");
+		const staticArea = browser.$("ui5-static-area");
+
+		assert.equal("rtl", staticArea.$(`.${componentId}`).getProperty("dir"), "dir property correctly set for static area item");
+	});
 });

--- a/packages/base/test/specs/StaticArea.spec.js
+++ b/packages/base/test/specs/StaticArea.spec.js
@@ -38,13 +38,41 @@ describe("Some configuration options can be changed at runtime", () => {
 		const componentId = browser.$("#with-static-area").getProperty("_id");
 		const staticArea = browser.$("ui5-static-area");
 
-		assert.notOk(staticArea.$(`.${componentId}`).getProperty("rtl"), "dir attribute not set for static area item");
+		assert.notOk(staticArea.$(`.${componentId}`).getAttribute("dir"), "dir attribute not set for static area item");
 	});
 
 	it("Test RTL set for static area items", () => {
 		const componentId = browser.$("#with-static-area-rtl").getProperty("_id");
 		const staticArea = browser.$("ui5-static-area");
 
-		assert.equal("rtl", staticArea.$(`.${componentId}`).getProperty("dir"), "dir property correctly set for static area item");
+		assert.equal(staticArea.$(`.${componentId}`).getAttribute("dir"), "rtl", "dir property correctly set for static area item");
+	});
+
+	it("Test setting RTL for a static area item owner", () => {
+		const componentId = browser.$("#with-static-area").getProperty("_id");
+		const staticArea = browser.$("ui5-static-area");
+
+		browser.$("#with-static-area").setAttribute("dir", "rtl");
+		browser.executeAsync( async (done) => {
+			await window["sap-ui-webcomponents-bundle"].applyDirection();
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+
+			return done();
+		});
+		assert.equal(staticArea.$(`.${componentId}`).getAttribute("dir"), "rtl", "dir attribute dynamically set for static area item owner");
+	});
+
+	it("Test removing RTL for a static area item owner", () => {
+		const componentId = browser.$("#with-static-area-rtl").getProperty("_id");
+		const staticArea = browser.$("ui5-static-area");
+
+		browser.$("#with-static-area-rtl-container").removeAttribute("dir");
+		browser.executeAsync( async (done) => {
+			await window["sap-ui-webcomponents-bundle"].applyDirection();
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+
+			return done();
+		});
+		assert.notOk(staticArea.$(`.${componentId}`).getAttribute("dir"), "dir attribute dynamically removed for static area item owner");
 	});
 });


### PR DESCRIPTION
When `dir="rtl"` is set on some DOM element that is not the body, RTL mode is applied only on the components (like `ui5-select`), but not on their popovers, as the `dir="rtl"` is not transferred to the static area item.

This change sets the dir attribute on the static area item such that it matches the effective dir attribute of the component.