### PR TITLE
fix(ui5-daypicker): fix js error

### DIFF
--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -54,6 +54,7 @@ const metadata = {
 			type: Integer,
 			multiple: true,
 			compareValues: true,
+			noAttribute: true,
 		},
 
 		/**


### PR DESCRIPTION
Waiting for @vladitasev before merging this.
This PR addresses an issue that is currently present in the master branch only.

# Steps to reproduce
1. Go to https://sap.github.io/ui5-webcomponents/master/playground/components/DatePicker/
2. Open the first datepicker
3. Select a date
4. Check the console

# Analys
The framework sets a multiple attribute's value to string when we pass an array with only one item inside because the DOM doesn't support arrays. Later, when we read the attribute and try to set the value to the property the error is thrown, because we **can't** read multiple attribute from the DOM(Array or Object).

# Solution
One solution that we discussed with @ilhan007 is to internally treat every multiple property as if it has ```noAttribute``` set.