### PR TITLE
refactor(ui5-checkbox): support RTL with CSS logical props

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-XfwM5Q5x9CyXTd3ewO6fAuUW9Hs=
+EVdDz32V+MkIXAU69+fVpUoZ1gs=

--- a/packages/base/src/locale/getEffectiveDir.js
+++ b/packages/base/src/locale/getEffectiveDir.js
@@ -1,8 +1,13 @@
 import { getRTL } from "../config/RTL.js";
+import { isIE } from "../Device.js";
 
 const GLOBAL_DIR_CSS_VAR = "--_ui5_dir";
 
 const getEffectiveDir = element => {
+	if (!isIE() && element.localName === "ui5-checkbox") {
+		return;
+	}
+
 	const doc = window.document;
 	const dirValues = ["ltr", "rtl"]; // exclude "auto" and "" from all calculations
 	const locallyAppliedDir = getComputedStyle(element).getPropertyValue(GLOBAL_DIR_CSS_VAR);

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -80,11 +80,15 @@
 }
 
 :host([text]) .ui5-checkbox-root {
-	padding-right: 0;
+	padding-right: 0; /* applies in IE, overwritten in the rest */
+	padding-inline-end: 0; /* applies in Chrome, Safari, FF */
+	padding-inline-start: var(--_ui5_checkbox_wrapper_padding); /* applies in Chrome, Safari, FF */
 }
 
 :host([text]) .ui5-checkbox-root:focus::before {
-	right: 0;
+	right: 0; /* applies in IE, overwritten in the rest */
+	inset-inline-start: var(--_ui5_checkbox_focus_position); /* applies in Chrome, Safari, FF */
+	inset-inline-end: 0; /* applies in Chrome, Safari, FF */
 }
 
 .ui5-checkbox-root {
@@ -95,7 +99,9 @@
 	width: 100%;
 	min-height: var(--_ui5_checkbox_width_height);
 	min-width: var(--_ui5_checkbox_width_height);
-	padding: 0 var(--_ui5_checkbox_wrapper_padding);
+	padding: 0 var(--_ui5_checkbox_wrapper_padding); /* applies in IE, overwritten in the rest */
+	padding-inline-start: var(--_ui5_checkbox_wrapper_padding); /* applies in Chrome, Safari, FF */
+	padding-inline-end: var(--_ui5_checkbox_wrapper_padding); /* applies in Chrome, Safari, FF */
 	box-sizing: border-box;
 	outline: none;
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
@@ -113,9 +119,11 @@ https://github.com/philipwalton/flexbugs/issues/231
 .ui5-checkbox-root:focus::before {
 	content: "";
 	position: absolute;
+	left: var(--_ui5_checkbox_focus_position); /* applies in IE, overwritten in the rest */
+	right: var(--_ui5_checkbox_focus_position); /* applies in IE, overwritten in the rest */
+	inset-inline-start: var(--_ui5_checkbox_focus_position); /* applies in Chrome, Safari, FF */
+	inset-inline-end: var(--_ui5_checkbox_focus_position); /* applies in Chrome, Safari, FF */
 	top: var(--_ui5_checkbox_focus_position);
-	left: var(--_ui5_checkbox_focus_position);
-	right: var(--_ui5_checkbox_focus_position);
 	bottom: var(--_ui5_checkbox_focus_position);
 	border: var(--_ui5_checkbox_focus_outline);
 }
@@ -160,7 +168,9 @@ https://github.com/philipwalton/flexbugs/issues/231
 }
 
 .ui5-checkbox-root .ui5-checkbox-label {
-	margin-left: var(--_ui5_checkbox_wrapper_padding);
+	margin-left: var(--_ui5_checkbox_wrapper_padding); /* applies in IE, overwritten in the rest */
+	margin-inline-start: var(--_ui5_checkbox_wrapper_padding); /* applies in Chrome, Safari, FF */
+	margin-inline-end: 0; /* applies in Chrome, Safari, FF */
 	cursor: default;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -175,7 +185,6 @@ https://github.com/philipwalton/flexbugs/issues/231
 	height: var(--_ui5_checkbox_icon_size);
 	color: currentColor;
 	cursor: default;
-    position: absolute;
 }
 
 /* RTL */

--- a/packages/main/test/pages/CheckBox-rtl.html
+++ b/packages/main/test/pages/CheckBox-rtl.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<title>ui5-checkbox</title>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+	<script>delete Document.prototype.adoptedStyleSheets;</script>
+
+	<style>
+		ui5-checkbox:not(.ui5-cb-testing-wrap) {
+			border: 1px solid red;
+		}
+	</style>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor);" dir="rtl">
+	<ui5-checkbox></ui5-checkbox>
+	<ui5-checkbox id="cbError" value-state="Error"></ui5-checkbox>
+	<ui5-checkbox id="truncatingCb" text="Long long long text that should truncate at some point" style="width: 300px"></ui5-checkbox>
+	<ui5-checkbox text="Long long long text that should truncate at some point"></ui5-checkbox>
+
+	<br><br>
+	<ui5-title>Text Wrapping</ui5-title>
+	<ui5-checkbox id="wrappingCb" wrapping-type="Normal" class="ui5-cb-testing-wrap" text="Longest ever text written in English that have to wraps because it is so long of course!" style="width: 300px"></ui5-checkbox>
+	<ui5-checkbox wrapping-type="Normal" text="Longest ever text written in English that wraps because it's too long of course!" style="width: 300px"></ui5-checkbox>
+
+	<br><br>
+	<ui5-title>Change Event Test</ui5-title>
+	<ui5-checkbox id="cb1" text="Long long long text"></ui5-checkbox>
+	<ui5-checkbox id="cb2" disabled></ui5-checkbox>
+	<ui5-input id="field"></ui5-input>
+
+	<br>
+	<ui5-title>ACC Test - aria-label</ui5-title>
+	<ui5-checkbox id="accCb" accessible-name="Hello world"></ui5-checkbox>
+	<br />
+	<ui5-checkbox value-state="Warning" text="Long long long text" indeterminate checked></ui5-checkbox>
+	<ui5-checkbox value-state="Error" text="Long long long text" indeterminate checked></ui5-checkbox>
+	<ui5-checkbox value-state="None" text="Long long long text" indeterminate checked></ui5-checkbox>
+	<ui5-checkbox value-state="Success" text="Long long long text" indeterminate checked></ui5-checkbox>
+	<ui5-checkbox value-state="Information" text="Long long long text" indeterminate checked></ui5-checkbox>
+
+	<br />
+	<ui5-checkbox id="checkboxChecked" checked></ui5-checkbox>
+
+	<script>
+		var hcb = false;
+		var input = document.querySelector("#field");
+		var checkBox1 = document.querySelector("#cb1");
+		var checkBox2 = document.querySelector("#cb2");
+		var counter = 0;
+
+		[checkBox1, checkBox2].forEach(function(el) {
+			el.addEventListener("ui5-change", function(event) {
+				counter += 1;
+				input.value = counter;
+			});
+		});
+</script>
+</body>
+</html>


### PR DESCRIPTION
To reduce the calls to getEffectiveDir() and improve the performance of the components in use-cases of hundreds of items, we started refactoring the styles of small group of components that are usually displayed within an item (Checkbox, RadioButton, Icon, Button, Avatar, Label) to make use if CSS logical props, instead of relying on dir="rtl" set within the ShadowDOM.

The change uses CSS logical props in the CheckBox component to support RTL, without relying on dir="RTL" for modern browsers. The "dir" attribute is never set in the CheckBOX's ShadowDOM by getEffectiveDir(). 
Note: For IE we keep the old logic, dir is set by the framework and the old styles are applied.