### PR TITLE
feat(ui5-panel): noAnimation property introduced

### DIFF
--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -91,6 +91,17 @@ const metadata = {
 		},
 
 		/**
+		 * Indicates whether the transition between the expanded and the collapsed state of the component is animated. By default the animation is enabled.
+		 *
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 */
+		 noAnimation: {
+			type: Boolean
+		},
+
+		/**
 		 * Sets the accessible aria role of the component.
 		 * Depending on the usage, you can change the role from the default <code>Form</code>
 		 * to <code>Region</code> or <code>Complementary</code>.
@@ -280,8 +291,8 @@ class Panel extends UI5Element {
 		return true;
 	}
 
-	shouldAnimate() {
-		return getAnimationMode() !== AnimationMode.None;
+	shouldNotAnimate() {
+		return this.noAnimation || getAnimationMode() === AnimationMode.None;
 	}
 
 	_headerClick(event) {
@@ -329,7 +340,7 @@ class Panel extends UI5Element {
 
 		this.collapsed = !this.collapsed;
 
-		if (!this.shouldAnimate()) {
+		if (this.shouldNotAnimate()) {
 			this.fireEvent("toggle");
 			return;
 		}
@@ -365,7 +376,7 @@ class Panel extends UI5Element {
 	get classes() {
 		return {
 			headerBtn: {
-				"ui5-panel-header-button-animated": this.shouldAnimate(),
+				"ui5-panel-header-button-animated": !this.shouldNotAnimate(),
 			},
 		};
 	}

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -96,6 +96,7 @@ const metadata = {
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
+		 * @since 1.0.0-rc.16
 		 */
 		 noAnimation: {
 			type: Boolean

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -99,7 +99,7 @@ const metadata = {
 		 * @since 1.0.0-rc.16
 		 */
 		 noAnimation: {
-			type: Boolean
+			type: Boolean,
 		},
 
 		/**

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -58,7 +58,7 @@
 	}
 </style>
 
-	<ui5-panel id="p1" collapsed accessible-role="Complementary">
+	<ui5-panel id="p1" collapsed accessible-role="Complementary" no-animation>
 
 		<!-- Panel header -->
 		<div slot="header" class="header">

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -100,6 +100,14 @@ describe("Panel general interaction", () => {
 		assert.strictEqual(field.getProperty("value"), "3", "Press should be called 3 times");
 	});
 
+	it("tests toggle expand/collapse animation", () => {
+		const panelWithAnimationIcon = browser.$("#panel-expandable").shadow$(".ui5-panel-header-button");
+		const panelWithoutAnimationIcon = browser.$("#p1").shadow$(".ui5-panel-header-button");
+
+		assert.ok(panelWithAnimationIcon.hasClass("ui5-panel-header-button-animated"), "Animation is presented");
+		assert.notOk(panelWithoutAnimationIcon.hasClass("ui5-panel-header-button-animated"), "Animation is turn off");
+	});
+
 	describe("Accessibility", () => {
 
 		it("tests whether aria attributes are set correctly with native header", () => {


### PR DESCRIPTION
New property called noAnimation is added to the ui5-panel component. When set to true, the ui5-panel is expanded/collapsed without animation.

FIXES: #3505 
