### PR TITLE
fix(ui5-select): selection change with keyboard

### DIFF
--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -23,6 +23,7 @@
 		aria-required="{{required}}"
 		aria-expanded="{{_isPickerOpen}}"
 		@keydown="{{_onkeydown}}"
+		@keypress="{{_handleKeyboardNavigation}}"
 		@keyup="{{_onkeyup}}"
 		@focusin="{{_onfocusin}}"
 		@focusout="{{_onfocusout}}"

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -462,14 +462,11 @@ class Select extends UI5Element {
 			this._handleSelectionChange();
 		} else if (isUp(event) || isDown(event)) {
 			this._handleArrowNavigation(event);
-		} else {
-			this._handleKeyboardNavigation(event);
 		}
 	}
 
 	_handleKeyboardNavigation(event) {
-		// Waiting for the actual symbol to trigger the keydown event
-		if (event.shiftKey && event.key === "Shift") {
+		if (isEnter(event)) {
 			return;
 		}
 


### PR DESCRIPTION
Checks inside onkeydown handler were not enough and _handleKeyboardNavigation method is called event when the tab key is pressed. Executing _handleKeyboardNavigation method when the tab key is pressed leads to change of the selection because event.key returns "tab" which is added to the string that determinates which item should be selected.

_handleKeyboardNavigation  is handled on keypress event which is fired when only symbol key is pressed.