### PR TITLE
fix(ui5-ToggleButton): keyboard handling now compliant with the specification

### DIFF
--- a/packages/main/src/ToggleButton.js
+++ b/packages/main/src/ToggleButton.js
@@ -72,7 +72,10 @@ class ToggleButton extends Button {
 	_onkeyup(event) {
 		if (isSpaceShift(event)) {
 			event.preventDefault();
+			return;
 		}
+
+		super._onkeyup(event);
 	}
 }
 

--- a/packages/main/src/ToggleButton.js
+++ b/packages/main/src/ToggleButton.js
@@ -1,4 +1,5 @@
 import isLegacyBrowser from "@ui5/webcomponents-base/dist/isLegacyBrowser.js";
+import { isSpaceShift } from "@ui5/webcomponents-base/dist/Keys.js";
 import Button from "./Button.js";
 import ToggleButtonTemplate from "./generated/templates/ToggleButtonTemplate.lit.js";
 
@@ -66,6 +67,12 @@ class ToggleButton extends Button {
 
 	_onclick() {
 		this.pressed = !this.pressed;
+	}
+
+	_onkeyup(event) {
+		if (isSpaceShift(event)) {
+			event.preventDefault();
+		}
 	}
 }
 


### PR DESCRIPTION
If [SPACE] is pressed, releases the ToggleButton without changing its state