### PR TITLE
fix(framework): Multiple properties have no attribute

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-EDyKy0JUgyCZ34E/jIs5Wgbb/2g=
+9tF7yEWQXVH9MvgcDDfgmFxdVoU=

--- a/packages/base/src/UI5ElementMetadata.js
+++ b/packages/base/src/UI5ElementMetadata.js
@@ -126,7 +126,7 @@ class UI5ElementMetadata {
 	 */
 	hasAttribute(propName) {
 		const propData = this.getProperties()[propName];
-		return propData.type !== Object && !propData.noAttribute;
+		return propData.type !== Object && !propData.noAttribute && !propData.multiple;
 	}
 
 	/**

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -54,7 +54,6 @@ const metadata = {
 			type: Integer,
 			multiple: true,
 			compareValues: true,
-			noAttribute: true,
 		},
 
 		/**

--- a/packages/main/src/MultiInput.js
+++ b/packages/main/src/MultiInput.js
@@ -49,7 +49,6 @@ const metadata = {
 		 */
 		tokens: {
 			type: HTMLElement,
-			multiple: true,
 		},
 	},
 	events: /** @lends  sap.ui.webcomponents.main.MultiInput.prototype */ {


### PR DESCRIPTION
A recent change (https://github.com/SAP/ui5-webcomponents/pull/3604) introduced this bug. `DayPicker.js` has a `multiple` property of type `Integer`, which is a `DataType.js` descentent, hence it was affected by the new code, introduced by the above change.

Additionally: 
 - `noAttribute: true` is no longer needed for `DayPicker.js`
 - `multiple: true` is not needed for `MultiInput.js` (this metadata entity is only valid for properties, not for slots)

fixes: https://github.com/SAP/ui5-webcomponents/pull/3677