### PR TITLE
fix (ui5-avatar, ui5-icon): attach onclick handler based on interactive property

### DIFF
--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -343,12 +343,14 @@ class Avatar extends UI5Element {
 		return this._hasImage;
 	}
 
-	_onclick(event) {
-		if (this.interactive) {
-			// prevent the native event and fire custom event to ensure the noConfict "ui5-click" is fired
-			event.stopPropagation();
-			this.fireEvent("click");
-		}
+	onBeforeRendering() {
+		this._onclick = this.interactive ? this._onClickHandler.bind(this) : undefined;
+	}
+
+	_onClickHandler(event) {
+		// prevent the native event and fire custom event to ensure the noConfict "ui5-click" is fired
+		event.stopPropagation();
+		this.fireEvent("click");
 	}
 
 	_onkeydown(event) {

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -247,12 +247,10 @@ class Icon extends UI5Element {
 		}
 	}
 
-	_onclick(event) {
-		if (this.interactive) {
-			// prevent the native event and fire custom event to ensure the noConfict "ui5-click" is fired
-			event.stopPropagation();
-			this.fireEvent("click");
-		}
+	_onClickHandler(event) {
+		// prevent the native event and fire custom event to ensure the noConfict "ui5-click" is fired
+		event.stopPropagation();
+		this.fireEvent("click");
 	}
 
 	get _dir() {
@@ -338,6 +336,8 @@ class Icon extends UI5Element {
 		this.accData = iconData.accData;
 		this.ltr = iconData.ltr;
 		this.packageName = iconData.packageName;
+
+		this._onclick = this.interactive ? this._onClickHandler.bind(this) : undefined;
 
 		if (this.accessibleName) {
 			this.effectiveAccessibleName = this.accessibleName;


### PR DESCRIPTION
Having the `onclick` handler attached, makes the screen readers read the element as clickable even if `interactive` is set to false.
With this change the click handler is only attached if the `interactive` property is true.

Fixes: #3683 