### PR TITLE
fix (ui5-side-navigation): fix exploratory testing issues

### DIFF
--- a/packages/main/src/themes/TreeListItem.css
+++ b/packages/main/src/themes/TreeListItem.css
@@ -99,3 +99,9 @@
 	justify-content: space-between;
 	width: 100%;
 }
+
+/* RTL */
+.ui5-li-root-tree[dir="rtl"] {
+	padding-left: 1rem;
+	padding-right: 0;
+}


### PR DESCRIPTION
Fixed the following issues from #3623

Text too close to the icons in RTL.
Too much right padding in RTL.
Icons are too close to the border of the items.