### PR TITLE
chore: add interfaces JSDoc

### DIFF
--- a/packages/main/src/ComboBoxGroupItem.js
+++ b/packages/main/src/ComboBoxGroupItem.js
@@ -42,6 +42,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-cb-group-item
  * @public
+ * @implements sap.ui.webcomponents.main.IComboBoxItem
  * @since 1.0.0-rc.15
  */
 class ComboBoxGroupItem extends UI5Element {

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -98,6 +98,15 @@ const IListItem = "sap.ui.webcomponents.main.IListItem";
 const IMultiComboBoxItem = "sap.ui.webcomponents.main.IMultiComboBoxItem";
 
 /**
+ * Interface for components that may be slotted inside <code>ui5-segmented-button</code> as items
+ *
+ * @name sap.ui.webcomponents.main.ISegmentedButtonItem
+ * @interface
+ * @public
+ */
+const ISegmentedButtonItem = "sap.ui.webcomponents.main.ISegmentedButtonItem";
+
+/**
  * Interface for components that may be slotted inside <code>ui5-select</code> as options
  *
  * @name sap.ui.webcomponents.main.ISelectOption
@@ -172,6 +181,7 @@ export {
 	IInputSuggestionItem,
 	IListItem,
 	IMultiComboBoxItem,
+	ISegmentedButtonItem,
 	ISelectOption,
 	ITab,
 	ITableCell,

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -35,7 +35,7 @@ const metadata = {
 		 * <b>Note:</b> Multiple items are allowed.
 		 * <br><br>
 		 * <b>Note:</b> Use the <code>ui5-segmented-button-item</code> for the intended design.
-		 * @type {sap.ui.webcomponents.main.IButton[]}
+		 * @type {sap.ui.webcomponents.main.ISegmentedButtonItem[]}
 		 * @slot items
 		 * @public
 		 */

--- a/packages/main/src/SegmentedButtonItem.js
+++ b/packages/main/src/SegmentedButtonItem.js
@@ -91,6 +91,7 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.SegmentedButtonItem
  * @extends ToggleButton
  * @tagname ui5-segmented-button-item
+ * @implements sap.ui.webcomponents.main.ISegmentedButtonItem
  * @public
  */
 class SegmentedButtonItem extends ToggleButton {

--- a/packages/main/src/TableGroupRow.js
+++ b/packages/main/src/TableGroupRow.js
@@ -92,6 +92,7 @@ const metadata = {
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-table-group-row
  * @since 1.0.0-rc.15
+ * @implements sap.ui.webcomponents.main.ITableRow
  * @public
  */
 class TableGroupRow extends UI5Element {

--- a/packages/main/src/TableGroupRow.js
+++ b/packages/main/src/TableGroupRow.js
@@ -1,6 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { fetchI18nBundle, getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import CheckBox from "./CheckBox.js";
 import TableGroupRowTemplate from "./generated/templates/TableGroupRowTemplate.lit.js";
 import TableMode from "./types/TableMode.js";
 
@@ -110,6 +111,12 @@ class TableGroupRow extends UI5Element {
 
 	static get template() {
 		return TableGroupRowTemplate;
+	}
+
+	static get dependencies() {
+		return [
+			CheckBox,
+		];
 	}
 
 	constructor() {


### PR DESCRIPTION
It's preferable to add interfaces information in JSDoc for all components that are intended to slot specific items.

*Additionally:* `ui5-table-group-row` was missing a dependency.