### PR TITLE
chore(ui5-segmented-button): fix jsdoc

### DIFF
--- a/packages/main/src/SegmentedButtonItem.js
+++ b/packages/main/src/SegmentedButtonItem.js
@@ -13,6 +13,8 @@ const metadata = {
 		/**
 		 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
 		 *
+		 * @type {ButtonDesign}
+		 * @defaultvalue "Default"
 		 * @public
 		 */
 		design: {
@@ -23,6 +25,8 @@ const metadata = {
 		/**
 		 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
 		 *
+		 * @type {boolean}
+		 * @defaultvalue false
 		 * @public
 		 */
 		iconEnd: {
@@ -32,16 +36,8 @@ const metadata = {
 		/**
 		 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
 		 *
-		 * @public
-		 */
-		iconSize: {
-			type: String,
-			defaultValue: undefined,
-		},
-
-		/**
-		 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
-		 *
+		 * @type {boolean}
+		 * @defaultvalue false
 		 * @public
 		 */
 		submits: {


### PR DESCRIPTION
 - Removed the `iconSize` property that no longer exists in `Button.js`
 - Added the correct JSDoc for the `type` and `defaultValue` of the overridden properties