### PR TITLE
fix(ui5-card-header): no longer fires click event twice

### DIFF
--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -37,7 +37,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Use <code>ui5-card-header</code> for the intended design.
 		 * @type {HTMLElement[]}
-         * @since 1.0.0-rc.15
+		 * @since 1.0.0-rc.15
 		 * @slot content
 		 * @public
 		 */

--- a/packages/main/src/CardHeader.js
+++ b/packages/main/src/CardHeader.js
@@ -230,7 +230,9 @@ class CardHeader extends UI5Element {
 		await fetchI18nBundle("@ui5/webcomponents");
 	}
 
-	_headerClick() {
+	_headerClick(event) {
+		event.stopImmediatePropagation(); // prevents the native browser "click" event from firing
+
 		if (this.interactive) {
 			this.fireEvent("click");
 		}

--- a/packages/main/test/pages/Card.html
+++ b/packages/main/test/pages/Card.html
@@ -204,10 +204,12 @@
 	</ui5-card>
 
 	<script>
-		card.addEventListener("ui5-click", function (event) {
+		function onClick(event) {
 			console.log(event);
 			field.value = parseInt(field.value) + 1;
-		});
+		}
+
+		[cardHeader, cardHeader2].forEach(x => { x.addEventListener("click", onClick) });
 	</script>
 </body>
 

--- a/packages/main/test/pages/Card.html
+++ b/packages/main/test/pages/Card.html
@@ -209,7 +209,9 @@
 			field.value = parseInt(field.value) + 1;
 		}
 
-		[cardHeader, cardHeader2].forEach(x => { x.addEventListener("click", onClick) });
+		[cardHeader, cardHeader2].forEach(function (el) {
+			el.addEventListener("click", onClick);
+		});
 	</script>
 </body>
 

--- a/packages/main/test/pages/Card.html
+++ b/packages/main/test/pages/Card.html
@@ -210,7 +210,7 @@
 		}
 
 		[cardHeader, cardHeader2].forEach(function (el) {
-			el.addEventListener("click", onClick);
+			el.addEventListener("ui5-click", onClick);
 		});
 	</script>
 </body>

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -19,8 +19,8 @@ describe("Card general interaction", () => {
 	});
 
 	it("tests header's click event with mouse click, Enter and Space", () => {
-		const cardHeader = $("#cardHeader").shadow$(".ui5-card-header");
-		const cardHeader2 = $("#cardHeader2").shadow$(".ui5-card-header");
+		const cardHeader = browser.$("#cardHeader").shadow$(".ui5-card-header");
+		const cardHeader2 = browser.$("#cardHeader2").shadow$(".ui5-card-header");
 		const field = browser.$("#field");
 
 		cardHeader.click();

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -19,7 +19,6 @@ describe("Card general interaction", () => {
 	});
 
 	it("tests header's click event with mouse click, Enter and Space", () => {
-		browser.pause(5000)
 		const cardHeader = browser.$("#cardHeader").shadow$(".ui5-card-header");
 		const cardHeader2 = browser.$("#cardHeader2").shadow$(".ui5-card-header");
 		const field = browser.$("#field");
@@ -28,8 +27,6 @@ describe("Card general interaction", () => {
 		cardHeader.keys("Space");
 		cardHeader.keys("Enter");
 
-		browser.pause(5000)
-		browser.debug();
 		assert.strictEqual(field.getProperty("value"), "3", "The header's click event should be called 3 times.");
 
 		cardHeader2.click();

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -21,6 +21,11 @@ describe("Card general interaction", () => {
 	it("tests header's click event with mouse click, Enter and Space", () => {
 		const cardHeader = browser.$("#cardHeader").shadow$(".ui5-card-header");
 		const cardHeader2 = browser.$("#cardHeader2").shadow$(".ui5-card-header");
+		// TODO: the field is bound to the "ui5-click" event, but it misses out a test case
+		// change it to be bound to the "click" event, so we can test
+		// if the browser's native 'click' event is not fired to prevent double firing of "click"
+		// Currently this does not work right, because that "click" event
+		// does not fire at all when running the test with WDIO/webdriver
 		const field = browser.$("#field");
 
 		cardHeader.click();

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -19,6 +19,7 @@ describe("Card general interaction", () => {
 	});
 
 	it("tests header's click event with mouse click, Enter and Space", () => {
+		browser.pause(5000)
 		const cardHeader = browser.$("#cardHeader").shadow$(".ui5-card-header");
 		const cardHeader2 = browser.$("#cardHeader2").shadow$(".ui5-card-header");
 		const field = browser.$("#field");
@@ -27,6 +28,8 @@ describe("Card general interaction", () => {
 		cardHeader.keys("Space");
 		cardHeader.keys("Enter");
 
+		browser.pause(5000)
+		browser.debug();
 		assert.strictEqual(field.getProperty("value"), "3", "The header's click event should be called 3 times.");
 
 		cardHeader2.click();

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -18,16 +18,16 @@ describe("Card general interaction", () => {
 		assert.notOk(status.isExisting(), "The status DOM is not rendered.");
 	});
 
-	it("tests headerPress upon click, Enter and Space", () => {
-		const cardHeader = browser.$("#cardHeader").shadow$(".ui5-card-header");
-		const cardHeader2 = browser.$("#cardHeader2").shadow$(".ui5-card-header");
+	it("tests header's click event with mouse click, Enter and Space", () => {
+		const cardHeader = $("#cardHeader").shadow$(".ui5-card-header");
+		const cardHeader2 = $("#cardHeader2").shadow$(".ui5-card-header");
 		const field = browser.$("#field");
 
 		cardHeader.click();
 		cardHeader.keys("Space");
 		cardHeader.keys("Enter");
 
-		assert.strictEqual(field.getProperty("value"), "3", "The headerPress event should be called 3 times.");
+		assert.strictEqual(field.getProperty("value"), "3", "The header's click event should be called 3 times.");
 
 		cardHeader2.click();
 		cardHeader2.keys("Space");


### PR DESCRIPTION
This change stops the native browser click event from firing.
Also fixed the firing of the click event on an non-interactive header.

Fixes: #3786
