### PR TITLE
docs(Input): correct icon type in jsdocs comments

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -56,7 +56,7 @@ const metadata = {
 		/**
 		 * Defines the icon to be displayed in the component.
 		 *
-		 * @type {sap.ui.webcomponents.main.IIcon}
+		 * @type {sap.ui.webcomponents.main.IIcon[]}
 		 * @slot
 		 * @public
 		 */
@@ -356,7 +356,8 @@ const metadata = {
 			noAttribute: true,
 		},
 
-		_inputIconFocused: {
+		_input
+		Focused: {
 			type: Boolean,
 			noAttribute: true,
 		},

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -356,8 +356,7 @@ const metadata = {
 			noAttribute: true,
 		},
 
-		_input
-		Focused: {
+		_inputIconFocused: {
 			type: Boolean,
 			noAttribute: true,
 		},


### PR DESCRIPTION
This PR fixes the typing error of the `icon` slot, as it's possible to pass multiple `Icons` to the Input.