### PR TITLE
fix(ui5-input): remove data-sap-no-tab-ref attribute from the inner input

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -33,7 +33,6 @@
 			@keyup="{{_onkeyup}}"
 			@click={{_click}}
 			@focusin={{innerFocusIn}}
-			data-sap-no-tab-ref
 			data-sap-focus-ref
 			step="{{nativeInputAttributes.step}}"
 			min="{{nativeInputAttributes.min}}"


### PR DESCRIPTION
The `data-sap-no-tab-ref` is removed to allow container controls which are checking for tabbable children to pass the focus to it via the TAB key.

Issue: #3603