### PR TITLE
fix(ui5-label): wrapping now works when used in CustomListItem

### DIFF
--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -13,13 +13,16 @@
 
 .ui5-label-root {
 	width: 100%;
+	cursor: inherit;
+}
+
+:host([wrapping-type="Normal"]) .ui5-label-root {
+	white-space: normal;
 }
 
 :host(:not([wrapping-type="Normal"])) .ui5-label-root {
-	font-weight: inherit;
 	display: inline-block;
 	white-space: nowrap;
-	cursor: inherit;
 	overflow: hidden;
 }
 

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -115,6 +115,18 @@
 			<ui5-date-picker style="width: 320px; margin: 0 16px;" id="ui5-datepicker"></ui5-date-picker>
 		</div>
 	</section>
+
+	<section class="group">
+		<h2>Label in CustomListItem</h2>
+		<ui5-list>
+			<ui5-li-custom>
+				<div style="display: flex; flex-direction: column">
+					<ui5-label style="width: 200px"> Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+					<ui5-label wrapping-type="Normal" style="width: 200px">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+	</section>
 </body>
 
 </html>


### PR DESCRIPTION
CustomListItem sets the `white-space` style to `nowrap`. The solution is to explicitly set the style of the label to `normal` when wrapping is required.
In addition fixed the cursor - it should always be `text`.

Fixes #3324 