### PR TITLE
fix(ui5-li-groupheader): change role option

### DIFF
--- a/packages/main/src/GroupHeaderListItem.hbs
+++ b/packages/main/src/GroupHeaderListItem.hbs
@@ -4,11 +4,11 @@
 	@focusin="{{_onfocusin}}"
 	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
-	role="option"
+	aria-label="{{ariaLabelText}}"
+	aria-roledescription="{{groupHeaderText}}"
+	role="group"
 	style="list-style-type: none;"
 >
-	<span class="ui5-hidden-text">{{groupHeaderText}} {{accessibleName}}</span>
-
 	<div id="{{_id}}-content" class="ui5-li-content">
 		<span class="ui5-ghli-title"><slot></slot></span>
 	</div>

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -86,6 +86,10 @@ class GroupHeaderListItem extends ListItemBase {
 		return this.i18nBundle.getText(GROUP_HEADER_TEXT);
 	}
 
+	get ariaLabelText() {
+		return [this.textContent, this.accessibleName].filter(Boolean).join(" ");
+	}
+
 	static async onDefine() {
 		await Promise.all([
 			fetchI18nBundle("@ui5/webcomponents"),

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -62,6 +62,7 @@
 
 	<br><br><br>
 	<ui5-list id="listSelectedItem" mode="MultiSelect">
+		<ui5-li-groupheader id="group-header">New Items</ui5-li-groupheader>
 		<ui5-li id="not-selected-country">Argentina</ui5-li>
 		<ui5-li id="selected-country" selected >Bulgaria</ui5-li>
 	</ui5-list>

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -388,4 +388,10 @@ describe("List Tests", () => {
 		accInfo = selectedItem.getProperty("_accInfo");
 		assert.strictEqual(accInfo.listItemAriaLabel, "Selected", "Selected text is part of the label");
 	});
+
+	it('group headers should not be with role options', () => {
+		const groupHeader = $("#listSelectedItem #group-header").shadow$(".ui5-ghli-root");
+
+		assert.strictEqual(groupHeader.getAttribute("role"), "group", "Item label is empty");
+	});
 });


### PR DESCRIPTION
Fixes points 1 & 2 of #3806 

The group header should not be treated as an item (option) and should not be calculated with the posinset and setsize values.
With this change we set role `group` with `aria-roledescription` of Group Header to the `ui5-li-groupheader` root element.