### PR TITLE
fix(ui5-color-palette-popover): fix event params

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-M0SFEasPG/FtqwK50V2lGbbEmk4=
+0i7CdPvWJ4Me9qWUtT9kxv7aVKE=

--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -187,7 +187,7 @@ class ColorPalettePopover extends UI5Element {
 
 	onSelectedColor(event) {
 		this.closePopover();
-		this.fireEvent("item-click", event);
+		this.fireEvent("item-click", event.detail);
 	}
 
 	get colorPaletteColors() {


### PR DESCRIPTION
Prior to this change, you could access the selected colours like this: ```event.detail.detail.color```.
Now it is fixed and can be accessed like this: ```event.detail.color```

BREAKING CHANGE: The selected color is now available as it is documented: ```event.detail.color```