### PR TITLE
fix(ui5-combobox): Fix value reset on ESC #3886

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -15,6 +15,7 @@ import {
 	isUp,
 	isDown,
 	isEnter,
+	isEscape,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import * as Filters from "./ComboBoxFilters.js";
 
@@ -623,6 +624,10 @@ class ComboBox extends UI5Element {
 		if (isEnter(event)) {
 			this._fireChangeEvent();
 			this._closeRespPopover();
+		}
+
+		if (isEscape(event) && !this.open) {
+			this.value = this._lastValue;
 		}
 
 		if (isShow(event) && !this.readonly && !this.disabled) {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -228,6 +228,35 @@ describe("General interaction", () => {
 
 	});
 
+	it ("Value should be reset on ESC key", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
+
+		const combo = $("#combo2");
+		const input = combo.shadow$("[inner-input]");
+
+		input.click();
+
+		input.keys("Al");
+		// Close picker
+		input.keys("Escape");
+		// Reset value
+		input.keys("Escape");
+
+		assert.strictEqual(combo.getProperty("value"), "", "Value should be cleared");
+
+		input.keys("Al");
+		// Chose itemr
+		input.keys("Enter");
+		// Clear current value
+		input.keys("");
+		// Enter another value
+		input.keys("Al");
+		// Reset value
+		input.keys("Escape");
+
+		assert.strictEqual(combo.getProperty("value"), "Algeria", "Value should be restored to the last confirmed one");
+	});
+
 	it ("Tests change event after type and item select", () => {
 		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 


### PR DESCRIPTION
Issue #3784:

When the picker is closed the entered value is not cleared. When the picker is opened, it closes but the value remains in the input field.

Now the component is synced with the desired by specifications behavior.
If the suggestions popover is opened: ESC closes it.
If the suggestions are not opened: ESC resets the value to the last confirmed by the user with 'ENTER' or item click, or if there isn't one - with the initial value of the component when focused by the user.****