### PR TITLE
fix(ui5-tokenizer): Prevent re-rendering error

### DIFF
--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -155,6 +155,8 @@ class Tokenizer extends UI5Element {
 			const popover = await this.getPopover();
 			popover.close();
 		}
+
+		this._nMoreCount = this.overflownTokens.length;
 	}
 
 	onEnterDOM() {
@@ -198,7 +200,6 @@ class Tokenizer extends UI5Element {
 	}
 
 	onAfterRendering() {
-		this._nMoreCount = this.overflownTokens.length;
 		this._scrollEnablement.scrollContainer = this.expanded ? this.contentDom : this;
 	}
 


### PR DESCRIPTION
The update of `this._nMoreCount` property in onAfterRendering was causing too many re-rendering cycles causing the framework to throw. 

Issue: #3867