### PR TITLE
fix(ui5-dialog): fix console warning from exploratory testing

### DIFF
--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -280,13 +280,20 @@ class Dialog extends Popup {
 	_show() {
 		super._show();
 		this._center();
-		this._attachResizeHandlers();
 	}
 
 	onBeforeRendering() {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
 		this.onDesktop = isDesktop();
+
+		if (this._screenResizeHandler) {
+			this._detachResizeHandlers();
+		}
+	}
+
+	onAfterRendering() {
+		this._attachResizeHandlers();
 	}
 
 	onExitDOM() {
@@ -445,7 +452,7 @@ class Dialog extends Popup {
 			style = window.getComputedStyle(this),
 			minWidth = Number.parseFloat(style.minWidth),
 			minHeight = Number.parseFloat(style.minHeight),
-			maxWidth = 	window.innerWidth - left,
+			maxWidth = window.innerWidth - left,
 			maxHeight = window.innerHeight - top;
 
 		let width = Number.parseFloat(style.width),

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -286,10 +286,7 @@ class Dialog extends Popup {
 		this._isRTL = this.effectiveDir === "rtl";
 		this.onPhone = isPhone();
 		this.onDesktop = isDesktop();
-
-		if (this._screenResizeHandler) {
-			this._detachResizeHandlers();
-		}
+		this._detachResizeHandlers();
 	}
 
 	onAfterRendering() {


### PR DESCRIPTION
There is no ResizeHandler warning when a dialog is created dynamically

Fixes: #3620

