### PR TITLE
Avatar doc

### DIFF
--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -237,7 +237,7 @@ const metadata = {
  *
  * <ul>
  * <li>[SPACE, ENTER, RETURN] - Fires the <code>click</code> event if the <code>interactive</code> property is set to true.</li>
- * <li>[SHIFT] - If [SPACE] or [ENTER],[RETURN] is pressed, pressing [SHIFT] releases the component without triggering the click event.</li>
+ * <li>[SHIFT] - If [SPACE] is pressed, pressing [SHIFT] releases the component without triggering the click event.</li>
  * </ul>
  * <br><br>
  *

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -205,3 +205,7 @@
 .ui5-avatar-initials {
 	color: inherit;
 }
+
+::slotted(*) {
+	pointer-events: none;
+}

--- a/packages/main/test/samples/AvatarGroup.sample.html
+++ b/packages/main/test/samples/AvatarGroup.sample.html
@@ -82,12 +82,18 @@
 
 					popAvatar.colorScheme = avatarGroup.colorScheme[avatarIndex];
 					popAvatar.initials = avatarRef.initials;
-					popAvatar.image = avatarRef.image;
+					while (popAvatar.firstChild) {
+						popAvatar.removeChild(popAvatar.firstChild);
+					}
+
+					for (let i = 0; i < avatarRef.image.length; i++) {
+						popAvatar.appendChild(avatarRef.image[i])
+					}
+
 					popAvatar.icon = avatarRef.icon;
-	
+
 					personPopover.showAt(avatarRef);
 				}
-	
 				function onButtonClicked(targetRef) {
 					const hiddenItems = avatarGroup.hiddenItems;
 					const placeholder = peoplePopover.querySelector(".placeholder");
@@ -241,7 +247,7 @@
 						const avatarColor = avatarGroup.colorScheme[index];
 
 						html += `<div class="avatar-slot" style="padding: 5px">
-									<ui5-avatar interactive icon="${avatar.icon}" initials="${avatar.initials}" color-scheme"${color}">`;
+									<ui5-avatar interactive icon="${avatar.icon}" initials="${avatar.initials}" color-scheme="${avatarColor}">`;
 						if (avatar.image.length > 0) {
 							html += `<img src="${avatar.image[0].src}">`
 						}


### PR DESCRIPTION
After introducing image slot in `ui5-avatar` samples in the playground were not adjusted to it. Also color property was changed to color-scheme.

Images used inside the `image` slot were blocking the click event and the focus was not able to be applied.