### PR TITLE
feat(ui5-side-navigation): Items now have tooltip

### DIFF
--- a/packages/fiori/src/SideNavigation.hbs
+++ b/packages/fiori/src/SideNavigation.hbs
@@ -14,6 +14,7 @@
 					icon="{{this.item.icon}}"
 					.associatedItem="{{this.item}}"
 					text="{{this.item.text}}"
+					title="{{this.item.text}}"
 					?has-children="{{this.item.items.length}}"
 					?expanded="{{this.item.expanded}}"
 					?selected="{{this.selected}}"
@@ -23,6 +24,7 @@
 							<ui5-tree-item
 								.associatedItem="{{this}}"
 								text="{{this.text}}"
+								title="{{this.text}}"
 								icon="{{this.icon}}"
 								?selected="{{this.selected}}"
 							>
@@ -53,6 +55,7 @@
 						icon="{{this.item.icon}}"
 						.associatedItem="{{this.item}}"
 						text="{{this.item.text}}"
+						title="{{this.item.text}}"
 						?has-children="{{this.item.items.length}}"
 						?expanded="{{this.item.expanded}}"
 						?selected="{{this.selected}}"
@@ -62,6 +65,7 @@
 								<ui5-tree-item
 									.associatedItem="{{this}}"
 									text="{{this.text}}"
+									title="{{this.text}}"
 									?selected="{{this.selected}}"
 								>
 								</ui5-tree-item>

--- a/packages/fiori/src/SideNavigation.hbs
+++ b/packages/fiori/src/SideNavigation.hbs
@@ -14,7 +14,7 @@
 					icon="{{this.item.icon}}"
 					.associatedItem="{{this.item}}"
 					text="{{this.item.text}}"
-					title="{{this.item.text}}"
+					title="{{this.item._tooltip}}"
 					?has-children="{{this.item.items.length}}"
 					?expanded="{{this.item.expanded}}"
 					?selected="{{this.selected}}"
@@ -24,7 +24,7 @@
 							<ui5-tree-item
 								.associatedItem="{{this}}"
 								text="{{this.text}}"
-								title="{{this.text}}"
+								title="{{this._tooltip}}"
 								icon="{{this.icon}}"
 								?selected="{{this.selected}}"
 							>
@@ -55,7 +55,7 @@
 						icon="{{this.item.icon}}"
 						.associatedItem="{{this.item}}"
 						text="{{this.item.text}}"
-						title="{{this.item.text}}"
+						title="{{this.item._tooltip}}"
 						?has-children="{{this.item.items.length}}"
 						?expanded="{{this.item.expanded}}"
 						?selected="{{this.selected}}"
@@ -65,7 +65,7 @@
 								<ui5-tree-item
 									.associatedItem="{{this}}"
 									text="{{this.text}}"
-									title="{{this.text}}"
+									title="{{this._tooltip}}"
 									?selected="{{this.selected}}"
 								>
 								</ui5-tree-item>

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -68,6 +68,17 @@ const metadata = {
 		wholeItemToggleable: {
 			type: Boolean,
 		},
+
+		/**
+		 * Defines the tooltip of the component.
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @private
+		 * @since 1.0.0-rc.16
+		 */
+		 title: {
+			type: String,
+		},
 	},
 
 	events: /** @lends sap.ui.webcomponents.fiori.SideNavigationItem.prototype */ {
@@ -113,6 +124,10 @@ const metadata = {
 class SideNavigationItem extends UI5Element {
 	static get metadata() {
 		return metadata;
+	}
+
+	get _tooltip() {
+		return this.title || this.text;
 	}
 }
 

--- a/packages/fiori/src/SideNavigationItemPopoverContent.hbs
+++ b/packages/fiori/src/SideNavigationItemPopoverContent.hbs
@@ -1,20 +1,22 @@
 <ui5-responsive-popover
 	vertical-align="Top"
 >
-    <ui5-list
-	    mode="None"
-        @ui5-item-click="{{handleListItemClick}}"
-    >
-	    <ui5-li
-		    ?selected="{{_popoverContent.mainItemSelected}}"
-		    .associatedItem="{{_popoverContent.mainItem}}"
-	    >{{_popoverContent.mainItem.text}}</ui5-li>
+	<ui5-list
+		mode="None"
+		@ui5-item-click="{{handleListItemClick}}"
+	>
+		<ui5-li
+			title="{{_popoverContent.mainItem.text}}"
+			?selected="{{_popoverContent.mainItemSelected}}"
+			.associatedItem="{{_popoverContent.mainItem}}"
+		>{{_popoverContent.mainItem.text}}</ui5-li>
 
-        {{#each _popoverContent.subItems}}
-            <ui5-li
-	            ?selected="{{this.selected}}"
-                .associatedItem="{{this}}"
-            >{{this.text}}</ui5-li>
-        {{/each}}
-    </ui5-list>
+		{{#each _popoverContent.subItems}}
+			<ui5-li
+				title="{{this.text}}"
+				?selected="{{this.selected}}"
+				.associatedItem="{{this}}"
+			>{{this.text}}</ui5-li>
+		{{/each}}
+	</ui5-list>
 </ui5-responsive-popover>

--- a/packages/fiori/src/SideNavigationItemPopoverContent.hbs
+++ b/packages/fiori/src/SideNavigationItemPopoverContent.hbs
@@ -6,14 +6,14 @@
 		@ui5-item-click="{{handleListItemClick}}"
 	>
 		<ui5-li
-			title="{{_popoverContent.mainItem.text}}"
+			title="{{_popoverContent.mainItem._tooltip}}"
 			?selected="{{_popoverContent.mainItemSelected}}"
 			.associatedItem="{{_popoverContent.mainItem}}"
 		>{{_popoverContent.mainItem.text}}</ui5-li>
 
 		{{#each _popoverContent.subItems}}
 			<ui5-li
-				title="{{this.text}}"
+				title="{{this._tooltip}}"
 				?selected="{{this.selected}}"
 				.associatedItem="{{this}}"
 			>{{this.text}}</ui5-li>

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -42,6 +42,17 @@ const metadata = {
 		icon: {
 			type: String,
 		},
+
+		/**
+		 * Defines the tooltip of the component.
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @private
+		 * @since 1.0.0-rc.16
+		 */
+		title: {
+			type: String,
+		},
 	},
 
 	events: /** @lends sap.ui.webcomponents.fiori.SideNavigationSubItem.prototype */ {
@@ -71,6 +82,10 @@ const metadata = {
 class SideNavigationSubItem extends UI5Element {
 	static get metadata() {
 		return metadata;
+	}
+
+	get _tooltip() {
+		return this.title || this.text;
 	}
 }
 

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -73,9 +73,9 @@
 			</div>
 
 			<!-- Items -->
-			<ui5-side-navigation-item text="Home" icon="home" ></ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Home" icon="home" title="Home tooltip"></ui5-side-navigation-item>
 			<ui5-side-navigation-item text="People" expanded icon="group">
-				<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="From My Team" icon="employee-approvals" title="From My Team tooltip"></ui5-side-navigation-sub-item>
 				<ui5-side-navigation-sub-item text="From Other Teams" icon="employee-rejections"></ui5-side-navigation-sub-item>
 			</ui5-side-navigation-item>
 			<ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
@@ -85,8 +85,8 @@
 			</ui5-side-navigation-item>
 
 			<!-- Fixed Items -->
-			<ui5-side-navigation-item slot="fixedItems" text="Usefull Links" icon="chain-link">
-				<ui5-side-navigation-sub-item text="Vacation Tool"></ui5-side-navigation-sub-item>
+			<ui5-side-navigation-item slot="fixedItems" text="Useful Links" icon="chain-link" title="Useful links tooltip">
+				<ui5-side-navigation-sub-item text="Vacation Tool" title="Vacation Tool tooltip"></ui5-side-navigation-sub-item>
 				<ui5-side-navigation-sub-item text="HR tool"></ui5-side-navigation-sub-item>
 			</ui5-side-navigation-item>
 			<ui5-side-navigation-item slot="fixedItems" text="History" icon="history"></ui5-side-navigation-item>

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -95,6 +95,39 @@ describe("Component Behavior", () => {
 			});
 
 			assert.strictEqual(showHeader, false, "Header is not displayed");
+
+			// clean up
+			browser.$("#sn1").setProperty("collapsed", false);
+		});
+
+		it("Tests tooltips when expanded", () => {
+			const sideNavigation = browser.$("#sn1");
+			const items = sideNavigation.$$("ui5-side-navigation-item");
+			const renderedItems = sideNavigation.shadow$("ui5-tree").shadow$("ui5-list").$$("ui5-li-tree");
+			const firstItemSubItems = items[1].$$("ui5-side-navigation-sub-item");
+		
+			assert.strictEqual(items[0].getAttribute("text"), renderedItems[0].getAttribute("title"), "Text is set as tooltip to root item");
+			assert.strictEqual(firstItemSubItems[0].getAttribute("text"), renderedItems[2].getAttribute("title"), "Text is set as tooltip to sub item");
+		});
+
+		it("Tests tooltips when collapsed", () => {
+			browser.$("#sn1").setProperty("collapsed", true);
+			const sideNavigation = browser.$("#sn1");
+			const items = sideNavigation.$$("ui5-side-navigation-item");
+			const renderedItems = sideNavigation.shadow$("ui5-tree").shadow$("ui5-list").$$("ui5-li-tree");
+
+			assert.strictEqual(items[0].getAttribute("text"), renderedItems[0].getAttribute("title"), "Text is set as tooltip to root item");
+
+			renderedItems[1].click();
+
+			const staticAreaItemClassName = browser.getStaticAreaItemClassName("#sn1");
+			const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+			const popoverItems = popover.$("ui5-list").$$("ui5-li");
+
+			assert.strictEqual(items[1].getAttribute("text"), popoverItems[0].getAttribute("title"));
+
+			// clean up
+			browser.$("#sn1").setProperty("collapsed", false);
 		});
 	});
 });

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -104,19 +104,38 @@ describe("Component Behavior", () => {
 			const sideNavigation = browser.$("#sn1");
 			const items = sideNavigation.$$("ui5-side-navigation-item");
 			const renderedItems = sideNavigation.shadow$("ui5-tree").shadow$("ui5-list").$$("ui5-li-tree");
-			const firstItemSubItems = items[1].$$("ui5-side-navigation-sub-item");
-		
-			assert.strictEqual(items[0].getAttribute("text"), renderedItems[0].getAttribute("title"), "Text is set as tooltip to root item");
-			assert.strictEqual(firstItemSubItems[0].getAttribute("text"), renderedItems[2].getAttribute("title"), "Text is set as tooltip to sub item");
+			const secondItemSubItems = items[1].$$("ui5-side-navigation-sub-item");
+
+			assert.strictEqual(renderedItems[0].getAttribute("title"), items[0].getAttribute("title"), "Title is set as tooltip to root item");
+			assert.strictEqual(renderedItems[1].getAttribute("title"), items[1].getAttribute("text"), "Text is set as tooltip to root item when title is not specified");
+
+			// sub items
+			assert.strictEqual(renderedItems[2].getAttribute("title"), secondItemSubItems[0].getAttribute("title"), "Title is set as tooltip to sub item");
+			assert.strictEqual(renderedItems[3].getAttribute("title"), secondItemSubItems[1].getAttribute("text"), "Text is set as tooltip to sub item when title is not specified");
+
+			// fixed items
+			const fixedItems = sideNavigation.$$("ui5-side-navigation-item[slot=fixedItems]");
+			let renderedFixedItems = sideNavigation.shadow$$("ui5-tree")[1].shadow$("ui5-list").$$("ui5-li-tree");
+			renderedFixedItems[0].shadow$("ui5-icon.ui5-li-tree-toggle-icon").click(); // expand the item
+			renderedFixedItems = sideNavigation.shadow$$("ui5-tree")[1].shadow$("ui5-list").$$("ui5-li-tree");
+			const firstFixedItemSubItems = fixedItems[0].$$("ui5-side-navigation-sub-item");
+
+			assert.strictEqual(renderedFixedItems[0].getAttribute("title"), fixedItems[0].getAttribute("title"), "Title is set as tooltip to root fixed item");
+			assert.strictEqual(renderedFixedItems[2].getAttribute("title"), firstFixedItemSubItems[1].getAttribute("text"), "Text is set as tooltip to sub item when title is not specified");
+
+			// clean up
+			renderedFixedItems[0].shadow$("ui5-icon.ui5-li-tree-toggle-icon").click(); // collapse the item
 		});
 
 		it("Tests tooltips when collapsed", () => {
 			browser.$("#sn1").setProperty("collapsed", true);
 			const sideNavigation = browser.$("#sn1");
 			const items = sideNavigation.$$("ui5-side-navigation-item");
+			const secondItemSubItems = items[1].$$("ui5-side-navigation-sub-item");
 			const renderedItems = sideNavigation.shadow$("ui5-tree").shadow$("ui5-list").$$("ui5-li-tree");
 
-			assert.strictEqual(items[0].getAttribute("text"), renderedItems[0].getAttribute("title"), "Text is set as tooltip to root item");
+			assert.strictEqual(renderedItems[0].getAttribute("title"), items[0].getAttribute("title"), "Title is set as tooltip to root item");
+			assert.strictEqual(renderedItems[1].getAttribute("title"), items[1].getAttribute("text"), "Text is set as tooltip to root item when title is not specified");
 
 			renderedItems[1].click();
 
@@ -124,7 +143,8 @@ describe("Component Behavior", () => {
 			const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 			const popoverItems = popover.$("ui5-list").$$("ui5-li");
 
-			assert.strictEqual(items[1].getAttribute("text"), popoverItems[0].getAttribute("title"));
+			assert.strictEqual(popoverItems[0].getAttribute("title"), items[1].getAttribute("text"), "Text is set as tooltip to sub item when title is not specified");
+			assert.strictEqual(popoverItems[1].getAttribute("title"), secondItemSubItems[0].getAttribute("title"), "Title is set as tooltip to sub item");
 
 			// clean up
 			browser.$("#sn1").setProperty("collapsed", false);


### PR DESCRIPTION
Items now have `title` property. If it is not specified, the text property is used as their tooltip. It is shown in both expanded and collapsed state.

Fixes #3549

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
