### PR TITLE
fix(ui5-badge): update accent colors for color-scheme=8

### DIFF
--- a/packages/main/src/themes/base/Badge-parameters.css
+++ b/packages/main/src/themes/base/Badge-parameters.css
@@ -30,8 +30,8 @@
 	--ui5-badge-color-scheme-7-color: var(--sapAccentColor7);
 
 	--ui5-badge-color-scheme-8-background: var(--sapLegendBackgroundColor18);
-	--ui5-badge-color-scheme-8-border: var(--sapAccentColor18);
-	--ui5-badge-color-scheme-8-color: var(--sapAccentColor18);
+	--ui5-badge-color-scheme-8-border: var(--sapLegendColor18);
+	--ui5-badge-color-scheme-8-color: var(--sapLegendColor18);
 
 	--ui5-badge-color-scheme-9-background: var(--sapLegendBackgroundColor10);
 	--ui5-badge-color-scheme-9-border: var(--sapAccentColor10);


### PR DESCRIPTION
The previous accent colors were incorrect.

Fixes #3923
