### PR TITLE
fix: ComboBox arrow now correctly toggles the picker

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -431,6 +431,8 @@ class ComboBox extends UI5Element {
 	_focusout(event) {
 		const focusedOutToValueStateMessage = event.relatedTarget && event.relatedTarget.shadowRoot && event.relatedTarget.shadowRoot.querySelector(".ui5-valuestatemessage-root");
 
+		this._fireChangeEvent();
+
 		if (focusedOutToValueStateMessage) {
 			event.stopImmediatePropagation();
 			return;
@@ -440,8 +442,6 @@ class ComboBox extends UI5Element {
 			this.focused = false;
 			!isPhone() && this._closeRespPopover(event);
 		}
-
-		this._fireChangeEvent();
 	}
 
 	_afterOpenPopover() {

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -430,13 +430,18 @@ class ComboBox extends UI5Element {
 
 	_focusout(event) {
 		const focusedOutToValueStateMessage = event.relatedTarget && event.relatedTarget.shadowRoot && event.relatedTarget.shadowRoot.querySelector(".ui5-valuestatemessage-root");
+
 		if (focusedOutToValueStateMessage) {
 			event.stopImmediatePropagation();
-		} else {
-			this.focused = false;
-			this._fireChangeEvent();
-			!isPhone() && this._closeRespPopover();
+			return;
 		}
+
+		if (!this.shadowRoot.contains(event.relatedTarget)) {
+			this.focused = false;
+			!isPhone() && this._closeRespPopover(event);
+		}
+
+		this._fireChangeEvent();
 	}
 
 	_afterOpenPopover() {

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -76,7 +76,7 @@
 		<ui5-combobox id="" style="width: 360px;" placeholder="Hello World"></ui5-combobox>
 		<ui5-combobox id="" style="width: 360px;" readonly value="readonly"></ui5-combobox>
 		<ui5-combobox id="" style="width: 360px;" required value="required"></ui5-combobox>
-		<ui5-combobox id="" style="width: 360px;" value-state="Error">
+		<ui5-combobox id="value-state-error" style="width: 360px;" value-state="Error">
 			<ui5-cb-item text="Algeria"></ui5-cb-item>
 			<ui5-cb-item text="Argentina"></ui5-cb-item>
 			<ui5-cb-item text="Australia"></ui5-cb-item>

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html>
 
@@ -83,8 +84,8 @@
 			<ui5-cb-item text="Bahrain"></ui5-cb-item>
 			<ui5-cb-item text="Belgium"></ui5-cb-item>
 			<ui5-cb-item text="Bosnia and Herzegovina"></ui5-cb-item>
-			<div slot="valueStateMessage">Information message. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
-			<div slot="valueStateMessage">Information message 2. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
+			<div slot="valueStateMessage">Information message. This is a <a href="#test1">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
+			<div slot="valueStateMessage">Information message 2. This is a <a href="#test2">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 		</ui5-combobox>
 		<ui5-combobox id="" style="width: 360px;" value-state="Warning">
 			<ui5-cb-item text="Algeria"></ui5-cb-item>

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -201,7 +201,7 @@ describe("General interaction", () => {
 		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 		popover.$("ui5-list").$$("ui5-li")[0].click();
 
-		assert.strictEqual(placeholder.getText(), "Argentina", "Text should be empty");
+		assert.strictEqual(placeholder.getText(), "Argentina", "Text should not be empty");
 		assert.strictEqual(counter.getText(), "1", "Call count should be 1");
 
 		arrow.click();
@@ -210,6 +210,41 @@ describe("General interaction", () => {
 
 		popover.$("ui5-list").$$("ui5-li")[1].click();
 		assert.strictEqual(counter.getText(), "2", "Call count should be 2");
+	});
+
+	it ("Tests change event with value state and links", () => {
+		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
+
+		const counter = $("#change-count");
+		const combo = $("#value-state-error");
+		const placeholder = $("#change-placeholder");
+		const arrow = combo.shadow$("[input-icon]");
+
+		browser.execute(() => {
+			document.querySelector("[value-state='Error']").addEventListener("ui5-change", function(event) {
+				document.getElementById("change-placeholder").innerHTML = event.target.value;
+				document.getElementById("change-count").innerHTML = parseInt(document.getElementById("change-count").innerHTML) + 1;
+			})
+		});
+
+		// open picker
+		arrow.click();
+
+		combo.keys("B");
+		combo.keys("a");
+
+		assert.strictEqual(placeholder.getText(), "", "Text should be empty");
+		assert.strictEqual(counter.getText(), "0", "Call count should be 0");
+
+		// click on first item
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#value-state-error");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const link = popover.$(".ui5-responsive-popover-header.ui5-valuestatemessage-root a");
+
+		link.click();
+
+		assert.strictEqual(placeholder.getText(), "Bahrain", "Text should not be empty");
+		assert.strictEqual(counter.getText(), "1", "Call count should be 1");
 	});
 
 	it ("Tests change event after pressing enter key", () => {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -18,6 +18,19 @@ describe("General interaction", () => {
 		assert.ok(popover.getProperty("opened"), "Popover should be displayed")
 	});
 
+	it ("Should close the popover when clicking on the arrow second time", () => {
+		const combo = $("#combo");
+		const arrow = combo.shadow$("[input-icon]");
+		const staticAreaItemClassName = browser.getStaticAreaItemClassName("#combo");
+		const popover = browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		assert.ok(popover.getProperty("opened"), "Popover should be displayed")
+
+		arrow.click();
+
+		assert.ok(!popover.getProperty("opened"), "Popover should not be displayed")
+	});
+
 	it ("Items filtration", () => {
 		browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
 
@@ -194,8 +207,6 @@ describe("General interaction", () => {
 		arrow.click();
 
 		assert.strictEqual(counter.getText(), "1", "Call count should be 1");
-
-		arrow.click();
 
 		popover.$("ui5-list").$$("ui5-li")[1].click();
 		assert.strictEqual(counter.getText(), "2", "Call count should be 2");


### PR DESCRIPTION
Pressing the arrow of the ComboBox web component now correctly toggles the picker on desktop. 
