### PR TITLE
fix(ui5-multi-combobox): revert selection after close button is pressed

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -625,7 +625,6 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_listSelectionChange(event) {
-
 		// sync list items and cb items
 		this.syncItems(event.target.items);
 
@@ -716,7 +715,7 @@ class MultiComboBox extends UI5Element {
 		this._itemsBeforeOpen = this.items.map(item => {
 			return {
 				ref: item,
-				selected: item.selected
+				selected: item.selected,
 			};
 		});
 	}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -625,21 +625,36 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_listSelectionChange(event) {
-		event.target.items.forEach(item => {
+
+		// sync list items and cb items
+		this.syncItems(event.target.items);
+
+		// don't call selection change right after selection as user can cancel it on phone
+		if (!isPhone()) {
+			this.fireSelectionChange();
+		}
+
+		if (!event.detail.selectionComponentPressed && !isSpace(event.detail)) {
+			this.allItemsPopover.close();
+			this.value = "";
+
+			// if the item (not checkbox) is clicked, call the selection change
+			if (isPhone()) {
+				this.fireSelectionChange();
+			}
+
+			this.fireEvent("input");
+		}
+	}
+
+	syncItems(listItems) {
+		listItems.forEach(item => {
 			this.items.forEach(mcbItem => {
 				if (mcbItem._id === item.getAttribute("data-ui5-token-id")) {
 					mcbItem.selected = item.selected;
 				}
 			});
 		});
-
-		this.fireSelectionChange();
-
-		if (!event.detail.selectionComponentPressed && !isSpace(event.detail)) {
-			this.allItemsPopover.close();
-			this.value = "";
-			this.fireEvent("input");
-		}
 	}
 
 	fireSelectionChange() {
@@ -697,6 +712,15 @@ class MultiComboBox extends UI5Element {
 		}
 	}
 
+	_beforeOpen() {
+		this._itemsBeforeOpen = this.items.map(item => {
+			return {
+				ref: item,
+				selected: item.selected
+			};
+		});
+	}
+
 	async onAfterRendering() {
 		await this._getRespPopover();
 		await this._getList();
@@ -725,6 +749,22 @@ class MultiComboBox extends UI5Element {
 		} else {
 			this.closePopover();
 		}
+	}
+
+	handleCancel() {
+		this._itemsBeforeOpen.forEach(item => {
+			item.ref.selected = item.selected;
+		});
+
+		this.togglePopover();
+	}
+
+	handleOK() {
+		if (isPhone()) {
+			this.fireSelectionChange();
+		}
+
+		this.togglePopover();
 	}
 
 	async openPopover() {

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -4,8 +4,8 @@
 	class="ui5-multi-combobox-all-items-responsive-popover"
 	hide-arrow
 	_disable-initial-focus
-	@ui5-selection-change={{_listSelectionChange}}
 	@ui5-after-close={{_toggle}}
+	@ui5-before-open={{_beforeOpen}}
 	@ui5-after-open={{_toggle}}
 >
 	{{#if _isPhone}}
@@ -16,7 +16,7 @@
 					class="ui5-responsive-popover-close-btn"
 					icon="decline"
 					design="Transparent"
-					@click="{{togglePopover}}"
+					@click="{{handleCancel}}"
 				>
 				</ui5-button>
 			</div>
@@ -65,7 +65,7 @@
 		{{/if}}
 	{{/unless}}
 
-	<ui5-list separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list">
+	<ui5-list @ui5-selection-change={{_listSelectionChange}} separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list">
 		{{#each _filteredItems}}
 				<ui5-li
 					type="{{../_listItemsType}}"
@@ -83,7 +83,7 @@
 		<div slot="footer" class="ui5-responsive-popover-footer">
 			<ui5-button
 				design="Transparent"
-				@click="{{togglePopover}}"
+				@click="{{handleOK}}"
 			>{{_dialogOkButton}}</ui5-button>
 		</div>
 	{{/if}}


### PR DESCRIPTION
User can cancel its selection by pressing the close button of the dialog on mobile phone. In this case, selection will be reverted and no event will be called at all. If the OK button is pressed selection will replicate to tokens and fire event `selection-change`

FIXES: #3764