### PR TITLE
fix: detach events correctly to prevent memory leaks

### DIFF
--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -26,7 +26,7 @@ class EventProvider {
 		}
 
 		eventListeners = eventListeners.filter(fn => fn !== fnFunction);
-        this._eventRegistry[eventName] = eventListeners;
+		this._eventRegistry[eventName] = eventListeners;
 
 		if (eventListeners.length === 0) {
 			eventRegistry.delete(eventName);

--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -19,14 +19,13 @@ class EventProvider {
 
 	detachEvent(eventName, fnFunction) {
 		const eventRegistry = this._eventRegistry;
-		let eventListeners = eventRegistry.get(eventName);
+		const eventListeners = eventRegistry.get(eventName);
 
 		if (!eventListeners) {
 			return;
 		}
-
-		eventListeners = eventListeners.filter(fn => fn !== fnFunction);
-		this._eventRegistry[eventName] = eventListeners;
+		const indexOfFnToDetach = eventListeners.indexOf(fnFunction);
+		if(~indexOfFnToDetach) eventListeners[eventName].splice(indexOfFnToDetach, 1);
 
 		if (eventListeners.length === 0) {
 			eventRegistry.delete(eventName);

--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -25,7 +25,7 @@ class EventProvider {
 			return;
 		}
 		const indexOfFnToDetach = eventListeners.indexOf(fnFunction);
-		if(~indexOfFnToDetach) eventListeners[eventName].splice(indexOfFnToDetach, 1);
+		if (~indexOfFnToDetach) eventListeners[eventName].splice(indexOfFnToDetach, 1);
 
 		if (eventListeners.length === 0) {
 			eventRegistry.delete(eventName);

--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -25,7 +25,10 @@ class EventProvider {
 			return;
 		}
 		const indexOfFnToDetach = eventListeners.indexOf(fnFunction);
-		if (~indexOfFnToDetach) eventListeners[eventName].splice(indexOfFnToDetach, 1);
+
+		if (indexOfFnToDetach !== -1) {
+			eventListeners[eventName].splice(indexOfFnToDetach, 1);
+		}
 
 		if (eventListeners.length === 0) {
 			eventRegistry.delete(eventName);

--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -26,6 +26,7 @@ class EventProvider {
 		}
 
 		eventListeners = eventListeners.filter(fn => fn !== fnFunction);
+        this._eventRegistry[eventName] = eventListeners;
 
 		if (eventListeners.length === 0) {
 			eventRegistry.delete(eventName);

--- a/packages/base/src/EventProvider.js
+++ b/packages/base/src/EventProvider.js
@@ -27,7 +27,7 @@ class EventProvider {
 		const indexOfFnToDetach = eventListeners.indexOf(fnFunction);
 
 		if (indexOfFnToDetach !== -1) {
-			eventListeners[eventName].splice(indexOfFnToDetach, 1);
+			eventListeners.splice(indexOfFnToDetach, 1);
 		}
 
 		if (eventListeners.length === 0) {


### PR DESCRIPTION
In `detachEvents` the `eventRegistry` was never updated when detaching an event, therefore the events weren't cleaned up and caused memory leaks.

Here's an example caused by `attachLanguageChange`, this memory leak occurs with all components that have translatable texts:

1. Open [codeSandbox](https://2qini.csb.app/) in fullscreen mode (for some reason the Performance Monitor doesn't work with codeSandbox in IDE mode - [here you can find the link to the codeSandbox w/o fullscreen mode](https://codesandbox.io/s/hopeful-cannon-2qini?file=/src/App.js))
2. Open dev tools and the [Performance Monitor](https://developer.chrome.com/blog/new-in-devtools-64/#perf-monitor)
3. Click on "Toggle Calendar" multiple times and see that the DOM Nodes are not garbage collected.

I'm not sure where else the detacher is used, but this could have a huge impact to performance with many components rendered, especially when navigating between pages.


https://user-images.githubusercontent.com/9749730/133593242-9361854c-4870-4c2f-84dc-f8c0bf4abd5f.mp4

Thanks @AndrianStoikov for letting us know that we got a memory leak by creating [this issue](https://github.com/SAP/ui5-webcomponents-react/issues/2127). It also helped me a lot to find the root cause of it. 