### PR TITLE
fix(ui5-multi-combobox): prevent setting max-width of dialog header on mobile

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -875,7 +875,7 @@ class MultiComboBox extends UI5Element {
 				"padding": "0.9125rem 1rem",
 			},
 			popoverHeader: {
-				"max-width": `${this._inputWidth}px`,
+				"max-width": isPhone() ? "100%" : `${this._inputWidth}px`,
 			},
 		};
 	}


### PR DESCRIPTION
FIXES: #3763