### PR TITLE
fix(ui5-file-uploader): Button is activated with Enter/Space key with screen reader virtual cursor

### DIFF
--- a/packages/main/src/FileUploader.hbs
+++ b/packages/main/src/FileUploader.hbs
@@ -6,6 +6,7 @@
 	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	@keyup="{{_onkeyup}}"
+	@click="{{_onclick}}"
 >
 	<div class="ui5-file-uploader-mask">
 		{{#unless hideInput}}

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -285,15 +285,21 @@ class FileUploader extends UI5Element {
 		});
 	}
 
+	_onclick(event) {
+		this._input.click(event);
+	}
+
 	_onkeydown(event) {
 		if (isEnter(event)) {
 			this._input.click(event);
+			event.preventDefault();
 		}
 	}
 
 	_onkeyup(event) {
 		if (isSpace(event)) {
 			this._input.click(event);
+			event.preventDefault();
 		}
 	}
 

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -286,7 +286,9 @@ class FileUploader extends UI5Element {
 	}
 
 	_onclick(event) {
-		this._input.click(event);
+		if (event.isMarked === "button") {
+			this._input.click(event);
+		}
 	}
 
 	_onkeydown(event) {


### PR DESCRIPTION
Upload files button now is activated with Enter/Space key with screen reader virtual cursor  ON"

Fixes:  https://github.com/SAP/ui5-webcomponents/issues/3767
Closes: https://github.com/SAP/ui5-webcomponents/issues/3767