### PR TITLE
fix(ui5-tree): Unnecessary scrollbar in RTL mode removed

### DIFF
--- a/packages/fiori/src/themes/InvisibleTextStyles.css
+++ b/packages/fiori/src/themes/InvisibleTextStyles.css
@@ -6,3 +6,8 @@
 	top: -1000px;
 	pointer-events: none;
 }
+
+[dir=rtl] .ui5-hidden-text {
+	left: auto;
+	right: -1000px;
+}

--- a/packages/main/src/themes/InvisibleTextStyles.css
+++ b/packages/main/src/themes/InvisibleTextStyles.css
@@ -6,3 +6,8 @@
 	top: -1000px;
 	pointer-events: none;
 }
+
+[dir=rtl] .ui5-hidden-text {
+	left: auto;
+	right: -1000px;
+}


### PR DESCRIPTION
fix(ui5-tree): Unnecessary scrollbar in RTL mode removed

ui5-hidden-text "left: property value of -1000px was causing additional space in overflow: auto controls in RTL mode and needs
to be preseted to its "right" property.

Fixes #3947
Fixes #3503
Part of #3623