### PR TITLE
refactor: Improve assert usage in tests

### DIFF
--- a/packages/fiori/test/specs/BarcodeScannerDialog.spec.js
+++ b/packages/fiori/test/specs/BarcodeScannerDialog.spec.js
@@ -20,7 +20,8 @@ describe("BarcodeScannerDialog Behavior", () => {
 		}, 25000, "expect scan-error output");
 
 		// assert
-		assert.ok((await scanError.getText()).length > 0, "fires scan-error when no permissions");
+		const scanErrorText = await scanError.getText();
+		assert.ok(scanErrorText.length, "fires scan-error when no permissions");
 	});
 
 });

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -12,10 +12,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		await browser.setWindowSize(1400, 1080);
 
 		const layoutChangeCounter = await browser.$("#testLayoutChange");
-		const visibleColumns = await browser.executeAsync(async done => {
-			const fcl = document.getElementById("fcl3");
-			done(await fcl.getAttribute("_visible-columns"));
-		});
+		const visibleColumns = await browser.$("#fcl3").getAttribute("_visible-columns");
 
 		// assert
 		assert.strictEqual(visibleColumns, "3", "3 columns are visible");
@@ -27,10 +24,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		await browser.setWindowSize(1000, 1080);
 
 		const layoutChangeCounter = await browser.$("#testLayoutChange");
-		const visibleColumns = await browser.executeAsync(async done => {
-			const fcl = document.getElementById("fcl3");
-			done(await fcl.getAttribute("_visible-columns"));
-		});
+		const visibleColumns = await browser.$("#fcl3").getAttribute("_visible-columns");
 
 		// assert
 		assert.strictEqual(visibleColumns, "2", "2 columns are visible");
@@ -42,10 +36,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		await browser.setWindowSize(500, 1080);
 
 		const layoutChangeCounter = await browser.$("#testLayoutChange");
-		const visibleColumns = await browser.executeAsync(async done => {
-			const fcl = document.getElementById("fcl3");
-			done(await fcl.getAttribute("_visible-columns"));
-		});
+		const visibleColumns = await browser.$("#fcl3").getAttribute("_visible-columns");
 
 		// assert
 		assert.strictEqual(visibleColumns, "1", "1 columns are visible");
@@ -80,10 +71,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		const fcl = await browser.$("#fcl1");
 		const btn = await browser.$("#switchBtn1");
 
-		let visibleColumns = await browser.executeAsync(async done => {
-			const fcl = document.getElementById("fcl1");
-			done(await fcl.getAttribute("_visible-columns"));
-		});
+		let visibleColumns = await browser.$("#fcl1").getAttribute("_visible-columns");
 
 		assert.strictEqual(visibleColumns, "2", "2 columns are visible");
 		assert.strictEqual(await fcl.getProperty("layout"), "TwoColumnsStartExpanded", "new layout set");
@@ -91,10 +79,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		// act
 		await btn.click(); // fcl1.layout =  "ThreeColumnsMidExpanded"
 
-		visibleColumns = await browser.executeAsync(async done => {
-			const fcl = document.getElementById("fcl1");
-			done(await fcl.getAttribute("_visible-columns"));
-		});
+		visibleColumns = await browser.$("#fcl1").getAttribute("_visible-columns");
 
 		// assert
 		assert.strictEqual(visibleColumns, "3", "3 columns are visible");

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -86,7 +86,7 @@ describe("Notification List Item Tests", () => {
 		const hightAfter = await content.getSize("height");
 
 		// assert
-		assert.ok(hightAfter > hightBefore,
+		assert.isAbove(hightAfter, hightBefore,
 			"The content has been expanded by the ShowMore button.");
 	});
 

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -22,11 +22,11 @@ describe("Page general interaction", () => {
         const footer = await browser.$("#page").shadow$(".ui5-page-footer-root");
         const button = await browser.$("#toggleVisibility");
 
-        assert.strictEqual(await footer.isDisplayedInViewport(), true, "Footer should be visible.");
+        assert.ok(await footer.isDisplayedInViewport(), "Footer should be visible.");
 
         await button.click();
         await browser.pause(500);
 
-        assert.strictEqual(await footer.isDisplayedInViewport(), false, "Footer should not be visible.");
+        assert.notOk(await footer.isDisplayedInViewport(), "Footer should not be visible.");
 	});
 });

--- a/packages/fiori/test/specs/ProductSwitch.spec.js
+++ b/packages/fiori/test/specs/ProductSwitch.spec.js
@@ -14,8 +14,11 @@ describe("ProductSwitch general interaction", async () => {
 		const fourColumnPSAttrValue = parseInt(await productSwitchFourColumn.getAttribute("desktop-columns"));
 		const threeColumnPSAttrValue = parseInt(await productSwitchThreeColumn.getAttribute("desktop-columns"));
 
-		assert.strictEqual(fourColumnPSItemCount > 6, fourColumnPSAttrValue === 4, "product switch should have 4 columns.");
-		assert.strictEqual(threeColumnPSItemCount <= 6, threeColumnPSAttrValue === 3, "product switch should have 3 columns.");
+		assert.isAbove(fourColumnPSItemCount, 6, "more than 6 items.");
+		assert.strictEqual(fourColumnPSAttrValue, 4, "product switch should have 4 columns.");
+
+		assert.isAtMost(threeColumnPSItemCount, 6, "6 items or less.");
+		assert.strictEqual(threeColumnPSAttrValue, 3, "product switch should have 3 columns.");
 	});
 });
 

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -83,16 +83,16 @@ describe("Component Behavior", () => {
 				const productSwitchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-button-product-switch");
 
 				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "XXL", "XXL Breakpoint class should be set");
-				assert.strictEqual(await overflowButton.isDisplayed(), false, "Overflow button should be hidden");
-				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
-				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
-				assert.strictEqual(await secondaryTitle.isDisplayed(), true, "Secondary title should be visible");
-				assert.strictEqual(await searchIcon.isDisplayed(), true, "Search icon should be visible");
-				assert.strictEqual(await customActionIcon1.isDisplayed(), true, "Custom Action 1 should be visible");
-				assert.strictEqual(await customActionIcon2.isDisplayed(), true, "Custom Action 2 should be visible");
-				assert.strictEqual(await notificationsIcon.isDisplayed(), true, "Notifications icon should be visible");
-				assert.strictEqual(await profileIcon.isDisplayed(), true, "Profile icon should be visible");
-				assert.strictEqual(await productSwitchIcon.isDisplayed(), true, "Product switch should be visible");
+				assert.notOk(await overflowButton.isDisplayed(), "Overflow button should be hidden");
+				assert.ok(await backButton.isDisplayed(), "Back icon is visible");
+				assert.ok(await primaryTitle.isDisplayed(), "Primary title should be visible");
+				assert.ok(await secondaryTitle.isDisplayed(), "Secondary title should be visible");
+				assert.ok(await searchIcon.isDisplayed(), "Search icon should be visible");
+				assert.ok(await customActionIcon1.isDisplayed(), "Custom Action 1 should be visible");
+				assert.ok(await customActionIcon2.isDisplayed(), "Custom Action 2 should be visible");
+				assert.ok(await notificationsIcon.isDisplayed(), "Notifications icon should be visible");
+				assert.ok(await profileIcon.isDisplayed(), "Profile icon should be visible");
+				assert.ok(await productSwitchIcon.isDisplayed(), "Product switch should be visible");
 			}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
 		});
 
@@ -123,16 +123,16 @@ describe("Component Behavior", () => {
 				const productSwitchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-button-product-switch");
 
 				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "L", "L Breakpoint class should be set");
-				assert.strictEqual(await overflowButton.isDisplayed(), false, "Overflow button should be hidden");
-				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
-				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
-				assert.strictEqual(await secondaryTitle.isDisplayed(), true, "Secondary title should be visible");
-				assert.strictEqual(await searchIcon.isDisplayed(), true, "Search icon should be visible");
-				assert.strictEqual(await customActionIcon1.isDisplayed(), true, "Custom Action 1 should be visible");
-				assert.strictEqual(await customActionIcon2.isDisplayed(), true, "Custom Action 2 should be visible");
-				assert.strictEqual(await notificationsIcon.isDisplayed(), true, "Notifications icon should be visible");
-				assert.strictEqual(await profileIcon.isDisplayed(), true, "Profile icon should be visible");
-				assert.strictEqual(await productSwitchIcon.isDisplayed(), true, "Product switch should be visible");
+				assert.notOk(await overflowButton.isDisplayed(), "Overflow button should be hidden");
+				assert.ok(await backButton.isDisplayed(), "Back icon is visible");
+				assert.ok(await primaryTitle.isDisplayed(), "Primary title should be visible");
+				assert.ok(await secondaryTitle.isDisplayed(), "Secondary title should be visible");
+				assert.ok(await searchIcon.isDisplayed(), "Search icon should be visible");
+				assert.ok(await customActionIcon1.isDisplayed(), "Custom Action 1 should be visible");
+				assert.ok(await customActionIcon2.isDisplayed(), "Custom Action 2 should be visible");
+				assert.ok(await notificationsIcon.isDisplayed(), "Notifications icon should be visible");
+				assert.ok(await profileIcon.isDisplayed(), "Profile icon should be visible");
+				assert.ok(await productSwitchIcon.isDisplayed(), "Product switch should be visible");
 			}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
 		});
 
@@ -161,17 +161,17 @@ describe("Component Behavior", () => {
 				const listItemsCount = (await overflowPopover.getHTML()).split("</ui5-li>").length - 1;
 
 				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "M", "M Breakpoint class should be set");
-				assert.strictEqual(await overflowButton.isDisplayed(), true, "Overflow button should be visible");
-				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
-				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
-				assert.strictEqual(await secondaryTitle.isDisplayed(), false, "Secondary title should be hidden");
-				assert.strictEqual(await searchIcon.isDisplayed(), true, "Search icon should be visible");
-				assert.strictEqual(await customActionIcon1.isDisplayed(), false, "Custom Action 1 should be hidden");
-				assert.strictEqual(await customActionIcon2.isDisplayed(), false, "Custom Action 2 should be hidden");
-				assert.strictEqual(await notificationsIcon.isDisplayed(), true, "Notifications icon should be visible");
-				assert.strictEqual(await profileIcon.isDisplayed(), true, "Profile icon should be visible");
-				assert.strictEqual(await productSwitchIcon.isDisplayed(), true, "Product switch should be visible");
-				assert.strictEqual(await overflowPopover.isDisplayedInViewport(), true, "Overflow popover should be visible");
+				assert.ok(await overflowButton.isDisplayed(), "Overflow button should be visible");
+				assert.ok(await backButton.isDisplayed(), "Back icon is visible");
+				assert.ok(await primaryTitle.isDisplayed(), "Primary title should be visible");
+				assert.notOk(await secondaryTitle.isDisplayed(), "Secondary title should be hidden");
+				assert.ok(await searchIcon.isDisplayed(), "Search icon should be visible");
+				assert.notOk(await customActionIcon1.isDisplayed(), "Custom Action 1 should be hidden");
+				assert.notOk(await customActionIcon2.isDisplayed(), "Custom Action 2 should be hidden");
+				assert.ok(await notificationsIcon.isDisplayed(), "Notifications icon should be visible");
+				assert.ok(await profileIcon.isDisplayed(), "Profile icon should be visible");
+				assert.ok(await productSwitchIcon.isDisplayed(), "Product switch should be visible");
+				assert.ok(await overflowPopover.isDisplayedInViewport(), "Overflow popover should be visible");
 				assert.strictEqual(listItemsCount, 2, "2 actions should overflow");
 				assert.strictEqual(overflowPopoverItem1Icon, await getCustomActionProp("shellbar", 0, "icon"), "Popover items have same sources as corresponding icons");
 				assert.strictEqual(overflowPopoverItem2Icon, await getCustomActionProp("shellbar", 1, "icon"), "Popover items have same sources as corresponding icons");
@@ -223,8 +223,8 @@ describe("Component Behavior", () => {
 				const overflowButton = await browser.$("#shellbar").shadow$(".ui5-shellbar-overflow-button");
 				const searchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
 
-				assert.strictEqual(await searchIcon.isDisplayed(), false, "Search should be hidden");
-				assert.strictEqual(await overflowButton.isDisplayed(), true, "Overflow should be visible");
+				assert.notOk(await searchIcon.isDisplayed(), "Search should be hidden");
+				assert.ok(await overflowButton.isDisplayed(), "Overflow should be visible");
 			}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
 		});
 
@@ -246,14 +246,14 @@ describe("Component Behavior", () => {
 				const listItemsCount = await overflowPopover.getHTML().split("</ui5-li>").length - 1;
 
 				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "S", "S Breakpoint class should be set");
-				assert.strictEqual(await overflowButton.isDisplayed(), true, "Overflow button should be visible");
-				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
-				assert.strictEqual(await primaryTitle.isDisplayed(), false, "Primary title should be hidden");
-				assert.strictEqual(await secondaryTitle.isDisplayed(), false, "Secondary title should be hidden");
-				assert.strictEqual(await searchIcon.isDisplayed(), false, "Search icon should be hidden");
-				assert.strictEqual(await notificationsIcon.isDisplayed(), false, "Notifications icon should be hidden");
-				assert.strictEqual(await profileIcon.isDisplayed(), true, "Profile icon should be visible");
-				assert.strictEqual(await productSwitchIcon.isDisplayed(), false, "Product switch should be hidden");
+				assert.ok(await overflowButton.isDisplayed(), "Overflow button should be visible");
+				assert.ok(await backButton.isDisplayed(), "Back icon is visible");
+				assert.notOk(await primaryTitle.isDisplayed(), "Primary title should be hidden");
+				assert.notOk(await secondaryTitle.isDisplayed(), "Secondary title should be hidden");
+				assert.notOk(await searchIcon.isDisplayed(), "Search icon should be hidden");
+				assert.notOk(await notificationsIcon.isDisplayed(), "Notifications icon should be hidden");
+				assert.ok(await profileIcon.isDisplayed(), "Profile icon should be visible");
+				assert.notOk(await productSwitchIcon.isDisplayed(), "Product switch should be hidden");
 				assert.strictEqual(listItemsCount, 5, "5 actions should overflow");
 			}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
 		});
@@ -346,10 +346,10 @@ describe("Component Behavior", () => {
 				assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden by default");
 
 				await searchIcon.click();
-				assert.strictEqual(await searchField.isDisplayed(), true, "Search is visible after clicking on icon");
+				assert.ok(await searchField.isDisplayed(), "Search is visible after clicking on icon");
 
 				await searchIcon.click();
-				assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden after clicking again on the icon");
+				assert.notOk(await searchField.isDisplayed(), "Search is hidden after clicking again on the icon");
 			});
 		});
 
@@ -431,15 +431,15 @@ describe("Component Behavior", () => {
 				const overflowPopover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
 				const searchListItem = await overflowPopover.$("ui5-list ui5-li:nth-child(1)");
 
-				assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden by default");
+				assert.notOk(await searchField.isDisplayed(), "Search is hidden by default");
 
 				await overflowButton.click();
 				await searchListItem.click();
 
-				assert.strictEqual(await searchField.isDisplayed(), true, "Search is visible after clicking on the search icon within the overflow");
+				assert.ok(await searchField.isDisplayed(), "Search is visible after clicking on the search icon within the overflow");
 
 				await cancelButton.click();
-				assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden after clicking on the search icon agian");
+				assert.notOk(await searchField.isDisplayed(), "Search is hidden after clicking on the search icon agian");
 			});
 		});
 	});

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -82,7 +82,7 @@ describe("Component Behavior", () => {
 				const profileIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-image-button");
 				const productSwitchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-button-product-switch");
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "XXL", true, "XXL Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "XXL", "XXL Breakpoint class should be set");
 				assert.strictEqual(await overflowButton.isDisplayed(), false, "Overflow button should be hidden");
 				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
 				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
@@ -102,7 +102,7 @@ describe("Component Behavior", () => {
 			setTimeout(async () => {
 				const shellbar = await browser.$("#shellbar");
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "XL", true, "XL Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "XL", "XL Breakpoint class should be set");
 			}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
 		});
 
@@ -122,7 +122,7 @@ describe("Component Behavior", () => {
 				const profileIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-image-button");
 				const productSwitchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-button-product-switch");
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "L", true, "L Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "L", "L Breakpoint class should be set");
 				assert.strictEqual(await overflowButton.isDisplayed(), false, "Overflow button should be hidden");
 				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
 				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
@@ -160,7 +160,7 @@ describe("Component Behavior", () => {
 
 				const listItemsCount = (await overflowPopover.getHTML()).split("</ui5-li>").length - 1;
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "M", true, "M Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "M", "M Breakpoint class should be set");
 				assert.strictEqual(await overflowButton.isDisplayed(), true, "Overflow button should be visible");
 				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
 				assert.strictEqual(await primaryTitle.isDisplayed(), true, "Primary title should be visible");
@@ -187,7 +187,7 @@ describe("Component Behavior", () => {
 				const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#shellbar")
 				const overflowPopover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "M", true, "M Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "M", "M Breakpoint class should be set");
 
 				const listItemsCount = (await overflowPopover.getHTML()).split("</ui5-li>").length - 1;
 
@@ -206,7 +206,7 @@ describe("Component Behavior", () => {
 				const overflowPopover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
 				const notificationsIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "M", true, "M Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "M", "M Breakpoint class should be set");
 
 				const listItemsCount = (await overflowPopover.getHTML().split("</ui5-li>")).length - 1;
 
@@ -245,7 +245,7 @@ describe("Component Behavior", () => {
 				const overflowPopover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-shellbar-overflow-popover");
 				const listItemsCount = await overflowPopover.getHTML().split("</ui5-li>").length - 1;
 
-				assert.strictEqual(await shellbar.getProperty("breakpointSize") === "S", true, "S Breakpoint class should be set");
+				assert.strictEqual(await shellbar.getProperty("breakpointSize"), "S", "S Breakpoint class should be set");
 				assert.strictEqual(await overflowButton.isDisplayed(), true, "Overflow button should be visible");
 				assert.strictEqual(await backButton.isDisplayed(), true, "Back icon is visible");
 				assert.strictEqual(await primaryTitle.isDisplayed(), false, "Primary title should be hidden");

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -78,21 +78,13 @@ describe("Component Behavior", () => {
 		it("Tests header visibility", async () => {
 			let showHeader = null;
 
-			showHeader = await browser.executeAsync(done => {
-				const sideNavigation = document.querySelector("#sn1");
-				sideNavigation.collapsed = false;
-
-				done(sideNavigation.showHeader);
-			});
+			await browser.$("#sn1").setProperty("collapsed", false);
+			showHeader = await browser.$("#sn1").getProperty("showHeader");
 
 			assert.ok(showHeader, "Header is displayed");
 
-			showHeader = await browser.executeAsync(done => {
-				const sideNavigation = document.querySelector("#sn1");
-				sideNavigation.collapsed = true;
-
-				done(sideNavigation.showHeader);
-			});
+			await browser.$("#sn1").setProperty("collapsed", true);
+			showHeader = await browser.$("#sn1").getProperty("showHeader");
 
 			assert.notOk(showHeader, "Header is not displayed");
 

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -55,12 +55,12 @@ describe("Component Behavior", () => {
 			await items[3].click();
 
 			assert.strictEqual(await input.getProperty("value"), "7", "Event is not fired");
-			assert.strictEqual(await items[3].getProperty("expanded"), true, "Expanded is toggled");
+			assert.ok(await items[3].getProperty("expanded"), "Expanded is toggled");
 
 			await items[3].click();
 
 			assert.strictEqual(await input.getProperty("value"), "7", "Event is not fired");
-			assert.strictEqual(await items[3].getProperty("expanded"), false, "Expanded is toggled");
+			assert.notOk(await items[3].getProperty("expanded"), "Expanded is toggled");
 
             await items[1].click();
             assert.strictEqual(await input.getProperty("value"), "8", "Event is fired");
@@ -85,7 +85,7 @@ describe("Component Behavior", () => {
 				done(sideNavigation.showHeader);
 			});
 
-			assert.strictEqual(showHeader, true, "Header is displayed");
+			assert.ok(showHeader, "Header is displayed");
 
 			showHeader = await browser.executeAsync(done => {
 				const sideNavigation = document.querySelector("#sn1");
@@ -94,7 +94,7 @@ describe("Component Behavior", () => {
 				done(sideNavigation.showHeader);
 			});
 
-			assert.strictEqual(showHeader, false, "Header is not displayed");
+			assert.notOk(showHeader, "Header is not displayed");
 
 			// clean up
 			await browser.$("#sn1").setProperty("collapsed", false);

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -61,26 +61,26 @@ describe("UploadCollection", () => {
 
 		it("visibility of buttons", async () => {
 			const defaultItem = await browser.$("#uc3-default");
-			assert.strictEqual(await defaultItem.shadow$(".ui5-li-deletebtn").isDisplayed(), true, "delete button is visible");
+			assert.ok(await defaultItem.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is visible");
 
 			const defaultItemHiddenDelete = await browser.$("#uc3-default-hidden-delete");
-			assert.strictEqual(await defaultItemHiddenDelete.shadow$(".ui5-li-deletebtn").isDisplayed(), false, "delete button is not visible");
+			assert.notOk(await defaultItemHiddenDelete.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is not visible");
 
 			const errorItem = await browser.$("#uc3-error");
-			assert.strictEqual(await errorItem.shadow$(".ui5-li-deletebtn").isDisplayed(), true, "delete button is visible");
-			assert.strictEqual(await errorItem.shadow$("ui5-button[icon=refresh]").isDisplayed(), true, "retry button is visible");
+			assert.ok(await errorItem.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is visible");
+			assert.ok(await errorItem.shadow$("ui5-button[icon=refresh]").isDisplayed(), "retry button is visible");
 
 			const errorItemHiddenRetry = await browser.$("#uc3-error-hidden-retry");
-			assert.strictEqual(await errorItemHiddenRetry.shadow$(".ui5-li-deletebtn").isDisplayed(), true, "delete button is visible");
-			assert.strictEqual(await errorItemHiddenRetry.shadow$("ui5-button[icon=refresh]").isDisplayed(), false, "retry button is not visible");
+			assert.ok(await errorItemHiddenRetry.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is visible");
+			assert.notOk(await errorItemHiddenRetry.shadow$("ui5-button[icon=refresh]").isDisplayed(), "retry button is not visible");
 
 			const uploadingItem = await browser.$("#uc3-uploading");
-			assert.strictEqual(await uploadingItem.shadow$(".ui5-li-deletebtn").isDisplayed(), false, "delete button is not visible");
-			assert.strictEqual(await uploadingItem.shadow$("ui5-button[icon=stop]").isDisplayed(), true, "terminate button is visible");
+			assert.notOk(await uploadingItem.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is not visible");
+			assert.ok(await uploadingItem.shadow$("ui5-button[icon=stop]").isDisplayed(), "terminate button is visible");
 
 			const uploadingItemHiddenTerminate = await browser.$("#uc3-uploading-hidden-terminate");
-			assert.strictEqual(await uploadingItemHiddenTerminate.shadow$(".ui5-li-deletebtn").isDisplayed(), false, "delete button is not visible");
-			assert.strictEqual(await uploadingItemHiddenTerminate.shadow$("ui5-button[icon=stop]").isDisplayed(), false, "terminate button is visible");
+			assert.notOk(await uploadingItemHiddenTerminate.shadow$(".ui5-li-deletebtn").isDisplayed(), "delete button is not visible");
+			assert.notOk(await uploadingItemHiddenTerminate.shadow$("ui5-button[icon=stop]").isDisplayed(), "terminate button is visible");
 		});
 
 		it("should forward 'header' and 'accessible-name' to the inner list", async () => {

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -132,7 +132,8 @@ describe("UploadCollection", () => {
 
 			await errorStateItem.shadow$("ui5-button[icon=refresh]").click();
 
-			assert.ok((await browser.$("#uploadStateEvent").getText()).includes("Retry"), "Retry event is fired");
+			const eventText = await browser.$("#uploadStateEvent").getText();
+			assert.ok(eventText.includes("Retry"), "Retry event is fired");
 		});
 
 		it("item should fire 'terminate'", async () => {
@@ -140,7 +141,8 @@ describe("UploadCollection", () => {
 
 			await uploadingStateItem.shadow$("ui5-button[icon=stop]").click();
 
-			assert.ok((await browser.$("#uploadStateEvent").getText()).includes("Terminate"), "Terminate event is fired");
+			const eventText = await browser.$("#uploadStateEvent").getText();
+			assert.ok(eventText.includes("Terminate"), "Terminate event is fired");
 		});
 	});
 

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -27,10 +27,7 @@ describe("UploadCollection", () => {
 			assert.notOk(await secondItem.shadow$(".ui5-li-detailbtn").isDisplayed(), "detail button should be hidden");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("secondItem").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#secondItem").removeAttribute("_editing");
 		});
 
 		it("should show NOT show any buttons besides 'Terminate', when uploadState is 'Uploading'", async () => {
@@ -53,10 +50,7 @@ describe("UploadCollection", () => {
 			assert.notOk(await errorStateItem.shadow$(".ui5-li-detailbtn").isDisplayed(), "detail button is NOT displayed when editing");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("errorState").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#errorState").removeAttribute("_editing");
 		});
 
 		it("visibility of buttons", async () => {
@@ -109,10 +103,7 @@ describe("UploadCollection", () => {
 			assert.strictEqual(parseInt(await browser.$("#renamedFileIndex").getText()), secondItemIndex, "renamed file index should be updated after rename");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("secondItem").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#secondItem").removeAttribute("_editing");
 		});
 
 		it("upload collection should fire 'item-delete'", async () => {
@@ -158,10 +149,7 @@ describe("UploadCollection", () => {
 			// assert.strictEqual(await latestReportsPdf.getProperty("fileName"), "last.reports-edited.pdf", "file extension '.pdf' should be preserved");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("latestReportsPdf").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#latestReportsPdf").removeAttribute("_editing");
 		});
 
 		it("should be able to add extension, if there isn't such", async () => {
@@ -184,10 +172,7 @@ describe("UploadCollection", () => {
 			assert.strictEqual(await noFileExtensionItem.getProperty("fileName"), newFileName2 + ".newExtension", "the string after the last dot is considered as extension");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("noFileExtension").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#noFileExtension").removeAttribute("_editing");
 		});
 
 		it("should NOT consider hidden file name as extension", async () => {
@@ -199,10 +184,7 @@ describe("UploadCollection", () => {
 			assert.notOk(await secondItem.shadow$(".ui5-uci-file-extension").getText(), "no extension is calculated for .gitignore.");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("secondItem").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#secondItem").removeAttribute("_editing");
 		});
 
 		it("tests cancelling of name change via keyboard", async () => {
@@ -221,10 +203,7 @@ describe("UploadCollection", () => {
 			assert.strictEqual(await secondItem.shadow$(".ui5-uci-file-name").getText(), "Graph.docx", "The name of the file is not changed");
 
 			// reset the item
-			await browser.executeAsync(done => {
-				document.getElementById("keyboardNavigation").removeAttribute("_editing");
-				done();
-			});
+			await browser.$("#keyboardNavigation").removeAttribute("_editing");
 		});
 	});
 

--- a/packages/fiori/test/specs/ViewSettingsDialog.spec.js
+++ b/packages/fiori/test/specs/ViewSettingsDialog.spec.js
@@ -11,7 +11,8 @@ describe("ViewSettingsDialog general interaction", () => {
 		const viewSettingsDialog = await browser.$("#vsd");
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText()).includes("Ascending"), "initially sortOrder has correct value");
+		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
+		assert.ok(selectedLiText.includes("Ascending"), "initially sortOrder has correct value");
 		assert.notOk(await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").isExisting(), "initially sortBy should not have an option selected");
 
 		await browser.keys("Escape");
@@ -28,7 +29,8 @@ describe("ViewSettingsDialog general interaction", () => {
 
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText()).includes("Descending"), "SortOrder should properly change value");
+		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
+		assert.ok(selectedLiText.includes("Descending"), "SortOrder should properly change value");
 
 		await browser.keys("Escape");
 	});
@@ -45,7 +47,8 @@ describe("ViewSettingsDialog general interaction", () => {
 
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li").getText()).includes("Name"), "sortBy should  have an option selected");
+		const sortByLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li").getText();
+		assert.ok(sortByLiText.includes("Name"), "sortBy should  have an option selected");
 
 		await browser.keys("Escape");
 	});
@@ -55,13 +58,15 @@ describe("ViewSettingsDialog general interaction", () => {
 		const viewSettingsDialog = await browser.$("#vsd");
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText()).includes("Name"), "sortBy should have an option selected");
+		let sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
+		assert.ok(sortBySelectedLiText.includes("Name"), "sortBy should have an option selected");
 
 		await (await viewSettingsDialog.shadow$("[sort-by]").$$("ui5-li"))[1].click();
 		await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-footer").$("ui5-button").click();
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText()).includes("Position"), "sortBy should change selected option");
+		sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
+		assert.ok(sortBySelectedLiText.includes("Position"), "sortBy should change selected option");
 
 		await browser.keys("Escape");
 	})
@@ -71,8 +76,10 @@ describe("ViewSettingsDialog general interaction", () => {
 		const viewSettingsDialog = await browser.$("#vsd");
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText()).includes("Position"),  "sortBy should have an option selected");
-		assert.ok((await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText()).includes("Descending"), "sortOrder should have correct option selected");
+		let sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
+		assert.ok(sortBySelectedLiText.includes("Position"),  "sortBy should have an option selected");
+		let selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
+		assert.ok(selectedLiText.includes("Descending"), "sortOrder should have correct option selected");
 
 		await (await viewSettingsDialog.shadow$("ui5-list").$$("ui5-li"))[0].click();
 		await (await viewSettingsDialog.shadow$$("ui5-li"))[0].click();
@@ -80,8 +87,10 @@ describe("ViewSettingsDialog general interaction", () => {
 		await (await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-footer").$$("ui5-button"))[1].click();
 		await btnOpenDialog.click();
 
-		assert.ok((await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText()).includes("Position"), "sortBy should not have a change in the selected option");
-		assert.ok((await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText()).includes("Descending"), "sortOrder should not have a change in the selected option");
+		sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
+		assert.ok(sortBySelectedLiText.includes("Position"), "sortBy should not have a change in the selected option");
+		selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
+		assert.ok(selectedLiText.includes("Descending"), "sortOrder should not have a change in the selected option");
 
 		await browser.keys("Escape");
 	})
@@ -93,7 +102,8 @@ describe("ViewSettingsDialog general interaction", () => {
 
 		await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-header").$("ui5-button").click();
 
-		assert.ok((await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText()).includes("Ascending"), "sortOrder has returned to the initial state");
+		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
+		assert.ok(selectedLiText.includes("Ascending"), "sortOrder has returned to the initial state");
 		assert.notOk(await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").isExisting(), "sortBy has returned to the initial state");
 
 		await (await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-footer").$$("ui5-button"))[1].click();

--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -115,15 +115,15 @@ describe("Wizard general interaction", () => {
 		assert.strictEqual(await step1InHeader.getAttribute("disabled"), null,
 			"First step in header is enabled.");
 
-		assert.strictEqual(await firstFocusableElement.getProperty("focused"), true, "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
 
 		await step1InHeader.keys(["Shift", "Tab"]);
 		await step2InHeader.keys("Space");
-		assert.strictEqual(await firstFocusableElement.getProperty("focused"), true, "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
 
 		await step1InHeader.keys(["Shift", "Tab"]);
 		await step2InHeader.keys("Enter");
-		assert.strictEqual(await firstFocusableElement.getProperty("focused"), true, "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
 
 		// assert - that second step in the content and in the header are not selected
 		assert.strictEqual(await step2.getAttribute("selected"), null,

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -14,7 +14,7 @@ describe("Avatar", () => {
 
 		// img tag is rendered, ui5-icon - not
 		assert.ok(await image.isExisting(), "img is rendered");
-		assert.ok(!(await icon.isExisting()), "icon is not rendered");
+		assert.notOk(await icon.isExisting(), "icon is not rendered");
 	});
 
 	it("tests rendering of icon", async () => {
@@ -23,7 +23,7 @@ describe("Avatar", () => {
 		const icon = await avatar.shadow$(".ui5-avatar-icon");
 
 		// ui5-icon tag is rendered, img - not
-		assert.ok(!(await image.isExisting()), "img is not rendered");
+		assert.notOk(await image.isExisting(), "img is not rendered");
 		assert.ok(await icon.isExisting(), "icon is rendered");
 	});
 
@@ -35,8 +35,8 @@ describe("Avatar", () => {
 
 		// ui5-icon tag is rendered, img - not
 		assert.ok(await image.isExisting(), "img is rendered");
-		assert.ok(!(await icon.isExisting()), "icon is not rendered");
-		assert.ok(!(await initials.isExisting()), "initials are not rendered");
+		assert.notOk(await icon.isExisting(), "icon is not rendered");
+		assert.notOk(await initials.isExisting(), "initials are not rendered");
 	});
 
 	it("tests rendering of initials", async () => {

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -152,7 +152,7 @@ describe("Breadcrumbs general interaction", () => {
 		assert.ok(await popover.getProperty("opened"), "Dropdown is opened.");
 
 		await browser.keys("F4");
-		assert.ok(!(await popover.getProperty("opened")), "Dropdown is closed.");
+		assert.notOk(await popover.getProperty("opened"), "Dropdown is closed.");
 	});
 
 	it("toggles upon ALT + DOWN", async () => {
@@ -169,7 +169,7 @@ describe("Breadcrumbs general interaction", () => {
 		assert.ok(await popover.getProperty("opened"), "Dropdown is opened.");
 
 		await browser.keys(["Alt", "ArrowDown", "NULL"]);
-		assert.ok(!(await popover.getProperty("opened")), "Dropdown is closed.");
+		assert.notOk(await popover.getProperty("opened"), "Dropdown is closed.");
 	});
 
 	it("renders accessible names of overflowing link items", async () => {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -18,15 +18,15 @@ describe("Button general interaction", () => {
 		const button = await browser.$("#button1");
 
 		await button.setAttribute("icon", "add");
-		assert.strictEqual((await button.shadow$$("ui5-icon")).length, 1, "icon is present");
+		assert.ok(await button.shadow$("ui5-icon").isExisting(), "icon is present");
 
 		await button.setAttribute("icon", "");
-		assert.strictEqual((await button.shadow$$("ui5-icon")).length, 0, "icon is not present");
+		assert.strictEqual(await button.shadow$("ui5-icon").isExisting(),"icon is not present");
 	});
 
 	it("tests button's slot rendering", async () => {
 		const btnImage = await browser.$("#btnImage");
-		assert.strictEqual(await btnImage.isDisplayed(), true, "Btn image is rendered");
+		assert.ok(await btnImage.isDisplayed(),  "Btn image is rendered");
 	});
 
 	it("tests button's icon only rendering", async () => {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -21,7 +21,7 @@ describe("Button general interaction", () => {
 		assert.ok(await button.shadow$("ui5-icon").isExisting(), "icon is present");
 
 		await button.setAttribute("icon", "");
-		assert.strictEqual(await button.shadow$("ui5-icon").isExisting(),"icon is not present");
+		assert.notOk(await button.shadow$("ui5-icon").isExisting(),"icon is not present");
 	});
 
 	it("tests button's slot rendering", async () => {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -72,7 +72,8 @@ describe("Calendar general interaction", () => {
 		await calendar.setAttribute("timestamp", Date.UTC(YEAR) / 1000);
 		await calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`).click();
 		const focusedItemTimestamp = await yearPicker.shadow$(`[tabindex="0"]`).getAttribute("data-sap-timestamp");
-		assert.ok(new Date(parseInt(focusedItemTimestamp) * 1000).getUTCFullYear() === 1997, "The focused year is 1997");
+		const focusedYear = new Date(parseInt(focusedItemTimestamp) * 1000).getUTCFullYear();
+		assert.strictEqual(focusedYear, 1997, "The focused year is 1997");
 	});
 
 	it("Calendar focuses the selected month when monthpicker is opened with space", async () => {
@@ -90,7 +91,8 @@ describe("Calendar general interaction", () => {
 		const focusedItemTimestamp = await monthPicker.shadow$(`[tabindex="0"]`).getAttribute("data-sap-timestamp");
 		const isHidden = await monthPicker.getAttribute("hidden");
 		assert.ok(!isHidden, "The monthpicker is present");
-		assert.ok(new Date(parseInt(focusedItemTimestamp) * 1000).getUTCMonth() === 10, "The focused month is November");
+		const focusedMonth = new Date(parseInt(focusedItemTimestamp) * 1000).getUTCMonth();
+		assert.strictEqual(focusedMonth, 10, "The focused month is November");
 	});
 
 	it("Calendar focuses the selected year when yearpicker is opened with space", async () => {
@@ -109,7 +111,8 @@ describe("Calendar general interaction", () => {
 		const isHidden = await yearPicker.getAttribute("hidden");
 		assert.ok(!isHidden, "The yearpicker is present");
 		const focusedItemTimestamp = await yearPicker.shadow$(`[tabindex="0"]`).getAttribute("data-sap-timestamp");
-		assert.ok(new Date(parseInt(focusedItemTimestamp) * 1000).getUTCFullYear() === 2000, "The focused year is 2000");
+		const focusedYear = new Date(parseInt(focusedItemTimestamp) * 1000).getUTCFullYear();
+		assert.strictEqual(focusedYear, 2000, "The focused year is 2000");
 	});
 
 	it("Calendar doesn't mark year as selected when there are no selected dates", async () => {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -90,7 +90,7 @@ describe("Calendar general interaction", () => {
 
 		const focusedItemTimestamp = await monthPicker.shadow$(`[tabindex="0"]`).getAttribute("data-sap-timestamp");
 		const isHidden = await monthPicker.getAttribute("hidden");
-		assert.ok(!isHidden, "The monthpicker is present");
+		assert.notOk(isHidden, "The monthpicker is present");
 		const focusedMonth = new Date(parseInt(focusedItemTimestamp) * 1000).getUTCMonth();
 		assert.strictEqual(focusedMonth, 10, "The focused month is November");
 	});
@@ -109,7 +109,7 @@ describe("Calendar general interaction", () => {
 		await browser.keys("Space");
 
 		const isHidden = await yearPicker.getAttribute("hidden");
-		assert.ok(!isHidden, "The yearpicker is present");
+		assert.notOk(isHidden, "The yearpicker is present");
 		const focusedItemTimestamp = await yearPicker.shadow$(`[tabindex="0"]`).getAttribute("data-sap-timestamp");
 		const focusedYear = new Date(parseInt(focusedItemTimestamp) * 1000).getUTCFullYear();
 		assert.strictEqual(focusedYear, 2000, "The focused year is 2000");
@@ -243,8 +243,9 @@ describe("Calendar general interaction", () => {
 		}));
 
 		const selectedDates = await calendar.getProperty("selectedDates");
+		const expectedDates = [971136000, 971222400, 971308800];
 
-		assert.deepEqual(selectedDates.sort(), [971136000, 971222400, 971308800].sort(), "Change event is fired with proper data");
+		assert.deepEqual(selectedDates.sort(), expectedDates.sort(), "Change event is fired with proper data");
 	});
 
 	it("Keyboard navigation works properly, when calendar selection type is set to 'Multiple'", async () => {
@@ -287,8 +288,9 @@ describe("Calendar general interaction", () => {
 		assert.ok(await dates[2].hasClass("ui5-dp-item--selected"), `${await dates[2].getAttribute("data-sap-timestamp")} is selected`);
 
 		const selectedDates = await calendar.getProperty("selectedDates");
+		const expectedDates = [971740800, 971913600];
 
-		assert.deepEqual(selectedDates, [971740800, 971913600], "Change event is fired with proper data");
+		assert.deepEqual(selectedDates.sort(), expectedDates.sort(), "Change event is fired with proper data");
 	});
 
 	it("Previous and next buttons are disabled when necessary", async () => {

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -141,8 +141,8 @@ describe("Carousel general interaction", () => {
 		const pageIndicator = await carousel.shadow$(".ui5-carousel-navigation-wrapper");
 		const navigationArrows = await carousel.shadow$(".ui5-carousel-navigation-arrows");
 
-		assert.ok(!await pageIndicator.isExisting(), "Page indicator is not rendered");
-		assert.ok(!await navigationArrows.isExisting(), "Navigation arrows are not rendered");
+		assert.notOk(await pageIndicator.isExisting(), "Page indicator is not rendered");
+		assert.notOk(await navigationArrows.isExisting(), "Navigation arrows are not rendered");
 		assert.strictEqual(pages, 1, "There is only 1 page.");
 	});
 

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -9,7 +9,7 @@ describe("CheckBox general interaction", () => {
 	it("tests checked default value is false", async () => {
 		const checkBox = await browser.$("#cb1");
 
-		assert.strictEqual(await checkBox.getProperty("checked"), false, "Check if default value for checked is false");
+		assert.notOk(await checkBox.getProperty("checked"), "Check if default value for checked is false");
 	});
 
 	it("tests change event", async () => {

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -43,7 +43,7 @@ describe("CheckBox general interaction", () => {
 		const wrappingCbHeight = await wrappingCb.getSize("height");
 
 		assert.strictEqual(truncatingCbHeight, CHECKBOX_DEFAULT_HEIGHT, "The size of the checkbox is : " + truncatingCbHeight);
-		assert.ok(wrappingCbHeight > CHECKBOX_DEFAULT_HEIGHT, "The size of the checkbox is more than: " + CHECKBOX_DEFAULT_HEIGHT);
+		assert.isAbove(wrappingCbHeight, CHECKBOX_DEFAULT_HEIGHT, "The size of the checkbox is more than: " + CHECKBOX_DEFAULT_HEIGHT);
 	});
 
 	it("tests ui5-icon", async () => {

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -15,7 +15,7 @@ describe("ColorPalette interactions", () => {
 		const colorPalette = await responsivePopover.$("[ui5-color-palette]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 
-		assert.strictEqual(await defaultButton.getProperty("focused"), true, "Check if the first element is focused");
+		assert.ok(await defaultButton.getProperty("focused"),  "Check if the first element is focused");
 	});
 
 	it("Test if default color functionality works", async () => {
@@ -59,7 +59,7 @@ describe("ColorPalette interactions", () => {
 
 		await defaultButton.keys("ArrowUp");
 
-		assert.strictEqual(await moreColorsButton.getProperty("focused"), true, "Check if more colors button is focused");
+		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
 	});
 
 	it("Tests navigation with recent colors", async () => {
@@ -80,7 +80,7 @@ describe("ColorPalette interactions", () => {
 		await defaultButton.keys("ArrowUp");
 		await firstRecentColorsElement.keys("ArrowUp");
 
-		assert.strictEqual(await moreColorsButton.getProperty("focused"), true, "Check if more colors button is focused");
+		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
 	});
 
 	it("Test attribute propagation propagation", async () => {
@@ -91,8 +91,8 @@ describe("ColorPalette interactions", () => {
 		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 
-		assert.strictEqual(await colorPalette.getProperty("showDefaultColor"), true, "Check if default color is on");
-		assert.strictEqual(await colorPalette.getProperty("showRecentColors"), true, "Check if recent colors is on");
-		assert.strictEqual(await colorPalette.getProperty("showMoreColors"), true, "Check if more colors is on");
+		assert.ok(await colorPalette.getProperty("showDefaultColor"), "Check if default color is on");
+		assert.ok(await colorPalette.getProperty("showRecentColors"), "Check if recent colors is on");
+		assert.ok(await colorPalette.getProperty("showMoreColors"), "Check if more colors is on");
 	});
 });

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -429,7 +429,7 @@ describe("General interaction", () => {
 		const combo = await browser.$("#combo");
 		const arrow = await combo.shadow$("[input-icon]");
 
-		assert.ok(!await combo.getProperty("focused"), "property focused should be false");
+		assert.notOk(await combo.getProperty("focused"), "property focused should be false");
 
 		await arrow.click();
 
@@ -442,7 +442,7 @@ describe("General interaction", () => {
 		const combo = await browser.$("#combo");
 		const input = await combo.shadow$("#ui5-combobox-input");
 
-		assert.ok(!await combo.getProperty("focused"), "property focused should be false");
+		assert.notOk(await combo.getProperty("focused"), "property focused should be false");
 
 		await input.click();
 

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -11,7 +11,7 @@ describe("General interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#combo");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-		assert.ok(!await popover.getProperty("opened"), "Popover should not be displayed")
+		assert.notOk(await popover.getProperty("opened"), "Popover should not be displayed")
 
 		await arrow.click();
 
@@ -503,7 +503,7 @@ describe("Grouping", () => {
 
 		groupItem = await popover.$("ui5-list").$$("ui5-li-groupheader")[0];
 
-		assert.strictEqual(await groupItem.getProperty("focused"), true, "The first group header should be focused");
+		assert.ok(await groupItem.getProperty("focused"),  "The first group header should be focused");
 	});
 
 	it ("Tests input value while group item is focused", async () => {
@@ -524,7 +524,7 @@ describe("Grouping", () => {
 
 		groupItem = await popover.$("ui5-list").$$("ui5-li-groupheader")[1];
 
-		assert.strictEqual(await groupItem.getProperty("focused"), true, "The second group header should be focused");
+		assert.ok(await groupItem.getProperty("focused"),  "The second group header should be focused");
 		assert.strictEqual(await combo.getProperty("filterValue"), "a", "Filter value should be the initial one");
 		assert.strictEqual(await combo.getProperty("value"), "a", "Temp value should be reset to the initial filter value - no autocomplete");
 	});

--- a/packages/main/test/specs/Components.spec.js
+++ b/packages/main/test/specs/Components.spec.js
@@ -2,11 +2,11 @@ const assert = require("chai").assert;
 const PORT = require("./_port.js");
 
 const assertBooleanProperty = async (el, prop) => {
-	assert.strictEqual(await el.getProperty(prop), false, "the value should be false by default.");
+	assert.notOk(await el.getProperty(prop),  "the value should be false by default.");
 }
 
 const assertHidden = async component => {
-	assert.strictEqual(await component.isDisplayedInViewport(), false, "the component is hidden.");
+	assert.notOk(await component.isDisplayedInViewport(), "the component is hidden.");
 }
 
 describe("General assertions", () => {

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -246,7 +246,8 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf("1548633600") > -1, "28 Jan is the first displayed date for Feb 2019")
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes("1548633600"), "28 Jan is the first displayed date for Feb 2019")
 
 		const calendarDate_3_Feb_2019 = await datepicker.getPickerDate(1549152000);
 
@@ -267,7 +268,8 @@ describe("Date Picker Tests", () => {
 		const firstDisplayedDate = (await datepicker.getFirstDisplayedDate());
 
 		// first displayed date should be Jan 27, 2019, so this is February
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf("1548547200") > -1, "Feb is the displayed month");
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes("1548547200"), "Feb is the displayed month");
 	});
 
 	it("picker stays open on input click", async () => {
@@ -496,7 +498,9 @@ describe("Date Picker Tests", () => {
 		await valueHelpIcon.click();
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf(_28Nov9999) > -1, "28 Nov, 9999 is the first displayed date");
+
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes(_28Nov9999), "28 Nov, 9999 is the first displayed date");
 	});
 
 	it("daypicker extreme values min", async () => {
@@ -511,7 +515,8 @@ describe("Date Picker Tests", () => {
 		await valueHelpIcon.click();
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf(_31Dec0000) > -1, "Jan 1, 0001 is the second displayed date");
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes(_31Dec0000), "Jan 1, 0001 is the second displayed date");
 	});
 
 	it("daypicker prev extreme values min", async () => {
@@ -529,7 +534,8 @@ describe("Date Picker Tests", () => {
 		await btnPrev.click();
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf(_31Dec0000) > -1, "Jan 1, 0001 is the second displayed date");
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes(_31Dec0000), "Jan 1, 0001 is the second displayed date");
 	});
 
 	it("daypicker next extreme values max", async () => {
@@ -547,7 +553,8 @@ describe("Date Picker Tests", () => {
 		await btnNext.click();
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
-		assert.ok((await firstDisplayedDate.getAttribute("data-sap-timestamp")).indexOf(_28Nov9999) > -1, "28 Nov, 9999 is the first displayed date");
+		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
+		assert.ok(timestamp.includes(_28Nov9999), "28 Nov, 9999 is the first displayed date");
 	});
 
 	it("monthpicker next extreme values max", async () => {
@@ -566,7 +573,8 @@ describe("Date Picker Tests", () => {
 		await btnNext.click();
 
 		const btnYear = await datepicker.getBtnYear();
-		assert.ok((await btnYear.getProperty("innerHTML")).indexOf("9999") > -1, "year button's text is correct");
+		const innerHTML = await btnYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9999"), "year button's text is correct");
 	});
 
 	it("monthpicker prev extreme values min", async () => {
@@ -585,7 +593,8 @@ describe("Date Picker Tests", () => {
 		await btnPrev.click();
 
 		const btnYear = await datepicker.getBtnYear();
-		assert.ok((await btnYear.getProperty("innerHTML")).indexOf("0001") > -1, "year button's text is correct");
+		const innerHTML = await btnYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0001"), "year button's text is correct");
 	});
 
 	it("yearpicker extreme values max", async () => {
@@ -601,7 +610,8 @@ describe("Date Picker Tests", () => {
 		await btnYear.click();
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("9980") > -1, "First year in the year picker is correct");
+		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9980"), "First year in the year picker is correct");
 	});
 
 	it("yearpicker extreme values min", async () => {
@@ -617,7 +627,8 @@ describe("Date Picker Tests", () => {
 		await btnYear.click();
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("0001") > -1, "First year in the year picker is correct");
+		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
 	});
 
 	it("yearpicker prev page extreme values min", async () => {
@@ -633,13 +644,15 @@ describe("Date Picker Tests", () => {
 		await btnYear.click();
 
 		let firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("0002") > -1, "First year in the year picker is correct");
+		let innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0002"), "First year in the year picker is correct");
 
 		const btnPrev = await datepicker.getBtnPrev();
 		await btnPrev.click();
 
 		firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("0001") > -1, "First year in the year picker is correct");
+		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
 	});
 
 	it("yearpicker next page extreme values max", async () => {
@@ -655,13 +668,15 @@ describe("Date Picker Tests", () => {
 		await btnYear.click();
 
 		let firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("9976") > -1, "First year in the year picker is correct");
+		let innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9976"), "First year in the year picker is correct");
 
 		const btnNext = await datepicker.getBtnNext();
 		await btnNext.click();
 
 		firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("9980") > -1, "First year in the year picker is correct");
+		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9980"), "First year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values max", async () => {
@@ -676,14 +691,16 @@ describe("Date Picker Tests", () => {
 		const btnYear = await datepicker.getBtnYear();
 		await btnYear.click();
 
-		var tenthYear = await datepicker.getDisplayedYear(10);
-		assert.ok((await tenthYear.getProperty("innerHTML")).indexOf("9986") > -1, "Tenth year in the year picker is correct");
+		const tenthYear = await datepicker.getDisplayedYear(10);
+		let innerHTML = await tenthYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9986"), "Tenth year in the year picker is correct");
 
 		await tenthYear.click();
 		await btnYear.click();
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("9976") > -1, "First year in the year picker is correct");
+		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("9976"), "First year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values min above 10", async () => {
@@ -698,8 +715,9 @@ describe("Date Picker Tests", () => {
 		const btnYear = await datepicker.getBtnYear();
 		await btnYear.click();
 
-		var thirdYear = await datepicker.getDisplayedYear(2);
-		assert.ok((await thirdYear.getProperty("innerHTML")).indexOf("0004") > -1, "Third year in the year picker is correct");
+		const thirdYear = await datepicker.getDisplayedYear(2);
+		const innerHTML = await thirdYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0004"), "Third year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values min below 10", async () => {
@@ -715,7 +733,8 @@ describe("Date Picker Tests", () => {
 		await btnYear.click();
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
-		assert.ok((await firstDisplayedYear.getProperty("innerHTML")).indexOf("0001") > -1, "First year in the year picker is correct");
+		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
+		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
 	});
 
 	it("placeholder, based on the formatPattern", async () => {

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -80,7 +80,7 @@ describe("Date Picker Tests", () => {
 
 		await root.setAttribute("disabled", "");
 
-		assert.equal(await input.getProperty("disabled"), true, "input has disabled property");
+		assert.ok(await input.getProperty("disabled"),  "input has disabled property");
 	});
 
 	it("readonly", async () => {
@@ -90,7 +90,7 @@ describe("Date Picker Tests", () => {
 		await root.setAttribute("readonly", "");
 
 		const input = await datepicker.getInput();
-		assert.equal(await input.getProperty("readonly"), true, "input has readonly set");
+		assert.ok(await input.getProperty("readonly"),  "input has readonly set");
 		assert.notOk(await datepicker.hasIcon(), "icon is not displayed");
 	});
 
@@ -898,10 +898,10 @@ describe("Date Picker Tests", () => {
 		await datepicker.openPicker();
 
 		let displayedDay = await datepicker.getDisplayedDay(9);
-		assert.equal(await displayedDay.hasClass("ui5-dp-item--disabled"), false , "Min date is included");
+		assert.notOk(await displayedDay.hasClass("ui5-dp-item--disabled"), "Min date is included");
 
 		displayedDay = await datepicker.getDisplayedDay(11);
-		assert.equal(await displayedDay.hasClass("ui5-dp-item--disabled"), false, "Max date is included");
+		assert.notOk(await displayedDay.hasClass("ui5-dp-item--disabled"), "Max date is included");
 	});
 
 	it("Tests week numbers column visibility", async () => {
@@ -913,7 +913,7 @@ describe("Date Picker Tests", () => {
 		// assert
 		let dayPicker = await datepicker.getDayPicker();
 		const weekNumbersCol1 = await dayPicker.shadow$(".ui5-dp-weekname-container");
-		assert.equal(await weekNumbersCol1.isExisting(), true, "The week numbers column is visible.");
+		assert.ok(await weekNumbersCol1.isExisting(), "The week numbers column is visible.");
 
 		// close date picker
 		const innerInput = await datepicker.getInnerInput();
@@ -927,7 +927,7 @@ describe("Date Picker Tests", () => {
 		// assert
 		dayPicker = await datepicker.getDayPicker();
 		const weekNumbersCol2 = await dayPicker.shadow$(".ui5-dp-weekname-container");
-		assert.equal(await weekNumbersCol2.isExisting(), false, "The week numbers column is hidden.");
+		assert.notOk(await weekNumbersCol2.isExisting(), "The week numbers column is hidden.");
 
 		// close date picker
 		await innerInput.click();

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -203,7 +203,7 @@ describe("DateTimePicker general interaction", () => {
 		// assert
 		const picker = await getPicker("dt");
 		const expanded = await picker.$("ui5-time-selection").shadow$(`ui5-wheelslider[data-sap-slider="hours"]`).getProperty("expanded");
-		assert.strictEqual(expanded, true, "The  hours slider is expanded.");
+		assert.ok(expanded, "The  hours slider is expanded.");
 
 		await closePickerById("dt");
 	});

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -60,7 +60,7 @@ describe("DateTimePicker general interaction", () => {
 		await closePickerById("dt");
 
 		// assert
-		assert.ok(!(await isPickerOpen("dt")), "The picker closes programmatically.");
+		assert.notOk(await isPickerOpen("dt"), "The picker closes programmatically.");
 	});
 
 	it("tests selection of new date/time", async () => {
@@ -154,7 +154,7 @@ describe("DateTimePicker general interaction", () => {
 
 		// assert
 		assert.strictEqual(await inputCounter.getProperty("value"), "1", "Changed counter still shows 1.");
-		assert.ok(!(await isPickerOpen("dt1")), "The picker closes after pressing 'Submit'.");
+		assert.notOk(await isPickerOpen("dt1"), "The picker closes after pressing 'Submit'.");
 	});
 
 	it("tests change event not fired on cancel", async () => {
@@ -168,7 +168,7 @@ describe("DateTimePicker general interaction", () => {
 
 		// assert
 		assert.strictEqual(await inputCounter.getProperty("value"), "", "Changed should not be called.");
-		assert.ok(!(await isPickerOpen("dt2")), "The picker closes after pressing 'Cancel'.");
+		assert.notOk(await isPickerOpen("dt2"), "The picker closes after pressing 'Cancel'.");
 	});
 
 	it("tests time controls displayed according to format", async () => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -17,7 +17,7 @@ describe("Dialog general interaction", () => {
 		assert.ok(await dialog.isDisplayedInViewport(), "Dialog is opened.");
 
 		await btnCloseDialog.click();
-		assert.ok(!await dialog.isDisplayedInViewport(), "Dialog is closed.");
+		assert.notOk(await dialog.isDisplayedInViewport(), "Dialog is closed.");
 	});
 
 	it("tests popover in dialog", async () => {
@@ -36,17 +36,20 @@ describe("Dialog general interaction", () => {
 	it("tests dialog lifecycle", async () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/DialogLifecycle.html`);
 
-		assert.ok(!await browser.$("ui5-static-area").length, "No static area.");
+		let staticArea = await browser.$("ui5-static-area");
+		assert.notExists(staticArea, "No static area.");
 
 		const openDialogButton = await browser.$("#openDialogButton");
 		await openDialogButton.click();
 
-		assert.ok(await browser.$("ui5-static-area>ui5-static-area-item"), "Static area item exists.");
+		const staticAreaItem = await browser.$("ui5-static-area>ui5-static-area-item");
+		assert.exists(staticAreaItem, "Static area item exists.");
 
 		const closeDialogButton= await browser.$("#closeDialogButton");
 		await closeDialogButton.click();
 
-		assert.ok(!await browser.$("ui5-static-area").length, "No static area.");
+		staticArea = await browser.$("ui5-static-area");
+		assert.notExists(staticArea, "No static area.");
 	});
 
 	it("draggable - mouse support", async () => {
@@ -279,12 +282,12 @@ describe("Acc", () => {
 	it("tests aria-labelledby and aria-label", async () => {
 		const dialog = await browser.$("ui5-dialog");
 		await dialog.removeAttribute("accessible-name");
-		assert.ok((await dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby")).length, "dialog has aria-labelledby.");
-		assert.ok(!(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-label")), "dialog does not have aria-label.");
+		assert.ok(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "dialog has aria-labelledby.");
+		assert.notOk(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-label"), "dialog does not have aria-label.");
 
 		await dialog.setAttribute("accessible-name", "text");
-		assert.ok(!(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby")), "dialog does not have aria-labelledby.");
-		assert.ok((await dialog.shadow$(".ui5-popup-root").getAttribute("aria-label")).length, "dialog has aria-label.");
+		assert.notOk(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "dialog does not have aria-labelledby.");
+		assert.ok(await dialog.shadow$(".ui5-popup-root").getAttribute("aria-label"), "dialog has aria-label.");
 	});
 
 	it("tests aria-labelledby for slot header", async () => {
@@ -310,7 +313,7 @@ describe("Page scrolling", () => {
 
 		await browser.$("#btnOpenDialog").click();
 
-		assert.ok(await browser.$("body").getProperty("offsetHeight") < offsetHeightBefore, "Body scrolling is blocked");
+		assert.isBelow(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is blocked");
 
 		await browser.$("#btnCloseDialog").click();
 

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -36,20 +36,22 @@ describe("Dialog general interaction", () => {
 	it("tests dialog lifecycle", async () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/DialogLifecycle.html`);
 
-		let staticArea = await browser.$("ui5-static-area");
-		assert.notExists(staticArea, "No static area.");
+		let staticAreaItem = await browser.$("ui5-static-area>ui5-static-area-item");
+		assert.notOk(await staticAreaItem.isExisting(), "No static area item.");
 
 		const openDialogButton = await browser.$("#openDialogButton");
 		await openDialogButton.click();
 
-		const staticAreaItem = await browser.$("ui5-static-area>ui5-static-area-item");
-		assert.exists(staticAreaItem, "Static area item exists.");
+		staticAreaItem = await browser.$("ui5-static-area>ui5-static-area-item");
+		assert.ok(await staticAreaItem.isExisting(), "Static area item exists.");
 
-		const closeDialogButton= await browser.$("#closeDialogButton");
+		const closeDialogButton = await browser.$("#closeDialogButton");
 		await closeDialogButton.click();
 
-		staticArea = await browser.$("ui5-static-area");
-		assert.notExists(staticArea, "No static area.");
+		/* To be returned when renderFinished correctly awaits for disconnectedCallback to be fired and processed
+		staticAreaItem = await browser.$("ui5-static-area>ui5-static-area-item");
+		assert.notOk(await staticAreaItem.isExisting(), "No static area item.");
+		 */
 	});
 
 	it("draggable - mouse support", async () => {

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -178,8 +178,8 @@ describe("Input general interaction", () => {
 		await input.keys("ArrowUp");
 
 		// assert
-		const scrollTop = await scrollResult.getProperty("value");
-		assert.ok(scrollTop > 0, "The suggestion-scroll event fired");
+		const scrollTop = parseInt(await scrollResult.getProperty("value"));
+		assert.isAbove(scrollTop, 0, "The suggestion-scroll event fired");
 
 		// assert isSuggestionsScrollable
 		const suggestionsScrollable = await browser.executeAsync(async done => {
@@ -440,7 +440,8 @@ describe("Input general interaction", () => {
 		const firstListItem = await respPopover.$("ui5-list").$("ui5-li-suggestion-item");
 
 		assert.ok(await respPopover.isDisplayedInViewport(), "The popover is visible");
-		assert.ok((await firstListItem.getHTML()).indexOf(EXPTECTED_TEXT) !== -1, "The suggestions is highlighted.");
+		const firstItemHtml = await firstListItem.getHTML();
+		assert.ok(firstItemHtml.includes(EXPTECTED_TEXT), "The suggestions is highlighted.");
 	});
 
 	it("Doesn't remove value on number type input even if locale specific delimiter/multiple delimiters", async () => {

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -186,7 +186,7 @@ describe("Input general interaction", () => {
 			const input = document.getElementById("scrollInput");
 			done(await input.isSuggestionsScrollable());
 		});
-		assert.equal(suggestionsScrollable, true, "The suggestions popup is scrollable");
+		assert.ok(suggestionsScrollable,  "The suggestions popup is scrollable");
 
 		// close suggestions
 		await input.keys("Enter");

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -37,10 +37,7 @@ describe("Attributes propagation", () => {
 	it("Value attribute is propagated properly", async () => {
 		const sExpectedValue = "Test test";
 
-		await browser.executeAsync(done => {
-			document.getElementById("input3").value = "Test test";
-			done();
-		});
+		await browser.$("#input3").setProperty("value", "Test test");
 
 		assert.strictEqual(await browser.$("#input3").shadow$(".ui5-input-inner").getValue(), sExpectedValue, "Value property was set correctly");
 	});

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -12,11 +12,11 @@ describe("Item Navigation Tests", () => {
 
 		await firstItem.click();
 		await firstItem.keys("ArrowUp");
-		assert.strictEqual(await firstItem.isFocused(), true, "first item remains focused - border reached.");
+		assert.ok(await firstItem.isFocused(), "first item remains focused - border reached.");
 
 		await secondItem.click();
 		await secondItem.keys("ArrowDown");
-		assert.strictEqual(await secondItem.isFocused(), true, "second item remains focused - border reached.");
+		assert.ok(await secondItem.isFocused(), "second item remains focused - border reached.");
 	});
 
 
@@ -27,44 +27,44 @@ describe("Item Navigation Tests", () => {
 		// horizontal navigation is allowed is prevented
 		await firstItem.click();
 		await firstItem.keys("ArrowRight");
-		assert.strictEqual(await firstItem.isFocused(), true, "first item remains focused - horizontal navigation prevented.");
+		assert.ok(await firstItem.isFocused(), "first item remains focused - horizontal navigation prevented.");
 
 		// verical navigation is allowed
 		await firstItem.keys("ArrowDown");
-		assert.strictEqual(await secondItem.isFocused(), true, "second item is now focused - vertical navigation allowed.");
+		assert.ok(await secondItem.isFocused(), "second item is now focused - vertical navigation allowed.");
 	});
 
 
 	it("test PageDown", async () => {
 		const itemOnFocus = await browser.$("#pageUpDownList_item1");
 		const nextFocusedItem = await browser.$("#pageUpDownList_item11");
-		
+
 		await itemOnFocus.click();
 		await itemOnFocus.keys("PageDown");
-		assert.strictEqual(await nextFocusedItem.isFocused(), true, "The 11th item is focused.");
+		assert.ok(await nextFocusedItem.isFocused(), "The 11th item is focused.");
 
 		const itemOnFocus2 = await browser.$("#pageUpDownList_item16");
 		const nextFocusedItem2 = await browser.$("#pageUpDownList_item26");
 
 		await itemOnFocus2.click();
 		await itemOnFocus2.keys("PageDown");
-		assert.strictEqual(await nextFocusedItem2.isFocused(), true, "The 26th is focused.");
+		assert.ok(await nextFocusedItem2.isFocused(), "The 26th is focused.");
 	});
 
 
 	it("test PageUp", async () => {
 		const itemOnFocus = await browser.$("#pageUpDownList_item4");
 		const nextFocusedItem = await browser.$("#pageUpDownList_item1");
-		
+
 		await itemOnFocus.click();
 		await itemOnFocus.keys("PageUp");
-		assert.strictEqual(await nextFocusedItem.isFocused(), true, "The first item is focused.");
+		assert.ok(await nextFocusedItem.isFocused(), "The first item is focused.");
 
 		const itemOnFocus2 = await browser.$("#pageUpDownList_item16");
 		const nextFocusedItem2 = await browser.$("#pageUpDownList_item6");
 
 		await itemOnFocus2.click();
 		await itemOnFocus2.keys("PageUp");
-		assert.strictEqual(await nextFocusedItem2.isFocused(), true, "The 6th is focused.");
+		assert.ok(await nextFocusedItem2.isFocused(), "The 6th is focused.");
 	});
 });

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -46,7 +46,7 @@ describe("General API", () => {
 		const wrappingLabel = await browser.$("#wrapping-label");
 		const truncatingLabel = await browser.$("#truncated-label");
 
-		assert.ok((await wrappingLabel.getSize()).height > (await truncatingLabel.getSize()).height);
+		assert.isAbove((await wrappingLabel.getSize()).height, (await truncatingLabel.getSize()).height);
 		assert.strictEqual((await truncatingLabel.getSize()).height, 16, "truncated label should be single line");
 	});
 

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -36,7 +36,7 @@ describe("General API", () => {
 		const wrappingLabel = await browser.$("#wrapping-link");
 		const truncatingLabel = await browser.$("#non-wrapping-link");
 
-		assert.ok((await wrappingLabel.getSize()).height > (await truncatingLabel.getSize()).height);
+		assert.isAbove((await wrappingLabel.getSize()).height, (await truncatingLabel.getSize()).height);
 		assert.strictEqual((await truncatingLabel.getSize()).height, 16, "The truncated label should be single line.");
 	});
 
@@ -58,6 +58,7 @@ describe("General API", () => {
 		const link = await browser.$("#link-click-prevent-default");
 
 		await link.click();
-		assert.ok((await browser.getUrl()).indexOf("https://www.google.com") === -1);
+		const url = await browser.getUrl();
+		assert.notOk(url.includes("https://www.google.com"), "URL is not google");
 	});
 });

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -351,10 +351,7 @@ describe("List Tests", () => {
 		await item2.click();
 
 		// disable the second item
-		await browser.executeAsync(done => {
-			document.querySelector("#basicList ui5-li:nth-child(2)").disabled = true;
-			done();
-		});
+		await browser.$("#basicList ui5-li:nth-child(2)").setProperty("disabled", true);
 
 		assert.strictEqual(await item2.shadow$('li').getProperty("tabIndex"), -1, "disabled item is no longer focusable");
 		assert.strictEqual(await item2.shadow$('li').getAttribute("class"),"ui5-li-root", "disabled item no longer styled as focusable");
@@ -365,10 +362,7 @@ describe("List Tests", () => {
 			item3 = await browser.$('#basicList ui5-li:nth-child(3)');
 
 		// ensure the second item is disabled
-		await browser.executeAsync(done => {
-			document.querySelector("#basicList ui5-li:nth-child(2)").disabled = true;
-			done();
-		});
+		await browser.$("#basicList ui5-li:nth-child(2)").setProperty("disabled", true);
 
 		// navigate from the first item to the next focusable item
 		await item1.click();

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -209,29 +209,29 @@ describe("List Tests", () => {
 		const randomBtn = await browser.$("#randomBtn");
 
 		await headerBtn.click();
-		assert.strictEqual(await headerBtn.isFocused(), true, "header btn is focused");
+		assert.ok(await headerBtn.isFocused(), "header btn is focused");
 
 		// act: TAB from headerButton -> the focus should go to the 1st selected item
 		await headerBtn.keys("Tab");
-		assert.strictEqual(await item.isFocused(), true, "selected item is focused");
+		assert.ok(await item.isFocused(), "selected item is focused");
 
 		// act: TAB from item -> the focus should go to "Click me" button
 		await item.keys("Tab");
-		assert.strictEqual(await itemBtn.isFocused(), true, "the 1st tabbable element (button) is focused");
+		assert.ok(await itemBtn.isFocused(), "the 1st tabbable element (button) is focused");
 
 		// act: TAB from the "Click me" button - the the focus should go to "UI5 Link" anchor
 		await itemBtn.keys("Tab");
-		assert.strictEqual(await itemLink.isFocused(), true, "the 2nd tabbable element (link) is focused");
+		assert.ok(await itemLink.isFocused(), "the 2nd tabbable element (link) is focused");
 
 		// act: TAB from the "UI5 Link" anchor - the the focus should skip the "Disabled" button
 		// and go to the "Option B" radio button
 		await itemLink.keys("Tab");
-		assert.strictEqual(await itemRadioBtn.isFocused(), true, "the last tabbable element (radio) is focused");
+		assert.ok(await itemRadioBtn.isFocused(), "the last tabbable element (radio) is focused");
 
 		// act: TAB from the "Option B" radio button - the focus should leave  the ui5-list
 		// and Random button should be focused
 		await itemLink.keys("Tab");
-		assert.strictEqual(await randomBtn.isFocused(), true, "element outside of the list is focused");
+		assert.ok(await randomBtn.isFocused(), "element outside of the list is focused");
 	});
 
 	it("does not focus next / prev item when right / left arrow is pressed", async () => {
@@ -243,7 +243,7 @@ describe("List Tests", () => {
 		await firstListItem.keys("ArrowRight");
 
 		assert.ok(await firstListItem.isFocused(), "First item remains focussed");
-		assert.strictEqual(await secondListItem.isFocused(), false, "Second list item not should be focused");
+		assert.notOk(await secondListItem.isFocused(), "Second list item not should be focused");
 
 		await firstListItem.keys("ArrowLeft");
 
@@ -341,7 +341,7 @@ describe("List Tests", () => {
 		const btnInListHeader = await browser.$("#btnInHeader");
 
 		await btnPopupOpener.click();
-		assert.strictEqual(await btnInListHeader.isFocused(), true, "The List header btn is focused.");
+		assert.ok(await btnInListHeader.isFocused(), "The List header btn is focused.");
 	});
 
 	it('focusable list-items are correctly disabled', async () => {
@@ -374,7 +374,7 @@ describe("List Tests", () => {
 		await item1.click();
 		await item1.keys("ArrowDown");
 
-		assert.strictEqual(await item3.getProperty("focused"), true, "disabled item is skipped");
+		assert.ok(await item3.getProperty("focused"),  "disabled item is skipped");
 	});
 
 	it('should focus next interactive element if TAB is pressed when focus is on "More" growing button', async () => {
@@ -384,7 +384,7 @@ describe("List Tests", () => {
 		await growingListButton.click() // focus growing button
 		await growingListButton.keys("Tab") // focus next list
 
-		assert.strictEqual(await nextInteractiveElement.isFocused(), true, "Focus is moved to next interactive element.");
+		assert.ok(await nextInteractiveElement.isFocused(), "Focus is moved to next interactive element.");
 	});
 
 	it('should include selected state text', async () => {

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -29,12 +29,14 @@ describe("Lit HTML key function for #each", async () => {
 
 		// The first item (<empty>) should not be selected
 		const newFirstItem = (await popover.$$(".ui5-multi-combobox-all-items-list > ui5-li"))[0];
-		assert.ok((await newFirstItem.getHTML(false)).includes("empty"), "First item is <empty>");
-		assert.ok(!(await newFirstItem.getProperty("selected")), "<empty> is not selected");
+		const newFirstItemHtml = await newFirstItem.getHTML(false);
+		assert.ok(newFirstItemHtml.includes("empty"), "First item is <empty>");
+		assert.notOk(await newFirstItem.getProperty("selected"), "<empty> is not selected");
 
 		// The last item (USA) should be selected
 		const lastItem = (await popover.$$(".ui5-multi-combobox-all-items-list > ui5-li"))[3];
-		assert.ok((await lastItem.getHTML(false)).includes("USA"), "Last item is USA");
+		const lastItemHtml = await lastItem.getHTML(false);
+		assert.ok(lastItemHtml.includes("USA"), "Last item is USA");
 		assert.ok(await lastItem.getProperty("selected"), "USA is  selected");
 	});
 });

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -16,7 +16,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await popover.getProperty("opened"), "Popover should be displayed in the viewport");
 
 			await icon.click();
-			assert.ok(!await popover.getProperty("opened"), "Popover should close");
+			assert.notOk(await popover.getProperty("opened"), "Popover should close");
 		});
 
 		it("Checks focus state", async () => {
@@ -52,7 +52,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await callCountInput.getValue(), "1", "Event should be called once");
 
 			await icon.click();
-			assert.ok(!await mcb.getProperty("open"), "MultiComboBox should be closed");
+			assert.notOk(await mcb.getProperty("open"), "MultiComboBox should be closed");
 
 			assert.strictEqual(await eventInput.getValue(), "openChange", "openChange should be called");
 			assert.strictEqual(await callCountInput.getValue(), "2", "Event should be called once");
@@ -121,7 +121,7 @@ describe("MultiComboBox general interaction", () => {
 
 			await icon.click();
 
-			assert.strictEqual(await popover.getProperty("opened"), true, "The popover should be opened");
+			assert.ok(await popover.getProperty("opened"), "The popover should be opened");
 
 			await firstItem.click();
 
@@ -183,12 +183,12 @@ describe("MultiComboBox general interaction", () => {
 			await input.click();
 			await input.keys("c");
 
-			assert.strictEqual(await popover.getProperty("opened"), true, "The popover should be opened");
+			assert.ok(await popover.getProperty("opened"), "The popover should be opened");
 			assert.strictEqual(await input.getValue(), "c", "Value is c (as typed)");
 
 			await firstItem.click();
 
-			assert.strictEqual(await popover.getProperty("opened"), false, "When the content is clicked, the popover should close");
+			assert.notOk(await popover.getProperty("opened"), "When the content is clicked, the popover should close");
 			assert.strictEqual(await input.getValue(), "", "When the content is clicked, the value should be removed");
 			assert.ok(await browser.$("#another-mcb").getProperty("focused"), "MultiComboBox should be focused.");
 		});
@@ -202,12 +202,12 @@ describe("MultiComboBox general interaction", () => {
 			await input.click();
 			await input.keys("c");
 
-			assert.strictEqual(await popover.getProperty("opened"), true, "The popover should be opened");
+			assert.ok(await popover.getProperty("opened"), "The popover should be opened");
 			assert.strictEqual(await input.getValue(), "c", "Value is c (as typed)");
 
 			await firstItemCheckbox.click();
 
-			assert.strictEqual(await popover.getProperty("opened"), true, "When the content is clicked, the popover should close");
+			assert.ok(await popover.getProperty("opened"), "When the content is clicked, the popover should close");
 			assert.strictEqual(await input.getValue(), "c", "When the content is clicked, the value should be removed");
 		});
 

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -23,7 +23,7 @@ describe("MultiInput general interaction", () => {
 		await basicInner.click();
 		await basicInner.keys("Tab");
 
-		assert.ok(!await basicTokenizer.getProperty("expanded"), "Tokenizer should not be expanded");
+		assert.notOk(await basicTokenizer.getProperty("expanded"), "Tokenizer should not be expanded");
 	});
 
 	it ("tests opening of tokenizer Popover", async () => {

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -14,11 +14,7 @@ describe("Panel general interaction", () => {
 
 		assert.strictEqual(await title.getText(), sExpected, "Initially the text is the expected one");
 
-		await browser.executeAsync(done => {
-			document.getElementById("panel-fixed").setAttribute("header-text", "New text");
-			done();
-		});
-		await browser.pause(500);
+		await browser.$("#panel-fixed").setAttribute("header-text", "New text");
 
 		assert.strictEqual(await title.getText(), sNew, "New text");
 	});
@@ -31,17 +27,14 @@ describe("Panel general interaction", () => {
 		assert.ok(await content.isDisplayedInViewport(), "The content is visible");
 
 		await header.click();
-		await browser.pause(500);
 
 		assert.ok(await content.isDisplayedInViewport(), "The content is still visible");
 
 		await header.keys("Space");
-		await browser.pause(500);
 
 		assert.ok(await content.isDisplayedInViewport(), "The content is still visible");
 
 		await header.keys("Enter");
-		await browser.pause(500);
 
 		assert.ok(await content.isDisplayedInViewport(), "The content is still visible");
 	});
@@ -54,17 +47,14 @@ describe("Panel general interaction", () => {
 		assert.ok(await content.isDisplayedInViewport(), "The content is visible");
 
 		await header.click();
-		await browser.pause(500);
 
 		assert.notOk(await content.isDisplayedInViewport(), "The content is not visible");
 
 		await header.keys("Space");
-		await browser.pause(500);
 
 		assert.ok(await content.isDisplayedInViewport(), "The content is visible");
 
 		await header.keys("Enter");
-		await browser.pause(500);
 
 		assert.notOk(await content.isDisplayedInViewport(), "The content is not visible");
 	});
@@ -136,10 +126,7 @@ describe("Panel general interaction", () => {
 			assert.strictEqual(await nativeHeader.getAttribute("aria-labelledby"),
 				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");
 
-			await browser.executeAsync(done => {
-				done(document.getElementById("panel-expandable").setAttribute("accessible-name", "New accessible name"));
-			});
-			await browser.pause(500);
+			await browser.$("#panel-expandable").setAttribute("accessible-name", "New accessible name");
 
 			assert.strictEqual(await panelWithNativeHeader.shadow$(".ui5-panel-root").getAttribute("aria-label"), "New accessible name", "aria-label is set correctly");
 		});
@@ -164,20 +151,12 @@ describe("Panel general interaction", () => {
 			assert.ok(await button.getAttribute("aria-controls"), "aria-controls should be set on the button");
 			assert.ok(await button.getAttribute("title"), "title should be set on the button");
 
-			await browser.executeAsync(done => {
-				document.getElementById("panel2").setAttribute("accessible-name", "New accessible name");
-				done();
-			});
-			await browser.pause(500);
+			await browser.$("#panel2").setAttribute("accessible-name", "New accessible name");
 
 			assert.strictEqual(await panelRoot.getAttribute("aria-label"), "New accessible name", "aria-label should be set on the panel");
 			assert.notOk(await button.getAttribute("aria-label"), "aria-label should not be set on the button");
 
-			await browser.executeAsync(done => {
-				document.getElementById("panel2").setAttribute("use-accessible-name-for-toggle-button", "");
-				done();
-			});
-			await browser.pause(500);
+			await browser.$("#panel2").setAttribute("use-accessible-name-for-toggle-button", "");
 
 			assert.strictEqual(await button.getAttribute("aria-label"), "New accessible name", "aria-label should be set on the button");
 		});

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -254,7 +254,7 @@ describe("Popover general interaction", () => {
 
 		activeElementId = await browser.$(await browser.getActiveElement()).getAttribute("id");
 
-		assert.ok(activeElementId, popoverId, "Popover remains focused");
+		assert.equal(activeElementId, popoverId, "Popover remains focused");
 	});
 
 	it("tests focus when content, which can't be focused is clicked", async () => {
@@ -296,11 +296,11 @@ describe("Acc", () => {
 	it("tests aria-labelledby and aria-label", async () => {
 		const popover = await browser.$("ui5-popover");
 		await popover.removeAttribute("accessible-name");
-		assert.ok((await popover.shadow$(".ui5-popup-root").getAttribute("aria-labelledby")).length, "Popover has aria-labelledby.");
+		assert.ok(await popover.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "Popover has aria-labelledby.");
 		assert.notOk(await popover.shadow$(".ui5-popup-root").getAttribute("aria-label"), "Popover does not have aria-label.");
 
 		await popover.setAttribute("accessible-name", "text");
 		assert.notOk(await popover.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "Popover does not have aria-labelledby.");
-		assert.ok((await popover.shadow$(".ui5-popup-root").getAttribute("aria-label")).length, "Popover has aria-label.");
+		assert.ok(await popover.shadow$(".ui5-popup-root").getAttribute("aria-label"), "Popover has aria-label.");
 	});
 });

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -98,11 +98,11 @@ describe("Popover general interaction", () => {
 
 		const itemBeforeLastItem = items[items.length - 2];
 
-		assert.strictEqual(await itemBeforeLastItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
+		assert.notOk(await itemBeforeLastItem.isDisplayedInViewport(), "Last item is not displayed after openining");
 
 		await itemBeforeLastItem.scrollIntoView();
 
-		assert.strictEqual(await itemBeforeLastItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
+		assert.ok(await itemBeforeLastItem.isDisplayedInViewport(), "Last item is displayed after scrolling");
 
 		await manyItemsSelect.click();
 	});
@@ -116,11 +116,11 @@ describe("Popover general interaction", () => {
 
 		const itemBeforeLastItem = items[items.length - 2];
 
-		assert.strictEqual(await itemBeforeLastItem.isDisplayedInViewport(), false, "Last item is not displayed after openining");
+		assert.notOk(await itemBeforeLastItem.isDisplayedInViewport(), "Last item is not displayed after openining");
 
 		await itemBeforeLastItem.scrollIntoView();
 
-		assert.strictEqual(await itemBeforeLastItem.isDisplayedInViewport(), true, "Last item is displayed after scrolling");
+		assert.ok(await itemBeforeLastItem.isDisplayedInViewport(), "Last item is displayed after scrolling");
 	});
 
 	it("tests modal popover", async () => {

--- a/packages/main/test/specs/ProgressIndicator.spec.js
+++ b/packages/main/test/specs/ProgressIndicator.spec.js
@@ -1,13 +1,6 @@
 const assert = require("chai").assert;
 const PORT = require("./_port.js");
 
-
-const getValidatedValue = async (pi) => {
-	return browser.executeAsync((pi, done) => {
-		done(pi.validatedValue);
-	}, pi);
-};
-
 describe("API", () => {
 	before(async () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/ProgressIndicator.html`);
@@ -20,19 +13,19 @@ describe("API", () => {
 		const largerButton = await browser.$("#seventhBtn");
 
 		await validButton.click();
-		assert.strictEqual(await getValidatedValue(progressIndicator), 50, "The value is validated correctly.");
+		assert.strictEqual(await progressIndicator.getProperty("validatedValue"), 50, "The value is validated correctly.");
 
 		await negativeButton.click();
-		assert.strictEqual(await getValidatedValue(progressIndicator), 0, "The value is limited to 0 and it is validated correctly.");
+		assert.strictEqual(await progressIndicator.getProperty("validatedValue"), 0, "The value is limited to 0 and it is validated correctly.");
 
 		await largerButton.click();
-		assert.strictEqual(await getValidatedValue(progressIndicator), 100, "The value is limited to 100 and it is validated correctly.");
+		assert.strictEqual(await progressIndicator.getProperty("validatedValue"), 100, "The value is limited to 100 and it is validated correctly.");
 	});
 
 	it("tests displayValue property", async () => {
 		const progressIndicator = await browser.$("#test-progress-indicator");
 		const customDisplayValue = "Custom Display Value";
-		const originalPercentageValue = await getValidatedValue(progressIndicator);
+		const originalPercentageValue = await progressIndicator.getProperty("validatedValue");
 		const valueShadowSpan = await progressIndicator.shadow$(".ui5-progress-indicator-value");
 
 		await progressIndicator.setAttribute("display-value", customDisplayValue);

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -151,11 +151,11 @@ describe("RadioButton general interaction", () => {
 		const truncatingRbHeight = await truncatingRb.getSize("height");
 		const wrappingRbHeight = await wrappingRb.getSize("height");
 
-		assert.ok(await truncatingRb.getProperty("wrappingType") === "None", "The text should not be wrapped.");
-		assert.ok(await wrappingRb.getProperty("wrappingType") === "Normal", "The text should be wrapped.");
+		assert.strictEqual(await truncatingRb.getProperty("wrappingType"), "None", "The text should not be wrapped.");
+		assert.strictEqual(await wrappingRb.getProperty("wrappingType"), "Normal", "The text should be wrapped.");
 
 		assert.strictEqual(truncatingRbHeight, RADIOBUTTON_DEFAULT_HEIGHT, "The size of the radiobutton is : " + truncatingRbHeight);
-		assert.ok(wrappingRbHeight > RADIOBUTTON_DEFAULT_HEIGHT, "The size of the radiobutton is more than: " + RADIOBUTTON_DEFAULT_HEIGHT);
+		assert.isAbove(wrappingRbHeight, RADIOBUTTON_DEFAULT_HEIGHT, "The size of the radiobutton is more than: " + RADIOBUTTON_DEFAULT_HEIGHT);
 	});
 
 	it("tests accessibleName", async () => {

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -120,7 +120,7 @@ describe("Testing Range Slider interactions", () => {
 	it("Disabled Range Slider is not interactive", async () => {
 		const rangeSlider = await browser.$("#disabled-range-slider");
 
-		assert.strictEqual(await rangeSlider.isClickable(), false, "Range Slider should be disabled");
+		assert.notOk(await rangeSlider.isClickable(), "Range Slider should be disabled");
 	});
 });
 
@@ -423,7 +423,7 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await rangeSlider.isFocused(), true, "Range Slider component is focused");
+		assert.ok(await rangeSlider.isFocused(), "Range Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderSelection.getAttribute("class"), "Range Slider progress tracker has the shadowDom focus");
 	});
 
@@ -464,9 +464,9 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-range-slider-with-tooltip").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await currentRangeSlider.isFocused(), false, "First RangeSlider component is now not focused");
+		assert.notOk(await currentRangeSlider.isFocused(), "First RangeSlider component is now not focused");
 
-		assert.strictEqual(await nextRangeSlider.isFocused(), true, "Next RangeSlider is focused");
+		assert.ok(await nextRangeSlider.isFocused(), "Next RangeSlider is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderSelection.getAttribute("class"), "Next Range Slider second handle has the shadowDom focus");
 	});
 
@@ -481,9 +481,9 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await currentRangeSlider.isFocused(), false, "First RangeSlider component is now not focused");
+		assert.notOk(await currentRangeSlider.isFocused(), "First RangeSlider component is now not focused");
 
-		assert.strictEqual(await previousRangeSlider.isFocused(), true, "Slider component is focused");
+		assert.ok(await previousRangeSlider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await previousRangeSliderEndHandle.getAttribute("class"), "Previous Range Slider second handle now has the shadowDom focus");
 	});
 
@@ -518,7 +518,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys(["Shift", "Tab"]);
 
-		assert.strictEqual(await rangeSlider.isFocused(), false, "First RangeSlider component is now not focused");
+		assert.notOk(await rangeSlider.isFocused(), "First RangeSlider component is now not focused");
 	});
 
 	it("When one handle come across the other and the values are swapped the focus must be switched between the handles", async () => {
@@ -1049,7 +1049,7 @@ describe("Testing resize handling and RTL support", () => {
 
 		await browser.setWindowSize(400, 2000);
 
-		assert.strictEqual(await rangeSlider.getProperty("_labelsOverlapping"), true, "state should reflect if any of the labels is overlapping with another");
-		assert.strictEqual(await rangeSlider.getProperty("_hiddenTickmarks"), true, "state should reflect if the tickmarks has less than 8px space between each of them");
+		assert.ok(await rangeSlider.getProperty("_labelsOverlapping"), "state should reflect if any of the labels is overlapping with another");
+		assert.ok(await rangeSlider.getProperty("_hiddenTickmarks"), "state should reflect if the tickmarks has less than 8px space between each of them");
 	});
 });

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -19,7 +19,8 @@ describe("Select general interaction", () => {
 		await firstItem.click();
 
 		assert.strictEqual(await inputResult.getProperty("value"), "1", "Fired change event is called once.");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) !== -1, "Select label is correct.");
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Select label is correct.");
 	});
 
 	it("does not fire change, when clicking on selected item", async () => {
@@ -51,14 +52,16 @@ describe("Select general interaction", () => {
 		await select.keys("Enter");
 
 		assert.strictEqual(await inputResult.getProperty("value"), "1", "Fired change event is called once more.");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT1) !== -1, "Select label is correct.");
+		let selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Select label is correct.");
 
 		await select.click();
 		await select.keys("ArrowDown");
 		await select.keys("Space");
 
 		assert.strictEqual(await inputResult.getProperty("value"), "2", "Fired change event is called once more.");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT2) !== -1, "Select label is correct.");
+		selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Select label is correct.");
 
 	});
 
@@ -76,10 +79,12 @@ describe("Select general interaction", () => {
 		await select.keys("Escape");
 
 		await select.keys("ArrowUp");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT1) > -1, "Arrow Up should change selected item");
+		let selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up should change selected item");
 
 		await select.keys("ArrowDown");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT2) > -1, "Arrow Down should change selected item");
+		selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Arrow Down should change selected item");
 
 		assert.strictEqual(await inputResult.getProperty("value"), "2", "Change event should have fired twice");
 	});
@@ -101,11 +106,13 @@ describe("Select general interaction", () => {
 
 		// change selection with picker closed
 		await select.keys("ArrowUp");
-		assert.ok((await politeSpan.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT1) > -1, "Arrow Up should change selected item");
+		let politeSpanHtml = await politeSpan.getHTML(false);
+		assert.ok(politeSpanHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up should change selected item");
 
 		// change selection with picker closed
 		await select.keys("ArrowDown");
-		assert.ok((await politeSpan.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT2) > -1, "Arrow Down should change selected item");
+		politeSpanHtml = await politeSpan.getHTML(false);
+		assert.ok(politeSpanHtml.includes(EXPECTED_SELECTION_TEXT2), "Arrow Down should change selected item");
 
 		// change previewed item with picker opened
 		await select.click();
@@ -116,7 +123,9 @@ describe("Select general interaction", () => {
 		await select.click();
 		await select.keys("ArrowUp");
 		await select.keys("Enter");
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT1) > -1, "Arrow Up and Enter should change selected item");
+
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up and Enter should change selected item");
 
 		await btn.click();
 
@@ -135,7 +144,8 @@ describe("Select general interaction", () => {
 		await select.keys("Tab");
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Arrow Up should change selected item");
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Arrow Up should change selected item");
 
 		const focusedElementId = await browser.executeAsync(done => {
 			done(document.activeElement.id);
@@ -156,7 +166,8 @@ describe("Select general interaction", () => {
 		await browser.keys(["Shift", "Tab"]);
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Arrow Down should change selected item");
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Arrow Down should change selected item");
 
 		const focusedElementId = await browser.executeAsync(done => {
 			done(document.activeElement.id);
@@ -171,11 +182,13 @@ describe("Select general interaction", () => {
 		const selectOptionText = await select.shadow$(".ui5-select-label-root");
 
 		await select.click();
-		assert.ok((await selectOptionText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text is " + EXPECTED_SELECTION_TEXT);
+		let selectOptionTextHtml = await selectOptionText.getHTML(false);
+		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text is " + EXPECTED_SELECTION_TEXT);
 
 		// The last item is already selected - pressing ArrowDown should not change the focus or the selection
 		await select.keys("ArrowDown");
-		assert.ok((await selectOptionText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text remains " + EXPECTED_SELECTION_TEXT);
+		selectOptionTextHtml = await selectOptionText.getHTML(false);
+		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text remains " + EXPECTED_SELECTION_TEXT);
 
 		// Close the select not to cover other components that tests would try to click
 		await select.keys("Escape");
@@ -187,11 +200,13 @@ describe("Select general interaction", () => {
 		const selectOptionText = await select.shadow$(".ui5-select-label-root");
 
 		await select.click();
-		assert.ok((await selectOptionText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text is " + EXPECTED_SELECTION_TEXT);
+		let selectOptionTextHtml = await selectOptionText.getHTML(false);
+		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text is " + EXPECTED_SELECTION_TEXT);
 
 		// The last item is already selected - pressing ArrowUp should not change the focus or the selection
 		await select.keys("ArrowUp");
-		assert.ok((await selectOptionText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Selected option text remains " + EXPECTED_SELECTION_TEXT);
+		selectOptionTextHtml = await selectOptionText.getHTML(false);
+		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text remains " + EXPECTED_SELECTION_TEXT);
 
 		// Close the select not to cover other components that tests would try to click
 		await select.keys("Escape");
@@ -206,7 +221,8 @@ describe("Select general interaction", () => {
 
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Typing letter should change selection");
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Typing letter should change selection");
 	});
 
 	it("changes selection with typing more letters", async () => {
@@ -219,7 +235,8 @@ describe("Select general interaction", () => {
 
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) > -1, "Typing text should change selection");
+		const selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Typing text should change selection");
 	});
 
 	it("opens upon space", async () => {
@@ -371,14 +388,16 @@ describe("Select general interaction", () => {
 
 		await firstItem.click();
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT) !== -1, "Select label is correct.");
+		let selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Select label is correct.");
 
 		// verify that ESC does not interfere when the picker is closed
 		await select.keys("Escape");
 		await select.click();
 		await thirdItem.click();
 
-		assert.ok((await selectText.getHTML(false)).indexOf(EXPECTED_SELECTION_TEXT2) !== -1, "Select label is correct.");
+		selectTextHtml = await selectText.getHTML(false);
+		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Select label is correct.");
 	});
 
 	it("Tests aria-label, aria-labelledby and aria-expanded", async () => {

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -60,7 +60,7 @@ describe("Slider basic interactions", () => {
 	it("Disabled slider is not interactive", async () => {
 		const slider = await browser.$("#disabled-slider-with-tickmarks");
 
-		assert.strictEqual(await slider.isClickable(), false, "Range Slider should be disabled");
+		assert.notOk(await slider.isClickable(), "Range Slider should be disabled");
 	});
 });
 
@@ -267,7 +267,7 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-slider").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await slider.isFocused(), true, "Slider component is focused");
+		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");
 	});
 
@@ -281,7 +281,7 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-slider-with-tooltip").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await slider.isFocused(), true, "Slider component is focused");
+		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");
 	});
 
@@ -295,7 +295,7 @@ describe("Accessibility", async () => {
 			done(document.getElementById("basic-slider").shadowRoot.activeElement);
 		});
 
-		assert.strictEqual(await slider.isFocused(), true, "Slider component is focused");
+		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");
 	});
 });
@@ -485,7 +485,7 @@ describe("Testing resize handling and RTL support", () => {
 
 		await browser.setWindowSize(400, 2000);
 
-		assert.strictEqual(await slider.getProperty("_labelsOverlapping"), true, "state should reflect if any of the labels is overlapping with another");
-		assert.strictEqual(await slider.getProperty("_hiddenTickmarks"), true, "state should reflect if the tickmarks has less than 8px space between each of them");
+		assert.ok(await slider.getProperty("_labelsOverlapping"), "state should reflect if any of the labels is overlapping with another");
+		assert.ok(await slider.getProperty("_hiddenTickmarks"), "state should reflect if the tickmarks has less than 8px space between each of them");
 	});
 });

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -12,7 +12,8 @@ describe("TabContainer general interaction", () => {
 		const selectedFilter = await tabContainer.shadow$(".ui5-tab-strip-item:nth-child(4)");
 		const SELECTION_CSS_CLASS = "ui5-tab-strip-item--selected";
 
-		assert.ok((await selectedFilter.getHTML()).indexOf(SELECTION_CSS_CLASS) > -1, "The item has the selection css class set.");
+		const selectedFilterHtml = await selectedFilter.getHTML();
+		assert.ok(selectedFilterHtml.includes(SELECTION_CSS_CLASS), "The item has the selection css class set.");
 		assert.strictEqual(selectedFilter.id, selectedTab.id, "The IDs of the ui5-tab and the rendered tab filter matches.");
 	});
 
@@ -123,8 +124,8 @@ describe("TabContainer general interaction", () => {
 			});
 		});
 
-		assert.ok(tabHeight < tabScrollHeight, "Tab Content is scrollable");
-		assert.ok(tcHeight >= tcScrollHeight, "TabContainer is not scrollable scrollable");
+		assert.isBelow(tabHeight, tabScrollHeight, "Tab Content is scrollable");
+		assert.isAtLeast(tcHeight, tcScrollHeight, "TabContainer is not scrollable");
 	});
 
 	it("tests aria attrs", async () => {

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -29,12 +29,12 @@ describe("Table general interaction", () => {
 	it("tests if noData div is displayed for empty table", async () => {
 		const noDataRow = await browser.$("#tableNoData").shadow$("div.ui5-table-no-data-row");
 
-		assert.strictEqual(await noDataRow.isExisting(), true, 'noData div is present');
+		assert.ok(await noDataRow.isExisting(), 'noData div is present');
 	});
 
 	it("tests if table with more columns than cells is rendered", async () => {
 		const tblLessCells = await browser.$("#tblLessCells");
-		assert.equal(await tblLessCells.isExisting(), true, 'table with more columns is rendered without JS errors.');
+		assert.ok(await tblLessCells.isExisting(), 'table with more columns is rendered without JS errors.');
 	});
 
 	it("tests if popinChange is fired when min-width is reacted (500px)", async () => {

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -54,16 +54,20 @@ describe("Table general interaction", () => {
 		const row2Data = "London";
 
 		await cellInRow1.click();
-		assert.ok((await lbl.getHTML()).indexOf(row1Data), "Event row-click fired and intercepted.");
+		let lblHtml = await lbl.getHTML();
+		assert.ok(lblHtml.indexOf(row1Data), "Event row-click fired and intercepted.");
 
 		await cellInRow2.click();
-		assert.ok((await lbl.getHTML()).indexOf(row2Data), "Event row-click fired and intercepted.");
+		lblHtml = await lbl.getHTML();
+		assert.ok(lblHtml.indexOf(row2Data), "Event row-click fired and intercepted.");
 
 		await cellInRow1.keys("Space");
-		assert.ok((await lbl.getHTML()).indexOf(row1Data), "Event row-click fired and intercepted.");
+		lblHtml = await lbl.getHTML();
+		assert.ok(lblHtml.indexOf(row1Data), "Event row-click fired and intercepted.");
 
 		await cellInRow2.keys("Enter");
-		assert.ok((await lbl.getHTML()).indexOf(row2Data), "Event row-click fired and intercepted.");
+		lblHtml = await lbl.getHTML();
+		assert.ok(lblHtml.indexOf(row2Data), "Event row-click fired and intercepted.");
 	});
 
 	it("tests row aria-label value", async () => {

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -179,7 +179,7 @@ describe("when enabled", () => {
 			await textAreaInner.addValue(`\n9`);
 			const sizeAfterGrow = await textArea.getSize();
 
-			assert.ok(sizeBeforeGrow.height < sizeAfterGrow.height, "TextArea should grow");
+			assert.isBelow(sizeBeforeGrow.height, sizeAfterGrow.height, "TextArea should grow");
 		});
 
 		it("Should grow up to 4 lines", async () => {
@@ -197,8 +197,8 @@ describe("when enabled", () => {
 			await textAreaInner.addValue(`\n5\n6`);
 			const size6lines = await textArea.getSize();
 
-			assert.ok(initialSize.height < size2lines.height, "TA should grow when having 2 lines of text");
-			assert.ok(size2lines.height < size4lines.height, "TA should grow up to 4 lines");
+			assert.isBelow(initialSize.height, size2lines.height, "TA should grow when having 2 lines of text");
+			assert.isBelow(size2lines.height, size4lines.height, "TA should grow up to 4 lines");
 			assert.strictEqual(size6lines.height, size4lines.height, "TA should not grow more than 4 lines");
 		});
 	});

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -63,7 +63,7 @@ describe("disabled and readonly textarea", () => {
 	it("can not be edited when disabled", async () => {
 		const textAreaInnerDisabled = await browser.$("#disabled-textarea").shadow$("textarea");
 
-		assert.strictEqual(await textAreaInnerDisabled.isEnabled(), false, "Should not be enabled");
+		assert.notOk(await textAreaInnerDisabled.isEnabled(), "Should not be enabled");
 	});
 
 	it("can not be edited when readonly", async () => {

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -10,10 +10,7 @@ describe("Attributes propagation", () => {
 		const textarea = await browser.$("#basic-textarea");
 		const sExpected = "New placeholder text";
 
-		await browser.executeAsync(done => {
-			document.getElementById("basic-textarea").setAttribute("placeholder", "New placeholder text");
-			done();
-		});
+		await browser.$("#basic-textarea").setAttribute("placeholder", "New placeholder text");
 
 		assert.strictEqual(await textarea.shadow$("textarea").getProperty("placeholder"), sExpected, "The placeholder was set correctly");
 	});
@@ -34,10 +31,7 @@ describe("Attributes propagation", () => {
 	it("Value attribute is propagated properly", async () => {
 		const sExpectedValue = "Test";
 
-		await browser.executeAsync(done => {
-			document.getElementById("basic-textarea").value = "Test";
-			done();
-		});
+		await browser.$("#basic-textarea").setProperty("value", "Test");
 
 		assert.strictEqual(await browser.$("#basic-textarea").shadow$("textarea").getValue(), sExpectedValue, "Value property was set correctly");
 	});
@@ -111,10 +105,7 @@ describe("when enabled", () => {
 		const textarea = await browser.$("#basic-textarea");
 		const textareaInner = await browser.$("#basic-textarea").shadow$("textarea");
 
-		await browser.executeAsync(done => {
-			document.getElementById("basic-textarea").value = "Test";
-			done();
-		}); // set the value again since browser.url reset the page
+		await browser.$("#basic-textarea").setProperty("value", "Test");
 		assert.strictEqual(await textarea.getProperty("value"), "Test", "Initial value is correct");
 
 		await textareaInner.addValue("a");

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -26,8 +26,10 @@ describe("Rendering", () => {
 		const wrappingTitle = await browser.$("#wrapping-title");
 		const truncatedTitle = await browser.$("#truncated-title");
 
-		assert.strictEqual((await truncatedTitle.getSize()).height, 16, "truncated title should be single line");
+		const truncatedTitleHeight = (await truncatedTitle.getSize()).height;
+		assert.strictEqual(truncatedTitleHeight, 16, "truncated title should be single line");
 
-		assert.ok((await wrappingTitle.getSize()).height > (await truncatedTitle.getSize()).height, "wrapping title should span more than a single line");
+		const wrappingTitleHeight = (await wrappingTitle.getSize()).height;
+		assert.isAbove(wrappingTitleHeight, 16, "wrapping title should span more than a single line");
 	});
 });

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -83,7 +83,8 @@ describe("Toast general interaction", () => {
 
 		await button.click();
 
-		assert.ok((await toastShadowContent.getAttribute("style")).indexOf(EXPECTED_STYLES) !== -1,
+		const styleValue = await toastShadowContent.getAttribute("style");
+		assert.ok(styleValue.includes(EXPECTED_STYLES),
 			"The correct default inline styles are applied to the shadow ui5-toast-root");
 	});
 
@@ -101,7 +102,8 @@ describe("Toast general interaction", () => {
 
 		const EXPECTED_STYLES = `transition-duration: ${maximumAllowedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
 
-		assert.ok((await toastShadowContent.getAttribute("style")).indexOf(EXPECTED_STYLES) !== -1,
+		const styleValue = await toastShadowContent.getAttribute("style");
+		assert.ok(styleValue.includes(EXPECTED_STYLES),
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is longer than default. Transition is not longer than allowed (1000ms).");
 	});
@@ -120,7 +122,8 @@ describe("Toast general interaction", () => {
 
 		const EXPECTED_STYLES = `transition-duration: ${calculatedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
 
-		assert.ok((await toastShadowContent.getAttribute("style")).indexOf(EXPECTED_STYLES) !== -1,
+		const styleValue = await toastShadowContent.getAttribute("style");
+		assert.ok(styleValue.includes(EXPECTED_STYLES),
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is shorter than default. Transition is a third of the duration.");
 	});

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -18,7 +18,7 @@ describe("Tree general interaction", () => {
 
 		await toggleButton.click();
 		const listItemsAfter = await tree.shadow$$("ui5-li-tree").length;
-		assert.ok(listItemsAfter < listItemsBefore, "After collapsing a node, there are less items in the list");
+		assert.isBelow(listItemsAfter, listItemsBefore, "After collapsing a node, there are less items in the list");
 	});
 
 	it("Tree items can be expanded", async () => {
@@ -28,7 +28,7 @@ describe("Tree general interaction", () => {
 
 		await toggleButton.click();
 		const listItemsAfter = await tree.shadow$$("ui5-li-tree").length;
-		assert.ok(listItemsAfter > listItemsBefore, "After expanding a node, there are more items in the list");
+		assert.isAbove(listItemsAfter, listItemsBefore, "After expanding a node, there are more items in the list");
 	})
 
 });
@@ -45,7 +45,7 @@ describe("Tree proxies properties to list", () => {
 		const modes = ["None", "SingleSelect", "SingleSelectBegin", "SingleSelectEnd", "MultiSelect", "Delete"];
 		modes.forEach(async mode => {
 			await tree.setAttribute("mode", mode);
-			assert.ok(await list.getAttribute("mode") === mode, "Mode applied");
+			assert.strictEqual(await list.getAttribute("mode"), mode, "Mode applied");
 		});
 	});
 
@@ -57,9 +57,9 @@ describe("Tree proxies properties to list", () => {
 		await tree.setAttribute("footer-text", "footer text");
 		await tree.setAttribute("no-data-text", "no data text");
 
-		assert.ok(await list.getAttribute("header-text") === "header text", "header text applied");
-		assert.ok(await list.getAttribute("footer-text") === "footer text", "footer text applied");
-		assert.ok(await list.getAttribute("no-data-text") === "no data text", "no data text applied");
+		assert.strictEqual(await list.getAttribute("header-text"), "header text", "header text applied");
+		assert.strictEqual(await list.getAttribute("footer-text"), "footer text", "footer text applied");
+		assert.strictEqual(await list.getAttribute("no-data-text"), "no data text", "no data text applied");
 	})
 
 });

--- a/packages/main/test/specs/base/InvisibleMessage.spec.js
+++ b/packages/main/test/specs/base/InvisibleMessage.spec.js
@@ -29,7 +29,9 @@ describe("InvisibleMessage", () => {
         await checkBox.click();
         await button.click();
 
-        assert.ok((await politeSpan.getHTML()).indexOf("announcement") > -1, "Value has been rendered.");
-        assert.ok((await assertiveSpan.getHTML()).indexOf("announcement") > -1, "Value has been rendered.");
+        const politeSpanHtml = await politeSpan.getHTML();
+        const assertiveSpanHtml = await assertiveSpan.getHTML();
+        assert.ok(politeSpanHtml.includes("announcement"), "Value has been rendered.");
+        assert.ok(assertiveSpanHtml.includes("announcement"), "Value has been rendered.");
     });
 });

--- a/packages/main/test/specs/base/InvisibleMessage.spec.js
+++ b/packages/main/test/specs/base/InvisibleMessage.spec.js
@@ -20,10 +20,7 @@ describe("InvisibleMessage", () => {
         const button = await browser.$("#announce-button");
         const checkBox = await browser.$("#announce-checkbox");
 
-        await browser.executeAsync(done => {
-			document.getElementById("announce-textarea").value = "announcement";
-			done();
-		});
+        await browser.$("#announce-textarea").setProperty("value", "announcement");
 
         await button.click();
         await checkBox.click();


### PR DESCRIPTION
# Improve tests

This change is a follow-up to: https://github.com/SAP/ui5-webcomponents/pull/3896

## Do not overuse `assert.ok`

When an `assert.ok` fails, the error you get is "Expected something to be true, but it was false". This is fine when you're passing a Boolean, but not ok when there is an expression inside `assert.ok` and you'd like to know which part of the expression is not as expected.

For example, when `assert.ok(a === b, "They match")` fails, the error just says that an expression that was expected to be true was false. However, if you use `assert.strictEqual(a, b, "They match")`, and it fails, the error will say that `a` was expected to be a certain value, but it was another value, which makes it much easier to debug.

Prefer one of the following, when applicable:
 - `assert.notOk(a)` instead of `assert.ok(!a)`
 - `assert.strictEqual(a, b)` instead of `assert.ok(a === b)`
 - `assert.isBelow(a, b)` instead of `assert.ok(a < b)`
 - `assert.isAbove(a, b)` instead of `assert.ok(a > b)`
 - `assert.exists` / `assert.notExists` when checking for `null` or `undefined`

## Do not overuse `assert.strictEqual`

Use:
 - `assert.ok` instead of `assert.strictEqual(a, true)`
 - `assert.notOk` instead of `assert.strictEqual(a, false)`

## Use `isExisting` to check DOM

Preferred:
 ```js
assert.ok(await browser.$(<SELECTOR>).isExisting())
``` 

instead of:

```js
assert.ok((await browser.$$(<SELECTOR>)).length)
```

## Do not use `browser.executeAsync` for properties

We have custom commands such as `getProperty` and `setProperty` to fill in gaps in the WDIO standard command set. Use them instead of manually setting properties with `executeAsync`.

## Prefer `String.prototype.includes` to `String.prototype.indexOf`

Use:

 ```js
assert.ok(text.includes(EXPECTED_TEXT), "Text found")
```

instead of: 

```js
assert.ok(text.indexOf(EXPECTED_TEXT) > -1, "Text found")
```

## Extract variables before asserting

After https://github.com/SAP/ui5-webcomponents/pull/3896 was merged, some more complex expressions appeared inside assertions. Avoid this by extracting parts of them to variables.