### PR TITLE
chore: Update tests docs

### DIFF
--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -63,46 +63,16 @@ or
 Make sure you're running the `start` command while running single test specs, as it provides a server and the ability to change
 files, and test the changes on the fly.
 
-## 2.4 Getting the tests to run on Windows
-
-When you first try to run the tests on a Windows machine, you're most likely to get an error saying `node-gyp` is not installed.
-
-Certain modules required by the test setup have a dependency to [Node gyp](https://github.com/nodejs/node-gyp). 
-Normally, it is installed along with the other dependencies from NPM, but for a Windows environment specifically, this is not enough, and
-some manual steps must be performed:
- 1. Install Windows build tools:
-```shell
-npm install --global --production windows-build-tools --vs2015
-```
-Note the `--vs2015` flag.
-
-Also note that this might take some time to complete as several GB might be downloaded in the process.
-
- 2. Configure the right version of Windows build tools for Node.js:
-```shell
-npm config set msvs_version 2015 -–global
-```
-
- 3. Install Python 2.7 if you don't already have it: https://www.python.org/download/releases/2.7/
-
- 4. Set the version of Python to 2.7
-```shell
-npm config set python python2.7
-```
-
-This should be enough to be able to run `yarn test` successfully. If you still get an error about `node-gyp`,
-you should install Windows build tools 2015 (from step 1) manually: https://www.microsoft.com/en-us/download/details.aspx?id=48159.
-
 ## 3. Writing tests
 
 The simplest test would look something like this:
 
 ```js
-describe("ui5-demo rendering", () => {
-	browser.url("http://localhost:8080/test-resources/pages/index.html");
+describe("ui5-demo rendering", async () => {
+	await browser.url("http://localhost:8080/test-resources/pages/index.html");
 
-	it("tests if web component is correctly rendered", () => {
-		const innerContent = browser.$("#myFirstComponent").shadow$("div");
+	it("tests if web component is correctly rendered", async () => {
+		const innerContent = await browser.$("#myFirstComponent").shadow$("div");
 		assert.ok(innerContent, "content rendered");
 	});
 });
@@ -179,3 +149,42 @@ Debugging with WDIO is really simple. Just follow these 3 steps:
 	  
 Google Chrome will then open in a new window, controlled by WDIO via the ChromeDriver, and your test will pause on your 
 breakpoint of choice. Proceed to debug normally.	 
+
+## 5. Using the synchronous syntax for writing texts
+
+WebdriverIO still supports (although now deprecated) the *synchronous* syntax for writing tests. Click [here](https://webdriver.io/docs/sync-vs-async/) for more information on "sync vs async".
+
+UI5 Web Components versions up to, including, `1.0.0-rc.15`, used to recommend the *synchronous* syntax, as it is easier to use.
+
+If you have already written tests for your custom UI5 Web Components using the *synchronous* syntax, and you update to a later version than `1.0.0-rc.15`, your tests will no longer run.
+You have 2 options:
+ - Rewrite all tests to use the *asynchronous* syntax. Click the link above to see some examples. This is the **recommended** approach, because the *synchronous* syntax will no longer work with future `nodejs` versions.
+ - For the time being, adapt your WebdriverIO configuration to continue supporting the *synchronous* syntax.
+
+### 5.1 Supporting the synchronous syntax for writing tests
+
+ - Change your `config/wdio.conf.js` file's content from:
+
+ ```js
+ module.exports = require("@ui5/webcomponents-tools/components-package/wdio.js");
+ ```
+ to:
+
+ ```js
+ module.exports = require("@ui5/webcomponents-tools/components-package/wdio.sync.js");
+ ```
+
+ This will give you the exact same WebdriverIO configuration, but with *synchronous* custom commands (such as `getProperty`, `setProperty`, `hasClass`, etc...).
+
+ - Manually install `@wdio/sync`
+
+ You can install it with `npm`:
+
+ `npm i --save-dev @wdio/sync`
+
+ or with `yarn`:
+
+ `yarn add -D @wdio/sync`
+
+ Just installing the package (with no extra configuration) is enough to let WebdriverIO run the *synchronous* tests.
+ 

--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -150,7 +150,63 @@ Debugging with WDIO is really simple. Just follow these 3 steps:
 Google Chrome will then open in a new window, controlled by WDIO via the ChromeDriver, and your test will pause on your 
 breakpoint of choice. Proceed to debug normally.	 
 
-## 5. Using the synchronous syntax for writing texts
+## 5. Best practices for writing tests
+
+### Do not overuse `assert.ok`
+
+When an `assert.ok` fails, the error you get is "Expected something to be true, but it was false". This is fine when you're passing a Boolean, but not ok when there is an expression inside `assert.ok` and you'd like to know which part of the expression is not as expected.
+
+For example, when `assert.ok(a === b, "They match")` fails, the error just says that an expression that was expected to be true was false. However, if you use `assert.strictEqual(a, b, "They match")`, and it fails, the error will say that `a` was expected to be a certain value, but it was another value, which makes it much easier to debug.
+
+Prefer one of the following, when applicable:
+- `assert.notOk(a)` instead of `assert.ok(!a)`
+- `assert.strictEqual(a, b)` instead of `assert.ok(a === b)`
+- `assert.isBelow(a, b)` instead of `assert.ok(a < b)`
+- `assert.isAbove(a, b)` instead of `assert.ok(a > b)`
+- `assert.exists` / `assert.notExists` when checking for `null` or `undefined`
+
+### Do not overuse `assert.strictEqual`
+
+Use:
+- `assert.ok` instead of `assert.strictEqual(a, true)`
+- `assert.notOk` instead of `assert.strictEqual(a, false)`
+
+### Use `isExisting` to check DOM
+
+Preferred:
+ ```js
+assert.ok(await browser.$(<SELECTOR>).isExisting())
+``` 
+
+instead of:
+
+```js
+assert.ok((await browser.$$(<SELECTOR>)).length)
+```
+
+### Do not use `browser.executeAsync` for properties
+
+We have custom commands such as `getProperty` and `setProperty` to fill in gaps in the WDIO standard command set. Use them instead of manually setting properties with `executeAsync`.
+
+### Use `assert.includes` instead of string functions
+
+Use:
+
+ ```js
+assert.includes(text, EXPECTED_TEXT, "Text found")
+```
+
+instead of:
+
+```js
+assert.ok(text.indexOf(EXPECTED_TEXT) > -1, "Text found")
+```
+
+### Extract variables before asserting
+
+Avoid complex expressions inside `assert`s by extracting parts of them to variables and only asserting the variables.
+
+## 6. Using the synchronous syntax for writing texts
 
 WebdriverIO still supports (although now deprecated) the *synchronous* syntax for writing tests. Click [here](https://webdriver.io/docs/sync-vs-async/) for more information on "sync vs async".
 

--- a/packages/tools/components-package/wdio.sync.js
+++ b/packages/tools/components-package/wdio.sync.js
@@ -1,0 +1,344 @@
+exports.config = {
+	//
+	// ====================
+	// Runner Configuration
+	// ====================
+	//
+	// WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+	// on a remote machine).
+	runner: 'local',
+
+	//
+	// ==================
+	// Specify Test Files
+	// ==================
+	// Define which test specs should run. The pattern is relative to the directory
+	// from which `wdio` was called. Notice that, if you are calling `wdio` from an
+	// NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+	// directory is where your package.json resides, so `wdio` will be called from there.
+	//
+	specs: [
+		'./test/specs/**/*.js'
+	],
+	// Patterns to exclude.
+	exclude: [
+		// 'path/to/excluded/files'
+	],
+	//
+	// ============
+	// Capabilities
+	// ============
+	// Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+	// time. Depending on the number of capabilities, WebdriverIO launches several test
+	// sessions. Within your capabilities you can overwrite the spec and exclude options in
+	// order to group specific specs to a specific capability.
+	//
+	// First, you can define how many instances should be started at the same time. Let's
+	// say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+	// set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+	// files and you set maxInstances to 10, all spec files will get tested at the same time
+	// and 30 processes will get spawned. The property handles how many capabilities
+	// from the same test should run tests.
+	//
+	maxInstances: 10,
+	//
+	// If you have trouble getting all important capabilities together, check out the
+	// Sauce Labs platform configurator - a great tool to configure your capabilities:
+	// https://docs.saucelabs.com/reference/platforms-configurator
+	//
+	capabilities: [{
+		// maxInstances can get overwritten per capability. So if you have an in-house Selenium
+		// grid with only 5 firefox instances available you can make sure that not more than
+		// 5 instances get started at a time.
+		maxInstances: process.env.TRAVIS ? 1 : 5,
+		//
+		browserName: 'chrome',
+		'goog:chromeOptions': {
+			// to run chrome headless the following flags are required
+			// (see https://developers.google.com/web/updates/2017/04/headless-chrome)
+			args: ['--headless', '--disable-gpu'],
+			// args: ['--disable-gpu'],
+		}
+	}],
+	//
+	// port to find chromedriver
+	port: 9515, // default
+	// ===================
+	// Test Configurations
+	// ===================
+	// Define all options that are relevant for the WebdriverIO instance here
+	//
+	// Level of logging verbosity: trace | debug | info | warn | error
+	logLevel: 'error',
+	//
+	// Warns when a deprecated command is used
+	deprecationWarnings: true,
+	//
+	// If you only want to run your tests until a specific amount of tests have failed use
+	// bail (default is 0 - don't bail, run all tests).
+	bail: 0,
+	//
+	// Set a base URL in order to shorten url command calls. If your `url` parameter starts
+	// with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+	// If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+	// gets prepended directly.
+	baseUrl: undefined, // This is important since WDIO 7+ does not accept an empty string for baseUrl
+	path: '',
+	//
+	// Default timeout for all waitFor* commands.
+	waitforTimeout: 10000,
+	//
+	// Default timeout in milliseconds for request
+	// if Selenium Grid doesn't send response
+	connectionRetryTimeout: 90000,
+	//
+	// Default request retries count
+	connectionRetryCount: 3,
+	//
+	// Test runner services
+	// Services take over a specific job you don't want to take care of. They enhance
+	// your test setup with almost no effort. Unlike plugins, they don't add new
+	// commands. Instead, they hook themselves up into the test process.
+	services: ['chromedriver'],
+	// options
+	chromeDriverArgs: ['--port=9515'], // default
+	// Framework you want to run your specs with.
+	// The following are supported: Mocha, Jasmine, and Cucumber
+	// see also: https://webdriver.io/docs/frameworks.html
+	//
+	// Make sure you have the wdio adapter package for the specific framework installed
+	// before running any tests.
+	framework: 'mocha',
+	//
+	// Test reporter for stdout.
+	// The only one supported by default is 'dot'
+	// see also: https://webdriver.io/docs/dot-reporter.html
+	reporters: ['dot', 'spec'],
+
+	//
+	// Options to be passed to Mocha.
+	// See the full list at http://mochajs.org/
+	mochaOpts: {
+		ui: 'bdd',
+		timeout: 60000
+	},
+	//
+	// =====
+	// Hooks
+	// =====
+	// WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+	// it and to build services around it. You can either apply a single function or an array of
+	// methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+	// resolved to continue.
+	/**
+	 * Gets executed once before all workers get launched.
+	 * @param {Object} config wdio configuration object
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 */
+	// onPrepare: function (config, capabilities) {
+	// },
+	/**
+	 * Gets executed just before initialising the webdriver session and test framework. It allows you
+	 * to manipulate configurations depending on the capability or spec.
+	 * @param {Object} config wdio configuration object
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 * @param {Array.<String>} specs List of spec file paths that are to be run
+	 */
+	// beforeSession: function (config, capabilities, specs) {
+	// },
+	/**
+	 * Gets executed before test execution begins. At this point you can access to all global
+	 * variables like `browser`. It is the perfect place to define custom commands.
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 * @param {Array.<String>} specs List of spec file paths that are to be run
+	 */
+	before: function (capabilities, specs) {
+		browser.addCommand("isFocusedDeep", function () {
+			return browser.execute(function (elem) {
+				let activeElement = document.activeElement;
+
+				while (activeElement.shadowRoot) {
+					if (activeElement.shadowRoot.activeElement) {
+						activeElement = activeElement.shadowRoot.activeElement;
+					} else {
+						break;
+					}
+				}
+				return elem === activeElement;
+			}, this);
+		}, true);
+
+		browser.addCommand("setProperty", function(property, value) {
+			return browser.execute((elem, property, value) => {
+				return elem[property] = value;
+			}, this, property, value);
+		}, true);
+
+		browser.addCommand("setAttribute", function(attribute, value) {
+			return browser.execute((elem, attribute, value) => {
+				return elem.setAttribute(attribute, value);
+			}, this, attribute, value);
+		}, true);
+
+		browser.addCommand("removeAttribute", function(attribute) {
+			return browser.execute((elem, attribute) => {
+				return elem.removeAttribute(attribute);
+			}, this, attribute);
+		}, true);
+
+		browser.addCommand("hasClass", function(className) {
+			return browser.execute((elem, className) => {
+				return elem.classList.contains(className);
+			}, this, className);
+		}, true);
+
+		browser.addCommand("getStaticAreaItemClassName", function(selector) {
+			return browser.execute(async (selector) => {
+				const staticAreaItem = await document.querySelector(selector).getStaticAreaItemDomRef();
+				return staticAreaItem.host.classList[0];
+			}, selector);
+		}, false);
+	},
+	/**
+	 * Runs before a WebdriverIO command gets executed.
+	 * @param {String} commandName hook command name
+	 * @param {Array} args arguments that command would receive
+	 */
+	beforeCommand: function (commandName, args) {
+		const waitFor = [
+			"$",
+			"$$",
+			"getAttribute",
+			"getCSSProperty",
+			"getHTML",
+			"getProperty",
+			"getSize",
+			"getStaticAreaItemClassName", // custom
+			"getText",
+			"getValue",
+			"hasClass", // custom
+			"isDisplayed",
+			"isDisplayedInViewport",
+			"isEnabled",
+			"isExisting",
+			"isFocused",
+			"isFocusedDeep", // custom
+			"shadow$",
+			"shadow$$",
+		];
+		if (waitFor.includes(commandName)) {
+			browser.executeAsync(function (done) {
+				window["sap-ui-webcomponents-bundle"].renderFinished().then(done);
+			});
+		}
+	},
+
+	/**
+	 * Hook that gets executed before the suite starts
+	 * @param {Object} suite suite details
+	 */
+	// beforeSuite: function (suite) {
+	// },
+	/**
+	 * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+	 * @param {Object} test test details
+	 */
+	// beforeTest: function (test) {
+	// },
+	/**
+	 * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+	 * beforeEach in Mocha)
+	 */
+	// beforeHook: function () {
+	// },
+	/**
+	 * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+	 * afterEach in Mocha)
+	 */
+	// afterHook: function () {
+	// },
+	/**
+	 * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+	 * @param {Object} test test details
+	 */
+	// afterTest: function (test) {
+	// },
+	/**
+	 * Hook that gets executed after the suite has ended
+	 * @param {Object} suite suite details
+	 */
+	// afterSuite: function (suite) {
+	// },
+
+	/**
+	 * Runs after a WebdriverIO command gets executed
+	 * @param {String} commandName hook command name
+	 * @param {Array} args arguments that command would receive
+	 * @param {Number} result 0 - command success, 1 - command error
+	 * @param {Object} error error object if any
+	 */
+	afterCommand: function (commandName, args, result, error) {
+
+		// url -> set configuration first
+		if (commandName === "url" && !args[0].includes("do-not-change-configuration")) {
+			browser.execute(function() {
+				window["sap-ui-webcomponents-bundle"].configuration.setNoConflict(true);
+			});
+		}
+
+		const waitFor = [
+			"addValue",
+			"clearValue",
+			"click",
+			"doubleClick",
+			"dragAndDrop",
+			"keys",
+			"pause",
+			"removeAttribute", // custom
+			"setAttribute", // custom
+			"setProperty", // custom
+			"setValue",
+			"setWindowSize",
+			"touchAction",
+			"url"
+		];
+		if (waitFor.includes(commandName)) {
+			browser.executeAsync(function (done) {
+				window["sap-ui-webcomponents-bundle"].renderFinished().then(done);
+			});
+		}
+	},
+	/**
+	 * Gets executed after all tests are done. You still have access to all global variables from
+	 * the test.
+	 * @param {Number} result 0 - test pass, 1 - test fail
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 * @param {Array.<String>} specs List of spec file paths that ran
+	 */
+	// after: function (result, capabilities, specs) {
+	// },
+	/**
+	 * Gets executed right after terminating the webdriver session.
+	 * @param {Object} config wdio configuration object
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 * @param {Array.<String>} specs List of spec file paths that ran
+	 */
+	// afterSession: function (config, capabilities, specs) {
+	// },
+	/**
+	 * Gets executed after all workers got shut down and the process is about to exit.
+	 * @param {Object} exitCode 0 - success, 1 - fail
+	 * @param {Object} config wdio configuration object
+	 * @param {Array.<Object>} capabilities list of capabilities details
+	 * @param {<Object>} results object containing test results
+	 */
+	// onComplete: function(exitCode, config, capabilities, results) {
+	// },
+	/**
+	 * Gets executed when a refresh happens.
+	 * @param {String} oldSessionId session ID of the old session
+	 * @param {String} newSessionId session ID of the new session
+	 */
+	//onReload: function(oldSessionId, newSessionId) {
+	//}
+}

--- a/packages/tools/lib/init-package/resources/test/specs/Demo.spec.js
+++ b/packages/tools/lib/init-package/resources/test/specs/Demo.spec.js
@@ -1,11 +1,11 @@
 const assert = require("assert");
 
-describe("INIT_PACKAGE_VAR_TAG rendering", () => {
-	browser.url("http://localhost:INIT_PACKAGE_VAR_PORT/test-resources/pages/index.html");
+describe("INIT_PACKAGE_VAR_TAG rendering", async () => {
+	await browser.url("http://localhost:INIT_PACKAGE_VAR_PORT/test-resources/pages/index.html");
 
-	it("tests if web component is correctly rendered", () => {
+	it("tests if web component is correctly rendered", async () => {
 
-		const innerContent = browser.$("#myFirstComponent").shadow$("div");
+		const innerContent = await browser.$("#myFirstComponent").shadow$("div");
 
 		assert.ok(innerContent, "content rendered");
 	});


### PR DESCRIPTION
This is a follow-up change to: https://github.com/SAP/ui5-webcomponents/pull/3896

 - Documentation on testing updated 
 - The old `wdio.js` file copied as `wdio.sync.js`
 - When creating a new package, the demo component's test now uses the *asynchronous* syntax

BREAKING CHANGE: The `@wdio/sync` package is no longer a dependency to `@ui5/webcomponents-tools`, therefore the *synchronous* syntax for writing tests is no longer supported out of the box. If you had already written tests,  using the *synchronous* syntax, you must:
 - Install `@wdio/sync` manually as a `devDependency` to your project
 - Start using `module.exports = require("@ui5/webcomponents-tools/components-package/wdio.sync.js");` in your `config/wdio.conf.js` file.