### PR TITLE
refactor: Use assert.include in tests

### DIFF
--- a/docs/dev/Testing Web Components.md
+++ b/docs/dev/Testing Web Components.md
@@ -188,18 +188,21 @@ assert.ok((await browser.$$(<SELECTOR>)).length)
 
 We have custom commands such as `getProperty` and `setProperty` to fill in gaps in the WDIO standard command set. Use them instead of manually setting properties with `executeAsync`.
 
-### Use `assert.includes` instead of string functions
+### Use `assert.include` instead of string functions
 
 Use:
 
  ```js
-assert.includes(text, EXPECTED_TEXT, "Text found")
+assert.include(text, EXPECTED_TEXT, "Text found")
+assert.notInclude(text, NOT_EXPECTED_TEXT, "Text not found")
 ```
 
 instead of:
 
 ```js
 assert.ok(text.indexOf(EXPECTED_TEXT) > -1, "Text found")
+assert.ok(text.includes(EXPECTED_TEXT), "Text found")
+assert.notOk(text.includes(NOT_EXPECTED_TEXT), "Text not found")
 ```
 
 ### Extract variables before asserting

--- a/packages/base/test/specs/ConfigurationChange.spec.js
+++ b/packages/base/test/specs/ConfigurationChange.spec.js
@@ -22,6 +22,6 @@ describe("Some configuration options can be changed at runtime", () => {
 			config.setNoConflict({events: ["selection-change"]});
 			done(config.getNoConflict());
 		});
-		assert.strictEqual(res.events.includes("selection-change"), true, "selection-change was successfully registered as a no conflict event");
+		assert.include(res.events, "selection-change", "selection-change was successfully registered as a no conflict event");
 	});
 });

--- a/packages/base/test/specs/ConfigurationScript.spec.js
+++ b/packages/base/test/specs/ConfigurationScript.spec.js
@@ -50,7 +50,7 @@ describe("Configuration script has effect", () => {
 			const config = window['sap-ui-webcomponents-bundle'].configuration;
 			done(config.getNoConflict());
 		});
-		assert.strictEqual(res.events.includes("selection-change"), true, "selectionChange was successfully registered as a no conflict event");
+		assert.include(res.events, "selection-change", "selectionChange was successfully registered as a no conflict event");
 	});
 
 	it("Tests that animationMode is applied", async () => {

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -124,7 +124,7 @@ describe("UploadCollection", () => {
 			await errorStateItem.shadow$("ui5-button[icon=refresh]").click();
 
 			const eventText = await browser.$("#uploadStateEvent").getText();
-			assert.ok(eventText.includes("Retry"), "Retry event is fired");
+			assert.include(eventText, "Retry", "Retry event is fired");
 		});
 
 		it("item should fire 'terminate'", async () => {
@@ -133,7 +133,7 @@ describe("UploadCollection", () => {
 			await uploadingStateItem.shadow$("ui5-button[icon=stop]").click();
 
 			const eventText = await browser.$("#uploadStateEvent").getText();
-			assert.ok(eventText.includes("Terminate"), "Terminate event is fired");
+			assert.include(eventText, "Terminate", "Terminate event is fired");
 		});
 	});
 

--- a/packages/fiori/test/specs/ViewSettingsDialog.spec.js
+++ b/packages/fiori/test/specs/ViewSettingsDialog.spec.js
@@ -12,7 +12,7 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
-		assert.ok(selectedLiText.includes("Ascending"), "initially sortOrder has correct value");
+		assert.include(selectedLiText, "Ascending", "initially sortOrder has correct value");
 		assert.notOk(await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").isExisting(), "initially sortBy should not have an option selected");
 
 		await browser.keys("Escape");
@@ -30,7 +30,7 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
-		assert.ok(selectedLiText.includes("Descending"), "SortOrder should properly change value");
+		assert.include(selectedLiText, "Descending", "SortOrder should properly change value");
 
 		await browser.keys("Escape");
 	});
@@ -48,7 +48,7 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		const sortByLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li").getText();
-		assert.ok(sortByLiText.includes("Name"), "sortBy should  have an option selected");
+		assert.include(sortByLiText, "Name", "sortBy should  have an option selected");
 
 		await browser.keys("Escape");
 	});
@@ -59,14 +59,14 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		let sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
-		assert.ok(sortBySelectedLiText.includes("Name"), "sortBy should have an option selected");
+		assert.include(sortBySelectedLiText, "Name", "sortBy should have an option selected");
 
 		await (await viewSettingsDialog.shadow$("[sort-by]").$$("ui5-li"))[1].click();
 		await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-footer").$("ui5-button").click();
 		await btnOpenDialog.click();
 
 		sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
-		assert.ok(sortBySelectedLiText.includes("Position"), "sortBy should change selected option");
+		assert.include(sortBySelectedLiText, "Position", "sortBy should change selected option");
 
 		await browser.keys("Escape");
 	})
@@ -77,9 +77,9 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		let sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
-		assert.ok(sortBySelectedLiText.includes("Position"),  "sortBy should have an option selected");
+		assert.include(sortBySelectedLiText, "Position",  "sortBy should have an option selected");
 		let selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
-		assert.ok(selectedLiText.includes("Descending"), "sortOrder should have correct option selected");
+		assert.include(selectedLiText, "Descending", "sortOrder should have correct option selected");
 
 		await (await viewSettingsDialog.shadow$("ui5-list").$$("ui5-li"))[0].click();
 		await (await viewSettingsDialog.shadow$$("ui5-li"))[0].click();
@@ -88,9 +88,9 @@ describe("ViewSettingsDialog general interaction", () => {
 		await btnOpenDialog.click();
 
 		sortBySelectedLiText = await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").getText();
-		assert.ok(sortBySelectedLiText.includes("Position"), "sortBy should not have a change in the selected option");
+		assert.include(sortBySelectedLiText, "Position", "sortBy should not have a change in the selected option");
 		selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
-		assert.ok(selectedLiText.includes("Descending"), "sortOrder should not have a change in the selected option");
+		assert.include(selectedLiText, "Descending", "sortOrder should not have a change in the selected option");
 
 		await browser.keys("Escape");
 	})
@@ -103,7 +103,7 @@ describe("ViewSettingsDialog general interaction", () => {
 		await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-header").$("ui5-button").click();
 
 		const selectedLiText = await viewSettingsDialog.shadow$("ui5-list").$("ui5-li[selected]").getText();
-		assert.ok(selectedLiText.includes("Ascending"), "sortOrder has returned to the initial state");
+		assert.include(selectedLiText, "Ascending", "sortOrder has returned to the initial state");
 		assert.notOk(await viewSettingsDialog.shadow$("[sort-by]").$("ui5-li[selected]").isExisting(), "sortBy has returned to the initial state");
 
 		await (await viewSettingsDialog.shadow$("ui5-dialog").$(".ui5-vsd-footer").$$("ui5-button"))[1].click();

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -247,7 +247,7 @@ describe("Date Picker Tests", () => {
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes("1548633600"), "28 Jan is the first displayed date for Feb 2019")
+		assert.include(timestamp, "1548633600", "28 Jan is the first displayed date for Feb 2019")
 
 		const calendarDate_3_Feb_2019 = await datepicker.getPickerDate(1549152000);
 
@@ -269,7 +269,7 @@ describe("Date Picker Tests", () => {
 
 		// first displayed date should be Jan 27, 2019, so this is February
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes("1548547200"), "Feb is the displayed month");
+		assert.include(timestamp, "1548547200", "Feb is the displayed month");
 	});
 
 	it("picker stays open on input click", async () => {
@@ -500,7 +500,7 @@ describe("Date Picker Tests", () => {
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes(_28Nov9999), "28 Nov, 9999 is the first displayed date");
+		assert.include(timestamp, _28Nov9999, "28 Nov, 9999 is the first displayed date");
 	});
 
 	it("daypicker extreme values min", async () => {
@@ -516,7 +516,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes(_31Dec0000), "Jan 1, 0001 is the second displayed date");
+		assert.include(timestamp, _31Dec0000, "Jan 1, 0001 is the second displayed date");
 	});
 
 	it("daypicker prev extreme values min", async () => {
@@ -535,7 +535,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes(_31Dec0000), "Jan 1, 0001 is the second displayed date");
+		assert.include(timestamp, _31Dec0000, "Jan 1, 0001 is the second displayed date");
 	});
 
 	it("daypicker next extreme values max", async () => {
@@ -554,7 +554,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedDate = await datepicker.getFirstDisplayedDate();
 		const timestamp = await firstDisplayedDate.getAttribute("data-sap-timestamp");
-		assert.ok(timestamp.includes(_28Nov9999), "28 Nov, 9999 is the first displayed date");
+		assert.include(timestamp, _28Nov9999, "28 Nov, 9999 is the first displayed date");
 	});
 
 	it("monthpicker next extreme values max", async () => {
@@ -574,7 +574,7 @@ describe("Date Picker Tests", () => {
 
 		const btnYear = await datepicker.getBtnYear();
 		const innerHTML = await btnYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9999"), "year button's text is correct");
+		assert.include(innerHTML, "9999", "year button's text is correct");
 	});
 
 	it("monthpicker prev extreme values min", async () => {
@@ -594,7 +594,7 @@ describe("Date Picker Tests", () => {
 
 		const btnYear = await datepicker.getBtnYear();
 		const innerHTML = await btnYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0001"), "year button's text is correct");
+		assert.include(innerHTML, "0001", "year button's text is correct");
 	});
 
 	it("yearpicker extreme values max", async () => {
@@ -611,7 +611,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9980"), "First year in the year picker is correct");
+		assert.include(innerHTML, "9980", "First year in the year picker is correct");
 	});
 
 	it("yearpicker extreme values min", async () => {
@@ -628,7 +628,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
+		assert.include(innerHTML, "0001", "First year in the year picker is correct");
 	});
 
 	it("yearpicker prev page extreme values min", async () => {
@@ -645,14 +645,14 @@ describe("Date Picker Tests", () => {
 
 		let firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		let innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0002"), "First year in the year picker is correct");
+		assert.include(innerHTML, "0002", "First year in the year picker is correct");
 
 		const btnPrev = await datepicker.getBtnPrev();
 		await btnPrev.click();
 
 		firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
+		assert.include(innerHTML, "0001", "First year in the year picker is correct");
 	});
 
 	it("yearpicker next page extreme values max", async () => {
@@ -669,14 +669,14 @@ describe("Date Picker Tests", () => {
 
 		let firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		let innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9976"), "First year in the year picker is correct");
+		assert.include(innerHTML, "9976", "First year in the year picker is correct");
 
 		const btnNext = await datepicker.getBtnNext();
 		await btnNext.click();
 
 		firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9980"), "First year in the year picker is correct");
+		assert.include(innerHTML, "9980", "First year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values max", async () => {
@@ -693,14 +693,14 @@ describe("Date Picker Tests", () => {
 
 		const tenthYear = await datepicker.getDisplayedYear(10);
 		let innerHTML = await tenthYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9986"), "Tenth year in the year picker is correct");
+		assert.include(innerHTML, "9986", "Tenth year in the year picker is correct");
 
 		await tenthYear.click();
 		await btnYear.click();
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("9976"), "First year in the year picker is correct");
+		assert.include(innerHTML, "9976", "First year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values min above 10", async () => {
@@ -717,7 +717,7 @@ describe("Date Picker Tests", () => {
 
 		const thirdYear = await datepicker.getDisplayedYear(2);
 		const innerHTML = await thirdYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0004"), "Third year in the year picker is correct");
+		assert.include(innerHTML, "0004", "Third year in the year picker is correct");
 	});
 
 	it("yearpicker click extreme values min below 10", async () => {
@@ -734,7 +734,7 @@ describe("Date Picker Tests", () => {
 
 		const firstDisplayedYear = await datepicker.getFirstDisplayedYear();
 		const innerHTML = await firstDisplayedYear.getProperty("innerHTML");
-		assert.ok(innerHTML.includes("0001"), "First year in the year picker is correct");
+		assert.include(innerHTML, "0001", "First year in the year picker is correct");
 	});
 
 	it("placeholder, based on the formatPattern", async () => {

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -13,7 +13,7 @@ describe("Icon general interaction", () => {
 		const ICON_TOOLTIP_TEXT = "Save";
 
 		assert.ok(iconRoot, "Icon is rendered");
-		assert.strictEqual((await iconTooltip.getHTML(false)).includes(ICON_TOOLTIP_TEXT), true,
+		assert.include(await iconTooltip.getHTML(false), ICON_TOOLTIP_TEXT,
 			"Built-in tooltip is correct");
 	});
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -438,7 +438,7 @@ describe("Input general interaction", () => {
 
 		assert.ok(await respPopover.isDisplayedInViewport(), "The popover is visible");
 		const firstItemHtml = await firstListItem.getHTML();
-		assert.ok(firstItemHtml.includes(EXPTECTED_TEXT), "The suggestions is highlighted.");
+		assert.include(firstItemHtml, EXPTECTED_TEXT, "The suggestions is highlighted.");
 	});
 
 	it("Doesn't remove value on number type input even if locale specific delimiter/multiple delimiters", async () => {

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -59,6 +59,6 @@ describe("General API", () => {
 
 		await link.click();
 		const url = await browser.getUrl();
-		assert.notOk(url.includes("https://www.google.com"), "URL is not google");
+		assert.notInclude(url, "https://www.google.com", "URL is not google");
 	});
 });

--- a/packages/main/test/specs/LitKeyFunction.spec.js
+++ b/packages/main/test/specs/LitKeyFunction.spec.js
@@ -30,13 +30,13 @@ describe("Lit HTML key function for #each", async () => {
 		// The first item (<empty>) should not be selected
 		const newFirstItem = (await popover.$$(".ui5-multi-combobox-all-items-list > ui5-li"))[0];
 		const newFirstItemHtml = await newFirstItem.getHTML(false);
-		assert.ok(newFirstItemHtml.includes("empty"), "First item is <empty>");
+		assert.include(newFirstItemHtml, "empty", "First item is <empty>");
 		assert.notOk(await newFirstItem.getProperty("selected"), "<empty> is not selected");
 
 		// The last item (USA) should be selected
 		const lastItem = (await popover.$$(".ui5-multi-combobox-all-items-list > ui5-li"))[3];
 		const lastItemHtml = await lastItem.getHTML(false);
-		assert.ok(lastItemHtml.includes("USA"), "Last item is USA");
+		assert.include(lastItemHtml, "USA", "Last item is USA");
 		assert.ok(await lastItem.getProperty("selected"), "USA is  selected");
 	});
 });

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -20,7 +20,7 @@ describe("Select general interaction", () => {
 
 		assert.strictEqual(await inputResult.getProperty("value"), "1", "Fired change event is called once.");
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Select label is correct.");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Select label is correct.");
 	});
 
 	it("does not fire change, when clicking on selected item", async () => {
@@ -53,7 +53,7 @@ describe("Select general interaction", () => {
 
 		assert.strictEqual(await inputResult.getProperty("value"), "1", "Fired change event is called once more.");
 		let selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Select label is correct.");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT1, "Select label is correct.");
 
 		await select.click();
 		await select.keys("ArrowDown");
@@ -61,7 +61,7 @@ describe("Select general interaction", () => {
 
 		assert.strictEqual(await inputResult.getProperty("value"), "2", "Fired change event is called once more.");
 		selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Select label is correct.");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT2, "Select label is correct.");
 
 	});
 
@@ -80,11 +80,11 @@ describe("Select general interaction", () => {
 
 		await select.keys("ArrowUp");
 		let selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up should change selected item");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT1, "Arrow Up should change selected item");
 
 		await select.keys("ArrowDown");
 		selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Arrow Down should change selected item");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT2, "Arrow Down should change selected item");
 
 		assert.strictEqual(await inputResult.getProperty("value"), "2", "Change event should have fired twice");
 	});
@@ -107,12 +107,12 @@ describe("Select general interaction", () => {
 		// change selection with picker closed
 		await select.keys("ArrowUp");
 		let politeSpanHtml = await politeSpan.getHTML(false);
-		assert.ok(politeSpanHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up should change selected item");
+		assert.include(politeSpanHtml, EXPECTED_SELECTION_TEXT1, "Arrow Up should change selected item");
 
 		// change selection with picker closed
 		await select.keys("ArrowDown");
 		politeSpanHtml = await politeSpan.getHTML(false);
-		assert.ok(politeSpanHtml.includes(EXPECTED_SELECTION_TEXT2), "Arrow Down should change selected item");
+		assert.include(politeSpanHtml, EXPECTED_SELECTION_TEXT2, "Arrow Down should change selected item");
 
 		// change previewed item with picker opened
 		await select.click();
@@ -125,7 +125,7 @@ describe("Select general interaction", () => {
 		await select.keys("Enter");
 
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT1), "Arrow Up and Enter should change selected item");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT1, "Arrow Up and Enter should change selected item");
 
 		await btn.click();
 
@@ -145,7 +145,7 @@ describe("Select general interaction", () => {
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Arrow Up should change selected item");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Arrow Up should change selected item");
 
 		const focusedElementId = await browser.executeAsync(done => {
 			done(document.activeElement.id);
@@ -167,7 +167,7 @@ describe("Select general interaction", () => {
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Arrow Down should change selected item");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Arrow Down should change selected item");
 
 		const focusedElementId = await browser.executeAsync(done => {
 			done(document.activeElement.id);
@@ -183,12 +183,12 @@ describe("Select general interaction", () => {
 
 		await select.click();
 		let selectOptionTextHtml = await selectOptionText.getHTML(false);
-		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text is " + EXPECTED_SELECTION_TEXT);
+		assert.include(selectOptionTextHtml, EXPECTED_SELECTION_TEXT, "Selected option text is " + EXPECTED_SELECTION_TEXT);
 
 		// The last item is already selected - pressing ArrowDown should not change the focus or the selection
 		await select.keys("ArrowDown");
 		selectOptionTextHtml = await selectOptionText.getHTML(false);
-		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text remains " + EXPECTED_SELECTION_TEXT);
+		assert.include(selectOptionTextHtml, EXPECTED_SELECTION_TEXT, "Selected option text remains " + EXPECTED_SELECTION_TEXT);
 
 		// Close the select not to cover other components that tests would try to click
 		await select.keys("Escape");
@@ -201,12 +201,12 @@ describe("Select general interaction", () => {
 
 		await select.click();
 		let selectOptionTextHtml = await selectOptionText.getHTML(false);
-		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text is " + EXPECTED_SELECTION_TEXT);
+		assert.include(selectOptionTextHtml, EXPECTED_SELECTION_TEXT, "Selected option text is " + EXPECTED_SELECTION_TEXT);
 
 		// The last item is already selected - pressing ArrowUp should not change the focus or the selection
 		await select.keys("ArrowUp");
 		selectOptionTextHtml = await selectOptionText.getHTML(false);
-		assert.ok(selectOptionTextHtml.includes(EXPECTED_SELECTION_TEXT), "Selected option text remains " + EXPECTED_SELECTION_TEXT);
+		assert.include(selectOptionTextHtml, EXPECTED_SELECTION_TEXT, "Selected option text remains " + EXPECTED_SELECTION_TEXT);
 
 		// Close the select not to cover other components that tests would try to click
 		await select.keys("Escape");
@@ -222,7 +222,7 @@ describe("Select general interaction", () => {
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Typing letter should change selection");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Typing letter should change selection");
 	});
 
 	it("changes selection with typing more letters", async () => {
@@ -236,7 +236,7 @@ describe("Select general interaction", () => {
 		const selectText = await select.shadow$(".ui5-select-label-root");
 
 		const selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Typing text should change selection");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Typing text should change selection");
 	});
 
 	it("opens upon space", async () => {
@@ -389,7 +389,7 @@ describe("Select general interaction", () => {
 		await firstItem.click();
 
 		let selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT), "Select label is correct.");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT, "Select label is correct.");
 
 		// verify that ESC does not interfere when the picker is closed
 		await select.keys("Escape");
@@ -397,7 +397,7 @@ describe("Select general interaction", () => {
 		await thirdItem.click();
 
 		selectTextHtml = await selectText.getHTML(false);
-		assert.ok(selectTextHtml.includes(EXPECTED_SELECTION_TEXT2), "Select label is correct.");
+		assert.include(selectTextHtml, EXPECTED_SELECTION_TEXT2, "Select label is correct.");
 	});
 
 	it("Tests aria-label, aria-labelledby and aria-expanded", async () => {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -13,7 +13,7 @@ describe("TabContainer general interaction", () => {
 		const SELECTION_CSS_CLASS = "ui5-tab-strip-item--selected";
 
 		const selectedFilterHtml = await selectedFilter.getHTML();
-		assert.ok(selectedFilterHtml.includes(SELECTION_CSS_CLASS), "The item has the selection css class set.");
+		assert.include(selectedFilterHtml, SELECTION_CSS_CLASS, "The item has the selection css class set.");
 		assert.strictEqual(selectedFilter.id, selectedTab.id, "The IDs of the ui5-tab and the rendered tab filter matches.");
 	});
 

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -84,7 +84,7 @@ describe("Toast general interaction", () => {
 		await button.click();
 
 		const styleValue = await toastShadowContent.getAttribute("style");
-		assert.ok(styleValue.includes(EXPECTED_STYLES),
+		assert.include(styleValue, EXPECTED_STYLES,
 			"The correct default inline styles are applied to the shadow ui5-toast-root");
 	});
 
@@ -103,7 +103,7 @@ describe("Toast general interaction", () => {
 		const EXPECTED_STYLES = `transition-duration: ${maximumAllowedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
 
 		const styleValue = await toastShadowContent.getAttribute("style");
-		assert.ok(styleValue.includes(EXPECTED_STYLES),
+		assert.include(styleValue, EXPECTED_STYLES,
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is longer than default. Transition is not longer than allowed (1000ms).");
 	});
@@ -123,7 +123,7 @@ describe("Toast general interaction", () => {
 		const EXPECTED_STYLES = `transition-duration: ${calculatedTransition}ms; transition-delay: ${calculatedDelay}; opacity: 0;`;
 
 		const styleValue = await toastShadowContent.getAttribute("style");
-		assert.ok(styleValue.includes(EXPECTED_STYLES),
+		assert.include(styleValue, EXPECTED_STYLES,
 				"The correct custom inline styles are applied to the shadow ui5-toast-root," +
 				"when the duration is shorter than default. Transition is a third of the duration.");
 	});

--- a/packages/main/test/specs/base/InvisibleMessage.spec.js
+++ b/packages/main/test/specs/base/InvisibleMessage.spec.js
@@ -28,7 +28,7 @@ describe("InvisibleMessage", () => {
 
         const politeSpanHtml = await politeSpan.getHTML();
         const assertiveSpanHtml = await assertiveSpan.getHTML();
-        assert.ok(politeSpanHtml.includes("announcement"), "Value has been rendered.");
-        assert.ok(assertiveSpanHtml.includes("announcement"), "Value has been rendered.");
+        assert.include(politeSpanHtml, "announcement", "Value has been rendered.");
+        assert.include(assertiveSpanHtml, "announcement", "Value has been rendered.");
     });
 });


### PR DESCRIPTION
This is a follow-up to: https://github.com/SAP/ui5-webcomponents/pull/3969

`assert.include` and `assert.notInclude` should be used instead of string manipulation functions.