### PR TITLE
refactor: Use custom select strategy in tests

### DIFF
--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -38,9 +38,7 @@ describe("BusyIndicator general interaction", () => {
 		const busyIndicator = await browser.$("#indicator1");
 		await busyIndicator.click();
 
-		let innerFocusElement = await browser.executeAsync(done => {
-			done(document.getElementById("indicator1").shadowRoot.activeElement);
-		});
+		let innerFocusElement = await browser.custom$("activeElement", "#indicator1");
 
 		innerFocusElement = await browser.$(innerFocusElement);
 

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -219,17 +219,13 @@ describe("Carousel general interaction", () => {
 
 		await browser.keys("F7");
 
-		let innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("carouselF7").shadowRoot.activeElement);
-		});
+		let innerFocusedElement = await browser.custom$("activeElement", "#carouselF7");
 
 		assert.ok(await browser.$(innerFocusedElement).hasClass("ui5-carousel-root"), "Carousel is focused");
 
 		await browser.keys("F7");
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("carouselF7Button").shadowRoot.activeElement);
-		});
+		innerFocusedElement = innerFocusedElement = await browser.custom$("activeElement", "#carouselF7Button");
 
 		assert.ok(await browser.$(innerFocusedElement).hasClass("ui5-button-root"), "Button is focused");
 
@@ -237,17 +233,13 @@ describe("Carousel general interaction", () => {
 
 		await browser.keys("F7");
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("carouselF7").shadowRoot.activeElement);
-		});
+		innerFocusedElement = await browser.custom$("activeElement", "#carouselF7");
 
 		assert.ok(await browser.$(innerFocusedElement).hasClass("ui5-carousel-root"), "Carousel is focused");
 
 		await browser.keys("F7");
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("carouselF7Input").shadowRoot.activeElement);
-		});
+		innerFocusedElement = await browser.custom$("activeElement", "#carouselF7Input");
 
 		assert.ok(await browser.$(innerFocusedElement).hasClass("ui5-input-inner"), "Input is focused");
 
@@ -261,9 +253,7 @@ describe("Carousel general interaction", () => {
 
 		await browser.keys("F7");
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("carouselF7Input").shadowRoot.activeElement);
-		});
+		innerFocusedElement = await browser.custom$("activeElement", "#carouselF7Input");
 
 		assert.ok(await browser.$(innerFocusedElement).hasClass("ui5-input-inner"), "Input is focused");
 	});

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -378,18 +378,14 @@ describe("Accessibility", async () => {
 
 		await rangeSlider.click();
 
-		let innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		let innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderEndHandle.getAttribute("class"), "RangeSlider second handle has the shadowDom focus");
 
 		await rangeSlider.setProperty("startValue", 30);
 		await rangeSliderStartHandle.click({ x: -200});
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderStartHandle.getAttribute("class"), "RangeSlider second handle has the shadowDom focus");
 	});
@@ -403,9 +399,7 @@ describe("Accessibility", async () => {
 		await rangeSlider.setProperty("endValue", 60);
 		await rangeSlider.click();
 
-		let innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderSelection.getAttribute("class"), "RangeSlider progress bar has the shadowDom focus");
 	});
@@ -419,9 +413,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys("Tab");
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.ok(await rangeSlider.isFocused(), "Range Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderSelection.getAttribute("class"), "Range Slider progress tracker has the shadowDom focus");
@@ -433,9 +425,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys("Tab");
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderStartHandle.getAttribute("class"), "Range Slider first handle has the hadowDom focus");
 	});
@@ -446,9 +436,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys("Tab");
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderEndHandle.getAttribute("class"), "Range Slider second handle has the shadowDom focus");
 	});
@@ -460,9 +448,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys("Tab");
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider-with-tooltip").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider-with-tooltip");
 
 		assert.notOk(await currentRangeSlider.isFocused(), "First RangeSlider component is now not focused");
 
@@ -477,9 +463,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys(["Shift", "Tab"]);
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.notOk(await currentRangeSlider.isFocused(), "First RangeSlider component is now not focused");
 
@@ -493,9 +477,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys(["Shift", "Tab"]);
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderStartHandle.getAttribute("class"), "Range Slider first handle has the shadowDom focus");
 	});
@@ -506,9 +488,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys(["Shift", "Tab"]);
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await rangeSliderSelection.getAttribute("class"), "Range Slider first handle has the shadowDom focus");
 	});
@@ -527,9 +507,7 @@ describe("Accessibility", async () => {
 		const endHandle = await rangeSlider.shadow$(".ui5-slider-handle--end");
 
 		await startHandle.dragAndDrop({ x: 400, y: 1 });
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await endHandle.getAttribute("class"), "Range Slider second handle now has the shadowDom focus");
 	});
@@ -900,18 +878,14 @@ describe("Accessibility: Testing keyboard handling", async () => {
 		await startHandle.click();
 		await browser.keys("End");
 
-		let innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		let innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await rangeSlider.getProperty("endValue"), 100, "The original end-value is set to min and switched as a start-value");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await endHandle.getAttribute("class"), "Range Slider second handle now has the shadowDom focus");
 
 		await browser.keys("Home");
 
-		innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-range-slider").shadowRoot.activeElement);
-		});
+		innerFocusedElement = await browser.custom$("activeElement", "#basic-range-slider");
 
 		assert.strictEqual(await rangeSlider.getProperty("startValue"), 0, "The original end-value is set to min and switched as a start-value");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await startHandle.getAttribute("class"), "Range Slider second handle now has the shadowDom focus");

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -263,9 +263,7 @@ describe("Accessibility", async () => {
 
 		await slider.click();
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-slider");
 
 		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");
@@ -277,9 +275,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys("Tab");
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-slider-with-tooltip").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-slider-with-tooltip");
 
 		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");
@@ -291,9 +287,7 @@ describe("Accessibility", async () => {
 
 		await browser.keys(["Shift", "Tab"]);
 
-		const innerFocusedElement = await browser.executeAsync(done => {
-			done(document.getElementById("basic-slider").shadowRoot.activeElement);
-		});
+		const innerFocusedElement = await browser.custom$("activeElement", "#basic-slider");
 
 		assert.ok(await slider.isFocused(), "Slider component is focused");
 		assert.strictEqual(await browser.$(innerFocusedElement).getAttribute("class"), await sliderHandle.getAttribute("class"), "Slider handle has the shadowDom focus");

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -152,8 +152,8 @@ exports.config = {
 	 * @param {Array.<Object>} capabilities list of capabilities details
 	 * @param {Array.<String>} specs List of spec file paths that are to be run
 	 */
-	before: function (capabilities, specs) {
-		browser.addCommand("isFocusedDeep", async function () {
+	before: async function (capabilities, specs) {
+		await browser.addCommand("isFocusedDeep", async function () {
 			return browser.executeAsync(function (elem, done) {
 				let activeElement = document.activeElement;
 
@@ -168,46 +168,50 @@ exports.config = {
 			}, this);
 		}, true);
 
-		browser.addCommand("setProperty", async function(property, value) {
+		await browser.addCommand("setProperty", async function(property, value) {
 			return browser.executeAsync((elem, property, value, done) => {
 				elem[property] = value;
 				done();
 			}, this, property, value);
 		}, true);
 
-		browser.addCommand("setAttribute", async function(attribute, value) {
+		await browser.addCommand("setAttribute", async function(attribute, value) {
 			return browser.executeAsync((elem, attribute, value, done) => {
 				elem.setAttribute(attribute, value);
 				done();
 			}, this, attribute, value);
 		}, true);
 
-		browser.addCommand("removeAttribute", async function(attribute) {
+		await browser.addCommand("removeAttribute", async function(attribute) {
 			return browser.executeAsync((elem, attribute, done) => {
 				elem.removeAttribute(attribute);
 				done();
 			}, this, attribute);
 		}, true);
 
-		browser.addCommand("hasClass", async function(className) {
+		await browser.addCommand("hasClass", async function(className) {
 			return browser.executeAsync((elem, className, done) => {
 				done(elem.classList.contains(className));
 			}, this, className);
 		}, true);
 
-		browser.addCommand("getStaticAreaItemClassName", async function(selector) {
+		await browser.addCommand("getStaticAreaItemClassName", async function(selector) {
 			return browser.executeAsync(async (selector, done) => {
 				const staticAreaItem = await document.querySelector(selector).getStaticAreaItemDomRef();
 				done(staticAreaItem.host.classList[0]);
 			}, selector);
 		}, false);
+
+		await browser.addLocatorStrategy('activeElement', (selector) => {
+			return document.querySelector(selector).shadowRoot.activeElement;
+		});
 	},
 	/**
 	 * Runs before a WebdriverIO command gets executed.
 	 * @param {String} commandName hook command name
 	 * @param {Array} args arguments that command would receive
 	 */
-	beforeCommand: function (commandName, args) {
+	beforeCommand: async function (commandName, args) {
 		const waitFor = [
 			"$",
 			"$$",
@@ -230,7 +234,7 @@ exports.config = {
 			"shadow$$",
 		];
 		if (waitFor.includes(commandName)) {
-			browser.executeAsync(function (done) {
+			await browser.executeAsync(function (done) {
 				window["sap-ui-webcomponents-bundle"].renderFinished().then(done);
 			});
 		}


### PR DESCRIPTION
 - Using `executeAsync` to query the browser for an element is ok, but there is an official pattern in WebdriverIO: [Custom locator strategy](https://webdriver.io/docs/api/browser/custom$). A very common use case in our tests is to get the `activeElement` inside a `shadowRoot`. A custom locator strategy is defined globally for that, and used in all relevant tests.
 - The `before` and `beforeCommand` lifecycle hooks in `wdio.js` were not awaiting for all async operations (only `afterCommand` was). This is now also fixed.