### PR TITLE
refactor: Use waitUntil in tests

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-EprRE5A8CqkEPb+7ZfK0SMKlpPY=
+EMRk2f0bPOfeT0GWqFws0pitpz4=

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -25,8 +25,13 @@ describe("Page general interaction", () => {
         assert.ok(await footer.isDisplayedInViewport(), "Footer should be visible.");
 
         await button.click();
-        await browser.pause(500);
 
-        assert.notOk(await footer.isDisplayedInViewport(), "Footer should not be visible.");
+		await browser.waitUntil(async () => {
+			const footerVisible = await footer.isDisplayedInViewport();
+			return !footerVisible;
+		}, {
+			timeout: 500,
+			timeoutMsg: "expected footer to not be visible after 500ms"
+		});
 	});
 });

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -26,10 +26,7 @@ describe("Page general interaction", () => {
 
         await button.click();
 
-		await browser.waitUntil(async () => {
-			const footerVisible = await footer.isDisplayedInViewport();
-			return !footerVisible;
-		}, {
+		await browser.waitUntil(async () => !(await footer.isDisplayedInViewport()), {
 			timeout: 500,
 			timeoutMsg: "expected footer to not be visible after 500ms"
 		});

--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -213,7 +213,6 @@ describe("Wizard general interaction", () => {
 		// Note: scrollIntoView works in Chrome, but if we start executing the test on every browser,
 		// this test should be reworked.
 		await scrollMarker.scrollIntoView();
-		await browser.pause(500);
 
 		// assert - that second step in the content and in the header are properly selected
 		assert.strictEqual(await step2.getAttribute("selected"), "true", "Second step in the content is selected.");
@@ -243,7 +242,6 @@ describe("Wizard general interaction", () => {
 		await btnToStep2.click(); // click to get back to step 2
 		await sw.click(); // click to dynamically expand content in step 2
 		await scrollMarker.scrollIntoView(); // scroll to step 3
-		await browser.pause(500);
 
 		assert.strictEqual(await step3.getAttribute("selected"), "true",
 			"Third step in the content is selected.");

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -22,12 +22,14 @@ describe("BusyIndicator general interaction", () => {
 		const busyIndicator = await browser.$("#busy-container");
 		const busyArea = await busyIndicator.shadow$(".ui5-busy-indicator-busy-area");
 
-		await browser.pause(3000);
 		assert.notOk(await busyArea.isExisting(), "busy area is not yet created");
 
 		await busyIndicator.setAttribute("active", "");
-		await browser.pause(3000);
-		assert.ok(await busyArea.isExisting(), "busy area is created");
+
+		await browser.waitUntil(() => busyArea.isExisting(), {
+			timeout: 3000,
+			timeoutMsg: "Busy area must be created after 3000ms"
+		});
 
 		// reset
 		await busyIndicator.removeAttribute("active");

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -26,7 +26,7 @@ describe("BusyIndicator general interaction", () => {
 
 		await busyIndicator.setAttribute("active", "");
 
-		await browser.waitUntil(() => busyArea.isExisting(), {
+		await busyArea.waitForExist({
 			timeout: 3000,
 			timeoutMsg: "Busy area must be created after 3000ms"
 		});

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -69,7 +69,11 @@ describe("General interaction", () => {
 		await input.click();
 		await input.keys("b");
 
-		await browser.pause(200);
+		await browser.waitUntil(() => popover.getProperty("opened"), {
+			timeout: 200,
+			timeoutMsg: "Popover should be displayed"
+		});
+
 		assert.ok(await popover.getProperty("opened"), "Popover should be displayed");
 		assert.strictEqual(await input.getProperty("value"), "Bahrain", "Value should be Bahrain");
 

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -1,22 +1,20 @@
 const assert = require("chai").assert;
 const PORT = require("./_port.js");
 
-const openPickerById = async (id, options) => {
-	const res = await browser.executeAsync((id, options, done) => {
+const openPickerById = (id, options) => {
+	return browser.executeAsync((id, options, done) => {
 		done(document.querySelector(`#${id}`).openPicker(options));
 	}, id, options);
-	await browser.pause(1000);
-	return res;
 }
 
-const closePickerById = async id => {
-	return await browser.executeAsync((id, done) => {
+const closePickerById = id => {
+	return browser.executeAsync((id, done) => {
 		done(document.querySelector(`#${id}`).closePicker());
 	}, id);
 }
 
-const isPickerOpen = async id => {
-	return await browser.executeAsync((id, done) => {
+const isPickerOpen = id => {
+	return browser.executeAsync((id, done) => {
 		done(document.querySelector(`#${id}`).isOpen());
 	}, id);
 }

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -255,10 +255,13 @@ describe("Dialog general interaction", () => {
 
 		const closeButton = await browser.$("#dynamic-dialog-close-button");
 
-		await browser.pause(500);
-
-		const activeElement = await browser.$(await browser.getActiveElement());
-		assert.strictEqual(await activeElement.getProperty("id"), await closeButton.getProperty("id"), "the active element is the close button");
+		await browser.waitUntil(async () => {
+			const activeElement = await browser.$(await browser.getActiveElement());
+			return await activeElement.getProperty("id") === await closeButton.getProperty("id");
+		}, {
+			timeout: 500,
+			timeoutMsg: "the active element must be the close button"
+		});
 
 		await closeButton.click();
 	});

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -454,7 +454,6 @@ describe("Input general interaction", () => {
 		await input.keys("3");
 		await input.keys("Tab");
 
-		await browser.pause(500);
 		assert.strictEqual(parseFloat(await input.getProperty("value")).toPrecision(3), "1.22", "Value is not lost");
 	});
 

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -260,9 +260,11 @@ describe("List Tests", () => {
 		const loadMoreResult = await browser.$("#loadMoreResult");
 
 		await btn.click();
-		await browser.pause(1000);
 
-		// assert.strictEqual(await loadMoreResult.getProperty("value"), "1", "The event loadMore is fired.");
+		await browser.waitUntil(async () => await loadMoreResult.getProperty("value") === "1", {
+			timeout: 1000,
+			timeoutMsg: "The event loadMore must be fired"
+		});
 	});
 
 	it("detailPress event is fired", async () => {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -262,7 +262,7 @@ describe("List Tests", () => {
 		await btn.click();
 
 		await browser.waitUntil(async () => await loadMoreResult.getProperty("value") === "1", {
-			timeout: 1000,
+			timeout: 2000,
 			timeoutMsg: "The event loadMore must be fired"
 		});
 	});

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -28,14 +28,18 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await mcb.getProperty("focused"), "MultiComboBox should be focused.");
 
 			await input.keys("ArrowLeft");
-			await browser.pause(300);
 
-			assert.notOk(await mcb.getProperty("focused"), "MultiComboBox should no longer be focused.");
+			await browser.waitUntil(async () => !(await mcb.getProperty("focused")), {
+				timeout: 500,
+				timeoutMsg: "MultiComboBox should no longer be focused"
+			});
 
 			await input.keys("ArrowRight");
-			await browser.pause(500);
 
-			assert.ok(await mcb.getProperty("focused"), "MultiComboBox should be focused again.");
+			await browser.waitUntil(() => mcb.getProperty("focused"), {
+				timeout: 500,
+				timeoutMsg: "MultiComboBox should be focused again"
+			});
 		});
 
 		it("MultiComboBox open property is set correctly", async () => {

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -64,15 +64,28 @@ describe("Panel general interaction", () => {
 		const field = await browser.$("#field1");
 
 		await header.click();
-		await browser.pause(500);
+
+		await browser.waitUntil(async () => await field.getProperty("value") === "1", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 
 		await header.keys("Space");
-		await browser.pause(500);
+
+		await browser.waitUntil(async () => await field.getProperty("value") === "2", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 
 		await header.keys("Enter");
-		await browser.pause(500);
 
-		assert.strictEqual(await field.getProperty("value"), "3", "Press should be called 3 times");
+		await browser.waitUntil(async () => await field.getProperty("value") === "3", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 	});
 
 	it("tests toggle event upon icon click with custom header", async () => {
@@ -80,15 +93,28 @@ describe("Panel general interaction", () => {
 		const field = await browser.$("#field2");
 
 		await icon.click();
-		await browser.pause(500);
+
+		await browser.waitUntil(async () => await field.getProperty("value") === "1", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 
 		await icon.keys("Space");
-		await browser.pause(500);
+
+		await browser.waitUntil(async () => await field.getProperty("value") === "2", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 
 		await icon.keys("Enter");
-		await browser.pause(500);
 
-		assert.strictEqual(await field.getProperty("value"), "3", "Press should be called 3 times");
+		await browser.waitUntil(async () => await field.getProperty("value") === "3", {
+			timeout: 500,
+			interval: 100,
+			timeoutMsg: "Press called"
+		});
 	});
 
 	it("tests toggle expand/collapse animation", async () => {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -55,15 +55,26 @@ describe("TabContainer general interaction", () => {
 		assert.ok(await arrowRight.isDisplayed(), "'Right Arrow' should be initially shown");
 
 		await arrowRight.click();
-		await browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		assert.ok(await arrowLeft.isDisplayed(), "'Left Arrow' should be visible after 'Right arrow' click");
+		await arrowLeft.waitForDisplayed({
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Left Arrow' should be visible after 'Right arrow' click"
+		});
 
 		await arrowLeft.click();
-		await browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		assert.notOk(await arrowLeft.isDisplayed(), "'Left Arrow' should be hidden after 'Left arrow' click");
-		assert.ok(await arrowRight.isDisplayed(), "'Right Arrow' should be visible  after 'Left arrow' click");
+		await arrowLeft.waitForDisplayed({
+			reverse: true,
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Left Arrow' should be hidden after 'Left arrow' click"
+		});
+		await arrowRight.waitForDisplayed({
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Right Arrow' should be visible  after 'Left arrow' click"
+		});
 	});
 
 	it("scroll works on textOnly TabContainer", async () => {
@@ -76,15 +87,26 @@ describe("TabContainer general interaction", () => {
 		assert.ok(await arrowRight.isDisplayed(), "'Right Arrow' should be initially shown");
 
 		await arrowRight.click();
-		await browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		assert.ok(await arrowLeft.isDisplayed(), "'Left Arrow' should be visible after 'Right arrow' click");
+		await arrowLeft.waitForDisplayed({
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Left Arrow' should be visible after 'Right arrow' click"
+		});
 
 		await arrowLeft.click();
-		await browser.pause(1000); // TODO: wait for animation finish. Remove when solved on framework level
 
-		assert.notOk(await arrowLeft.isDisplayed(), "'Left Arrow' should be hidden after 'Left arrow' click");
-		assert.ok(await arrowRight.isDisplayed(), "'Right Arrow' should be visible  after 'Left arrow' click");
+		await arrowLeft.waitForDisplayed({
+			reverse: true,
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Left Arrow' should be hidden after 'Left arrow' click"
+		});
+		await arrowRight.waitForDisplayed({
+			timeout: 1000,
+			interval: 100,
+			timeoutMsg: "'Right Arrow' should be visible  after 'Left arrow' click"
+		});
 
 		// act: open overflow
 		const overflowBtn = await browser.$("#tabContainerTextOnly").shadow$(".ui-tc__overflowButton");
@@ -98,7 +120,6 @@ describe("TabContainer general interaction", () => {
 
 		// act: resize, so the overflow button is not visible
 		await browser.setWindowSize(1400, 1080);
-		await browser.pause(500);
 
 		// assert: the overflow popover is closed.
 		assert.strictEqual(await overflowPopover.isDisplayedInViewport(), false,

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -116,11 +116,10 @@ describe("Table general interaction", () => {
 			// act
 			await btnScroll.click();
 
-			await browser.pause(500);
-
-			// assert
-			assert.strictEqual(await inputResult.getProperty("value"), "1",
-				"The load-more is fired.");
+			await browser.waitUntil(async () => (await inputResult.getProperty("value")) === "1", {
+				timeout: 1000,
+				timeoutMsg: "The load-more event must be fired."
+			});
 		});
 	});
 

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -22,7 +22,6 @@ describe("TimePicker general interaction", () => {
 		// act
 		await timepicker.setProperty("value", "11:12:13");
 		await timepicker.shadow$("ui5-input").$(".ui5-time-picker-input-icon-button").click();
-		// await browser.pause(500);
 
 		const hoursSliderValue = await timepickerPopover.$("ui5-time-selection").shadow$(`ui5-wheelslider[data-sap-slider="hours"]`).getValue();
 		const minutesSliderValue = await timepickerPopover.$("ui5-time-selection").shadow$(`ui5-wheelslider[data-sap-slider="minutes"]`).getValue();

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -134,13 +134,14 @@ describe("Toast general interaction", () => {
 
 		await button.click();
 
-		// Give time for the animation to end and _ontransitionend to be called
-		await browser.pause(1000);
-
-		assert.notOk(await toast.getProperty("open"),
-		"Open property should be false after Toast is closed");
-		assert.notOk(await toast.getProperty("domRendered"),
-		"domRendered property value should be false after Toast is closed");
+		await browser.waitUntil(async () => {
+			const open = await toast.getProperty("open");
+			const domRendered = await toast.getProperty("domRendered");
+			return !open && !domRendered;
+		}, {
+			timeout: 1000,
+			timeoutMsg: "After 1000ms the toast should be closed and domRendered should be false"
+		});
 	});
 
 	it("tests minimum allowed duration", async () => {

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -308,7 +308,8 @@ exports.config = {
 			"setValue",
 			"setWindowSize",
 			"touchAction",
-			"url"
+			"url",
+			"scrollIntoView"
 		];
 		if (waitFor.includes(commandName)) {
 			await browser.executeAsync(function (done) {

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -303,13 +303,13 @@ exports.config = {
 			"keys",
 			"pause",
 			"removeAttribute", // custom
+			"scrollIntoView",
 			"setAttribute", // custom
 			"setProperty", // custom
 			"setValue",
 			"setWindowSize",
 			"touchAction",
 			"url",
-			"scrollIntoView"
 		];
 		if (waitFor.includes(commandName)) {
 			await browser.executeAsync(function (done) {


### PR DESCRIPTION
This change fixes one often failing test (List - load more button) and re-adds a commented-out similar test.

Using `browser.pause` in tests is generally an anti-pattern. WebdriverIO recommend the `browser.waitUntil` and element `waitFor*` commands instead. See [browser.pause](https://webdriver.io/docs/api/browser/pause/)

The main advantage of `browser.waitUntil` compared to `browser.pause` is that it polls each `500ms` (can be even lowered with the `interval` option) and the test execution immediately resumes after the first time the condition is evaluated to `true`. This may be much sooner than the `timeout` value. This allows to set a high value for the timeout, when uncertain, but in reality the test will rarely wait this much. On the other hand, `browser.pause` blocks test execution for the given amount unconditionally.

Reasons for `browser.pause` removal:
 - `scrollIntoView` is now synchronized with the rendering and pauses are not needed after calling it
 - reworked with `browser.waitUntil` for 90% of the occurrences
 - does not seem to be needed any more

`browser.pause` is now used in only 3 tests when we want to confirm that after some time nothing changed (f.e. a popover is still open after 1 second despite some action). `browser.waitUntil` is not suitable for this use case, because there is no change that we're awaiting (but the opposite, asserting there was no change).