### PR TITLE
feat(ui5-tree): introduce item-mouseover/item-mouseout events

### DIFF
--- a/packages/main/src/Tree.hbs
+++ b/packages/main/src/Tree.hbs
@@ -29,6 +29,8 @@
             @ui5-toggle="{{../_onListItemToggle}}"
             @ui5-step-in="{{../_onListItemStepIn}}"
             @ui5-step-out="{{../_onListItemStepOut}}"
+            @mouseover="{{../_onListItemMouseOver}}"
+            @mouseout="{{../_onListItemMouseOut}}"
         >
             {{> treeListItemContent}}
         </ui5-li-tree>

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -159,6 +159,32 @@ const metadata = {
 		},
 
 		/**
+		 * Fired when the mouse cursor enters the tree item borders.
+		 * @event sap.ui.webcomponents.main.Tree#item-mouseover
+		 * @param {HTMLElement} item the hovered item.
+		 * @since 1.0.0-rc.16
+		 * @public
+		 */
+		"item-mouseover": {
+			detail: {
+				item: { type: HTMLElement },
+			},
+		},
+
+		/**
+		 * Fired when the mouse cursor leaves the tree item borders.
+		 * @event sap.ui.webcomponents.main.Tree#item-mouseout
+		 * @param {HTMLElement} item the hovered item.
+		 * @since 1.0.0-rc.16
+		 * @public
+		 */
+		"item-mouseout": {
+			detail: {
+				item: { type: HTMLElement },
+			},
+		},
+
+		/**
 		 * Fired when a tree item is activated.
 		 *
 		 * @event sap.ui.webcomponents.main.Tree#item-click
@@ -335,6 +361,18 @@ class Tree extends UI5Element {
 		const listItem = event.detail.item;
 		const treeItem = listItem.treeItem;
 		this.fireEvent("item-delete", { item: treeItem });
+	}
+
+	_onListItemMouseOver(event) {
+		const treeItem = event.target.treeItem;
+
+		this.fireEvent("item-mouseover", { item: treeItem });
+	}
+
+	_onListItemMouseOut(event) {
+		const treeItem = event.target.treeItem;
+
+		this.fireEvent("item-mouseout", { item: treeItem });
 	}
 
 	_onListSelectionChange(event) {

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -129,6 +129,13 @@
 			}
 		});
 
+		document.getElementById("tree").addEventListener("itemMouseover", function(event) {
+			console.log("Item mouseover: ", event.detail.item);
+		});
+		document.getElementById("tree").addEventListener("itemMouseout", function(event) {
+			console.log("Item mouseout: ", event.detail.item);
+		});
+
 		document.getElementById("tree").addEventListener("itemClick", function(event) {
 			console.log("Item clicked: ", event.detail.item);
 		});


### PR DESCRIPTION
Introduced new itemMouseover and itemMouseout events that are fired when the mouse cursor enters/leaves tree item.

Events are introduced because ui5-tree-item is abstract component which doesn't have hbs template and developers are not able listen for mouseover / mouseout events.

Fixes: #3918