### PR TITLE
chore: remove redundant assert

### DIFF
--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -74,7 +74,6 @@ describe("General interaction", () => {
 			timeoutMsg: "Popover should be displayed"
 		});
 
-		assert.ok(await popover.getProperty("opened"), "Popover should be displayed");
 		assert.strictEqual(await input.getProperty("value"), "Bahrain", "Value should be Bahrain");
 
 


### PR DESCRIPTION
The `waitUntil` covers this assertion.