### PR TITLE
fix(ui5-combobox): Autocomplete on Safari

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -398,7 +398,6 @@ class ComboBox extends UI5Element {
 		}
 
 		this._initialRendering = false;
-		this._isKeyNavigation = false;
 	}
 
 	async onAfterRendering() {
@@ -415,6 +414,13 @@ class ComboBox extends UI5Element {
 		this._itemFocused = false;
 		this.toggleValueStatePopover(this.shouldOpenValueStateMessagePopover);
 		this.storeResponsivePopoverWidth();
+
+		if (this._autocomplete && this.filterValue !== this.value) {
+			this.inner.setSelectionRange(
+				this._isKeyNavigation ? "" : this.filterValue.length,
+				this.value.length
+			);
+		}
 	}
 
 	shouldClosePopover() {
@@ -425,6 +431,8 @@ class ComboBox extends UI5Element {
 		this.focused = true;
 
 		this._lastValue = this.value;
+
+		this._autocomplete = false;
 
 		!isPhone() && event.target.setSelectionRange(0, this.value.length);
 	}
@@ -529,10 +537,11 @@ class ComboBox extends UI5Element {
 		this._clearFocus();
 
 		// autocomplete
-		if (this._autocomplete && value !== "") {
-			const item = this._autoCompleteValue(value);
+		if (this._autocomplete) {
+			const item = this._getFirstMatchingItem(value);
+			this._applyAtomicValueAndSelection(item, value, true);
 
-			if (!this._selectionChanged && (item && !item.selected && !item.isGroupItem)) {
+			if (value !== "" && !this._selectionChanged && (item && !item.selected && !item.isGroupItem)) {
 				this.fireEvent("selection-change", {
 					item,
 				});
@@ -549,7 +558,7 @@ class ComboBox extends UI5Element {
 			return;
 		}
 
-		if (!this._filteredItems.length) {
+		if (!this._filteredItems.length || value === "") {
 			this._closeRespPopover();
 		} else {
 			this._openRespPopover();
@@ -609,7 +618,8 @@ class ComboBox extends UI5Element {
 		this._filteredItems[indexOfItem].selected = true;
 
 		// autocomplete
-		const item = this._autoCompleteValue(this.value);
+		const item = this._getFirstMatchingItem(this.value);
+		this._applyAtomicValueAndSelection(item, "", true);
 
 		if ((item && !item.selected)) {
 			this.fireEvent("selection-change", {
@@ -624,6 +634,7 @@ class ComboBox extends UI5Element {
 	_keydown(event) {
 		const isArrowKey = isDown(event) || isUp(event);
 		this._autocomplete = !(isBackSpace(event) || isDelete(event));
+		this._isKeyNavigation = false;
 
 		if (isArrowKey) {
 			this.handleArrowKeyPress(event);
@@ -690,7 +701,7 @@ class ComboBox extends UI5Element {
 		}
 	}
 
-	_autoCompleteValue(current) {
+	_getFirstMatchingItem(current) {
 		const currentlyFocusedItem = this.items.find(item => item.focused === true);
 
 		if (currentlyFocusedItem && currentlyFocusedItem.isGroupItem) {
@@ -700,24 +711,20 @@ class ComboBox extends UI5Element {
 
 		const matchingItems = this._startsWithMatchingItems(current).filter(item => !item.isGroupItem);
 
-		let value;
-		if (matchingItems.length) {
-			value = matchingItems[0] ? matchingItems[0].text : current;
-		} else {
-			value = current;
-		}
-
-		this._applyAtomicValueAndSelection(value, this._isKeyNavigation || matchingItems.length);
-
 		if (matchingItems.length) {
 			return matchingItems[0];
 		}
 	}
 
-	_applyAtomicValueAndSelection(value, highlightValue) {
+	_applyAtomicValueAndSelection(item, filterValue, highlightValue) {
+		if (!item) {
+			return;
+		}
+
+		const value = (item && item.text) || "";
 		this.inner.value = value;
 		if (highlightValue) {
-			this.inner.setSelectionRange(this.filterValue.length, value.length);
+			this.inner.setSelectionRange(filterValue.length, value.length);
 		}
 		this.value = value;
 	}


### PR DESCRIPTION
Safari losses input's text highlighting after invalidation of the ComboBox web component.
In order to restore the highlighting, we need to duplicate the highlight functionality onAfterRendering

Fixes: https://github.com/SAP/ui5-webcomponents/issues/3680