### PR TITLE
chore: Create a test for EventProvider

### DIFF
--- a/packages/base/bundle.esm.js
+++ b/packages/base/bundle.esm.js
@@ -1,4 +1,5 @@
 import { registerThemePropertiesLoader } from "./dist/AssetRegistry.js";
+import EventProvider from "./dist/EventProvider.js";
 
 // ESM bundle targets browsers with native support
 import "./dist/features/OpenUI5Support.js";
@@ -54,4 +55,5 @@ window["sap-ui-webcomponents-bundle"] = {
 	getI18nBundle,
 	renderFinished,
 	applyDirection,
+	EventProvider,
 };

--- a/packages/base/test/specs/EventProvider.spec.js
+++ b/packages/base/test/specs/EventProvider.spec.js
@@ -1,0 +1,63 @@
+const assert = require("chai").assert;
+
+describe("Event provider attaches and detaches listeners properly", () => {
+	before(async () => {
+		await browser.url("http://localhost:9191/test-resources/pages/AllTestElements.html");
+	});
+
+	it("Tests that listeners can be removed (1 listener)", async () => {
+
+		const res = await browser.executeAsync(done => {
+			let timesCalled = 0;
+			const ep = new window["sap-ui-webcomponents-bundle"].EventProvider();
+			const callback = () => {
+				timesCalled++;
+			};
+
+			// Setup
+			ep.attachEvent("test", callback);
+
+			// Act
+			ep.fireEvent("test"); // should execute the callback and increase the counter
+
+			// Setup
+			ep.detachEvent("test", callback);
+
+			// Act
+			ep.fireEvent("test"); // should not execute the callback and increase the counter
+
+			done(timesCalled);
+		});
+
+		assert.strictEqual(res, 1, "The callback should be called exactly once");
+	});
+
+	it("Tests that listeners can be removed (more than 1 listener)", async () => {
+
+		const res = await browser.executeAsync(done => {
+			let timesCalled = 0;
+			const ep = new window["sap-ui-webcomponents-bundle"].EventProvider();
+			const callback = () => {
+				timesCalled++;
+			};
+			const somePreviousCallback = () => {};
+
+			// Setup
+			ep.attachEvent("test", somePreviousCallback); // Attach something so that after detachEvent the listeners array is not empty!
+			ep.attachEvent("test", callback);
+
+			// Act
+			ep.fireEvent("test"); // should execute the callback and increase the counter
+
+			// Setup
+			ep.detachEvent("test", callback);
+
+			// Act
+			ep.fireEvent("test"); // should not execute the callback and increase the counter
+
+			done(timesCalled);
+		});
+
+		assert.strictEqual(res, 1, "The callback should be called exactly once");
+	});
+});


### PR DESCRIPTION
The test will pass after: https://github.com/SAP/ui5-webcomponents/pull/3941 is merged

**Important:** The error is masked by this code:
```js
if (eventListeners.length === 0) {
	eventRegistry.delete(eventName);
}
```
when there is only **1** event listener!

The true test for the error requires that at least one more listener exists before the `detachEvent` is called. This way the `eventRegistry.delete` does not take place, and the memory leak manifests.