### PR TITLE
fix(ui5-icon): allow CSS props inheritance for input-icon implementations

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -34,3 +34,13 @@
 	transform: scale(-1, 1);
 	transform-origin: center;
 }
+
+/* Input elements need to control Icon's internal paddings to achieve some designs */
+:host([input-icon]) .ui5-icon-root {
+	width: inherit;
+	padding: inherit;
+	height: inherit;
+	border: inherit;
+	background: inherit;
+	color: inherit;
+}

--- a/packages/main/src/themes/InputIcon.css
+++ b/packages/main/src/themes/InputIcon.css
@@ -13,6 +13,7 @@
 	border-left: 1px solid transparent;
 	min-width: 1rem;
 	min-height: 1rem;
+	display: contents;
 }
 
 [input-icon][pressed] {


### PR DESCRIPTION
Hovering the padding shows the tooltip of the wrapper element. To prevent that
in input controls we need to change some CSS props to the Icon's internals as
adding padding to the host element is not a solution.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/3534