### PR TITLE
fix(ui5-table-row): use activeElement within the current shadow DOM

### DIFF
--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -241,7 +241,7 @@ class TableRow extends UI5Element {
 			return;
 		}
 
-		if (!this.contains(document.activeElement)) {
+		if (!this.contains(this.getRootNode().activeElement)) {
 			// If the user clickes on non-focusable element within the ui5-table-cell,
 			// the focus goes to the body, se we have to bring it back to the row.
 			// If the user clicks on input, button or similar clickable element,
@@ -266,7 +266,7 @@ class TableRow extends UI5Element {
 	}
 
 	_getActiveElementTagName() {
-		return document.activeElement.localName.toLocaleLowerCase();
+		return this.getRootNode().activeElement.localName.toLocaleLowerCase();
 	}
 
 	activate() {


### PR DESCRIPTION
`document.activeElement` does not travers into shadow DOMs.

Therefore, if the `ui5-table` is contained in a shadow DOM, it will never contain `document.activeElement`.

Similarly, the `document.activeElement` will never be the `ui5-table-row`.

To get the desired effect, get the root node for the current element and check which is the activeElement
within that DOM.

Fixes #4023

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
