### PR TITLE
fix:Updating the dep5 file - Making the repo compatible with reuse 0.13.0

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -30,17 +30,7 @@ Copyright: 2020 SAP SE or an SAP affiliate company and OpenUI5 contributors
 License: Apache-2.0
 
 
-Files: /packages/main/test/pages/diffable-html.js packages/playground/docs/pages/content/main/diffable-html.js
-Copyright: Feross Aboukhadijeh <https://feross.org>
-License: MIT
-
-
-Files: /packages/playground/assets/js/vendor/lunr.min.js
-Copyright: 2017 Oliver Nightingale
-License: MIT
-
-
-Files: packages/playground/assets/js/webcomponentsjs/* /packages/base/src/thirdparty/Array.from.js /packages/base/src/thirdparty/events-polyfills.js /packages/base/src/thirdparty/Object.assign.js /packages/base/src/thirdparty/template.js /packages/base/src/thirdparty/webcomponents-sd-ce-pf.js
+Files: packages/playground/assets/js/webcomponentsjs/* packages/ie11/src/thirdparty/Array.from.js packages/ie11/src/thirdparty/events-polyfills.js packages/ie11/src/thirdparty/Object.assign.js packages/ie11/src/thirdparty/template.js packages/ie11/src/thirdparty/webcomponents-sd-ce-pf.js
 Copyright: 2018 The Polymer Project Authors
 License: BSD-3-Clause-Clear
 
@@ -48,3 +38,11 @@ Files: packages/base/dist/sap/ui/thirdparty/caja-html-sanitizer.js
 Copyright: Google Inc.
 License: Apache-2.0
 Comment: these files belong to: Google-Caja JS HTML Sanitizer
+
+Files: packages/main/test/pages/diffable-html.js
+Copyright: Feross Aboukhadijeh <https://feross.org>
+License: MIT
+
+Files: packages/playground/assets/js/vendor/lunr.min.js
+Copyright: 2017 Oliver Nightingale
+License: MIT


### PR DESCRIPTION
Fixes #3598 

I changed the following - 
1. I remove the '/' in the `dep5` file for files referring the `MIT` license - as they were not detected under `MIT` license by the reuse tool.
2. I remove the '/' in the `dep5` file for files referring the `BSD-3-Clause-Clear` license - as they were not detected under the  `BSD-3-Clause-Clear` license by the reuse tool.
3. I update the paths of files under `BSD-3-Clause-Clear` license as the files are not present at the old path. 
4. I also remove the line from `dep5` file referring to file - `packages/playground/docs/pages/content/main/diffable-html.js` as the file no longer a part of the repository.
5. Tested the repository for compliance on local system with `reuse version 0.13.0` and it was compliant.