### PR TITLE
fix: Allow normalEvents to propagate across the shadow DOM boundary

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -713,7 +713,7 @@ class UI5Element extends HTMLElement {
 
 		const normalEvent = new CustomEvent(name, {
 			detail: data,
-			composed: false,
+			composed: true,
 			bubbles,
 			cancelable,
 		});


### PR DESCRIPTION
fix: Allow normalEvents to propagate across the shadow DOM boundary into the standard DOM.

Fixes #4037