### PR TITLE
feat(ui5-select): adjust input and icon to sap_horizon

### DIFF
--- a/packages/main/src/themes/InputIcon.css
+++ b/packages/main/src/themes/InputIcon.css
@@ -13,6 +13,7 @@
 	border-left: 1px solid transparent;
 	min-width: 1rem;
 	min-height: 1rem;
+	border-radius: var(--_ui5_input_icon_border_radius);
 }
 
 [input-icon][pressed] {

--- a/packages/main/src/themes/InputIcon.css
+++ b/packages/main/src/themes/InputIcon.css
@@ -6,7 +6,7 @@
 */
 
 [input-icon] {
-	color: var(--sapContent_IconColor);
+	color: var(--_ui5_input_icon_color);
 	cursor: pointer;
 	outline: none;
 	padding: var(--_ui5_input_icon_padding);
@@ -16,17 +16,17 @@
 }
 
 [input-icon][pressed] {
-	background: var(--sapButton_Selected_Background);
-	color: var(--sapButton_Active_TextColor);
+	background: var(--_ui5_input_icon_pressed_bg);
+	color: var(--_ui5_input_icon_pressed_color);
 }
 
 [input-icon]:active {
 	background-color: var(--sapButton_Active_Background);
-	color: var(--sapButton_Active_TextColor);
+	color: var(--_ui5_input_icon_pressed_color);
 }
 
 [input-icon]:not([pressed]):not(:active):hover {
-	background: var(--sapButton_Lite_Hover_Background);
+	background: var(--_ui5_input_icon_hover_bg);
 }
 
 [input-icon]:hover {

--- a/packages/main/src/themes/Select.css
+++ b/packages/main/src/themes/Select.css
@@ -21,7 +21,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	color: var(--sapField_TextColor);
+	color: var(--_ui5_select_label_olor);
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;

--- a/packages/main/src/themes/base/InputIcon-parameters.css
+++ b/packages/main/src/themes/base/InputIcon-parameters.css
@@ -1,3 +1,7 @@
 :root {
 	--_ui5_input_icon_padding: .5625rem .6875rem;
+	--_ui5_input_icon_color: var(--sapContent_IconColor);
+	--_ui5_input_icon_pressed_color: var(--sapButton_Active_TextColor);
+	--_ui5_input_icon_pressed_bg: var(--sapButton_Selected_Background);
+	--_ui5_input_icon_hover_bg: var(--sapButton_Lite_Hover_Background);
 }

--- a/packages/main/src/themes/base/InputIcon-parameters.css
+++ b/packages/main/src/themes/base/InputIcon-parameters.css
@@ -4,4 +4,5 @@
 	--_ui5_input_icon_pressed_color: var(--sapButton_Active_TextColor);
 	--_ui5_input_icon_pressed_bg: var(--sapButton_Selected_Background);
 	--_ui5_input_icon_hover_bg: var(--sapButton_Lite_Hover_Background);
+	--_ui5_input_icon_border_radius: 0;
 }

--- a/packages/main/src/themes/base/Select-parameters.css
+++ b/packages/main/src/themes/base/Select-parameters.css
@@ -7,4 +7,5 @@
 	--_ui5_select_rtl_hover_icon_left_border: none;
 	--_ui5_select_rtl_hover_icon_right_border: none;
 	--_ui5_select_focus_width: 1px;
+	--_ui5_select_label_olor: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/sap_horizon/InputIcon-parameters.css
+++ b/packages/main/src/themes/sap_horizon/InputIcon-parameters.css
@@ -5,4 +5,5 @@
 	--_ui5_input_icon_pressed_color: var(--sapNeutralColor); /*#5B738B */
 	--_ui5_input_icon_pressed_bg: transparent;
 	--_ui5_input_icon_hover_bg: transparent;
+	--_ui5_input_icon_border_radius: 0.5rem;
 }

--- a/packages/main/src/themes/sap_horizon/InputIcon-parameters.css
+++ b/packages/main/src/themes/sap_horizon/InputIcon-parameters.css
@@ -1,0 +1,8 @@
+@import "../base/InputIcon-parameters.css";
+
+:root {
+	--_ui5_input_icon_color: var(--sapNeutralColor); /*#5B738B */
+	--_ui5_input_icon_pressed_color: var(--sapNeutralColor); /*#5B738B */
+	--_ui5_input_icon_pressed_bg: transparent;
+	--_ui5_input_icon_hover_bg: transparent;
+}

--- a/packages/main/src/themes/sap_horizon/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Select-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/Select-parameters.css";
+
+:root {
+	--_ui5_select_label_olor: var(--sapTitleColor); /* #223548; */
+}

--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -13,7 +13,7 @@
 @import "../base/Dialog-parameters.css";
 @import "../base/GroupHeaderListItem-parameters.css";
 @import "./Input-parameters.css";
-@import "../base/InputIcon-parameters.css";
+@import "./InputIcon-parameters.css";
 @import "./Link-parameters.css";
 @import "./List-parameters.css";
 @import "../base/ListItemBase-parameters.css";
@@ -24,7 +24,7 @@
 @import "./Popover-parameters.css";
 @import "../base/ProgressIndicator-parameters.css";
 @import "./RadioButton-parameters.css";
-@import "../base/Select-parameters.css";
+@import "./Select-parameters.css";
 @import "../base/Switch-parameters.css";
 @import "./TabContainer-parameters.css";
 @import "../base/TextArea-parameters.css";


### PR DESCRIPTION
The icon's background and color, and the selected option's text within the input field had to be updated to full fill the sap_horizon design. The options will be updated with the list item implementation.

before: Notice how the icon's bg overlaps the focus outline
<img width="543" alt="Screenshot 2021-10-05 at 14 24 40" src="https://user-images.githubusercontent.com/15702139/136015977-13bc91f3-26bd-4537-a386-52beb1a0dfc6.png">

after: besides the bug with the icon bg, the icon color is changed and the text color is also changed
<img width="550" alt="Screenshot 2021-10-05 at 14 39 39" src="https://user-images.githubusercontent.com/15702139/136015985-6faf8c2e-353f-45ed-b46b-c33c655f9abe.png">
.
