### PR TITLE
fix(ui5-checkbox): fix component square's border-radius

### DIFF
--- a/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
@@ -19,7 +19,7 @@
 	--_ui5_checkbox_inner_disabled_border_color: #A9B4BE;
 	--_ui5_checkbox_inner_active_border_color: #354A5F;
 	--_ui5_checkbox_focus_position: 0.5625rem;
-	--_ui5_checkbox_inner_border_radius: .125rem;
+	--_ui5_checkbox_inner_border_radius: 0.25rem;
 	--_ui5_checkbox_inner_success_border: 0.125rem solid var(--sapField_SuccessColor);
 	--_ui5_checkbox_inner_readonly_border: 0.125rem solid var(--sapField_ReadOnly_BorderColor);
 	--_ui5_checkbox_inner_background: var(--sapHighlightTextColor);


### PR DESCRIPTION
The border-radius of the square box in now 0.25rem in sap_horizon, not 0.125rem as previously.