### PR TITLE
fix(ui5-list) Sample fix: ',' doesn`t appear after deletion of item

### DIFF
--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -313,7 +313,7 @@
 
 			mutated = false;
 			cleanList();
-			fillList(items.join());
+			fillList(items.join(""));
 			updateInfo(3);
 		};
 


### PR DESCRIPTION
Exploratory testing bug fixed:
Minor: In the test page, there should be 
items.join("") instead of items.join() because currently there are unwanted comas between the items when we reset the list.