### PR TITLE
fix(ui5-list): preventing space keydown

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -734,9 +734,6 @@ class List extends UI5Element {
 	}
 
 	_onkeydown(event) {
-		if (isSpace(event)) {
-			event.preventDefault(); // prevent scroll
-		}
 		if (isTabNext(event)) {
 			this._handleTabNext(event);
 		}


### PR DESCRIPTION
Preventing the Space key on keydown is redundant since it should be already handled in its children separately.

Fixes: #4049 