### PR TITLE
chore: align transition effect of radio and cb

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -111,6 +111,7 @@
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
 	transition: var(--_ui5_checkbox_transition);
 	border: var(--_ui5_checkbox_default_focus_border);
+	border-radius: var(--_ui5_checkbox_border_radius);
 	box-sizing: border-box;
 }
 

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -12,7 +12,7 @@
 	color: var(--_ui5_radio_button_color);
 	cursor: pointer;
 	border-radius: var(--_ui5_radio_button_border_radius);
-	transition: var(--_ui5_radio_button_hover_transition);
+	transition: var(--_ui5_radio_button_transition);
 }
 
 /* checked */
@@ -144,6 +144,8 @@
 	width: var(--_ui5_radio_button_inner_width);
 	box-sizing: border-box;
 	border: var(--_ui5_radio_button_border);
+	border-radius: var(--_ui5_radio_button_border_radius);
+	transition: var(--_ui5_radio_button_transition);
 	cursor: pointer;
 }
 

--- a/packages/main/src/themes/base/RadioButton-parameters.css
+++ b/packages/main/src/themes/base/RadioButton-parameters.css
@@ -21,7 +21,7 @@
 	--_ui5_radio_button_focus_border: none;
 	--_ui5_radio_button_focus_outline: block;
 	--_ui5_radio_button_hover_shadow: none;
-	--_ui5_radio_button_hover_transition: none;
+	--_ui5_radio_button_transition: none;
 	--_ui5_radio_button_hover_background: inherit;
 	--_ui5_radio_button_color: var(--sapField_BorderColor);
 	--_ui5_radio_button_label_offset: 1px;

--- a/packages/main/src/themes/sap_horizon/RadioButton-parameters.css
+++ b/packages/main/src/themes/sap_horizon/RadioButton-parameters.css
@@ -22,7 +22,7 @@
 	--_ui5_radio_button_focus_outline: none;
 	--_ui5_radio_button_hover_shadow: 0px 0px 2px rgba(131, 150, 168, 0.16), 0px 8px 16px rgba(131, 150, 168, 0.16);
 	--_ui5_radio_button_hover_background: var(--sapHighlightTextColor);
-	--_ui5_radio_button_hover_transition: background-color 200ms ease-in-out;
+	--_ui5_radio_button_transition: all 0.2s ease-in-out;
 	--_ui5_radio_button_label_offset: 0.375rem;
 	--_ui5_radio_button_label_color: var(--sapTitleColor);
 	--_ui5_radio_button_items_align: center;


### PR DESCRIPTION
For the RadioButton we used to transition the background, but now also the box shadow and the focus outline as well, making it smoother.
For the Checkbox - small change, addition of a border-radius to the root element, otherwise you can notice a small bug in the focus border during its transition as the rectangle corners of the root are seen for a moment