### PR TITLE
fix(ui5-dialog):  Background of header is using parameter 

### DIFF
--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -19,6 +19,10 @@
 	max-width: 100%;
 }
 
+.ui5-popup-header-root {
+	background: var(--sapPageHeader_Background);
+}
+
 :host([draggable]) .ui5-popup-header-root,
 :host([draggable]) ::slotted([slot="header"]) {
 	cursor: move;


### PR DESCRIPTION
Parameter -sapPageHeader_Background  is set to the header background, so it is configurable. 

Fixes: #4093
