### PR TITLE
fix(ui5-avatar): correct background when image slot is used

### DIFF
--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -179,6 +179,10 @@
 	background-color: var(--ui5-avatar-placeholder);
 }
 
+:host([_has-image]) {
+	background-color: transparent;
+}
+
 :host([image-fit-type="Contain"]) .ui5-avatar-img {
 	background-size: contain;
 }


### PR DESCRIPTION
Fixes: #4097 