### PR TITLE
feat(framework): Implement better custom theme support

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-vr58R5RNtd2EKYl1nWCk9F59qUw=
+By5B1K3Pq1rzoc8ZDxA0OLyjqm4=

--- a/packages/base/src/InitialConfiguration.js
+++ b/packages/base/src/InitialConfiguration.js
@@ -106,6 +106,14 @@ const parseURLParameters = () => {
 	});
 };
 
+const normalizeParamValue = (param, value) => {
+	if (param === "theme" && value.includes("@")) { // the theme parameter might have @<URL-TO-THEME> in the value - strip this
+		return value.split("@")[0];
+	}
+
+	return value;
+};
+
 const applyURLParam = (key, value, paramType) => {
 	const lowerCaseValue = value.toLowerCase();
 	const param = key.split(`${paramType}-`)[1];
@@ -113,6 +121,9 @@ const applyURLParam = (key, value, paramType) => {
 	if (booleanMapping.has(value)) {
 		value = booleanMapping.get(lowerCaseValue);
 	}
+
+	value = normalizeParamValue(param, value);
+
 	initialConfig[param] = value;
 };
 

--- a/packages/base/src/theming/getThemeDesignerTheme.js
+++ b/packages/base/src/theming/getThemeDesignerTheme.js
@@ -1,6 +1,6 @@
 const getThemeMetadata = () => {
 	// Check if the class was already applied, most commonly to the link/style tag with the CSS Variables
-	let el = document.querySelector(".sapThemeMetaData-Base-baseLib");
+	let el = document.querySelector(".sapThemeMetaData-Base-baseLib") || document.querySelector(".sapThemeMetaData-UI5-sap-ui-core");
 	if (el) {
 		return getComputedStyle(el).backgroundImage;
 	}
@@ -8,6 +8,7 @@ const getThemeMetadata = () => {
 	el = document.createElement("span");
 	el.style.display = "none";
 	el.classList.add("sapThemeMetaData-Base-baseLib");
+	el.classList.add("sapThemeMetaData-UI5-sap-ui-core");
 	document.body.appendChild(el);
 	const metadata = getComputedStyle(el).backgroundImage;
 	document.body.removeChild(el);

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -20,6 +20,10 @@
 
 	<!-- CUSTOM THEME: my_custom_theme
 	<link rel="stylesheet" type="text/css" href="./css/css_variables.css">
+	 -->
+
+	<!-- ANOTHER CUSTOM THEME: custom_belize@url
+	<link rel="stylesheet" type="text/css" href="./css/css_variables2.css?version=1.93.0&sap-ui-dist-version=1.93.0">
 	-->
 
 	<!-- OPENUI5 WITH CSS VARIABLES


### PR DESCRIPTION
This change improves custom theme detection in 2 ways:
 - If the theme has an `@` in its name, in the format: `custom_theme@https://url.to.theme`, the theme name is recognized as `custom_theme` (the other part is stripped)
 - The theme detection code now also expects the `sapThemeMetaData-UI5-sap-ui-core` marker class, in addition to the default `sapThemeMetaData-Base-baseLib`. Any of these will trigger custom theme recognition.