### PR TITLE
chore: fix DatePicker docs

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -353,7 +353,7 @@ const metadata = {
  * {
  *	"calendarType": "Japanese"
  * }
- * &lt;/script&gt;</code>
+ * &lt;/script&gt;</code></pre>
  *
  * <h3>ES6 Module Import</h3>
  *


### PR DESCRIPTION
Add closing `</pre>` to prevent documentation from breaking.