### PR TITLE
refactor(ui5-input): make suggestion-scroll event protected

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -418,8 +418,7 @@ const metadata = {
 		 * @event sap.ui.webcomponents.main.Input#suggestion-scroll
 		 * @param {Integer} scrollTop The current scroll position.
 		 * @param {HTMLElement} scrollContainer The scroll container.
-		 * @private
-		 * @deprecated - This event has restricted usage and may be removed in future versions.
+		 * @protected
 		 * @since 1.0.0-rc.8
 		 */
 		"suggestion-scroll": {


### PR DESCRIPTION
The usage of suggestion-scroll is unclear and there is no UX pattern where such an event is needed.  However, in order to keep the event compatible with frameworks, we've decided on making it protected.

BREAKING CHANGE: The "suggestion-scroll" event has been removed as there is no such UX specified.