### PR TITLE
refactor: allow single quotes for style in hbs

### DIFF
--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -80,7 +80,7 @@ HTMLLitVisitor.prototype.ContentStatement = function(content) {
 		isNodeValue = closingIndex > openingIndex;
 	}
 
-	isStyleAttribute = !isNodeValue && contentStatement.match(/style *= *["']?$/);
+	isStyleAttribute = !isNodeValue && contentStatement.match(/style *= *["']? *$/);
 
 	if (!isStyleAttribute && contentStatement.match(/style=/)) {
 		console.log("WARNING: style hard-coded", contentStatement);


### PR DESCRIPTION
The style map discovery now allows spaces around the `=`, and also both single and double quotes. Also, spaces after the quotes are allowed.