### PR TITLE
fix(ui5-datetime-picker): console error not thrown on Firefox browser

### DIFF
--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -319,7 +319,7 @@ class DateTimePicker extends DatePicker {
 			...this._previewValues,
 			calendarTimestamp: event.detail.timestamp,
 			calendarValue: event.detail.values[0],
-			timeSelectionValue: event.path[1].lastChild.value,
+			timeSelectionValue: event.composedPath()[1].lastChild.value,
 		};
 	}
 


### PR DESCRIPTION
Console error isn't thrown now, when user is selecting a date from
the calendar part of the component in Firefox browser.

Fixes: #4136