### PR TITLE
fix(ui5-combobox) always focus the next/previous element on TAB/SHIFT+TAB

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -722,7 +722,7 @@ class ComboBox extends UI5Element {
 			this._isValueStateFocused = false;
 		}
 
-		if (isTabNext(event) || isTabPrevious(event)) {
+		if ((isTabNext(event) || isTabPrevious(event)) && this.open) {
 			this._closeRespPopover();
 		}
 

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -16,6 +16,8 @@ import {
 	isDown,
 	isEnter,
 	isEscape,
+	isTabNext,
+	isTabPrevious,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import * as Filters from "./ComboBoxFilters.js";
 
@@ -718,6 +720,10 @@ class ComboBox extends UI5Element {
 			this.focused = true;
 			this.value = !this.open ? this._lastValue : this.value;
 			this._isValueStateFocused = false;
+		}
+
+		if (isTabNext(event) || isTabPrevious(event)) {
+			this._closeRespPopover();
 		}
 
 		if (isShow(event) && !this.readonly && !this.disabled) {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -728,4 +728,24 @@ describe("Keyboard navigation", async () => {
 
 		assert.strictEqual(await prevListItem.getProperty("focused"), false, "The previously focused item is no longer focused");
 	});
+
+	it ("Should focus the next/previous focusable element on TAB/SHIFT+TAB",  async () => {
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/ComboBox.html`);
+
+		const combo = await browser.$("#combo-grouping");
+		const arrow = await combo.shadow$("[input-icon]");
+
+		const prevCombo = await browser.$("#value-state-grouping");
+		const nextCombo = await browser.$("#combobox-two-column-layout");
+
+		await arrow.click();
+		await combo.keys("Tab");
+
+		assert.strictEqual(await nextCombo.getProperty("focused"), true, "The first group header should be focused");
+
+		await arrow.click();
+		await browser.keys(["Shift", "Tab"]);
+
+		assert.strictEqual(await prevCombo.getProperty("focused"), true, "The input should be focused");		
+	});
 });

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -741,11 +741,11 @@ describe("Keyboard navigation", async () => {
 		await arrow.click();
 		await combo.keys("Tab");
 
-		assert.strictEqual(await nextCombo.getProperty("focused"), true, "The first group header should be focused");
+		assert.strictEqual(await nextCombo.getProperty("focused"), true, "The next combobox should be focused");
 
 		await arrow.click();
 		await browser.keys(["Shift", "Tab"]);
 
-		assert.strictEqual(await prevCombo.getProperty("focused"), true, "The input should be focused");		
+		assert.strictEqual(await prevCombo.getProperty("focused"), true, "The previous combobox should be focused");
 	});
 });


### PR DESCRIPTION
Focus next or previous element on TAB or SHIFT + TAB even if the picker is currently opened.

Issue #3965 