### PR TITLE
feat(ui5-popup): adjust bold text in header

### DIFF
--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -44,11 +44,14 @@
     margin: 0;
     color: var(--sapPageHeader_TextColor);
     font-size: 1rem;
-    font-weight: var(--_ui5_popup_header_footer_font_weight);
     font-family: "72override", var(--sapFontFamily);
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+.ui5-popup-header-root .ui5-popup-header-text {
+	font-weight: var(--_ui5_popup_header_footer_font_weight);
 }
 
 .ui5-popup-content {


### PR DESCRIPTION
By design the header text should be bold. As we do not know what will be set in the header slot of the popup, by developers or components developers, we will only make bold the when it is set with header-text.
