### PR TITLE
fix(ui5-panel): add border bottom, when fixed

### DIFF
--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -86,3 +86,7 @@
 	width: var(--_ui5_panel_button_root_width);
 	margin-right: .25rem;
 }
+
+:host([fixed]:not([collapsed]):not([_has-header])) .ui5-panel-header {
+	border-bottom: 0.0625rem solid var(--sapGroup_TitleBorderColor);
+}


### PR DESCRIPTION
Add bottom border, when the panel is fixed and expanded, with no header slot.
