### PR TITLE
feat(ui5-panel, ui5-table): SAP Horizon focus outline

### DIFF
--- a/packages/main/src/themes/GrowingButton.css
+++ b/packages/main/src/themes/GrowingButton.css
@@ -23,7 +23,7 @@
 }
 
 [growing-button-inner]:focus {
-	outline: var(--_ui5_load_more_outline_width) dotted var(--sapContent_FocusColor);
+	outline: var(--_ui5_load_more_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	outline-offset: -0.125rem;
 	border-color: transparent;
 }

--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -50,6 +50,10 @@
 	border-radius: var(--_ui5_panel_border_radius);
 }
 
+:host(:not([collapsed]):not([_has-header]):not([fixed])) .ui5-panel-header:focus {
+	border-radius: var(--_ui5_panel_border_radius_expanded);
+}
+
 :host(:not([collapsed])) .ui5-panel-header-button {
 	transform: rotate(90deg);
 }

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -26,7 +26,7 @@ table {
 
 .ui5-table-header-row:focus {
 	outline: var(--ui5_table_header_row_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-	outline-offset: -0.125rem;
+	outline-offset: -0.0625rem;
 }
 
 tr {
@@ -80,7 +80,7 @@ tr {
 	text-align: center;
 }
 
-:host([sticky-column-header]) .ui5-table-select-all-column {
+:host([sticky-column-header]) .ui5-table-header-row {
 	position: sticky;
 	top: 0;
 	z-index: 99;

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -26,7 +26,7 @@ table {
 
 .ui5-table-header-row:focus {
 	outline: var(--ui5_table_header_row_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-	outline-offset: -0.0625rem;
+	outline-offset: -0.125rem;
 }
 
 tr {

--- a/packages/main/src/themes/TableColumn.css
+++ b/packages/main/src/themes/TableColumn.css
@@ -24,12 +24,6 @@ th[dir="rtl"] {
 	padding-left: 1rem;
 }
 
-:host([sticky]) th {
-	position: sticky;
-	top: 0;
-	z-index: 99;
-}
-
 th ::slotted([ui5-label]) {
 	font-weight: var(--ui5_table_header_row_font_weight);
 	font-size: var(--sapFontMediumSize);

--- a/packages/main/src/themes/TableGroupRow.css
+++ b/packages/main/src/themes/TableGroupRow.css
@@ -18,7 +18,7 @@
 }
 
 .ui5-table-group-row-root:focus {
-	outline: var(--ui5_table_row_outline_width) dotted var(--sapContent_FocusColor);
+	outline: var(--ui5_table_row_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	outline-offset: -0.0625rem;
 }
 

--- a/packages/main/src/themes/base/Panel-parameters.css
+++ b/packages/main/src/themes/base/Panel-parameters.css
@@ -4,6 +4,7 @@
 	--_ui5_panel_button_root_width: 3rem;
 	--_ui5_panel_background_color: var(--sapGroup_TitleBackground);
 	--_ui5_panel_border_radius: 0px;
+	--_ui5_panel_border_radius_expanded: 0;
 	--_ui5_panel_border_bottom: 1px solid var(--sapGroup_TitleBorderColor);
 	--_ui5_panel_outline_offset: -3px;
 	--_ui5_panel_title_font_weight: normal;

--- a/packages/main/src/themes/sap_horizon/GrowingButton-parameters.css
+++ b/packages/main/src/themes/sap_horizon/GrowingButton-parameters.css
@@ -1,3 +1,5 @@
+@import "../base/GrowingButton-parameters.css";
+
 :root {
 	--_ui5_load_more_outline_width: var(--sapContent_FocusWidth);
 }

--- a/packages/main/src/themes/sap_horizon/GrowingButton-parameters.css
+++ b/packages/main/src/themes/sap_horizon/GrowingButton-parameters.css
@@ -1,0 +1,3 @@
+:root {
+	--_ui5_load_more_outline_width: var(--sapContent_FocusWidth);
+}

--- a/packages/main/src/themes/sap_horizon/Panel-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Panel-parameters.css
@@ -6,7 +6,7 @@
 	--_ui5_panel_background_color: var(--sapGroup_ContentBackground);
 	--_ui5_panel_border_radius: var(--sapElement_BorderCornerRadius);
 	--_ui5_panel_border_bottom: none;
-	--_ui5_panel_outline_offset: -0.0625rem;
+	--_ui5_panel_outline_offset: -0.125rem;
 	--_ui5_panel_title_font_weight: bold;
 	--_ui5_panel_border_radius_expanded: var(--sapElement_BorderCornerRadius) var(--sapElement_BorderCornerRadius) 0 0;
 }

--- a/packages/main/src/themes/sap_horizon/Panel-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Panel-parameters.css
@@ -8,4 +8,5 @@
 	--_ui5_panel_border_bottom: none;
 	--_ui5_panel_outline_offset: 0px;
 	--_ui5_panel_title_font_weight: bold;
+	--_ui5_panel_border_radius_expanded: var(--sapElement_BorderCornerRadius) var(--sapElement_BorderCornerRadius) 0 0;
 }

--- a/packages/main/src/themes/sap_horizon/Panel-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Panel-parameters.css
@@ -6,7 +6,7 @@
 	--_ui5_panel_background_color: var(--sapGroup_ContentBackground);
 	--_ui5_panel_border_radius: var(--sapElement_BorderCornerRadius);
 	--_ui5_panel_border_bottom: none;
-	--_ui5_panel_outline_offset: 0px;
+	--_ui5_panel_outline_offset: -0.0625rem;
 	--_ui5_panel_title_font_weight: bold;
 	--_ui5_panel_border_radius_expanded: var(--sapElement_BorderCornerRadius) var(--sapElement_BorderCornerRadius) 0 0;
 }

--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -40,7 +40,6 @@
 @import "./CalendarHeader-parameters.css";
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
-@import "../base/GrowingButton-parameters.css";
 @import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "./MultiComboBox-parameters.css";

--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -50,3 +50,4 @@
 @import "./Table-parameters.css";
 @import "./TableRow-parameters.css";
 @import "./TableColumn-parameters.css";
+@import "./GrowingButton-parameters.css";


### PR DESCRIPTION
- Add focus outline for More button of table and groups
- Adjust focus border radius for panel depending on the collapse state
- Sticky is now applied to the header row instead of applying it to each column header, since this lead to a visual bug in sap horizon (in future we should remove the remaining logic for sticky in the js of the columns)