### PR TITLE
fix(ui5-wizard): remove unneeded aria properties

### DIFF
--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -58,19 +58,6 @@ const metadata = {
 	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.Wizard.prototype */ {
 		/**
-		 * Sets the accessible aria name of the component.
-		 *
-		 * @type {String}
-		 * @defaultvalue undefined
-		 * @public
-		 * @since 1.0.0-rc.15
-		 */
-		accessibleName: {
-			type: String,
-			defaultValue: undefined,
-		},
-
-		/**
 		 * Defines the width of the <code>ui5-wizard</code>.
 		 * @private
 		 */
@@ -806,7 +793,7 @@ class Wizard extends UI5Element {
 	}
 
 	get ariaLabelText() {
-		return this.accessibleName || Wizard.i18nBundle.getText(WIZARD_NAV_ARIA_ROLE_DESCRIPTION);
+		return Wizard.i18nBundle.getText(WIZARD_NAV_ARIA_ROLE_DESCRIPTION);
 	}
 
 	get effectiveStepSwitchThreshold() {

--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -99,29 +99,6 @@ const metadata = {
 		branching: {
 			type: Boolean,
 		},
-
-		/**
-		 * Sets the accessible aria name of the component.
-		 *
-		 * @type {String}
-		 * @defaultvalue ""
-		 * @public
-		 * @since 1.0.0-rc.15
-		 */
-		accessibleName: {
-			type: String,
-		},
-
-		/**
-		 * Defines the aria-labelledby of the step.
-		 * @type {String}
-		 * @defaultvalue ""
-		 * @public
-		 * @since 1.0.0-rc.15
-		 */
-		accessibleNameRef: {
-			type: String,
-		},
 	},
 	slots: /** @lends sap.ui.webcomponents.fiori.WizardStep.prototype */ {
 		/**


### PR DESCRIPTION
- Remove accessible-name on Wizard level as it is unneeded, the region has a default aria-label and the wizard itself should be used along with a page with title.
- Remove accessible-name and accessible-name-ref from Wizard Step, as it does not work and also again not needed. The wizard step title is used as a label of the element.
