### PR TITLE
chore: do not bundle the barcode scanner component for IE11

### DIFF
--- a/packages/fiori/bundle.common.js
+++ b/packages/fiori/bundle.common.js
@@ -34,7 +34,6 @@ import "./dist/illustrations/tnt/UnsuccessfulAuth";
 
 // FIORI components
 import Bar from "./dist/Bar.js";
-import BarcodeScannerDialog from "./dist/BarcodeScannerDialog.js";
 import FilterItem from "./dist/FilterItem.js";
 import FilterItemOption from "./dist/FilterItemOption.js";
 import FlexibleColumnLayout from "./dist/FlexibleColumnLayout.js";

--- a/packages/fiori/bundle.esm.js
+++ b/packages/fiori/bundle.esm.js
@@ -4,5 +4,6 @@ import testAssets from "@ui5/webcomponents/bundle.esm.js";
 import "./dist/Assets.js";
 
 import "./bundle.common.js";
+import BarcodeScannerDialog from "./dist/BarcodeScannerDialog.js";
 
 export default testAssets;


### PR DESCRIPTION
Remove it from the common fiori bundle and manually add it to the ESM bundle only.