### PR TITLE
fix(ui5-shellbar): press on custom action throws JS error

### DIFF
--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -682,9 +682,10 @@ class ShellBar extends UI5Element {
 		this._updateItemsInfo(newItems);
 	}
 
-	_toggleActionPopover() {
+	async _toggleActionPopover() {
 		const overflowButton = this.shadowRoot.querySelector(".ui5-shellbar-overflow-button");
-		this.overflowPopover.showAt(overflowButton);
+		const overflowPopover = await this._getOverflowPopover();
+		overflowPopover.showAt(overflowButton);
 	}
 
 	onEnterDOM() {
@@ -725,7 +726,7 @@ class ShellBar extends UI5Element {
 
 		if (refItemId) {
 			const shellbarItem = this.items.find(item => {
-				return item.shadowRoot.querySelector(`#${refItemId}`);
+				return item.__id === refItemId;
 			});
 
 			const prevented = !shellbarItem.fireEvent("item-click", { targetRef: event.target }, true);
@@ -946,6 +947,11 @@ class ShellBar extends UI5Element {
 		const staticAreaItem = await this.getStaticAreaItemDomRef();
 		this.overflowPopover = staticAreaItem.querySelector(".ui5-shellbar-overflow-popover");
 		this.menuPopover = staticAreaItem.querySelector(".ui5-shellbar-menu-popover");
+	}
+
+	async _getOverflowPopover() {
+		const staticAreaItem = await this.getStaticAreaItemDomRef();
+		return staticAreaItem.querySelector(".ui5-shellbar-overflow-popover");
 	}
 
 	async _getMenuPopover() {

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -268,6 +268,12 @@
 			window["result-key"].value = item.getAttribute("data-key");
 		});
 
+		Array.from(document.querySelectorAll("ui5-shellbar-item")).forEach(function(item) {
+			item.addEventListener("item-click", function(event) {
+				console.log(event.detail.targetRef);
+			});
+		});
+
 		["disc", "call"].forEach(function(id) {
 			var currenItem = window[id][0] || window[id];
 			currenItem.addEventListener("ui5-itemClick", function(event) {


### PR DESCRIPTION
Pressing on custom action throws JS error 
To reproduce, open the link and click on random ui5-shellbar-item 
https://sap.github.io/ui5-webcomponents/master/playground/fiori/pages/ShellBar/

The ShellBarItem used to have template before, but we have recently remove it, and any access to the shadowRoot that previously worked, now resolves to null as the ShellBarItem.

In addition, make the overflow popover open safely by always requiring it explicitly, not relying on a side effect, that other will be called and initialise the popover beforehand.