### PR TITLE
refactor(ui5-shellbar-item): rename "item-click" to "click"

### DIFF
--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -728,7 +728,7 @@ class ShellBar extends UI5Element {
 				return item.shadowRoot.querySelector(`#${refItemId}`);
 			});
 
-			const prevented = !shellbarItem.fireEvent("item-click", { targetRef: event.target }, true);
+			const prevented = !shellbarItem.fireEvent("click", { targetRef: event.target }, true);
 
 			this._defaultItemPressPrevented = prevented;
 		}

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -47,6 +47,7 @@ const metadata = {
 		 * @allowPreventDefault
 		 * @param {HTMLElement} targetRef DOM ref of the clicked element
 		 * @public
+		 * @native
 		 */
 		"click": {
 			detail: {

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -43,12 +43,12 @@ const metadata = {
 		/**
 		 * Fired, when the item is pressed.
 		 *
-		 * @event sap.ui.webcomponents.fiori.ShellBarItem#item-click
+		 * @event sap.ui.webcomponents.fiori.ShellBarItem#click
 		 * @allowPreventDefault
 		 * @param {HTMLElement} targetRef DOM ref of the clicked element
 		 * @public
 		 */
-		"item-click": {
+		"click": {
 			detail: {
 				targetRef: { type: HTMLElement },
 			},

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -271,7 +271,7 @@
 		});
 
 		Array.from(document.querySelectorAll("ui5-shellbar-item")).forEach(function(item) {
-			item.addEventListener("item-click", function(event) {
+			item.addEventListener("ui5-click", function(event) {
 				wcToastTC.show();
 			});
 		});

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -270,6 +270,12 @@
 			window["result-key"].value = item.getAttribute("data-key");
 		});
 
+		Array.from(document.querySelectorAll("ui5-shellbar-item")).forEach(function(item) {
+			item.addEventListener("item-click", function(event) {
+				wcToastTC.show();
+			});
+		});
+
 		["disc", "call"].forEach(function(id) {
 			var currenItem = window[id][0] || window[id];
 			currenItem.addEventListener("ui5-click", function(event) {

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -213,6 +213,8 @@
 		<ui5-shellbar-item icon="discussion" count="2" id="test-invalidation-item"/>
 	</ui5-shellbar>
 
+	<ui5-toast id="wcToastTC">Custom Action Fired</ui5-toast>
+	
 	<script>
 		mySearch.addEventListener("suggestionItemSelect", function (event) {
 			 console.log(event);
@@ -270,7 +272,7 @@
 
 		["disc", "call"].forEach(function(id) {
 			var currenItem = window[id][0] || window[id];
-			currenItem.addEventListener("ui5-itemClick", function(event) {
+			currenItem.addEventListener("ui5-click", function(event) {
 				event.preventDefault();
 				window["press-input"].value = event.target.id;
 				window["custom-item-popover"].showAt(event.detail.targetRef);


### PR DESCRIPTION
Change event name from **"item-click"** to **"click"** as  it belongs to the ShellBarItem, not the ShellBar and using "item" in the event's name does not make sense and this is also the rule we used throughout the major API change activity in RC.15.

BREAKING CHANGE: ShellBarItem's event **"item-click"** has been renamed to **"click"**.