### PR TITLE
refactor(ui5-breadcrumbs-item): remove stableDomRef public property

### DIFF
--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -9,7 +9,8 @@
             <ui5-link @click="{{_openRespPopover}}"
                 accessible-role="button"
                 aria-label="{{_dropdownArrowAccessibleNameText}}"
-                aria-haspopup="{{_ariaHasPopup}}">
+                aria-haspopup="{{_ariaHasPopup}}"
+                data-ui5-stable="moreLink">
                 <ui5-icon name="slim-arrow-down"
                     title="{{_dropdownArrowAccessibleNameText}}"></ui5-icon>
             </ui5-link>

--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -9,8 +9,7 @@
             <ui5-link @click="{{_openRespPopover}}"
                 accessible-role="button"
                 aria-label="{{_dropdownArrowAccessibleNameText}}"
-                aria-haspopup="{{_ariaHasPopup}}"
-                data-ui5-stable="moreLink">
+                aria-haspopup="{{_ariaHasPopup}}">
                 <ui5-icon name="slim-arrow-down"
                     title="{{_dropdownArrowAccessibleNameText}}"></ui5-icon>
             </ui5-link>

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -441,10 +441,6 @@ class Breadcrumbs extends UI5Element {
 	_preprocessItems() {
 		this.items.forEach(item => {
 			item._getRealDomRef = () => this.getDomRef().querySelector(`[data-ui5-stable*=${item.stableDomRef}]`);
-			item._getOverflowDomRef = async () => {
-				this.responsivePopover = await this._respPopover();
-				return this.responsivePopover.querySelector(`[data-ui5-stable*=${item.stableDomRef}]`);
-			};
 		});
 	}
 
@@ -553,10 +549,6 @@ class Breadcrumbs extends UI5Element {
 
 	get _cancelButtonText() {
 		return Breadcrumbs.i18nBundle.getText(BREADCRUMBS_CANCEL_BUTTON);
-	}
-
-	get moreLinkDomRef() {
-		return this.shadowRoot.querySelector(`[data-ui5-stable*="moreLink"]`);
 	}
 
 	static get dependencies() {

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -229,6 +229,10 @@ class Breadcrumbs extends UI5Element {
 		}
 	}
 
+	onBeforeRendering() {
+		this._preprocessItems();
+	}
+
 	onAfterRendering() {
 		this._cacheWidths();
 		this._updateOverflow();
@@ -434,6 +438,16 @@ class Breadcrumbs extends UI5Element {
 		return item.innerText || Array.from(item.children).some(child => !child.hidden);
 	}
 
+	_preprocessItems() {
+		this.items.forEach(item => {
+			item._getRealDomRef = () => this.getDomRef().querySelector(`[data-ui5-stable*=${item.stableDomRef}]`);
+			item._getOverflowDomRef = async () => {
+				this.responsivePopover = await this._respPopover();
+				return this.responsivePopover.querySelector(`[data-ui5-stable*=${item.stableDomRef}]`);
+			};
+		});
+	}
+
 	getCurrentLocationLabelWrapper() {
 		return this.shadowRoot.querySelector(".ui5-breadcrumbs-current-location > span");
 	}
@@ -539,6 +553,10 @@ class Breadcrumbs extends UI5Element {
 
 	get _cancelButtonText() {
 		return Breadcrumbs.i18nBundle.getText(BREADCRUMBS_CANCEL_BUTTON);
+	}
+
+	get moreLinkDomRef() {
+		return this.shadowRoot.querySelector(`[data-ui5-stable*="moreLink"]`);
 	}
 
 	static get dependencies() {

--- a/packages/main/src/BreadcrumbsItem.js
+++ b/packages/main/src/BreadcrumbsItem.js
@@ -96,16 +96,6 @@ class BreadcrumbsItem extends UI5Element {
 	get stableDomRef() {
 		return `${this._id}-stable-dom-ref`;
 	}
-
-	/**
-	 * Returns the <code>ui5-shellbar-item</code> matching DOM ref
-	 * (list item) inside the overflow area.
-	 * @private
-	 */
-	async getOverflowDomRef() {
-		const domRef = await this._getOverflowDomRef();
-		return domRef;
-	}
 }
 
 BreadcrumbsItem.define();

--- a/packages/main/src/BreadcrumbsItem.js
+++ b/packages/main/src/BreadcrumbsItem.js
@@ -54,16 +54,6 @@ const metadata = {
 		 accessibleName: {
 			type: String,
 		},
-
-		/**
-		 * Defines the stable selector that you can use via <code>getStableDomRef</code> method.
-		 * @type {string}
-		 * @public
-		 */
-		stableDomRef: {
-			type: String,
-		},
-
 	},
 	slots: /** @lends sap.ui.webcomponents.main.BreadcrumbsItem.prototype */ {
 		/**
@@ -101,6 +91,20 @@ const metadata = {
 class BreadcrumbsItem extends UI5Element {
 	static get metadata() {
 		return metadata;
+	}
+
+	get stableDomRef() {
+		return `${this._id}-stable-dom-ref`;
+	}
+
+	/**
+	 * Returns the <code>ui5-shellbar-item</code> matching DOM ref
+	 * (list item) inside the overflow area.
+	 * @private
+	 */
+	async getOverflowDomRef() {
+		const domRef = await this._getOverflowDomRef();
+		return domRef;
 	}
 }
 

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -6,28 +6,19 @@ describe("Breadcrumbs general interaction", () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
 	});
 
-	it("tests getDomRef and getOverflowDomRef", async () => {
-		const testData = await browser.executeAsync(async (done) => {
-			const breadCrumbsItemInOverflow = document.getElementById("firstItemWithACCName");
+	it("tests getDomRef", async () => {
+		const res = await browser.executeAsync(async (done) => {
 			const breadCrumbsItemOutOfOverflow = document.getElementById("lastItemWithACCName");
 
 			// act
-			const res1 = {
-				item: breadCrumbsItemInOverflow,
-				realDomRef: await breadCrumbsItemInOverflow.getOverflowDomRef(),
-			};
-			const res2 = {
+			done({
 				item: breadCrumbsItemOutOfOverflow,
 				realDomRef: breadCrumbsItemOutOfOverflow.getDomRef(),
-			};
-
-			done([res1, res2]);
+			});
 		});
 
 		// assert
-		assert.strictEqual(testData[0].item["_id"], testData[0].realDomRef["_id"],
-			"getOverflowDomRef corrcetly returns the matching 'ui5-li' inside the overflow.");
-		assert.strictEqual(testData[1].item["_id"], testData[1].realDomRef["_id"],
+		assert.strictEqual(res.item["_id"], res.realDomRef["_id"],
 			"getDomRef corrcetly returns the matching ui5-link outside the overflow.");
 	});
 

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -6,6 +6,31 @@ describe("Breadcrumbs general interaction", () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
 	});
 
+	it("tests getDomRef and getOverflowDomRef", async () => {
+		const testData = await browser.executeAsync(async (done) => {
+			const breadCrumbsItemInOverflow = document.getElementById("firstItemWithACCName");
+			const breadCrumbsItemOutOfOverflow = document.getElementById("lastItemWithACCName");
+
+			// act
+			const res1 = {
+				item: breadCrumbsItemInOverflow,
+				realDomRef: await breadCrumbsItemInOverflow.getOverflowDomRef(),
+			};
+			const res2 = {
+				item: breadCrumbsItemOutOfOverflow,
+				realDomRef: breadCrumbsItemOutOfOverflow.getDomRef(),
+			};
+
+			done([res1, res2]);
+		});
+
+		// assert
+		assert.strictEqual(testData[0].item["_id"], testData[0].realDomRef["_id"],
+			"getOverflowDomRef corrcetly returns the matching 'ui5-li' inside the overflow.");
+		assert.strictEqual(testData[1].item["_id"], testData[1].realDomRef["_id"],
+			"getDomRef corrcetly returns the matching ui5-link outside the overflow.");
+	});
+
 	it("fires link-click event", async () => {
 		const breadcrumbs = await browser.$("#breadcrumbs1"),
 			link = (await breadcrumbs.shadow$$("ui5-link"))[1];


### PR DESCRIPTION
Remove BreadcrumbsItem's `stableDomRef` public property, as calling `getDomRef` on BreadcrumbsItem's now returns the matching actual DOM ref, typically `ui5-link`.
In case it is requested we can later add API to get the "showMore" link DOM Ref and the matching actual DOM Ref inside the overflow area.

BREAKING CHANGE: BreadcrumbsItem's `stableDomRef` property has been removed - use 
`getDomRef` to get the matching actual DOM ref