### PR TITLE
refactor(ui5-popover): simplify calcPlacement()

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -493,9 +493,6 @@ class Popover extends Popup {
 		let maxHeight = clientHeight;
 		let maxWidth = clientWidth;
 
-		let width = "";
-		let height = "";
-
 		const placementType = this.getActualPlacementType(targetRect, popoverSize);
 
 		this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placementType, targetRect);
@@ -505,14 +502,10 @@ class Popover extends Popup {
 
 		if (this.horizontalAlign === PopoverHorizontalAlign.Stretch && isVertical) {
 			popoverSize.width = targetRect.width;
-			width = `${targetRect.width}px`;
+			this._width = `${targetRect.width}px`;
 		} else if (this.verticalAlign === PopoverVerticalAlign.Stretch && !isVertical) {
 			popoverSize.height = targetRect.height;
-			height = `${targetRect.height}px`;
 		}
-
-		this._width = width;
-		this._height = height;
 
 		const arrowOffset = this.hideArrow ? 0 : arrowSize;
 
@@ -528,11 +521,11 @@ class Popover extends Popup {
 			break;
 		case PopoverPlacementType.Bottom:
 			left = this.getVerticalLeft(targetRect, popoverSize);
+			top = targetRect.bottom + arrowOffset;
 
 			if (allowTargetOverlap) {
-				top = Math.max(Math.min(targetRect.bottom + arrowOffset, clientHeight - popoverSize.height), 0);
+				top = Math.max(Math.min(top, clientHeight - popoverSize.height), 0);
 			} else {
-				top = targetRect.bottom + arrowOffset;
 				maxHeight = clientHeight - targetRect.bottom - arrowOffset;
 			}
 			break;
@@ -545,14 +538,14 @@ class Popover extends Popup {
 			}
 			break;
 		case PopoverPlacementType.Right:
+			left = targetRect.left + targetRect.width + arrowOffset;
+			top = this.getHorizontalTop(targetRect, popoverSize);
+
 			if (allowTargetOverlap) {
-				left = Math.max(Math.min(targetRect.left + targetRect.width + arrowOffset, clientWidth - popoverSize.width), 0);
+				left = Math.max(Math.min(left, clientWidth - popoverSize.width), 0);
 			} else {
-				left = targetRect.left + targetRect.width + arrowOffset;
 				maxWidth = clientWidth - targetRect.right - arrowOffset;
 			}
-
-			top = this.getHorizontalTop(targetRect, popoverSize);
 			break;
 		}
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -199,26 +199,34 @@
 	<ui5-button id="btnMoveFocus">focusable element</ui5-button>
 	<br>
 	<br>
-	<ui5-title>placement-type="Right", but no space on the right</ui5-title>
+	<ui5-title>placement-type="Right" (default)</ui5-title>
 	<p>No space on the Right, try Left, Bottom, Top</p>
 	<ui5-button id="btnFullWidth" class="popover7auto">Click me !</ui5-button>
+	<ui5-button id="btnNormalWidth">Click me !</ui5-button>
 	<br>
 	<br>
 	<ui5-title>placement-type="Right" (default) and allow-target-overlap=true </ui5-title>
 	<p>No space on the right, try Left, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthTargetOverlap" class="popover7auto">Click me !</ui5-button>
+	<ui5-button id="btnNormalWidthTargetOverlap">Click me !</ui5-button>
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Left", but no space on the left</ui5-title>
+	<ui5-title>placement-type="Left"</ui5-title>
 	<p>No space on the Left, try Right, Bottom, Top</p>
 	<ui5-button id="btnFullWidthLeft" class="popover7auto">Click me !</ui5-button>
+	<div class="popover13auto">
+		<ui5-button id="btnNormalWidthLeft">Click me !</ui5-button>
+	</div>
 
 	<br>
 	<br>
 	<ui5-title>placement-type="Left" and allow-target-overlap=true</ui5-title>
 	<p>No space on the right, try Roght, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthLeftTargetOverlap" class="popover7auto">Click me !</ui5-button>
+	<div class="popover13auto">
+		<ui5-button id="btnNormalWidthLeftTargetOverlap">Click me !</ui5-button>
+	</div>
 
 	<br>
 	<br>
@@ -230,7 +238,7 @@
 	<ui5-title>placement-type="Bottom"</ui5-title>
 	<ui5-button id="btnFullWidthBottom" class="popover7auto">Click me !</ui5-button>
 
-	<ui5-popover header-text="My Heading" id="popFullWidth" class="popover6auto" >
+	<ui5-popover header-text="My Heading" id="popFullWidth" class="popover6auto">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -453,17 +461,29 @@
 		btnFullWidth.addEventListener("click", function (event) {
 			popFullWidth.showAt(btnFullWidth);
 		});
+		btnNormalWidth.addEventListener("click", function (event) {
+			popFullWidth.showAt(btnNormalWidth);
+		});
 
 		btnFullWidthTargetOverlap.addEventListener("click", function (event) {
 			popFullWidthTargetOverlap.showAt(btnFullWidthTargetOverlap);
+		});
+		btnNormalWidthTargetOverlap.addEventListener("click", function (event) {
+			popFullWidthTargetOverlap.showAt(btnNormalWidthTargetOverlap);
 		});
 
 		btnFullWidthLeft.addEventListener("click", function (event) {
 			popFullWidthLeft.showAt(btnFullWidthLeft);
 		});
+		btnNormalWidthLeft.addEventListener("click", function (event) {
+			popFullWidthLeft.showAt(btnNormalWidthLeft);
+		});
 
 		btnFullWidthLeftTargetOverlap.addEventListener("click", function (event) {
 			popFullWidthLeftTargetOverlap.showAt(btnFullWidthLeftTargetOverlap);
+		});
+		btnNormalWidthLeftTargetOverlap.addEventListener("click", function (event) {
+			popFullWidthLeftTargetOverlap.showAt(btnNormalWidthLeftTargetOverlap);
 		});
 
 		btnFullWidthTop.addEventListener("click", function (event) {


### PR DESCRIPTION
- Removed unused property `_height`
- Unified switch/case statements
- Added more samples to the test page