### PR TITLE
fix(ui5-multi-combobox) Arrow navigation through items when the suggestions popover is closed

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -664,19 +664,26 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_navigateToNextItem() {
+		let isItemMatched = false;
+
+		const value = this.value;
 		const items = this.items;
 		const itemsCount = items.length;
 		const previousItemIdx = this.currentItemIdx;
+		const prevItem = items[previousItemIdx];
+		const matchingItems = this.value && this._filterItems(value);
 
-		if (previousItemIdx > -1 && items[previousItemIdx].text !== this.value) {
+		if (previousItemIdx > -1 && prevItem && prevItem.text !== value) {
 			this.currentItemIdx = -1;
+		} else {
+			isItemMatched = previousItemIdx > -1 && prevItem.text === value;
 		}
 
 		if (previousItemIdx >= itemsCount - 1) {
 			return;
 		}
 
-		let currentItem = this.items[++this.currentItemIdx];
+		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
 
 		while (this.currentItemIdx < itemsCount - 1 && currentItem.selected) {
 			currentItem = this.items[++this.currentItemIdx];
@@ -691,26 +698,41 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_navigateToPrevItem() {
+		let previousItemIdx = this.currentItemIdx;
+
 		const items = this.items;
-		const previousItemIdx = this.currentItemIdx;
+		const prevItem = items[previousItemIdx];
+		const prevItemText = prevItem && prevItem.text;
+		const value = this.value;
 
-		if (previousItemIdx <= 0 || items[previousItemIdx].text !== this.value) {
-			this.currentItemIdx = this.currentItemIdx === 0 ? 0 : -1;
-			return;
-		}
-
-		let currentItem = this.items[--this.currentItemIdx];
-
-		while (currentItem.selected && this.currentItemIdx > 0) {
-			currentItem = this.items[--this.currentItemIdx];
-		}
-
-		if (currentItem.selected) {
+		if (prevItem && prevItem.text && value && prevItemText !== value) {
 			this.currentItemIdx = previousItemIdx;
 			return;
 		}
 
-		this.value = currentItem.text;
+		if (previousItemIdx > -1 && !value) {
+			previousItemIdx = -1;
+		}
+
+		if (previousItemIdx === 0 && prevItemText === value) {
+			return;
+		}
+
+		if (previousItemIdx === -1) {
+			this.currentItemIdx = items.length;
+		}
+
+		let currentItem = items[--this.currentItemIdx];
+
+		while (this.currentItemIdx > 0 && currentItem.selected) {
+			currentItem = items[--this.currentItemIdx];
+		}
+
+		if (currentItem && currentItem.selected) {
+			this.currentItemIdx = previousItemIdx;
+		} else if (currentItem) {
+			this.value = currentItem.text;
+		}
 	}
 
 	handleEnter() {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -666,26 +666,26 @@ class MultiComboBox extends UI5Element {
 	_navigateToNextItem() {
 		let isItemMatched = false;
 		let previousItemIdx = this.currentItemIdx;
-	
+
 		const value = this.value;
 		const items = this.items;
 		const itemsCount = items.length;
 		const prevItem = items[previousItemIdx];
 		const matchingItems = this.value && this._filterItems(value);
-	
+
 		if (previousItemIdx > -1 && prevItem && prevItem.text !== value) {
 			this.currentItemIdx = -1;
 			previousItemIdx = -1;
 		} else {
 			isItemMatched = previousItemIdx > -1 && prevItem.text === value;
 		}
-	
+
 		if (previousItemIdx >= itemsCount - 1) {
 			return;
 		}
-	
+
 		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
-	
+
 		if (matchingItems.length > 1) {
 			while (this.currentItemIdx < matchingItems.length - 1 && currentItem.selected) {
 				currentItem = matchingItems[++this.currentItemIdx];
@@ -695,40 +695,40 @@ class MultiComboBox extends UI5Element {
 				currentItem = items[++this.currentItemIdx];
 			}
 		}
-	
+
 		if (currentItem.selected === true) {
 			this.currentItemIdx = previousItemIdx;
 			return;
 		}
-	
+
 		this.value = currentItem.text;
 	}
-	
+
 	_navigateToPrevItem() {
 		let isItemMatched = false;
 		let currentItem;
-	
+
 		const items = this.items;
 		const previousItemIdx = this.currentItemIdx;
 		const prevItem = items[previousItemIdx];
 		const prevItemText = prevItem && prevItem.text;
 		const value = this.value;
 		const matchingItems = this.value && this._filterItems(value);
-	
+
 		if (prevItem && prevItemText && value && prevItemText !== value) {
 			this.currentItemIdx = -1;
 		} else {
 			isItemMatched = previousItemIdx > -1 && prevItemText === value;
 		}
-	
+
 		if (previousItemIdx > -1 && !value) {
 			this.currentItemIdx = -1;
 		}
-	
+
 		if (previousItemIdx === 0 && prevItemText === value) {
 			return;
 		}
-	
+
 		if (this.currentItemIdx < 1 && !isItemMatched) {
 			this.currentItemIdx = matchingItems.length ? matchingItems.length - 1 : items.length - 1;
 			currentItem = matchingItems.length ? matchingItems[this.currentItemIdx] : items[this.currentItemIdx];
@@ -737,7 +737,7 @@ class MultiComboBox extends UI5Element {
 		} else {
 			currentItem = matchingItems.length ? matchingItems[--this.currentItemIdx] : items[--this.currentItemIdx];
 		}
-	
+
 		if (matchingItems.length > 1) {
 			while (this.currentItemIdx > 0 && currentItem.selected) {
 				currentItem = matchingItems[--this.currentItemIdx];
@@ -747,7 +747,7 @@ class MultiComboBox extends UI5Element {
 				currentItem = items[--this.currentItemIdx];
 			}
 		}
-	
+
 		if (currentItem && currentItem.selected) {
 			this.currentItemIdx = previousItemIdx;
 		} else if (currentItem) {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -656,10 +656,8 @@ class MultiComboBox extends UI5Element {
 		const firstListItem = this.list.items[0];
 
 		if (isOpen) {
-			firstListItem.focus();
-			firstListItem.selected = true;
 			this.list._itemNavigation.setCurrentItem(firstListItem);
-			this.fireSelectionChange();
+			firstListItem.focus();
 		} else if (!this.readonly) {
 			this._navigateToNextItem();
 		}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -685,8 +685,14 @@ class MultiComboBox extends UI5Element {
 
 		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
 
-		while (this.currentItemIdx < itemsCount - 1 && currentItem.selected) {
-			currentItem = this.items[++this.currentItemIdx];
+		if (matchingItems.length) {
+			while (this.currentItemIdx < matchingItems.length - 1 && currentItem.selected) {
+				currentItem = matchingItems[++this.currentItemIdx];
+			}
+		} else {
+			while (this.currentItemIdx < itemsCount - 1 && currentItem.selected) {
+				currentItem = items[++this.currentItemIdx];
+			}
 		}
 
 		if (currentItem.selected === true) {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -705,8 +705,8 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_navigateToPrevItem() {
-		let isItemMatched = false;
 		let currentItem;
+		let isItemMatched = false;
 
 		const items = this.items;
 		const previousItemIdx = this.currentItemIdx;

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -670,25 +670,39 @@ class MultiComboBox extends UI5Element {
 		const value = this.value;
 		const items = this.items;
 		const itemsCount = items.length;
-		const prevItem = items[previousItemIdx];
 		const matchingItems = this.value && this._filterItems(value);
+		const prevItem = previousItemIdx > -1  && items[previousItemIdx] && items[previousItemIdx].text === value ? items[previousItemIdx] : matchingItems[previousItemIdx];
 
-		if (previousItemIdx > -1 && prevItem && prevItem.text !== value) {
+		if (prevItem && prevItem.text !== value) {
 			this.currentItemIdx = -1;
 			previousItemIdx = -1;
 		} else {
-			isItemMatched = previousItemIdx > -1 && prevItem.text === value;
+			isItemMatched = previousItemIdx > -1 && prevItem && prevItem.text === value;
 		}
 
-		if (previousItemIdx >= itemsCount - 1) {
+		if (previousItemIdx === itemsCount - 1 && items[previousItemIdx].text === value) {
 			return;
+		}
+
+		if (previousItemIdx > itemsCount) {
+			this.currentItemIdx = -1;
 		}
 
 		if (!matchingItems.length && !isItemMatched && value) {
 			return;
 		}
 
-		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
+		let currentItem;
+
+		if (!isItemMatched && matchingItems.length) {
+			currentItem = matchingItems[++this.currentItemIdx];
+		} else {
+			// If the previous item index corresponds to a filtered item 
+			// we should find its index among unfilted items
+			let currentItemIdx = items.findIndex(item => item.text === value);
+			this.currentItemIdx = currentItemIdx !== -1 ? currentItemIdx : this.currentItemIdx;
+			currentItem = items[++this.currentItemIdx]
+		}
 
 		if (matchingItems.length > 1) {
 			while (this.currentItemIdx < matchingItems.length - 1 && currentItem.selected) {
@@ -716,12 +730,12 @@ class MultiComboBox extends UI5Element {
 
 		const items = this.items;
 		const previousItemIdx = this.currentItemIdx;
-		const prevItem = items[previousItemIdx];
-		const prevItemText = prevItem && prevItem.text;
 		const value = this.value;
 		const matchingItems = this.value && this._filterItems(value);
+		const prevItem = previousItemIdx > -1  && items[previousItemIdx].text === value ? items[previousItemIdx] : matchingItems[previousItemIdx];
+		const prevItemText = prevItem && prevItem.text;
 
-		if (prevItem && prevItemText && value && prevItemText !== value) {
+		if ((prevItemText && value && prevItemText !== value) || (value && previousItemIdx > -1)) {
 			this.currentItemIdx = -1;
 		} else {
 			isItemMatched = previousItemIdx > -1 && prevItemText === value;
@@ -731,11 +745,7 @@ class MultiComboBox extends UI5Element {
 			this.currentItemIdx = -1;
 		}
 
-		if (previousItemIdx === 0 && prevItemText === value) {
-			return;
-		}
-
-		if (!matchingItems.length && !isItemMatched && value) {
+		if (previousItemIdx === 0 && items[previousItemIdx].text === value) {
 			return;
 		}
 
@@ -743,6 +753,8 @@ class MultiComboBox extends UI5Element {
 			this.currentItemIdx = matchingItems.length ? matchingItems.length - 1 : items.length - 1;
 			currentItem = matchingItems.length ? matchingItems[this.currentItemIdx] : items[this.currentItemIdx];
 		} else if (isItemMatched) {
+			let currentItemIdx = items.findIndex(item => item.text === value);
+			this.currentItemIdx = currentItemIdx !== -1 ? currentItemIdx : this.currentItemIdx;
 			currentItem = items[--this.currentItemIdx];
 		} else {
 			currentItem = matchingItems.length ? matchingItems[--this.currentItemIdx] : items[--this.currentItemIdx];

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -707,8 +707,8 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_navigateToPrevItem() {
-		let currentItem;
 		let isItemMatched = false;
+		let currentItem;
 
 		const items = this.items;
 		const previousItemIdx = this.currentItemIdx;

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -702,6 +702,8 @@ class MultiComboBox extends UI5Element {
 		}
 
 		this.value = currentItem.text;
+		this._innerInput.value = currentItem.text;
+		this._innerInput.setSelectionRange(0, currentItem.text.length);
 	}
 
 	_navigateToPrevItem() {
@@ -752,6 +754,8 @@ class MultiComboBox extends UI5Element {
 			this.currentItemIdx = previousItemIdx;
 		} else if (currentItem) {
 			this.value = currentItem.text;
+			this._innerInput.value = currentItem.text;
+			this._innerInput.setSelectionRange(0, currentItem.text.length);
 		}
 	}
 

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -665,27 +665,28 @@ class MultiComboBox extends UI5Element {
 
 	_navigateToNextItem() {
 		let isItemMatched = false;
-
+		let previousItemIdx = this.currentItemIdx;
+	
 		const value = this.value;
 		const items = this.items;
 		const itemsCount = items.length;
-		const previousItemIdx = this.currentItemIdx;
 		const prevItem = items[previousItemIdx];
 		const matchingItems = this.value && this._filterItems(value);
-
+	
 		if (previousItemIdx > -1 && prevItem && prevItem.text !== value) {
 			this.currentItemIdx = -1;
+			previousItemIdx = -1;
 		} else {
 			isItemMatched = previousItemIdx > -1 && prevItem.text === value;
 		}
-
+	
 		if (previousItemIdx >= itemsCount - 1) {
 			return;
 		}
-
+	
 		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
-
-		if (matchingItems.length) {
+	
+		if (matchingItems.length > 1) {
 			while (this.currentItemIdx < matchingItems.length - 1 && currentItem.selected) {
 				currentItem = matchingItems[++this.currentItemIdx];
 			}
@@ -694,46 +695,59 @@ class MultiComboBox extends UI5Element {
 				currentItem = items[++this.currentItemIdx];
 			}
 		}
-
+	
 		if (currentItem.selected === true) {
 			this.currentItemIdx = previousItemIdx;
 			return;
 		}
-
+	
 		this.value = currentItem.text;
 	}
-
+	
 	_navigateToPrevItem() {
-		let previousItemIdx = this.currentItemIdx;
-
+		let isItemMatched = false;
+		let currentItem;
+	
 		const items = this.items;
+		const previousItemIdx = this.currentItemIdx;
 		const prevItem = items[previousItemIdx];
 		const prevItemText = prevItem && prevItem.text;
 		const value = this.value;
-
-		if (prevItem && prevItem.text && value && prevItemText !== value) {
-			this.currentItemIdx = previousItemIdx;
-			return;
+		const matchingItems = this.value && this._filterItems(value);
+	
+		if (prevItem && prevItemText && value && prevItemText !== value) {
+			this.currentItemIdx = -1;
+		} else {
+			isItemMatched = previousItemIdx > -1 && prevItemText === value;
 		}
-
+	
 		if (previousItemIdx > -1 && !value) {
-			previousItemIdx = -1;
+			this.currentItemIdx = -1;
 		}
-
+	
 		if (previousItemIdx === 0 && prevItemText === value) {
 			return;
 		}
-
-		if (previousItemIdx === -1) {
-			this.currentItemIdx = items.length;
-		}
-
-		let currentItem = items[--this.currentItemIdx];
-
-		while (this.currentItemIdx > 0 && currentItem.selected) {
+	
+		if (this.currentItemIdx < 1 && !isItemMatched) {
+			this.currentItemIdx = matchingItems.length ? matchingItems.length - 1 : items.length - 1;
+			currentItem = matchingItems.length ? matchingItems[this.currentItemIdx] : items[this.currentItemIdx];
+		} else if (isItemMatched) {
 			currentItem = items[--this.currentItemIdx];
+		} else {
+			currentItem = matchingItems.length ? matchingItems[--this.currentItemIdx] : items[--this.currentItemIdx];
 		}
-
+	
+		if (matchingItems.length > 1) {
+			while (this.currentItemIdx > 0 && currentItem.selected) {
+				currentItem = matchingItems[--this.currentItemIdx];
+			}
+		} else {
+			while (this.currentItemIdx > 0 && currentItem.selected) {
+				currentItem = items[--this.currentItemIdx];
+			}
+		}
+	
 		if (currentItem && currentItem.selected) {
 			this.currentItemIdx = previousItemIdx;
 		} else if (currentItem) {

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -684,6 +684,10 @@ class MultiComboBox extends UI5Element {
 			return;
 		}
 
+		if (!matchingItems.length && !isItemMatched && value) {
+			return;
+		}
+
 		let currentItem = matchingItems.length && !isItemMatched ? matchingItems[++this.currentItemIdx] : this.items[++this.currentItemIdx];
 
 		if (matchingItems.length > 1) {
@@ -728,6 +732,10 @@ class MultiComboBox extends UI5Element {
 		}
 
 		if (previousItemIdx === 0 && prevItemText === value) {
+			return;
+		}
+
+		if (!matchingItems.length && !isItemMatched && value) {
 			return;
 		}
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -435,6 +435,66 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("focused"), true, "The input should be focused");
 			assert.equal(await listItem.getProperty("focused"), false, "The first item is not focused");
 		});
+
+		it ("should navigate through the items with arrow keys when the picker is closed", async () => {
+			const mcb = await browser.$("#mcb");
+
+			await mcb.click();
+			await mcb.keys("ArrowDown");
+
+			assert.equal(await mcb.getProperty("value"), "Cosy", "The first item name is seleted");
+
+			await mcb.keys("ArrowDown");
+			assert.equal(await mcb.getProperty("value"), "Compact", "The second item name is selected");
+
+			await mcb.keys("ArrowUp");
+			assert.equal(await mcb.getProperty("value"), "Cosy", "The value is set back to the first item name");
+
+			await mcb.keys("ArrowUp");
+			assert.equal(await mcb.getProperty("value"), "Cosy", "The value remains the same when pressing arrow up while the first item is set");
+		});
+
+		it ("should only navigate through not already selected items with arrow keys when the picker is closed", async () => {
+			const mcb = await browser.$("#mcb-error");
+			const input = await mcb.shadow$("input");
+
+			await input.click();
+			await input.keys("ArrowDown");
+
+			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item is set");
+
+			await input.keys("ArrowDown");
+			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item remains set");
+
+			await input.keys("ArrowUp");
+			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item remains set");
+		});
+
+		it ("should reset current navigation state on user input", async () => {
+			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+			const mcb = await browser.$("#mcb");
+
+			await mcb.click();
+			await mcb.keys("ArrowDown");
+			await mcb.keys("ArrowDown");
+
+			assert.equal(await mcb.getProperty("value"), "Compact", "The second item name is selected");
+
+			await mcb.keys("a");
+			await mcb.keys("ArrowDown");
+
+			assert.equal(await mcb.getProperty("value"), "Cosy", "The value is set to the first item name");
+
+			await mcb.keys("ArrowDown");
+			await mcb.keys("ArrowDown");
+
+			assert.equal(await mcb.getProperty("value"), "Condensed", "The value is set to the third item name");
+
+			await mcb.keys("a");
+			await mcb.keys("ArrowUp");
+			assert.equal(await mcb.getProperty("value"), "Condenseda", "The value remains the same");
+		});
 	});
 
 	describe("General", () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -494,7 +494,7 @@ describe("MultiComboBox general interaction", () => {
 
 			await mcb.keys("a");
 			await mcb.keys("ArrowUp");
-			assert.equal(await mcb.getProperty("value"), "Condenseda", "The value remains the same");
+			assert.equal(await mcb.getProperty("value"), "Longest word in the world 2", "Last value should be selected");
 		});
 
 	it ("should set matching item if there is user input", async () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -470,7 +470,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item remains set");
 		});
 
-		it ("should reset current navigation state on user input", async () => {
+		it ("should reset current navigation state on user input if no matching item is found", async () => {
 			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -481,6 +481,7 @@ describe("MultiComboBox general interaction", () => {
 
 			assert.equal(await mcb.getProperty("value"), "Compact", "The second item name is selected");
 
+			await mcb.setProperty("value", "");
 			await mcb.keys("a");
 			await mcb.keys("ArrowDown");
 
@@ -495,7 +496,20 @@ describe("MultiComboBox general interaction", () => {
 			await mcb.keys("ArrowUp");
 			assert.equal(await mcb.getProperty("value"), "Condenseda", "The value remains the same");
 		});
+
+	it ("should set matching item if there is user input", async () => {
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+		const mcb = await browser.$("#mcb");
+
+		await mcb.setProperty("value", "l");
+		await mcb.click();
+		await mcb.keys("ArrowDown");
+
+		assert.equal(await mcb.getProperty("value"), "Longest word in the world", "The value is set to the first item name");
 	});
+});
+
 
 	describe("General", () => {
 		before(async () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -470,30 +470,28 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item remains set");
 		});
 
-		it ("should reset current navigation state on user input if no matching item is found", async () => {
+		it ("should not navigate user input if no matching filtered item is found", async () => {
 			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
 
 			await mcb.click();
-			await mcb.keys("ArrowDown");
-			await mcb.keys("ArrowDown");
-
-			assert.equal(await mcb.getProperty("value"), "Compact", "The second item name is selected");
-
-			await mcb.setProperty("value", "");
-			await mcb.keys("a");
-			await mcb.keys("ArrowDown");
-
-			assert.equal(await mcb.getProperty("value"), "Cosy", "The value is set to the first item name");
-
-			await mcb.keys("ArrowDown");
-			await mcb.keys("ArrowDown");
-
-			assert.equal(await mcb.getProperty("value"), "Condensed", "The value is set to the third item name");
-
 			await mcb.keys("a");
 			await mcb.keys("ArrowUp");
+			assert.equal(await mcb.getProperty("value"), "a", "No item is selected because there is no matching one");
+
+			await mcb.keys("ArrowDown");
+			assert.equal(await mcb.getProperty("value"), "a", "No item is selected because there is no matching one");
+		});
+
+		it ("arrow up when the first or no item is selected should go to the last item", async () => {
+			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+			const mcb = await browser.$("#mcb");
+
+			await mcb.click();
+			await mcb.keys("ArrowUp");
+
 			assert.equal(await mcb.getProperty("value"), "Longest word in the world 2", "Last value should be selected");
 		});
 


### PR DESCRIPTION
Issue #4010

Enable arrow navigation through the items when the item's picker is not open.
