### PR TITLE
chore: start shipping .css files to NPM

### DIFF
--- a/packages/fiori/.npmignore
+++ b/packages/fiori/.npmignore
@@ -1,4 +1,3 @@
-*.css
 dist/resources
 dist/test-resources
 lib/

--- a/packages/main/.npmignore
+++ b/packages/main/.npmignore
@@ -1,4 +1,3 @@
-*.css
 dist/resources
 dist/test-resources
 lib/

--- a/packages/theming/.npmignore
+++ b/packages/theming/.npmignore
@@ -1,4 +1,3 @@
-*.css
 dist/resources
 dist/test-resources
 node_modules/


### PR DESCRIPTION
The CSP-compliance for Firefox/Safari requires the `/dist/css/` directory for the following packages to be in NPM:
 - `@ui5/webcomponents-base`
 - `@ui5/webcomponents-theming`
 - `@ui5/webcomponents`
 - `@ui5/webcomponents-fiori`

Currently only  `@ui5/webcomponents-base` ships its .css files.