### PR TITLE
fix(popups): Tabindex of block layer is 0 

### DIFF
--- a/packages/main/src/PopupBlockLayer.hbs
+++ b/packages/main/src/PopupBlockLayer.hbs
@@ -1,6 +1,6 @@
 <div class="ui5-block-layer"
     ?hidden={{_blockLayerHidden}}
-    tabindex="1"
+    tabindex="0"
     style="{{styles.blockLayer}}"
 	@keydown="{{_preventBlockLayerFocus}}"
     @mousedown="{{_preventBlockLayerFocus}}">


### PR DESCRIPTION
In popups block layer tabindex is set to 1 which is a valiolation of some accessibility html validators. 
To resolve the issue we are setting the tabindex  to 0 of the block layer.

FIXES: 4187
