### PR TITLE
refactor(ui5-shellbar): extract profile btn as HBS partial

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -155,20 +155,7 @@
 			></ui5-button>
 
 			{{#if hasProfile}}
-				<ui5-button
-					profile-btn
-					id="{{this._id}}-item-3"
-					@click={{_handleProfilePress}}
-					style="{{styles.items.profile}}"
-					title="{{_profileText}}"
-					._buttonAccInfo="{{accInfo.profile}}"
-					class="ui5-shellbar-button ui5-shellbar-image-button"
-					data-ui5-stable="profile"
-				>
-					<slot
-						name="profile"
-					></slot>
-				</ui5-button>
+				{{> profileBtn}}
 			{{/if}}
 
 			{{#if showProductSwitch}}
@@ -187,6 +174,21 @@
 		</div>
 	</div>
 </div>
+
+{{#*inline "profileBtn"}}
+	<ui5-button
+		profile-btn
+		id="{{this._id}}-item-3"
+		@click={{_handleProfilePress}}
+		style="{{styles.items.profile}}"
+		title="{{_profileText}}"
+		._buttonAccInfo="{{accInfo.profile}}"
+		class="ui5-shellbar-button ui5-shellbar-image-button"
+		data-ui5-stable="profile"
+	>
+		<slot name="profile"></slot>
+	</ui5-button>
+{{/inline}}
 
 {{#*inline "coPilot"}}
 	<svg @click="{{_coPilotClick}}" focusable="false" width="44" role="presentation" aria-hidden="true" height="44" viewBox="-150 -150 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ui5-shellbar-coPilot">

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -155,7 +155,7 @@
 			></ui5-button>
 
 			{{#if hasProfile}}
-				{{> profileBtn}}
+				{{> profileButton}}
 			{{/if}}
 
 			{{#if showProductSwitch}}
@@ -175,7 +175,7 @@
 	</div>
 </div>
 
-{{#*inline "profileBtn"}}
+{{#*inline "profileButton"}}
 	<ui5-button
 		profile-btn
 		id="{{this._id}}-item-3"


### PR DESCRIPTION
The stakeholders can't provide own 'title' for the ShellBar's profile button. We show "profile", which is not what the stakeholders need. As currently, it's not possible to replace a specific text in the i18n bundle, we would need to provide either a HBS template hook, or an API to allow developers set their own text. The template hook is the simplest solution without any change in the APIs.
Extract the profile button mark up as Handlebars partial to allow custom component developers to overwrite the Handlebars partial and change the profile button "title" to the desired one.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/4009