### PR TITLE
fix(ui5-date-time-picker): proper visualization on mobile

### DIFF
--- a/packages/main/src/themes/TimeSelection.css
+++ b/packages/main/src/themes/TimeSelection.css
@@ -17,6 +17,10 @@
 	height: 90vh;
 }
 
+:host(.ui5-dt-time.ui5-dt-cal--hidden) .ui5-time-selection-root.ui5-phone {
+	height: 80vh;
+}
+
 [ui5-wheelslider] {
 	padding-left: 0.25rem;
 	padding-right: 0.25rem;


### PR DESCRIPTION
There is no vertical scroll in the corresponding component
popover when navigated to the time picker part.