### PR TITLE
docs: fix SAP logo path

### DIFF
--- a/packages/tools/lib/documentation/templates/template.js
+++ b/packages/tools/lib/documentation/templates/template.js
@@ -33,6 +33,6 @@ module.exports = {
         <a class="separator" href="https://www.sap.com/about/legal/privacy.html" target="_blank">Privacy Policy</a>
         <a href="https://www.sap.com/about/legal/impressum.html" target="_blank">Legal</a>
       </div>
-      <img src="../../../../../../assets/images/sap-logo-svg.svg" alt="Sap Logo" />
+      <img src="../../../assets/images/sap-logo-svg.svg" alt="Sap Logo" />
     </footer>`
 };


### PR DESCRIPTION
Correct the SAP logo path in the footer to start displaying it.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/3126