### PR TITLE
fix(ui5-list): remove highlighting on items after tap on mobile

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-FNJQMNguBdwfNetzIV90Ud4CNxA=
+88dfgAaZhJbBnk8fY3GOimuDUBc=

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -5,6 +5,7 @@
 	display: block;
 	max-width: 100%;
 	width: 100%;
+	-webkit-tap-highlight-color: transparent;
 }
 
 :host([indent]) .ui5-list-root {


### PR DESCRIPTION
Part of #4258

When tapping on list items in Chrome on Android, items would unintendedly receive a light-blue overlay.
This change removes this overlay.