### PR TITLE
POC feat(ui5-list): Postpone selection of items

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -718,7 +718,6 @@ class List extends UI5Element {
 				key: event.detail.key,
 			});
 		}
-		this._selectionRequested = false;
 	}
 
 	resumeSelection() {
@@ -727,6 +726,7 @@ class List extends UI5Element {
 		} else {
 			console.warn("postponed item no longer exists"); // eslint-disable-line
 		}
+		this._selectionRequested = false;
 	}
 
 	handleSingleSelect(item) {
@@ -924,6 +924,7 @@ class List extends UI5Element {
 		const pressedItem = event.detail.item;
 
 		if (!this._selectionRequested && this.mode !== ListMode.Delete) {
+			this._selectionRequested = true;
 			this.onSelectionRequested({
 				detail: {
 					item: pressedItem,
@@ -936,6 +937,8 @@ class List extends UI5Element {
 
 		this.fireEvent("item-press", { item: pressedItem });
 		this.fireEvent("item-click", { item: pressedItem });
+
+		this._selectionRequested = false;
 	}
 
 	// This is applicable to NoficationListItem

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -190,7 +190,7 @@ const metadata = {
 		 * @since 1.0.1
 		 */
 		postponeSelection: {
-			type: Boolean
+			type: Boolean,
 		},
 
 		/**
@@ -697,7 +697,7 @@ class List extends UI5Element {
 
 		if (this[`handle${this.mode}`]) {
 			if (this.postponeSelection && !resuming) {
-				this._postponedItem = {detail: {...event.detail}};
+				this._postponedItem = { detail: { ...event.detail } };
 			} else {
 				selectionChange = this[`handle${this.mode}`](event.detail.item, event.detail.selected);
 			}
@@ -725,7 +725,7 @@ class List extends UI5Element {
 		if (this.items.indexOf(this._postponedItem.detail.item) !== -1) {
 			this.onSelectionRequested(this._postponedItem, true);
 		} else {
-			console.warn("postponed item no longer exists")
+			console.warn("postponed item no longer exists"); // eslint-disable-line
 		}
 	}
 
@@ -936,7 +936,6 @@ class List extends UI5Element {
 
 		this.fireEvent("item-press", { item: pressedItem });
 		this.fireEvent("item-click", { item: pressedItem });
-
 	}
 
 	// This is applicable to NoficationListItem

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -75,6 +75,16 @@
 
 	<br/><br/>
 
+	<ui5-list header-text="API: Postpone" mode="SingleSelect" postpone-selection='true'>
+		<ui5-li >Active item - press</ui5-li>
+		<ui5-li >Active item - press</ui5-li>
+		<ui5-li selected type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Inactive">Inactive item</ui5-li>
+		<ui5-li type="Detail">Detail item</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
+
 	<ui5-list header-text="API: ListItem type='Active/Inactive/Detail'" mode="SingleSelect">
 		<ui5-li >Active item - press</ui5-li>
 		<ui5-li >Active item - press</ui5-li>
@@ -133,7 +143,7 @@
 	<ui5-label id="itemPress2">[Event] itemPress :: n/a</ui5-label>
 	<br/><br/>
 	<ui5-label id="selectionChange2">[Event] selectionChange :: n/a</ui5-label>
-	<ui5-list id="myList4" mode="MultiSelect" header-text="API: mode='MultiSelect'">
+	<ui5-list postpone-selection='true' id="myList4" mode="MultiSelect" header-text="API: mode='MultiSelect'">
 		<ui5-li id="country1" selected>Argentina</ui5-li>
 		<ui5-li id="country2">Bulgaria</ui5-li>
 		<ui5-li id="country3">China</ui5-li>

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -50,6 +50,21 @@
 	<br><br><br>
 	
 	<br/>
+	<ui5-list id="listPostpone" header-text="API: postponeSelection" postpone-selection='true' mode="SingleSelect">
+		<ui5-li id="country1">Argentina</ui5-li>
+		<ui5-li id="country2" selected >Bulgaria</ui5-li>
+		<ui5-li id="country3">China</ui5-li>
+	</ui5-list>
+	<ui5-input id="itemPressResultField3" placeholder="itemPress result"></ui5-input>
+	<ui5-input id="itemPressFocusedResultField" placeholder="itemPress focused result"></ui5-input>
+	<ui5-input id="selectionChangeResultField3" placeholder="selectionChange result"></ui5-input>
+	<ui5-input id="selectionPostponeResultField" placeholder="selectionPostpone result"></ui5-input>
+
+	<ui5-button id="resumeSelectionBtn">Resume Selection</ui5-button>
+
+	<br><br><br>
+	
+	<br/>
 	<ui5-list id="listEvents" mode="SingleSelectEnd">
 		<ui5-li id="country1">Argentina</ui5-li>
 		<ui5-li id="country2" selected >Bulgaria</ui5-li>
@@ -245,6 +260,8 @@
 		var itemDeleteCounter = 0;
 		var itemPressCounter = 0;
 		var itemPressCounter2 = 0;
+		var itemPressCounter3 = 0;
+		var selectionPostponeCounter = 0;
 		var selectionChangeCounter = 0;
 		var selectionChangeCounter2 = 0;
 
@@ -268,6 +285,26 @@
 		listEvents.addEventListener("ui5-selectionChange", function(event) {
 			selectionChangeResultPreviousItemsParameter.value = event.detail.previouslySelectedItems[0].id;
 		})
+
+		listPostpone.addEventListener("ui5-itemPress", function (event) {
+			itemPressCounter3 += 1;
+			itemPressResultField3.value = itemPressCounter3;
+			itemPressFocusedResultField.value = event.detail.item.focused;
+		});
+
+		listPostpone.addEventListener("ui5-selectionChange", function (event) {
+			selectionChangeCounter2 += 1;
+			selectionChangeResultField3.value = selectionChangeCounter2;
+		});
+
+		listPostpone.addEventListener("ui5-selectionPostpone", function (event) {
+			selectionPostponeCounter += 1;
+			selectionPostponeResultField.value = selectionPostponeCounter;
+		});
+
+		resumeSelectionBtn.addEventListener("click", function(event) {
+			listPostpone.resumeSelection();
+		});
 
 		listEvents2.addEventListener("ui5-itemPress", function (event) {
 			itemPressCounter2 += 1;

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -60,6 +60,36 @@ describe("List Tests", () => {
 		assert.strictEqual(await selectionChangeResultField2.getProperty("value"), "1", "selectionChange event has been fired.");
 	});
 
+	it("itemPress and selectionPostpone events are fired in Single selection", async () => {
+		const itemPressResultField3 = await browser.$("#itemPressResultField3");
+		const itemPressFocusedResultField = await browser.$("#itemPressFocusedResultField");
+		const selectionChangeResultField3 = await browser.$("#selectionChangeResultField3");
+		const selectionPostponeResultField = await browser.$("#selectionPostponeResultField");
+		const firstItem = await browser.$("#listPostpone #country1");
+		const secondItem = await browser.$("#listPostpone #country2");
+
+		assert.strictEqual(await secondItem.getAttribute("selected"), "true", "second item is selected initially.");
+
+		await firstItem.click();
+
+		assert.strictEqual(await firstItem.getAttribute("selected"), null, "first item isn't selected (being postponed) after clicking first item.");
+		assert.strictEqual(await secondItem.getAttribute("selected"), "true", "second item is still selected after clicking first item.");
+
+		assert.strictEqual(await itemPressResultField3.getProperty("value"), "1", "itemPress event has been fired once.");
+		assert.strictEqual(await itemPressFocusedResultField.getProperty("value"), "true", "first item has been focused as expected.");
+		assert.strictEqual(await selectionChangeResultField3.getProperty("value"), "", "selectionChange event hasn't fired.");
+		assert.strictEqual(await selectionPostponeResultField.getProperty("value"), "1", "selectionPostpone event has been fired.");
+
+		await browser.$("#resumeSelectionBtn").click();
+
+		assert.strictEqual(await firstItem.getAttribute("selected"), "true", "first item is selected (no longer postponed) on resuming selection.");
+		assert.strictEqual(await secondItem.getAttribute("selected"), null, "second item is no longer selected on resuming selection.");
+
+		assert.strictEqual(await itemPressResultField3.getProperty("value"), "1", "itemPress event hasn't been fired on resuming selection.");
+		assert.strictEqual(await selectionChangeResultField3.getProperty("value"), "", "selectionChange still event hasn't fired on resuming selection.");
+		assert.strictEqual(await selectionPostponeResultField.getProperty("value"), "1", "selectionPostpone hasn't been fired on resuming selection.");
+	});
+
 	it("selectionChange events provides previousSelection item", async () => {
 		const selectionChangeResultPreviousItemsParameter = await browser.$("#selectionChangeResultPreviousItemsParameter");
 		const firstItem = await browser.$("#listEvents #country1");


### PR DESCRIPTION
Background: The app developer wants to be able to put a confirmation
Dialog before the actual select of an item on user interaction.

Solution: We introduce a new property called "postponeSelection" which
when set to "true" prevents/postpones the selection of an item. The
actual selection could be made on a later state with the public method
called "resumeSelection". In case of "MultiSelect" mode, all selection
is postponed and the resumed item is the last one which was postponed.

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
