### PR TITLE
fix(inputs): adjust value and placeholder styles

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -135,6 +135,7 @@
 	visibility: hidden;
 }
 [inner-input]::-webkit-input-placeholder {
+	font-weight: normal;
 	font-style: var(--_ui5-input-placeholder-style);
 	color: var(--_ui5-input-placeholder-color);
 	padding-right: 0.125rem;
@@ -147,6 +148,7 @@
 	visibility: hidden;
 }
 [inner-input]::-moz-placeholder {
+	font-weight: normal;
 	font-style: var(--_ui5-input-placeholder-style);
 	color: var(--sapField_PlaceholderTextColor);
 	padding-right: 0.125rem;
@@ -159,6 +161,7 @@
 	visibility: hidden;
 }
 [inner-input]:-ms-input-placeholder {
+	font-weight: normal;
 	font-style: italic;
 	color: var(--sapField_PlaceholderTextColor);
 	padding-right: 0.125rem;
@@ -254,6 +257,15 @@
 
 :host([value-state="Error"]) [inner-input] {
 	font-weight: var(--_ui5_input_error_font_weight);
+}
+
+:host([value-state="Warning"]) [inner-input] {
+	font-weight: var(--_ui5_input_warning_font_weight);
+}
+
+:host([value-state="Information"]) [inner-input] {
+	font-style: var(--_ui5_input_information_font_style);
+	font-weight: var(--_ui5_input_information_font_weight);
 }
 
 :host([value-state="Error"]:not([readonly])) {

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -133,25 +133,29 @@
 
 .ui5-textarea-inner::-webkit-input-placeholder {
 	/* Chrome/Opera/Safari */
+	font-weight: normal;
 	font-style: var(--_ui5_textarea_placeholder_font_style);
 	color: var(--sapField_PlaceholderTextColor);
 }
 
 .ui5-textarea-inner::-moz-placeholder {
 	/* Firefox 19+ */
+	font-weight: normal;
 	font-style: var(--_ui5_textarea_placeholder_font_style);
 	color: var(--sapField_PlaceholderTextColor);
 }
 
 .ui5-textarea-inner:-ms-input-placeholder {
 	/* IE 10+ */
+	font-weight: normal;
 	font-style: var(--_ui5_textarea_placeholder_font_style);
 	color: var(--sapField_PlaceholderTextColor);
 }
 
 .ui5-textarea-inner:-moz-placeholder {
 	/* Firefox 18- */
-	font-style: italic;
+	font-weight: normal;
+	font-style: var(--_ui5_textarea_placeholder_font_style);
 	color: var(--sapField_PlaceholderTextColor);
 }
 
@@ -171,6 +175,10 @@
 :host([value-state="Error"]) .ui5-textarea-inner,
 :host([value-state="Warning"]) .ui5-textarea-inner {
 	font-style: var(--_ui5_input_error_warning_font_style);
+}
+
+:host([value-state="Warning"]) .ui5-textarea-inner {
+	font-weight: var(--_ui5_input_warning_font_weight);
 }
 
 :host([value-state="Warning"]:not([readonly])) .ui5-textarea-inner,

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -18,9 +18,12 @@
 	--_ui5_input_state_border_width: 0.125rem;
 	--_ui5-input-information_border_width: 0.125rem;
 	--_ui5_input_error_font_weight: normal;
+	--_ui5_input_warning_font_weight: normal;
+	--_ui5_input_information_font_weight: normal;
 	--_ui5_input_focus_border_width: 1px;
 	--_ui5_input_error_warning_border_style: solid;
 	--_ui5_input_error_warning_font_style: inherit;
+	--_ui5_input_information_font_style: inherit;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;
 	--_ui5_input_disabled_border_color: var(--sapField_ReadOnly_BorderColor);

--- a/packages/main/src/themes/base/TextArea-parameters.css
+++ b/packages/main/src/themes/base/TextArea-parameters.css
@@ -18,4 +18,5 @@
 	--_ui5_textarea_value_state_focus_outline: var(--_ui5_input_focus_border_width) dotted var(--sapContent_FocusColor);
 	--_ui5_textarea_after_element_display: none;
 	--_ui5_textarea_placeholder_font_style: italic;
+	--_ui5_input_warning_font_weight: normal;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Input-parameters.css
@@ -7,8 +7,13 @@
 	--_ui5-input-information_border_width: var(--sapField_BorderWidth);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_information_font_style: italic;
 	--_ui5_input_error_font_weight: bold;
+	--_ui5_input_warning_font_weight: bold;
+	--_ui5_input_information_font_weight: bold;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;
 	--_ui5_input_icon_padding: 0.65rem 0.75rem;
+	--_ui5-input-placeholder-style: normal;
+	--_ui5-input-placeholder-color: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/TextArea-parameters.css
@@ -5,4 +5,6 @@
 	--_ui5_textarea_warning_border_style: dashed;
 	--_ui5_textarea_error_warning_border_width: 2 * var(--sapField_BorderWidth);
 	--_ui5_textarea_information_border_width: 0.0625rem;
+	--_ui5_textarea_placeholder_font_style: normal;
+	--_ui5_input_warning_font_weight: bold;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Input-parameters.css
@@ -7,8 +7,13 @@
 	--_ui5-input-information_border_width: var(--sapField_BorderWidth);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_information_font_style: italic;
 	--_ui5_input_error_font_weight: bold;
+	--_ui5_input_warning_font_weight: bold;
+	--_ui5_input_information_font_weight: bold;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;
 	--_ui5_input_icon_padding: 0.65rem 0.75rem;
+	--_ui5-input-placeholder-style: normal;
+	--_ui5-input-placeholder-color: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/TextArea-parameters.css
@@ -5,4 +5,6 @@
 	--_ui5_textarea_warning_border_style: dashed;
 	--_ui5_textarea_error_warning_border_width: 2 * var(--sapField_BorderWidth);
 	--_ui5_textarea_information_border_width: 0.0625rem;
+	--_ui5_textarea_placeholder_font_style: normal;
+	--_ui5_input_warning_font_weight: bold;
 }


### PR DESCRIPTION
Text and placeholder styles were not correct in SAP Quartz HC themes according to the specification.

FIXES: #3849 
