### PR TITLE
feat(ui5-li): add disabled property

### DIFF
--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -74,6 +74,13 @@ const metadata = {
 		read: {
 			type: Boolean,
 		},
+		 /**
+		 * @private
+		 * @since 1.1.0
+		 */
+		disabled: {
+			type: Boolean,
+		},
 
 		/**
 		 * Defines if a busy indicator would be displayed over the item.

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -129,6 +129,13 @@ const metadata = {
 			type: Integer,
 			defaultValue: 0,
 		},
+		 /**
+		 * @private
+		 * @since 1.1.0
+		 */
+		disabled: {
+			type: Boolean,
+		},
 
 		/**
 		 * If set to <code>Uploading</code> or <code>Error</code>, a progress indicator showing the <code>progress</code> is displayed.

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -39,11 +39,11 @@ const metadata = {
 		/**
 		 * Defines whether <code>ui5-li</code> is in disabled state.
 		 * <br><br>
-		 * <b>Note:</b> A disabled <code>ui5-li</code> is noninteractive.
+		 * <b>Note:</b> A disabled <code>ui5-li</code> is noninteractive and it is excluded from keyboard handling.
 		 * @type {boolean}
 		 * @defaultvalue false
-		 * @protected
-		 * @since 1.0.0-rc.12
+		 * @public
+		 * @since 1.1.0
 		 */
 		disabled: {
 			type: Boolean,


### PR DESCRIPTION
Currently the logic is implemented in ui5-li / ui5-list but it is marked as protected because it is used only internally in ui5-option.

Application developers want to be able to disabled some ui5-li in their list and now it is possible via this change
Close: #2560 

TODO: 
We have to check how this will appear in ui5-notifcation-list-item / ui5-upload-collection-item documentation and if the behavior should be implemented there too.