### PR TITLE
chore: add fiori i18n texts to testAssets

### DIFF
--- a/packages/fiori/bundle.esm.js
+++ b/packages/fiori/bundle.esm.js
@@ -1,4 +1,5 @@
 import testAssets from "@ui5/webcomponents/bundle.esm.js";
+import * as defaultFioriTexts from "./dist/generated/i18n/i18n-defaults.js";
 
 // FIORI assets
 import "./dist/Assets.js";
@@ -6,4 +7,5 @@ import "./dist/Assets.js";
 import "./bundle.common.js";
 import BarcodeScannerDialog from "./dist/BarcodeScannerDialog.js";
 
+testAssets.defaultTexts = {...testAssets.defaultTexts, ...defaultFioriTexts };
 export default testAssets;


### PR DESCRIPTION
The i18n texts for the fiori package were not exposed via the global testAssets objects.
Now, we can make use of them in the tests.