### PR TITLE
fix(ui5-date-picker): do not use the title attribute

### DIFF
--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -39,30 +39,26 @@
 <body class="datepicker1auto">
 	<div style='width:500px;'>
 		<ui5-date-picker id='ui5-datepicker--startDate'
-			placeholder='Delivery Date...'
-			title='Delivery Date!'>
+			placeholder='Delivery Date...'>
 		</ui5-date-picker>
 
 		<ui5-date-picker id='ui5-datepicker-value-state-message'
 		placeholder='Delivery Date...'
-		value-state="Error"
-		title='Delivery Date!'>
+		value-state="Error">
 			<div slot="valueStateMessage">Information message. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 			<div slot="valueStateMessage">Information message 2. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 		</ui5-date-picker>
 
-		<h3>placeholder + title + events</h3>
+		<h3>placeholder + events</h3>
 		<ui5-date-picker id='dp5'
-			placeholder='Delivery Date...'
-			title='Delivery Date!'>
+			placeholder='Delivery Date...'>
 		</ui5-date-picker>
 		<ui5-label id="lblChange">change: N/A</ui5-label><br/>
 		<ui5-label id="lblLiveChange">input: N/A</ui5-label><br/>
 
-		<h3>placeholder + title + prevented default events</h3>
+		<h3>placeholder + prevented default events</h3>
 		<ui5-date-picker id='dpPrevent'
-			placeholder='Delivery Date...'
-			title='Delivery Date!'>
+			placeholder='Delivery Date...'>
 		</ui5-date-picker>
 		<ui5-label id="lblChangePrevent">change: N/A</ui5-label><br/>
 		<ui5-label id="lblLiveChangePrevent">input: N/A</ui5-label><br/>

--- a/packages/main/test/samples/DatePicker.sample.html
+++ b/packages/main/test/samples/DatePicker.sample.html
@@ -22,13 +22,13 @@
 	<h3>DatePicker with Placeholder, Tooltip, Events, ValueState and valueStateMessage</h3>
 	<div class="snippet">
 		<div class="datepicker-width">
-			<ui5-date-picker id='myDatepicker2' placeholder='Delivery Date...' title='Delivery Date!'>
+			<ui5-date-picker id='myDatepicker2' placeholder='Delivery Date...'>
 				<div slot="valueStateMessage">The value is not valid. Please provide valid value</div>
 			</ui5-date-picker>
 		</div>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-date-picker id='myDatepicker2' placeholder='Delivery Date...' title='Delivery Date!'>
+<ui5-date-picker id='myDatepicker2' placeholder='Delivery Date...'>
 	<div slot="valueStateMessage">The value is not valid. Please provide valid value</div>
 </ui5-date-picker>
 <script>


### PR DESCRIPTION
Removes the title attributes from all date picker samples
to comply with the fiori accessibility guidelines.

FIXES: #3534
