### PR TITLE
make speech output more comprehensive

### DIFF
--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -24,12 +24,12 @@
 
 	{{#unless noCloseButton}}
 		<ui5-button
-				icon="decline"
-				icon-size=".75rem"
-				design="Transparent"
-				class="ui5-messagestrip-close-button"
-				title="{{_closeButtonText}}"
-				@click={{_closeClick}}
+			icon="decline"
+			icon-size=".75rem"
+			design="Transparent"
+			class="ui5-messagestrip-close-button"
+			._buttonAccInfo="{{accInfo.button}}"
+			@click={{_closeClick}}
 		></ui5-button>
 	{{/unless}}
 </div>

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -10,7 +10,14 @@ import MessageStripType from "./types/MessageStripType.js";
 import MessageStripTemplate from "./generated/templates/MessageStripTemplate.lit.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
-import { MESSAGE_STRIP_CLOSE_BUTTON } from "./generated/i18n/i18n-defaults.js";
+import {
+	MESSAGE_STRIP_CLOSE_BUTTON,
+	MESSAGE_STRIP_CLOSABLE,
+	MESSAGE_STRIP_ERROR,
+	MESSAGE_STRIP_WARNING,
+	MESSAGE_STRIP_SUCCESS,
+	MESSAGE_STRIP_INFORMATION,
+} from "./generated/i18n/i18n-defaults.js";
 
 // Styles
 import messageStripCss from "./generated/themes/MessageStrip.css.js";
@@ -189,12 +196,25 @@ class MessageStrip extends UI5Element {
 		};
 	}
 
+	get designAnnouncementMappings() {
+		return {
+			"Information": this.i18nBundle.getText(MESSAGE_STRIP_INFORMATION),
+			"Positive": this.i18nBundle.getText(MESSAGE_STRIP_SUCCESS),
+			"Negative": this.i18nBundle.getText(MESSAGE_STRIP_ERROR),
+			"Warning": this.i18nBundle.getText(MESSAGE_STRIP_WARNING),
+		};
+	}
+
 	get hiddenText() {
-		return `Message Strip ${this.type} ${this.noCloseButton ? "" : "closable"}`;
+		return `${this.designAnnouncementMappings[this.type]} ${this.noCloseButton ? "" : this._closableText}`;
 	}
 
 	get _closeButtonText() {
 		return this.i18nBundle.getText(MESSAGE_STRIP_CLOSE_BUTTON);
+	}
+
+	get _closableText() {
+		return this.i18nBundle.getText(MESSAGE_STRIP_CLOSABLE);
 	}
 
 	get classes() {
@@ -218,6 +238,14 @@ class MessageStrip extends UI5Element {
 
 	get typeClasses() {
 		return MessageStrip.typeClassesMappings()[this.type];
+	}
+
+	get accInfo() {
+		return {
+			"button": {
+				"title": this._closeButtonText,
+			},
+		};
 	}
 }
 

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -113,7 +113,22 @@ ARIA_LABEL_LIST_MULTISELECTABLE=Contains Multi-Selectable Items
 ARIA_LABEL_LIST_DELETABLE=Contains Deletable Items
 
 #XTOL: Tooltip of messgae strip close button
-MESSAGE_STRIP_CLOSE_BUTTON=Message Strip Close
+MESSAGE_STRIP_CLOSE_BUTTON=Information Bar Close
+
+#XACT: ARIA announcement for the MessageStrip's closable state
+MESSAGE_STRIP_CLOSABLE=Closable
+
+#XACT: ARIA announcement for the MessageStrip's "Error" state
+MESSAGE_STRIP_ERROR=Error Information Bar
+
+#XACT: ARIA announcement for the MessageStrip's "Warning" state
+MESSAGE_STRIP_WARNING=Warning Information Bar
+
+#XACT: ARIA announcement for the MessageStrip's "Success" state
+MESSAGE_STRIP_SUCCESS=Success Information Bar
+
+#XACT: ARIA announcement for the MessageStrip's "Information" state
+MESSAGE_STRIP_INFORMATION=Information Bar
 
 #XFLD: MultiComboBox dialog button
 MULTICOMBOBOX_DIALOG_OK_BUTTON=OK

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -21,7 +21,7 @@ describe("ARIA Support", () => {
 
 	it("Test close button title text", () => {
 
-		const closeButton = browser.$("#messageStrip").shadow$(".ui5-message-strip-close-button").shadow$("button");
+		const closeButton = browser.$("#messageStrip").shadow$(".ui5-messagestrip-close-button").shadow$("button");
 		let resourceBundleText = null;
 
 		resourceBundleText = browser.execute(() => {

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -15,3 +15,36 @@ describe("MessageStrip general interaction", () => {
 		assert.strictEqual(input.getProperty("value"), "3", "Close should be called 3 times");
 	});
 });
+
+describe("ARIA Support", () => {
+	browser.url("http://localhost:8080/test-resources/pages/MessageStrip.html");
+
+	it("Test close button title text", () => {
+
+		const closeButton = browser.$("#messageStrip").shadow$(".ui5-message-strip-close-button").shadow$("button");
+		let resourceBundleText = null;
+
+		resourceBundleText = browser.execute(() => {
+			const messageStrip = document.getElementById("messageStrip");
+			return messageStrip.i18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CLOSE_BUTTON);
+		});
+
+		assert.strictEqual(closeButton.getAttribute("title"), resourceBundleText, "Close button title is correct");
+	});
+
+	it("Test hidden text element content", () => {
+
+		const messageStrip = browser.$("#messageStrip");
+		let invisibleText = messageStrip.shadow$(".ui5-hidden-text");
+		let resourceBundleText = null;
+
+		resourceBundleText = browser.execute(() => {
+			const messageStrip = document.getElementById("messageStrip");
+			const msgStripi18nBundle = messageStrip.i18nBundle;
+			return `${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_INFORMATION)} ${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CLOSABLE)}`;
+		});
+
+		assert.strictEqual(invisibleText.getText(), resourceBundleText, "Hidden element content is correct");
+	});
+});
+


### PR DESCRIPTION
Couple enhancements are included in that change:
-> Close button information is read out only once when button is accessed.
-> Information regarding the ui5-message-strip is more comprehensive now.

FIXES: #3447
