### PR TITLE
fix(ui5-dialog): remove unnecessary paddings for the content

### DIFF
--- a/packages/main/src/themes/MultiComboBox.css
+++ b/packages/main/src/themes/MultiComboBox.css
@@ -4,7 +4,6 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
-	--_ui5_popup_content_padding: 0;
 }
 
 .ui5-multi-combobox-root {

--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -56,9 +56,6 @@
 
 .ui5-popup-content {
     overflow: auto;
-
-    /* Consider how to make this top level */
-    padding: var(--_ui5_popup_content_padding);
     box-sizing: border-box;
 }
 

--- a/packages/main/src/themes/ResponsivePopover.css
+++ b/packages/main/src/themes/ResponsivePopover.css
@@ -4,10 +4,6 @@
 	min-height: 2rem;
 }
 
-:host(:not([with-padding])) {
-	--_ui5_popup_content_padding: 0;
-}
-
 :host([opened]) {
 	display: inline-block;
 }

--- a/packages/main/src/themes/base/PopupsCommon-parameters.css
+++ b/packages/main/src/themes/base/PopupsCommon-parameters.css
@@ -1,5 +1,4 @@
 :root {
-	--_ui5_popup_content_padding: .4375em;
 	--_ui5_popup_viewport_margin: 10px;
 	--_ui5-popup-border-radius: 0.25rem;
 	--_ui5_popup_header_shadow: var(--sapContent_Shadow0);

--- a/packages/main/src/themes/sap_horizon/PopupsCommon-parameters.css
+++ b/packages/main/src/themes/sap_horizon/PopupsCommon-parameters.css
@@ -1,7 +1,6 @@
 @import "../base/PopupsCommon-parameters.css";
 
 :root {
-	--_ui5_popup_content_padding: .4375em;
 	--_ui5_popup_viewport_margin: 10px;
 	--_ui5-popup-border-radius: 0.75rem;
 	--_ui5_popup_header_shadow: none;


### PR DESCRIPTION
The Dialog should not have default paddings.
This change also affects: Popover, ResponsivePopover, MultiComboBox

Fixes #4402

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
