### PR TITLE
fix(ui5-input): fix event handling in firefox

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -772,7 +772,7 @@ class Input extends UI5Element {
 	}
 
 	_handleInput(event) {
-		const inputDomRef = this.getInputDOMRef();
+		const inputDomRef = this.getInputDOMRefSync();
 		const emptyValueFiredOnNumberInput = this.value && this.isTypeNumber && !inputDomRef.value;
 
 		this.suggestionSelectionCanceled = false;
@@ -1012,7 +1012,16 @@ class Input extends UI5Element {
 		return "";
 	}
 
-	getInputDOMRef() {
+	async getInputDOMRef() {
+		if (isPhone() && this.Suggestions) {
+			await this.Suggestions._getSuggestionPopover();
+			return this.Suggestions && this.Suggestions.responsivePopover.querySelector(".ui5-input-inner-phone");
+		}
+
+		return this.nativeInput;
+	}
+
+	getInputDOMRefSync() {
 		if (isPhone() && this.Suggestions) {
 			return this.Suggestions && this.Suggestions.responsivePopover.querySelector(".ui5-input-inner-phone");
 		}

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -771,8 +771,8 @@ class Input extends UI5Element {
 		});
 	}
 
-	async _handleInput(event) {
-		const inputDomRef = await this.getInputDOMRef();
+	_handleInput(event) {
+		const inputDomRef = this.getInputDOMRef();
 		const emptyValueFiredOnNumberInput = this.value && this.isTypeNumber && !inputDomRef.value;
 
 		this.suggestionSelectionCanceled = false;
@@ -1012,9 +1012,8 @@ class Input extends UI5Element {
 		return "";
 	}
 
-	async getInputDOMRef() {
+	getInputDOMRef() {
 		if (isPhone() && this.Suggestions) {
-			await this.Suggestions._getSuggestionPopover();
 			return this.Suggestions && this.Suggestions.responsivePopover.querySelector(".ui5-input-inner-phone");
 		}
 


### PR DESCRIPTION
Fixes #3982

The issue comes from the fact that the handler of the event is calling ```event.stopImmediatePropagation();``` and in the meantime, the handler is async. This leads to waiting for the async code to run, while the native event propagates out of the shadow root. And only after that, the code tries to stop the propagation of the native event.

```getInputDOMRef``` method can safely be made sync, because in InputSuggestions constructor, we are calling ```_getSuggestionPopover``` which gets the reference to the responsive popover & later we don't need to look for it in the DOM.
