### PR TITLE
fix(ui5-input): fix value  truncation

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -253,6 +253,7 @@
 :host([value-state="Error"]) [inner-input],
 :host([value-state="Warning"]) [inner-input] {
 	font-style: var(--_ui5_input_error_warning_font_style);
+	text-indent: var(--_ui5_input_error_warning_text_indent);
 }
 
 :host([value-state="Error"]) [inner-input] {
@@ -266,6 +267,7 @@
 :host([value-state="Information"]) [inner-input] {
 	font-style: var(--_ui5_input_information_font_style);
 	font-weight: var(--_ui5_input_information_font_weight);
+	text-indent: var(--_ui5_input_information_text_indent);
 }
 
 :host([value-state="Error"]:not([readonly])) {

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -23,6 +23,8 @@
 	--_ui5_input_focus_border_width: 1px;
 	--_ui5_input_error_warning_border_style: solid;
 	--_ui5_input_error_warning_font_style: inherit;
+	--_ui5_input_error_warning_text_indent: 0;
+	--_ui5_input_information_text_indent: 0;
 	--_ui5_input_information_font_style: inherit;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;

--- a/packages/main/src/themes/sap_belize_hcb/Input-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Input-parameters.css
@@ -6,6 +6,7 @@
 	--_ui5-input-border: 1px solid var(--sapField_BorderColor);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_error_warning_text_indent: 0.125rem;
 	--_ui5_input_error_font_weight: bold;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;

--- a/packages/main/src/themes/sap_belize_hcw/Input-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/Input-parameters.css
@@ -6,6 +6,7 @@
 	--_ui5-input-border: 1px solid var(--sapField_BorderColor);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_error_warning_text_indent: 0.125rem;
 	--_ui5_input_error_font_weight: bold;
 	--_ui5_input_disabled_color: var(--sapContent_DisabledTextColor);
 	--_ui5_input_disabled_font_weight: normal;

--- a/packages/main/src/themes/sap_fiori_3_hcb/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Input-parameters.css
@@ -7,7 +7,9 @@
 	--_ui5-input-information_border_width: var(--sapField_BorderWidth);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_error_warning_text_indent: 0.125rem;
 	--_ui5_input_information_font_style: italic;
+	--_ui5_input_information_text_indent: 0.125rem;
 	--_ui5_input_error_font_weight: bold;
 	--_ui5_input_warning_font_weight: bold;
 	--_ui5_input_information_font_weight: bold;

--- a/packages/main/src/themes/sap_fiori_3_hcw/Input-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Input-parameters.css
@@ -7,7 +7,9 @@
 	--_ui5-input-information_border_width: var(--sapField_BorderWidth);
 	--_ui5_input_error_warning_border_style: dashed;
 	--_ui5_input_error_warning_font_style: italic;
+	--_ui5_input_error_warning_text_indent: 0.125rem;
 	--_ui5_input_information_font_style: italic;
+	--_ui5_input_information_text_indent: 0.125rem;
 	--_ui5_input_error_font_weight: bold;
 	--_ui5_input_warning_font_weight: bold;
 	--_ui5_input_information_font_weight: bold;


### PR DESCRIPTION
- When text style is italic, the text is usually cut off from the end. The issue is always reproducible in RTL mode, since the text's slope is to the right, but it can be reproduced in LTR mode as well depending on the font used.

FIXES: #3810 
