### PR TITLE
fix(Playground): apply RTL properly

### DIFF
--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -115,9 +115,11 @@ function setRTL() {
   if (rtlIsEnabled) {
     setTimeout(() => {
       body.setAttribute("dir", "rtl");
+      window["sap-ui-webcomponents-bundle"].applyDirection();
     }, 0);
   } else {
     body.removeAttribute("dir");
+    window["sap-ui-webcomponents-bundle"].applyDirection();
   }
 }
 


### PR DESCRIPTION
Currently we only set dir="rtl" to the body of the Playground samples, but some of the components need to re-render to apply specific RTL styles and that can be triggered by the `applyDirection` method as suggested in this PR.

There are multiple examples, let's see one

1. Go to https://sap.github.io/ui5-webcomponents/master/playground/components/Table/
2. Observe the first Table sample
3. Set RTL via the Settings menu

4. Some of the texts in the columns' header remain unaligned

5. Run `window["sap-ui-webcomponents-bundle"].applyDirection();` in the console
and observe how the texts are properly aligned.