### PR TITLE
fix(ui5-li-custom): removed height restriction

### DIFF
--- a/packages/main/src/themes/CustomListItem.css
+++ b/packages/main/src/themes/CustomListItem.css
@@ -4,7 +4,7 @@
 }
 
 :host {
-	height: var(--_ui5_custom_list_item_height);
+	height: auto;
 	box-sizing: border-box;
 }
 

--- a/packages/main/src/themes/CustomListItem.css
+++ b/packages/main/src/themes/CustomListItem.css
@@ -4,6 +4,7 @@
 }
 
 :host {
+	min-height: var(--_ui5_list_item_base_height);
 	height: auto;
 	box-sizing: border-box;
 }

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -10,7 +10,6 @@
 	--_ui5_checkbox_root_side_padding: .6875rem;
 	--_ui5_checkbox_icon_size: 1rem;
 	--_ui5_checkbox_partially_icon_size: .75rem;
-	--_ui5_custom_list_item_height: 3rem;
 	--_ui5_custom_list_item_rb_min_width: 2.75rem;
 	--_ui5_day_picker_item_width: 2.25rem;
 	--_ui5_day_picker_item_height: 2.875rem;
@@ -161,7 +160,6 @@
 	--_ui5_color-palette-button-height: 2rem;
 
 	/* Custom List Item */
-	--_ui5_custom_list_item_height: 2rem;
 	--_ui5_custom_list_item_rb_min_width: 2rem;
 
 	/* DayPicker */


### PR DESCRIPTION
CustomListItem is no longer restricted to a hardcoded height. Now it
aligns its height depending on its content.

fixes: #4450

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
