### PR TITLE
fix(plaground): adjust main wrapper paddings

### DIFF
--- a/packages/playground/_sass/layout.scss
+++ b/packages/playground/_sass/layout.scss
@@ -64,6 +64,8 @@
     -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     overflow-y: scroll;
+    padding-top: 3rem;
+    box-sizing: border-box;
   }
 }
 
@@ -96,7 +98,7 @@
   justify-content: space-between;
   align-items: center;
   background-color: #000;
-  z-index: 10;
+  z-index: 150;
 
   .main-content, .main-content-header {
     padding-top: 0;


### PR DESCRIPTION
- display breadcrumbs in the playground
- sets playground padding higher z-index to get over components stylings

FIXES: https://github.com/SAP/ui5-webcomponents/issues/3817