### PR TITLE
refactor: use backwards-compatible child communication method

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -251,7 +251,8 @@ class UI5Element extends HTMLElement {
 
 			// Listen for any invalidation on the child if invalidateOnChildChange is true or an object (ignore when false or not set)
 			if (child.isUI5Element && slotData.invalidateOnChildChange) {
-				(child.attachInvalidate || child._attachChange)(this._getChildChangeListener(slotName));
+				const method = (child.attachInvalidate || child._attachChange).bind(child);
+				method(this._getChildChangeListener(slotName));
 			}
 
 			// Listen for the slotchange event if the child is a slot itself
@@ -311,7 +312,8 @@ class UI5Element extends HTMLElement {
 
 		children.forEach(child => {
 			if (child && child.isUI5Element) {
-				(child.detachInvalidate || child._detachChange)(this._getChildChangeListener(slotName));
+				const method = (child.detachInvalidate || child._detachChange).bind(child);
+				method(this._getChildChangeListener(slotName));
 			}
 
 			if (isSlot(child)) {

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -251,7 +251,7 @@ class UI5Element extends HTMLElement {
 
 			// Listen for any invalidation on the child if invalidateOnChildChange is true or an object (ignore when false or not set)
 			if (child.isUI5Element && slotData.invalidateOnChildChange) {
-				child.attachInvalidate(this._getChildChangeListener(slotName));
+				(child.attachInvalidate || child._attachChange)(this._getChildChangeListener(slotName));
 			}
 
 			// Listen for the slotchange event if the child is a slot itself
@@ -311,7 +311,7 @@ class UI5Element extends HTMLElement {
 
 		children.forEach(child => {
 			if (child && child.isUI5Element) {
-				child.detachInvalidate(this._getChildChangeListener(slotName));
+				(child.detachInvalidate || child._detachChange)(this._getChildChangeListener(slotName));
 			}
 
 			if (isSlot(child)) {


### PR DESCRIPTION
**Background:**
Change https://github.com/SAP/ui5-webcomponents/pull/3604 refactors a few entities in `UI5Element.js`:
 - `_attachChange` protected method -> `attachInvalidate` public method
 - `_detachChange` protected method -> `detachInvalidate` public method
 - `change` -> `invalidate` (internally used event name - not relevant to the solution, mentioned for completeness only)

This leads to issues when there are 2 versions of UI5 Web Components on the same page - one with the above-mentioned refactoring, and one without, because the code assumes that `attachChange` / `detachChange` will be unconditionally present on all UI5 Elements.

**Solution**
Call whichever method exists on the children - either the new version, or the old one. They have the same signature (accept a callback) and execute this callback under the exact same conditions, as the refactoring was pure renaming.

Example: the parent container (latest version) calls `_attachChange` on a child of an older version. The child internally calls `this._eventProvider.attachEvent("change", callback);` on its own `EventProvider` instance, and later when the child gets invalidated, its `this._eventProvider.fireEvent("change", { ...changeInfo, target: this });` code executes, which will trigger the callback, attached by the parent. The fact that the child calls the event `change` and not `invalidate` does not matter since this name must be unique only in the scope of the element itself - only the callback needs to be fired.