### PR TITLE
feat(framework): introduce runtimes and version info

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-88dfgAaZhJbBnk8fY3GOimuDUBc=
+iQmSZq5T2BMuDzVl562yf1w3IZc=

--- a/packages/base/lib/generate-version-info/index.js
+++ b/packages/base/lib/generate-version-info/index.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+
+const version = JSON.parse(fs.readFileSync("package.json")).version;
+
+// Parse version
+const matches = version.match(/^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$/);
+if (!matches) {
+	throw new Error("Unsupported version format");
+}
+
+const isNext = version.match(/[a-f0-9]{9}$/);
+const buildTime = Math.floor(new Date().getTime() / 1000);
+
+const fileContent = `const VersionInfo = {
+	version: "${version}",
+	major: ${matches[1]},
+	minor: ${matches[2]},
+	patch: ${matches[3]},
+	suffix: "${matches[4]}",
+	isNext: ${isNext ? "true" : "false"},
+	buildTime: ${buildTime},
+};
+export default VersionInfo;`;
+
+mkdirp.sync("dist/generated/");
+fs.writeFileSync("dist/generated/VersionInfo.js", fileContent);

--- a/packages/base/package-scripts.js
+++ b/packages/base/package-scripts.js
@@ -2,6 +2,7 @@ const resolve = require("resolve");
 
 const assetParametersScript = resolve.sync("@ui5/webcomponents-base/lib/generate-asset-parameters/index.js");
 const stylesScript = resolve.sync("@ui5/webcomponents-base/lib/generate-styles/index.js");
+const versionScript = resolve.sync("@ui5/webcomponents-base/lib/generate-version-info/index.js");
 const serve = resolve.sync("@ui5/webcomponents-tools/lib/serve/index.js");
 const generateHash = resolve.sync("@ui5/webcomponents-tools/lib/hash/generate.js");
 const hashIsUpToDate = resolve.sync("@ui5/webcomponents-tools/lib/hash/upToDate.js");
@@ -13,7 +14,7 @@ const UP_TO_DATE = `node "${hashIsUpToDate}" dist/ hash.txt && echo "Up to date.
 const scripts = {
 	clean: "rimraf dist && rimraf .port",
 	lint: "eslint . --config config/.eslintrc.js",
-	prepare: "nps clean integrate copy generateAssetParameters generateStyles",
+	prepare: "nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles",
 	integrate: {
 		default: "nps integrate.copy-used-modules integrate.copy-overlay integrate.replace-amd integrate.replace-export-true integrate.replace-export-false integrate.amd-to-es6 integrate.replace-global-core-usage integrate.esm-abs-to-rel integrate.third-party",
 		"copy-used-modules": `node "${copyUsedModules}" ./used-modules.txt dist/`,
@@ -40,6 +41,7 @@ const scripts = {
 		test: `copy-and-watch "test/**/*.*" dist/test-resources`,
 	},
 	generateAssetParameters: `node "${assetParametersScript}"`,
+	generateVersionInfo: `node "${versionScript}"`,
 	generateStyles: `node "${stylesScript}"`,
 	watch: {
 		default: 'concurrently "nps watch.test" "nps watch.src" "nps watch.bundle" "nps watch.styles"',

--- a/packages/base/src/Boot.js
+++ b/packages/base/src/Boot.js
@@ -4,6 +4,7 @@ import insertFontFace from "./FontFace.js";
 import insertSystemCSSVars from "./SystemCSSVars.js";
 import { getTheme } from "./config/Theme.js";
 import applyTheme from "./theming/applyTheme.js";
+import { registerCurrentRuntime } from "./Runtimes.js";
 import { getFeature } from "./FeaturesRegistry.js";
 
 let booted = false;
@@ -22,6 +23,8 @@ const boot = async () => {
 	if (booted) {
 		return;
 	}
+
+	registerCurrentRuntime();
 
 	const OpenUI5Support = getFeature("OpenUI5Support");
 	if (OpenUI5Support) {

--- a/packages/base/src/CustomElementsRegistry.js
+++ b/packages/base/src/CustomElementsRegistry.js
@@ -1,11 +1,24 @@
 import setToArray from "./util/setToArray.js";
+import getSharedResource from "./getSharedResource.js";
+import {
+	getCurrentRuntimeIndex,
+	getRuntime,
+	compareCurrentRuntimeWith,
+	runtimeWarningsEnabled,
+	logDisableRuntimeWarningsInstructions,
+	getAllRuntimes,
+} from "./Runtimes.js";
+import Logger from "./util/Logger.js";
+
+const Tags = getSharedResource("Tags", new Map());
 
 const Definitions = new Set();
-const Failures = new Set();
+let Failures = {};
 let failureTimeout;
 
 const registerTag = tag => {
 	Definitions.add(tag);
+	Tags.set(tag, getCurrentRuntimeIndex());
 };
 
 const isTagRegistered = tag => {
@@ -17,18 +30,53 @@ const getAllRegisteredTags = () => {
 };
 
 const recordTagRegistrationFailure = tag => {
-	Failures.add(tag);
+	const tagRegRuntimeIndex = Tags.get(tag);
+	Failures[tagRegRuntimeIndex] = Failures[tagRegRuntimeIndex] || new Set();
+	Failures[tagRegRuntimeIndex].add(tag);
+
 	if (!failureTimeout) {
 		failureTimeout = setTimeout(() => {
 			displayFailedRegistrations();
+			Failures = {};
 			failureTimeout = undefined;
 		}, 1000);
 	}
 };
 
 const displayFailedRegistrations = () => {
-	console.warn(`The following tags have already been defined by a different UI5 Web Components version: ${setToArray(Failures).join(", ")}`); // eslint-disable-line
-	Failures.clear();
+	if (!runtimeWarningsEnabled()) {
+		return;
+	}
+
+	const allRuntimes = getAllRuntimes();
+	const logger = new Logger(`There are currently ${allRuntimes.length} UI5 Web Components instances on this HMTL page (loading order: ${allRuntimes.map(ver => ver.descriptor).join(", ")}).`);
+
+	Object.keys(Failures).forEach(otherRuntimeIndex => {
+		const currentRuntime = getRuntime();
+		const otherRuntime = getRuntime(otherRuntimeIndex);
+		const comparison = compareCurrentRuntimeWith(otherRuntimeIndex);
+
+		let compareWord;
+		if (comparison > 0) {
+			compareWord = "an older";
+		} else if (comparison < 0) {
+			compareWord = "a newer";
+		} else {
+			compareWord = "the same";
+		}
+		logger.para(`Runtime ${currentRuntime.descriptor} failed to define ${Failures[otherRuntimeIndex].size} tag(s) as they were defined by a runtime of ${compareWord} version (${otherRuntime.descriptor}): ${setToArray(Failures[otherRuntimeIndex]).sort().join(", ")}.`);
+		if (comparison > 0) {
+			logger.line(`WARNING! If your code uses features of the above web components, unavailable in version ${otherRuntime.version}, it might not work as expected!`);
+		} else {
+			logger.line(`Since the above web components were defined by ${comparison < 0 ? "a newer" : "the same"} version runtime, they should be compatible with your code.`);
+		}
+	});
+
+	logger.para(`To prevent other runtimes from defining tags that you use, consider using scoping or have third-party libraries use scoping: https://github.com/SAP/ui5-webcomponents/blob/master/docs/Scoping.md.`);
+
+	logDisableRuntimeWarningsInstructions(logger);
+
+	logger.console("warn");
 };
 
 export {

--- a/packages/base/src/Runtimes.js
+++ b/packages/base/src/Runtimes.js
@@ -1,0 +1,120 @@
+import VersionInfo from "./generated/VersionInfo.js";
+import RuntimeRegistry from "./runtime/RuntimeRegistry.js";
+import getSharedResource from "./getSharedResource.js";
+import Logger from "./util/Logger.js";
+
+let currentRuntimeIndex;
+let showWarnings = true;
+
+/**
+ * Central registry where all runtimes register themselves by pushing a Runtime instance object.
+ * The index in the registry servers as an ID for the runtime.
+ * @type {*}
+ */
+const registry = getSharedResource("Runtimes", new RuntimeRegistry());
+
+/**
+ * Returns the runtime object for a given runtime (current runtime by default)
+ *
+ * @param runtimeIndex the index of the runtime (current runtime if undefined)
+ * @returns {*}
+ */
+const getRuntime = runtimeIndex => {
+	if (runtimeIndex === undefined) {
+		runtimeIndex = getCurrentRuntimeIndex();
+	}
+	return registry.getRuntime(runtimeIndex);
+};
+
+/**
+ * Registers the current runtime in the shared runtimes resource registry
+ */
+const registerCurrentRuntime = () => {
+	if (currentRuntimeIndex === undefined) {
+		currentRuntimeIndex = registry.registerRuntime(VersionInfo);
+	}
+};
+
+/**
+ * Returns the index of the current runtime's object in the shared runtimes resource registry
+ * @returns {*}
+ */
+const getCurrentRuntimeIndex = () => {
+	if (currentRuntimeIndex === undefined) {
+		registerCurrentRuntime();
+	}
+
+	return currentRuntimeIndex;
+};
+
+/**
+ * Compares the current runtime's version with the version of another runtime on the same page (in the shared runtimes resource registry)
+ * @param otherRuntimeIndex The index in the registry of the runtime to be compared with
+ * @returns {number} Positive number if the current runtime's version is newer, 0 if equal, negative number if the current runtime's version is older
+ */
+const compareCurrentRuntimeWith = otherRuntimeIndex => {
+	// Always consider the current runtime newer than a runtime with "undefined" index
+	if (otherRuntimeIndex === undefined) {
+		return 1;
+	}
+
+	const currentRuntime = getRuntime();
+	const otherRuntime = getRuntime(otherRuntimeIndex);
+	return currentRuntime.compareTo(otherRuntime);
+};
+
+/**
+ * Call this method to stop runtime-related console warnings such as "Tags already defined by another runtime"
+ */
+const disableRuntimeWarnings = () => {
+	showWarnings = false;
+};
+
+/**
+ * Determines whether runtime-related warnings are enabled
+ * @returns {boolean}
+ */
+const runtimeWarningsEnabled = () => {
+	return showWarnings;
+};
+
+/**
+ * Receives as a parameter a util/Logger.js class instance and logs instructions how to disable runtime-related warnings
+ * @param logger
+ */
+const logDisableRuntimeWarningsInstructions = logger => {
+	if (!(logger instanceof Logger)) {
+		throw new Error("logger must be a Logger class instance");
+	}
+
+	logger.para(`To suppress runtime related warnings such as this one, add the following code to your bundle:`);
+	logger.line(`import { disableRuntimeWarnings } from "@ui5/webcomponents-base/dist/Runtimes.js";`);
+	logger.line(`disableRuntimeWarnings();`);
+};
+
+/**
+ * Returns an array with all runtimes
+ * @returns {*}
+ */
+const getAllRuntimes = () => registry.getAllRuntimes();
+
+/**
+ * Set an alias for the the current app/library/microfrontend which will appear in debug messages and console warnings
+ * @param alias
+ */
+const setRuntimeAlias = alias => {
+	const currentRuntime = getRuntime();
+	currentRuntime.customAlias = alias;
+};
+
+export {
+	getRuntime,
+	getCurrentRuntimeIndex,
+	registerCurrentRuntime,
+	compareCurrentRuntimeWith,
+	disableRuntimeWarnings,
+	runtimeWarningsEnabled,
+	getAllRuntimes,
+	logDisableRuntimeWarningsInstructions,
+	setRuntimeAlias,
+};

--- a/packages/base/src/runtime/Runtime.js
+++ b/packages/base/src/runtime/Runtime.js
@@ -1,0 +1,57 @@
+class Runtime {
+	constructor(versionInfo, index) {
+		["version", "major", "minor", "patch", "suffix", "isNext", "buildTime"].forEach(prop => {
+			this[prop] = versionInfo[prop];
+		});
+		this.index = index;
+		this.customAlias = undefined;
+		this.compareResultCache = new WeakMap();
+	}
+
+	get alias() {
+		return this.customAlias ? this.customAlias : `Unspecified runtime ${this.index}`;
+	}
+
+	get descriptor() {
+		return `${this.version} - ${this.alias}`;
+	}
+
+	compareTo(otherVer) {
+		if (this.compareResultCache.has(otherVer)) {
+			return this.compareResultCache.get(otherVer);
+		}
+
+		// If any of the two is a next version, bigger buildTime wins
+		if (this.isNext || otherVer.isNext) {
+			return this.buildTime - otherVer.buildTime;
+		}
+
+		// If major versions differ, bigger one wins
+		const majorDiff = this.major - otherVer.major;
+		if (majorDiff) {
+			return majorDiff;
+		}
+
+		// If minor versions differ, bigger one wins
+		const minorDiff = this.minor - otherVer.minor;
+		if (minorDiff) {
+			return minorDiff;
+		}
+
+		// If patch versions differ, bigger one wins
+		const patchDiff = this.patch - otherVer.patch;
+		if (patchDiff) {
+			return patchDiff;
+		}
+
+		// Bigger suffix wins, f.e. rc10 > rc9
+		// Important: suffix is alphanumeric, must use natural compare
+		const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+		const result = collator.compare(this.suffix, otherVer.suffix);
+
+		this.compareResultCache.set(otherVer, result);
+		return result;
+	}
+}
+
+export default Runtime;

--- a/packages/base/src/runtime/RuntimeRegistry.js
+++ b/packages/base/src/runtime/RuntimeRegistry.js
@@ -1,0 +1,23 @@
+import Runtime from "./Runtime.js";
+
+class RuntimeRegistry {
+	constructor() {
+		this.registry = [];
+	}
+
+	registerRuntime(VersionInfo) {
+		const nextIndex = this.registry.length;
+		this.registry.push(new Runtime(VersionInfo, nextIndex));
+		return nextIndex;
+	}
+
+	getRuntime(index) {
+		return this.registry[index];
+	}
+
+	getAllRuntimes() {
+		return this.registry;
+	}
+}
+
+export default RuntimeRegistry;

--- a/packages/base/src/util/Logger.js
+++ b/packages/base/src/util/Logger.js
@@ -1,0 +1,36 @@
+class Logger {
+	constructor(initialMsg = "") {
+		this.clear();
+		this.append(initialMsg);
+	}
+
+	clear() {
+		this.output = "";
+	}
+
+	append(msg) {
+		this.output = `${this.output}${msg}`;
+		return this;
+	}
+
+	line(msg) {
+		this.append(`\n${msg}`);
+		return this;
+	}
+
+	para(msg) {
+		this.append(`\n\n${msg}`);
+		return this;
+	}
+
+	getOutput() {
+		return this.output;
+	}
+
+	console(method = "log") {
+		console[method](this.output); // eslint-disable-line
+		this.clear();
+	}
+}
+
+export default Logger;

--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -1,6 +1,9 @@
 import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "@ui5/webcomponents-base/dist/Theming.js";
 // import "./customI18n.js";
 
+import { setRuntimeAlias } from "@ui5/webcomponents-base/dist/Runtimes.js";
+setRuntimeAlias("UI5 Web Components Playground");
+
 import "./csp.js"; // import from a separate module to ensure that the code has executed before other modules are executed
 
 // Calendars


### PR DESCRIPTION
# 1. Build time version info

During the build of the `base` package, the `dist/generated/VersionInfo.js` file is generated and contains enough information to be able to definitively compare the versions of two UI5 Web Components runtimes.

## Comparing versions

Algorithm:
 - If at least one of the two compared runtimes is a `@next` version, comparison is by build time (basically time published to NPM)
 - Otherwise versions are compared semantically by major/minor/patch/suffix. 

## Runtimes registration

Every runtime is now registered in the Shared resources repository by order of appearance.
Enter: 
```js
document.head.querySelector("ui5-shared-resources").Runtimes
```
in the browser console in order to see how many and which runtimes are present on the page.

## Runtime aliases

Each runtime can register an "alias" for easier debugging and console messages:
```js
import { setRuntimeAlias } from "@ui5/webcomponents-base/dist/Runtimes.js";
setRuntimeAlias("UI5 Web Components Playground");
```
This is especially recommended for libraries/micro-frontends.

## Runtime-related warnings

When several runtimes coexist, there will sometimes be warnings in the console. These may be turned off:
```js
import { disableRuntimeWarnings } from "@ui5/webcomponents-base/dist/Runtimes.js";
disableRuntimeWarnings();
```
and this is an explicit action by the app/library, acknowledging they accept and understand the mixing of runtimes on the same page.

![image](https://user-images.githubusercontent.com/15844574/97319337-73532080-1875-11eb-8bc0-c606ce32f47c.png)

# 2. Custom elements registration

For every custom element we now store information which runtime defined it. Whenever a newer/older/same version runtime tries to define the same tag, relevant information is output to the console as a warning (which runtime created the tag originally, whether this is a problem or not, etc...)

Enter: 
```js
document.head.querySelector("ui5-shared-resources").Tags
```
in the browser console in order to see which tags were defined on this HTML page and by which runtime (the number is the index of the runtime in the runtime registry above).

# 4. Misc changes:
 - `Logger` class added for building complex console messages consisting of paragraphs and new lines