### PR TITLE
feat(focus-visible-polyfill): add focus-visible polyfill

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-88dfgAaZhJbBnk8fY3GOimuDUBc=
+aKxGk3Y/6U1RbreNR+5xid2EcC0=

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -32,6 +32,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
+    "focus-visible": "^5.2.0",
     "lit-html": "2.0.1"
   },
   "devDependencies": {

--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -19,6 +19,7 @@ import arraysAreEqual from "./util/arraysAreEqual.js";
 import getClassCopy from "./util/getClassCopy.js";
 import { markAsRtlAware } from "./locale/RTLAwareRegistry.js";
 import preloadLinks from "./theming/preloadLinks.js";
+import "focus-visible";
 
 let autoId = 0;
 

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -17,10 +17,16 @@ const packageFile = JSON.parse(fs.readFileSync("./package.json"));
 const packageName = packageFile.name;
 const DEPLOY_PUBLIC_PATH = process.env.DEPLOY_PUBLIC_PATH || "";
 
-const warningsToSkip = [{
-	warningCode: "THIS_IS_UNDEFINED",
-	filePath: /.+zxing.+/,
-}];
+const warningsToSkip = [
+	{
+		warningCode: "THIS_IS_UNDEFINED",
+		filePath: /.+zxing.+/,
+	},
+	{
+		warningCode: "THIS_IS_UNDEFINED",
+		filePath: /focus-visible.js/,
+	},
+];
 
 function ui5DevImportCheckerPlugin() {
 	return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,6 +3715,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
 folder-hash@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/folder-hash/-/folder-hash-4.0.1.tgz#1603c46bdb899843e292ecdfca9e540dd22e1236"


### PR DESCRIPTION
Added [focus visible polyfill](https://github.com/WICG/focus-visible) to `UI5Element`.

Polyfill adds a `focus-visible` class to the focused element, in situations in which the `:focus-visible` pseudo-selector should match.

Relates to SAP Horizon Experimental theme implementation.