### PR TITLE
fix(ui5-button): aria-hidden attribute applied over the button's icon

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -27,6 +27,7 @@
 			class="ui5-button-icon"
 			name="{{icon}}"
 			part="icon"
+			aria-hidden="true"
 			?show-tooltip={{showIconTooltip}}
 		></ui5-icon>
 	{{/if}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -449,13 +449,14 @@ class Button extends UI5Element {
 	}
 
 	get tabIndexValue() {
-		const tabindex = this.getAttribute("tabindex");
+		// const tabindex = this.getAttribute("tabindex");
 
-		if (tabindex) {
-			return tabindex;
-		}
+		// if (tabindex) {
+		// 	return tabindex;
+		// }
 
-		return this.nonInteractive ? "-1" : this._tabIndex;
+		// return this.nonInteractive ? "-1" : this._tabIndex;
+		return ""
 	}
 
 	get showIconTooltip() {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -449,14 +449,13 @@ class Button extends UI5Element {
 	}
 
 	get tabIndexValue() {
-		// const tabindex = this.getAttribute("tabindex");
+		const tabindex = this.getAttribute("tabindex");
 
-		// if (tabindex) {
-		// 	return tabindex;
-		// }
+		if (tabindex) {
+			return tabindex;
+		}
 
-		// return this.nonInteractive ? "-1" : this._tabIndex;
-		return ""
+		return this.nonInteractive ? "-1" : this._tabIndex;
 	}
 
 	get showIconTooltip() {

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -280,7 +280,7 @@ class Icon extends UI5Element {
 	}
 
 	get tabIndex() {
-		return this.interactive ? "0" : "";
+		return this.interactive ? "0" : undefined;
 	}
 
 	get isDecorative() {

--- a/packages/main/src/Icon.js
+++ b/packages/main/src/Icon.js
@@ -280,7 +280,7 @@ class Icon extends UI5Element {
 	}
 
 	get tabIndex() {
-		return this.interactive ? "0" : "-1";
+		return this.interactive ? "0" : "";
 	}
 
 	get isDecorative() {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -34,6 +34,7 @@ describe("Button general interaction", () => {
 		const oButtonIconOnlyBlankText = await browser.$("#icon-only-blank-text");
 
 		assert.strictEqual(await oButtonIconOnlyComment.getAttribute("icon-only"), "", "Button comment has attribute icon-only");
+		assert.strictEqual(await oButtonIconOnlyComment.shadow$("ui5-icon").getAttribute("aria-hidden"), "true", "aria-hidden is set");
 		assert.strictEqual(await oButtonIconOnlyBlankText.getAttribute("icon-only"), "", "Button blank text has attribute icon-only");
 	});
 


### PR DESCRIPTION
- The aria-hidden attribute is used over the button's icon
as role presentation on the icon SVG is ignored in this case.

Fixes #3441
