### PR TITLE
feat(ui5-shellbar): improved accessibilityTexts property

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -46,7 +46,7 @@
 
 				{{#if primaryTitle}}
 					<h1 class="ui5-shellbar-menu-button-title">
-						<bdi class="{{classes.title}}">{{primaryTitle}}</bdi>
+						<bdi>{{primaryTitle}}</bdi>
 					</h1>
 				{{/if}}
 

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -117,6 +117,7 @@ const metadata = {
 		 *
 		 * It supports the following fields:
 		 * - <code>profileButtonTitle</code>: defines the tooltip for the profile button
+		 * - <code>logoTitle</code>: defines the tooltip for the logo
 		 *
 		 * @type {object}
 		 * @public
@@ -1012,7 +1013,6 @@ class ShellBar extends UI5Element {
 				"ui5-shellbar-menu-button--interactive": this.hasMenuItems,
 				"ui5-shellbar-menu-button": true,
 			},
-			title: {},
 			items: {
 				notification: {
 					"ui5-shellbar-hidden-button": this.isIconHidden("bell"),
@@ -1121,7 +1121,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get _logoText() {
-		return ShellBar.i18nBundle.getText(SHELLBAR_LOGO);
+		return this.accessibilityTexts.logoTitle || ShellBar.i18nBundle.getText(SHELLBAR_LOGO);
 	}
 
 	get _copilotText() {

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -219,6 +219,7 @@
 	<ui5-toast id="wcToastTC">Custom Action Fired</ui5-toast>
 
 	<ui5-shellbar id="sbAcc">
+		<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
 		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
 	</ui5-shellbar>
 
@@ -302,6 +303,7 @@
 
 		sbAcc.accessibilityTexts = {
 			profileButtonTitle: "John Dow",
+			logoTitle: "Custom logo title",
 		};
 	</script>
 </body>

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -31,10 +31,13 @@ describe("Component Behavior", () => {
 	describe("Аccessibility", () => {
 		it("tests accessibilityTexts property", async () => {
 			const PROFILE_BTN_CUSTOM_TOOLTIP = "John Dow";
+			const LOGO_CUSTOM_TOOLTIP = "Custom logo title";
 			const sb = await browser.$("#sbAcc");
 
 			assert.strictEqual(await sb.getProperty("_profileText"), PROFILE_BTN_CUSTOM_TOOLTIP,
 				"Profile button tooltip can be cutomized.");
+			assert.strictEqual(await sb.getProperty("_logoText"), LOGO_CUSTOM_TOOLTIP,
+				"Logo tooltip can be cutomized.");
 		});
 	});
 


### PR DESCRIPTION
Improved accessibilityTexts property to allow customisation of `ui5-shellbar` logo tooltip.

Logo tooltip could be changed in following way:

```
<script>
    sbAcc.accessibilityTexts = {
	  logoTitle: "My new logo title",
    };
</script>
```

Fixes: #4426 