### PR TITLE
fix: Breadcrumbs no longer throws an error when empty

### DIFF
--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -318,7 +318,7 @@ class Breadcrumbs extends UI5Element {
 			map.set(item, this._getElementWidth(link) || 0);
 		}
 
-		if (this._endsWithCurrentLocationLabel && label) {
+		if (items.length && this._endsWithCurrentLocationLabel && label) {
 			const item = items[items.length - 1];
 			map.set(item, this._getElementWidth(label));
 		}

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -132,6 +132,18 @@
 		</ui5-breadcrumbs>
 	</div>
 
+	<div class="breadcrumbs9auto">
+		<h2>Empty Breadcrumbs</h2>
+		<ui5-breadcrumbs></ui5-breadcrumbs>
+	</div>
+
+	<div class="breadcrumbs9auto">
+		<h2>Empty Breadcrumbs with Location only</h2>
+		<ui5-breadcrumbs>
+			<ui5-breadcrumbs-item>Location</ui5-breadcrumbs-item>
+		</ui5-breadcrumbs>
+	</div>
+
 	Last pressed link: <span id="result"></span>
 
 

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -58,7 +58,7 @@
 
 	<h2>Breadcrumbs with current location</h2>
 
-	<ui5-breadcrumbs id="breadcrumbs2" separator-class="breadcrumbs6auto">
+	<ui5-breadcrumbs id="breadcrumbs2" separator-class="Slash">
 		<ui5-breadcrumbs-item href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link2</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>
@@ -71,7 +71,7 @@
 
 	<h2>Breadcrumbs with no current location</h2>
 
-	<ui5-breadcrumbs id="breadcrumbs3" design="NoCurrentPage" separator-class="breadcrumbs6auto">
+	<ui5-breadcrumbs id="breadcrumbs3" design="NoCurrentPage" separator-class="Slash">
 		<ui5-breadcrumbs-item href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link2</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>
@@ -91,7 +91,7 @@
 		<ui5-option>GreaterThan</ui5-option>
 	</ui5-select>
 	<div class="breadcrumbs7auto">
-		<ui5-breadcrumbs id="breadcrumbs4" separator-class="breadcrumbs6auto">
+		<ui5-breadcrumbs id="breadcrumbs4" separator-class="Slash">
 			<ui5-breadcrumbs-item href="#">Link1 </ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="#">Link2</ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>
@@ -120,7 +120,7 @@
 
 		<h2>Breadcrumbs with overflowing links</h2>
 
-		<ui5-breadcrumbs id="breadcrumbs1" separator-class="breadcrumbs6auto">
+		<ui5-breadcrumbs id="breadcrumbs1" separator-class="Slash">
 			<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link1 </ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link2</ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>

--- a/packages/main/test/pages/styles/Breadcrumbs.css
+++ b/packages/main/test/pages/styles/Breadcrumbs.css
@@ -26,10 +26,6 @@ h2 {
     display: inline-block
 }
 
-.breadcrumbs6auto {
-    Slash
-}
-
 .breadcrumbs7auto {
     margin-top: 0.5rem
 }


### PR DESCRIPTION
 - fixed the code that breaks when there are no items
 - additionally, fixed the test page after `separator-class="Slash"` had been mistakenly identified as a `class` attribute by the script that refactored all test pages a while ago and extracted all hard-coded CSS to a separate file

@kineticjs Please investigate how Breadcrumbs should look like with no items and one item only. Currently, even with one item, nothing is displayed. If that is not intended, please create an issue or a follow-up change to fix that.

closes: https://github.com/SAP/ui5-webcomponents/issues/4562