### PR TITLE
fix: Scoping issues corrected

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-BZ5aGlAxilLKkR431uBOgeJ+uUU=
+0KpYdce4OrU70VpvAgA0qr2FulM=

--- a/packages/fiori/src/MediaGallery.js
+++ b/packages/fiori/src/MediaGallery.js
@@ -468,7 +468,7 @@ class MediaGallery extends UI5Element {
 	}
 
 	get _carousel() {
-		return this.shadowRoot.querySelector("ui5-carousel");
+		return this.shadowRoot.querySelector("[ui5-carousel]");
 	}
 
 	get _display() {
@@ -476,11 +476,11 @@ class MediaGallery extends UI5Element {
 	}
 
 	get _mainItem() {
-		return this.shadowRoot.querySelector(".ui5-media-gallery-display ui5-media-gallery-item");
+		return this.shadowRoot.querySelector(".ui5-media-gallery-display [ui5-media-gallery-item]");
 	}
 
 	get _overflowBtn() {
-		return this.shadowRoot.querySelector(".ui5-media-gallery-overflow ui5-button");
+		return this.shadowRoot.querySelector(".ui5-media-gallery-overflow [ui5-button]");
 	}
 
 	get _visibleItems() {

--- a/packages/fiori/src/themes/MediaGallery.css
+++ b/packages/fiori/src/themes/MediaGallery.css
@@ -125,13 +125,13 @@
 }
 
 .ui5-media-gallery-thumbnail,
-.ui5-media-gallery-overflow ui5-button {
+.ui5-media-gallery-overflow [ui5-button] {
     width: 4rem;
     height: 4rem;
     flex-shrink: 0;
 }
 
-.ui5-media-gallery-overflow ui5-button {
+.ui5-media-gallery-overflow [ui5-button] {
     background: var(--_ui5_media_gallery_overflow_btn_background);
     color: var(--_ui5_media_gallery_overflow_btn_color);
     border: var(--_ui5_media_gallery_overflow_btn_border);

--- a/packages/fiori/src/themes/ViewSettingsDialog.css
+++ b/packages/fiori/src/themes/ViewSettingsDialog.css
@@ -7,7 +7,7 @@
 	width: 100%;
 }
 
-.ui5-vsd-header > ui5-bar {
+.ui5-vsd-header > [ui5-bar] {
 	height: 4rem;
 }
 

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -16,6 +16,7 @@ import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import ColorPaletteTemplate from "./generated/templates/ColorPaletteTemplate.lit.js";
 import ColorPaletteDialogTemplate from "./generated/templates/ColorPaletteDialogTemplate.lit.js";
 import ColorPaletteItem from "./ColorPaletteItem.js";
+import Button from "./Button.js";
 import {
 	COLORPALETTE_CONTAINER_LABEL,
 	COLOR_PALETTE_MORE_COLORS_TEXT,
@@ -178,7 +179,7 @@ class ColorPalette extends UI5Element {
 
 	static get dependencies() {
 		const ColorPaletteMoreColors = getFeature("ColorPaletteMoreColors");
-		return [ColorPaletteItem].concat(ColorPaletteMoreColors ? ColorPaletteMoreColors.dependencies : []);
+		return [ColorPaletteItem, Button].concat(ColorPaletteMoreColors ? ColorPaletteMoreColors.dependencies : []);
 	}
 
 	static async onDefine() {
@@ -252,20 +253,20 @@ class ColorPalette extends UI5Element {
 	}
 
 	_onclick(event) {
-		if (event.target.localName === "ui5-color-palette-item") {
+		if (event.target.hasAttribute("ui5-color-palette-item")) {
 			this.selectColor(event.target);
 		}
 	}
 
 	_onkeyup(event) {
-		if (isSpace(event) && event.target.localName === "ui5-color-palette-item") {
+		if (isSpace(event) && event.target.hasAttribute("ui5-color-palette-item")) {
 			event.preventDefault();
 			this.selectColor(event.target);
 		}
 	}
 
 	_onkeydown(event) {
-		if (isEnter(event) && event.target.localName === "ui5-color-palette-item") {
+		if (isEnter(event) && event.target.hasAttribute("ui5-color-palette-item")) {
 			this.selectColor(event.target);
 		}
 	}

--- a/packages/main/src/ColorPalettePopover.hbs
+++ b/packages/main/src/ColorPalettePopover.hbs
@@ -2,19 +2,21 @@
 	hide-arrow
 	content-only-on-desktop
 	placement-type="Bottom"
-	>
+>
 	<div slot="header" class="ui5-cp-header">
 		<ui5-title
-			class="ui5-cp-title">{{_colorPaletteTitle}}</ui5-title>
+			class="ui5-cp-title"
+		>{{_colorPaletteTitle}}</ui5-title>
 	</div>
 	<div>
-		<ui5-color-palette 
+		<ui5-color-palette
 			?show-more-colors="{{this.showMoreColors}}"
 			?show-recent-colors="{{this.showRecentColors}}"
 			?show-default-color="{{this.defaultColor}}"
 			default-color="{{this.defaultColor}}"
 			popup-mode
-			@item-click="{{onSelectedColor}}">
+			@ui5-item-click="{{onSelectedColor}}"
+		>
 			{{#each colorPaletteColors}}
 				<slot name="{{this._individualSlot}}"></slot>
 			{{/each}}

--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -13,6 +13,7 @@ import {
 } from "./generated/i18n/i18n-defaults.js";
 
 import Button from "./Button.js";
+import Title from "./Title.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import ColorPalette from "./ColorPalette.js";
 
@@ -145,6 +146,7 @@ class ColorPalettePopover extends UI5Element {
 		return [
 			ResponsivePopover,
 			Button,
+			Title,
 			ColorPalette,
 		];
 	}

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -537,7 +537,7 @@ class MultiComboBox extends UI5Element {
 
 		const tokensCount = this._tokenizer.tokens.length - 1;
 
-		if (!event.relatedTarget || event.relatedTarget.localName !== "ui5-token") {
+		if (!event.relatedTarget || !event.relatedTarget.hasAttribute("ui5-token")) {
 			this._tokenizer.tokens.forEach(token => { token.selected = false; });
 			this._tokenizer.scrollToStart();
 		}

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -107,6 +107,7 @@ class ResponsivePopover extends Popover {
 
 	static get dependencies() {
 		return [
+			...Popover.dependencies,
 			Button,
 			Dialog,
 			Title,

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -250,7 +250,7 @@ class Tokenizer extends UI5Element {
 	}
 
 	_handleTokenSelection(event) {
-		if (event.target.localName === "ui5-token") {
+		if (event.target.hasAttribute("ui5-token")) {
 			this._tokens.forEach(token => {
 				if (token !== event.target) {
 					token.selected = false;

--- a/packages/main/src/themes/TabSeparatorInOverflow.css
+++ b/packages/main/src/themes/TabSeparatorInOverflow.css
@@ -3,6 +3,6 @@
 	border-bottom: 0.0625rem solid var(--sapGroup_TitleBorderColor);
 	margin: 0 0.5rem;
 }
-ui5-list>.ui5-tc__separator:first-child {
+[ui5-list]>.ui5-tc__separator:first-child {
 	min-height: 0.5rem;
 }

--- a/packages/main/src/themes/ValueStateMessage.css
+++ b/packages/main/src/themes/ValueStateMessage.css
@@ -14,7 +14,7 @@
 	left: 0.5rem;
 }
 
-ui5-responsive-popover .ui5-valuestatemessage-header .ui5-input-value-state-message-icon {
+[ui5-responsive-popover] .ui5-valuestatemessage-header .ui5-input-value-state-message-icon {
 	left: 1rem;
 }
 
@@ -48,7 +48,7 @@ ui5-responsive-popover .ui5-valuestatemessage-header .ui5-input-value-state-mess
 	border: var(--_ui5_value_state_message_border);
 }
 
-ui5-responsive-popover .ui5-valuestatemessage-header {
+[ui5-responsive-popover] .ui5-valuestatemessage-header {
 	min-height: 2rem;
 	padding: var(--_ui5_value_state_header_padding);
 }
@@ -73,4 +73,4 @@ ui5-responsive-popover .ui5-valuestatemessage-header {
 	outline-offset: -0.125rem;
 	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	border-radius: var(--_ui5_value_state_message_focus_border_radius);
-} 
+}


### PR DESCRIPTION
⚠️  *Important for component developers:*

UI5 Web Components tag names may vary. Users can take advantage of the "scoping" feature (https://github.com/SAP/ui5-webcomponents/pull/2091), so for example `ui5-button` could be used as `ui5-button-demo`. However, it will always have a `ui5-button` attribute set, no matter what its name is. 

Example
```html
<ui5-button-demo ui5-button>Click me</ui5-button-demo>
```

This attribute will always be there, even if the scoping feature is not used:

Example
```html
<ui5-button ui5-button>Click me</ui5-button>
```

**You must only use this attribute in your code, never the tag name.**

The following are not allowed:
 - using the tag name in CSS
 - comparing `localName` of a component
 - querying the shadow root with a hard-coded local name.

Also, it is important to set `dependencies` for all components, otherwise the `.hbs` preprocessor will not scope some of the components used in the shadow root, and the scoping feature will break.

closes: https://github.com/SAP/ui5-webcomponents/issues/4528