### PR TITLE
fix(ui5-breadcrumbs): correct missing label for single breadcrumb

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-0KpYdce4OrU70VpvAgA0qr2FulM=
+6YiE/tv+O4z5p0flJGMvfbR+4jo=

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -434,7 +434,7 @@ class Breadcrumbs extends UI5Element {
 
 	_hasVisibleContent(item) {
 		// the check is not complete but may be extended in the future if needed to cover
-		// cases becides the standard (UX-recommended) ones
+		// cases besides the standard (UX-recommended) ones
 		return item.innerText || Array.from(item.children).some(child => !child.hidden);
 	}
 
@@ -454,7 +454,7 @@ class Breadcrumbs extends UI5Element {
 
 	get _currentLocationText() {
 		const items = this.getSlottedNodes("items");
-		if (this._endsWithCurrentLocationLabel && items.length > 1) {
+		if (this._endsWithCurrentLocationLabel && items.length) {
 			const item = items[items.length - 1];
 			if (this._isItemVisible(item)) {
 				return item.innerText;

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -139,7 +139,7 @@
 
 	<div class="breadcrumbs9auto">
 		<h2>Empty Breadcrumbs with Location only</h2>
-		<ui5-breadcrumbs>
+		<ui5-breadcrumbs id="breadcrumbsWithSingleItem">
 			<ui5-breadcrumbs-item>Location</ui5-breadcrumbs-item>
 		</ui5-breadcrumbs>
 	</div>

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -140,6 +140,14 @@ describe("Breadcrumbs general interaction", () => {
 		assert.strictEqual(await breadcrumbs.getProperty("_overflowSize"), expectedCountItemsInOverflowAfter, "a link is added to the overflow");
 	});
 
+	it("standard breadcrumb with single item shows location", async () => {
+		const breadcrumbs = await browser.$("#breadcrumbsWithSingleItem"),
+			label = (await breadcrumbs.shadow$("ui5-label"));
+
+		// Check
+		assert.strictEqual(await label.getText(), "Location", "label is displayed");
+	});
+
 	it("opens upon space", async () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/Breadcrumbs.html`);
 

--- a/packages/theming/hash.txt
+++ b/packages/theming/hash.txt
@@ -1,1 +1,1 @@
-rZnyMTmoc2CFM82C+7zGHcw3GGY=
+CQhk8M6oN0XzkZBkgImthR2kdTs=


### PR DESCRIPTION
Add the missing label of breadcrumbs with a single item.

Fixes #4565