### PR TITLE
test(ui5-breadcrumbs): fix false-positive event listener tests

### DIFF
--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -161,7 +161,7 @@
 		});
 
 		// log events
-		breadcrumbs1.addEventListener("item-click", (event) => {result.innerText = event.detail.item.innerText});
+		breadcrumbs1.addEventListener("ui5-item-click", (event) => {result.innerText = event.detail.item.innerText});
 
 		extendSizeBtn.addEventListener("click", () => resizeContainer(true));
 		shrinkSizeBtn.addEventListener("click", () => resizeContainer());

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -31,6 +31,7 @@ describe("Breadcrumbs general interaction", () => {
 
 		// Check
 		const eventResult = await browser.$("#result");
+		assert.isNotEmpty(eventResult.innerText, 'label should have a value');
 		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
 	});
 
@@ -50,6 +51,7 @@ describe("Breadcrumbs general interaction", () => {
 
 		// Check
 		const eventResult = await browser.$("#result");
+		assert.isNotEmpty(eventResult.innerText, 'label should have a value');
 		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
 	});
 

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -31,8 +31,8 @@ describe("Breadcrumbs general interaction", () => {
 
 		// Check
 		const eventResult = await browser.$("#result");
-		assert.isNotEmpty(eventResult.innerText, 'label should have a value');
-		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
+		assert.isNotEmpty(await eventResult.getText(), 'label should have a value');
+		assert.strictEqual(await eventResult.getText(), await link.getText(), "label for pressed link is correct");
 	});
 
 	it("fires link-click event when link in overflow", async () => {
@@ -51,8 +51,8 @@ describe("Breadcrumbs general interaction", () => {
 
 		// Check
 		const eventResult = await browser.$("#result");
-		assert.isNotEmpty(eventResult.innerText, 'label should have a value');
-		assert.strictEqual(eventResult.innerText, link.innerText, "label for pressed link is correct");
+		assert.isNotEmpty(await eventResult.getText(), 'label should have a value');
+		assert.strictEqual(await eventResult.getText(), await link.getText(), "label for pressed link is correct");
 	});
 
 	it("updates layout on container resize", async () => {

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -37,8 +37,7 @@ describe("Breadcrumbs general interaction", () => {
 
 	it("fires link-click event when link in overflow", async () => {
 		const breadcrumbs = await browser.$("#breadcrumbs1"),
-			overflowArrowLink = (await breadcrumbs.shadow$$("ui5-link"))[0],
-			link = (await breadcrumbs.shadow$$("ui5-link"))[1];
+			overflowArrowLink = (await breadcrumbs.shadow$$("ui5-link"))[0];
 
 
 		// Act
@@ -52,7 +51,7 @@ describe("Breadcrumbs general interaction", () => {
 		// Check
 		const eventResult = await browser.$("#result");
 		assert.isNotEmpty(await eventResult.getText(), 'label should have a value');
-		assert.strictEqual(await eventResult.getText(), await link.getText(), "label for pressed link is correct");
+		assert.strictEqual(await eventResult.getText(), await firstItem.getProperty('innerText'), "label for pressed link is correct");
 	});
 
 	it("updates layout on container resize", async () => {


### PR DESCRIPTION
Two tests checking for item-click event are passing, although the eventlistener isn't called in the test run, probably due to the noConflict configuration here: https://github.com/SAP/ui5-webcomponents/blob/b030586bc7354d9ab9a8074805e54df96246a831/packages/tools/components-package/wdio.js#L308

It can be reproduced by following the commits in this PR chronologically.