### PR TITLE
feat(ui5-link): accessibilityAttributes property implemented

### DIFF
--- a/packages/main/src/Link.hbs
+++ b/packages/main/src/Link.hbs
@@ -7,7 +7,8 @@
 	tabindex="{{tabIndex}}"
 	?disabled="{{disabled}}"
 	aria-label="{{ariaLabelText}}"
-	aria-haspopup="{{ariaHaspopup}}"
+	aria-haspopup="{{accessibilityAttributes.hasPopup}}"
+	aria-expanded="{{accessibilityAttributes.expanded}}"
 	@focusin={{_onfocusin}}
 	@focusout={{_onfocusout}}
 	@click={{_onclick}}

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -132,8 +132,13 @@ const metadata = {
 		 * It supports the following fields:
 		 *
 		 * <ul>
-		 * 		<li><code>expanded</code>: Indicates whether the anchor element, or another grouping element it controls, is currently expanded or collapsed.Accepts boolean values.</li>
-		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element.Accepts the following values:
+		 * 		<li><code>expanded</code>: Indicates whether the anchor element, or another grouping element it controls, is currently expanded or collapsed. Accepts the following string values:
+		 *			<ul>
+		 *				<li><code>true</code></li>
+		 *				<li><code>false</code></li>
+		 *			<ul>
+		 * 		</li>
+		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element. Accepts the following string values:
 		 * 			<ul>
 		 *				<li><code>Dialog</code></li>
 		 *				<li><code>Grid</code></li>

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -116,7 +116,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the accessibility role of the component.
+		 * Defines the ARIA role of the component.
 		 * @defaultvalue ""
 		 * @private
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -134,7 +134,7 @@ const metadata = {
 		 * - <code>hasPopup</code>: indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element
 		 * @type {object}
 		 * @public
-		 * @since 1.3.0
+		 * @since 1.1.0
 		 */
 		 accessibilityAttributes: {
 			type: Object,

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -116,19 +116,6 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the aria-haspopup value of the component.
-		 *
-		 * @type String
-		 * @defaultvalue undefined
-		 * @private
-		 * @since 1.0.0-rc.15
-		 */
-		 ariaHaspopup: {
-			type: String,
-			defaultValue: undefined,
-		},
-
-		/**
 		 * Defines the accessibility role of the component.
 		 * @defaultvalue ""
 		 * @private
@@ -136,6 +123,21 @@ const metadata = {
 		 */
 		 accessibleRole: {
 			type: String,
+		},
+
+		/**
+		 * An object of strings that defines several additional accessibility attribute values
+		 * for customization depending on the use case.
+		 *
+		 * It supports the following fields:
+		 * - <code>expanded</code>: indicates whether the anchor element, or another grouping element it controls, is currently expanded or collapsed
+		 * - <code>hasPopup</code>: indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element
+		 * @type {object}
+		 * @public
+		 * @since 1.3.0
+		 */
+		 accessibilityAttributes: {
+			type: Object,
 		},
 
 		_rel: {

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -130,8 +130,19 @@ const metadata = {
 		 * for customization depending on the use case.
 		 *
 		 * It supports the following fields:
-		 * - <code>expanded</code>: indicates whether the anchor element, or another grouping element it controls, is currently expanded or collapsed
-		 * - <code>hasPopup</code>: indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element
+		 *
+		 * <ul>
+		 * 		<li><code>expanded</code>: Indicates whether the anchor element, or another grouping element it controls, is currently expanded or collapsed.Accepts boolean values.</li>
+		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element.Accepts the following values:
+		 * 			<ul>
+		 *				<li><code>Dialog</code></li>
+		 *				<li><code>Grid</code></li>
+		 *				<li><code>ListBox</code></li>
+		 *				<li><code>Menu</code></li>
+		 *				<li><code>Tree</code></li>
+		 * 			</ul>
+		 * 		</li>
+		 * </ul>
 		 * @type {object}
 		 * @public
 		 * @since 1.1.0

--- a/packages/main/src/types/HasPopup.js
+++ b/packages/main/src/types/HasPopup.js
@@ -1,0 +1,62 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * Different types of HasPopup.
+ * @lends sap.ui.webcomponents.main.types.HasPopup.prototype
+ * @public
+ */
+const PopupTypes = {
+	/**
+	 * Dialog popup type
+	 * @public
+	 * @type {Dialog}
+	 */
+	Dialog: "Dialog",
+
+	/**
+	 * Grid popup type.
+	 * @public
+	 * @type {Grid}
+	 */
+	Grid: "Grid",
+
+	/**
+	 * ListBox popup type.
+	 * @public
+	 * @type {ListBox}
+	 */
+	ListBox: "ListBox",
+
+	 /**
+	  * Menu popup type.
+	  * @public
+	  * @type {Menu}
+	  */
+	Menu: "Menu",
+
+	 /**
+	  * Tree popup type.
+	  * @public
+	  * @type {Tree}
+	  */
+	Tree: "Tree",
+};
+
+/**
+ * @class
+ * Different types of HasPopup.
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.types.HasPopup
+ * @public
+ * @enum {string}
+ */
+class HasPopup extends DataType {
+	static isValid(value) {
+		return !!PopupTypes[value];
+	}
+}
+
+HasPopup.generateTypeAccessors(PopupTypes);
+
+export default HasPopup;

--- a/packages/main/src/types/HasPopup.js
+++ b/packages/main/src/types/HasPopup.js
@@ -7,7 +7,7 @@ import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
  */
 const PopupTypes = {
 	/**
-	 * Dialog popup type
+	 * Dialog popup type.
 	 * @public
 	 * @type {Dialog}
 	 */

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -89,7 +89,30 @@
 			elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna
 			aliquyam erat
 		</span>
-		<ui5-link id="collapseExpandTrigger">Less</ui5-link>
+		<ui5-link id="collapseExpandLink">Less</ui5-link>
+	</section>
+
+	<section class="group">
+		<h2>Link opens a dialog</h2>
+		<ui5-link id="signInLink">Sign in</ui5-link>
+		<ui5-dialog id="signInDialog" header-text="Sign in form">
+			<section class="login-form">
+				<div>
+					<ui5-label for="email" type="Email" required>Email: </ui5-label>
+					<ui5-input id="email"></ui5-input>
+				</div>
+		
+				<div>
+					<ui5-label for="password" required>Password: </ui5-label>
+					<ui5-input id="password" type="Password"></ui5-input>
+				</div>
+			</section>
+		
+			<div slot="footer"	class="dialog-footer">
+				<div style="flex: 1;"></div>
+				<ui5-button id="closeDialogButton" design="Emphasized">Sign in</ui5-button>
+			</div>
+		</ui5-dialog>
 	</section>
 
 	<script>
@@ -97,8 +120,11 @@
 		var link = document.querySelector("#link");
 		var linkClickPreventDefault = document.querySelector("#link-click-prevent-default");
 		var input = document.querySelector("#helper-input");
-		var collapseExpandTrigger = document.getElementById("collapseExpandTrigger");
+		var collapseExpandLink = document.getElementById("collapseExpandLink");
 		var collapsibleText = document.getElementById("collapsibleText");
+		var signInLink = document.getElementById("signInLink");
+		var singInDialog = document.getElementById("signInDialog");
+		var closeSignInDialogButton = document.getElementById("closeDialogButton");
 
 		[link, disLink].forEach(function(element) {
 			element.addEventListener("click", function(event) {
@@ -106,19 +132,31 @@
 			});
 		});
 
+		signInLink.addEventListener("click", function(event) {
+			singInDialog.show();
+		});
+
+		signInLink.accessibilityAttributes = {
+			hasPopup: "Dialog"
+		};
+
+		closeSignInDialogButton.addEventListener("click", function(event) {
+			singInDialog.close();
+		});
+
 		linkClickPreventDefault.addEventListener("click", function(event) {
 			event.preventDefault();
 		});
 
-		collapseExpandTrigger.accessibilityAttributes = {
+		collapseExpandLink.accessibilityAttributes = {
 			expanded: "true"
-		}
+		};
 
-		collapseExpandTrigger.addEventListener("click", function(event) {
-			collapseExpandTrigger.accessibilityAttributes = {
-				expanded: collapseExpandTrigger.accessibilityAttributes["expanded"] === "true" ? "false" : "true"
-			}
-			collapseExpandTrigger.innerText = collapseExpandTrigger.innerText === "More" ? "Less" : "More";
+		collapseExpandLink.addEventListener("click", function(event) {
+			collapseExpandLink.accessibilityAttributes = {
+				expanded: collapseExpandLink.accessibilityAttributes["expanded"] === "true" ? "false" : "true"
+			};
+			collapseExpandLink.innerText = collapseExpandLink.innerText === "More" ? "Less" : "More";
 			collapsibleText.style["display"] = collapsibleText.style["display"] === "-webkit-box" ? "" : "-webkit-box";
 			collapsibleText.style["-webkit-line-clamp"] = collapsibleText.style["-webkit-line-clamp"] === "2" ? "" : "2";
 			collapsibleText.style["-webkit-box-orient"] = collapsibleText.style["-webkit-box-orient"] === "vertical" ? "" : "vertical";

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -76,11 +76,29 @@
 		<ui5-link id="ariaLblBy" accessible-name-ref="lbl">Go to</ui5-link>
 	</section>
 
+	<section class="group">
+		<h2>Collapsible text</h2>
+		<span id="collapsibleText">
+			Maxlines ... Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed
+			diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+			erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
+			rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+			dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+			sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+			erat, sed diam voluptua. Lorem ipsum dolor sit amet, consetetur sadipscing
+			elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna
+			aliquyam erat
+		</span>
+		<ui5-link id="collapseExpandTrigger">Less</ui5-link>
+	</section>
+
 	<script>
 		var disLink = document.querySelector("#disabled-link");
 		var link = document.querySelector("#link");
 		var linkClickPreventDefault = document.querySelector("#link-click-prevent-default");
 		var input = document.querySelector("#helper-input");
+		var collapseExpandTrigger = document.getElementById("collapseExpandTrigger");
+		var collapsibleText = document.getElementById("collapsibleText");
 
 		[link, disLink].forEach(function(element) {
 			element.addEventListener("click", function(event) {
@@ -90,6 +108,21 @@
 
 		linkClickPreventDefault.addEventListener("click", function(event) {
 			event.preventDefault();
+		});
+
+		collapseExpandTrigger.accessibilityAttributes = {
+			expanded: "true"
+		}
+
+		collapseExpandTrigger.addEventListener("click", function(event) {
+			collapseExpandTrigger.accessibilityAttributes = {
+				expanded: collapseExpandTrigger.accessibilityAttributes["expanded"] === "true" ? "false" : "true"
+			}
+			collapseExpandTrigger.innerText = collapseExpandTrigger.innerText === "More" ? "Less" : "More";
+			collapsibleText.style["display"] = collapsibleText.style["display"] === "-webkit-box" ? "" : "-webkit-box";
+			collapsibleText.style["-webkit-line-clamp"] = collapsibleText.style["-webkit-line-clamp"] === "2" ? "" : "2";
+			collapsibleText.style["-webkit-box-orient"] = collapsibleText.style["-webkit-box-orient"] === "vertical" ? "" : "vertical";
+			collapsibleText.style["overflow"] = collapsibleText.style["overflow"] === "hidden" ? "" : "hidden";
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/styles/Link.css
+++ b/packages/main/test/pages/styles/Link.css
@@ -14,3 +14,17 @@ html,
 .link2auto {
     width: 100px
 }
+
+.login-form {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	align-items: flex-start;
+	margin: 3rem 6rem;
+}
+
+.login-form > div {
+	display: grid;
+	width: 15rem;
+	margin-bottom: .5rem;
+}

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -72,7 +72,7 @@ describe("General API", () => {
 	it("Open dialog link has propper aria-haspopup attribute", async () => {
 		const link = await browser.$("#signInLink");
 
-		assert.strictEqual(await link.shadow$("a").getAttribute("aria-haspopup"), "Dialog", "Propper aria-haspopup attribute is set");
+		assert.strictEqual(await link.shadow$("a").getAttribute("aria-haspopup"), "Dialog", "Proper aria-haspopup attribute is set");
 	});
 
 });

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -61,11 +61,18 @@ describe("General API", () => {
 		assert.notInclude(url, "https://www.google.com", "URL is not google");
 	});
 
-	it("Collabsible element has aria expanded attribute", async () => {
-		const link = await browser.$("#collapseExpandTrigger");
+	it("Collabsible element has aria-expanded attribute", async () => {
+		const link = await browser.$("#collapseExpandLink");
 
 		assert.strictEqual(await link.shadow$("a").getAttribute("aria-expanded"), "true", "The text is expanded");
 		await link.click();
 		assert.strictEqual(await link.shadow$("a").getAttribute("aria-expanded"), "false", "The text is collapsed");
 	});
+
+	it("Open dialog link has propper aria-haspopup attribute", async () => {
+		const link = await browser.$("#signInLink");
+
+		assert.strictEqual(await link.shadow$("a").getAttribute("aria-haspopup"), "Dialog", "Propper aria-haspopup attribute is set");
+	});
+
 });

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -41,7 +41,6 @@ describe("General API", () => {
 	});
 
 	it("should prevent clicking on disabled link", async () => {
-		const disLink = await browser.$("#disabled-link");
 		const input = await browser.$("#helper-input");
 
 		assert.strictEqual(await input.getValue(), "0", "Click should not be fired and value of input should not be changed.");
@@ -60,5 +59,13 @@ describe("General API", () => {
 		await link.click();
 		const url = await browser.getUrl();
 		assert.notInclude(url, "https://www.google.com", "URL is not google");
+	});
+
+	it("Collabsible element has aria expanded attribute", async () => {
+		const link = await browser.$("#collapseExpandTrigger");
+
+		assert.strictEqual(await link.shadow$("a").getAttribute("aria-expanded"), "true", "The text is expanded");
+		await link.click();
+		assert.strictEqual(await link.shadow$("a").getAttribute("aria-expanded"), "false", "The text is collapsed");
 	});
 });


### PR DESCRIPTION
The ui5-link component now supports accessibilityAttributes property,
which enables users to supply additional accessibility attribute
values. As a result the control could now be used as a collapsible
link.

Related to: #3546