### PR TITLE
doc(ui5-view-settings-dialog): fix imported component doc

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -195,7 +195,7 @@ const metadata = {
  *
  * <h3>ES6 Module Import</h3>
  *
- * <code>import "@ui5/webcomponents/dist/ViewSettingsDialog";</code>
+ * <code>import "@ui5/webcomponents-fiori/dist/ViewSettingsDialog";</code>
  *
  * @constructor
  * @author SAP SE


### PR DESCRIPTION
I've tried to import from `@ui5/webcomponents/dist/ViewSettingsDialog` as indicated `Overview` on [ViewSettingsDialog](https://sap.github.io/ui5-webcomponents/playground/components/ViewSettingsDialog/).

However, it did not work. 

So I modified import component part as same as [document](https://github.com/SAP/ui5-webcomponents/blob/aea5b030fe8115fac4c020c48b40f3941be96c23/packages/fiori/README.md).

`@ui5/webcomponents/dist/ViewSettingsDialog` to `@ui5/webcomponents-fiori/dist/ViewSettingsDialog`.

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/Guidelines.md#commit-message-style)
