### PR TITLE
fix(ui5-popover): restrict arrow going out of bounds

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -450,11 +450,11 @@ class Popover extends Popup {
 	 * Restricts the arrow's coordinates within the bounds of the popover.
 	 * @private
 	 * @param {{x: number, y: number}} arrow arrow's coordinates
-	 * @param {number} isVertical if the popover is placed vertically relative to the opener
+	 * @param {boolean} isVertical if the popover is placed vertically relative to the opener
 	 * @param {number} top popover's top
 	 * @param {number} left popover's left
 	 * @param {{width: number, height: number}} popoverSize popover's width and height
-	 * @param {number} borderRadius borderRadius
+	 * @param {number} borderRadius value of the border-radius property
 	 * @returns {{x: number, y: number}} Arrow's coordinates
 	 */
 	_clampArrowPlacement({ x, y }, isVertical, top, left, { width, height }, borderRadius) {

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -284,6 +284,10 @@ class Popover extends Popup {
 		return 10; // px
 	}
 
+	static get ARROW_MARGIN() {
+		return 6; // px
+	}
+
 	onEnterDOM() {
 		ResizeHandler.register(this, this._handleResize);
 	}
@@ -422,31 +426,12 @@ class Popover extends Popup {
 			top = Math.max(top, this._top);
 		}
 
-		let { arrowX, arrowY } = placement;
-		const isVertical = this.actualPlacementType === PopoverPlacementType.Top
-			|| this.actualPlacementType === PopoverPlacementType.Bottom;
+		const isVertical = this.actualPlacementType === PopoverPlacementType.Top || this.actualPlacementType === PopoverPlacementType.Bottom;
+		const borderRadius = Number.parseInt(window.getComputedStyle(this).getPropertyValue("border-radius"));
+		const arrow = this._clampArrowPlacement(placement.arrow, isVertical, this._top, this._left, popoverSize, borderRadius);
 
-		if (isVertical) {
-			const popoverOnLeftBorderOffset = Popover.VIEWPORT_MARGIN - this._left;
-			const popoverOnRightBorderOffset = this._left + popoverSize.width + Popover.VIEWPORT_MARGIN - document.documentElement.clientWidth;
-			if (popoverOnLeftBorderOffset > 0) {
-				arrowX -= popoverOnLeftBorderOffset;
-			} else if (popoverOnRightBorderOffset > 0) {
-				arrowX += popoverOnRightBorderOffset;
-			}
-		}
-		this.arrowTranslateX = Math.round(arrowX);
-
-		if (!isVertical) {
-			const popoverOnTopBorderOffset = Popover.VIEWPORT_MARGIN - this._top;
-			const popoverOnBottomBorderOffset = this._top + popoverSize.height + Popover.VIEWPORT_MARGIN - document.documentElement.clientHeight;
-			if (popoverOnTopBorderOffset > 0) {
-				arrowY -= popoverOnTopBorderOffset;
-			} else if (popoverOnBottomBorderOffset > 0) {
-				arrowY += popoverOnBottomBorderOffset;
-			}
-		}
-		this.arrowTranslateY = Math.round(arrowY);
+		this.arrowTranslateX = arrow.x;
+		this.arrowTranslateY = arrow.y;
 
 		top = this._adjustForIOSKeyboard(top);
 
@@ -459,6 +444,59 @@ class Popover extends Popup {
 		if (stretching && this._width) {
 			this.style.width = this._width;
 		}
+	}
+
+	/**
+	 * Restricts the arrow's coordinates within the bounds of the popover.
+	 * @private
+	 * @param {{x: number, y: number}} arrow arrow's coordinates
+	 * @param {number} isVertical if the popover is placed vertically relative to the opener
+	 * @param {number} top popover's top
+	 * @param {number} left popover's left
+	 * @param {{width: number, height: number}} popoverSize popover's width and height
+	 * @param {number} borderRadius borderRadius
+	 * @returns {{x: number, y: number}} Arrow's coordinates
+	 */
+	_clampArrowPlacement({ x, y }, isVertical, top, left, { width, height }, borderRadius) {
+		const maxY = this._getArrowRange(height, borderRadius);
+		const maxX = this._getArrowRange(width, borderRadius);
+
+		if (isVertical) {
+			const popoverOnLeftBorderOffset = Popover.VIEWPORT_MARGIN - left;
+			const popoverOnRightBorderOffset = left + width + Popover.VIEWPORT_MARGIN - document.documentElement.clientWidth;
+
+			if (popoverOnLeftBorderOffset > 0) {
+				x = Math.max(x - popoverOnLeftBorderOffset, -maxX);
+			} else if (popoverOnRightBorderOffset > 0) {
+				x = Math.min(x + popoverOnRightBorderOffset, maxX);
+			}
+		}
+
+		if (!isVertical) {
+			const popoverOnTopBorderOffset = Popover.VIEWPORT_MARGIN - top;
+			const popoverOnBottomBorderOffset = top + height + Popover.VIEWPORT_MARGIN - document.documentElement.clientHeight;
+			if (popoverOnTopBorderOffset > 0) {
+				y = Math.max(y - popoverOnTopBorderOffset, -maxY);
+			} else if (popoverOnBottomBorderOffset > 0) {
+				y = Math.min(y + popoverOnBottomBorderOffset, maxY);
+			}
+		}
+
+		return {
+			x: Math.round(x),
+			y: Math.round(y),
+		};
+	}
+
+	/**
+	 * Returns the allowed range for the popover arrow based on its dimension.
+	 * @private
+	 * @param {number} dimension the height or width of the popover
+	 * @param {number} borderRadius border radius of the popover
+	 * @returns {number}
+	 */
+	_getArrowRange(dimension, borderRadius) {
+		return Math.floor((dimension / 2) - (borderRadius + Popover.ARROW_MARGIN));
 	}
 
 	/**
@@ -475,7 +513,7 @@ class Popover extends Popup {
 
 		const actualTop = Math.ceil(this.getBoundingClientRect().top);
 
-		return top + (parseInt(this.style.top || "0") - actualTop);
+		return top + (Number.parseInt(this.style.top || "0") - actualTop);
 	}
 
 	getPopoverSize() {
@@ -502,6 +540,9 @@ class Popover extends Popup {
 		return this.shadowRoot.querySelector(".ui5-popover-arrow");
 	}
 
+	/**
+	 * @private
+	 */
 	calcPlacement(targetRect, popoverSize) {
 		let left = 0;
 		let top = 0;
@@ -587,8 +628,6 @@ class Popover extends Popup {
 		this._maxHeight = Math.round(maxHeight - Popover.VIEWPORT_MARGIN);
 		this._maxWidth = Math.round(maxWidth - Popover.VIEWPORT_MARGIN);
 
-		const arrowPos = this.getArrowPosition(targetRect, popoverSize, left, top, isVertical);
-
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {
 			this._left = Math.round(left);
 		}
@@ -597,9 +636,10 @@ class Popover extends Popup {
 			this._top = Math.round(top);
 		}
 
+		const arrowPos = this.getArrowPosition(targetRect, popoverSize, left, top, isVertical);
+
 		return {
-			arrowX: arrowPos.x,
-			arrowY: arrowPos.y,
+			arrow: arrowPos,
 			top: this._top,
 			left: this._left,
 			placementType,

--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -16,54 +16,7 @@
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 	<script nomodule src="../../resources/bundle.es5.js"></script>
-
-	<style>
-		.myBtn {
-			position: absolute;
-		}
-
-		#myBtn1 {
-			top: 0;
-			left: 0;
-		}
-
-		#myBtn2 {
-			top: 0;
-			right: 0;
-		}
-
-		#myBtn3 {
-			top: 50%;
-			left: 0;
-		}
-
-		#myBtn4 {
-			top: 50%;
-			right: 0;
-		}
-
-		#myBtn5 {
-			bottom: 0;
-			left: 0;
-		}
-
-		#myBtn6 {
-			bottom: 0;
-			right: 0;
-		}
-
-		#customSizeBtn {
-			position: absolute;
-			top: 0;
-			left: 50%;
-			transform: translateX(-50%);
-		}
-
-		.customSize {
-			height: 100px;
-			width: 100px;
-		}
-	</style>
+	<link rel="stylesheet" href="styles/PopoverArrowBounds.css">
 </head>
 
 <body>

--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html class="popover1auto">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>PopoverArrowBounds</title>
+
+	<script data-ui5-config type="application/json">
+		{
+			"language": "EN",
+			"libs": "sap.ui.webcomponents.main"
+		}
+	</script>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+	<style>
+		.myBtn {
+			position: absolute;
+		}
+
+		#myBtn1 {
+			top: 0;
+			left: 0;
+		}
+
+		#myBtn2 {
+			top: 0;
+			right: 0;
+		}
+
+		#myBtn3 {
+			top: 50%;
+			left: 0;
+		}
+
+		#myBtn4 {
+			top: 50%;
+			right: 0;
+		}
+
+		#myBtn5 {
+			bottom: 0;
+			left: 0;
+		}
+
+		#myBtn6 {
+			bottom: 0;
+			right: 0;
+		}
+
+		#customSizeBtn {
+			position: absolute;
+			top: 0;
+			left: 50%;
+			transform: translateX(-50%);
+		}
+
+		.customSize {
+			height: 100px;
+			width: 100px;
+		}
+	</style>
+</head>
+
+<body class="popover2auto">
+	<ui5-button id="myBtn1" data-placement-type="Left" class="myBtn">1</ui5-button>
+	<ui5-button id="myBtn2" data-placement-type="Left" class="myBtn">2</ui5-button>
+	<ui5-button id="myBtn3" data-placement-type="Bottom" class="myBtn">3</ui5-button>
+	<ui5-button id="myBtn4" data-placement-type="Top" class="myBtn">4</ui5-button>
+	<ui5-button id="myBtn5" data-placement-type="Left" class="myBtn">5</ui5-button>
+	<ui5-button id="myBtn6" data-placement-type="Left" class="myBtn">6</ui5-button>
+
+	<ui5-toggle-button id="customSizeBtn">Bigger Popover</ui5-toggle-button>
+
+	<ui5-popover id="myPopover">My Popover</ui5-popover>
+
+	<script>
+
+		var myPopover = document.getElementById("myPopover");
+		
+		Array.from(document.querySelectorAll(".myBtn")).forEach(function (btn) {
+			btn.addEventListener("click", function() {
+				myPopover.placementType = btn.dataset.placementType;
+				myPopover.showAt(btn);
+			});
+		});
+
+		var customSizeBtn = document.getElementById("customSizeBtn");
+		customSizeBtn.addEventListener("click", function (event) {
+			myPopover.classList.toggle("customSize");
+		})
+	</script>
+</body>
+
+</html>

--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>PopoverArrowBounds</title>
 
 	<script data-ui5-config type="application/json">
@@ -67,7 +66,7 @@
 	</style>
 </head>
 
-<body class="popover2auto">
+<body>
 	<ui5-button id="myBtn1" data-placement-type="Left" class="myBtn">1</ui5-button>
 	<ui5-button id="myBtn2" data-placement-type="Left" class="myBtn">2</ui5-button>
 	<ui5-button id="myBtn3" data-placement-type="Bottom" class="myBtn">3</ui5-button>
@@ -80,7 +79,6 @@
 	<ui5-popover id="myPopover">My Popover</ui5-popover>
 
 	<script>
-
 		var myPopover = document.getElementById("myPopover");
 		
 		Array.from(document.querySelectorAll(".myBtn")).forEach(function (btn) {

--- a/packages/main/test/pages/styles/PopoverArrowBounds.css
+++ b/packages/main/test/pages/styles/PopoverArrowBounds.css
@@ -1,0 +1,45 @@
+.myBtn {
+	position: absolute;
+}
+
+#myBtn1 {
+	top: 0;
+	left: 0;
+}
+
+#myBtn2 {
+	top: 0;
+	right: 0;
+}
+
+#myBtn3 {
+	top: 50%;
+	left: 0;
+}
+
+#myBtn4 {
+	top: 50%;
+	right: 0;
+}
+
+#myBtn5 {
+	bottom: 0;
+	left: 0;
+}
+
+#myBtn6 {
+	bottom: 0;
+	right: 0;
+}
+
+#customSizeBtn {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+}
+
+.customSize {
+	height: 100px;
+	width: 100px;
+}


### PR DESCRIPTION
Part of #4581

The arrow of the Popover is now restricted within a range along each
dimension.  The border-radius of the Popover in the different themes is
considered.

This solves the issue where the Popover may be opened by a
small element placed at the corners of the viewport.
