### PR TITLE
feat: stable-dom-ref supported for abstract items

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-9Cw2r3iroIa9+t3zf9W9NFHa8/I=
+lg+vUkF4ZlVbMOpRYDqgaTP5Rvc=

--- a/packages/fiori/src/ShellBarItem.js
+++ b/packages/fiori/src/ShellBarItem.js
@@ -82,7 +82,7 @@ class ShellBarItem extends UI5Element {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 }
 

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -54,8 +54,8 @@
 			secondary-title="Second Title"
 			id="shellbarwithitems"
 	>
-		<ui5-shellbar-item icon="accelerated" text="Hello World!" title="Schedule"></ui5-shellbar-item>
-		<ui5-shellbar-item id="accept" icon="accept" text="Hello World!" title="Approve"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="accelerated" text="Hello World!" title="Schedule" stable-dom-ref="schedule"></ui5-shellbar-item>
+		<ui5-shellbar-item id="accept" icon="accept" text="Hello World!" title="Approve" stable-dom-ref="accept"></ui5-shellbar-item>
 		<ui5-shellbar-item id="warning" icon="alert" text="Hello World!" title="Warning"></ui5-shellbar-item>
 		<ui5-shellbar-item icon="discussion" text="Hello World!" count="42" title="42 Messages"></ui5-shellbar-item>
 		<ui5-shellbar-item icon="error" text="Hello World!" title="Attention"></ui5-shellbar-item>

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -57,6 +57,13 @@ describe("Component Behavior", () => {
 
 
 	describe("ui5-shellbar-item", async () => {
+		it("tests the stable-dom-ref attribute", async () => {
+			const shellbar = await browser.$("#shellbarwithitems");
+			const innerButtonWithStableDomRef = await shellbar.shadow$(`[data-ui5-stable="schedule"]`);
+
+			assert.ok(await innerButtonWithStableDomRef.isExisting(), "There is indeed an element in the Shellbar's shadow root with an attribute, matching the stable dom ref");
+		});
+
 		it("tests count property", async () => {
 			const shellbar = await browser.$("#shellbarwithitems");
 			const icon = await shellbar.shadow$("ui5-button[data-count]");

--- a/packages/main/src/BreadcrumbsItem.js
+++ b/packages/main/src/BreadcrumbsItem.js
@@ -94,7 +94,7 @@ class BreadcrumbsItem extends UI5Element {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 }
 

--- a/packages/main/src/MultiComboBoxItem.js
+++ b/packages/main/src/MultiComboBoxItem.js
@@ -34,7 +34,7 @@ class MultiComboBoxItem extends ComboBoxItem {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 }
 

--- a/packages/main/src/Option.js
+++ b/packages/main/src/Option.js
@@ -117,7 +117,7 @@ class Option extends UI5Element {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 }
 

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -196,7 +196,7 @@ class Tab extends UI5Element {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 
 	/**

--- a/packages/main/src/TabSeparator.js
+++ b/packages/main/src/TabSeparator.js
@@ -63,7 +63,7 @@ class TabSeparator extends UI5Element {
 	}
 
 	get stableDomRef() {
-		return `${this._id}-stable-dom-ref`;
+		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 
 	get stripPresentation() {

--- a/packages/theming/hash.txt
+++ b/packages/theming/hash.txt
@@ -1,1 +1,1 @@
-CQhk8M6oN0XzkZBkgImthR2kdTs=
+rZnyMTmoc2CFM82C+7zGHcw3GGY=


### PR DESCRIPTION
closes: https://github.com/SAP/ui5-webcomponents/issues/4593

This change allows developers to set stable DOM refs to abstract items via the `stable-dom-ref` attribute.

**Background:**
Currently, all abstract items that support the stable dom ref concept, form their stable dom refs as follows:
```js
`${this._id}-stable-dom-ref`
```
Then, developers can call `getDomRef()` on the abstract item:
```
shellBarItem.getDomRef(); // returns the ui5-button instance in the shadow root
```
The presumption is that developers should only call this method and should not care about how exactly the reference is constructed internally.

**The problem:**
There are scenarios, involving third-party services, that must rely solely on DOM APIs. Therefore, the `.getDomRef()` invocation solution is not always applicable. There must be a way for developers to explicitly set a `stable-dom-ref` attribute on an abstract item, and then be able to to find an element in the parent's shadow root with a matching `data-ui5-stable` selector 

**The solution**
If the developer sets a `stable-dom-ref` attribute on an abstract item, this same value will be used for the `data-ui5-stable` value of its physical counterpart in the parent's shadow root.
Therefore, the way stable dom ref is formed is now:
```js
this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref
```

**Example**:

Consider the following HTML:
```html
<ui5-shellbar>
	<ui5-shellbar-item icon="accelerated" text="Hello World!" stable-dom-ref="schedule"></ui5-shellbar-item>
</ui5-shellbar>
```

Then:
```js
document.querySelector("[ui5-shellbar]").shadowRoot.querySelector(`[data-ui5-stable="schedule"]`))
```

returns the `ui5-button` instance that represents the shellbar item.
