### PR TITLE
fix(ui5-media-gallery-item): add missing icon import

### DIFF
--- a/packages/fiori/src/MediaGalleryItem.js
+++ b/packages/fiori/src/MediaGalleryItem.js
@@ -3,6 +3,7 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import Icon from "@ui5/webcomponents/dist/Icon.js";
+import "@ui5/webcomponents-icons/dist/background.js";
 import MediaGalleryItemLayout from "./types/MediaGalleryItemLayout.js";
 // Template
 import MediaGalleryItemTemplate from "./generated/templates/MediaGalleryItemTemplate.lit.js";


### PR DESCRIPTION
The icon is used within the template, but not imported and may cause an error in apps that don't load the entire icons bundle, but import only the icons they use.