### PR TITLE
fix(ui5-title): replace custom heading CSS vars with SAP theming-base vars

### DIFF
--- a/packages/main/src/themes/base/Title-parameters.css
+++ b/packages/main/src/themes/base/Title-parameters.css
@@ -1,8 +1,8 @@
 :root {
-	--ui5_title_level_1Size: 1.625rem;
-	--ui5_title_level_2Size: 1.375rem;
-	--ui5_title_level_3Size: 1.250rem;
-	--ui5_title_level_4Size: 1.125rem;
-	--ui5_title_level_5Size: 1rem;
-	--ui5_title_level_6Size: 0.875rem;
+	--ui5_title_level_1Size: var(--sapFontHeader1Size);
+	--ui5_title_level_2Size: var(--sapFontHeader2Size);
+	--ui5_title_level_3Size: var(--sapFontHeader3Size);
+	--ui5_title_level_4Size: var(--sapFontHeader4Size);
+	--ui5_title_level_5Size: var(--sapFontHeader5Size);
+	--ui5_title_level_6Size: var(--sapFontHeader6Size);
 }


### PR DESCRIPTION
This PR replaces the custom heading level with the theme dependant `theming-base-content` CSS vars. 

I am not sure if this was implemented this way on purpose. If it was, feel free to close this PR, but please explain why it was implemented like this :) 