### PR TITLE
docs(ui5-media-gallery): fix types for `MediaGalleryLayouts`

### DIFF
--- a/packages/fiori/src/types/MediaGalleryLayout.js
+++ b/packages/fiori/src/types/MediaGalleryLayout.js
@@ -9,21 +9,21 @@ const MediaGalleryLayouts = {
 	/**
 	 * The layout is determined automatically.
 	 * @public
-	 * @type {Left}
+	 * @type {Auto}
 	 */
 	 Auto: "Auto",
 
 	/**
 	 * Displays the layout as a vertical split between the thumbnails list and the selected image.
 	 * @public
-	 * @type {Left}
+	 * @type {Vertical}
 	 */
 	Vertical: "Vertical",
 
 	/**
 	 * Displays the layout as a horizontal split between the thumbnails list and the selected image.
 	 * @public
-	 * @type {Right}
+	 * @type {Horizontal}
 	 */
 	Horizontal: "Horizontal",
 };


### PR DESCRIPTION
This PR replaces the `@type` annotations to the correct ones for `MediaGalleryLayouts`. 
The wrong annotations led to incorrect entries in our React wrapper implementation, which we fixed manually, so it is not urgent that the PR is merged.