### PR TITLE
fix: remove import.meta.url

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-szYyW44cZK3NGYhnSr0FnfBhiD8=
+U086uAbpTzMpjyqJA4gs6NyEWlE=

--- a/packages/base/src/Runtimes.js
+++ b/packages/base/src/Runtimes.js
@@ -1,6 +1,5 @@
 import VersionInfo from "./generated/VersionInfo.js";
 import getSharedResource from "./getSharedResource.js";
-import metaUrl from "./util/metaUrl.js"; // eslint-disable-line
 
 let currentRuntimeIndex;
 let currentRuntimeAlias = "";
@@ -22,7 +21,6 @@ const registerCurrentRuntime = () => {
 		currentRuntimeIndex = Runtimes.length;
 		Runtimes.push({
 			...VersionInfo,
-			url: metaUrl,
 			alias: currentRuntimeAlias,
 			description: `Runtime ${currentRuntimeIndex} - ver ${VersionInfo.version}${currentRuntimeAlias ? ` (${currentRuntimeAlias})` : ""}`,
 		});

--- a/packages/base/src/features/F6Navigation.js
+++ b/packages/base/src/features/F6Navigation.js
@@ -1,6 +1,6 @@
-import { registerFeature } from "../../dist/FeaturesRegistry.js";
-import { isF6Next, isF6Previous } from "../../dist/Keys.js";
-import { getFirstFocusableElement } from "../../dist/util/FocusableElements.js";
+import { registerFeature } from "../FeaturesRegistry.js";
+import { isF6Next, isF6Previous } from "../Keys.js";
+import { getFirstFocusableElement } from "../util/FocusableElements.js";
 
 class F6Navigation {
 	init() {

--- a/packages/base/src/util/metaUrl.js
+++ b/packages/base/src/util/metaUrl.js
@@ -1,3 +1,0 @@
-const metaUrl = import.meta.url;
-
-export default metaUrl;


### PR DESCRIPTION
`import.meta.url` breaks on webpack 4, and with webpack 5 gets resolved at build time to the file system path which is not the intended use of the feature.

Fixes: #4627