### PR TITLE
fix(ui5-breadcrumbs): provide accessible-name-ref to ui5-link

### DIFF
--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -19,9 +19,7 @@
             <li class="ui5-breadcrumbs-link-wrapper" @click="{{../_onLinkPress}}" 
                 id="{{this._id}}-link-wrapper">
                 
-                {{#if this.accessibleNameRef}}
-                    <span id="{{this.accessibleNameRef}}" class="ui5-hidden-text">{{this.accessibleName}}</span>
-                {{/if}}
+                <span id="{{this.accessibleNameRef}}" class="ui5-hidden-text">{{this._accessibleNameText}}</span>
 
                 <ui5-link
                     href="{{this.href}}"
@@ -36,7 +34,7 @@
 
         {{#if _endsWithCurrentLocationLabel}}
         <li class="ui5-breadcrumbs-current-location" @click="{{../_onLabelPress}}">
-            <span id={{this._id}}-labelWrapper>
+            <span aria-label="{{_currentLocationAccName}}" id={{this._id}}-labelWrapper>
                 <ui5-label
                     aria-current="page">
                     {{_currentLocationText}}

--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -18,11 +18,16 @@
         {{#each _linksData}}
             <li class="ui5-breadcrumbs-link-wrapper" @click="{{../_onLinkPress}}" 
                 id="{{this._id}}-link-wrapper">
+                
+                {{#if this.accessibleNameRef}}
+                    <span id="{{this.accessibleNameRef}}" class="ui5-hidden-text">{{this.accessibleName}}</span>
+                {{/if}}
+
                 <ui5-link
                     href="{{this.href}}"
                     target="{{this.target}}"
                     id="{{this._id}}-link"
-                    aria-label="{{this.accessibleName}}"
+                    accessible-name-ref="{{this.accessibleNameRef}}"
                     data-ui5-stable="{{this.stableDomRef}}">
                     {{this.innerText}}
                 </ui5-link>

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -516,7 +516,14 @@ class Breadcrumbs extends UI5Element {
 			items.pop();
 		}
 
-		return items.filter(item => this._isItemVisible(item));
+		// filter by visible and add accessible name ref property
+		return items.reduce((result, item) => {
+			if (this._isItemVisible(item)) {
+				item.accessibleNameRef = item.accessibleName ? `${item.id}-accessible-name-ref` : undefined;
+				result.push(item);
+			}
+			return result;
+		}, []);
 	}
 
 	/**

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -34,6 +34,9 @@ AVATAR_GROUP_MOVE=Press ARROW keys to move.
 #XACT: ARIA announcement for the badge
 BADGE_DESCRIPTION=Badge
 
+#XACT: position (current and max. value) of a Breadcrumb item which should be announced by screenreaders
+BREADCRUMB_ITEM_POS=Item {0} of {1}
+
 #XACT: ARIA announcement for the breadcrumbs
 BREADCRUMBS_ARIA_LABEL=Breadcrumb Trail
 

--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -1,3 +1,5 @@
+@import "./InvisibleTextStyles.css";
+
 .ui5-breadcrumbs-root {
     white-space: nowrap;
     outline: none;

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -59,7 +59,7 @@
 	<h2>Breadcrumbs with current location</h2>
 
 	<ui5-breadcrumbs id="breadcrumbs2">
-		<ui5-breadcrumbs-item href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
+		<ui5-breadcrumbs-item accessible-name="testing" href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link2</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link4</ui5-breadcrumbs-item>

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -59,7 +59,7 @@
 	<h2>Breadcrumbs with current location</h2>
 
 	<ui5-breadcrumbs id="breadcrumbs2">
-		<ui5-breadcrumbs-item accessible-name="testing" href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
+		<ui5-breadcrumbs-item href="https://www.sap.com">Link1 </ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="https://www.sap.com" target="_blank">Link2</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link3</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link4</ui5-breadcrumbs-item>

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -208,7 +208,7 @@ describe("Breadcrumbs general interaction", () => {
 		assert.strictEqual(await listItem.getProperty("accessibleName"), expectedAriaLabel, "label for first link is correct");
 	});
 
-	it.only("renders accessible names of non-overflowing link items", async () => {
+	it("renders accessible names of non-overflowing link items", async () => {
 		const breadcrumbs = await browser.$("#breadcrumbsWithAccName"),
 			link = (await breadcrumbs.shadow$$("ui5-link"))[3], // we take the 3rd link, because the first two overflow
 			expectedAccessibleNameRef = 'lastItemWithACCName-accessible-name-ref';

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -208,12 +208,12 @@ describe("Breadcrumbs general interaction", () => {
 		assert.strictEqual(await listItem.getProperty("accessibleName"), expectedAriaLabel, "label for first link is correct");
 	});
 
-	it("renders accessible names of non-overflowing link items", async () => {
+	it.only("renders accessible names of non-overflowing link items", async () => {
 		const breadcrumbs = await browser.$("#breadcrumbsWithAccName"),
-			link = (await breadcrumbs.shadow$$("ui5-link"))[3],
-			expectedAriaLabel = "last link acc name";
+			link = (await breadcrumbs.shadow$$("ui5-link"))[3], // we take the 3rd link, because the first two overflow
+			expectedAccessibleNameRef = 'lastItemWithACCName-accessible-name-ref';
 
 		// Check
-		assert.strictEqual(await link.getProperty("ariaLabel"), expectedAriaLabel, "label for last link is correct");
+		assert.strictEqual(await link.getProperty("accessibleNameRef"), expectedAccessibleNameRef, "label for last link is correct");
 	});
 });


### PR DESCRIPTION
Setting aria-label attribute to the `ui5-link` no longer works because the property was removed in favor of `accessible-name-ref`. 

With this change we introduce a span element with text content equals the accessible name and we pass it to the `ui5-link`
using the `accessible-name-ref` property.