### PR TITLE
fix(popovers): correct list items height of input dropdowns

### DIFF
--- a/packages/main/src/themes/SelectPopover.css
+++ b/packages/main/src/themes/SelectPopover.css
@@ -8,3 +8,7 @@
 	border-bottom-left-radius: var(--_ui5_select_option_focus_border_radius);
 	border-bottom-right-radius: var(--_ui5_select_option_focus_border_radius);
 }
+
+.ui5-select-popover [ui5-li] {
+	height: var(--_ui5_list_item_dropdown_base_height);
+}

--- a/packages/main/src/themes/Suggestions.css
+++ b/packages/main/src/themes/Suggestions.css
@@ -12,3 +12,8 @@
 	border-bottom-left-radius: var(--_ui5_suggestions_item_focus_border_radius);
 	border-bottom-right-radius: var(--_ui5_suggestions_item_focus_border_radius);
 }
+
+.ui5-suggestions-popover [ui5-li],
+.ui5-suggestions-popover [ui5-li-suggestion-item] {
+	height: var(--_ui5_list_item_dropdown_base_height);
+}

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -40,6 +40,7 @@
 	--_ui5_list_item_title_size: var(--sapFontLargeSize);
 	--_ui5_list_item_img_size: 3rem;
 	--_ui5_list_item_img_margin: 0.5rem 0.75rem 0.5rem 0rem;
+	--_ui5_list_item_dropdown_base_height: 2.5rem;
 	--_ui5_list_item_base_height: 2.75rem;
 	--_ui5_list_item_icon_size: 1.125rem;
 	--_ui5_list_item_selection_btn_margin_top: calc(-1 * var(--_ui5_checkbox_wrapper_padding));
@@ -197,6 +198,7 @@
 	--_ui5_list_item_cb_margin_right: .5rem;
 	--_ui5_list_item_title_size: var(--sapFontSize);
 	--_ui5_list_item_img_margin: 0.55rem 0.75rem 0.5rem 0rem;
+	--_ui5_list_item_dropdown_base_height: 2rem;
 	--_ui5_list_item_base_height: 2rem;
 	--_ui5_list_item_icon_size: 1rem;
 	--_ui5_list_item_selection_btn_margin_top: calc(-1 * var(--_ui5_checkbox_wrapper_padding));


### PR DESCRIPTION
List items of suggestion popovers are now aligned with FIori visual specification and have correct height of 2.5rem for Cozy and 2rem for Compact.

Fixes: #4616