### PR TITLE
feat(ui5-button): implement accessibilityAttributes property

### DIFF
--- a/docs/2-advanced/07-accessibility.md
+++ b/docs/2-advanced/07-accessibility.md
@@ -61,6 +61,7 @@ The mapping of the accessibility APIs to ARIA attributes is described in the fol
 | `accessibleNameRef`                           | `aria-label`    | Alternative for `aria-labelledby`. Receives ID (or many IDs) of the elements that serve as labels of the component. Those labels are passed as a concatenated string to the `aria-label` attribute. |
 | `accessibleRole`                              | `role`          | Sets the accessible aria role of the component.                                                                                                                                                     |
 | `accessibilityTexts` (`FlexibleColumnLayout`) | `aria-label`    | An object of strings that define several additional accessibility texts for further customization.                                                                                                  |
+| `accessibilityAttributes`                     | `aria-expanded`, `aria-haspopup`, `aria-controls`    | An object of strings that defines several additional accessibility attribute values for customization depending on the use case. |
 | `accessibilityRoles` (`FlexibleColumnLayout`) | `role`          | An object of strings that define several additional accessibility roles for further customization.                                                                                                  |
 | `required`                                    | `aria-required` | Defines whether the component is required.                                                                                                                                                          |
 | `readonly`                                    | `aria-readonly` | Defines whether the component is read-only.                                                                                                                                                         |
@@ -118,7 +119,7 @@ The `accessible-name-ref` property is currently supported in:
 
 ### accessibilityTexts
 
-This property accepts `object` with properties values for different parts of the FlexibleColumnLayout elements. For more detailed information on every object property, read the API description in [FlexibleColumnLayout](https://sap.github.io/ui5-webcomponents/playground/components/FlexibleColumnLayout). 
+This property accepts `object` with property values for different parts of the FlexibleColumnLayout elements. For more detailed information on every object property, read the API description in [FlexibleColumnLayout](https://sap.github.io/ui5-webcomponents/playground/components/FlexibleColumnLayout). 
 
 Setting the property on the custom element as:
 ```html
@@ -141,6 +142,33 @@ Will result in the shadow DOM as:
     </span>
     ...
 </div>
+```
+
+---
+
+### accessibilityAttributes
+
+This property accepts an `object` with property values, which will be used to generate additinal accessibility attributes to the root element. For more detailed information on every object property, read the API description in [Button](https://sap.github.io/ui5-webcomponents/playground/components/Button/). 
+
+Setting the property on the custom element as:
+```html
+<ui5-button id="button">...</ui5-button>
+<ui5-dialog id="dialogIdentificator">...</ui5-dialog>
+
+<script>
+    const component = document.getElemetnById("button");
+    component.accessibilityAttributes = {
+        hasPopup: "dialog",
+        controls: "dialogIdentificator"
+    };
+</script>
+```
+
+Will result in the shadow DOM as: 
+```html
+<button type="button" class="ui5-button-root" part="button" aria-controls="dialogIdentificator" aria-haspopup="dialog">
+	...
+</button>
 ```
 
 ---

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -112,7 +112,7 @@
 					data-ui5-stable="toggle-search"
 					@click={{_handleSearchIconPress}}
 					title="{{_searchText}}"
-					._buttonAccInfo="{{accInfo.search}}"
+					accessibilityAttributes={{accInfo.search.accessibilityAttributes}}
 				></ui5-button>
 			{{/if}}
 
@@ -141,7 +141,6 @@
 				data-ui5-notifications-count="{{notificationsCount}}"
 				@click={{_handleNotificationsPress}}
 				title="{{_notificationsText}}"
-				._buttonAccInfo="{{accInfo.notifications}}"
 				data-ui5-stable="notifications"
 			></ui5-button>
 			{{/if}}
@@ -153,7 +152,7 @@
 				icon="sap-icon://overflow"
 				@click="{{_handleOverflowPress}}"
 				title="{{_overflowText}}"
-				._buttonAccInfo="{{accInfo.overflow}}"
+				accessibilityAttributes={{accInfo.overflow.accessibilityAttributes}}
 				data-ui5-stable="overflow"
 			></ui5-button>
 
@@ -170,7 +169,6 @@
 				data-ui5-text="Product Switch"
 				@click={{_handleProductSwitchPress}}
 				title="{{_productsText}}"
-				._buttonAccInfo="{{accInfo.products}}"
 				data-ui5-stable="product-switch"
 			></ui5-button>
 			{{/if}}
@@ -185,7 +183,6 @@
 		@click={{_handleProfilePress}}
 		style="{{styles.items.profile}}"
 		title="{{_profileText}}"
-		._buttonAccInfo="{{accInfo.profile}}"
 		class="ui5-shellbar-button ui5-shellbar-image-button"
 		data-ui5-stable="profile"
 	>

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -112,7 +112,7 @@
 					data-ui5-stable="toggle-search"
 					@click={{_handleSearchIconPress}}
 					title="{{_searchText}}"
-					accessibilityAttributes={{accInfo.search.accessibilityAttributes}}
+					.accessibilityAttributes={{accInfo.search.accessibilityAttributes}}
 				></ui5-button>
 			{{/if}}
 
@@ -152,7 +152,7 @@
 				icon="sap-icon://overflow"
 				@click="{{_handleOverflowPress}}"
 				title="{{_overflowText}}"
-				accessibilityAttributes={{accInfo.overflow.accessibilityAttributes}}
+				.accessibilityAttributes={{accInfo.overflow.accessibilityAttributes}}
 				data-ui5-stable="overflow"
 			></ui5-button>
 

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -1168,23 +1168,16 @@ class ShellBar extends UI5Element {
 
 	get accInfo() {
 		return {
-			notifications: {
-				"title": this._notificationsText,
-			},
-			profile: {
-				"title": this._profileText,
-			},
-			products: {
-				"title": this._productsText,
-			},
 			search: {
-				"ariaExpanded": this.showSearchField,
-				"title": this._searchText,
+				"accessibilityAttributes": {
+					expanded: this.showSearchField,
+				},
 			},
 			overflow: {
-				"title": this._overflowText,
-				"ariaHaspopup": true,
-				"ariaExpanded": this._overflowPopoverExpanded,
+				"accessibilityAttributes": {
+					expanded: true,
+					hadPopup: this._overflowPopoverExpanded,
+				},
 			},
 		};
 	}

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -171,6 +171,15 @@ const metadata = {
 			multiple: true,
 		},
 
+		_menuPopoverExpanded: {
+			type: Boolean,
+			noAttribute: true,
+		},
+		_overflowPopoverExpanded: {
+			type: Boolean,
+			noAttribute: true,
+		},
+
 		_fullWidthSearch: {
 			type: Boolean,
 			noAttribute: true,
@@ -493,6 +502,22 @@ class ShellBar extends UI5Element {
 		this.fireEvent("logo-click", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-logo"),
 		});
+	}
+
+	_menuPopoverBeforeOpen() {
+		this._menuPopoverExpanded = true;
+	}
+
+	_menuPopoverAfterClose() {
+		this._menuPopoverExpanded = false;
+	}
+
+	_overflowPopoverBeforeOpen() {
+		this._overflowPopoverExpanded = true;
+	}
+
+	_overflowPopoverAfterClose() {
+		this._overflowPopoverExpanded = false;
 	}
 
 	_logoKeyup(event) {
@@ -1090,7 +1115,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get menuBtnHasPopup() {
-		return this.hasMenuItems ? true : undefined;
+		return this.hasMenuItems ? HasPopup.Menu : undefined;
 	}
 
 	get menuBtnTabindex() {
@@ -1098,7 +1123,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get menuPopoverExpanded() {
-		return HasPopup.Menu;
+		return this.hasMenuItems ? this._menuPopoverExpanded : undefined;
 	}
 
 	get _shellbarText() {
@@ -1165,6 +1190,7 @@ class ShellBar extends UI5Element {
 				"title": this._overflowText,
 				"accessibilityAttributes": {
 					hasPopup: HasPopup.Menu,
+					expanded: this._overflowPopoverExpanded,
 				},
 			},
 		};

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -10,6 +10,7 @@ import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
+import HasPopup from "@ui5/webcomponents/dist/types/HasPopup.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import "@ui5/webcomponents-icons/dist/search.js";
 import "@ui5/webcomponents-icons/dist/bell.js";
@@ -169,14 +170,7 @@ const metadata = {
 			type: String,
 			multiple: true,
 		},
-		_menuPopoverExpanded: {
-			type: Boolean,
-			noAttribute: true,
-		},
-		_overflowPopoverExpanded: {
-			type: Boolean,
-			noAttribute: true,
-		},
+
 		_fullWidthSearch: {
 			type: Boolean,
 			noAttribute: true,
@@ -499,22 +493,6 @@ class ShellBar extends UI5Element {
 		this.fireEvent("logo-click", {
 			targetRef: this.shadowRoot.querySelector(".ui5-shellbar-logo"),
 		});
-	}
-
-	_menuPopoverBeforeOpen() {
-		this._menuPopoverExpanded = true;
-	}
-
-	_menuPopoverAfterClose() {
-		this._menuPopoverExpanded = false;
-	}
-
-	_overflowPopoverBeforeOpen() {
-		this._overflowPopoverExpanded = true;
-	}
-
-	_overflowPopoverAfterClose() {
-		this._overflowPopoverExpanded = false;
 	}
 
 	_logoKeyup(event) {
@@ -1120,7 +1098,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get menuPopoverExpanded() {
-		return this.hasMenuItems ? this._menuPopoverExpanded : undefined;
+		return HasPopup.Menu;
 	}
 
 	get _shellbarText() {
@@ -1175,8 +1153,7 @@ class ShellBar extends UI5Element {
 			},
 			overflow: {
 				"accessibilityAttributes": {
-					expanded: true,
-					hadPopup: this._overflowPopoverExpanded,
+					hasPopup: HasPopup.Menu,
 				},
 			},
 		};

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -1146,12 +1146,23 @@ class ShellBar extends UI5Element {
 
 	get accInfo() {
 		return {
+			notifications: {
+				"title": this._notificationsText,
+			},
+			profile: {
+				"title": this._profileText,
+			},
+			products: {
+				"title": this._productsText,
+			},
 			search: {
+				"title": this._searchText,
 				"accessibilityAttributes": {
 					expanded: this.showSearchField,
 				},
 			},
 			overflow: {
+				"title": this._overflowText,
 				"accessibilityAttributes": {
 					hasPopup: HasPopup.Menu,
 				},

--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -1,5 +1,7 @@
 <ui5-popover class="ui5-shellbar-menu-popover"
 	placement-type="Bottom"
+	@ui5-before-open={{_menuPopoverBeforeOpen}}
+	@ui5-after-close={{_menuPopoverAfterClose}}
 >
 	<ui5-list separators="None" mode="SingleSelect" @ui5-selection-change={{_menuItemPress}}>
 		{{#each _menuPopoverItems}}
@@ -12,6 +14,8 @@
 	placement-type="Bottom"
 	horizontal-align="{{popoverHorizontalAlign}}"
 	hide-arrow
+	@ui5-before-open={{_overflowPopoverBeforeOpen}}
+	@ui5-after-close={{_overflowPopoverAfterClose}}
 >
 	<ui5-list separators="None" @ui5-item-click="{{_handleActionListClick}}">
 		{{#each _hiddenIcons}}

--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -1,7 +1,5 @@
 <ui5-popover class="ui5-shellbar-menu-popover"
 	placement-type="Bottom"
-	@ui5-before-open={{_menuPopoverBeforeOpen}}
-	@ui5-after-close={{_menuPopoverAfterClose}}
 >
 	<ui5-list separators="None" mode="SingleSelect" @ui5-selection-change={{_menuItemPress}}>
 		{{#each _menuPopoverItems}}
@@ -14,8 +12,6 @@
 	placement-type="Bottom"
 	horizontal-align="{{popoverHorizontalAlign}}"
 	hide-arrow
-	@ui5-before-open={{_overflowPopoverBeforeOpen}}
-	@ui5-after-close={{_overflowPopoverAfterClose}}
 >
 	<ui5-list separators="None" @ui5-item-click="{{_handleActionListClick}}">
 		{{#each _hiddenIcons}}

--- a/packages/main/src/AvatarGroup.hbs
+++ b/packages/main/src/AvatarGroup.hbs
@@ -17,7 +17,7 @@
 			<slot name="overflowButton"></slot>
 		{{else}}
 			<ui5-button
-				accessibilityAttributes="{{_overflowButtonAccAttributes}}"
+				.accessibilityAttributes="{{_overflowButtonAccAttributes}}"
 				aria-label="{{_overflowButtonAriaLabelText}}"
 				?hidden="{{_overflowBtnHidden}}"
 				?non-interactive={{_isGroup}}

--- a/packages/main/src/AvatarGroup.hbs
+++ b/packages/main/src/AvatarGroup.hbs
@@ -17,7 +17,7 @@
 			<slot name="overflowButton"></slot>
 		{{else}}
 			<ui5-button
-				._buttonAccInfo="{{_overflowButtonAccInfo}}"
+				accessibilityAttributes="{{_overflowButtonAccAttributes}}"
 				aria-label="{{_overflowButtonAriaLabelText}}"
 				?hidden="{{_overflowBtnHidden}}"
 				?non-interactive={{_isGroup}}

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -329,9 +329,9 @@ class AvatarGroup extends UI5Element {
 		return this._isGroup ? this._getAriaHasPopup() : undefined;
 	}
 
-	get _overflowButtonAccInfo() {
+	get _overflowButtonAccAttributes() {
 		return {
-			ariaHaspopup: this._isGroup ? undefined : this._getAriaHasPopup(),
+			hasPopup: this._isGroup ? undefined : this._getAriaHasPopup(),
 		};
 	}
 

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -15,11 +15,11 @@
 	@touchstart="{{_ontouchstart}}"
 	@touchend="{{_ontouchend}}"
 	tabindex={{tabIndexValue}}
-	aria-expanded="{{accInfo.ariaExpanded}}"
-	aria-controls="{{accInfo.ariaControls}}"
-	aria-haspopup="{{accInfo.ariaHaspopup}}"
+	aria-expanded="{{accessibilityAttributes.expanded}}"
+	aria-controls="{{accessibilityAttributes.controls}}"
+	aria-haspopup="{{accessibilityAttributes.hasPopup}}"
 	aria-label="{{ariaLabelText}}"
-	title="{{accInfo.title}}"
+	title="{{title}}"
 	part="button"
 >
 	{{#if icon}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -183,13 +183,35 @@ const metadata = {
 		},
 
 		/**
-		 * @type {String}
-		 * @defaultvalue ""
-		 * @private
-		 * @since 1.0.0-rc.8
+		 * An object of strings that defines several additional accessibility attribute values
+		 * for customization depending on the use case.
+		 *
+		 * It supports the following fields:
+		 *
+		 * <ul>
+		 * 		<li><code>expanded</code>: Indicates whether the button, or another grouping element it controls, is currently expanded or collapsed. Accepts the following string values:
+		 *			<ul>
+		 *				<li><code>true</code></li>
+		 *				<li><code>false</code></li>
+		 *			<ul>
+		 * 		</li>
+		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the button. Accepts the following string values:
+		 * 			<ul>
+		 *				<li><code>Dialog</code></li>
+		 *				<li><code>Grid</code></li>
+		 *				<li><code>ListBox</code></li>
+		 *				<li><code>Menu</code></li>
+		 *				<li><code>Tree</code></li>
+		 * 			</ul>
+		 * 		</li>
+		 * 		<li><code>controls</code>: Identifies the element (or elements) whose contents or presence are controlled by the button element. Accepts a string value.</li>
+		 * </ul>
+		 * @type {object}
+		 * @public
+		 * @since 1.1.0
 		 */
-		ariaExpanded: {
-			type: String,
+		accessibilityAttributes: {
+			type: Object,
 		},
 
 		/**
@@ -201,10 +223,6 @@ const metadata = {
 		},
 
 		_iconSettings: {
-			type: Object,
-		},
-
-		_buttonAccInfo: {
 			type: Object,
 		},
 
@@ -439,15 +457,6 @@ class Button extends UI5Element {
 			return node.nodeType !== Node.COMMENT_NODE
 			&& (node.nodeType !== Node.TEXT_NODE || node.nodeValue.trim().length !== 0);
 		}).length;
-	}
-
-	get accInfo() {
-		return {
-			"ariaExpanded": this.ariaExpanded || (this._buttonAccInfo && this._buttonAccInfo.ariaExpanded),
-			"ariaControls": this._buttonAccInfo && this._buttonAccInfo.ariaControls,
-			"ariaHaspopup": this._buttonAccInfo && this._buttonAccInfo.ariaHaspopup,
-			"title": this.title || (this._buttonAccInfo && this._buttonAccInfo.title),
-		};
 	}
 
 	static typeTextMappings() {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -208,7 +208,7 @@ const metadata = {
 		 * </ul>
 		 * @type {object}
 		 * @public
-		 * @since 1.1.0
+		 * @since 1.2.0
 		 */
 		accessibilityAttributes: {
 			type: Object,

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -27,7 +27,7 @@
 			icon="decline"
 			design="Transparent"
 			class="ui5-message-strip-close-button"
-			title="{{accInfo.button.title}}"
+			title="{{_closeButtonText}}"
 			@click={{_closeClick}}
 		></ui5-button>
 	{{/unless}}

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -27,7 +27,7 @@
 			icon="decline"
 			design="Transparent"
 			class="ui5-message-strip-close-button"
-			._buttonAccInfo="{{accInfo.button}}"
+			title="{{accInfo.button.title}}"
 			@click={{_closeClick}}
 		></ui5-button>
 	{{/unless}}

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -249,14 +249,6 @@ class MessageStrip extends UI5Element {
 	get designClasses() {
 		return MessageStrip.designClassesMappings()[this.design];
 	}
-
-	get accInfo() {
-		return {
-			"button": {
-				"title": this._closeButtonText,
-			},
-		};
-	}
 }
 
 MessageStrip.define();

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -24,7 +24,7 @@
 						class="ui5-panel-header-button {{classes.headerBtn}}"
 						icon="slim-arrow-right"
 						@click="{{_toggleButtonClick}}"
-						accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
+						.accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
 						title="{{accInfo.button.title}}"
 						accessible-name="{{accInfo.button.ariaLabelButton}}"
 					></ui5-button>

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -24,7 +24,8 @@
 						class="ui5-panel-header-button {{classes.headerBtn}}"
 						icon="slim-arrow-right"
 						@click="{{_toggleButtonClick}}"
-						._buttonAccInfo="{{accInfo.button}}"
+						accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
+						title="{{accInfo.button.title}}"
 						accessible-name="{{accInfo.button.ariaLabelButton}}"
 					></ui5-button>
 				{{else}}

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -175,10 +175,6 @@ const metadata = {
 			type: Boolean,
 			noAttribute: true,
 		},
-
-		_buttonAccInfo: {
-			type: Object,
-		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Panel.prototype */ {
 
@@ -409,8 +405,10 @@ class Panel extends UI5Element {
 	get accInfo() {
 		return {
 			"button": {
-				"ariaExpanded": this.expanded,
-				"ariaControls": `${this._id}-content`,
+				"accessibilityAttributes": {
+					"expanded": this.expanded,
+					"controls": `${this._id}-content`,
+				},
 				"title": this.toggleButtonTitle,
 				"ariaLabelButton": !this.nonFocusableButton && this.useAccessibleNameForToggleButton ? this.effectiveAccessibleName : undefined,
 			},

--- a/packages/main/src/SegmentedButtonItem.hbs
+++ b/packages/main/src/SegmentedButtonItem.hbs
@@ -20,7 +20,7 @@
 		@touchend="{{_ontouchend}}"
 		tabindex={{tabIndexValue}}
 		aria-label="{{ariaLabelText}}"
-		title="{{accInfo.title}}"
+		title="{{title}}"
 >
 	{{#if icon}}
 		<ui5-icon

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -29,7 +29,7 @@
 	<ui5-icon name="invalid_name"></ui5-icon>
 	<ui5-button design="Emphasized" icon="invalid_name">Press</ui5-button>
 
-	<ui5-button id="button1" design="Emphasized" aria-expanded="true">Action Bar Button</ui5-button>
+	<ui5-button id="button1" design="Emphasized">Action Bar Button</ui5-button>
 	<ui5-button class="button2auto">Primary <br> button</ui5-button>
 	<ui5-button class="button2auto button3auto" design="Transparent">Secondary <span >button</span></ui5-button>
 	<ui5-button disabled id="button-disabled">Inactive</ui5-button>
@@ -189,6 +189,39 @@
 	<ui5-button icon="alert" title="Fire an alert"></ui5-button>
 	<ui5-button icon="arrow-down" title="Go down"></ui5-button>
 
+	<br/>
+	<br/>
+
+	<ui5-button id="openDialogButton" design="Emphasized">Show Registration Dialog</ui5-button>
+
+		<ui5-dialog id="registration-dialog" header-text="Register Form">
+			<section class="login-form">
+				<div>
+					<ui5-label for="username" required>Username: </ui5-label>
+					<ui5-input id="username"></ui5-input>
+				</div>
+
+				<div>
+					<ui5-label for="password" required>Password: </ui5-label>
+					<ui5-input id="password" type="Password" value-state="Error"></ui5-input>
+				</div>
+
+				<div>
+					<ui5-label for="email" type="Email" required>Email: </ui5-label>
+					<ui5-input id="email"></ui5-input>
+				</div>
+
+				<div>
+					<ui5-label for="address">Address: </ui5-label>
+					<ui5-input id="address"></ui5-input>
+				</div>
+			</section>
+
+			<div slot="footer">
+				<div style="flex: 1;"></div>
+				<ui5-button id="closeDialogButton" design="Emphasized">Register</ui5-button>
+			</div>
+		</ui5-dialog>
     <script>
 		var clickCounter = document.querySelector("#click-counter");
 		var button = document.querySelector("#button1");
@@ -200,6 +233,33 @@
 				clickCount += 1;
 				clickCounter.value = clickCount;
 			});
+		});
+
+		button.accessibilityAttributes = {
+			expanded: "true"
+		};
+
+		button.addEventListener("click", function(event) {
+			button.accessibilityAttributes = {
+				expanded: button.accessibilityAttributes.expanded === "true" ? "false" : "true"
+			};
+		});
+
+		var dialogOpener = document.getElementById("openDialogButton");
+		var dialog = document.getElementById("registration-dialog");
+		var dialogCloser = document.getElementById("closeDialogButton");
+
+		dialogOpener.accessibilityAttributes = {
+			hasPopup: "dialog",
+			controls: dialog.id,
+		}
+
+		dialogOpener.addEventListener("click", function() {
+			dialog.show();
+		});
+
+		dialogCloser.addEventListener("click", function() {
+			dialog.close();
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/styles/Button.css
+++ b/packages/main/test/pages/styles/Button.css
@@ -25,3 +25,18 @@
 .button4auto {
     width: 6rem;
 }
+
+.login-form {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	align-items: flex-start;
+	margin: 3rem 6rem;
+}
+
+.login-form > div {
+	display: grid;
+	width: 15rem;
+	margin-bottom: .5rem;
+}
+

--- a/packages/main/test/samples/Dialog.sample.html
+++ b/packages/main/test/samples/Dialog.sample.html
@@ -45,6 +45,11 @@
 			var dialog = document.getElementById("hello-dialog");
 			var dialogCloser = document.getElementById("closeDialogButton");
 
+			dialogOpener.accessibilityAttributes = {
+				hasPopup: "dialog",
+				controls: dialog.id,
+			}
+
 			dialogOpener.addEventListener("click", function() {
 				dialog.show();
 			});
@@ -91,6 +96,11 @@
 	var dialog = document.getElementById("hello-dialog");
 	var dialogCloser = document.getElementById("closeDialogButton");
 
+	dialogOpener.accessibilityAttributes = {
+		hasPopup: "dialog",
+		controls: dialog.id,
+	}
+
 	dialogOpener.addEventListener("click", function() {
 		dialog.show();
 	});
@@ -129,6 +139,11 @@
 		var dialog2 = document.getElementById("resize-draggable-dialog");
 		var dialogOpener2 = document.getElementById("resizable-draggable-open");
 		var dialogCloser2 = document.getElementById("resizable-drggable-close");
+
+		dialogOpener2.accessibilityAttributes = {
+			hasPopup: "dialog",
+			controls: dialog2.id,
+		}
 	
 		dialogOpener2.addEventListener("click", function() {
 			dialog2.show();

--- a/packages/main/test/specs/AvatarGroup.spec.js
+++ b/packages/main/test/specs/AvatarGroup.spec.js
@@ -149,12 +149,12 @@ describe("ARIA attributes", () => {
 		it("aria-haspopup is correct", async () => {
 			const avatarGroup = await browser.$("#avatar-group-individual");
 			const ariaHasPopupContainer = await avatarGroup.getProperty("_containerAriaHasPopup");
-			const overflowButtonAccInfo = await avatarGroup.getProperty("_overflowButtonAccInfo");
+			const overflowButtonAccAttributes = await avatarGroup.getProperty("_overflowButtonAccAttributes");
 
 			// container
 			assert.notExists(ariaHasPopupContainer, "should not have aria-haspopup attribute");
 			// overflow button
-			assert.strictEqual(overflowButtonAccInfo.ariaHaspopup, "menu", "overflow button should have aria-haspopup for type individual");
+			assert.strictEqual(overflowButtonAccAttributes.hasPopup, "menu", "overflow button should have aria-haspopup for type individual");
 		});
 
 		it("aria-label is correct", async () => {
@@ -190,12 +190,12 @@ describe("ARIA attributes", () => {
 		it("aria-haspopup is correct", async () => {
 			const avatarGroup = await browser.$("#avatar-group-group");
 			const ariaHasPopupContainer = await avatarGroup.getProperty("_containerAriaHasPopup");
-			const overflowButtonAccInfo = await avatarGroup.getProperty("_overflowButtonAccInfo");
+			const overflowButtonAccAttributes = await avatarGroup.getProperty("_overflowButtonAccAttributes");
 
 			// container
 			assert.strictEqual(ariaHasPopupContainer, "menu", "should have 'menu' set to aria-haspopup attribute");
 			// overflow button
-			assert.notExists(overflowButtonAccInfo.ariaHaspopup, "overflow button should not have aria-haspopup for type group");
+			assert.notExists(overflowButtonAccAttributes.ariaHaspopup, "overflow button should not have aria-haspopup for type group");
 		});
 
 		it("aria-label is correct", async () => {

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -81,19 +81,23 @@ describe("Button general interaction", () => {
 		assert.strictEqual(await field.getProperty("value"), "6", "click should be called 6 times");
 	});
 
-	it("setting aria-expanded on the host is reflected on the button tag", async () => {
+	it("aria-expanded is properly applied on the button tag", async () => {
 		const button = await browser.$("#button1");
 		const innerButton = await button.shadow$("button");
 
 		assert.strictEqual(await innerButton.getAttribute("aria-expanded"), "true", "Attribute is reflected");
 
-		await button.setAttribute("aria-expanded", "false");
+		await button.click();
 
 		assert.strictEqual(await innerButton.getAttribute("aria-expanded"), "false", "Attribute is reflected");
+	});
 
-		await button.removeAttribute("aria-expanded");
+	it("aria-haspopup and aira-controls are properly applied on the button tag", async () => {
+		const button = await browser.$("#openDialogButton");
+		const innerButton = await button.shadow$("button");
 
-		assert.strictEqual(await innerButton.getAttribute("aria-expanded"), null, "Attribute is reflected");
+		assert.strictEqual(await innerButton.getAttribute("aria-haspopup"), "dialog", "Attribute is reflected");
+		assert.strictEqual(await innerButton.getAttribute("aria-controls"), "registration-dialog", "Attribute is reflected");
 	});
 
 	it("setting accessible-name-ref on the host is reflected on the button tag", async () => {


### PR DESCRIPTION
The ui5-button component now supports 'accessibilityAttributes' property,
which enables users to supply additional accessibility attributes for
the button element.
A standard use case would be to provide the corresponding accessibility attributes
for a button opening a popover or a dialog.

Related to: #3546