### PR TITLE
fix(ui5-switch): adjust focus outline

### DIFF
--- a/packages/main/src/themes/base/Switch-parameters.css
+++ b/packages/main/src/themes/base/Switch-parameters.css
@@ -3,26 +3,16 @@
 	--_ui5_switch_height: 2.75rem;
 	--_ui5_switch_width: 3.875rem;
 	--_ui5_switch_no_label_width: 3.25rem;
-	--_ui5_switch_no_label_width_horizon: 3.875rem;
 
 	--_ui5_switch_root_outline_top_bottom: 0.25rem;
-	--_ui5_switch_root_outline_left_right: -0.125rem;
-	--_ui5_switch_root_outline_top_bottom_horizon: 0.3125rem;
-	--_ui5_switch_root_outline_left_right_horizon: -0.0625rem;
-	--_ui5_switch_root_outline_top_bottom_hcb: 0.1875rem;
-	--_ui5_switch_root_outline_left_right_hcb: -0.1875rem;
+	--_ui5_switch_root_outline_left_right: 0;
 
 	--_ui5_switch_compact_height: 2rem;
 	--_ui5_switch_compact_width: 3.5rem;
 	--_ui5_switch_compact_no_label_width: 2.5rem;
-	--_ui5_switch_compact_no_label_width_horizon: 3.5rem;
 
 	--_ui5_switch_compact_root_outline_top_bottom: 0.0625rem;
-	--_ui5_switch_compact_root_outline_left_right: -0.125rem;
-	--_ui5_switch_compact_root_outline_top_bottom_horizon: 0.125em;
-	--_ui5_switch_compact_root_outline_left_right_horizon: -0.125rem;
-	--_ui5_switch_compact_root_outline_top_bottom_hcb: 0;
-	--_ui5_switch_compact_root_outline_left_right_hcb: -0.1875rem;
+	--_ui5_switch_compact_root_outline_left_right: 0;
 	
 	--_ui5_switch_foucs_border_size: 1px;
 	--_ui5_switch_focus_outline: var(--_ui5_switch_foucs_border_size) dotted var(--sapContent_FocusColor);
@@ -36,7 +26,6 @@
 	/* switch track */
 	--_ui5_switch_track_height: 1.375rem;
 	--_ui5_switch_track_no_label_height: 1.25rem;
-	--_ui5_switch_track_no_label_height_horizont:var(--_ui5_switch_track_height);
 	--_ui5-switch-track-border: 1px solid;
 	--_ui5-switch-track-border_color: var(--sapContent_ForegroundBorderColor);
 	--_ui5-switch_handle-off-hover_box_shadow: none;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -234,16 +234,11 @@
 	--_ui5_switch_text_on_left: calc(-100% + 1.5625rem);
 	--_ui5_switch_slide_transform: translateX(100%) translateX(-1.5rem);
 	--_ui5_switch_no_label_width: var(--_ui5_switch_compact_no_label_width);
-	--_ui5_switch_no_label_width_horizon: var(--_ui5_switch_compact_no_label_width_horizon);
 	--_ui5_switch_rtl_transform: translateX(-100%) translateX(1.5rem);
 	--_ui5_switch_text_right: calc(-100% + 1.5625rem);
 
 	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom);
 	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right);
-	--_ui5_switch_root_outline_top_bottom_horizon: var(--_ui5_switch_compact_root_outline_top_bottom_horizon);
-	--_ui5_switch_root_outline_left_right_horizon: var(--_ui5_switch_compact_root_outline_left_right_horizon);
-	--_ui5_switch_root_outline_top_bottom_hcb: var(--_ui5_switch_compact_root_outline_top_bottom_hcb);
-	--_ui5_switch_root_outline_left_right_hcb: var(--_ui5_switch_compact_root_outline_left_right_hcb);
 
 	--_ui5_tc_item_text: 2rem;
 	--_ui5_tc_item_text_line_height: 1.325rem;

--- a/packages/main/src/themes/sap_belize_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Switch-parameters.css
@@ -3,7 +3,6 @@
 :root {
 	/* Switch */
 	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
-	--_ui5_switch_root_outline_left_right: 0;
 	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;

--- a/packages/main/src/themes/sap_belize_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Switch-parameters.css
@@ -2,10 +2,9 @@
 
 :root {
 	/* Switch */
-	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_root_outline_top_bottom_hcb);
-	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_root_outline_left_right_hcb);
-	--_ui5_switch_compact_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom_hcb);
-	--_ui5_switch_compact_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right_hcb);
+	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
+	--_ui5_switch_root_outline_left_right: 0;
+	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;
 	--_ui5_switch_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);

--- a/packages/main/src/themes/sap_belize_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/Switch-parameters.css
@@ -3,7 +3,6 @@
 :root {
 	/* Switch */
 	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
-	--_ui5_switch_root_outline_left_right: 0;
 	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;

--- a/packages/main/src/themes/sap_belize_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/Switch-parameters.css
@@ -2,10 +2,9 @@
 
 :root {
 	/* Switch */
-	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_root_outline_top_bottom_hcb);
-	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_root_outline_left_right_hcb);
-	--_ui5_switch_compact_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom_hcb);
-	--_ui5_switch_compact_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right_hcb);
+	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
+	--_ui5_switch_root_outline_left_right: 0;
+	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;
 	--_ui5_switch_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);

--- a/packages/main/src/themes/sap_fiori_3_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Switch-parameters.css
@@ -3,7 +3,6 @@
 :root {
 	/* Switch */
 	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
-	--_ui5_switch_root_outline_left_right: 0;
 	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;

--- a/packages/main/src/themes/sap_fiori_3_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Switch-parameters.css
@@ -2,10 +2,9 @@
 
 :root {
 	/* Switch */
-	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_root_outline_top_bottom_hcb);
-	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_root_outline_left_right_hcb);
-	--_ui5_switch_compact_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom_hcb);
-	--_ui5_switch_compact_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right_hcb);
+	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
+	--_ui5_switch_root_outline_left_right: 0;
+	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;
 	--_ui5_switch_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);

--- a/packages/main/src/themes/sap_fiori_3_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Switch-parameters.css
@@ -3,7 +3,6 @@
 :root {
 	/* Switch */
 	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
-	--_ui5_switch_root_outline_left_right: 0;
 	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;

--- a/packages/main/src/themes/sap_fiori_3_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Switch-parameters.css
@@ -2,10 +2,9 @@
 
 :root {
 	/* Switch */
-	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_root_outline_top_bottom_hcb);
-	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_root_outline_left_right_hcb);
-	--_ui5_switch_compact_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom_hcb);
-	--_ui5_switch_compact_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right_hcb);
+	--_ui5_switch_root_outline_top_bottom: 0.1875rem;
+	--_ui5_switch_root_outline_left_right: 0;
+	--_ui5_switch_compact_root_outline_top_bottom: 0;
 	--_ui5_switch_foucs_size: 0.125rem;
 	--_ui5_switch_root_after_outline: none;
 	--_ui5_switch_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);

--- a/packages/main/src/themes/sap_horizon/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Switch-parameters.css
@@ -8,10 +8,10 @@
 
 	--_ui5_switch_root_after_boreder: none;
 	--_ui5_switch_focus_outline:none;
-	--_ui5_switch_root_outline_top_bottom: var(--_ui5_switch_root_outline_top_bottom_horizon);
-	--_ui5_switch_root_outline_left_right: var(--_ui5_switch_root_outline_left_right_horizon);
-	--_ui5_switch_compact_root_outline_top_bottom: var(--_ui5_switch_compact_root_outline_top_bottom_horizon);
-	--_ui5_switch_compact_root_outline_left_right: var(--_ui5_switch_compact_root_outline_left_right_horizon);
+	--_ui5_switch_root_outline_top_bottom: 0.3125rem;
+	--_ui5_switch_root_outline_left_right: 0.125rem;
+	--_ui5_switch_compact_root_outline_top_bottom: 0.125rem;
+	--_ui5_switch_compact_root_outline_left_right: 0.125rem;
 	--_ui5_switch_root_after_boreder_radius: 0.25rem;
 	--_ui5_switch_handle_semantic_checked_hover_bg: var(--_ui5_switch_handle_checked_bg);
 	--_ui5_switch_handle_semantic_hover_bg: var(--_ui5_switch_handle_checked_bg);
@@ -21,9 +21,9 @@
 	--_ui5_switch_track_semantic_not_checked_border_color: transparent;
 	--_ui5_switch_track_semantic_checked_hover_border_color: transparent;
 	--_ui5_switch_track_semantic_hover_border_color:transparent;
-	--_ui5_switch_no_label_width: var(--_ui5_switch_no_label_width_horizon);
-	--_ui5_switch_compact_no_label_width: var(--_ui5_switch_compact_no_label_width_horizon);
-	--_ui5_switch_track_no_label_height: var(--_ui5_switch_track_no_label_height_horizont);
+	--_ui5_switch_no_label_width: 3.875rem;
+	--_ui5_switch_compact_no_label_width: 3.5rem;
+	--_ui5_switch_track_no_label_height: var(--_ui5_switch_track_height);
 	--_ui5_switch_handle_hover_border_color: transparent;
 	--_ui5-switch-track-icon-display: inline-block;
 	--_ui5-switch_handle-off-hover_box_shadow: var(--sapContent_Interaction_Shadow);

--- a/packages/main/src/themes/sap_horizon_exp/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/Switch-parameters.css
@@ -15,7 +15,7 @@
 	--_ui5-switch-root-box-shadow: 0 0 2px rgb(27 144 255 / 16%), 0 8px 16px rgb(27 144 255 / 16%);
 	--_ui5-switch-focus: none;
 	--_ui5_switch_root_outline_top_bottom: -0.25rem;
-	--_ui5_switch_root_outline_left_right: -0.25rem;
+	--_ui5_switch_root_outline_left_right: 0.125rem;;
 	--_ui5_switch_root_after_boreder_radius: 2rem;
 	--_ui5_switch_track_no_label_height: 24px;
 	--_ui5_switch_track_height: 24px;


### PR DESCRIPTION
The ui5-switch component focus outline is drawn
with the help of a pseudo element. This pseudo
element is displayed bigger than the actual
ui5-switch root element. As a result the focus
outline could get cut off.

Related to: #2925
