### PR TITLE
fix(ui5-li-tree): correct usage of i18nBudnle

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-mynJJ8iqCJTPTtaBHwQ5V8swDaA=
+uKfEt82uNaFhQO8HDwOUDAd2Q+s=

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -331,7 +331,10 @@ class TreeListItem extends ListItem {
 	}
 
 	static async onDefine() {
-		TreeListItem.i18nBundle = await getI18nBundle("@ui5/webcomponents");
+		[TreeListItem.i18nBundle] = await Promise.all([
+			getI18nBundle("@ui5/webcomponents"),
+			super.onDefine(),
+		]);
 	}
 }
 


### PR DESCRIPTION
ListItem is extended by TreeListItem. ListItem has its own onDefine method which is not called by TreeListItem's onDefine method which leads to errors when `ui5-li-tree` is used and ListItem is not imported separately.

Solution is based on: #4128 

Fixes: #4667 