### PR TITLE
chore: fix docs and tag misuse in CSS

### DIFF
--- a/packages/fiori/README.md
+++ b/packages/fiori/README.md
@@ -14,8 +14,11 @@ such as a common header (ShellBar).
 |-------------------------------------------|--------------------------------|-----------------------------------------------------------------------|
 | Bar                                       | `ui5-bar`                      | `import "@ui5/webcomponents-fiori/dist/Bar.js";`                      |
 | Barcode Scanner Dialog                    | `ui5-barcode-scanner-dialog`   | `import "@ui5/webcomponents-fiori/dist/BarcodeScannerDialog.js";`     |
+| Dynamic Side Content                      | `ui5-dynamic-side-content`     | `import "@ui5/webcomponents-fiori/dist/DynamicSideContent.js";`       |
 | Flexible Column Layout                    | `ui5-flexible-column-layout`   | `import "@ui5/webcomponents-fiori/dist/FlexibleColumnLayout.js";`     |
 | Illustrated Message                       | `ui5-illustrated-message`      | `import "@ui5/webcomponents-fiori/dist/IllustratedMessage.js";`       |
+| Media Gallery                             | `ui5-media-gallery`            | `import "@ui5/webcomponents-fiori/dist/MediaGallery.js";`             |
+| Media Gallery Item                        | `ui5-media-gallery-item`       | comes with  `ui5-media-gallery`                                       |
 | Notification List Item                    | `ui5-li-notifcation`           | `import "@ui5/webcomponents-fiori/dist/NotifcationListItem.js";`      |
 | Notification Group List Item              | `ui5-li-notification-group`    | `import "@ui5/webcomponents-fiori/dist/NotifcationListGroupItem.js";` |
 | Notification Action                       | `ui5-notification-action`      | `import "@ui5/webcomponents-fiori/dist/NotificationAction.js";`       |

--- a/packages/fiori/src/MediaGalleryItem.js
+++ b/packages/fiori/src/MediaGalleryItem.js
@@ -165,7 +165,7 @@ const metadata = {
  * </ul>
  *
  * <h3>ES6 Module Import</h3>
- * <code>import "@ui5/webcomponents-fiori/dist/MediaGalleryItem.js";</code>
+ * <code>import "@ui5/webcomponents-fiori/dist/MediaGalleryItem.js";</code> (comes with <code>ui5-media-gallery</code>)
  *
  * @constructor
  * @author SAP SE

--- a/packages/main/README.md
+++ b/packages/main/README.md
@@ -61,6 +61,7 @@ Provides general purpose UI building blocks such as buttons, labels, inputs and 
 | Select                   | `ui5-select`                | `import "@ui5/webcomponents/dist/Select.js";`              |
 | Select Option            | `ui5-option`                | comes with `ui5-select `                                   |
 | Slider                   | `ui5-slider`                | `import "@ui5/webcomponents/dist/Slider.js";`              |
+| Split Button             | `ui5-split-button`          | `import "@ui5/webcomponents/dist/SplitButton.js";`         |
 | Step Input               | `ui5-step-input`            | `import "@ui5/webcomponents/dist/StepInput.js";`           |
 | Suggestion Item          | `ui5-suggestion-item`       | comes with `InputSuggestions.js` feature - see below       |
 | Switch                   | `ui5-switch`                | `import "@ui5/webcomponents/dist/Switch.js";`              |

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -267,7 +267,7 @@ const metadata = {
  * <h3>ES6 Module Import</h3>
  * <code>import "@ui5/webcomponents/dist/Select";</code>
  * <br>
- * <code>import "@ui5/webcomponents/dist/Option";</code>
+ * <code>import "@ui5/webcomponents/dist/Option";</code> (comes with <code>ui5-select</code>)
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Select

--- a/packages/main/src/SplitButton.js
+++ b/packages/main/src/SplitButton.js
@@ -251,8 +251,8 @@ const metadata = {
  * the style to provide visual feedback to the user that it is pressed or hovered over with
  * the mouse cursor. A disabled <code>ui5-split-button</code> appears inactive and any of the two buttons
  * cannot be pressed.
- * <br><br>
- * <b>Keyboard handing</b>
+ *
+ * <h3>Keyboard Handling</h3>
  * <ul>
  * <li><code>Space</code> or <code>Enter</code> - triggers the default action</li>
  * <li><code>Shift</code> or <code>Escape</code> - if <code>Space</code> is pressed, releases the default action button without triggering the click event.</li>
@@ -261,6 +261,7 @@ const metadata = {
  * <ul>
  * <li><code>click</code> for the first button (default action)</li>
  * <li><code>arrow-click</code> for the second button (arrow action)</li>
+ * </ul>
  * </ul>
  *
  * <h3>ES6 Module Import</h3>

--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -58,7 +58,7 @@
 	border-radius: var(--_ui5_button_border_radius);
 }
 
-:host([design="Emphasized"]) ui5-button[focused] {
+:host([design="Emphasized"]) [ui5-button][focused] {
 	outline-color: transparent;
 }
 

--- a/packages/main/test/samples/ColorPalette.sample.html
+++ b/packages/main/test/samples/ColorPalette.sample.html
@@ -1,5 +1,8 @@
-<header>
+<header class="component-heading">
 	<h2 class="control-header">ColorPalette</h2>
+	<div class="component-heading-since">
+		<span><!--since_tag_marker--></span>
+	</div>
 </header>
 
 <div class="component-package">@ui5/webcomponents</div>


### PR DESCRIPTION
- fix SplitButton styles - it relies on ui5-button, instead of the system [ui5-button] attribute, breaking the scoping case.
- fix some issues in the SplitButton's Overview section
- update public module imports
