### PR TITLE
feat(jsdoc): remove attr name for Object props

### DIFF
--- a/docs/5-development/03-understanding-components-metadata.md
+++ b/docs/5-development/03-understanding-components-metadata.md
@@ -61,7 +61,7 @@ Properties of type `Object`, properties with `multiple` set to`true` and propert
 | `type`         | Property type                | N/A       | The type of the property. For more information on types see the table below.                                  |
 | `defaultValue` | Any valid value for the type | undefined | Default value of the property. Cannot be set for type "Boolean". Booleans are always false by default in HTML.|
 | `multiple`     | Boolean                      | false     | Indicates whether the property represents a single value or is an array of values of the given type.          |
-| `noAttribute`  | Boolean                      | false     | No attribute equivalent will be created for that property. Always false for properties of type Object.        |
+| `noAttribute`  | Boolean                      | false     | No attribute equivalent will be created for that property. Always true for properties of type Object.        |
 
 The `type` setting is required.
 

--- a/packages/tools/lib/documentation/templates/api-properties-section.js
+++ b/packages/tools/lib/documentation/templates/api-properties-section.js
@@ -21,7 +21,9 @@ module.exports = {
               {{/if}}
                 <br>
               {{#if (toKebabCase this.name)}}
-                <code>{{toKebabCase this.name}}</code>
+                  {{#unless this.noattribute}}
+                     <code>{{toKebabCase this.name}}</code>
+                 {{/unless}}
               {{/if}}
             </div>
             <div class="cell api-table-content-cell">{{this.type}}</div>

--- a/packages/tools/lib/jsdoc/plugin.js
+++ b/packages/tools/lib/jsdoc/plugin.js
@@ -33,6 +33,8 @@
  *
  *   native
  *
+ *   noattribute
+ *
  *   allowPreventDefault
  *
  * It furthermore listens to the following JSDoc3 events to implement additional functionality
@@ -2097,6 +2099,13 @@ exports.defineTags = function(dictionary) {
 		mustHaveValue: false,
 		onTagged: function(doclet, tag) {
 			doclet.native = true;
+		}
+	});
+
+	dictionary.defineTag('noattribute', {
+		mustHaveValue: false,
+		onTagged: function(doclet, tag) {
+			doclet.noattribute = true;
 		}
 	});
 };

--- a/packages/tools/lib/jsdoc/template/publish.js
+++ b/packages/tools/lib/jsdoc/template/publish.js
@@ -2804,6 +2804,10 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 						attrib("export", undefined, '', true);
 					}
 
+					if (member.noattribute) {
+						attrib("noattribute", true);
+					}
+
 					if (member.readonly) {
 						attrib("readonly", member.readonly, null);
 					}
@@ -2815,7 +2819,14 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 					if ( member.since ) {
 						attrib("since", extractVersion(member.since));
 					}
-					attrib("type", listTypes(member.type));
+
+					var type = listTypes(member.type);
+					attrib("type", type);
+
+					if ((type === "object" || type === "Object") && visibility(member) === "public") {
+						attrib("noattribute", true);
+					}
+
 					tag("description", normalizeWS(member.description), true);
 					if (member.defaultvalue) {
 						attrib("defaultValue", member.defaultvalue);
@@ -3854,7 +3865,7 @@ function createAPIJS(symbols, filename) {
 
 	var output = [];
 
-	var rkeywords = /^(?:abstract|as|boolean|break|byte|case|catch|char|class|continue|const|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|is|long|namespace|native|new|null|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|use|var|void|volatile|while|with)$/;
+	var rkeywords = /^(?:abstract|as|boolean|break|byte|case|catch|char|class|continue|const|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|is|long|namespace|native|new|null|noattribute|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|use|var|void|volatile|while|with)$/;
 
 	function isNoKeyword($) { return !rkeywords.test($.name); }
 


### PR DESCRIPTION
With this change we enhance the JSDOC parser to automatically omit attribute names for properties of type "Object" or "object". The code literally checks if the type is equal to the "Object" and "object" strings.
```js
/**
 * @type {object}
 * @public
 */
```
To complement the auto detection which only checks for the "Object" and "object" strings, we also introduce a new JSDOC tag, called "noattribute" to manually and explicitly tag a member for which the attribute counterpart should not be displayed in the API reference:
 
```js
 /**
 * @noattribute
 * @public
 */
```
After this change the attribute counterpart of the following properties of type Object will be omitted (automatically detected):

- Links
accessibilityAttributes
- ShellBar
accessibilityTexts
- FCL
accessibilityRoles
accessibilityTexts

FIXES: https://github.com/SAP/ui5-webcomponents/issues/4674