### PR TITLE
doc(ui5-split-button): fix import module doc typo

### DIFF
--- a/packages/main/src/SplitButton.js
+++ b/packages/main/src/SplitButton.js
@@ -266,7 +266,7 @@ const metadata = {
  *
  * <h3>ES6 Module Import</h3>
  *
- * <code>import @ui5/webcomponents/dist/SplitButton.js";</code>
+ * <code>import "@ui5/webcomponents/dist/SplitButton.js";</code>
  *
  * @constructor
  * @author SAP SE


### PR DESCRIPTION
Fix typo on [split-button](https://sap.github.io/ui5-webcomponents/playground/components/SplitButton/)

**"(double quotes)** is missing from the documentation!

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
