### PR TITLE
fix(framework): Tabbable elements error

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-U/+Rgew0cZ7fMsn5kLscb7DWRHA=
+73TsV1IL6tr6n2zpA7yMRpPgTds=

--- a/packages/base/src/util/TabbableElements.js
+++ b/packages/base/src/util/TabbableElements.js
@@ -27,6 +27,10 @@ const getTabbables = (nodes, tabbables) => {
 			currentNode = Array.from(children).find(node => node.tagName !== "STYLE");
 		}
 
+		if (!currentNode) {
+			return;
+		}
+
 		if (isNodeTabbable(currentNode)) {
 			tabbablesNodes.push(currentNode);
 		}


### PR DESCRIPTION
The code in `TabbableElements.js` may throw an error, if the shadow root is empty, because `currentNode` will be `undefined` and then the following code will be executed:

```js
if (currentNode.tagName === "SLOT") {
```