### PR TITLE
chore: remove non-existing props

### DIFF
--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -1,7 +1,6 @@
 <ui5-responsive-popover
 	id="{{_id}}-responsive-popover"
 	allow-target-overlap
-	stay-open-on-scroll
 	placement-type="Bottom"
 	horizontal-align="Left"
 	?disable-scrolling="{{_isIE}}"

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -6,7 +6,6 @@
 	allow-target-overlap
 	_hide-header
 	hide-arrow
-	stay-open-on-scroll
 	@ui5-after-close="{{onResponsivePopoverAfterClose}}"
 	@wheel="{{_handleWheel}}"
 	@keydown="{{_onkeydown}}"


### PR DESCRIPTION
The `stayOpenOnScroll` private property has been removed from the Popover long time ago with the [PR](https://github.com/SAP/ui5-webcomponents/pull/779)
