### PR TITLE
doc(ui5-tabcontainer): fix typo in code sample

### DIFF
--- a/packages/main/test/samples/TabContainer.sample.html
+++ b/packages/main/test/samples/TabContainer.sample.html
@@ -276,7 +276,7 @@
 		</ui5-tabcontainer>
 
 		<ui5-tabcontainer tab-layout="Inline" collapsed fixed>
-			<ui5-tab icon="laptop" ext="Monitors" additional-text="(10)">
+			<ui5-tab icon="laptop" text="Monitors" additional-text="(10)">
 			</ui5-tab>
 			<ui5-tab icon="video" text="Cameras" additional-text="(2)" selected>
 			</ui5-tab>
@@ -295,7 +295,7 @@
 </ui5-tabcontainer>
 
 <ui5-tabcontainer tab-layout="Inline" collapsed fixed>
-	<ui5-tab icon="laptop" ext="Monitors" additional-text="(10)">
+	<ui5-tab icon="laptop" text="Monitors" additional-text="(10)">
 	</ui5-tab>
 	<ui5-tab icon="video" text="Cameras" additional-text="(2)" selected>
 	</ui5-tab>


### PR DESCRIPTION
Attribute `text` was missing a `t` for component `ui5-tabcontainer`.

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/master/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
