### PR TITLE
fix(ui5-input): aria-invalid is now properly rendered

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -19,7 +19,7 @@
 			maxlength="{{maxlength}}"
 			role="{{accInfo.input.role}}"
 			aria-controls="{{accInfo.input.ariaControls}}"
-			?aria-invalid="{{accInfo.input.ariaInvalid}}"
+			aria-invalid="{{accInfo.input.ariaInvalid}}"
 			aria-haspopup="{{accInfo.input.ariaHasPopup}}"
 			aria-describedby="{{accInfo.input.ariaDescribedBy}}"
 			aria-roledescription="{{accInfo.input.ariaRoledescription}}"


### PR DESCRIPTION
The attribute aria-invalid="true" is now fully rendered, as otherwise, it will not be announced by JAWS screen reader.
 
Fixes #4723