### PR TITLE
feat(ui5-button): add new tooltip property

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -42,7 +42,7 @@
 		design="Transparent"
 		@click="{{startArrowClick}}"
 		style="{{styles.arrows.start}}"
-		title="{{accStartArrowText}}"
+		tooltip="{{accStartArrowText}}"
 	></ui5-button>
 {{/inline}}
 
@@ -54,6 +54,6 @@
 		icon="slim-arrow-left"
 		design="Transparent"
 		@click="{{endArrowClick}}"
-		title="{{accEndArrowText}}"
+		tooltip="{{accEndArrowText}}"
 	></ui5-button>
 {{/inline}}

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -15,7 +15,7 @@
 			design="Transparent"
 			@click="{{_onBtnToggleClick}}"
 			class="ui5-nli-group-toggle-btn"
-			title="{{toggleBtnAccessibleName}}"
+			tooltip="{{toggleBtnAccessibleName}}"
 			aria-label="{{toggleBtnAccessibleName}}"
 		></ui5-button>
 
@@ -43,7 +43,7 @@
 					design="Transparent"
 					@click="{{_onBtnOverflowClick}}"
 					class="ui5-nli-overflow-btn"
-					title="{{overflowBtnAccessibleName}}"
+					tooltip="{{overflowBtnAccessibleName}}"
 					aria-label="{{overflowBtnAccessibleName}}"
 				></ui5-button>
 			{{else}}
@@ -67,7 +67,7 @@
 				icon="decline"
 				design="Transparent"
 				@click="{{_onBtnCloseClick}}"
-				title="{{closeBtnAccessibleName}}"
+				tooltip="{{closeBtnAccessibleName}}"
 				aria-label="{{closeBtnAccessibleName}}"
 				close-btn
 			></ui5-button>

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -17,7 +17,7 @@
 				design="Transparent"
 				@click="{{_onBtnOverflowClick}}"
 				class="ui5-nli-overflow-btn"
-				title="{{overflowBtnAccessibleName}}"
+				tooltip="{{overflowBtnAccessibleName}}"
 				aria-label="{{overflowBtnAccessibleName}}"
 			></ui5-button>
 		{{else}}
@@ -40,7 +40,7 @@
 				icon="decline"
 				design="Transparent"
 				@click="{{_onBtnCloseClick}}"
-				title="{{closeBtnAccessibleName}}"
+				tooltip="{{closeBtnAccessibleName}}"
 				aria-label="{{closeBtnAccessibleName}}"
 				close-btn
 			></ui5-button>

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -111,7 +111,7 @@
 					data-ui5-notifications-count="{{notificationsCount}}"
 					data-ui5-stable="toggle-search"
 					@click={{_handleSearchIconPress}}
-					title="{{_searchText}}"
+					tooltip="{{_searchText}}"
 					.accessibilityAttributes={{accInfo.search.accessibilityAttributes}}
 				></ui5-button>
 			{{/if}}
@@ -122,7 +122,7 @@
 					style="{{this.styles}}"
 					class="{{this.classes}}"
 					icon="{{this.icon}}"
-					title="{{this.title}}"
+					tooltip="{{this.title}}"
 					data-count="{{this.count}}"
 					data-ui5-notifications-count="{{../notificationsCount}}"
 					data-ui5-external-action-item-id="{{this.refItemid}}"
@@ -140,7 +140,7 @@
 				data-ui5-text="Notifications"
 				data-ui5-notifications-count="{{notificationsCount}}"
 				@click={{_handleNotificationsPress}}
-				title="{{_notificationsText}}"
+				tooltip="{{_notificationsText}}"
 				data-ui5-stable="notifications"
 			></ui5-button>
 			{{/if}}
@@ -151,7 +151,7 @@
 				class="{{classes.items.overflow}} ui5-shellbar-button ui5-shellbar-overflow-button-shown ui5-shellbar-overflow-button"
 				icon="sap-icon://overflow"
 				@click="{{_handleOverflowPress}}"
-				title="{{_overflowText}}"
+				tooltip="{{_overflowText}}"
 				.accessibilityAttributes={{accInfo.overflow.accessibilityAttributes}}
 				data-ui5-stable="overflow"
 			></ui5-button>
@@ -168,7 +168,7 @@
 				icon="sap-icon://grid"
 				data-ui5-text="Product Switch"
 				@click={{_handleProductSwitchPress}}
-				title="{{_productsText}}"
+				tooltip="{{_productsText}}"
 				data-ui5-stable="product-switch"
 			></ui5-button>
 			{{/if}}
@@ -182,7 +182,7 @@
 		id="{{this._id}}-item-3"
 		@click={{_handleProfilePress}}
 		style="{{styles.items.profile}}"
-		title="{{_profileText}}"
+		tooltip="{{_profileText}}"
 		class="ui5-shellbar-button ui5-shellbar-image-button"
 		data-ui5-stable="profile"
 	>

--- a/packages/fiori/src/UploadCollectionItem.hbs
+++ b/packages/fiori/src/UploadCollectionItem.hbs
@@ -63,7 +63,7 @@
 					<ui5-button
 						icon="refresh"
 						design="Transparent"
-						title="{{_retryButtonTooltip}}"
+						tooltip="{{_retryButtonTooltip}}"
 						@click="{{_onRetry}}"
 						@keyup="{{_onRetryKeyup}}"
 					></ui5-button>
@@ -72,7 +72,7 @@
 					<ui5-button
 						icon="stop"
 						design="Transparent"
-						title="{{_terminateButtonTooltip}}"
+						tooltip="{{_terminateButtonTooltip}}"
 						@click="{{_onTerminate}}"
 						@keyup="{{_onTerminateKeyup}}">
 					</ui5-button>
@@ -82,7 +82,7 @@
 					<ui5-button
 						id="{{_id}}-editing-button"
 						design="Transparent"
-						title="{{_editButtonTooltip}}"
+						tooltip="{{_editButtonTooltip}}"
 						icon="edit"
 						@click="{{onDetailClick}}"
 						@keyup="{{_onDetailKeyup}}"

--- a/packages/fiori/test/pages/Bar.html
+++ b/packages/fiori/test/pages/Bar.html
@@ -20,9 +20,9 @@
 	<section>
 		<ui5-title level="3">Header design</ui5-title>
 		<ui5-bar design="Header">
-			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 			<ui5-label>Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 		<br>
 

--- a/packages/fiori/test/pages/BarcodeScannerDialog.html
+++ b/packages/fiori/test/pages/BarcodeScannerDialog.html
@@ -25,7 +25,7 @@
 
 	<ui5-barcode-scanner-dialog id="dlgScan"></ui5-barcode-scanner-dialog>
 
-	<ui5-button id="btnScan" icon="camera" title="Start Camera">Scan</ui5-button>
+	<ui5-button id="btnScan" icon="camera" tooltip="Start Camera">Scan</ui5-button>
 	<div>
 		<ui5-label id="scanResult"></ui5-label>
 		<ui5-label id="scanError"></ui5-label>

--- a/packages/fiori/test/pages/Page.html
+++ b/packages/fiori/test/pages/Page.html
@@ -22,7 +22,7 @@
 <body class="page1auto">
 	<ui5-page id="page" background-design="List" floating-footer show-footer>
 		<ui5-bar design="Header" slot="header">
-			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 			<ui5-label>Title</ui5-label>
 			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>

--- a/packages/fiori/test/samples/Bar.sample.html
+++ b/packages/fiori/test/samples/Bar.sample.html
@@ -13,16 +13,16 @@
 	<h3>Header Bar</h3>
 	<div class="snippet">
 		<ui5-bar design="Header">
-			<ui5-button icon="home" title="Go home" design="Transparent" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
 			<ui5-label id="basic-label">Header Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-bar design="Header">
-	<ui5-button icon="home" title="Go home" design="Transparent" slot="startContent"></ui5-button>
+	<ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
 	<ui5-label>Header Title</ui5-label>
-	<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 </ui5-bar>
 	</xmp></pre>
 </section>
@@ -30,16 +30,16 @@
 	<h3>Subheader Bar</h3>
 	<div class="snippet">
 		<ui5-bar design="Subheader">
-			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 			<ui5-label id="basic-label">Subheader Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-bar design="Subheader">
-	<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+	<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 	<ui5-label>Subheader Title</ui5-label>
-	<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 </ui5-bar>
 	</xmp></pre>
 </section>

--- a/packages/fiori/test/samples/Bar2.sample.html
+++ b/packages/fiori/test/samples/Bar2.sample.html
@@ -13,16 +13,16 @@
 	<h3>Header Bar</h3>
 	<div class="snippet">
 		<ui5-bar design="Header">
-			<ui5-button icon="home" title="Go home" design="Transparent" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
 			<ui5-label id="basic-label">Header Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-bar design="Header">
-	<ui5-button icon="home" title="Go home" design="Transparent" slot="startContent"></ui5-button>
+	<ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
 	<ui5-label>Header Title</ui5-label>
-	<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 </ui5-bar>
 	</xmp></pre>
 </section>
@@ -30,16 +30,16 @@
 	<h3>Subheader Bar</h3>
 	<div class="snippet">
 		<ui5-bar design="Subheader">
-			<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+			<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 			<ui5-label id="basic-label">Subheader Title</ui5-label>
-			<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-bar design="Subheader">
-	<ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+	<ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
 	<ui5-label>Subheader Title</ui5-label>
-	<ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 </ui5-bar>
 	</xmp></pre>
 </section>

--- a/packages/fiori/test/samples/BarcodeScannerDialog.sample.html
+++ b/packages/fiori/test/samples/BarcodeScannerDialog.sample.html
@@ -14,7 +14,7 @@
 	<div class="snippet">
 		<ui5-barcode-scanner-dialog id="dlgScan"></ui5-barcode-scanner-dialog>
 
-		<ui5-button id="btnScan" icon="camera" title="Start Camera">Scan</ui5-button>
+		<ui5-button id="btnScan" icon="camera" tooltip="Start Camera">Scan</ui5-button>
 		<div>
 			<ui5-label id="scanResult"></ui5-label>
 			<ui5-label id="scanError"></ui5-label>
@@ -39,7 +39,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-barcode-scanner-dialog id="dlgScan"></ui5-barcode-scanner-dialog>
 
-<ui5-button id="btnScan" icon="camera" title="Start Camera">Scan</ui5-button>
+<ui5-button id="btnScan" icon="camera" tooltip="Start Camera">Scan</ui5-button>
 <ui5-label id="scanResult"></ui5-label>
 <ui5-label id="scanError"></ui5-label>
 

--- a/packages/fiori/test/samples/Page.sample.html
+++ b/packages/fiori/test/samples/Page.sample.html
@@ -21,9 +21,9 @@
 	<div class="snippet">
         <ui5-page id="page" style="height: 700px; width: 500px" background-design="List" floating-footer show-footer>
             <ui5-bar design="Header" slot="header">
-                <ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+                <ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
                 <ui5-label>Title</ui5-label>
-                <ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+                <ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
             </ui5-bar>
 
             <div>
@@ -80,9 +80,9 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-page id="page" background-design="List" floating-footer show-footer>
     <ui5-bar design="Header" slot="header">
-        <ui5-button icon="home" title="Go home" slot="startContent"></ui5-button>
+        <ui5-button icon="home" tooltip="Go home" slot="startContent"></ui5-button>
         <ui5-label>Title</ui5-label>
-        <ui5-button icon="action-settings" title="Go to settings" slot="endContent"></ui5-button>
+        <ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
     </ui5-bar>
 
     <div>

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -99,9 +99,9 @@ describe("FlexibleColumnLayout Behavior", () => {
 		const endArrowContainerText = "End Arrow Container";
 
 		// assert
-		assert.strictEqual(await startArrow.getAttribute("title"), startArrowText1,
+		assert.strictEqual(await startArrow.getAttribute("tooltip"), startArrowText1,
 			"Start arrow has the correct tooltip.");
-		assert.strictEqual(await endArrow.getAttribute("title"), endArrowText,
+		assert.strictEqual(await endArrow.getAttribute("tooltip"), endArrowText,
 			"End arrow has the correct tooltip.");
 		assert.strictEqual(await startArrowContainerDOM.getAttribute("aria-label"), startArrowContainerText,
 			"Start arrow container has the correct label.");

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -112,7 +112,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		await startArrow.click();
 
 		// assert
-		assert.strictEqual(await startArrow.getAttribute("title"), startArrowText2,
+		assert.strictEqual(await startArrow.getAttribute("tooltip"), startArrowText2,
 			"Start arrow has the correct tooltip.");
 	});
 

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -19,7 +19,7 @@
 	aria-controls="{{accessibilityAttributes.controls}}"
 	aria-haspopup="{{accessibilityAttributes.hasPopup}}"
 	aria-label="{{ariaLabelText}}"
-	title="{{title}}"
+	title="{{tooltip}}"
 	part="button"
 >
 	{{#if icon}}

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -117,10 +117,10 @@ const metadata = {
 		 * <b>Note:</b> Tooltips should only be set to icon-only buttons.
 		 * @type {string}
 		 * @defaultvalue: ""
-		 * @private
-		 * @since 1.0.0-rc.11
+		 * @public
+		 * @since 1.2.0
 		 */
-		title: {
+		tooltip: {
 			type: String,
 		},
 
@@ -193,7 +193,7 @@ const metadata = {
 		 *			<ul>
 		 *				<li><code>true</code></li>
 		 *				<li><code>false</code></li>
-		 *			<ul>
+		 *			</ul>
 		 * 		</li>
 		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the button. Accepts the following string values:
 		 * 			<ul>
@@ -482,7 +482,7 @@ class Button extends UI5Element {
 	}
 
 	get showIconTooltip() {
-		return this.iconOnly && !this.title;
+		return this.iconOnly && !this.tooltip;
 	}
 
 	get ariaLabelText() {

--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -66,7 +66,7 @@
 {{#*inline "arrow-back"}}
 	<ui5-button
         arrow-back
-        title="{{previousPageText}}"
+        tooltip="{{previousPageText}}"
         class="ui5-carousel-navigation-button {{classes.navPrevButton}}"
         icon="slim-arrow-left"
         tabindex="-1"
@@ -77,7 +77,7 @@
 {{#*inline "arrow-forward"}}
     <ui5-button
         arrow-forward
-        title="{{nextPageText}}"
+        tooltip="{{nextPageText}}"
         class="ui5-carousel-navigation-button {{classes.navNextButton}}"
         icon="slim-arrow-right"
         tabindex="-1"

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -136,7 +136,7 @@ const metadata = {
 		 *			<ul>
 		 *				<li><code>true</code></li>
 		 *				<li><code>false</code></li>
-		 *			<ul>
+		 *			</ul>
 		 * 		</li>
 		 * 		<li><code>hasPopup</code>: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the anchor element. Accepts the following string values:
 		 * 			<ul>

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -95,7 +95,7 @@
 				icon="decline"
 				?disabled="{{disableDeleteButton}}"
 				@click="{{onDelete}}"
-				title="{{deleteText}}"
+				tooltip="{{deleteText}}"
 			></ui5-button>
 		</div>
 	{{/if}}

--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -27,7 +27,7 @@
 			icon="decline"
 			design="Transparent"
 			class="ui5-message-strip-close-button"
-			title="{{_closeButtonText}}"
+			tooltip="{{_closeButtonText}}"
 			@click={{_closeClick}}
 		></ui5-button>
 	{{/unless}}

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -25,7 +25,7 @@
 						icon="slim-arrow-right"
 						@click="{{_toggleButtonClick}}"
 						.accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
-						title="{{accInfo.button.title}}"
+						tooltip="{{accInfo.button.title}}"
 						accessible-name="{{accInfo.button.ariaLabelButton}}"
 					></ui5-button>
 				{{else}}

--- a/packages/main/src/TabContainer.hbs
+++ b/packages/main/src/TabContainer.hbs
@@ -19,7 +19,7 @@
 					icon="{{overflowMenuIcon}}"
 					data-ui5-stable="overflow-start"
 					tabindex="-1"
-					title="{{overflowMenuTitle}}"
+					tooltip="{{overflowMenuTitle}}"
 					aria-haspopup="true"
 					icon-end>{{this._startOverflowText}}</ui5-button>
 			{{/if}}
@@ -51,7 +51,7 @@
 					icon="{{overflowMenuIcon}}"
 					data-ui5-stable="overflow-end"
 					tabindex="-1"
-					title="{{overflowMenuTitle}}"
+					tooltip="{{overflowMenuTitle}}"
 					aria-haspopup="true"
 					icon-end>{{this._endOverflowText}}</ui5-button>
 			{{/if}}

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -183,11 +183,11 @@
 	<br/>
 	<ui5-title>Buttons with tooltip</ui5-title>
 	<br/>
-	<ui5-button icon="message-information" title="Go home"></ui5-button>
-	<ui5-button icon="accept" title="Accept terms & conditions"></ui5-button>
-	<ui5-button icon="action-settings" title="Go to settings"></ui5-button>
-	<ui5-button icon="alert" title="Fire an alert"></ui5-button>
-	<ui5-button icon="arrow-down" title="Go down"></ui5-button>
+	<ui5-button id="customTooltip" icon="message-information" tooltip="Go home"></ui5-button>
+	<ui5-button icon="accept" tooltip="Accept terms & conditions"></ui5-button>
+	<ui5-button icon="action-settings" tooltip="Go to settings"></ui5-button>
+	<ui5-button icon="alert" tooltip="Fire an alert"></ui5-button>
+	<ui5-button icon="arrow-down" tooltip="Go down"></ui5-button>
 
 	<br/>
 	<br/>

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -105,4 +105,10 @@ describe("Button general interaction", () => {
 
 		assert.strictEqual(await button.getAttribute("aria-label"), "Download Application", "Attribute is reflected");
 	});
+
+	it("setting tooltip on the host is reflected on the button tag", async () => {
+		const button = await browser.$("#customTooltip").shadow$("button");
+
+		assert.strictEqual(await button.getAttribute("title"), "Go home", "Attribute is reflected");
+	});
 });


### PR DESCRIPTION
Problem description:
The ui5-button tooltip text was supplied trough the
private "title" property. As result the same title
attribute was placed to the ui5-button element and
to the inner native button element, which was causing
duplicate tooltip announcements.

Solution:
New public "tooltip" property is added, which results
in placing "tooltip" attribute to the ui5-button element
and a "title" attribute to the inner native button element.

Fixes: #4689
