### PR TITLE
fix(ui5-button): remove focus on phone and tablet

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -9,6 +9,7 @@ import {
 	isPhone,
 	isTablet,
 	isCombi,
+	isDesktop,
 	isSafari,
 } from "@ui5/webcomponents-base/dist/Device.js";
 import ButtonDesign from "./types/ButtonDesign.js";
@@ -436,7 +437,9 @@ class Button extends UI5Element {
 			return;
 		}
 		this.active = false;
-		this.focused = false;
+		if (isDesktop()) {
+			this.focused = false;
+		}
 	}
 
 	_onfocusin(event) {
@@ -445,7 +448,9 @@ class Button extends UI5Element {
 		}
 
 		event.isMarked = "button";
-		this.focused = true;
+		if (isDesktop()) {
+			this.focused = true;
+		}
 	}
 
 	get hasButtonType() {

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -301,6 +301,6 @@ bdi {
 	text-shadow: none;
 }
 
-:host([design="Transparent"]:not([active]):hover) {
+:host([design="Transparent"]:not([active]):not([_is-touch]):hover) {
 	border-color: var(--sapButton_Lite_Hover_BorderColor);
 }


### PR DESCRIPTION
Focus outline removed on phone and tablet devices. Now "focused" attribute is placed only on Desktop devices.