### PR TITLE
Recursive tabs demo

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-UNpXLkY2d6jg4nyjNFOUoEdObmA=
+PUQ2w1tOJiuIh55f5+PDj/v3IoE=

--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -92,6 +92,9 @@ import StandardListItem from "./dist/StandardListItem.js";
 import CustomListItem from "./dist/CustomListItem.js";
 import GroupHeaderListItem from "./dist/GroupHeaderListItem.js";
 
+import Tabs from "./dist/Tabs.js";
+import Tb from "./dist/Tb.js";
+
 // used in test pages
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import { isIE } from "@ui5/webcomponents-base/dist/Device.js";

--- a/packages/main/src/Tabs.hbs
+++ b/packages/main/src/Tabs.hbs
@@ -2,7 +2,7 @@
 
 	<div class="menu" @click="{{_handleMenuClick}}">
 		{{#each _menu}}
-			<button .associatedTab="{{this}}">{{this._id}}</button>
+			<button .associatedTab="{{this}}">{{this.title}}</button>
 		{{/each}}
 	</div>
 

--- a/packages/main/src/Tabs.hbs
+++ b/packages/main/src/Tabs.hbs
@@ -1,0 +1,14 @@
+<div class="root">
+
+	<div class="menu" @click="{{_handleMenuClick}}">
+		{{#each _menu}}
+			<button .associatedTab="{{this}}">{{this._id}}</button>
+		{{/each}}
+	</div>
+
+
+	{{#each tabs}}
+		<slot name="{{this._effectiveSlotName}}"></slot>
+	{{/each}}
+
+</div>

--- a/packages/main/src/Tabs.hbs
+++ b/packages/main/src/Tabs.hbs
@@ -2,7 +2,9 @@
 
 	<div class="menu" @click="{{_handleMenuClick}}">
 		{{#each _menu}}
-			<button .associatedTab="{{this}}">{{this.title}}</button>
+			<span class="menu-item">
+				<button .associatedTab="{{this}}">{{this.title}}</button>
+			</span>
 		{{/each}}
 	</div>
 

--- a/packages/main/src/Tabs.js
+++ b/packages/main/src/Tabs.js
@@ -1,0 +1,89 @@
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import TabsCss from "./generated/themes/Tabs.css.js";
+import TabsTemplate from "./generated/templates/TabsTemplate.lit.js";
+/**
+ * @public
+ */
+const metadata = {
+	tag: "ui5-tabs",
+	managedSlots: true,
+	properties: /** @lends sap.ui.webcomponents.main.Tabs.prototype */ {
+		/**
+		 * @private
+		 */
+		selectedTab: {
+			type: Object,
+		},
+	},
+	slots: /** @lends sap.ui.webcomponents.main.Tabs.prototype */ {
+		/**
+		 */
+		"default": {
+			propertyName: "tabs",
+			type: HTMLElement,
+			individualSlots: true,
+		},
+	},
+	events: /** @lends sap.ui.webcomponents.main.Tabs.prototype */ {
+	},
+};
+
+const walk = (tabs, callback) => {
+	[...tabs].forEach(tab => {
+		callback(tab);
+		if (tab.subtabs) {
+			walk(tab.subtabs, callback);
+		}
+	});
+};
+
+/**
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.Tabs
+ * @extends UI5Element
+ * @tagname ui5-Tabs
+ * @since 1.0.0-rc.6
+ * @implements sap.ui.webcomponents.main.ITabs
+ * @public
+ */
+class Tabs extends UI5Element {
+	static get metadata() {
+		return metadata;
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	static get styles() {
+		return TabsCss;
+	}
+
+	static get template() {
+		return TabsTemplate;
+	}
+
+	get _menu() {
+		const items = [];
+		walk(this.tabs, tab => {
+			items.push(tab);
+		});
+
+		return items;
+	}
+
+	_handleMenuClick(event) {
+		this.selectedTab = event.target.associatedTab;
+		console.log("Selected tab is:", this.selectedTab);
+
+		walk(this.tabs, tab => {
+			tab.selectedTab = this.selectedTab;
+		});
+	}
+}
+
+Tabs.define();
+
+export default Tabs;

--- a/packages/main/src/Tabs.js
+++ b/packages/main/src/Tabs.js
@@ -2,6 +2,8 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import TabsCss from "./generated/themes/Tabs.css.js";
 import TabsTemplate from "./generated/templates/TabsTemplate.lit.js";
+import Tb from "./Tb.js";
+
 /**
  * @public
  */
@@ -23,6 +25,7 @@ const metadata = {
 			propertyName: "tabs",
 			type: HTMLElement,
 			individualSlots: true,
+			invalidateOnChildChange: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Tabs.prototype */ {
@@ -63,6 +66,10 @@ class Tabs extends UI5Element {
 
 	static get template() {
 		return TabsTemplate;
+	}
+
+	static get dependencies() {
+		return [Tb];
 	}
 
 	get _menu() {

--- a/packages/main/src/Tb.hbs
+++ b/packages/main/src/Tb.hbs
@@ -1,0 +1,9 @@
+<div class="tb">
+
+	<slot name="{{this._defaultSlotName}}"></slot>
+
+	{{#each subtabs}}
+		<slot name="{{this._effectiveSlotName}}"></slot>
+	{{/each}}
+
+</div>

--- a/packages/main/src/Tb.js
+++ b/packages/main/src/Tb.js
@@ -1,0 +1,76 @@
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import TbCss from "./generated/themes/Tb.css.js";
+import TbTemplate from "./generated/templates/TbTemplate.lit.js";
+/**
+ * @public
+ */
+const metadata = {
+	tag: "ui5-tb",
+	managedSlots: true,
+	properties: /** @lends sap.ui.webcomponents.main.Tb.prototype */ {
+		/**
+		 * @private
+		 */
+		selectedTab: {
+			type: Object,
+		},
+	},
+	slots: /** @lends sap.ui.webcomponents.main.Tb.prototype */ {
+		/**
+		 */
+		"default": {
+			type: HTMLElement,
+		},
+		"subtabs": {
+			type: HTMLElement,
+			individualSlots: true,
+		},
+	},
+	events: /** @lends sap.ui.webcomponents.main.Tb.prototype */ {
+	},
+};
+
+/**
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.main.Tb
+ * @extends UI5Element
+ * @tagname ui5-Tb
+ * @since 1.0.0-rc.6
+ * @implements sap.ui.webcomponents.main.ITb
+ * @public
+ */
+class Tb extends UI5Element {
+	static get metadata() {
+		return metadata;
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	static get styles() {
+		return TbCss;
+	}
+
+	static get template() {
+		return TbTemplate;
+	}
+
+	isOnSelectedTabPath() {
+		return this.selectedTab === this || this.subtabs.some(subtab => subtab.isOnSelectedTabPath());
+	}
+
+	get _effectiveSlotName() {
+		return this.isOnSelectedTabPath() ? this._individualSlot : "disabled-slot";
+	}
+
+	get _defaultSlotName() {
+		return this.selectedTab === this ? "" : "disabled-slot";
+	}
+}
+
+Tb.define();
+
+export default Tb;

--- a/packages/main/src/Tb.js
+++ b/packages/main/src/Tb.js
@@ -25,6 +25,7 @@ const metadata = {
 		"subtabs": {
 			type: HTMLElement,
 			individualSlots: true,
+			invalidateOnChildChange: true,
 		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Tb.prototype */ {

--- a/packages/main/src/themes/Tabs.css
+++ b/packages/main/src/themes/Tabs.css
@@ -1,0 +1,4 @@
+.root {
+	width: 100%;
+	padding: 0;
+}

--- a/packages/main/src/themes/Tabs.css
+++ b/packages/main/src/themes/Tabs.css
@@ -2,3 +2,11 @@
 	width: 100%;
 	padding: 0;
 }
+
+.menu {
+	margin: 0 0 10px 0;
+}
+
+.menu-item {
+	margin: 5px;
+}

--- a/packages/main/src/themes/Tb.css
+++ b/packages/main/src/themes/Tb.css
@@ -1,0 +1,4 @@
+.tb {
+	width: 100%;
+	padding: 0;
+}

--- a/packages/main/test/pages/Tabs.html
+++ b/packages/main/test/pages/Tabs.html
@@ -6,7 +6,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-	<title>Card</title>
+	<title>Recursive tabs</title>
 
 	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../resources/bundle.esm.js" type="module"></script>
@@ -19,12 +19,23 @@
 
 	<ui5-tabs>
 		<ui5-tb title="Tab 1">
-			This is the content in the default slot of Tab 1
+			This is the content in the default slot of <ui5-label>Tab 1</ui5-label>
+
 			<ui5-tb slot="subtabs" title="Tab 1.1">Content of Tab 1.1</ui5-tb>
-			<ui5-tb slot="subtabs" title="Tab 1.2">Content of Tab 1.2</ui5-tb>
+
+			<ui5-tb slot="subtabs" title="Tab 1.2">
+				Content of Tab 1.2
+
+				<ui5-tb slot="subtabs" title="Tab 1.2.1">Content of Tab 1.2.1</ui5-tb>
+
+				<ui5-tb slot="subtabs" title="Tab 1.2.2">Content of Tab 1.2.2</ui5-tb>
+			</ui5-tb>
+
+			<ui5-tb slot="subtabs" title="Tab 1.3">Content of Tab 1.3</ui5-tb>
 		</ui5-tb>
 
-		<ui5-tb title="Tab 2">This is Tab 2</ui5-tb>
+		<ui5-tb title="Tab 2">This is Tab 2 <ui5-icon name="add"></ui5-icon></ui5-tb>
+
 		<ui5-tb title="Tab 3">Here is Tab 3</ui5-tb>
 	</ui5-tabs>
 

--- a/packages/main/test/pages/Tabs.html
+++ b/packages/main/test/pages/Tabs.html
@@ -18,14 +18,14 @@
 <body class="card1auto">
 
 	<ui5-tabs>
-		<ui5-tb txt="Tab 1">
-			Tab 1
-			<ui5-tb slot="subtabs">Tab 1.1</ui5-tb>
-			<ui5-tb slot="subtabs">Tab 1.2</ui5-tb>
+		<ui5-tb title="Tab 1">
+			This is the content in the default slot of Tab 1
+			<ui5-tb slot="subtabs" title="Tab 1.1">Content of Tab 1.1</ui5-tb>
+			<ui5-tb slot="subtabs" title="Tab 1.2">Content of Tab 1.2</ui5-tb>
 		</ui5-tb>
 
-		<ui5-tb txt="Tab 2">Tab 2</ui5-tb>
-		<ui5-tb txt="Tab 3">Tab 3</ui5-tb>
+		<ui5-tb title="Tab 2">This is Tab 2</ui5-tb>
+		<ui5-tb title="Tab 3">Here is Tab 3</ui5-tb>
 	</ui5-tabs>
 
 

--- a/packages/main/test/pages/Tabs.html
+++ b/packages/main/test/pages/Tabs.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<title>Card</title>
+
+	<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script nomodule src="../../resources/bundle.es5.js"></script>
+
+
+</head>
+
+<body class="card1auto">
+
+	<ui5-tabs>
+		<ui5-tb txt="Tab 1">
+			Tab 1
+			<ui5-tb slot="subtabs">Tab 1.1</ui5-tb>
+			<ui5-tb slot="subtabs">Tab 1.2</ui5-tb>
+		</ui5-tb>
+
+		<ui5-tb txt="Tab 2">Tab 2</ui5-tb>
+		<ui5-tb txt="Tab 3">Tab 3</ui5-tb>
+	</ui5-tabs>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
This POC shows how to display only one of many recursive tabs.

 - both the tab container and the tabs have a `selectedTab` private property of type `Object`
 - when the user chooses from the menu, `selectedTab` is set on the container and on all children recursively (propagated down the tree) and at any moment the value of `selectedTab` is the same for the whole tree (container and all tabs/subtabs)
 - we only show the tabs/subtabs which are **on the path of the selected tab** - this is achieved by setting either the `_individualSlot` for the tab/subtab (in which case it will be shown), or a "dummy" value, which will make sure nothing does into this slot