### PR TITLE
fix: attached boot tasks always run

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-aK/rjb0Q0fVNOkWz9m2BgWJlwko=
+OCEvzFO5EdRSX+NMWOs+WHOgqNY=

--- a/packages/base/src/Boot.js
+++ b/packages/base/src/Boot.js
@@ -1,4 +1,3 @@
-import EventProvider from "./EventProvider.js";
 import whenDOMReady from "./util/whenDOMReady.js";
 import insertFontFace from "./FontFace.js";
 import insertSystemCSSVars from "./SystemCSSVars.js";
@@ -8,15 +7,15 @@ import { registerCurrentRuntime } from "./Runtimes.js";
 import { getFeature } from "./FeaturesRegistry.js";
 
 let bootPromise;
-const eventProvider = new EventProvider();
 
 /**
  * Attach a callback that will be executed on boot
  * @public
  * @param listener
  */
-const attachBoot = listener => {
-	eventProvider.attachEvent("boot", listener);
+const attachBoot = async listener => {
+	await boot();
+	listener();
 };
 
 const boot = async () => {
@@ -46,7 +45,6 @@ const boot = async () => {
 		OpenUI5Support && OpenUI5Support.attachListeners();
 		insertFontFace();
 		insertSystemCSSVars();
-		await eventProvider.fireEventAsync("boot");
 
 		resolve();
 	});

--- a/packages/base/src/util/InvisibleMessage.js
+++ b/packages/base/src/util/InvisibleMessage.js
@@ -5,17 +5,19 @@ import { attachBoot } from "../Boot.js";
 let politeSpan;
 let assertiveSpan;
 
+const setOutOfViewportStyles = el => {
+	el.style.position = "absolute";
+	el.style.clip = "rect(1px,1px,1px,1px)";
+	el.style.userSelect = "none";
+	el.style.left = "-1000px";
+	el.style.top = "-1000px";
+	el.style.pointerEvents = "none";
+};
+
 attachBoot(() => {
 	if (politeSpan && assertiveSpan) {
 		return;
 	}
-
-	const styles = `position: absolute;
-	clip: rect(1px,1px,1px,1px);
-	user-select: none;
-	left: -1000px;
-	top: -1000px;
-	pointer-events: none;`;
 
 	politeSpan = document.createElement("span");
 	assertiveSpan = document.createElement("span");
@@ -29,8 +31,8 @@ attachBoot(() => {
 	politeSpan.setAttribute("role", "alert");
 	assertiveSpan.setAttribute("role", "alert");
 
-	politeSpan.style.cssText = styles;
-	assertiveSpan.style.cssText = styles;
+	setOutOfViewportStyles(politeSpan);
+	setOutOfViewportStyles(assertiveSpan);
 
 	getSingletonElementInstance("ui5-static-area").appendChild(politeSpan);
 	getSingletonElementInstance("ui5-static-area").appendChild(assertiveSpan);


### PR DESCRIPTION
With the old implementation it was possible for `boot` to run without executing all attached callbacks (the ones attached after boot is over).

Additionally, reworked `InvisibleMessage.js` to be CSP-compliant.