### PR TITLE
fix(ui5-color-palette-popover): update documentation

### DIFF
--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -69,7 +69,7 @@ const metadata = {
 		/**
 		 * Defines the content of the component.
 		 * @type {HTMLElement[]}
-		 * @slot
+		 * @slot colors
 		 * @public
 		 */
 		"default": {


### PR DESCRIPTION
Including the name of the slot in the documentation
