### PR TITLE
fix(ui5-tabcontainer): fix overflow button runtime error

### DIFF
--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -905,7 +905,11 @@ class TabContainer extends UI5Element {
 		const focusableTabs = [];
 
 		if (!this._getStartOverflow().hasAttribute("hidden")) {
-			focusableTabs.push(this._getStartOverflow().querySelector("[ui5-button]"));
+			if (this.shadowRoot.querySelector('slot[name=startOverflowButton]')) {
+				focusableTabs.push(this.shadowRoot.querySelector('slot[name=startOverflowButton]'));
+			} else {
+				focusableTabs.push(this._getStartOverflow().querySelector("[ui5-button]"));
+			}
 		}
 
 		this._getTabs().forEach(tab => {
@@ -915,7 +919,11 @@ class TabContainer extends UI5Element {
 		});
 
 		if (!this._getEndOverflow().hasAttribute("hidden")) {
-			focusableTabs.push(this._getEndOverflow().querySelector("[ui5-button]"));
+			if (this.shadowRoot.querySelector('slot[name=overflowButton]')) {
+				focusableTabs.push(this.shadowRoot.querySelector('slot[name=overflowButton]'));
+			} else {
+				focusableTabs.push(this._getEndOverflow().querySelector("[ui5-button]"));
+			}
 		}
 
 		return focusableTabs;


### PR DESCRIPTION
Runtime error is no longer thrown when custom overflow buttons are used via slots
FIXES: #4770