### PR TITLE
docs: use primitive types for JSDoc

### DIFF
--- a/packages/fiori/src/Bar.js
+++ b/packages/fiori/src/Bar.js
@@ -39,7 +39,7 @@ const metadata = {
 
 		/**
 		 * Defines if the component middle area needs to be centered between start and end area
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @private
 		 */
 		_shrinked: {

--- a/packages/fiori/src/BarcodeScannerDialog.js
+++ b/packages/fiori/src/BarcodeScannerDialog.js
@@ -56,7 +56,7 @@ const metadata = {
 		 * Fires when the scan is completed successfuuly.
 		 *
 		 * @event sap.ui.webcomponents.fiori.BarcodeScannerDialog#scan-success
-		 * @param {String} text the scan result as string
+		 * @param {string} text the scan result as string
 		 * @param {Object} rawBytes the scan result as a Uint8Array
 		 * @public
 		 */
@@ -71,7 +71,7 @@ const metadata = {
 		 * Fires when the scan fails with error.
 		 *
 		 * @event sap.ui.webcomponents.fiori.BarcodeScannerDialog#scan-error
-		 * @param {String} message the error message
+		 * @param {string} message the error message
 		 * @public
 		 */
 		 "scan-error": {

--- a/packages/fiori/src/DynamicSideContent.js
+++ b/packages/fiori/src/DynamicSideContent.js
@@ -202,10 +202,10 @@ const metadata = {
 		/**
 		 * Fires when the current breakpoint has been changed.
 		 * @event sap.ui.webcomponents.fiori.DynamicSideContent#layout-change
-		 * @param {String} currentBreakpoint the current breakpoint.
-		 * @param {String} previousBreakpoint the breakpoint that was active before change to current breakpoint.
-		 * @param {Boolean} mainContentVisible visibility of the main content.
-		 * @param {Boolean} sideContentVisible visibility of the side content.
+		 * @param {string} currentBreakpoint the current breakpoint.
+		 * @param {string} previousBreakpoint the breakpoint that was active before change to current breakpoint.
+		 * @param {boolean} mainContentVisible visibility of the main content.
+		 * @param {boolean} sideContentVisible visibility of the side content.
 		 * @public
 		 */
 		"layout-change": {
@@ -345,7 +345,7 @@ class DynamicSideContent extends UI5Element {
 
 	/**
 	 * Toggles visibility of main and side contents on S screen size (mobile device).
-	 * @type {String}
+	 * @type {string}
 	 * @public
 	 */
 	 toggleContents() {

--- a/packages/fiori/src/FilterItem.js
+++ b/packages/fiori/src/FilterItem.js
@@ -14,7 +14,7 @@ const metadata = {
 		/**
 		 * Defines the text of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */
@@ -25,7 +25,7 @@ const metadata = {
 		/**
 		 * Defines the additional text of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @private
 		 */

--- a/packages/fiori/src/FilterItemOption.js
+++ b/packages/fiori/src/FilterItemOption.js
@@ -10,7 +10,7 @@ const metadata = {
 		 * Defines the text of the component.
 		 *
 		 * @public
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 */
 		text: {
@@ -21,7 +21,7 @@ const metadata = {
 		 * Defines whether the option is selected
 		 *
 		 * @public
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @defaultvalue false
 		 */
 		selected: {

--- a/packages/fiori/src/SortItem.js
+++ b/packages/fiori/src/SortItem.js
@@ -9,7 +9,7 @@ const metadata = {
 		/**
 		 * Defines the text of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */
@@ -19,7 +19,7 @@ const metadata = {
 
 		/**
 		 * Defines if the component is selected.
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public
 		 */

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -47,7 +47,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 * @since 1.2.0

--- a/packages/fiori/src/TimelineItem.js
+++ b/packages/fiori/src/TimelineItem.js
@@ -107,7 +107,7 @@ const metadata = {
 		/**
 		 * Defines the indicator line width.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @private
 		 */
 		_lineWidth: {

--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -144,8 +144,8 @@ const metadata = {
 		 * Fired when confirmation button is activated.
 		 *
 		 * @event sap.ui.webcomponents.fiori.ViewSettingsDialog#confirm
-		 * @param {String} sortOrder The current sort order selected.
-		 * @param {String} sortBy The currently selected <code>ui5-sort-item</code> text attribute.
+		 * @param {string} sortOrder The current sort order selected.
+		 * @param {string} sortBy The currently selected <code>ui5-sort-item</code> text attribute.
 		 * @public
 		 */
 		confirm: {
@@ -160,8 +160,8 @@ const metadata = {
 		 * Fired when cancel button is activated.
 		 *
 		 * @event sap.ui.webcomponents.fiori.ViewSettingsDialog#cancel
-		 * @param {String} sortOrder The current sort order selected.
-		 * @param {String} sortBy The currently selected <code>ui5-sort-item</code> text attribute.
+		 * @param {string} sortOrder The current sort order selected.
+		 * @param {string} sortBy The currently selected <code>ui5-sort-item</code> text attribute.
 		 * @public
 		 */
 		cancel: {

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -126,7 +126,7 @@ const metadata = {
 		 * @event sap.ui.webcomponents.fiori.Wizard#step-change
 		 * @param {HTMLElement} step The new step.
 		 * @param {HTMLElement} previousStep The previous step.
-		 * @param {Boolean} changeWithClick The step change occurs due to user's click or 'Enter'/'Space' key press on step within the navigation.
+		 * @param {boolean} changeWithClick The step change occurs due to user's click or 'Enter'/'Space' key press on step within the navigation.
 		 * @public
 		 */
 		"step-change": {
@@ -985,7 +985,7 @@ class Wizard extends UI5Element {
 	 * @param {HTMLElement} selectedStep the old step
 	 * @param {HTMLElement} stepToSelect the step to be selected
 	 * @param {Integer} stepToSelectIndex the index of the newly selected step
-	 * @param {Boolean} changeWithClick the selection changed due to user click in the step navigation
+	 * @param {boolean} changeWithClick the selection changed due to user click in the step navigation
 	 * @private
 	 */
 	switchSelectionFromOldToNewStep(selectedStep, stepToSelect, stepToSelectIndex, changeWithClick) {

--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -12,7 +12,7 @@ const metadata = {
 		 *
 		 * <b>Note:</b> The text is displayed in the <code>ui5-wizard</code> navigation header.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -27,7 +27,7 @@ const metadata = {
 		 *
 		 * <b>Note:</b> the text is displayed in the <code>ui5-wizard</code> navigation header.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -45,7 +45,7 @@ const metadata = {
 		 *
 		 * The SAP-icons font provides numerous options.
 		 * See all the available icons in the <ui5-link target="_blank" href="https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 */

--- a/packages/fiori/src/WizardTab.js
+++ b/packages/fiori/src/WizardTab.js
@@ -11,7 +11,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.fiori.WizardTab.prototype */ {
 		/**
 		 * Defines the <code>icon</code> of the step.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @private
 		 */
@@ -21,7 +21,7 @@ const metadata = {
 
 		/**
 		 * Defines the <code>titleText</code> of the step.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @private
 		 * @since 1.0.0-rc.15
@@ -32,7 +32,7 @@ const metadata = {
 
 		/**
 		 * Defines the <code>subtitleText</code> of the step.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @private
 		 * @since 1.0.0-rc.15
@@ -43,7 +43,7 @@ const metadata = {
 
 		/**
 		 * Defines the number that will be displayed in place of the <code>icon</code>, when it's missing.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @private
 		 */
@@ -105,7 +105,7 @@ const metadata = {
 
 		/**
 		 * Defines the tabindex of the step.
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue -1
 		 * @private
 		 */

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -39,7 +39,7 @@ const metadata = {
 
 		/**
 		 * Defines text to be displayed below the component. It can be used to inform the user of the current operation.
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @defaultvalue ""
 		 * @since 1.0.0-rc.7

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -160,7 +160,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -173,7 +173,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.1.0

--- a/packages/main/src/Card.js
+++ b/packages/main/src/Card.js
@@ -53,7 +53,7 @@ const metadata = {
 		 * <b>Note:</b> <code>accessibleName</code> should be always set, unless <code>accessibleNameRef</code> is set.
 		 *
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.16
@@ -65,7 +65,7 @@ const metadata = {
 		/**
 		 * Defines the IDs of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.16

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -35,7 +35,7 @@ const metadata = {
 
 		/**
 		 * Receives id(or many ids) of the elements that label the component
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.1.0
@@ -48,7 +48,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @defaultvalue ""
 		 * @since 1.1.0

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -116,7 +116,7 @@ const metadata = {
 		 * @event sap.ui.webcomponents.main.ColorPalette#item-click
 		 * @public
 		 * @since 1.0.0-rc.15
-		 * @param {String} color the selected color
+		 * @param {string} color the selected color
 		 */
 		"item-click": {
 			details: {

--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -43,7 +43,7 @@ const metadata = {
 		/**
 		 * Defines the index of the item inside of the ColorPalette.
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 */
 		index: {
 			type: String,
@@ -52,7 +52,7 @@ const metadata = {
 		/**
 		 * Defines if the ColorPalette is on phone mode.
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		phone: {
 			type: Boolean,

--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -84,7 +84,7 @@ const metadata = {
 		 *
 		 * @event sap.ui.webcomponents.main.ColorPalettePopover#item-click
 		 * @public
-		 * @param {String} color the selected color
+		 * @param {string} color the selected color
 		 */
 		"item-click": {
 			details: {

--- a/packages/main/src/ColorPicker.js
+++ b/packages/main/src/ColorPicker.js
@@ -42,7 +42,7 @@ const metadata = {
 		/**
 		 * Defines the HEX code of the currently selected color
 		 * *Note*: If Alpha(transperancy) is set it is not included in this property. Use <code>color</code> property.
-		 * @type {String}
+		 * @type {string}
 		 * @private
 		 */
 		hex: {
@@ -53,7 +53,7 @@ const metadata = {
 
 		/**
 		 * Defines the current main color which is selected via the hue slider and is shown in the main color square.
-		 * @type {String}
+		 * @type {string}
 		 * @private
 		 */
 		_mainColor: {

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -212,7 +212,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -224,7 +224,7 @@ const metadata = {
 
 		/**
 		 * Receives id(or many ids) of the elements that label the component
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -170,7 +170,7 @@ const metadata = {
 		/**
 		 * Defines the aria-label attribute for the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @since 1.0.0-rc.15
 		 */
@@ -181,7 +181,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -244,8 +244,8 @@ const metadata = {
 		 * @event
 		 * @allowPreventDefault
 		 * @public
-		 * @param {String} value The submitted value.
-		 * @param {Boolean} valid Indicator if the value is in correct format pattern and in valid range.
+		 * @param {string} value The submitted value.
+		 * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 		*/
 		change: {
 			details: {
@@ -264,8 +264,8 @@ const metadata = {
 		 * @event
 		 * @allowPreventDefault
 		 * @public
-		 * @param {String} value The submitted value.
-		 * @param {Boolean} valid Indicator if the value is in correct format pattern and in valid range.
+		 * @param {string} value The submitted value.
+		 * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 		*/
 		input: {
 			details: {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -313,7 +313,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @since 1.0.0-rc.15
 		 */
@@ -324,7 +324,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the input.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -1488,7 +1488,7 @@ class Input extends UI5Element {
 
 	/**
 	 * Removes the fractional part of floating-point number.
-	 * @param {String} value the numeric value of Input of type "Number"
+	 * @param {string} value the numeric value of Input of type "Number"
 	 */
 	removeFractionalPart(value) {
 		if (value.includes(".")) {

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -117,7 +117,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the input
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -208,7 +208,7 @@ const metadata = {
 		/**
 		 * Defines the accessible name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -220,7 +220,7 @@ const metadata = {
 		/**
 		 * Defines the IDs of the elements that label the input.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -234,7 +234,7 @@ const metadata = {
 		 * Defines the accessible role of the component.
 		 * <br><br>
 		 * @public
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue "list"
 		 * @since 1.0.0-rc.15
 		 */

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -77,7 +77,7 @@ const metadata = {
 		 * Used to define the role of the list item.
 		 *
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue "listitem"
 		 * @since 1.0.0-rc.9
 		 *

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -73,7 +73,7 @@ const metadata = {
 		/**
 		 * Defines the accessible name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -86,7 +86,7 @@ const metadata = {
 		/**
 		 * Defines the IDs of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.1.0
@@ -556,7 +556,7 @@ class Popup extends UI5Element {
 	 *
 	 * @protected
 	 * @abstract
-	 * @returns {String}
+	 * @returns {string}
 	 */
 	get _ariaLabelledBy() {} // eslint-disable-line
 
@@ -565,13 +565,13 @@ class Popup extends UI5Element {
 	 *
 	 * @protected
 	 * @abstract
-	 * @returns {String}
+	 * @returns {string}
 	 */
 	get _ariaModal() {} // eslint-disable-line
 
 	/**
 	 * Ensures ariaLabel is never null or empty string
-	 * @returns {String|undefined}
+	 * @returns {string|undefined}
 	 * @protected
 	 */
 	get _ariaLabel() {

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -189,7 +189,7 @@ const metadata = {
 		/**
 		 * Defines the IDs of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.1.0

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -502,7 +502,7 @@ class RangeSlider extends SliderBase {
 	 * - mouse press position - cursor coordinates relative to the start/end handles
 	 * - selected inner element via a keyboard navigation
 	 *
-	 * @param {String} valuePropAffectedByInteraction The value that will get modified by the interaction
+	 * @param {string} valuePropAffectedByInteraction The value that will get modified by the interaction
 	 * @private
 	 */
 	_setAffectedValue(valuePropAffectedByInteraction) {

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -90,7 +90,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: undefined
 		 * @public
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -40,7 +40,7 @@ const metadata = {
 		 * <b>Note:</b> If you are using the <code>header</code> slot, this property will have no effect
 		 *
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @defaultvalue false
 		 * @since 1.0.0-rc.16
 		 */

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -29,7 +29,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 * @since 1.0.3

--- a/packages/main/src/SegmentedButtonItem.js
+++ b/packages/main/src/SegmentedButtonItem.js
@@ -48,7 +48,7 @@ const metadata = {
 		 * Defines the index of the item inside of the SegmentedButton.
 		 *
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 */
 		posInSet: {
 			type: String,
@@ -58,7 +58,7 @@ const metadata = {
 		 * Defines how many items are inside of the SegmentedButton.
 		 *
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 */
 		sizeOfSet: {
 			type: String,

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -180,7 +180,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @since 1.0.0-rc.9
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -192,7 +192,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the select.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/SplitButton.js
+++ b/packages/main/src/SplitButton.js
@@ -97,7 +97,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 */

--- a/packages/main/src/StepInput.js
+++ b/packages/main/src/StepInput.js
@@ -189,7 +189,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @since 1.0.0-rc.15
 		 */
@@ -200,7 +200,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -221,7 +221,7 @@ const metadata = {
 		},
 
 		/**
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @private
 		 */
 		focused: {

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -100,7 +100,7 @@ const metadata = {
 		/**
 		 * Sets the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
 		 * @since 1.2.0
@@ -112,7 +112,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.1.0

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -281,7 +281,7 @@ const metadata = {
 
 		/**
 		 * Defines whether all rows are selected or not when table is in MultiSelect mode.
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @defaultvalue false
 		 * @since 1.0.0-rc.15
 		 * @private

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -219,7 +219,7 @@ const metadata = {
 		/**
 		 * Defines the accessible aria name of the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @public
 		 * @since 1.0.0-rc.15
 		 */
@@ -230,7 +230,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the textarea.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.0.0-rc.15

--- a/packages/main/src/TreeItem.js
+++ b/packages/main/src/TreeItem.js
@@ -12,7 +12,7 @@ const metadata = {
 		 * Defines the text of the tree item.
 		 *
 		 * @public
-		 * @type {String}
+		 * @type {string}
 		 * @defaultValue ""
 		 */
 		text: {
@@ -82,7 +82,7 @@ const metadata = {
 		 * If set, an icon will be displayed before the text, representing the tree item.
 		 *
 		 * @public
-		 * @type {String}
+		 * @type {string}
 		 * @defaultValue ""
 		 */
 		icon: {

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -43,7 +43,7 @@ const metadata = {
 		 * If set, an icon will be displayed before the text of the tree list item.
 		 *
 		 * @public
-		 * @type {String}
+		 * @type {string}
 		 * @defaultValue ""
 		 */
 		icon: {


### PR DESCRIPTION
Only use primitive types: `stirng`, `boolean` instead of JS objects(`String`, `Boolean`) for JSDoc.