### PR TITLE
fix: display methods in child components API

### DIFF
--- a/packages/tools/lib/documentation/templates/template.js
+++ b/packages/tools/lib/documentation/templates/template.js
@@ -23,6 +23,7 @@ module.exports = {
             {{> properties this}}
             {{> slots this}}
             {{> events this}}
+            {{> methods this}}
             {{> cssVariables this}} 
           </section>
         </section>


### PR DESCRIPTION
For child components, like the TreeItem, the playground only displays props and slots, but not methods. The change adds the method API info.