### PR TITLE
feat(ui5-radio-button): implement sap_horizon_exp theme

### DIFF
--- a/packages/main/src/RadioButton.hbs
+++ b/packages/main/src/RadioButton.hbs
@@ -16,7 +16,7 @@
 >
 
 	<div class='ui5-radio-inner {{classes.inner}}'>
-		<svg class="ui5-radio-svg" focusable="false" aria-hidden="true">
+		<svg viewBox="0 0 20 20" class="ui5-radio-svg" focusable="false" aria-hidden="true">
 			<circle class="ui5-radio-svg-outer" cx="50%" cy="50%" r="50%" />
 			<circle class="ui5-radio-svg-inner" cx="50%" cy="50%" r="22%" />
 		</svg>

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -24,6 +24,7 @@
 }
 
 :host([checked]) .ui5-radio-svg-inner {
+	fill-opacity: var(--_ui5_radio_button_checked_inner_fill_opacity);
 	fill: currentColor;
 }
 
@@ -33,8 +34,8 @@
 
 /* disabled */
 :host([disabled]) .ui5-radio-root {
-	color: var(--_ui5_radio_button_color);
-	opacity: var(--sapContent_DisabledOpacity);
+	color: var(--_ui5_radio_button_disabled_color);
+	opacity: var(--_ui5_radio_button_disabled_opacity);
 }
 
 :host([disabled][checked]) .ui5-radio-svg-outer {
@@ -65,6 +66,19 @@
 	border: var(--_ui5_radio_button_focus_border);
 }
 
+/* keyboard focus */
+:host(:not([disabled]).focus-visible) {
+	box-shadow: var(--_ui5_radio_button_focus_keyboard_shadow);
+	outline: var(--_ui5_radio_button_focus_keyboard_outline);
+
+	--_ui5_radio_button_hover_shadow: var(--_ui5_radio_button_focus_keyboard_hover_shadow);
+	--_ui5_radio_button_active_shadow: var(--_ui5_radio_button_focus_keyboard_active_shadow);
+}
+
+:host(:not([disabled]).focus-visible) .ui5-radio-root {
+	background: var(--_ui5_radio_button_focus_keyboard_background);
+}
+
 /* hovered */
 :host(:not([disabled]):hover) {
 	background: var(--_ui5_radio_button_hover_background);
@@ -82,9 +96,26 @@
 	stroke: var(--_ui5_radio_button_outer_ring_checked_hover_color);
 }
 
+/* active */
+:host(:not([disabled])[active]) {
+	box-shadow: var(--_ui5_radio_button_active_shadow);
+}
+
 /* active, checked */
 :host([active][checked]:not([value-state])) .ui5-radio-svg-outer {
 	stroke: var(--_ui5_radio_button_outer_ring_checked_hover_color);
+}
+
+:host([disabled]),
+:host([readonly]) {
+	--_ui5_radio_button_outer_ring_active_color: var(--_ui5_radio_button_disabled_outer_ring_active_color);
+	--_ui5_radio_button_label_color: var(--_ui5_radio_button_disabled_label_color);
+	--_ui5_radio_button_color: var(--_ui5_radio_button_disabled_color);
+	--_ui5_radio_button_checked_fill: var(--_ui5_radio_button_disabled_checked_fill);
+	--_ui5_radio_button_outer_ring_checked_hover_color: var(--_ui5_radio_button_disabled_outer_ring_checked_hover_color);
+	--_ui5_radio_button_hover_background: var(--_ui5_radio_button_disabled_hover_background);
+	--_ui5_radio_button_active_shadow: var(--_ui5_radio_button_disabled_active_shadow);
+	--_ui5_radio_button_hover_shadow: var(--_ui5_radio_button_disabled_hover_shadow);
 }
 
 /* active, not checked */
@@ -103,12 +134,12 @@
 
 /* readonly */
 :host([checked][readonly]) .ui5-radio-svg-inner {
-	fill: var(--sapContent_NonInteractiveIconColor);
+	fill: var(--_ui5_radio_button_readonly_checked_inner_fill);
 }
 
 :host([readonly]) .ui5-radio-root .ui5-radio-svg-outer {
-	fill: var(--sapField_ReadOnly_Background);
-	stroke: var(--sapField_ReadOnly_BorderColor);
+	fill: var(--_ui5_radio_button_readonly_inner_fill);
+	stroke: var(--_ui5_radio_button_readonly_inner_stroke);
 }
 
 /* value states */
@@ -217,10 +248,13 @@
 	fill: var(--_ui5_radio_button_outer_ring_bg);
 	stroke: currentColor;
 	stroke-width: var(--_ui5_radio_button_outer_ring_width);
+	transition: var(--_ui5_radio_button_outer_transition);
 }
 
 .ui5-radio-svg-inner {
 	fill: none;
+	fill-opacity: var(--_ui5_radio_button_inner_fill_opacity);
+	transition: var(--_ui5_radio_button_inner_transition);
 }
 
 .ui5-radio-svg-outer,

--- a/packages/main/src/themes/base/RadioButton-parameters.css
+++ b/packages/main/src/themes/base/RadioButton-parameters.css
@@ -16,6 +16,7 @@
 	--_ui5_radio_button_outer_ring_padding: 0 0.625rem;
 	--_ui5_radio_button_outer_ring_padding_with_label: 0 0.625rem;
 	--_ui5_radio_button_outer_ring_padding_rtl: 0 0.625rem;
+	--_ui5_radio_button_outer_transition: none;
 	--_ui5_radio_button_border_radius: 0;
 	--_ui5_radio_button_border: none;
 	--_ui5_radio_button_focus_border: none;
@@ -28,5 +29,33 @@
 	--_ui5_radio_button_label_color: var(--sapContent_LabelColor);
 	--_ui5_radio_button_items_align: unset;
 	--_ui5_radio_button_inner_width: initial;
+	--_ui5_radio_button_inner_transition: none;
+	--_ui5_radio_button_inner_fill_opacity: 1;
+	--_ui5_radio_button_inner_transition: none;
+	--_ui5_radio_button_checked_inner_fill_opacity: 1;
 	--_ui5_radio_button_border_readonly_focus_style: var(--sapContent_FocusStyle);
+	--_ui5_radio_button_active_shadow: none;
+	
+	/* keyboard focus */
+	--_ui5_radio_button_focus_keyboard_shadow: none;
+	--_ui5_radio_button_focus_keyboard_outline: block;
+	--_ui5_radio_button_focus_keyboard_background: transparent;
+	--_ui5_radio_button_focus_keyboard_hover_shadow: none;
+	--_ui5_radio_button_focus_keyboard_active_shadow: none;
+	
+	/* readonly */
+	--_ui5_radio_button_readonly_inner_stroke: var(--sapField_ReadOnly_BorderColor);
+	--_ui5_radio_button_readonly_inner_fill: var(--sapField_ReadOnly_Background);
+	--_ui5_radio_button_readonly_checked_inner_fill: var(--sapContent_NonInteractiveIconColor);
+	
+	/* disabled */
+	--_ui5_radio_button_disabled_opacity: var(--sapContent_DisabledOpacity);
+	--_ui5_radio_button_disabled_color: var(--sapField_BorderColor);
+	--_ui5_radio_button_disabled_label_color: var(--sapContent_LabelColor);
+	--_ui5_radio_button_disabled_checked_fill: var(--sapSelectedColor);
+	--_ui5_radio_button_disabled_hover_background: inherit;
+	--_ui5_radio_button_disabled_hover_shadow: none;
+	--_ui5_radio_button_disabled_active_shadow: none;
+	--_ui5_radio_button_disabled_outer_ring_active_color: var(--sapField_Hover_BorderColor);
+	--_ui5_radio_button_disabled_outer_ring_checked_hover_color: var(--sapField_Hover_BorderColor);
 }

--- a/packages/main/src/themes/sap_horizon_exp/RadioButton-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/RadioButton-parameters.css
@@ -2,29 +2,63 @@
 
 :root {
 	--_ui5_radio_button_height: 2rem;
-	--_ui5_radio_button_inner_size: 100%;
-	--_ui5_radio_button_svg_size: 1.25rem;
-	--_ui5_radio_button_svg_size: 1.25rem;
-	--_ui5_radio_button_checked_fill: var(--sapContent_FocusColor);
-	--_ui5_radio_button_color: var(--sapNeutralColor);
-	--_ui5_radio_button_outer_ring_color: var(--sapContent_FocusColor);
-	--_ui5_radio_button_outer_ring_hover_color: #475E75;
-	--_ui5_radio_button_outer_ring_active_color: #354A5F;
-	--_ui5_radio_button_outer_ring_checked_hover_color: var(--sapContent_FocusColor);
+	--_ui5_radio_button_inner_size: 2rem;
+	--_ui5_radio_button_svg_size: 1.125rem;
+	--_ui5_radio_button_checked_fill: var(--sapBlueColor4);
+	--_ui5_radio_button_hover_fill: #fff;
+
+	--_ui5_radio_button_color:  var(--sapGreyColor5);
+	--_ui5_radio_button_hover_color: var(--sapGreyColor6);
+	--_ui5_radio_button_disabled_color: var(--sapGreyColor3);
+	--_ui5_radio_button_outer_ring_color: var(--sapBlueColor4);
+	--_ui5_radio_button_outer_ring_hover_color: var(--sapGreyColor6);
+	--_ui5_radio_button_outer_ring_active_color: var(--sapGreyColor7);
+	--_ui5_radio_button_outer_ring_checked_hover_color: var(--sapBlueColor4);
 	--_ui5_radio_button_outer_ring_width: 2;
-	--_ui5_radio_button_outer_ring_bg: var(--sapHighlightTextColor);
+	--_ui5_radio_button_outer_ring_bg: transparent;
+	--_ui5_radio_button_outer_ring_padding: 0 0.375rem;
 	--_ui5_radio_button_outer_ring_padding: 0 0.375rem;
 	--_ui5_radio_button_outer_ring_padding_with_label: 0 0.625rem 0 0.375rem;
 	--_ui5_radio_button_outer_ring_padding_rtl: 0 0.375rem 0 0.625rem;
+	--_ui5_radio_button_outer_transition: stroke .2s ease-in-out;
 	--_ui5_radio_button_border_radius: 1rem;
-	--_ui5_radio_button_border: 0.125rem solid transparent;
-	--_ui5_radio_button_focus_border: 0.125rem solid var(--sapContent_FocusColor);
+	--_ui5_radio_button_border: none;
+	--_ui5_radio_button_border_width: 0;
+	--_ui5_radio_button_focus_border: none;
 	--_ui5_radio_button_focus_outline: none;
-	--_ui5_radio_button_hover_shadow: 0px 0px 2px rgba(131, 150, 168, 0.16), 0px 8px 16px rgba(131, 150, 168, 0.16);
-	--_ui5_radio_button_hover_background: var(--sapHighlightTextColor);
-	--_ui5_radio_button_transition: all 0.2s ease-in-out;
+	--_ui5_radio_button_hover_shadow: var(--shadow-grey-medium);
+	--_ui5_radio_button_hover_background: #fff;
+	--_ui5_radio_button_transition: box-shadow .2s ease-in-out, outline .2s ease-in-out, background-color .2s ease-in-out;
 	--_ui5_radio_button_label_offset: 0.375rem;
-	--_ui5_radio_button_label_color: var(--sapTitleColor);
+	--_ui5_radio_button_label_color: var(--sapGreyColor8);
+	--_ui5_radio_button_label_side_padding: 0.5rem;
 	--_ui5_radio_button_items_align: center;
 	--_ui5_radio_button_inner_width: 100%;
+	--_ui5_radio_button_inner_transition: fill-opacity .2s ease-in-out;
+	--_ui5_radio_button_inner_fill_opacity: 0;
+	--_ui5_radio_button_checked_inner_fill_opacity: 1;
+	--_ui5_radio_button_active_shadow: var(--shadow-grey-xs);
+	
+	/* keyboard focus */
+	--_ui5_radio_button_focus_keyboard_shadow: var(--shadow-blue-medium);
+	--_ui5_radio_button_focus_keyboard_outline: 2px solid var(--sapBlueColor4);
+	--_ui5_radio_button_focus_keyboard_background: #fff;
+	--_ui5_radio_button_focus_keyboard_hover_shadow: var(--shadow-blue-medium);
+	--_ui5_radio_button_focus_keyboard_active_shadow: var(--shadow-blue-xs);
+	
+	/* readonly */
+	--_ui5_radio_button_readonly_inner_stroke: var(--sapGreyColor3);
+	--_ui5_radio_button_readonly_inner_fill: transparent;
+	--_ui5_radio_button_readonly_checked_inner_fill: var(--sapGreyColor3);
+	
+	/* disabled */
+	--_ui5_radio_button_disabled_opacity: 1;
+	--_ui5_radio_button_disabled_color: var(--sapGreyColor3);
+	--_ui5_radio_button_disabled_label_color: var(--sapGreyColor3);
+	--_ui5_radio_button_disabled_checked_fill: var(--sapGreyColor3);
+	--_ui5_radio_button_disabled_hover_background: transparent;
+	--_ui5_radio_button_disabled_hover_shadow: none;
+	--_ui5_radio_button_disabled_active_shadow: none;
+	--_ui5_radio_button_disabled_outer_ring_active_color: var(--sapGreyColor3);
+	--_ui5_radio_button_disabled_outer_ring_checked_hover_color: var(--sapGreyColor3);
 }


### PR DESCRIPTION
SAP Horizon Experimental theme implementation for **Radio Buttons**.

I've added `viewBox` to `svg` tag to prevent the initial showing of the big unstyled svg.
If there are some concerns kindly let me know.

Theme name: **sap_horizon_exp**