### PR TITLE
fix(ui5-list): fix separators in SAP Horizon

### DIFF
--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -28,7 +28,7 @@
 
 /* focused & selected */
 :host([focused][selected]) {
-	border-bottom: var(--ui5-listitem-focused-border-bottom);
+	border-bottom: var(--ui5-listitem-focused-selected-border-bottom);
 }
 
 .ui5-li-root {
@@ -42,10 +42,6 @@
 }
 
 /* focused */
-:host([focused]) {
-	border-bottom: var(--ui5-listitem-focused-border-bottom);
-}
-
 :host([focused]) .ui5-li-root.ui5-li--focusable {
 	outline: none;
 }

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -22,8 +22,13 @@
 	border-bottom: var(--ui5-listitem-selected-border-bottom);
 }
 
-:host([selected][has-border]) {
+:host(:not([focused])[selected][has-border]) {
 	border-bottom: var(--ui5-listitem-selected-border-bottom);
+}
+
+/* focused & selected */
+:host([focused][selected]) {
+	border-bottom: var(--ui5-listitem-focused-border-bottom);
 }
 
 .ui5-li-root {
@@ -36,6 +41,11 @@
 	box-sizing: border-box;
 }
 
+/* focused */
+:host([focused]) {
+	border-bottom: var(--ui5-listitem-focused-border-bottom);
+}
+
 :host([focused]) .ui5-li-root.ui5-li--focusable {
 	outline: none;
 }
@@ -44,10 +54,10 @@
 	content: "";
 	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+	top: 0.0625rem;
+	right: 0.0625rem;
+	bottom: 0.0625rem;
+	left: 0.0625rem;
 	pointer-events: none;
 }
 

--- a/packages/main/src/themes/base/ListItemBase-parameters.css
+++ b/packages/main/src/themes/base/ListItemBase-parameters.css
@@ -2,7 +2,7 @@
 	--ui5-listitem-background-color: var(--sapList_Background);
 	--ui5-listitem-border-bottom: 1px solid var(--sapList_BorderColor);
 	--ui5-listitem-selected-border-bottom: 1px solid var(--sapList_SelectionBorderColor);
-	--ui5-listitem-focused-border-bottom: 1px solid transparent;
+	--ui5-listitem-focused-selected-border-bottom: 1px solid var(--sapList_SelectionBorderColor);
 	--ui5-listitem-active-border-color: var(--sapContent_ContrastFocusColor);
 	--_ui5_listitembase_focus_width: 1px;
 	--_ui5-listitembase_disabled_opacity: 0.5;

--- a/packages/main/src/themes/base/ListItemBase-parameters.css
+++ b/packages/main/src/themes/base/ListItemBase-parameters.css
@@ -2,6 +2,7 @@
 	--ui5-listitem-background-color: var(--sapList_Background);
 	--ui5-listitem-border-bottom: 1px solid var(--sapList_BorderColor);
 	--ui5-listitem-selected-border-bottom: 1px solid var(--sapList_SelectionBorderColor);
+	--ui5-listitem-focused-border-bottom: 1px solid transparent;
 	--ui5-listitem-active-border-color: var(--sapContent_ContrastFocusColor);
 	--_ui5_listitembase_focus_width: 1px;
 	--_ui5-listitembase_disabled_opacity: 0.5;

--- a/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
@@ -2,5 +2,4 @@
 
 :root {
 	--ui5-listitem-active-border-color: var(--sapContent_FocusColor);
-	--ui5-listitem-selected-border-bottom: 1px solid transparent;
 }

--- a/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
@@ -1,5 +1,6 @@
 @import "../base/ListItemBase-parameters.css";
 
 :root {
+	--ui5-listitem-focused-selected-border-bottom: 1px solid transparent;
 	--ui5-listitem-active-border-color: var(--sapContent_FocusColor);
 }

--- a/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ListItemBase-parameters.css
@@ -2,6 +2,5 @@
 
 :root {
 	--ui5-listitem-active-border-color: var(--sapContent_FocusColor);
-    --ui5-listitem-border-bottom: 1px solid transparent;
 	--ui5-listitem-selected-border-bottom: 1px solid transparent;
 }


### PR DESCRIPTION
**Background**
For some reason the bottom-border **--ui5-listitem-border-bottom**  has been left **transparent** in sap_horizon only 
and this parameter is responsible for the default (rest) state. In this state the bottom border is needed to separate the list items.

Changes:
- Show the border-bottom line in rest state, so that the list items are separated.
<img width="541" alt="Screenshot 2022-02-23 at 11 36 18" src="https://user-images.githubusercontent.com/15702139/155293460-9ebdbc23-21a6-43b4-9de3-90c7c268432a.png">

Additional  Changes. When comparing to the UI5 List I noticed other issues

- the focus outline merges with the selection outline of previous/next items. Add 1px offset to the focused outline to ensure it does not merge with the selection bottom border line of the next or previous items.
<img width="370" alt="Screenshot 2022-02-23 at 11 33 21" src="https://user-images.githubusercontent.com/15702139/155292981-84ee3127-64c3-4e20-a5ee-3fcfebcb95c3.png">

- the selection border-bottom is missing

before
<img width="349" alt="Screenshot 2022-02-23 at 11 53 54" src="https://user-images.githubusercontent.com/15702139/155296429-db1fefb9-80f3-4342-b79a-d5ff84d8534f.png">
after
<img width="294" alt="Screenshot 2022-02-23 at 11 54 17" src="https://user-images.githubusercontent.com/15702139/155296460-89020a0d-3234-4a1f-8fd0-c6f95326b720.png">


FIXES: https://github.com/SAP/ui5-webcomponents/issues/4803