### PR TITLE
chore: enforce "en" locale for datetime tests

### DIFF
--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1126,7 +1126,7 @@ describe("Date Picker Tests", () => {
 	});
 
 	it("Value state changes only on submit", async () => {
-		await browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker.html`);
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker.html?sap-ui-language=en`);
 		datepicker.id = "#dp33";
 
 		const innerInput = await datepicker.getInnerInput();

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -44,7 +44,7 @@ const getTimeSlidersCount = async id => {
 
 describe("DateTimePicker general interaction", () => {
 	before(async () => {
-		await browser.url(`http://localhost:${PORT}/test-resources/pages/DateTimePicker.html`);
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/DateTimePicker.html?sap-ui-language=en`);
 	});
 
 	it("tests picker opens/closes programmatically", async () => {

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -14,7 +14,7 @@ describe("TimePicker general interaction", () => {
 	});
 
 	it("tests sliders value", async () => {
-		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html`);
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html?sap-ui-language=en`);
 		const timepicker = await browser.$("#timepicker");
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#timepicker");
 		const timepickerPopover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
@@ -196,7 +196,7 @@ describe("TimePicker general interaction", () => {
 
 	it("test arrow navigation", async () => {
 		// arrange
-		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html`);
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html?sap-ui-language=en`);
 
 		const timepicker = await browser.$("#timepicker3"); //picker with 4 sliders
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#timepicker3");
@@ -217,7 +217,7 @@ describe("TimePicker general interaction", () => {
 
 	it("test closing the picker with the keyboard", async () => {
 		// arrange
-		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html`);
+		await browser.url(`http://localhost:${PORT}/test-resources/pages/TimePicker.html?sap-ui-language=en`);
 
 		const timepicker = await browser.$("#timepicker3");
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#timepicker3");


### PR DESCRIPTION
On some machines with locale different than "en", the tests are failing. The solution is to explicitly set the "en" locale.