### PR TITLE
fix(ui5-list): initial focus target

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-d0rKCGPSslUInvlc9d1bPYtCkKk=
+57Bf19Hmr/QQibZlChDm0ZN9vyw=

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -833,12 +833,7 @@ class List extends UI5Element {
 		// The focus arrives in the List for the first time.
 		// If there is selected item - focus it or focus the first item.
 		if (!this.getPreviouslyFocusedItem()) {
-			if (this.getFirstItem(x => x.selected && !x.disabled)) {
-				this.focusFirstSelectedItem();
-			} else {
-				this.focusFirstItem();
-			}
-
+			this.focusFirstItem();
 			event.stopImmediatePropagation();
 			return;
 		}
@@ -846,12 +841,7 @@ class List extends UI5Element {
 		// The focus returns to the List,
 		// focus the first selected item or the previously focused element.
 		if (!this.getForwardingFocus()) {
-			if (this.getFirstItem(x => x.selected && !x.disabled)) {
-				this.focusFirstSelectedItem();
-			} else {
-				this.focusPreviouslyFocusedItem();
-			}
-
+			this.focusPreviouslyFocusedItem();
 			event.stopImmediatePropagation();
 		}
 

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -135,7 +135,7 @@
 	<ui5-list id="keyboardTestList">
 		<div slot="header" class="header"><ui5-button id="headerBtn" design="Accept">Export</ui5-button></div>
 
-		<ui5-li>Argentina</ui5-li>
+		<ui5-li class="firstItem">Argentina</ui5-li>
 		<ui5-li-custom selected class="item">
 				<ui5-button class="itemBtn">Click me</ui5-button>
 				<ui5-link href="https://www.google.bg" target="_blank" class="itemLink">UI5 link</ui5-link>

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -217,6 +217,7 @@ describe("List Tests", () => {
 
 	it("keyboard handling on TAB", async () => {
 		const headerBtn = await browser.$("#headerBtn");
+		const firstItem = await browser.$("ui5-li.firstItem");
 		const item = await browser.$("ui5-li-custom.item");
 		const itemBtn = await browser.$("ui5-button.itemBtn");
 		const itemLink = await browser.$("ui5-link.itemLink");
@@ -228,7 +229,10 @@ describe("List Tests", () => {
 
 		// act: TAB from headerButton -> the focus should go to the 1st selected item
 		await headerBtn.keys("Tab");
-		assert.ok(await item.isFocused(), "selected item is focused");
+		assert.ok(await firstItem.isFocused(), "first item is focused");
+
+		await firstItem.keys("ArrowDown");
+		assert.ok(await item.isFocused(), "custom item is focused");
 
 		// act: TAB from item -> the focus should go to "Click me" button
 		await item.keys("Tab");


### PR DESCRIPTION
Compared to OpenUI5 current focus behaviour is not correct. Correct behaviour is:

- If the focus enters the list for first time the focused element should be the first list item.
- If some of the list items was focused in the past it should be focused again when the focus comes back to the list.

Fixes: #4806 