### PR TITLE
fix(ui5-flexible-column-layout): improve accessibility

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -1,6 +1,7 @@
 <div class="{{classes.root}}">
 	<div
-		role="{{accStartColumnRole}}"
+		role="{{_accAttributes.columns.start.role}}"
+		aria-hidden="{{_accAttributes.columns.start.ariaHidden}}"
 		class="{{classes.columns.start}}"
 		aria-labelledby="{{_id}}-startColumnText"
 	>
@@ -13,7 +14,8 @@
 	</div>
 
 	<div
-		role="{{accMiddleColumnRole}}"
+		role="{{_accAttributes.columns.middle.role}}"
+		aria-hidden="{{_accAttributes.columns.middle.ariaHidden}}"
 		class="{{classes.columns.middle}}"
 		aria-labelledby="{{_id}}-midColumnText"
 	>
@@ -26,7 +28,8 @@
 	</div>
 
 	<div
-		role="{{accEndColumnRole}}"
+		role="{{_accAttributes.columns.end.role}}"
+		aria-hidden="{{_accAttributes.columns.end.ariaHidden}}"
 		class="{{classes.columns.end}}"
 		aria-labelledby="{{_id}}-endColumnText"
 	>

--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -705,15 +705,24 @@ class FlexibleColumnLayout extends UI5Element {
 	}
 
 	get accStartColumnRole() {
-		return this.accessibilityRoles.startColumnRole || "region";
+		if (this.startColumnVisible) {
+			return this.accessibilityRoles.startColumnRole || "region";
+		}
+		return undefined;
 	}
 
 	get accMiddleColumnRole() {
-		return this.accessibilityRoles.midColumnRole || "region";
+		if (this.midColumnVisible) {
+			return this.accessibilityRoles.midColumnRole || "region";
+		}
+		return undefined;
 	}
 
 	get accEndColumnRole() {
-		return this.accessibilityRoles.endColumnRole || "region";
+		if (this.endColumnVisible) {
+			return this.accessibilityRoles.endColumnRole || "region";
+		}
+		return undefined;
 	}
 
 	get accStartArrowContainerRole() {
@@ -726,6 +735,25 @@ class FlexibleColumnLayout extends UI5Element {
 
 	get _effectiveLayoutsByMedia() {
 		return this._layoutsConfiguration || getLayoutsByMedia();
+	}
+
+	get _accAttributes() {
+		return {
+			columns: {
+				start: {
+					role: this.accStartColumnRole,
+					ariaHidden: !this.startColumnVisible || undefined,
+				},
+				middle: {
+					role: this.accMiddleColumnRole,
+					ariaHidden: !this.midColumnVisible || undefined,
+				},
+				end: {
+					role: this.accEndColumnRole,
+					ariaHidden: !this.endColumnVisible || undefined,
+				},
+			},
+		};
 	}
 
 	get accStartArrowText() {

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -407,7 +407,7 @@
 		</div>
 	</ui5-flexible-column-layout>
 
-	<ui5-flexible-column-layout id="fclAccRoles" layout="ThreeColumnsMidExpandedEndHidden">
+	<ui5-flexible-column-layout id="fclAccRoles" layout="ThreeColumnsMidExpanded">
 		<!-- start column -->
 		<div class="fcl4auto" slot="startColumn">
 		</div>
@@ -420,6 +420,12 @@
 		<!-- end column -->
 		<div class="fcl4auto" slot="endColumn">
 			
+		</div>
+	</ui5-flexible-column-layout>
+
+	<ui5-flexible-column-layout id="fclAccAttrs">
+		<!-- start column -->
+		<div class="fcl4auto" slot="startColumn">
 		</div>
 	</ui5-flexible-column-layout>
 

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -181,7 +181,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 			"Start column is not hidden from the acc tree.");
 
 		assert.strictEqual(await middleColumnDOM.getAttribute("aria-hidden"), "true",
-			"Middle column is hidden from the acc tre.");
+			"Middle column is hidden from the acc tree.");
 
 	});
 });

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -133,7 +133,7 @@ describe("FlexibleColumnLayout Behavior", () => {
 		assert.strictEqual(await middleColumnDOM.getAttribute("role"), "region",
 			"Middle column has the correct default role.");
 
-		assert.strictEqual(await endColumnDOM.getAttribute("role"), "region",
+		assert.strictEqual(await endColumnDOM.getAttribute("role"), null, /* hidden column */
 			"End column has the correct default role.");
 
 		assert.strictEqual(await startArrowContainerDOM.getAttribute("role"), null,
@@ -168,5 +168,20 @@ describe("FlexibleColumnLayout Behavior", () => {
 
 		assert.strictEqual(await endArrowContainerDOM.getAttribute("role"), "navigation",
 			"End arrow container has the correct custom role.");
+	});
+
+	it("tests acc attrs", async () => {
+		let fcl = await browser.$("#fclAccAttrs");
+
+		const startColumnDOM = await fcl.shadow$(".ui5-fcl-column--start");
+		const middleColumnDOM = await fcl.shadow$(".ui5-fcl-column--middle");
+
+		// assert
+		assert.strictEqual(await startColumnDOM.getAttribute("aria-hidden"), null,
+			"Start column is not hidden from the acc tree.");
+
+		assert.strictEqual(await middleColumnDOM.getAttribute("aria-hidden"), "true",
+			"Middle column is hidden from the acc tre.");
+
 	});
 });


### PR DESCRIPTION
Hidden columns are rendered in the DOM but not visible to the users, so they should be hidden from the accessibility tree.

Summary:
- remove the role attribute
- aria-hidden attribute set to true

Fixes: #4789