### PR TITLE
fix(ui5-popup): body styles are no longer modified 

### DIFF
--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -188,7 +188,7 @@ const createBlockingStyle = () => {
 
 createBlockingStyle();
 
-const bodyScrollingBlockers = new Set();
+const pageScrollingBlockers = new Set();
 
 /**
  * @class
@@ -200,7 +200,7 @@ const bodyScrollingBlockers = new Set();
  *
  * 1. The Popup class handles modality:
  *  - The "isModal" getter can be overridden by derivatives to provide their own conditions when they are modal or not
- *  - Derivatives may call the "blockBodyScrolling" and "unblockBodyScrolling" static methods to temporarily remove scrollbars on the body
+ *  - Derivatives may call the "blockPageScrolling" and "unblockPageScrolling" static methods to temporarily remove scrollbars on the html element
  *  - Derivatives may call the "open" and "close" methods which handle focus, manage the popup registry and for modal popups, manage the blocking layer
  *
  *  2. Provides blocking layer (relevant for modal popups only):
@@ -245,7 +245,7 @@ class Popup extends UI5Element {
 	static get template() {
 		return PopupTemplate;
 	}
-
+// $0.addEventListener("change", () => {debugger})
 	static get staticAreaTemplate() {
 		return PopupBlockLayer;
 	}
@@ -264,7 +264,7 @@ class Popup extends UI5Element {
 
 	onExitDOM() {
 		if (this.isOpen()) {
-			Popup.unblockBodyScrolling(this);
+			Popup.unblockPageScrolling(this);
 			this._removeOpenedPopup();
 		}
 
@@ -287,36 +287,31 @@ class Popup extends UI5Element {
 	}
 
 	/**
-	 * Temporarily removes scrollbars from the body
+	 * Temporarily removes scrollbars from the html element
 	 * @protected
 	 */
-	static blockBodyScrolling(popup) {
-		bodyScrollingBlockers.add(popup);
+	static blockPageScrolling(popup) {
+		pageScrollingBlockers.add(popup);
 
-		if (bodyScrollingBlockers.size !== 1) {
+		if (pageScrollingBlockers.size !== 1) {
 			return;
 		}
 
-		if (window.pageYOffset > 0) {
-			document.body.style.top = `-${window.pageYOffset}px`;
-		}
-		document.body.classList.add("ui5-popup-scroll-blocker");
+		document.documentElement.classList.add("ui5-popup-scroll-blocker");
 	}
 
 	/**
-	 * Restores scrollbars on the body, if needed
+	 * Restores scrollbars on the html element, if needed
 	 * @protected
 	 */
-	static unblockBodyScrolling(popup) {
-		bodyScrollingBlockers.delete(popup);
+	static unblockPageScrolling(popup) {
+		pageScrollingBlockers.delete(popup);
 
-		if (bodyScrollingBlockers.size !== 0) {
+		if (pageScrollingBlockers.size !== 0) {
 			return;
 		}
 
-		document.body.classList.remove("ui5-popup-scroll-blocker");
-		window.scrollTo(0, -parseFloat(document.body.style.top));
-		document.body.style.top = "";
+		document.documentElement.classList.remove("ui5-popup-scroll-blocker");
 	}
 
 	_scroll(e) {
@@ -446,7 +441,7 @@ class Popup extends UI5Element {
 			// create static area item ref for block layer
 			this.getStaticAreaItemDomRef();
 			this._blockLayerHidden = false;
-			Popup.blockBodyScrolling(this);
+			Popup.blockPageScrolling(this);
 		}
 
 		this._zIndex = getNextZIndex();
@@ -492,7 +487,7 @@ class Popup extends UI5Element {
 
 		if (this.isModal) {
 			this._blockLayerHidden = true;
-			Popup.unblockBodyScrolling(this);
+			Popup.unblockPageScrolling(this);
 		}
 
 		this.hide();

--- a/packages/main/src/Popup.js
+++ b/packages/main/src/Popup.js
@@ -245,7 +245,7 @@ class Popup extends UI5Element {
 	static get template() {
 		return PopupTemplate;
 	}
-// $0.addEventListener("change", () => {debugger})
+
 	static get staticAreaTemplate() {
 		return PopupBlockLayer;
 	}

--- a/packages/main/src/themes/PopupGlobal.css
+++ b/packages/main/src/themes/PopupGlobal.css
@@ -1,6 +1,3 @@
 .ui5-popup-scroll-blocker {
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    overflow: hidden;
+	overflow: hidden;
 }

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -457,14 +457,18 @@
 		<span>Hello World!</span>
 	</ui5-dialog>
 
-	<span id="scrollHelper" class="dialog9auto">SCroll Helper</span>
+	<div id="scrollHelper" class="dialog9scrollHelper">
+		<span>Scroll Helper</span>
+		<ui5-button id="scrolledBtn" class="scrolledBtn">open</ui5-button>
+	</div>
 
 	<script>
-		cbCompact.addEventListener("change", function () {
+		cbCompact.addEventListener("ui5-change", function () {
 			document.body.classList.toggle("ui5-content-density-compact", cbCompact.checked);
 		});
 
-		cbScrollable.addEventListener("change", function () {
+		cbScrollable.addEventListener("ui5-change", function () {
+			console.error("change")
 			scrollHelper.style.display = cbScrollable.checked ? "block" : "none";
 		});
 
@@ -580,6 +584,10 @@
 
 		window["btn-acc-name-ref"].addEventListener("click", function () {
 			window["dialog-acc-name-ref"].show();
+		});
+
+		window["scrolledBtn"].addEventListener("click", function () {
+			window["dialog"].show();
 		});
 
 	</script>

--- a/packages/main/test/pages/styles/Dialog.css
+++ b/packages/main/test/pages/styles/Dialog.css
@@ -38,9 +38,15 @@
     width: 300px
 }
 
-.dialog9auto {
+.dialog9scrollHelper {
     display: none;
     margin-top: 1000px;
+    width: 3000px;
+}
+
+.dialog9scrollHelper .scrolledBtn {
+    margin-left: 1500px;
+    margin-bottom: 200px;
 }
 
 /* Remove the responsive paddings for the content area of the Dialog */

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -334,40 +334,57 @@ describe("Page scrolling", () => {
 	});
 
 	it("tests that page scrolling is blocked and restored", async () => {
-		await browser.$("#cbScrollable").click();
-		const offsetHeightBefore = await browser.$("body").getProperty("offsetHeight");
-
 		await browser.$("#btnOpenDialog").click();
+		let pageOverflow = await browser.execute("return window.getComputedStyle(document.documentElement).overflow;");
 
-		assert.isBelow(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is blocked");
+		assert.strictEqual(pageOverflow, "hidden", "Page scrolling is blocked");
 
 		await browser.$("#btnCloseDialog").click();
+		pageOverflow = await browser.execute("return window.getComputedStyle(document.documentElement).overflow;");
 
-		assert.strictEqual(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is restored");
+		assert.strictEqual(pageOverflow, "visible", "Page scrolling is restored");
+	});
+
+	it("tests that page scrolling position is preserved", async () => {
+		// scroll position might change slightly when the scrollbars hide and then appear again
+		const SCROLLBAR_DELTA = 20;
+		await browser.$("#cbScrollable").click();
+		const scrolledButton = await $("#scrolledBtn");
+		await scrolledButton.scrollIntoView();
+		const scrollLeftBefore = await browser.$("html").getProperty("scrollLeft");
+		const scrollTopBefore = await browser.$("html").getProperty("scrollTop");
+		await scrolledButton.click();
+
+		assert.strictEqual(await browser.$("html").getProperty("scrollLeft"), scrollLeftBefore, "Horizontal page scroll position is preserved");
+		assert.approximately(await browser.$("html").getProperty("scrollTop"), scrollTopBefore, SCROLLBAR_DELTA, "Vertical page scroll position is preserved");
+
+		await browser.keys("Escape");
+
+		assert.strictEqual(await browser.$("html").getProperty("scrollLeft"), scrollLeftBefore, "Horizontal page scroll position is preserved");
+		assert.approximately(await browser.$("html").getProperty("scrollTop"), scrollTopBefore, SCROLLBAR_DELTA, "Vertical page scroll position is preserved");
+
 		await browser.$("#cbScrollable").click();
 	});
 
 	it("tests that page scrolling is blocked and restored after multiple show() of same dialog", async () => {
-		await browser.$("#cbScrollable").click();
-		const offsetHeightBefore = await browser.$("body").getProperty("offsetHeight");
-
 		await browser.$("#multiple-show").click();
+		let pageOverflow = await browser.execute("return window.getComputedStyle(document.documentElement).overflow;");
 
-		assert.isBelow(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is blocked");
+		assert.strictEqual(pageOverflow, "hidden", "Page scrolling is blocked");
 
 		await browser.$("#btnCloseDialog").click();
+		pageOverflow = await browser.execute("return window.getComputedStyle(document.documentElement).overflow;");
 
-		assert.strictEqual(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is restored");
-		await browser.$("#cbScrollable").click();
+		assert.strictEqual(pageOverflow, "visible", "Page scrolling is restored");
 	});
 
 	it("test page scrolling is restored after close with ESC", async () => {
 		await browser.$("#cbScrollable").click();
-		const offsetHeightBefore = await browser.$("body").getProperty("offsetHeight");
+		const scrollHeightBefore = await browser.$("html").getProperty("scrollHeight");
 
 		await browser.$("#btnOpenDialog").click();
 		await browser.keys("Escape");
-		assert.strictEqual(await browser.$("body").getProperty("offsetHeight"), offsetHeightBefore, "Body scrolling is restored");
+		assert.strictEqual(await browser.$("html").getProperty("scrollHeight"), scrollHeightBefore, "Body scrolling is restored");
 
 		await browser.$("#cbScrollable").click();
 	});


### PR DESCRIPTION
Popups add styles to the body element to prevent scrolling, which can disrupt the layout of the page.
Now the scrolling is prevented by adding `overflow: hidden` style to the html element.

Fixes #4347
