### PR TITLE
feat(ui5-multi-combobox, ui5-tokenizer):  Handle 'Space' key combinations

### DIFF
--- a/packages/base/src/Keys.js
+++ b/packages/base/src/Keys.js
@@ -111,6 +111,8 @@ const isSpace = event => (event.key ? (event.key === "Spacebar" || event.key ===
 
 const isSpaceShift = event => (event.key ? (event.key === "Spacebar" || event.key === " ") : event.keyCode === KeyCodes.SPACE) && checkModifierKeys(event, false, false, true);
 
+const isSpaceCtrl = event => (event.key ? (event.key === "Spacebar" || event.key === " ") : event.keyCode === KeyCodes.SPACE) && checkModifierKeys(event, true, false, false);
+
 const isLeft = event => (event.key ? (event.key === "ArrowLeft" || event.key === "Left") : event.keyCode === KeyCodes.ARROW_LEFT) && !hasModifierKeys(event);
 
 const isRight = event => (event.key ? (event.key === "ArrowRight" || event.key === "Right") : event.keyCode === KeyCodes.ARROW_RIGHT) && !hasModifierKeys(event);
@@ -230,6 +232,7 @@ export {
 	isEnterShift,
 	isSpace,
 	isSpaceShift,
+	isSpaceCtrl,
 	isLeft,
 	isRight,
 	isUp,

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -7,6 +7,8 @@ import {
 	isDown,
 	isUp,
 	isSpace,
+	isSpaceCtrl,
+	isSpaceShift,
 	isRight,
 	isHome,
 	isTabNext,
@@ -580,6 +582,10 @@ class MultiComboBox extends UI5Element {
 			return;
 		}
 
+		if (isSpaceShift(event)) {
+			event.preventDefault();
+		}
+
 		this._keyDown = true;
 		this[`_handle${event.key}`] && this[`_handle${event.key}`](event);
 	}
@@ -650,6 +656,12 @@ class MultiComboBox extends UI5Element {
 		}
 
 		event.preventDefault();
+
+		if (isSpaceCtrl(event)) {
+			const itemIdx = this.list.items.indexOf(event.target);
+			this.items[itemIdx].selected = !event.target.selected;
+			this.fireSelectionChange();
+		}
 
 		if (((isUp(event) && isFirstItem) || isHome(event)) && this.valueStateHeader) {
 			this.valueStateHeader.focus();
@@ -851,7 +863,7 @@ class MultiComboBox extends UI5Element {
 			this.fireSelectionChange();
 		}
 
-		if (!event.detail.selectionComponentPressed && !isSpace(event.detail)) {
+		if (!event.detail.selectionComponentPressed && !isSpace(event.detail) && !isSpaceCtrl(event.detail)) {
 			this.allItemsPopover.close();
 			this.value = "";
 

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -669,12 +669,6 @@ class MultiComboBox extends UI5Element {
 
 		event.preventDefault();
 
-		if (isSpaceCtrl(event)) {
-			const itemIdx = this.list.items.indexOf(event.target);
-			this.items[itemIdx].selected = !event.target.selected;
-			this.fireSelectionChange();
-		}
-
 		if (isCtrlA(event)) {
 			this._handleSelectAll(event);
 			return;

--- a/packages/main/src/Token.js
+++ b/packages/main/src/Token.js
@@ -5,6 +5,7 @@ import {
 	isBackSpace,
 	isSpace,
 	isDelete,
+	isSpaceCtrl,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/sys-cancel.js";
@@ -186,7 +187,7 @@ class Token extends UI5Element {
 			});
 		}
 
-		if (isSpace(event)) {
+		if (isSpace(event) || isSpaceCtrl(event)) {
 			event.preventDefault();
 
 			this._handleSelect();

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -7,6 +7,8 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import {
 	isSpace,
+	isSpaceCtrl,
+	isSpaceShift,
 	isLeftCtrl,
 	isRightCtrl,
 	isLeftShift,
@@ -265,7 +267,11 @@ class Tokenizer extends UI5Element {
 	}
 
 	_onkeydown(event) {
-		if (isSpace(event)) {
+		if (isSpaceShift(event)) {
+			event.preventDefault();
+		}
+
+		if (isSpace(event) || isSpaceCtrl(event)) {
 			event.preventDefault();
 
 			return this._handleTokenSelection(event, false);

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -737,7 +737,7 @@ describe("MultiComboBox general interaction", () => {
 			await input.click();
 			await mcb.keys(["Shift", "Space"]);
 
-			assert.strictEqual(await mcb.getProperty("value"), "", "Last token should be selected");
+			assert.strictEqual(await mcb.getProperty("value"), "", "Input field is empty");
 		});
 	});
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -713,7 +713,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await tokens.length, 0, "All selected filtered items are deselected");
 		});
 
-		it ("should select token with CTRL+SPACE", async () => {
+		it ("should select а token with CTRL+SPACE", async () => {
 			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -728,29 +728,6 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await tokens[2].getProperty("selected"), true, "Last token should be selected");
 		});
 
-		it ("should select item with CTRL+SPACE", async () => {
-			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
-
-			const mcb = await browser.$("#mcb");
-			const input = await mcb.shadow$("input");
-			const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#mcb");
-			const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-multi-combobox-all-items-responsive-popover");
-
-			await input.click();
-			await mcb.keys("F4");
-			await mcb.keys("ArrowDown");
-			await mcb.keys(["Control", "Space"]);
-
-			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
-			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
-
-			await browser.waitUntil(async () => (await listItem.getProperty("selected")), {
-				timeout: 500,
-				timeoutMsg: "Item is selected"
-			});
-		});
-	});
-
 	describe("General", () => {
 		before(async () => {
 			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -744,7 +744,10 @@ describe("MultiComboBox general interaction", () => {
 			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
 			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
 
-			assert.ok(await listItem.getAttribute("selected"), "Item is selected");
+			await browser.waitUntil(async () => (await listItem.getProperty("selected")), {
+				timeout: 500,
+				timeoutMsg: "Item is selected"
+			});
 		});
 	});
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -712,6 +712,40 @@ describe("MultiComboBox general interaction", () => {
 
 			assert.equal(await tokens.length, 0, "All selected filtered items are deselected");
 		});
+
+		it ("should select token with CTRL+SPACE", async () => {
+			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+			const mcb = await browser.$("#mcb-error");
+			const input = await mcb.shadow$("input");
+
+			await input.click();
+			await mcb.keys("ArrowLeft");
+			await mcb.keys(["Control", "Space"]);
+
+			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
+
+			assert.strictEqual(await tokens[2].getProperty("selected"), true, "Last token should be selected");
+		});
+
+		it ("should select item with CTRL+SPACE", async () => {
+			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+			const mcb = await browser.$("#mcb");
+			const input = await mcb.shadow$("input");
+			const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#mcb");
+			const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-multi-combobox-all-items-responsive-popover");
+
+			await input.click();
+			await mcb.keys("F4");
+			await mcb.keys("ArrowDown");
+			await mcb.keys(["Control", "Space"]);
+
+			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
+			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
+
+			assert.ok(await listItem.getAttribute("selected"), "Item is selected");
+		});
 	});
 
 	describe("General", () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -727,6 +727,7 @@ describe("MultiComboBox general interaction", () => {
 
 			assert.strictEqual(await tokens[2].getProperty("selected"), true, "Last token should be selected");
 		});
+	});
 
 	describe("General", () => {
 		before(async () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -727,6 +727,18 @@ describe("MultiComboBox general interaction", () => {
 
 			assert.strictEqual(await tokens[2].getProperty("selected"), true, "Last token should be selected");
 		});
+
+		it ("CTRL+SPACE should do nothing when pressed in the input field", async () => {
+			await browser.url(`http://localhost:${PORT}/test-resources/pages/MultiComboBox.html`);
+
+			const mcb = await browser.$("#mcb");
+			const input = await mcb.shadow$("input");
+
+			await input.click();
+			await mcb.keys(["Shift", "Space"]);
+
+			assert.strictEqual(await mcb.getProperty("value"), "", "Last token should be selected");
+		});
 	});
 
 	describe("General", () => {


### PR DESCRIPTION
Issue: #3090

Note: The CTRL+ SPACE handling should be implemented in the List, - as the 'Space' selection functionality, or not implemented at all, if it is not by the List UX specifications. 

Doing it in the MultiComboBox is wrong (if possible) as the individual 'SPACE' key is handled in the List.