### PR TITLE
fix(ui5-media-gallery-item): correct jsdoc

### DIFF
--- a/packages/fiori/src/MediaGalleryItem.js
+++ b/packages/fiori/src/MediaGalleryItem.js
@@ -123,7 +123,7 @@ const metadata = {
 		/**
 		 * Defines the content of the component.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {HTMLElement}
 		 * @slot content
 		 * @public
 		 */
@@ -135,7 +135,7 @@ const metadata = {
 		/**
 		 * Defines the content of the thumbnail.
 		 *
-		 * @type {HTMLElement[]}
+		 * @type {HTMLElement}
 		 * @slot
 		 * @public
 		 */


### PR DESCRIPTION
Corrected the jsdoc to specify that the app should be providing only a single item in the "content" and "thumbnail" slots of the ui5-media-gallery-item 
Any other items (second etc.) in those slots are currently ignored.
