### PR TITLE
fix(ui5-media-gallery): correct selector

### DIFF
--- a/packages/fiori/src/MediaGallery.js
+++ b/packages/fiori/src/MediaGallery.js
@@ -460,7 +460,7 @@ class MediaGallery extends UI5Element {
 	}
 
 	_onThumbnailClick(event) {
-		const item = event.target.closest("ui5-media-gallery-item");
+		const item = event.target.closest("[ui5-media-gallery-item]");
 
 		if (item.disabled) {
 			return;


### PR DESCRIPTION
Changed the tag-name selector to use attribute-name instead, as recommended by best practice.