### PR TITLE
fix(ui5-date-picker): remove time-zone test

### DIFF
--- a/packages/main/test/pages/DatePicker_test_page.html
+++ b/packages/main/test/pages/DatePicker_test_page.html
@@ -40,10 +40,6 @@
 	
 
 	<label id='lbl'>0</label>
-	<label for="inputTimezone">Timezone:</label>
-	<input id="inputTimezone" type="number"/>
-	<button id="btnApplyTimezone" onclick="stubTimezone();">Apply</button>
-	<button id="btnRestoreTimezone" onclick="restore();">Restore</button>
 	<button id="downThere" class="datepicker_test_page2auto"></button>
 	<label id='lblTomorrow'>0</label>
 	<label id='lblTomorrowDate'></label>
@@ -76,21 +72,6 @@
 	</section>
 
 	<script>
-		var originalGetDate = Date.prototype.getDate;
-
-		function stubTimezone() {
-			var timezone = parseInt(document.querySelector("#inputTimezone").value, 10);
-			Date.prototype.getDate = function() {
-				var stubedDate = new Date(this.getTime() + timezone * 60 * 60 * 1000);
-				return stubedDate.getUTCDate();
-			};
-		}
-
-		function restore() {
-			Date.prototype.getDate = originalGetDate;
-			document.querySelector("#inputTimezone").value = "";
-		};
-
 		var counter = 0;
 		var counterTomorrow = 0;
 		function increaseCounter() {

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -215,27 +215,6 @@ describe("Date Picker Tests", () => {
 		await valueHelpIcon.click();
 	});
 
-	// it("Calendar selection works on different timezones", async () => {
-	// 	datepicker.id = "#dp7";
-
-	// 	await browser.$("#inputTimezone").setValue(-6); //CST
-	// 	await browser.$("#btnApplyTimezone").click();
-
-	// 	const valueHelpIcon = await datepicker.getValueHelpIcon();
-	// 	await valueHelpIcon.click();
-
-	// 	let calendarDate_4_Jan_2019 = await datepicker.getPickerDate(1546560000); //Jan 4, 2019
-	// 	await calendarDate_4_Jan_2019.click();
-
-	// 	const innerInput = await datepicker.getInnerInput();
-	// 	assert.strictEqual(await innerInput.getProperty("value"), "Jan 4, 2019", "dp value is correct");
-	// 	//restore timezone
-	// 	await browser.$('#btnRestoreTimezone').click();
-
-	// 	// test needs to end with an assert, otherwise the next test seems to start before the click is finished and it hangs from time to time
-	// 	assert.equal(await browser.$("#inputTimezone").getValue(), "", "timezone is reset");
-	// });
-
 	it("respect first day of the week - monday", async () => {
 		await browser.url(`http://localhost:${PORT}/test-resources/pages/DatePicker_test_page.html?sap-ui-language=bg`);
 		datepicker.id = "#dp7_1";


### PR DESCRIPTION
- The DateFormat's parse method wasn't expected
to call getDate on the already correctly parsed
JavaScript Date object. The result is declared
invalid and replaced with null when the day doen't
match the one from the string. The time-zone test
is removed as we don't have a way to mock the JS Date.

Fixes: #4443