### PR TITLE
fix(ui5-view-settings-dialog): remove self reference

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -416,7 +416,6 @@ class ViewSettingsDialog extends UI5Element {
 			return {
 				text: item.text,
 				selected: item.selected,
-				associatedItem: item,
 				index,
 			};
 		});
@@ -565,8 +564,7 @@ class ViewSettingsDialog extends UI5Element {
 			sortDescending = !this._currentSettings.sortOrder[0].selected,
 			sortBy = _currentSortBySelected && _currentSortBySelected.text,
 			sortByElementIndex = _currentSortBySelected && _currentSortBySelected.index,
-			initSortIByItem = this.initSortByItems.find((item, index) => index === sortByElementIndex),
-			sortByItem = initSortIByItem && initSortIByItem.associatedItem;
+			sortByItem = this.sortItems[sortByElementIndex];
 		return {
 			sortOrder,
 			sortDescending,


### PR DESCRIPTION
remove self reference from associatedItem property in initSortByItems getters

FIXES: #4837