### PR TITLE
fix(ui5-date-picker): handle date selection via enter keyboard key

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -14,7 +14,6 @@ import {
 	isPageDownShiftCtrl,
 	isShow,
 	isF4,
-	isEnter,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isPhone, isIE } from "@ui5/webcomponents-base/dist/Device.js";
 import "@ui5/webcomponents-icons/dist/appointment-2.js";

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -472,10 +472,6 @@ class DatePicker extends DateComponentBase {
 			return;
 		}
 
-		if (isEnter(event)) {
-			this._updateValueAndFireEvents(event.target.value, true, ["change", "value-changed"]);
-		}
-
 		if (isPageUpShiftCtrl(event)) {
 			event.preventDefault();
 			this._modifyDateValue(1, "year");

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -302,6 +302,7 @@ describe("Date Picker Tests", () => {
 		await innerInput.keys("Enter");
 		tomorrowDate = await lblTomorrowDate.getHTML(false);
 		await browser.keys("\b\b\b\b\b\b\b\b\b\b\b\b\b");
+		await innerInput.keys("Enter");
 
 		// Type tomorrow and press Enter for the second time.
 		await innerInput.keys("tomorrow");

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -60,6 +60,7 @@ describe("DateRangePicker general interaction", () => {
 		await browser.keys("27/09/2019 - 10/10/2019");
 		await browser.keys("Enter");
 
+		await daterangepicker.waitForClickable();
 		const res = await browser.executeAsync(done => {
 			const myDRP = document.getElementById("daterange-picker4");
 			const startDateValue = myDRP.startDateValue;


### PR DESCRIPTION
- We don't need explicit handling on enter keyboard key
press after adaptations in the ui5-input control related
to change event handling.

Fixes: #4826
