### PR TITLE
fix(ui5-date-picker): remove aria-expanded attribute

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -677,7 +677,6 @@ class DatePicker extends DateComponentBase {
 			"ariaHasPopup": HasPopup.Grid,
 			"ariaAutoComplete": "none",
 			"ariaControls": `${this._id}-responsive-popover`,
-			"ariaExpanded": this.isOpen(),
 			"ariaRequired": this.required,
 			"ariaLabel": getEffectiveAriaLabelText(this),
 		};

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -150,9 +150,7 @@ class TimePicker extends TimePickerBase {
 			"ariaRoledescription": this.dateAriaDescription,
 			"ariaHasPopup": "dialog",
 			"ariaAutoComplete": "none",
-			"role": "combobox",
 			"ariaControls": `${this._id}-responsive-popover`,
-			"ariaExpanded": this.isOpen(),
 		};
 	}
 

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -17,6 +17,7 @@ describe("Date Picker Tests", () => {
 		assert.ok(await innerInput.isDisplayedInViewport(), "inner input is rendered");
 		assert.strictEqual(await innerInput.getAttribute("aria-roledescription"), "Date Input", "aria-roledescription attribute is added.");
 		assert.strictEqual(await innerInput.getAttribute("aria-haspopup"), "Grid", "aria-haspopup attribute is added.");
+		assert.notOk(await innerInput.getAttribute("aria-expanded"), "aria-expanded attribute isn't rendered.");
 	});
 
 	it("input receives value", async () => {


### PR DESCRIPTION
The aria-expanded attribute is removed from the
ui5-date-picker, ui5-daterange-picker, ui5-datetime-picker
input element for compliance with the combobox role removal.

Fixes: #4865