### PR TITLE
refactor: several fixes

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -482,7 +482,8 @@ class FlexibleColumnLayout extends UI5Element {
 			startColumnVisible: this.startColumnVisible,
 			midColumnVisible: this.midColumnVisible,
 			endColumnVisible: this.endColumnVisible,
-			arrowUsed,
+			arrowUsed, // for backwards compatibility
+			arrowsUsed: arrowUsed, // as documented
 			resize,
 		});
 	}

--- a/packages/main/src/types/ListGrowingMode.js
+++ b/packages/main/src/types/ListGrowingMode.js
@@ -1,15 +1,48 @@
-import GrowingMode from "./GrowingMode.js";
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * @lends sap.ui.webcomponents.main.types.ListGrowingMode.prototype
+ * @public
+ */
+const ListGrowingModes = {
+	/**
+	 * Component's <code>load-more</code> is fired upon pressing a "More" button.
+	 * at the bottom.
+	 * @public
+	 * @type {Button}
+	 */
+	Button: "Button",
+
+	/**
+	 * Component's <code>load-more</code> is fired upon scroll.
+	 * @public
+	 * @type {Scroll}
+	 */
+	Scroll: "Scroll",
+
+	/**
+	 * Component's growing is not enabled.
+	 * @public
+	 * @type {None}
+	 */
+	None: "None",
+};
 
 /**
  * @class
- * Defines the growing mode, used in the <code>ui5-List</code>.
+ * Defines the growing mode, used in the <code>ui5-list</code>.
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.types.ListGrowingMode
  * @public
  * @enum {string}
  */
-class ListGrowingMode extends GrowingMode {
+class ListGrowingMode extends DataType {
+	static isValid(value) {
+		return !!ListGrowingModes[value];
+	}
 }
+
+ListGrowingMode.generateTypeAccessors(ListGrowingModes);
 
 export default ListGrowingMode;

--- a/packages/main/src/types/TableGrowingMode.js
+++ b/packages/main/src/types/TableGrowingMode.js
@@ -1,4 +1,32 @@
-import GrowingMode from "./GrowingMode.js";
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * @lends sap.ui.webcomponents.main.types.TableGrowingMode.prototype
+ * @public
+ */
+const TableGrowingModes = {
+	/**
+	 * Component's <code>load-more</code> is fired upon pressing a "More" button.
+	 * at the bottom.
+	 * @public
+	 * @type {Button}
+	 */
+	Button: "Button",
+
+	/**
+	 * Component's <code>load-more</code> is fired upon scroll.
+	 * @public
+	 * @type {Scroll}
+	 */
+	Scroll: "Scroll",
+
+	/**
+	 * Component's growing is not enabled.
+	 * @public
+	 * @type {None}
+	 */
+	None: "None",
+};
 
 /**
  * @class
@@ -9,7 +37,12 @@ import GrowingMode from "./GrowingMode.js";
  * @public
  * @enum {string}
  */
-class TableGrowingMode extends GrowingMode {
+class TableGrowingMode extends DataType {
+	static isValid(value) {
+		return !!TableGrowingModes[value];
+	}
 }
+
+TableGrowingMode.generateTypeAccessors(TableGrowingModes);
 
 export default TableGrowingMode;


### PR DESCRIPTION
1) The event `layoutChange` in `ui5-flexible-column-layout`:

```js
		/**
		 * Fired when the layout changes via user interaction by clicking the arrows
		 * or by changing the component size due to resizing.
		 *
		 * @param {FCLLayout} layout The current layout
		 * @param {Array} columnLayout The effective column layout, f.e [67%, 33%, 0]
		 * @param {boolean} startColumnVisible Indicates if the start column is currently visible
		 * @param {boolean} midColumnVisible Indicates if the middle column is currently visible
		 * @param {boolean} endColumnVisible Indicates if the end column is currently visible
		 * @param {boolean} arrowsUsed Indicates if the layout is changed via the arrows
		 * @param {boolean} resize Indicates if the layout is changed via resizing
		 * @event sap.ui.webcomponents.fiori.FlexibleColumnLayout#layout-change
		 * @public
		 */
		"layout-change": {
			detail: {
				layout: { type: FCLLayout },
				columnLayout: { type: Array },
				startColumnVisible: { type: Boolean },
				midColumnVisible: { type: Boolean },
				endColumnVisible: { type: Boolean },
				arrowsUsed: { type: Boolean },
				resize: { type: Boolean },
			},
		},
```

documents an `arrowsUsed` parameter (plural), while the actual field in the object is called `arrowUsed`. Now, there is also an `arrowsUsed` field, as documented, but the old one has not been removed as this is what apps are currently using.

2) The `ListGrowingMode.js` and `TableGrowingMode.js` types have been explicitly defined, as otherwise the JSDoc plugin cannot understand them. It cannot track the inheritance.