### PR TITLE
refactor(ui5-title): remove custom css variables

### DIFF
--- a/packages/fiori/src/themes/ViewSettingsDialog.css
+++ b/packages/fiori/src/themes/ViewSettingsDialog.css
@@ -18,7 +18,7 @@
 
 .ui5-vsd-title {
 	margin-bottom: 0.3rem;
-	font-size: var(--ui5_title_level_5Size);
+	font-size: var(--sapFontHeader5Size);
 }
 
 .ui5-vsd-start {

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -6,7 +6,7 @@
 :host {
 	max-width: 100%;
 	color: var(--sapGroup_TitleTextColor);
-	font-size: var(--ui5_title_level_2Size);
+	font-size: var(--sapFontHeader2Size);
 	font-family: "72override", var(--sapFontFamily);
 	text-shadow: var(--sapContent_TextShadow);
 }
@@ -36,30 +36,30 @@
 
 /* Level H1 */
 :host([level="H1"]) {
-	font-size: var(--ui5_title_level_1Size);
+	font-size: var(--sapFontHeader1Size);
 }
 
 /* Level H2 */
 :host([level="H2"]) {
-	font-size: var(--ui5_title_level_2Size);
+	font-size: var(--sapFontHeader2Size);
 }
 
 /* Level H3 */
 :host([level="H3"]) {
-	font-size: var(--ui5_title_level_3Size);
+	font-size: var(--sapFontHeader3Size);
 }
 
 /* Level H4 */
 :host([level="H4"]) {
-	font-size: var(--ui5_title_level_4Size);
+	font-size: var(--sapFontHeader4Size);
 }
 
 /* Level H5 */
 :host([level="H5"]) {
-	font-size: var(--ui5_title_level_5Size);
+	font-size: var(--sapFontHeader5Size);
 }
 
 /* Level H6 */
 :host([level="H6"]) {
-	font-size: var(--ui5_title_level_6Size);
+	font-size: var(--sapFontHeader6Size);
 }

--- a/packages/main/src/themes/base/Title-parameters.css
+++ b/packages/main/src/themes/base/Title-parameters.css
@@ -1,8 +1,0 @@
-:root {
-	--ui5_title_level_1Size: var(--sapFontHeader1Size);
-	--ui5_title_level_2Size: var(--sapFontHeader2Size);
-	--ui5_title_level_3Size: var(--sapFontHeader3Size);
-	--ui5_title_level_4Size: var(--sapFontHeader4Size);
-	--ui5_title_level_5Size: var(--sapFontHeader5Size);
-	--ui5_title_level_6Size: var(--sapFontHeader6Size);
-}

--- a/packages/main/src/themes/sap_belize/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize/parameters-bundle.css
@@ -34,7 +34,6 @@
 @import "../base/GrowingButton-parameters.css";
 @import "../base/TextArea-parameters.css";
 @import "./TimePicker-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "../base/ToggleButton-parameters.css";
 @import "../base/Tokenizer-parameters.css";

--- a/packages/main/src/themes/sap_belize_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize_hcb/parameters-bundle.css
@@ -33,7 +33,6 @@
 @import "./TableRow-parameters.css";
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "./ToggleButton-parameters.css";
 @import "./WheelSlider-parameters.css";

--- a/packages/main/src/themes/sap_belize_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize_hcw/parameters-bundle.css
@@ -33,7 +33,6 @@
 @import "./TableRow-parameters.css";
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "../base/ToggleButton-parameters.css";
 @import "./YearPicker-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
@@ -38,7 +38,6 @@
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
 @import "../base/GrowingButton-parameters.css";
-@import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "../base/Tokenizer-parameters.css";
 @import "../base/ValueStateMessage-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -37,7 +37,6 @@
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
 @import "../base/GrowingButton-parameters.css";
-@import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "../base/Tokenizer-parameters.css";
 @import "../base/ValueStateMessage-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -34,7 +34,6 @@
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
 @import "./TimePicker-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "./ToggleButton-parameters.css";
 @import "./WheelSlider-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -34,7 +34,6 @@
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
 @import "./TimePicker-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "./ToggleButton-parameters.css";
 @import "./WheelSlider-parameters.css";

--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -43,7 +43,6 @@
 @import "./CalendarHeader-parameters.css";
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
-@import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "./Tokenizer-parameters.css";
 @import "./MultiComboBox-parameters.css";

--- a/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -43,7 +43,6 @@
 @import "./CalendarHeader-parameters.css";
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
-@import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "./Tokenizer-parameters.css";
 @import "./MultiComboBox-parameters.css";

--- a/packages/main/src/themes/sap_horizon_exp/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_exp/parameters-bundle.css
@@ -38,7 +38,6 @@
 @import "../base/Table-parameters.css";
 @import "../base/TableRow-parameters.css";
 @import "../base/GrowingButton-parameters.css";
-@import "../base/Title-parameters.css";
 @import "./Token-parameters.css";
 @import "../base/Tokenizer-parameters.css";
 @import "../base/ValueStateMessage-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_hcb/parameters-bundle.css
@@ -34,7 +34,6 @@
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
 @import "./TimePicker-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "./ToggleButton-parameters.css";
 @import "./WheelSlider-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -34,7 +34,6 @@
 @import "./GrowingButton-parameters.css";
 @import "./TextArea-parameters.css";
 @import "./TimePicker-parameters.css";
-@import "../base/Title-parameters.css";
 @import "../base/Toast-parameters.css";
 @import "./ToggleButton-parameters.css";
 @import "./WheelSlider-parameters.css";


### PR DESCRIPTION
The `ui5-title` used custom `ui5-` css variables for configuring the font size. As they are consistent in all themes I removed the custom variables which makes it more intuitive to modify the title font sizes via SAP Theme Designer.
