### PR TITLE
feat(ui5-breadcrumbs): add modifier key states to item-click event

### DIFF
--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -409,10 +409,16 @@ class Breadcrumbs extends UI5Element {
 		}
 	}
 
-	_onLabelPress() {
+	_onLabelPress(event) {
 		const items = this.getSlottedNodes("items"),
 			item = items[items.length - 1];
-		this.fireEvent("item-click", { item });
+		this.fireEvent("item-click", {
+			item,
+			altKey: event.altKey,
+			ctrlKey: event.ctrlKey,
+			shiftKey: event.shiftKey,
+			metaKey: event.metaKey,
+		 });
 	}
 
 	_onOverflowListItemSelect(event) {

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -123,11 +123,19 @@ const metadata = {
 		 * @event sap.ui.webcomponents.main.Breadcrumbs#item-click
 		 * @allowPreventDefault
 		 * @param {HTMLElement} item The clicked item.
+		 * @param {Boolean} altKey 	Returns whether the "ALT" key was pressed when the event was triggered.
+		 * @param {Boolean} shiftKey 	Returns whether the "SHIFT" key was pressed when the event was triggered.
+		 * @param {Boolean} ctrlKey 	Returns whether the "CTRL" key was pressed when the event was triggered.
+		 * @param {Boolean} metaKey 	Returns whether the "META" key was pressed when the event was triggered.
 		 * @public
 		 */
 		"item-click": {
 			detail: {
 				item: { type: HTMLElement },
+				altKey: { type: Boolean },
+				shiftKey: { type: Boolean },
+				ctrlKey: { type: Boolean },
+				metaKey: { type: Boolean },
 			},
 		},
 	},
@@ -390,7 +398,13 @@ class Breadcrumbs extends UI5Element {
 		const link = event.target,
 			items = this.getSlottedNodes("items"),
 			item = items.find(x => `${x._id}-link` === link.id);
-		if (!this.fireEvent("item-click", { item }, true)) {
+		if (!this.fireEvent("item-click", {
+			item,
+			altKey: event.altKey,
+			ctrlKey: event.ctrlKey,
+			shiftKey: event.shiftKey,
+			metaKey: event.metaKey,
+		}, true)) {
 			event.preventDefault();
 		}
 	}

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -178,8 +178,21 @@
 
 		var breadcrumbsPreventDefault = document.querySelector("#breadcrumbsPreventDefault");
 		breadcrumbsPreventDefault.addEventListener("ui5-item-click", (event) => {
+			let keyText ='';
+			if(event.detail.ctrlKey) {
+				keyText += 'CTRL:';
+			}
+			if(event.detail.altKey) {
+				keyText += 'ALT:';
+			}
+			if(event.detail.shiftKey) {
+				keyText += 'SHIFT:';
+			}
+			if(event.detail.metaKey) {
+				keyText += 'META:';
+			}
 			event.preventDefault();
-			result.innerText = event.detail.item.innerText;
+			result.innerText = keyText + event.detail.item.innerText;
 		});
 
 		extendSizeBtn.addEventListener("click", () => resizeContainer(true));


### PR DESCRIPTION
The change in this PR adds the modifier key states from the native click event to the components 'item-click' event.
Necessary in a usecase, where you have to use preventDefault to avoid a page refresh, but still want to open a link in a new tab when CTRL/CMD is pressed on click.

related: https://github.com/SAP/ui5-webcomponents/pull/4589

NOTE: it is not applied in this PR to items in the overflow dropdown, since it would be a lot of effort (changes in ui5-list and maybe deeper), and it would not be relevant for the abovementioned usecase (at least currently), since href attributes are not applied to them either, so the whole "open in new tab" thing doesn't work for them anyway (could be a future feature request though ;) )