### PR TITLE
fix(ui5-flexible-column-layout): correct column border styles for RTL

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.hbs
+++ b/packages/fiori/src/FlexibleColumnLayout.hbs
@@ -1,4 +1,7 @@
-<div class="{{classes.root}}">
+<div 
+	class="{{classes.root}}" 
+	dir="{{effectiveDir}}"
+	>
 	<div
 		role="{{_accAttributes.columns.start.role}}"
 		aria-hidden="{{_accAttributes.columns.start.ariaHidden}}"

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -47,6 +47,30 @@
 	border-left: var(--_ui5_fcl_column_border);
 }
 
+:host([_visible-columns="2"]) [dir="rtl"] .ui5-fcl-column--start {
+	border-left: var(--_ui5_fcl_column_border);
+}
+
+:host([_visible-columns="3"]) [dir="rtl"] .ui5-fcl-column--start {
+	border-left: var(--_ui5_fcl_column_border);
+}
+
+:host([_visible-columns="2"]) [dir="rtl"] .ui5-fcl-column--middle {
+	border-right: var(--_ui5_fcl_column_border)
+}
+
+:host([_visible-columns="3"]) [dir="rtl"] .ui5-fcl-column--middle {
+	border-right: var(--_ui5_fcl_column_border)
+}
+
+:host([_visible-columns="3"]) [dir="rtl"] .ui5-fcl-column--middle {
+	border-left: var(--_ui5_fcl_column_border)
+}
+
+:host([_visible-columns="3"]) [dir="rtl"] .ui5-fcl-column--end {
+	border-right: var(--_ui5_fcl_column_border);
+}
+
 .ui5-fcl-column--hidden {
 	display: none;
 }


### PR DESCRIPTION
Mirrored border styles (border-left <=> border-right) when RTL is set to the flexible column layout.

Fixes: #4906