### PR TITLE
fix(templates): fix context in nested loops

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-Ymcpo5BI0Vh4B+marW3XQhleQiI=
+ejwsRPaGV1cXCOdbT6J17VVr2XQ=

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -197,6 +197,7 @@ function normalizePath(sPath) {
 	if (result.indexOf("../") === 0) {
 		const absolutePath = replaceAll(this.paths[this.paths.length - 1], ".", "/") + "/" + result;
 		result = replaceAll(path.normalize(absolutePath), path.sep, ".");
+		result = result.replace("item.", "context.");
 	} else {
 		const blockPath = this.blockLevel > 0 ? "item" : "context";
 		result = result ? replaceAll(blockPath + "/" + result, "/", ".") : blockPath;


### PR DESCRIPTION
**Background**
This is a proposal to fix an issue that we encountered within the hbs2lit compiler, when there are multiple nested each blocks. In such a scenario, the compiler fails to apply the correct context.
Consider two nested loops, for example: 
 
 ```hbs
{{#each items}}
	{{#each tags}}
         {{!-- CORRECT - "this" has the correct value of the current "object" in "tags" array --}}
	{{/each}}
			

	{{#if name}}	
         {{!-- WRONG -  after the end of EACH LEVEL 2, the compiler does not consider that it is in "items" each
            and sets the "this" to "context" (the root), instead of the "object" from "items" array --}}
	{{/if}}  
{{#each items}}
```    
    
 **Solution**
 keep track of the current level of execution to correctly determine the "context"
 
   


FIXES: https://github.com/SAP/ui5-webcomponents/issues/4701