### PR TITLE
fix(framework): add more 72-* fonts as system styles

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-Ymcpo5BI0Vh4B+marW3XQhleQiI=
+3A147f62aHRSel1BUKBRiI/tr7o=

--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -36,6 +36,36 @@
 }
 
 @font-face {
+    font-family: '72-Bold';
+    font-style: normal;
+    src: local('72-Bold'),
+    url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2"),
+    url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold.woff?ui5-webcomponents) format("woff");
+}
+
+@font-face {
+    font-family: '72-Boldfull';
+    font-style: normal;
+    src: url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold-full.woff2?ui5-webcomponents) format("woff2"),
+         url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold-full.woff?ui5-webcomponents) format("woff");
+}
+
+@font-face {
+    font-family: '72-Light';
+    font-style: normal;
+    src: local('72-Light'),
+        url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light.woff2?ui5-webcomponents) format("woff2"),
+        url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light.woff?ui5-webcomponents) format("woff");
+}
+
+@font-face {
+    font-family: '72-Lightfull';
+    font-style: normal;
+    src: url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light-full.woff2?ui5-webcomponents) format("woff2"),
+    url(https://ui5.sap.com/sdk/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light-full.woff?ui5-webcomponents) format("woff");
+}
+
+@font-face {
     font-family: "72Black";
     font-style: bold;
     font-weight: 900;


### PR DESCRIPTION
**Issue**
The **72-Bold** font did not apply correctly on stakeholder side in FireFox (see the linked issue for more information.).
This can be also reproduced in our test pages by opening the Card test page **in sap_horizon in FireFox** via this [link](https://sap.github.io/ui5-webcomponents/master/playground/main/pages/Card/?sap-ui-theme=sap_horizon).
The headings in the Card header should have been bold, however they appear normal instead. I
<img width="301" alt="Screenshot 2022-03-21 at 15 08 55" src="https://user-images.githubusercontent.com/15702139/159267462-c463c063-7765-4b44-98be-5632f1962704.png">
In Chrome the issue is not reproducible, probably because of difference in the font loading.

<img width="298" alt="Screenshot 2022-03-21 at 15 09 51" src="https://user-images.githubusercontent.com/15702139/159267570-c8c32b7c-7be2-466e-ad05-d99b689b0d0d.png">


**Solution**
The insertion of the **72-Bold,  '72-Boldfull', '72-Light' and  '72-Lightfull'** fonts explicitly as part of the system vars
seem to resolve the issue. The changes is adding the ones that are missing, compared to [OpenUi5](https://github.com/SAP/openui5/blob/master/src/themelib_sap_fiori_3/src/sap/ui/core/themes/sap_fiori_3/shared.less#L257)
```css
// FontFace.css
@font-face {
    font-family: '72-Bold';
@font-face {
    font-family: '72-Boldfull';
@font-face {
    font-family: '72-Light';
@font-face {
    font-family: '72-Lightfull';
   ```
FIXES https://github.com/SAP/ui5-webcomponents/issues/4931