### PR TITLE
fix(ui5-li): correct focus handling

### DIFF
--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -89,7 +89,7 @@ class ListItemBase extends UI5Element {
 	}
 
 	_onfocusin(event) {
-		if (event.isMarked === "button" || event.isMarked === "link") {
+		if (event.target !== this.getFocusDomRef()) {
 			return;
 		}
 


### PR DESCRIPTION
When content list item content contains focusable element double focus appear (one to the list item and one to the nested focusable element). Now, we are not marking list item as focused if it is different from focus target.

Fixed: #4916 