### PR TITLE
chore: release v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+### Bug Fixes
+
+* **framework:** add 72-* font as system styles ([#4934](https://github.com/SAP/ui5-webcomponents/issues/4934)) ([8f9b0d2](https://github.com/SAP/ui5-webcomponents/commit/8f9b0d2)), closes  [#4931](https://github.com/SAP/ui5-webcomponents/issues/4931)
+* **localization:** fix js error if "sh" locale set ([#4905](https://github.com/SAP/ui5-webcomponents/issues/4905)) ([9ace82c](https://github.com/SAP/ui5-webcomponents/commit/9ace82c)), closes [#4904](https://github.com/SAP/ui5-webcomponents/issues/4904)
+* **ui5-flexible-column-layout:** correct column border styles for RTL ([#4919](https://github.com/SAP/ui5-webcomponents/issues/4919)) ([2f40bd7](https://github.com/SAP/ui5-webcomponents/commit/2f40bd7)), closes [#4906](https://github.com/SAP/ui5-webcomponents/issues/4906)
+* **ui5-li:** correct focus handling ([#4935](https://github.com/SAP/ui5-webcomponents/issues/4935)) ([1fdf415](https://github.com/SAP/ui5-webcomponents/commit/1fdf415)), closes [#4916](https://github.com/SAP/ui5-webcomponents/issues/4916)
+* **ui5-view-settings-dialog:** adjust scrollbar behavior  ([#4795](https://github.com/SAP/ui5-webcomponents/issues/4795)) ([ddcb01e](https://github.com/SAP/ui5-webcomponents/commit/ddcb01e)), closes [#4724](https://github.com/SAP/ui5-webcomponents/issues/4724) [#4725](https://github.com/SAP/ui5-webcomponents/issues/4725) [#4860](https://github.com/SAP/ui5-webcomponents/issues/4860)
+
+
+### Features
+
+* **ui5-select:** add aria-roledescription attribute ([#4921](https://github.com/SAP/ui5-webcomponents/issues/4921)) ([e4fa811](https://github.com/SAP/ui5-webcomponents/commit/e4fa811)), closes [#2910](https://github.com/SAP/ui5-webcomponents/issues/2910)
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+
+### Bug Fixes
+
+* **ui5-date-picker:** remove aria-expanded attribute ([#4866](https://github.com/SAP/ui5-webcomponents/issues/4866)) ([b62a0e9](https://github.com/SAP/ui5-webcomponents/commit/b62a0e9)), closes [#4865](https://github.com/SAP/ui5-webcomponents/issues/4865)
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
 		"packages/playground",
 		"packages/create-package"
 	],
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"command": {
 		"publish": {
 			"conventionalCommits": true

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
 		"packages/playground",
 		"packages/create-package"
 	],
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"command": {
 		"publish": {
 			"conventionalCommits": true

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-base
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+### Bug Fixes
+
+* **framework:** add 72-* font as system styles ([#4934](https://github.com/SAP/ui5-webcomponents/issues/4934)) ([8f9b0d2](https://github.com/SAP/ui5-webcomponents/commit/8f9b0d2))
+* **localization:** fix js error if "sh" locale set ([#4905](https://github.com/SAP/ui5-webcomponents/issues/4905)) ([9ace82c](https://github.com/SAP/ui5-webcomponents/commit/9ace82c)), closes [#4904](https://github.com/SAP/ui5-webcomponents/issues/4904)
+
+
+### Features
+
+* add ` sap_horizon_dark` and `sap_horizon_hcb(hcw)` theme params ([#4722](https://github.com/SAP/ui5-webcomponents/issues/4722)) ([dc070a1](https://github.com/SAP/ui5-webcomponents/commit/dc070a1))
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-base

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-base",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",
     "@openui5/sap.ui.core": "1.94.0",
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-base",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",
     "@openui5/sap.ui.core": "1.94.0",
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",

--- a/packages/create-package/CHANGELOG.md
+++ b/packages/create-package/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/create-webcomponents-package
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/create-webcomponents-package

--- a/packages/create-package/CHANGELOG.md
+++ b/packages/create-package/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/create-webcomponents-package
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/create-webcomponents-package

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/create-webcomponents-package",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: create package",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/create-webcomponents-package",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: create package",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/fiori/CHANGELOG.md
+++ b/packages/fiori/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-fiori
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/fiori/CHANGELOG.md
+++ b/packages/fiori/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+### Bug Fixes
+
+* **ui5-flexible-column-layout:** correct column border styles for RTL ([#4919](https://github.com/SAP/ui5-webcomponents/issues/4919)) ([2f40bd7](https://github.com/SAP/ui5-webcomponents/commit/2f40bd7)), closes [#4906](https://github.com/SAP/ui5-webcomponents/issues/4906)
+* **ui5-view-settings-dialog:** adjust scrollbar behavior  ([#4795](https://github.com/SAP/ui5-webcomponents/issues/4795)) ([ddcb01e](https://github.com/SAP/ui5-webcomponents/commit/ddcb01e)), closes [#4724](https://github.com/SAP/ui5-webcomponents/issues/4724) [#4725](https://github.com/SAP/ui5-webcomponents/issues/4725) [#4860](https://github.com/SAP/ui5-webcomponents/issues/4860)
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-fiori",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.fiori",
   "ui5": {
     "webComponentsPackage": true
@@ -42,15 +42,15 @@
     "directory": "packages/fiori"
   },
   "dependencies": {
-    "@ui5/webcomponents": "1.2.2",
-    "@ui5/webcomponents-base": "1.2.2",
-    "@ui5/webcomponents-icons": "1.2.2",
-    "@ui5/webcomponents-ie11": "1.2.2",
-    "@ui5/webcomponents-theming": "1.2.2",
+    "@ui5/webcomponents": "1.2.3",
+    "@ui5/webcomponents-base": "1.2.3",
+    "@ui5/webcomponents-icons": "1.2.3",
+    "@ui5/webcomponents-ie11": "1.2.3",
+    "@ui5/webcomponents-theming": "1.2.3",
     "@zxing/library": "^0.18.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-fiori",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.fiori",
   "ui5": {
     "webComponentsPackage": true
@@ -42,15 +42,15 @@
     "directory": "packages/fiori"
   },
   "dependencies": {
-    "@ui5/webcomponents": "1.2.1",
-    "@ui5/webcomponents-base": "1.2.1",
-    "@ui5/webcomponents-icons": "1.2.1",
-    "@ui5/webcomponents-ie11": "1.2.1",
-    "@ui5/webcomponents-theming": "1.2.1",
+    "@ui5/webcomponents": "1.2.2",
+    "@ui5/webcomponents-base": "1.2.2",
+    "@ui5/webcomponents-icons": "1.2.2",
+    "@ui5/webcomponents-ie11": "1.2.2",
+    "@ui5/webcomponents-theming": "1.2.2",
     "@zxing/library": "^0.18.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons-business-suite/CHANGELOG.md
+++ b/packages/icons-business-suite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-business-suite
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-business-suite

--- a/packages/icons-business-suite/CHANGELOG.md
+++ b/packages/icons-business-suite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-business-suite
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-business-suite

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-business-suite",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-business-suite",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons-tnt/CHANGELOG.md
+++ b/packages/icons-tnt/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-tnt
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-tnt

--- a/packages/icons-tnt/CHANGELOG.md
+++ b/packages/icons-tnt/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-tnt
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-tnt

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-tnt",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-tnt",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons
+
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.SAP-icons",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.SAP-icons",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/ie11/CHANGELOG.md
+++ b/packages/ie11/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-ie11
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/webcomponents-ie11

--- a/packages/ie11/CHANGELOG.md
+++ b/packages/ie11/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/webcomponents-ie11
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-ie11

--- a/packages/ie11/package.json
+++ b/packages/ie11/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-ie11",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.ie11",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1",
+    "@ui5/webcomponents-base": "1.2.2",
     "core-js": "^3.19.1",
     "css-vars-ponyfill": "^2.4.3",
     "lit-html": "2.0.1",
@@ -31,7 +31,7 @@
     "url-search-params-polyfill": "^8.1.0"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "resolve": "^1.20.0"
   }
 }

--- a/packages/ie11/package.json
+++ b/packages/ie11/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-ie11",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.ie11",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2",
+    "@ui5/webcomponents-base": "1.2.3",
     "core-js": "^3.19.1",
     "css-vars-ponyfill": "^2.4.3",
     "lit-html": "2.0.1",
@@ -31,7 +31,7 @@
     "url-search-params-polyfill": "^8.1.0"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "resolve": "^1.20.0"
   }
 }

--- a/packages/localization/CHANGELOG.md
+++ b/packages/localization/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+### Bug Fixes
+
+* **localization:** fix js error if "sh" locale set ([#4905](https://github.com/SAP/ui5-webcomponents/issues/4905)) ([9ace82c](https://github.com/SAP/ui5-webcomponents/commit/9ace82c)), closes [#4904](https://github.com/SAP/ui5-webcomponents/issues/4904)
+
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-localization

--- a/packages/localization/CHANGELOG.md
+++ b/packages/localization/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-localization
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-localization",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Localization for UI5 Web Components",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -28,12 +28,12 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-localization",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Localization for UI5 Web Components",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -28,12 +28,12 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2"
   }
 }

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+
+### Bug Fixes
+
+* **ui5-date-picker:** remove aria-expanded attribute ([#4866](https://github.com/SAP/ui5-webcomponents/issues/4866)) ([b62a0e9](https://github.com/SAP/ui5-webcomponents/commit/b62a0e9)), closes [#4865](https://github.com/SAP/ui5-webcomponents/issues/4865)
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+### Bug Fixes
+
+* **ui5-li:** correct focus handling ([#4935](https://github.com/SAP/ui5-webcomponents/issues/4935)) ([1fdf415](https://github.com/SAP/ui5-webcomponents/commit/1fdf415))
+
+
+### Features
+
+* **ui5-select:** add aria-roledescription attribute ([#4921](https://github.com/SAP/ui5-webcomponents/issues/4921)) ([e4fa811](https://github.com/SAP/ui5-webcomponents/commit/e4fa811)), closes [#2910](https://github.com/SAP/ui5-webcomponents/issues/2910)
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.main",
   "ui5": {
     "webComponentsPackage": true
@@ -42,14 +42,14 @@
     "directory": "packages/main"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.2",
-    "@ui5/webcomponents-icons": "1.2.2",
-    "@ui5/webcomponents-ie11": "1.2.2",
-    "@ui5/webcomponents-localization": "1.2.2",
-    "@ui5/webcomponents-theming": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3",
+    "@ui5/webcomponents-icons": "1.2.3",
+    "@ui5/webcomponents-ie11": "1.2.3",
+    "@ui5/webcomponents-localization": "1.2.3",
+    "@ui5/webcomponents-theming": "1.2.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.main",
   "ui5": {
     "webComponentsPackage": true
@@ -42,14 +42,14 @@
     "directory": "packages/main"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.2.1",
-    "@ui5/webcomponents-icons": "1.2.1",
-    "@ui5/webcomponents-ie11": "1.2.1",
-    "@ui5/webcomponents-localization": "1.2.1",
-    "@ui5/webcomponents-theming": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2",
+    "@ui5/webcomponents-icons": "1.2.2",
+    "@ui5/webcomponents-ie11": "1.2.2",
+    "@ui5/webcomponents-localization": "1.2.2",
+    "@ui5/webcomponents-theming": "1.2.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0"
   }
 }

--- a/packages/playground/CHANGELOG.md
+++ b/packages/playground/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+**Note:** Version bump only for package @ui5/webcomponents-playground
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-playground

--- a/packages/playground/CHANGELOG.md
+++ b/packages/playground/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-playground
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 **Note:** Version bump only for package @ui5/webcomponents-playground

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -63,7 +63,7 @@ nav_exclude: true
                 </div>
                 <h2 class="subtitle">Enterprise-flavored sugar on top of native APIs!</h2>
 
-                <div class="curr-version">Latest version:  <a class="curr-version-link" href="https://www.npmjs.com/package/@ui5/webcomponents">1.2.1</a></div>
+                <div class="curr-version">Latest version:  <a class="curr-version-link" href="https://www.npmjs.com/package/@ui5/webcomponents">1.2.2</a></div>
 
                 <a href="{{ "/playground/components" | absolute_url }}" class="get-started-button">Get Started</a>
            </div>

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -63,7 +63,7 @@ nav_exclude: true
                 </div>
                 <h2 class="subtitle">Enterprise-flavored sugar on top of native APIs!</h2>
 
-                <div class="curr-version">Latest version:  <a class="curr-version-link" href="https://www.npmjs.com/package/@ui5/webcomponents">1.2.2</a></div>
+                <div class="curr-version">Latest version:  <a class="curr-version-link" href="https://www.npmjs.com/package/@ui5/webcomponents">1.2.3</a></div>
 
                 <a href="{{ "/playground/components" | absolute_url }}" class="get-started-button">Get Started</a>
            </div>

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ui5/webcomponents-playground",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components Playground",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ui5/webcomponents-playground",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components Playground",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/theming/CHANGELOG.md
+++ b/packages/theming/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+### Features
+
+* add ` sap_horizon_dark` and `sap_horizon_hcb(hcw)` theme params ([#4722](https://github.com/SAP/ui5-webcomponents/issues/4722)) ([dc070a1](https://github.com/SAP/ui5-webcomponents/commit/dc070a1))
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-theming

--- a/packages/theming/CHANGELOG.md
+++ b/packages/theming/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-theming
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-theming",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.theming",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.1.36",
-    "@ui5/webcomponents-base": "1.2.1"
+    "@ui5/webcomponents-base": "1.2.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.1",
+    "@ui5/webcomponents-tools": "1.2.2",
     "chromedriver": "99.0.0",
     "cssnano": "^4.1.11",
     "glob": "^7.1.6",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-theming",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.theming",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.1.36",
-    "@ui5/webcomponents-base": "1.2.2"
+    "@ui5/webcomponents-base": "1.2.3"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "1.2.2",
+    "@ui5/webcomponents-tools": "1.2.3",
     "chromedriver": "99.0.0",
     "cssnano": "^4.1.11",
     "glob": "^7.1.6",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
+
+
+**Note:** Version bump only for package @ui5/webcomponents-tools
+
+
+
+
+
 ## [1.2.1](https://github.com/SAP/ui5-webcomponents/compare/v1.2.0...v1.2.1) (2022-03-02)
 
 **Note:** Version bump only for package @ui5/webcomponents-tools

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.3](https://github.com/SAP/ui5-webcomponents/compare/v1.2.2...v1.2.3) (2022-03-23)
+
+**Note:** Version bump only for package @ui5/webcomponents-tools
+
+
+
+
+
 ## [1.2.2](https://github.com/SAP/ui5-webcomponents/compare/v1.2.1...v1.2.2) (2022-03-22)
 
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-tools",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "UI5 Web Components: webcomponents.tools",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-tools",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "UI5 Web Components: webcomponents.tools",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is an intermediate patch release due to approaching DEV close on stakeholders' side. 
The releases include only pre-selected set of fixes on important stakeholders' issues.

The change log can be seen here:
1.2.2
- Changelog https://github.com/SAP/ui5-webcomponents/releases/tag/v1.2.2
- The release to NPM is performed from the https://github.com/SAP/ui5-webcomponents/tree/release-1.2.2 branch.

1.2.3
- Changelog https://github.com/SAP/ui5-webcomponents/releases/tag/v1.2.3
- The release to NPM is performed from the https://github.com/SAP/ui5-webcomponents/tree/release-1.2.3 branch.