### PR TITLE
fix(framework): fix scoping of self tag

### DIFF
--- a/packages/base/src/renderer/executeTemplate.js
+++ b/packages/base/src/renderer/executeTemplate.js
@@ -29,6 +29,6 @@ const getTagsToScope = component => {
 	}
 
 	return tagsToScope;
-}
+};
 
 export default executeTemplate;

--- a/packages/base/src/renderer/executeTemplate.js
+++ b/packages/base/src/renderer/executeTemplate.js
@@ -9,9 +9,26 @@ import { getCustomElementsScopingSuffix, shouldScopeCustomElement } from "../Cus
  * @returns {*}
  */
 const executeTemplate = (template, component) => {
-	const tagsToScope = component.constructor.getUniqueDependencies().map(dep => dep.getMetadata().getPureTag()).filter(shouldScopeCustomElement);
+	const tagsToScope = getTagsToScope(component);
 	const scope = getCustomElementsScopingSuffix();
 	return template(component, tagsToScope, scope);
 };
+
+/**
+ * Returns all tags, used inside component's template subject to scoping.
+ * @param component - the component
+ * @returns {Array[]}
+ * @private
+ */
+const getTagsToScope = component => {
+	const componentTag = component.constructor.getMetadata().getPureTag();
+	const deps = component.constructor.getUniqueDependencies().map(dep => dep.getMetadata().getPureTag()).filter(shouldScopeCustomElement);
+
+	if (shouldScopeCustomElement(componentTag)) {
+		deps.push(componentTag);
+	}
+
+	return deps;
+}
 
 export default executeTemplate;

--- a/packages/base/src/renderer/executeTemplate.js
+++ b/packages/base/src/renderer/executeTemplate.js
@@ -22,13 +22,13 @@ const executeTemplate = (template, component) => {
  */
 const getTagsToScope = component => {
 	const componentTag = component.constructor.getMetadata().getPureTag();
-	const deps = component.constructor.getUniqueDependencies().map(dep => dep.getMetadata().getPureTag()).filter(shouldScopeCustomElement);
+	const tagsToScope = component.constructor.getUniqueDependencies().map(dep => dep.getMetadata().getPureTag()).filter(shouldScopeCustomElement);
 
 	if (shouldScopeCustomElement(componentTag)) {
-		deps.push(componentTag);
+		tagsToScope.push(componentTag);
 	}
 
-	return deps;
+	return tagsToScope;
 }
 
 export default executeTemplate;


### PR DESCRIPTION
Currently, we determine the tags that need to be scoped within components' templates,
 based on the component's unique dependencies + app defined rules trough configuration:
```js
// executeTemplate.js
component.constructor.getUniqueDependencies().map(dep => dep.getMetadata().getPureTag()).filter(shouldScopeCustomElement);
```

However, there is one use-case when the Input web components uses `ui5-input` inside the InputPopoverTemplate
```hbs
// InputPopover.hbs
	<div class="input-root-phone">
		<ui5-input>
```
which is currently skipped from scoping due to the check below as the Input is not a dependency of itself
```js
// LitRenderer.js
// suffix && (tags || []).includes(tag) is falsy
const scopeTag = (tag, tags, suffix) => {
	const resultTag = suffix && (tags || []).includes(tag) ? `${tag}-${suffix}` : tag;
	return unsafeStatic(resultTag);
};
```

The solution in this PR is to consider component's own tag and add it to the list of tags subject to scoping, unless the tag is not explicitly excluded via configuration. This seems to be an edge case, so if alternative solution comes to mind, feel free to share it with me.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/4945
Closes: https://github.com/SAP/ui5-webcomponents/issues/4945