### PR TITLE
fix(ui5-time-picker): firing change event after input change submit

### DIFF
--- a/packages/main/src/TimePickerBase.js
+++ b/packages/main/src/TimePickerBase.js
@@ -256,8 +256,10 @@ class TimePickerBase extends UI5Element {
 			value = this.normalizeValue(value); // transform valid values (in any format) to the correct format
 		}
 
-		this.value = ""; // Do not remove! DurationPicker use case -> value is 05:10, user tries 05:12, after normalization value is changed back to 05:10 so no invalidation happens, but the input still shows 05:12. Thus we enforce invalidation with the ""
-		this.value = value;
+		if (!events.includes("input")) {
+			this.value = ""; // Do not remove! DurationPicker use case -> value is 05:10, user tries 05:12, after normalization value is changed back to 05:10 so no invalidation happens, but the input still shows 05:12. Thus we enforce invalidation with the ""
+			this.value = value;
+		}
 		this.tempValue = value; // if the picker is open, sync it
 		this._updateValueState(); // Change the value state to Error/None, but only if needed
 		events.forEach(event => {

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -90,7 +90,8 @@ describe("TimePicker general interaction", () => {
 	it("tests change event", async () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#timepickerChange");
 		const timepicker = await browser.$("#timepickerChange");
-		const icon = await timepicker.shadow$("ui5-input").$("ui5-icon");
+		const input = await timepicker.shadow$("ui5-input");
+		const icon = await input.$("ui5-icon");
 		const changeResult = await browser.$("#changeResult");
 
 		// act - submit the same time
@@ -128,6 +129,15 @@ describe("TimePicker general interaction", () => {
 
 		// assert
 		assert.strictEqual(await changeResult.getProperty("value"), "2", "Change fired as expected");
+
+		//act
+		await input.click();
+		await browser.keys("Backspace");
+		await browser.keys("7");
+		await browser.keys("Enter");
+
+		// assert
+		assert.strictEqual(await changeResult.getProperty("value"), "3", "Change fired as expected");
 	});
 
 	it("tests value state", async () => {


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-webcomponents/issues/4918
