### PR TITLE
feat(framework): Introduce resource reuse policies

### DIFF
--- a/packages/base/src/SharedResourcePolicy.js
+++ b/packages/base/src/SharedResourcePolicy.js
@@ -33,14 +33,14 @@ const setSharedResourcePolicy = (type, policy) => {
 const shouldUpdateResource = (resourceType, resourceRuntimeIndex) => {
 	const policy = getSharedResourcePolicy(resourceType);
 
-	// Always update regardless of versions
+	// Always reuse (never update) regardless of versions
 	if (policy === SharedResourceReusePolicy.Always) {
-		return true;
+		return false;
 	}
 
-	// Never update regardless of versions
+	// Never reuse (always update) regardless of versions
 	if (policy === SharedResourceReusePolicy.Never) {
-		return false;
+		return true;
 	}
 
 	// Only update if the current runtime is newer

--- a/packages/base/src/SharedResourcePolicy.js
+++ b/packages/base/src/SharedResourcePolicy.js
@@ -1,0 +1,66 @@
+import { getCurrentRuntimeIndex, compareRuntimes } from "./Runtimes.js";
+import SharedResourceReusePolicy from "./types/SharedResourceReusePolicy.js";
+import SharedResourceType from "./types/SharedResourceType.js";
+
+// Default policies per resource type. Can be overridden by calling "setSharedResourcePolicy"
+const policies = {};
+policies[SharedResourceType.ThemeProperties] = SharedResourceReusePolicy.OnlyNewer;
+
+/**
+ * Sets the shared resource policy (f.e. OnlyNewer) for the given type of shared resources (such as SVGIcons)
+ *
+ * @param type
+ * @param policy
+ */
+const setSharedResourcePolicy = (type, policy) => {
+	if (!SharedResourceReusePolicy[policy]) {
+		throw new Error(`Unsupported resource reuse policy: ${policy}`);
+	}
+	if (!SharedResourceType[type]) {
+		throw new Error(`Unsupported resource reuse policy type: ${type}`);
+	}
+
+	policies[type] = policy;
+};
+
+/**
+ * Determines whether a resource of a certain type/version should be updated by the current runtime
+ *
+ * @param resourceType the kind of resource that is about to be updated
+ * @param resourceRuntimeIndex the index of the runtime that created this resource (undefined means the runtime that created the resource did not set runtime info on it at all)
+ * @returns {boolean}
+ */
+const shouldUpdateResource = (resourceType, resourceRuntimeIndex) => {
+	const policy = getSharedResourcePolicy(resourceType);
+
+	// Always update regardless of versions
+	if (policy === SharedResourceReusePolicy.Always) {
+		return true;
+	}
+
+	// Never update regardless of versions
+	if (policy === SharedResourceReusePolicy.Never) {
+		return false;
+	}
+
+	// Only update if the current runtime is newer
+	const resourceRuntimeIsOlder = resourceRuntimeIndex === undefined; // The resource was created by a runtime before the introduction of the policies system
+	const currentRuntimeIsNewer = compareRuntimes(getCurrentRuntimeIndex(), parseInt(resourceRuntimeIndex)) === 1; // 1 means the current is newer, 0 means the same, -1 means the resource's runtime is newer
+	return resourceRuntimeIsOlder || currentRuntimeIsNewer;
+};
+
+/**
+ * Returns the shared resource policy for the given type of shared resources
+ *
+ * @param type
+ * @returns {*}
+ */
+const getSharedResourcePolicy = type => {
+	return policies[type];
+};
+
+export {
+	setSharedResourcePolicy,
+	getSharedResourcePolicy,
+	shouldUpdateResource,
+};

--- a/packages/base/src/SharedResourcePolicy.js
+++ b/packages/base/src/SharedResourcePolicy.js
@@ -7,7 +7,7 @@ const policies = {};
 policies[SharedResourceType.ThemeProperties] = SharedResourceReusePolicy.OnlyNewer;
 
 /**
- * Sets the shared resource policy (f.e. OnlyNewer) for the given type of shared resources (such as SVGIcons)
+ * Sets the shared resource policy (f.e. OnlyNewer) for the given type of shared resources (such as ThemeProperties)
  *
  * @param type
  * @param policy

--- a/packages/base/src/theming/applyTheme.js
+++ b/packages/base/src/theming/applyTheme.js
@@ -18,7 +18,7 @@ const loadThemeBase = async theme => {
 
 	const cssData = await getThemeProperties(BASE_THEME_PACKAGE, theme);
 	if (cssData) {
-		createOrUpdateStyle(cssData, "data-ui5-theme-properties", BASE_THEME_PACKAGE);
+		createOrUpdateStyle(cssData, "data-ui5-theme-properties", BASE_THEME_PACKAGE, theme);
 	}
 };
 
@@ -35,7 +35,7 @@ const loadComponentPackages = async theme => {
 
 		const cssData = await getThemeProperties(packageName, theme);
 		if (cssData) {
-			createOrUpdateStyle(cssData, "data-ui5-theme-properties", packageName);
+			createOrUpdateStyle(cssData, "data-ui5-theme-properties", packageName, theme);
 		}
 	});
 };

--- a/packages/base/src/types/SharedResourceReusePolicy.js
+++ b/packages/base/src/types/SharedResourceReusePolicy.js
@@ -1,0 +1,23 @@
+/**
+ * @public
+ * Policies for managing shared resources
+ */
+const SharedResourceReusePolicy = {
+	/**
+	 * Never use shared resources from other runtimes. Always overwrite existing resources.
+	 * Assumes the behavior prior to introducing the Shared Resources concept.
+	 */
+	Never: "Never",
+
+	/**
+	 * Always use shared resources from other runtimes, regardless whether they are newer or older. Never overwrite existing resources.
+	 */
+	Always: "Always",
+
+	/**
+	 * Only use shared resources from other runtimes, if they are of the same version or newer. Only overwrite existing resources, if older.
+	 */
+	OnlyNewer: "OnlyNewer",
+};
+
+export default SharedResourceReusePolicy;

--- a/packages/base/src/types/SharedResourceType.js
+++ b/packages/base/src/types/SharedResourceType.js
@@ -1,0 +1,12 @@
+/**
+ * @public
+ * Types of shared resources, supported by the resource sharing policy
+ */
+const SharedResourceType = {
+	/**
+	 * CSS Variables for themes
+	 */
+	ThemeProperties: "ThemeProperties",
+};
+
+export default SharedResourceType;

--- a/packages/main/bundle.common.bootstrap.js
+++ b/packages/main/bundle.common.bootstrap.js
@@ -8,3 +8,9 @@ setPackageCSSRoot("@ui5/webcomponents-base", "/resources/css/base/");
 setPackageCSSRoot("@ui5/webcomponents-theming", "/resources/css/theming/");
 setPackageCSSRoot("@ui5/webcomponents", "/resources/css/main/");
 setPackageCSSRoot("@ui5/webcomponents-fiori", "/css/");
+
+// Set custom resource sharing policies
+import { setSharedResourcePolicy } from "@ui5/webcomponents-base/dist/SharedResourcePolicy.js";
+import SharedResourceReusePolicy from "@ui5/webcomponents-base/dist/types/SharedResourceReusePolicy.js";
+import SharedResourceReuseType from "@ui5/webcomponents-base/dist/types/SharedResourceType.js";
+setSharedResourcePolicy(SharedResourceReuseType.ThemeProperties, SharedResourceReusePolicy.OnlyNewer); // This is the default, but having it here makes it easier to change and test


### PR DESCRIPTION
# Shared resources reuse policies

Starting from version `1.3`, UI5 Web Components will introduce the concept of shared resources reuse policy. This means that library/micro-frontend authors will have the ability to define under what conditions their frameworks/micro-frontends will reuse resources, created by other runtimes. The concept is only relevant for multi-runtime scenarios.

## Resource sharing policies

There are 3 policies:
 - **Always** reuse (never update existing resources, reuse resources even if created by an older version) - usually not recommended, but useful in niche scenarios
 - **Never** reuse (always update resources, never reuse resources even if created by a newer version) - not recommended, but can be useful for backward compatibility (as before the introduction of this system each runtime overwrites shared resources anyway)
 - **OnlyNewer** (only update resources if created by an older version, reuse resources if created by the same or newer version) - default, and recommended for most scenarios

## Types of Shared resources that currently support policies
 - **Theme properties** (the CSS Variables, set as a `style` tag, constructable stylesheet, or a `link` tag)

More will be added with time, potentially all assets.

## Usage

For example, the following code says "never reuse theme properties (CSS Vars), even if created by a newer version":

```js
import { setSharedResourcePolicy } from "@ui5/webcomponents-base/dist/SharedResourcePolicy.js";
import SharedResourceReusePolicy from "@ui5/webcomponents-base/dist/types/SharedResourceReusePolicy.js";
import SharedResourceReuseType from "@ui5/webcomponents-base/dist/types/SharedResourceType.js";
setSharedResourcePolicy(SharedResourceReuseType.ThemeProperties, SharedResourceReusePolicy.Never);
```

## Technical notes

The decision whether to update the `ThemeProperties` resource (CSS Vars stored in a `style`, `link` or constructable stylesheet) depends on 2 factors:
 - What `theme` are the CSS vars in this resource (link/style/stylesheet) for?
 - Which runtime created the resources (link/style/stylesheet)
If the theme is being changed, then always update the CSS Vars, naturally. However, if the theme is the same, then we must check whether the resource was created by the same/older/newer version and match this information against the currently defined reuse policy.

related to: https://github.com/SAP/ui5-webcomponents/issues/3781

Note: this fix will prevent older runtimes from overwriting resources, created by newer runtimes, in the long run (when libraries have updated to at least `1.3` and have this feature). It will not have immediate impact today. We cannot retrospectively modify the behavior of old versions of UI5 Web Components before the introduction of this system. Therefore, the problem reported in the issue will not be solved directly by this PR, and will be targeted with a workaround separately.