### PR TITLE
fix(ui5-date-picker): adjust initial value formatting

### DIFF
--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -414,7 +414,7 @@ class DatePicker extends DateComponentBase {
 			console.warn(`In order for the "name" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line
 		}
 
-		this.value = this.normalizeValue(this.value);
+		this.value = this.normalizeValue(this.value) || this.value;
 		this.liveValue = this.value;
 	}
 

--- a/packages/main/test/pages/DatePicker_test_page.html
+++ b/packages/main/test/pages/DatePicker_test_page.html
@@ -36,6 +36,7 @@
 	<ui5-date-picker id="dp11"></ui5-date-picker>
 	<ui5-date-picker id="dp13"></ui5-date-picker>
 	<ui5-date-picker id="dp16" format-pattern="long"></ui5-date-picker>
+	<ui5-date-picker value="Invalid value" id="dp20"></ui5-date-picker>
 	<ui5-button id="b1" design="Default">Set date</ui5-button>
 	
 

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1154,4 +1154,11 @@ describe("Date Picker Tests", () => {
 		await browser.keys("Backspace");
 		await browser.keys("Enter");
 	});
+
+	it("Invalid initial value isn't cleared due to formatting", async () => {
+		datepicker.id = "#dp20";
+		const input = await datepicker.getInput();
+
+		assert.equal(await input.getProperty("value"), "Invalid value", "the value isn't changed");
+	});
 });


### PR DESCRIPTION
Problem description:
When a value string is provided initially with an incorrect
format pattern, then this value gets cleared in the on
before rendering hook.

Solution:
The initial value remains unchanged if the internal formatter
isn't able to parse it.

Fixes: #4958