### PR TITLE
feat(ui5-input): introduce openPicker() functionality

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -593,6 +593,9 @@ class Input extends UI5Element {
 		// Indicates, if the user is typing. Gets reset once popup is closed
 		this.isTyping = false;
 
+		// Determines whether to manually show the suggestions popover
+		this._forceOpen = false;
+
 		// all sementic events
 		this.EVENT_CHANGE = "change";
 		this.EVENT_INPUT = "input";
@@ -632,7 +635,7 @@ class Input extends UI5Element {
 		if (this._isPhone) {
 			this.open = this.openOnMobile;
 		} else if (this._forceOpen) {
-			this.open = hasItems && isFocused;
+			this.open = true;
 		} else {
 			this.open = hasValue && hasItems && isFocused && this.isTyping;
 		}
@@ -849,6 +852,7 @@ class Input extends UI5Element {
 		this.lastConfirmedValue = "";
 		this.focused = false; // invalidating property
 		this.isTyping = false;
+		this._forceOpen = false;
 	}
 
 	_clearPopoverFocusAndSelection() {
@@ -989,8 +993,6 @@ class Input extends UI5Element {
 		if (isPhone()) {
 			(await this.getInputDOMRef()).focus();
 		}
-
-		this._forceOpen = false;
 	}
 
 	_afterClosePopover() {
@@ -1005,6 +1007,7 @@ class Input extends UI5Element {
 		this.isTyping = false;
 		this.openOnMobile = false;
 		this.open = false;
+		this._forceOpen = false;
 	}
 
 	/**
@@ -1036,17 +1039,15 @@ class Input extends UI5Element {
 	}
 
 	/**
-	 * Manually opens the suggestions popover, assuming items have been preloaded. Otherwise, does nothing.
+	 * Manually opens the suggestions popover, assuming suggestions are enabled. Otherwise, does nothing.
 	 * @public
 	 */
 	showItems() {
-		if (!this.Suggestions || this.disabled || this.readonly || !this.Suggestions._getItems().length) {
+		if (!this.Suggestions || this.disabled || this.readonly) {
 			return;
 		}
 
 		this._forceOpen = true;
-
-		return this.Suggestions.open();
 	}
 
 	enableSuggestions() {
@@ -1089,6 +1090,7 @@ class Input extends UI5Element {
 
 		this.isTyping = false;
 		this.openOnMobile = false;
+		this._forceOpen = false;
 	}
 
 	previewSuggestion(item) {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -631,6 +631,8 @@ class Input extends UI5Element {
 
 		if (this._isPhone) {
 			this.open = this.openOnMobile;
+		} else if (this._forceOpen) {
+			this.open = hasItems && isFocused;
 		} else {
 			this.open = hasValue && hasItems && isFocused && this.isTyping;
 		}
@@ -987,6 +989,8 @@ class Input extends UI5Element {
 		if (isPhone()) {
 			(await this.getInputDOMRef()).focus();
 		}
+
+		this._forceOpen = false;
 	}
 
 	_afterClosePopover() {
@@ -1029,6 +1033,20 @@ class Input extends UI5Element {
 	async _getPopover() {
 		const staticAreaItem = await this.getStaticAreaItemDomRef();
 		return staticAreaItem && staticAreaItem.querySelector("[ui5-popover]");
+	}
+
+	/**
+	 * Manually opens the suggestions popover, assuming items have been preloaded. Otherwise, does nothing.
+	 * @public
+	 */
+	showItems() {
+		if (!this.Suggestions || this.disabled || this.readonly || !this.Suggestions._getItems().length) {
+			return;
+		}
+
+		this._forceOpen = true;
+
+		return this.Suggestions.open();
 	}
 
 	enableSuggestions() {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -375,6 +375,14 @@ const metadata = {
 		},
 
 		/**
+		 * Determines whether to manually show the suggestions popover
+		 * @private
+		 */
+		_forceOpen: {
+			type: Boolean,
+		},
+
+		/**
 		 * Indicates whether the visual focus is on the value state header
 		 * @private
 		 */
@@ -593,9 +601,6 @@ class Input extends UI5Element {
 		// Indicates, if the user is typing. Gets reset once popup is closed
 		this.isTyping = false;
 
-		// Determines whether to manually show the suggestions popover
-		this._forceOpen = false;
-
 		// all sementic events
 		this.EVENT_CHANGE = "change";
 		this.EVENT_INPUT = "input";
@@ -635,7 +640,7 @@ class Input extends UI5Element {
 		if (this._isPhone) {
 			this.open = this.openOnMobile;
 		} else if (this._forceOpen) {
-			this.open = true;
+			this.open = isFocused;
 		} else {
 			this.open = hasValue && hasItems && isFocused && this.isTyping;
 		}
@@ -1042,7 +1047,7 @@ class Input extends UI5Element {
 	 * Manually opens the suggestions popover, assuming suggestions are enabled. Otherwise, does nothing.
 	 * @public
 	 */
-	showItems() {
+	openPicker() {
 		if (!this.Suggestions || this.disabled || this.readonly) {
 			return;
 		}

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -384,8 +384,8 @@
 		</span>
 	</div>
 
-	<h3>Input with showItems() on click</h3>
-	<ui5-input id="showItemsInput" show-suggestions show-clear-icon class="input3auto" placeholder="Click to show recent values"></ui5-input>
+	<h3>Input with openPicker() on focusin</h3>
+	<ui5-input id="openPickerInput" show-suggestions show-clear-icon class="input3auto" placeholder="Click to show recent values..."></ui5-input>
 
 	<script>
 		document.getElementById("submit-input").addEventListener("keypress", function(event) {
@@ -567,67 +567,59 @@
 			compactClearIconInput.toggleAttribute("readonly");
 		});
 
-		const showItemsInput = document.getElementById("showItemsInput");
+		const openPickerInput = document.getElementById("openPickerInput");
 		let recentItems = [];
-		showItemsInput.addEventListener("input", handleSuggestions);
-		showItemsInput.addEventListener("suggestion-item-select", handleSelection);
-		showItemsInput.addEventListener("click", handleHistory);
-		showItemsInput.addEventListener("focus", handleHistory);
+		openPickerInput.addEventListener("input", handleSuggestions);
+		openPickerInput.addEventListener("suggestion-item-select", handleSelection);
+		openPickerInput.addEventListener("click", handleHistory);
+		openPickerInput.addEventListener("focus", handleHistory);
 
 		function handleSuggestions() {
-			if (!showItemsInput.children.length) {
-				const loadingItem = document.createElement("ui5-suggestion-item");
-				loadingItem.text = "Loading...";
-				loadingItem.type = "Inactive";
-				showItemsInput.appendChild(loadingItem);
-			}
-
 			fetch('https://dummyjson.com/users?select=firstName,lastName&limit=100')
 				.then(res => res.json())
 				.then(({users}) => {
-					var value = showItemsInput.value;
+					var value = openPickerInput.value;
 					var suggestionItems = [];
 
-					[].slice.call(showItemsInput.children).forEach(child => {
-						showItemsInput.removeChild(child);
+					[].slice.call(openPickerInput.children).forEach(child => {
+						openPickerInput.removeChild(child);
 					});
 
 					const recentItemsGroup = document.createElement("ui5-suggestion-group-item");
 					recentItemsGroup.text = "Recent items";
-					showItemsInput.appendChild(recentItemsGroup);
+					openPickerInput.appendChild(recentItemsGroup);
 
 					if (recentItems.length) {
 						recentItems.forEach(name => {
 							const item = document.createElement("ui5-suggestion-item");
 							item.icon = "employee";
 							item.text = name;
-							showItemsInput.appendChild(item);
+							openPickerInput.appendChild(item);
 						})
 					} else {
 						const noRecentItem = document.createElement("ui5-suggestion-item");
 						noRecentItem.text = "No recent users";
 						noRecentItem.type = "Inactive";
-						showItemsInput.appendChild(noRecentItem);
+						openPickerInput.appendChild(noRecentItem);
 					}
 
 					if (value) {
+						let currentItems = Array.from(openPickerInput.children).map(({text}) => text);
 						suggestionItems = users
 							.map(({ firstName, lastName }) => `${firstName} ${lastName}`)
-							.filter(item => {
-								return item.toUpperCase().indexOf(value.toUpperCase()) === 0;
-							});
+							.filter(item => item.toUpperCase().indexOf(value.toUpperCase()) === 0 && !currentItems.includes(item));
 					}
 
 					if (suggestionItems.length) {
 						const suggestionsGroup = document.createElement("ui5-suggestion-group-item");
 						suggestionsGroup.text = "Suggestions";
-						showItemsInput.appendChild(suggestionsGroup);
+						openPickerInput.appendChild(suggestionsGroup);
 
 						suggestionItems.forEach(item => {
 							var li = document.createElement("ui5-suggestion-item");
 							li.icon = "employee";
 							li.text = item;
-							showItemsInput.appendChild(li);
+							openPickerInput.appendChild(li);
 						});
 					}
 				});
@@ -643,7 +635,7 @@
 
 		function handleHistory() {
 			handleSuggestions();
-			showItemsInput.showItems();
+			openPickerInput.openPicker();
 		}
 	</script>
 </body>

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -384,6 +384,14 @@
 		</span>
 	</div>
 
+	<h3>Input with showItems() on focus</h3>
+	<ui5-input id="showItemsInput" show-suggestions class="input3auto">
+		<ui5-suggestion-item text="Adam D" description="Administrative Support"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Aanya Sing" description="Administrative Support"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Allen K" description="Technical Support"></ui5-suggestion-item>
+		<ui5-suggestion-item text="Alex" description="Technical Support"></ui5-suggestion-item>
+	</ui5-input>
+
 	<script>
 		document.getElementById("submit-input").addEventListener("keypress", function(event) {
 			if (event.key === 'Enter') {
@@ -563,6 +571,9 @@
 		document.getElementById("clear-icon-readonly-toggle").addEventListener("click", event => {
 			compactClearIconInput.toggleAttribute("readonly");
 		});
+
+		const showItemsInput = document.getElementById("showItemsInput");
+		showItemsInput.addEventListener("click", () => showItemsInput.showItems());
 	</script>
 </body>
 </html>

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -384,13 +384,8 @@
 		</span>
 	</div>
 
-	<h3>Input with showItems() on focus</h3>
-	<ui5-input id="showItemsInput" show-suggestions class="input3auto">
-		<ui5-suggestion-item text="Adam D" description="Administrative Support"></ui5-suggestion-item>
-		<ui5-suggestion-item text="Aanya Sing" description="Administrative Support"></ui5-suggestion-item>
-		<ui5-suggestion-item text="Allen K" description="Technical Support"></ui5-suggestion-item>
-		<ui5-suggestion-item text="Alex" description="Technical Support"></ui5-suggestion-item>
-	</ui5-input>
+	<h3>Input with showItems() on click</h3>
+	<ui5-input id="showItemsInput" show-suggestions show-clear-icon class="input3auto" placeholder="Click to show recent values"></ui5-input>
 
 	<script>
 		document.getElementById("submit-input").addEventListener("keypress", function(event) {
@@ -573,7 +568,83 @@
 		});
 
 		const showItemsInput = document.getElementById("showItemsInput");
-		showItemsInput.addEventListener("click", () => showItemsInput.showItems());
+		let recentItems = [];
+		showItemsInput.addEventListener("input", handleSuggestions);
+		showItemsInput.addEventListener("suggestion-item-select", handleSelection);
+		showItemsInput.addEventListener("click", handleHistory);
+		showItemsInput.addEventListener("focus", handleHistory);
+
+		function handleSuggestions() {
+			if (!showItemsInput.children.length) {
+				const loadingItem = document.createElement("ui5-suggestion-item");
+				loadingItem.text = "Loading...";
+				loadingItem.type = "Inactive";
+				showItemsInput.appendChild(loadingItem);
+			}
+
+			fetch('https://dummyjson.com/users?select=firstName,lastName&limit=100')
+				.then(res => res.json())
+				.then(({users}) => {
+					var value = showItemsInput.value;
+					var suggestionItems = [];
+
+					[].slice.call(showItemsInput.children).forEach(child => {
+						showItemsInput.removeChild(child);
+					});
+
+					const recentItemsGroup = document.createElement("ui5-suggestion-group-item");
+					recentItemsGroup.text = "Recent items";
+					showItemsInput.appendChild(recentItemsGroup);
+
+					if (recentItems.length) {
+						recentItems.forEach(name => {
+							const item = document.createElement("ui5-suggestion-item");
+							item.icon = "employee";
+							item.text = name;
+							showItemsInput.appendChild(item);
+						})
+					} else {
+						const noRecentItem = document.createElement("ui5-suggestion-item");
+						noRecentItem.text = "No recent users";
+						noRecentItem.type = "Inactive";
+						showItemsInput.appendChild(noRecentItem);
+					}
+
+					if (value) {
+						suggestionItems = users
+							.map(({ firstName, lastName }) => `${firstName} ${lastName}`)
+							.filter(item => {
+								return item.toUpperCase().indexOf(value.toUpperCase()) === 0;
+							});
+					}
+
+					if (suggestionItems.length) {
+						const suggestionsGroup = document.createElement("ui5-suggestion-group-item");
+						suggestionsGroup.text = "Suggestions";
+						showItemsInput.appendChild(suggestionsGroup);
+
+						suggestionItems.forEach(item => {
+							var li = document.createElement("ui5-suggestion-item");
+							li.icon = "employee";
+							li.text = item;
+							showItemsInput.appendChild(li);
+						});
+					}
+				});
+		}
+
+		function handleSelection(event) {
+			const name = event.detail.item.text;
+			const idx = recentItems.indexOf(name);
+			idx > -1 && recentItems.splice(idx, 1);
+			recentItems.unshift(name);
+			recentItems.length > 5 && recentItems.pop();
+		}
+
+		function handleHistory() {
+			handleSuggestions();
+			showItemsInput.showItems();
+		}
 	</script>
 </body>
 </html>

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -63,6 +63,7 @@ describe("Input general interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#myInput2");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
+		// focus the input field which will display the suggestions
 		await input.click();
 
 		assert.ok(!(await popover.isDisplayedInViewport()), "The popover is not visible");
@@ -722,10 +723,9 @@ describe("Input general interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#showItemsInput");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-		// focus the input field which will display the suggestions
-		await input.click();
+		await input.focus();
 
-		assert.ok((await popover.isDisplayedInViewport()), "The popover is visible");
+		assert.ok(await popover.isDisplayedInViewport(), "The popover is visible");
 	});
 });
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -718,12 +718,12 @@ describe("Input general interaction", () => {
 		assert.ok(await input.getProperty("effectiveShowClearIcon"), "Clear icon should be shown");
 	});
 
-	it("Should open suggestions popover if showItems() is called on focusin", async () => {
-		const input = await browser.$("#showItemsInput");
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#showItemsInput");
+	it("Should open suggestions popover if openPicker() is called on focusin", async () => {
+		const input = await browser.$("#openPickerInput");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#openPickerInput");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-		await input.focus();
+		await input.click();
 
 		assert.ok(await popover.isDisplayedInViewport(), "The popover is visible");
 	});

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -63,7 +63,6 @@ describe("Input general interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#myInput2");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-		// focus the input field which will display the suggestions
 		await input.click();
 
 		assert.ok(!(await popover.isDisplayedInViewport()), "The popover is not visible");
@@ -716,6 +715,17 @@ describe("Input general interaction", () => {
 
 		await disable.click();
 		assert.ok(await input.getProperty("effectiveShowClearIcon"), "Clear icon should be shown");
+	});
+
+	it("Should open suggestions popover if showItems() is called on focusin", async () => {
+		const input = await browser.$("#showItemsInput");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#showItemsInput");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		// focus the input field which will display the suggestions
+		await input.click();
+
+		assert.ok((await popover.isDisplayedInViewport()), "The popover is visible");
 	});
 });
 


### PR DESCRIPTION
A new `openPicker()` method for manually opening the suggestions popover has been introduced.

Usage:
```js
<ui5-input id="myInput" show-suggestions></ui5-input>
------
myInput.addEventListener("event-type", () => {
	fetch(myRequest)
		.then((response) => {
			// Arrange items before calling openPicker, to prevent an empty popover from showing
			myInput.openPicker();
		});
});
```

A sample implementation with recent item history will be available in [Input with openPicker() on focusin
](https://sap.github.io/ui5-webcomponents/master/playground/main/pages/Input/#openPickerInput) once merged.