### PR TITLE
refactor(ui5-input): prevent opening an empty picker and update docu

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -640,7 +640,7 @@ class Input extends UI5Element {
 		if (this._isPhone) {
 			this.open = this.openOnMobile;
 		} else if (this._forceOpen) {
-			this.open = isFocused;
+			this.open = true;
 		} else {
 			this.open = hasValue && hasItems && isFocused && this.isTyping;
 		}
@@ -1044,11 +1044,12 @@ class Input extends UI5Element {
 	}
 
 	/**
-	 * Manually opens the suggestions popover, assuming suggestions are enabled. Otherwise, does nothing.
+	 * Manually opens the suggestions popover, assuming suggestions are enabled. Items must be preloaded for it to open.
+	 * @since 1.3.0
 	 * @public
 	 */
 	openPicker() {
-		if (!this.Suggestions || this.disabled || this.readonly) {
+		if (!this.suggestionItems.length || this.disabled || this.readonly) {
 			return;
 		}
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -385,7 +385,10 @@
 	</div>
 
 	<h3>Input with openPicker() on focusin</h3>
-	<ui5-input id="openPickerInput" show-suggestions show-clear-icon class="input3auto" placeholder="Click to show recent values..."></ui5-input>
+	<ui5-input id="openPickerInput" show-suggestions show-clear-icon class="input3auto" placeholder="Click to show recent values...">
+		<ui5-suggestion-group-item>Recent Items</ui5-suggestion-group-item>
+		<ui5-suggestion-item type="Inactive">No recent users</ui5-suggestion-item>
+	</ui5-input>
 
 	<script>
 		document.getElementById("submit-input").addEventListener("keypress", function(event) {


### PR DESCRIPTION
After this change, suggestion items must be preloaded for `openPicker` to take effect. The documentation has been updated accordingly.