### PR TITLE
fix(ui5-tokenizer): correct header paddings in nMore popover

### DIFF
--- a/packages/main/src/TokenizerPopover.hbs
+++ b/packages/main/src/TokenizerPopover.hbs
@@ -1,33 +1,32 @@
 <ui5-responsive-popover
 	tokenizer-popover="true"
 	style={{styles.popover}}
-	header-text={{morePopoverTitle}}
 	?content-only-on-desktop="{{hasValueState}}"
 	hide-arrow
 	placement-type="Bottom"
 	horizontal-align="Left"
 >
-	{{#unless hasValueState}}
-		<div slot="header" class="ui5-responsive-popover-header" style="{{styles.popoverHeader}}">
-			{{#if _isPhone}}
-				<div class="row" style="{{styles.popoverHeaderTitle}}">
-					<ui5-title level="H5" class="ui5-responsive-popover-header-text">Remove</ui5-title>
-					<ui5-button
-						class="ui5-responsive-popover-close-btn"
-						icon="decline"
-						design="Transparent"
-						@click="{{closeMorePopover}}"
-					>
-					</ui5-button>
-				</div>
-			{{/if}}
+	<div slot="header" class="ui5-responsive-popover-header" style="{{styles.popoverHeader}}">
+		{{#if _isPhone}}
+			<div class="row" style="{{styles.popoverHeaderTitle}}">
+				<ui5-title level="H5" class="ui5-responsive-popover-header-text">{{morePopoverTitle}}</ui5-title>
+				<ui5-button
+					class="ui5-responsive-popover-close-btn"
+					icon="decline"
+					design="Transparent"
+					@click="{{closeMorePopover}}"
+				>
+				</ui5-button>
+			</div>
+		{{/if}}
+		{{#unless hasValueState}}
 			<div class="{{classes.popoverValueState}}" style="{{styles.popoverValueStateMessage}}">
 				{{#each valueStateMessageText}}
 					{{this}}
 				{{/each}}
 			</div>
-		</div>
-	{{/unless}}
+		{{/unless}}
+	</div>
 	<ui5-list
 		class="ui5-tokenizer-list"
 		mode="Delete"


### PR DESCRIPTION
The paddings in the nMore responsive popover have been adjusted on mobile to match the VD spec. 
Previously, the custom header was applied only when a value state message was present. Now it is always applied, as there is currently no other way to determine when to set side padding (depending on the presence of a value state) on the built-in header :part of the ResponsivePopover.

Fixes: #4871