### PR TITLE
fix(ui5-label): prevent screenreader announcement of colon and asterisk

### DIFF
--- a/packages/main/src/Label.hbs
+++ b/packages/main/src/Label.hbs
@@ -9,5 +9,5 @@
 			<slot></slot>
 		</bdi>
 	</span>
-	<span class="ui5-label-required-colon"></span>
+	<span aria-hidden="true" class="ui5-label-required-colon"></span>
 </label>


### PR DESCRIPTION
Fixes: #4830