### PR TITLE
chore: revert breaking change

### DIFF
--- a/packages/fiori/src/FilterItem.js
+++ b/packages/fiori/src/FilterItem.js
@@ -1,4 +1,4 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import ListItem from "@ui5/webcomponents/dist/ListItem.js";
 
 /**
  * @public
@@ -32,7 +32,7 @@ const metadata = {
 	slots: /** @lends sap.ui.webcomponents.fiori.FilterItem.prototype */ {
 		/**
 		 * Defines the <code>values</code> list.
-         * @type {sap.ui.webcomponents.fiori.IFilterItemOption[]}
+		 * @type {sap.ui.webcomponents.fiori.IFilterItemOption[]}
 		 * @slot values
 		 * @public
 		 */
@@ -61,13 +61,13 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.FilterItem
- * @extends UI5Element
+ * @extends ListItem
  * @since 1.0.0-rc.16
  * @tagname ui5-filter-item
  * @implements sap.ui.webcomponents.fiori.IFilterItem
  * @public
  */
-class FilterItem extends UI5Element {
+class FilterItem extends ListItem {
 	static get metadata() {
 		return metadata;
 	}

--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -215,6 +215,7 @@ const metadata = {
  * @extends UI5Element
  * @tagname ui5-view-settings-dialog
  * @since 1.0.0-rc.16
+ * @appenddocs SortItem FilterItem FilterItemOption
  * @public
  */
 class ViewSettingsDialog extends UI5Element {


### PR DESCRIPTION
The FilterItem used to extend the ListItem, but after this [refactoring](https://github.com/SAP/ui5-webcomponents/pull/5013) the FilterItem becomes an abstract web component and extends the UI5Element. However, this is detected as BREAKING CHANGE by UI5 Web Components 4 React [release testing](https://github.com/SAP/ui5-webcomponents-react/pull/2796#issuecomment-1099895843) when trying to adopt the latest changes before releasing 1.3.0