### PR TITLE
chore: remove DEPLOY_PUBLIC_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - gem install jekyll-seo-tag
 
 script:
-- DEPLOY_PUBLIC_PATH=/resources/ ENABLE_CLDR=1 yarn build
+- ENABLE_CLDR=1 yarn build
 - yarn test
 
 deploy:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -56,7 +56,7 @@ if [ "$TRAVIS_BRANCH" == "$TRAVIS_LATEST_RELEASE_WEBSITE_BRANCH" ]; then
 
   # Run the build again so rollup can generate the correct public path urls
   cd $TRAVIS_BUILD_DIR
-  DEPLOY_PUBLIC_PATH=https://sap.github.io/ui5-webcomponents/assets/js/ui5-webcomponents/ yarn build:playground
+  yarn build:playground
 
   # Move master build folder to gh-pages folder
   cp -Rf $TRAVIS_BUILD_DIR/packages/playground/dist/* gh-pages
@@ -80,12 +80,12 @@ if [ "$TRAVIS_BRANCH" == "$TRAVIS_LATEST_RELEASE_WEBSITE_BRANCH" ]; then
 
   # Clean gh-pages existing contents
   rm -rf gh-pages/master|| exit 0
-  
+
   mkdir gh-pages/master
 
   # Run the build again so rollup can generate the correct public path urls
   cd $TRAVIS_BUILD_DIR
-  DEPLOY_PUBLIC_PATH=https://sap.github.io/ui5-webcomponents/master/assets/js/ui5-webcomponents/ yarn build:playground:master
+  yarn build:playground:master
 
   # Move master build folder to gh-pages folder
   cp -Rf $TRAVIS_BUILD_DIR/packages/playground/dist/* gh-pages/master

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "start:base": "cd packages/base && yarn start",
     "start:main": "cd packages/main && yarn start",
     "start:fiori": "cd packages/fiori && yarn start",
-    "start:playground": "yarn build:theming && cross-env DEPLOY_PUBLIC_PATH=/assets/js/ui5-webcomponents/ yarn build:main && cross-env DEPLOY_PUBLIC_PATH=/assets/js/ui5-webcomponents/ yarn build:fiori && yarn copy-css && cd packages/playground && yarn start",
+    "start:playground": "yarn build:theming && yarn build:main && yarn build:fiori && yarn copy-css && cd packages/playground && yarn start",
     "test:base": "cd packages/base && yarn test",
     "test:main": "cd packages/main && yarn test",
     "test:fiori": "cd packages/fiori && yarn test",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -56,7 +56,7 @@ const getScripts = (options) => {
 			src: 'nps "copy.src --watch --safe --skip-initial-copy"',
 			props: 'nps "copy.props --watch --safe --skip-initial-copy"',
 			test: 'nps "copy.test --watch --safe --skip-initial-copy"',
-			bundle: 'rollup --config config/rollup.config.js -w --environment DEV,DEPLOY_PUBLIC_PATH:/resources/',
+			bundle: 'rollup --config config/rollup.config.js -w --environment DEV',
 			styles: {
 				default: 'concurrently "nps watch.styles.themes" "nps watch.styles.components"',
 				themes: 'nps "build.styles.themes -w"',

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -151,12 +151,6 @@ const getES6Config = (input = "bundle.esm.js") => {
 			format: "esm",
 			sourcemap: true,
 		},
-		moduleContext: id => {
-			if (typeof id === "string" && id.includes("url-search-params-polyfill")) {
-				// suppress the rollup error for this module as it uses this in the global scope correctly even without changing the context here
-				return "window";
-			}
-		},
 		watch: {
 			clearScreen: false,
 		},

--- a/packages/tools/components-package/rollup.js
+++ b/packages/tools/components-package/rollup.js
@@ -12,7 +12,6 @@ const emptyModulePlugin = require("./rollup-plugins/empty-module.js");
 
 const packageFile = JSON.parse(fs.readFileSync("./package.json"));
 const packageName = packageFile.name;
-const DEPLOY_PUBLIC_PATH = process.env.DEPLOY_PUBLIC_PATH || "";
 
 const warningsToSkip = [{
 	warningCode: "THIS_IS_UNDEFINED",
@@ -108,8 +107,6 @@ const getPlugins = () => {
 
 		));
 	}
-
-	const publicPath = DEPLOY_PUBLIC_PATH;
 
 	plugins.push(ui5DevImportCheckerPlugin());
 


### PR DESCRIPTION
After the IE11 cleanup the rollup script no longer needs:
- `DEPLOY_PUBLIC_PATH`
- context overwrite for `url-search-params-polyfill`