### PR TITLE
refactor: optimize templates disk writes

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-D9V0qPmUSBitL9W+xbnAmLgAZI4=
+ai0RiZBkR3Azk/giBXslU7G28MU=

--- a/packages/tools/lib/hbs2ui5/index.js
+++ b/packages/tools/lib/hbs2ui5/index.js
@@ -40,7 +40,7 @@ const composeAbsoluteOutputDir = (file, outputDir) => {
 	const fileDir = file.split(path.sep).slice(1, -1).join(path.sep);
 
 	// (2) Compose full output dir - "dist/generated/templates/lvl1/lvl2"
-	return `${outputDir}${path.sep}${fileDir}`; 
+	return `${outputDir}${path.sep}${fileDir}`;
 };
 
 const wrapDirectory = (directory, outputDir) => {
@@ -72,7 +72,9 @@ const writeRenderers = (outputDir, controlName, fileContent) => {
 		// strip DOS line endings because the break the source maps
 		let fileContentUnix = fileContent.replace(/\r\n/g, "\n");
 		fileContentUnix = fileContentUnix.replace(/\r/g, "\n");
-		fs.writeFileSync(compiledFilePath, fileContentUnix);
+		if (!fs.existsSync(compiledFilePath) || `${fs.readFileSync(compiledFilePath)}` !== fileContentUnix) {
+			fs.writeFileSync(compiledFilePath, fileContentUnix);
+		}
 
 	} catch (e) {
 		console.log(e);

--- a/packages/tools/lib/hbs2ui5/index.js
+++ b/packages/tools/lib/hbs2ui5/index.js
@@ -72,6 +72,9 @@ const writeRenderers = (outputDir, controlName, fileContent) => {
 		// strip DOS line endings because the break the source maps
 		let fileContentUnix = fileContent.replace(/\r\n/g, "\n");
 		fileContentUnix = fileContentUnix.replace(/\r/g, "\n");
+
+		// Only write to the file system actual changes - each updated file, no matter if the same or not, triggers an expensive operation for rollup
+		// Note: .hbs files that include a changed .hbs file will also be recompiled as their content will be updated too
 		if (!fs.existsSync(compiledFilePath) || `${fs.readFileSync(compiledFilePath)}` !== fileContentUnix) {
 			fs.writeFileSync(compiledFilePath, fileContentUnix);
 		}


### PR DESCRIPTION
When rollup is in `watch` mode, and you change an `.hbs` file, this leads to all templates for the project being recompiled. This updates tens of files on the file system, leading to a big reaction by rollup. This is the reason you see several "created dist/resources in 3.7s" rollup messages in the console one after the other - rollup detects some files changed and recreates the bundle, but then it detects more files and does it again, potentially several times.

The proposed optimization only updates the files that really changed. Side effects:
 - if you change whitespaces in an `.hbs` file, rollup will not rebuild (as this will not produce a different template result)
