### PR TITLE
refactor(ui5-shellbar, ui5-progress-indicator, ui5-select, ui5-media-gallery): refactor RTL implementation - part 3

### DIFF
--- a/packages/fiori/src/MediaGallery.hbs
+++ b/packages/fiori/src/MediaGallery.hbs
@@ -1,5 +1,4 @@
-<div class="ui5-media-gallery-root"
-    dir={{effectiveDir}}>
+<div class="ui5-media-gallery-root">
     <div class="ui5-media-gallery-display-wrapper">
         <div class="ui5-media-gallery-display"
                 @click="{{_onDisplayAreaClick}}">

--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -1,6 +1,5 @@
 <div
 	class="{{classes.wrapper}}"
-	dir="{{effectiveDir}}"
 	role="banner"
 	aria-label="{{_shellbarText}}"
 	part="root"

--- a/packages/fiori/src/themes/MediaGallery.css
+++ b/packages/fiori/src/themes/MediaGallery.css
@@ -1,158 +1,153 @@
 :host {
-    height:100%;
+	height:100%;
 }
 
 :host,
 .ui5-media-gallery-display-wrapper,
 .ui5-media-gallery-display {
-    width: 100%;
+	width: 100%;
 }
 
 .ui5-media-gallery-root {
-    width: inherit;
-    height: inherit;
-    background: var(--sapBaseColor);
-    display: flex;
-    flex-direction: column;
-    position: relative;
+	width: inherit;
+	height: inherit;
+	background: var(--sapBaseColor);
+	display: flex;
+	flex-direction: column;
+	position: relative;
 }
 
 :host([menu-vertical-align="Top"]) .ui5-media-gallery-root {
-    flex-direction: column-reverse;
+	flex-direction: column-reverse;
 }
 
-:host([effective-layout="Horizontal"]) .ui5-media-gallery-root,
-:host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-root[dir="rtl"] {
-    flex-direction: row-reverse;
+:host([effective-layout="Horizontal"]) .ui5-media-gallery-root {
+	flex-direction: row-reverse;
 }
 
-:host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-root,
-:host([effective-layout="Horizontal"]) .ui5-media-gallery-root[dir="rtl"] {
-    flex-direction: row;
+:host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-root {
+	flex-direction: row;
 }
 
 /* DISPLAY */
 
 .ui5-media-gallery-display-wrapper {
-    display: flex;
-    justify-content: center;
-    position: relative;
+	display: flex;
+	justify-content: center;
+	position: relative;
 }
 
 /* when all thumbnails shown, thumbnails vs. dispplay width is 1:3 proportion */
 :host([effective-layout="Horizontal"][show-all-thumbnails]) .ui5-media-gallery-display-wrapper {
-    flex-grow: 3; /* takes 3/4 of the entire width, where remaining 1/4 are for thumbnails */
-    flex-basis: 0;
+	flex-grow: 3; /* takes 3/4 of the entire width, where remaining 1/4 are for thumbnails */
+	flex-basis: 0;
 }
 
 .ui5-media-gallery-display {
-    position:relative;
-    margin: 1rem;
-    display: flex;
-    justify-content: center;
+	position:relative;
+	margin: 1rem;
+	display: flex;
+	justify-content: center;
 }
 
 .ui5-media-gallery-display [ui5-media-gallery-item] {
-    z-index: 1;
+	z-index: 1;
 }
 
 /* mobile platform */
 [ui5-carousel] {
-    width: calc(100% - 2rem);
+	width: calc(100% - 2rem);
 }
 [ui5-carousel]::part(item) {
-    padding: 0;
-    overflow: hidden;
+	padding: 0;
+	overflow: hidden;
 }
 
 /* THUMBNAILS */
 .ui5-media-gallery-thumbnails-wrapper {
-    margin: 1rem 0 0 0;
+	margin-block: 1rem 0;
 }
 :host([menu-vertical-align="Top"]) .ui5-media-gallery-thumbnails-wrapper {
-    margin: 0 0 1rem 0;
+	margin-block: 0 1rem;
 }
 :host([effective-layout="Horizontal"]) .ui5-media-gallery-thumbnails-wrapper {
-    margin: 0 1rem 0 0;
+	margin-inline: 0 1rem;
 }
 :host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-thumbnails-wrapper {
-    margin: 0 0 0 1rem;
-}
-:host(:not([effective-layout="Horizontal"])) [dir="rtl"] .ui5-media-gallery-thumbnails-wrapper {
-    margin-right: 1rem;
+	margin-inline: 1rem 0;
 }
 
 /* show all thumbnails in a single scrollable row */
 :host([show-all-thumbnails]) .ui5-media-gallery-thumbnails-wrapper {
-    overflow-x: auto;
-    overflow-y: hidden;
+	overflow-x: auto;
+	overflow-y: hidden;
 }
 /* show all thumbnails in a scrollable area with multiple columns */
 :host([effective-layout="Horizontal"][show-all-thumbnails]) .ui5-media-gallery-thumbnails-wrapper {
-    overflow-y: auto;
-    overflow-x: hidden;
-    flex-grow:1; /* takes 1/4 of the entire width, where the remaining 3/4 are for the display */
-    flex-basis: 0;
+	overflow-y: auto;
+	overflow-x: hidden;
+	flex-grow:1; /* takes 1/4 of the entire width, where the remaining 3/4 are for the display */
+	flex-basis: 0;
 }
 
 .ui5-media-gallery-thumbnails-wrapper ul {
-    height: 5rem;
-    display: flex;
-    flex-wrap: nowrap;
-    padding-left: 0; /* disable browser default css */
-    margin-top: 0; /* disable browser default css */
-    margin-bottom: 0; /* disable browser default css */
-    list-style-type: none; /* disable browser default css */
-    padding-inline-start: 0; /* disable browser default css */
+	height: 5rem;
+	display: flex;
+	flex-wrap: nowrap;
+	padding-left: 0; /* disable browser default css */
+	margin-top: 0; /* disable browser default css */
+	margin-bottom: 0; /* disable browser default css */
+	list-style-type: none; /* disable browser default css */
+	padding-inline-start: 0; /* disable browser default css */
 }
 
 /* in horizontal layout, the menu is 1-4 vertical columns, depending on media size */
 :host([effective-layout="Horizontal"]) ul {
-    width: 5rem;
-    flex-wrap: wrap;
+	width: 5rem;
+	flex-wrap: wrap;
 }
 /* two columns on M-size */
 :host([effective-layout="Horizontal"][show-all-thumbnails][media-range="M"]) ul {
-    width: 10rem;
+	width: 10rem;
 }
 /* three columns on L-size */
 :host([effective-layout="Horizontal"][show-all-thumbnails][media-range="L"]) ul {
-    width: 15rem;
+	width: 15rem;
 }
 /* four columns on XL-size */
 :host([effective-layout="Horizontal"][show-all-thumbnails][media-range="XL"]) ul {
-    width: 20rem;
+	width: 20rem;
 }
 
 .ui5-media-gallery-thumbnail,
 .ui5-media-gallery-overflow [ui5-button] {
-    width: 4rem;
-    height: 4rem;
-    flex-shrink: 0;
+	width: 4rem;
+	height: 4rem;
+	flex-shrink: 0;
 }
 
 .ui5-media-gallery-overflow [ui5-button] {
-    background: var(--_ui5_media_gallery_overflow_btn_background);
-    color: var(--_ui5_media_gallery_overflow_btn_color);
-    border: var(--_ui5_media_gallery_overflow_btn_border);
+	background: var(--_ui5_media_gallery_overflow_btn_background);
+	color: var(--_ui5_media_gallery_overflow_btn_color);
+	border: var(--_ui5_media_gallery_overflow_btn_border);
 }
 
 .ui5-media-gallery-thumbnail,
 .ui5-media-gallery-overflow {
-    margin: 0 0 0 1rem;
+	margin: 0 0 0 1rem;
 }
 
 :host([menu-vertical-align="Top"]) .ui5-media-gallery-thumbnail,
 :host([menu-vertical-align="Top"]) .ui5-media-gallery-overflow {
-    margin: 1rem 0 0 1rem;
+	margin: 1rem 0 0 1rem;
 }
 
 :host([effective-layout="Horizontal"]) .ui5-media-gallery-thumbnail,
 :host([effective-layout="Horizontal"]) .ui5-media-gallery-overflow {
-    margin: 1rem 0 0 1rem;
+	margin: 1rem 0 0 1rem;
 }
 
 :host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-thumbnail,
 :host([effective-layout="Horizontal"][menu-horizontal-align="Right"]) .ui5-media-gallery-overflow {
-    margin: 1rem 1rem 0 0;
+	margin: 1rem 1rem 0 0;
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -26,7 +26,7 @@
 ::slotted([ui5-button][slot="startButton"]) {
 	height: 2.25rem;
 	padding: 0;
-	margin-left: 0.5rem;
+	margin-inline-start: 0.5rem;
 	border: none;
 	background: transparent;
 	outline-color: var(--_ui5_shellbar_logo_outline_color);
@@ -103,11 +103,11 @@ slot[name="profile"] {
 }
 
 :host(:not([primary-title])) .ui5-shellbar-menu-button span {
-	margin-left: 0;
+	margin-inline-start: 0;
 }
 
 :host([breakpoint-size="S"]) .ui5-shellbar-menu-button span {
-	margin-left: .5rem;
+	margin-inline-start: .5rem;
 }
 
 .ui5-shellbar-secondary-title {
@@ -124,7 +124,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-menu-button--interactive .ui5-shellbar-menu-button-arrow {
 	display: inline-block;
-	margin-left: 0.375rem;
+	margin-inline-start: 0.375rem;
 	width: 10px;
 	height: 10px;
 	width: 0px;
@@ -175,7 +175,7 @@ slot[name="profile"] {
 }
 
 :host([breakpoint-size="S"]) ::slotted([ui5-button][slot="startButton"]) {
-	margin-right: 0;
+	margin-inline-end: 0;
 }
 
 :host([breakpoint-size="M"]) .ui5-shellbar-root {
@@ -232,7 +232,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-overflow-container-left {
 	justify-content: flex-start;
-	margin-right: 0.5rem;
+	margin-inline-end: 0.5rem;
 	max-width: 75%;
 	flex-shrink: 0;
 	flex-grow: 0;
@@ -252,21 +252,21 @@ slot[name="profile"] {
 	padding: 0.25rem 0.5rem;
 	cursor: text;
 	-webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
+	-moz-user-select: text;
+	-ms-user-select: text;
 	user-select: text;
 }
 
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive {
 	-webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
 	user-select: none;
 	cursor: pointer;
 }
 
 :host(:not([with-logo])) .ui5-shellbar-menu-button {
-	margin-left: 0;
+	margin-inline-start: 0;
 }
 
 .ui5-shellbar-overflow-container-right {
@@ -283,12 +283,13 @@ slot[name="profile"] {
 }
 
 :host(:not([show-search-field])) .ui5-shellbar-overflow-container-right {
-	margin-left: 8rem;
+	margin-inline-start: 8rem;
 }
 
 .ui5-shellbar-overflow-container-right .ui5-shellbar-overflow-container-right-child {
 	display: flex;
 	justify-content: flex-end;
+	float: var(--_ui5_shellbar_overflow_container_float);
 }
 
 .ui5-shellbar-overflow-button {
@@ -309,7 +310,7 @@ slot[name="profile"] {
 }
 
 :host([breakpoint-size="S"]) .ui5-shellbar-overflow-container-right {
-	margin-left: 0;
+	margin-inline-start: 0;
 }
 
 .ui5-shellbar-overflow-button-shown {
@@ -327,11 +328,11 @@ slot[name="profile"] {
 }
 
 :host([breakpoint-size="L"]) .ui5-shellbar-with-searchfield .ui5-shellbar-overflow-container-right {
-	margin-left: 1rem;
+	margin-inline-start: 1rem;
 }
 
 :host([breakpoint-size="XL"]) .ui5-shellbar-with-searchfield .ui5-shellbar-overflow-container-right {
-	margin-left: 1rem;
+	margin-inline-start: 1rem;
 }
 
 :host(:not([notifications-count])) .ui5-shellbar-bell-button {
@@ -368,13 +369,13 @@ slot[name="profile"] {
 }
 
 .ui5-shellbar-menu-button {
-	margin-left: 0.5rem;
+	margin-inline-start: 0.5rem;
 }
 
 .ui5-shellbar-search-field {
 	flex-grow: 1;
 	min-width: 240px;
-	margin-left: 0.5rem;
+	margin-inline-start: 0.5rem;
 	max-width: 25rem;
 }
 
@@ -494,41 +495,8 @@ slot[name="profile"] {
 	stop-opacity: 0.2;
 }
 
-:host [dir="rtl"] ::slotted([ui5-button][slot="startButton"]) {
-	margin-left: 0.5rem;
-	margin-right: 0;
-}
-
-:host [dir="rtl"] .ui5-shellbar-menu-button {
-	margin-right: 0.5rem;
-	margin-left: 0;
-}
-
-[dir="rtl"] .ui5-shellbar-menu-button--interactive .ui5-shellbar-menu-button-arrow {
-	margin-right: 0.375rem;
-	margin-left: 0;
-}
-
-:host(:not([show-search-field])) [dir="rtl"] .ui5-shellbar-overflow-container-right {
-	margin-right: 8rem;
-	margin-left: 0;
-}
-
-[dir="rtl"] .ui5-shellbar-overflow-container-right {
-	margin-left: 0;
-}
-
-[dir="rtl"] .ui5-shellbar-overflow-container-right .ui5-shellbar-overflow-container-right-child {
-	float: left;
-}
-
-:host([breakpoint-size="S"]) [dir="rtl"] .ui5-shellbar-overflow-container-right {
-	margin-right: 0;
-}
-
 ::slotted([ui5-button][slot="startButton"]) {
-	margin-right: 0.5rem;
-	margin-left: 0;
+	margin-inline: 0 0.5rem;
 	justify-content: center;
 	align-items: center;
 }

--- a/packages/main/src/ProgressIndicator.hbs
+++ b/packages/main/src/ProgressIndicator.hbs
@@ -1,5 +1,4 @@
 <div class="ui5-progress-indicator-root {{classes.root}}"
-     dir="{{effectiveDir}}"
      role="progressbar"
      aria-valuemin="0"
      aria-valuenow="{{validatedValue}}"

--- a/packages/main/src/Select.hbs
+++ b/packages/main/src/Select.hbs
@@ -1,6 +1,5 @@
 <div
 	class="ui5-select-root ui5-input-focusable-element"
-	dir="{{effectiveDir}}"
 	id="{{_id}}-select"
 	@click="{{_onclick}}"
 >

--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -22,11 +22,11 @@
 
 .ui5-progress-indicator-bar {
 	background: var(--_ui5_progress_indicator_value_state_none);
-	justify-content: var(--_ui5_progress_indicator_bar_justify_content);
+	justify-content: flex-end;
 	height: 100%;
 	display: flex;
 	align-items: center;
-	flex-direction: var(--_ui5_progress_indicator_bar_flex_direction);
+	flex-direction: row;
 	color: var(--_ui5_progress_indicator_bar_color);
 	transition-property: width;
 	transition-timing-function: linear;
@@ -50,11 +50,11 @@
 }
 
 .ui5-progress-indicator-remaining-bar {
-	justify-content: var(--_ui5_progress_indicator_remaining_bar_justify_content);
+	justify-content: flex-start;
 	height: 100%;
 	display: flex;
 	align-items: center;
-	flex-direction: var(--_ui5_progress_indicator_bar_flex_direction);
+	flex-direction: row;
 	flex-grow: 1;
 	flex-basis: 0;
 	border: var(--_ui5_progress_indicator_border);

--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -22,16 +22,17 @@
 
 .ui5-progress-indicator-bar {
 	background: var(--_ui5_progress_indicator_value_state_none);
-	justify-content: flex-end;
+	justify-content: var(--_ui5_progress_indicator_bar_justify_content);
 	height: 100%;
 	display: flex;
 	align-items: center;
+	flex-direction: var(--_ui5_progress_indicator_bar_flex_direction);
 	color: var(--_ui5_progress_indicator_bar_color);
 	transition-property: width;
 	transition-timing-function: linear;
 	box-sizing: border-box;
 	border: var(--_ui5_progress_indicator_bar_border_max);
-	border-radius: 0.5rem 0 0 0.5rem;
+	border-radius: var(--_ui5_progress_indicator_bar_border_radius);
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-bar,
@@ -44,20 +45,21 @@
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-remaining-bar {
-	border-left: var(--_ui5_progress_indicator_border);
+	border-inline-start: var(--_ui5_progress_indicator_border);
 	border-radius: 0.5rem;
 }
 
 .ui5-progress-indicator-remaining-bar {
-	justify-content: flex-start;
+	justify-content: var(--_ui5_progress_indicator_remaining_bar_justify_content);
 	height: 100%;
 	display: flex;
 	align-items: center;
+	flex-direction: var(--_ui5_progress_indicator_bar_flex_direction);
 	flex-grow: 1;
 	flex-basis: 0;
 	border: var(--_ui5_progress_indicator_border);
-	border-left: none;
-	border-radius: 0 0.5rem 0.5rem 0;
+	border-inline-start: none;
+	border-radius: var(--_ui5_progress_indicator_remaining_bar_border_radius);
 	box-sizing: border-box;
 	color: var(--_ui5_progress_indicator_color);
 	overflow: hidden;
@@ -71,7 +73,7 @@
 }
 
 .ui5-progress-indicator-icon {
-	margin-left: 0.375rem;
+	margin-inline-start: 0.375rem;
 	width: var(--sapFontSmallSize);
 	height: var(--sapFontSmallSize);
 	display: var(--_ui5_progress_indicator_icon_visibility);
@@ -127,32 +129,4 @@
 
 :host([disabled]) .ui5-progress-indicator-root {
 	opacity: 0.5;
-}
-
-[dir="rtl"] .ui5-progress-indicator-bar {
-	border-radius: 0 0.5rem 0.5rem 0;
-	flex-direction: row-reverse;
-	justify-content: flex-start;
-}
-
-[dir="rtl"].ui5-progress-indicator-min-value .ui5-progress-indicator-bar,
-[dir="rtl"].ui5-progress-indicator-max-value .ui5-progress-indicator-remaining-bar {
-	border:none;
-}
-
-[dir="rtl"].ui5-progress-indicator-max-value .ui5-progress-indicator-bar {
-	border-radius: 0.5rem;
-}
-
-[dir="rtl"] .ui5-progress-indicator-remaining-bar {
-	border: var(--_ui5_progress_indicator_border);
-	border-right: none;
-	border-radius: 0.5rem 0 0 0.5rem;
-	flex-direction: row-reverse;
-	justify-content: flex-end;
-}
-
-[dir="rtl"].ui5-progress-indicator-min-value .ui5-progress-indicator-remaining-bar {
-	border-right: var(--_ui5_progress_indicator_border);
-	border-radius: 0.5rem;
 }

--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -1,158 +1,158 @@
 :host(:not([hidden])) {
-    display: inline-block;
-    min-height: 1rem;
-    min-width: 4rem;
-    width: 100%;
-    height: 1rem;
-    overflow: hidden;
+	display: inline-block;
+	min-height: 1rem;
+	min-width: 4rem;
+	width: 100%;
+	height: 1rem;
+	overflow: hidden;
 }
 
 .ui5-progress-indicator-root {
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    background: var(--_ui5_progress_indicator_background_none);
-    border-radius: 0.5rem;
-    overflow: hidden;
-    height: 100%;
-    width: 100%;
-    font-size: var(--sapFontSmallSize);
-    font-family: "72override", var(--sapFontFamily);
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	background: var(--_ui5_progress_indicator_background_none);
+	border-radius: 0.5rem;
+	overflow: hidden;
+	height: 100%;
+	width: 100%;
+	font-size: var(--sapFontSmallSize);
+	font-family: "72override", var(--sapFontFamily);
 }
 
 .ui5-progress-indicator-bar {
-    background: var(--_ui5_progress_indicator_value_state_none);
-    justify-content: flex-end;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    color: var(--_ui5_progress_indicator_bar_color);
-    transition-property: width;
-    transition-timing-function: linear;
-    box-sizing: border-box;
-    border: var(--_ui5_progress_indicator_bar_border_max);
-    border-radius: 0.5rem 0 0 0.5rem;
+	background: var(--_ui5_progress_indicator_value_state_none);
+	justify-content: flex-end;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	color: var(--_ui5_progress_indicator_bar_color);
+	transition-property: width;
+	transition-timing-function: linear;
+	box-sizing: border-box;
+	border: var(--_ui5_progress_indicator_bar_border_max);
+	border-radius: 0.5rem 0 0 0.5rem;
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-bar,
 .ui5-progress-indicator-max-value .ui5-progress-indicator-remaining-bar {
-    border:none;
+	border:none;
 }
 
 .ui5-progress-indicator-max-value .ui5-progress-indicator-bar {
-    border-radius: 0.5rem;
+	border-radius: 0.5rem;
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-remaining-bar {
-    border-left: var(--_ui5_progress_indicator_border);
-    border-radius: 0.5rem;
+	border-left: var(--_ui5_progress_indicator_border);
+	border-radius: 0.5rem;
 }
 
 .ui5-progress-indicator-remaining-bar {
-    justify-content: flex-start;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    flex-grow: 1;
-    flex-basis: 0;
-    border: var(--_ui5_progress_indicator_border);
-    border-left: none;
-    border-radius: 0 0.5rem 0.5rem 0;
-    box-sizing: border-box;
-    color: var(--_ui5_progress_indicator_color);
-    overflow: hidden;
+	justify-content: flex-start;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	flex-grow: 1;
+	flex-basis: 0;
+	border: var(--_ui5_progress_indicator_border);
+	border-left: none;
+	border-radius: 0 0.5rem 0.5rem 0;
+	box-sizing: border-box;
+	color: var(--_ui5_progress_indicator_color);
+	overflow: hidden;
 }
 
 .ui5-progress-indicator-value {
-    margin: 0 0.375rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+	margin: 0 0.375rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .ui5-progress-indicator-icon {
-    margin-left: 0.375rem;
-    width: var(--sapFontSmallSize);
-    height: var(--sapFontSmallSize);
-    display: var(--_ui5_progress_indicator_icon_visibility);
+	margin-left: 0.375rem;
+	width: var(--sapFontSmallSize);
+	height: var(--sapFontSmallSize);
+	display: var(--_ui5_progress_indicator_icon_visibility);
 }
 
 :host([value-state="Error"]) .ui5-progress-indicator-bar {
-    background: var(--_ui5_progress_indicator_value_state_error);
+	background: var(--_ui5_progress_indicator_value_state_error);
 }
 
 :host([value-state="Warning"]) .ui5-progress-indicator-bar {
-    background: var(--_ui5_progress_indicator_value_state_warning);
+	background: var(--_ui5_progress_indicator_value_state_warning);
 }
 
 :host([value-state="Success"]) .ui5-progress-indicator-bar {
-    background: var(--_ui5_progress_indicator_value_state_success);
+	background: var(--_ui5_progress_indicator_value_state_success);
 }
 
 :host([value-state="Information"]) .ui5-progress-indicator-bar {
-    background: var(--_ui5_progress_indicator_value_state_information);
+	background: var(--_ui5_progress_indicator_value_state_information);
 }
 
 :host([value-state="Error"]) .ui5-progress-indicator-root {
-    background: var(--_ui5_progress_indicator_background_error);
+	background: var(--_ui5_progress_indicator_background_error);
 }
 
 :host([value-state="Warning"]) .ui5-progress-indicator-root {
-    background: var(--_ui5_progress_indicator_background_warning);
+	background: var(--_ui5_progress_indicator_background_warning);
 }
 
 :host([value-state="Success"]) .ui5-progress-indicator-root {
-    background: var(--_ui5_progress_indicator_background_success);
+	background: var(--_ui5_progress_indicator_background_success);
 }
 
 :host([value-state="Information"]) .ui5-progress-indicator-root {
-    background: var(--_ui5_progress_indicator_background_information);
+	background: var(--_ui5_progress_indicator_background_information);
 }
 
 :host([value-state="Error"]) .ui5-progress-indicator-remaining-bar {
-    border-color: var(--_ui5_progress_indicator_border_color_error);
+	border-color: var(--_ui5_progress_indicator_border_color_error);
 }
 
 :host([value-state="Warning"]) .ui5-progress-indicator-remaining-bar {
-    border-color: var(--_ui5_progress_indicator_border_color_warning);
+	border-color: var(--_ui5_progress_indicator_border_color_warning);
 }
 
 :host([value-state="Success"]) .ui5-progress-indicator-remaining-bar {
-    border-color: var(--_ui5_progress_indicator_border_color_success);
+	border-color: var(--_ui5_progress_indicator_border_color_success);
 }
 
 :host([value-state="Information"]) .ui5-progress-indicator-remaining-bar {
-    border-color: var(--_ui5_progress_indicator_border_color_information);
+	border-color: var(--_ui5_progress_indicator_border_color_information);
 }
 
 :host([disabled]) .ui5-progress-indicator-root {
-    opacity: 0.5;
+	opacity: 0.5;
 }
 
 [dir="rtl"] .ui5-progress-indicator-bar {
-    border-radius: 0 0.5rem 0.5rem 0;
-    flex-direction: row-reverse;
-    justify-content: flex-start;
+	border-radius: 0 0.5rem 0.5rem 0;
+	flex-direction: row-reverse;
+	justify-content: flex-start;
 }
 
 [dir="rtl"].ui5-progress-indicator-min-value .ui5-progress-indicator-bar,
 [dir="rtl"].ui5-progress-indicator-max-value .ui5-progress-indicator-remaining-bar {
-    border:none;
+	border:none;
 }
 
 [dir="rtl"].ui5-progress-indicator-max-value .ui5-progress-indicator-bar {
-    border-radius: 0.5rem;
+	border-radius: 0.5rem;
 }
 
 [dir="rtl"] .ui5-progress-indicator-remaining-bar {
-    border: var(--_ui5_progress_indicator_border);
-    border-right: none;
-    border-radius: 0.5rem 0 0 0.5rem;
-    flex-direction: row-reverse;
-    justify-content: flex-end;
+	border: var(--_ui5_progress_indicator_border);
+	border-right: none;
+	border-radius: 0.5rem 0 0 0.5rem;
+	flex-direction: row-reverse;
+	justify-content: flex-end;
 }
 
 [dir="rtl"].ui5-progress-indicator-min-value .ui5-progress-indicator-remaining-bar {
-    border-right: var(--_ui5_progress_indicator_border);
-    border-radius: 0.5rem;
+	border-right: var(--_ui5_progress_indicator_border);
+	border-radius: 0.5rem;
 }

--- a/packages/main/src/themes/Select.css
+++ b/packages/main/src/themes/Select.css
@@ -16,7 +16,7 @@
 	flex-grow: 1;
 	align-self: center;
 	min-width: 1rem;
-	padding-left: 0.5rem;
+	padding-inline-start: 0.5rem;
 	cursor: pointer;
 	outline: none;
 	white-space: nowrap;
@@ -29,19 +29,9 @@
 }
 
 .ui5-select-option-icon {
-	padding-left: 0.5rem;
+	padding-inline-start: 0.5rem;
 	color: var(--sapField_TextColor);
 	align-self: center;
-}
-
-:host [dir="rtl"].ui5-select-root .ui5-select-label-root {
-	padding-left: 0;
-	padding-right: 0.5rem;
-}
-
-:host [dir="rtl"] .ui5-select-option-icon {
-	padding-right: 0.5rem;
-	padding-left: 0;
 }
 
 :host(:not([disabled])) {

--- a/packages/main/src/themes/base/Select-parameters.css
+++ b/packages/main/src/themes/base/Select-parameters.css
@@ -4,8 +4,6 @@
 	--_ui5_select_state_error_warning_border_style: solid;
 	--_ui5_select_state_error_warning_border_width: 0.125rem;
 	--_ui5_select_hover_icon_left_border: 1px solid transparent;
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: none;
 	--_ui5_select_focus_width: 1px;
 	--_ui5_select_label_olor: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -9,9 +9,6 @@
 	--_ui5_shellbar_overflow_container_float: none;
 
 	--_ui5_progress_indicator_bar_border_radius: 0.5rem 0 0 0.5rem;
-	--_ui5_progress_indicator_bar_flex_direction: row;
-	--_ui5_progress_indicator_bar_justify_content: flex-end;
-	--_ui5_progress_indicator_remaining_bar_justify_content: flex-start;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0 0.5rem 0.5rem 0;
 }
 
@@ -23,8 +20,5 @@
 	--_ui5_shellbar_overflow_container_float: left;
 
 	--_ui5_progress_indicator_bar_border_radius: 0 0.5rem 0.5rem 0;
-	--_ui5_progress_indicator_bar_flex_direction: row-reverse;
-	--_ui5_progress_indicator_bar_justify_content: flex-start;
-	--_ui5_progress_indicator_remaining_bar_justify_content: flex-end;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0.5rem 0 0 0.5rem;
 }

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -6,6 +6,7 @@
 	--_ui5_panel_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_timeline_scroll_container_offset: 0.5rem;
+	--_ui5_shellbar_overflow_container_float: none;
 }
 
 [dir="rtl"] {
@@ -13,4 +14,5 @@
 	--_ui5_panel_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_timeline_scroll_container_offset: -0.5rem;
+	--_ui5_shellbar_overflow_container_float: left;
 }

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -7,6 +7,12 @@
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_timeline_scroll_container_offset: 0.5rem;
 	--_ui5_shellbar_overflow_container_float: none;
+
+	--_ui5_progress_indicator_bar_border_radius: 0.5rem 0 0 0.5rem;
+	--_ui5_progress_indicator_bar_flex_direction: row;
+	--_ui5_progress_indicator_bar_justify_content: flex-end;
+	--_ui5_progress_indicator_remaining_bar_justify_content: flex-start;
+	--_ui5_progress_indicator_remaining_bar_border_radius: 0 0.5rem 0.5rem 0;
 }
 
 [dir="rtl"] {
@@ -15,4 +21,10 @@
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_timeline_scroll_container_offset: -0.5rem;
 	--_ui5_shellbar_overflow_container_float: left;
+
+	--_ui5_progress_indicator_bar_border_radius: 0 0.5rem 0.5rem 0;
+	--_ui5_progress_indicator_bar_flex_direction: row-reverse;
+	--_ui5_progress_indicator_bar_justify_content: flex-start;
+	--_ui5_progress_indicator_remaining_bar_justify_content: flex-end;
+	--_ui5_progress_indicator_remaining_bar_border_radius: 0.5rem 0 0 0.5rem;
 }

--- a/packages/main/src/themes/sap_belize_hcb/Select-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_belize_hcw/Select-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/Select-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/Select-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Select-parameters.css
@@ -6,7 +6,5 @@
 	--_ui5_select_state_error_warning_border_style: dashed;
 	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_rtl_hover_icon_left_border: none;
-	--_ui5_select_rtl_hover_icon_right_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
 	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/test/pages/ProgressIndicator.html
+++ b/packages/main/test/pages/ProgressIndicator.html
@@ -11,111 +11,109 @@
 		// delete Document.prototype.adoptedStyleSheets
 	</script>
 
-
 	<script src="../../resources/bundle.esm.js" type="module"></script>
 
-
-<link rel="stylesheet" type="text/css" href="styles/ProgressIndicator.css">
+	<link rel="stylesheet" type="text/css" href="styles/ProgressIndicator.css">
 </head>
 
 <body class="progressindicator1auto">
-    <br />
-    Value is 0
-    <br />
+	<br />
+	Value is 0
+	<br />
 	<ui5-progress-indicator value="0"></ui5-progress-indicator>
-    <br />
-    Value is 100
-    <br />
+	<br />
+	Value is 100
+	<br />
 	<ui5-progress-indicator value="100"></ui5-progress-indicator>
-    <br />
-    Value less than 50
-    <br />
+	<br />
+	Value less than 50
+	<br />
 	<ui5-progress-indicator value="25"></ui5-progress-indicator>
-    <br />
-    Value greater than 50
-    <br />
-    <ui5-progress-indicator value="75"></ui5-progress-indicator>
-    <br />
-    Value less than 50 without value
-    <br />
+	<br />
+	Value greater than 50
+	<br />
+	<ui5-progress-indicator value="75"></ui5-progress-indicator>
+	<br />
+	Value less than 50 without value
+	<br />
 	<ui5-progress-indicator value="25" hide-value></ui5-progress-indicator>
-    <br />
-    Value greater than 50 without value
-    <br />
-    <ui5-progress-indicator value="75" hide-value></ui5-progress-indicator>
-    <br />
-    ValueState.None
-    <br />
+	<br />
+	Value greater than 50 without value
+	<br />
+	<ui5-progress-indicator value="75" hide-value></ui5-progress-indicator>
+	<br />
+	ValueState.None
+	<br />
 	<ui5-progress-indicator value-state="None" value="25"></ui5-progress-indicator>
-    <br />
-    ValueState.Error
-    <br />
+	<br />
+	ValueState.Error
+	<br />
 	<ui5-progress-indicator value-state="Error" value="25"></ui5-progress-indicator>
-    <br />
-    ValueState.Warning
-    <br />
+	<br />
+	ValueState.Warning
+	<br />
 	<ui5-progress-indicator value-state="Warning" value="25"></ui5-progress-indicator>
-    <br />
-    ValueState.Success
-    <br />
+	<br />
+	ValueState.Success
+	<br />
 	<ui5-progress-indicator value-state="Success" value="25"></ui5-progress-indicator>
-    <br />
-    ValueState.Information
-    <br />
+	<br />
+	ValueState.Information
+	<br />
 	<ui5-progress-indicator value-state="Information" value="25"></ui5-progress-indicator>
-    <br />
-    Disabled
-    <br />
+	<br />
+	Disabled
+	<br />
 	<ui5-progress-indicator disabled value="25"></ui5-progress-indicator>
-    <br />
-    ValueState.None
-    <br />
+	<br />
+	ValueState.None
+	<br />
 	<ui5-progress-indicator value-state="None" value="60"></ui5-progress-indicator>
-    <br />
-    ValueState.Error
-    <br />
+	<br />
+	ValueState.Error
+	<br />
 	<ui5-progress-indicator value-state="Error" value="60"></ui5-progress-indicator>
-    <br />
-    ValueState.Warning
-    <br />
+	<br />
+	ValueState.Warning
+	<br />
 	<ui5-progress-indicator value-state="Warning" value="60"></ui5-progress-indicator>
-    <br />
-    ValueState.Success
-    <br />
+	<br />
+	ValueState.Success
+	<br />
 	<ui5-progress-indicator value-state="Success" value="60"></ui5-progress-indicator>
-    <br />
-    ValueState.Information
-    <br />
+	<br />
+	ValueState.Information
+	<br />
 	<ui5-progress-indicator value-state="Information" value="60"></ui5-progress-indicator>
-    <br />
-    Disabled
-    <br />
+	<br />
+	Disabled
+	<br />
 	<ui5-progress-indicator disabled value="60"></ui5-progress-indicator>
-    <br />
-    Custom Display Value
-    <br />
+	<br />
+	Custom Display Value
+	<br />
 	<ui5-progress-indicator value="25" display-value="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."></ui5-progress-indicator>
-    <br />
-    Custom Size 1
-    <br />
+	<br />
+	Custom Size 1
+	<br />
 	<ui5-progress-indicator value="25" class="progressindicator2auto"></ui5-progress-indicator>
-    <br />
-    Custom Size 2
-    <br />
+	<br />
+	Custom Size 2
+	<br />
 	<ui5-progress-indicator value="25" class="progressindicator2auto"></ui5-progress-indicator>
-    <br />
-    Test progress indicator
-    <br />
-    <ui5-progress-indicator id="test-progress-indicator"></ui5-progress-indicator>
-    <ui5-button id="firstBtn">Set 0 value</ui5-button>
-    <ui5-button id="secondBtn">Set 25 value</ui5-button>
-    <ui5-button id="thirdBtn">Set 50 value</ui5-button>
-    <ui5-button id="fourthBtn">Set 75 value</ui5-button>
-    <ui5-button id="fifthBtn">Set 100 value</ui5-button>
-    <ui5-button id="sixthBtn">Set negative value</ui5-button>
-    <ui5-button id="seventhBtn">Set larger than 100 value</ui5-button>
+	<br />
+	Test progress indicator
+	<br />
+	<ui5-progress-indicator id="test-progress-indicator"></ui5-progress-indicator>
+	<ui5-button id="firstBtn">Set 0 value</ui5-button>
+	<ui5-button id="secondBtn">Set 25 value</ui5-button>
+	<ui5-button id="thirdBtn">Set 50 value</ui5-button>
+	<ui5-button id="fourthBtn">Set 75 value</ui5-button>
+	<ui5-button id="fifthBtn">Set 100 value</ui5-button>
+	<ui5-button id="sixthBtn">Set negative value</ui5-button>
+	<ui5-button id="seventhBtn">Set larger than 100 value</ui5-button>
 
-    <script>
+	<script>
 		var progressIndicator = document.getElementById("test-progress-indicator");
 		var button1 = document.getElementById("firstBtn");
 		var button2 = document.getElementById("secondBtn");


### PR DESCRIPTION
Hello @SAP/ui5-webcomponents-topic-p 
this is related to the recently stopped support of IE, allowing us to implement RTL using features, not supported on IE, as the CSS logical properties. 

The Browser flips the paddings, margins, etc. automatically based on the direction - there is no need to write specific RTL styles manually. At least for the styles that have CSS logical prop alternative.

In case, there is no CSS logical props alternative or the use-case is very specifi, we can extract CSS vars which will have different value in RTL and LTR and add them to global rtl-parameters.css. The same pattern (sizes-parameters.css) that we currently use for the cozy/compact styles.

Doing so, from one hand side we turn more to native implementation and standards, from the other we want to avoid effectiveDir calls as internally getComputedStyle is called, which is slow.