### PR TITLE
refactor(ui5-popups): refactor RTL implementation - part 4

### DIFF
--- a/packages/main/src/Dialog.hbs
+++ b/packages/main/src/Dialog.hbs
@@ -27,7 +27,6 @@
 	{{#if _showResizeHandle }}
 		<ui5-icon
 			name="resize-corner"
-			dir="{{effectiveDir}}"
 			class="ui5-popup-resize-handle"
 			@mousedown="{{_onResizeMouseDown}}">
 		</ui5-icon>

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -5,7 +5,6 @@
 	aria-modal="{{_ariaModal}}"
 	aria-label="{{_ariaLabel}}"
 	aria-labelledby="{{_ariaLabelledBy}}"
-	dir="{{effectiveDir}}"
 	@keydown={{_onkeydown}}
 	@focusout={{_onfocusout}}
 	@mouseup={{_onmouseup}}

--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -68,13 +68,7 @@
 .ui5-popup-resize-handle {
 	position: absolute;
 	bottom: var(--_ui5_dialog_resize_handle_bottom);
-	right: var(--_ui5_dialog_resize_handle_right);
+	inset-inline-end: var(--_ui5_dialog_resize_handle_right);
 	cursor: se-resize;
 	color: var(--_ui5_dialog_resize_handle_color);
-}
-
-.ui5-popup-resize-handle[dir=rtl] {
-	left: -0.25rem;
-	right: unset;
-	cursor: sw-resize;
 }

--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -69,6 +69,6 @@
 	position: absolute;
 	bottom: var(--_ui5_dialog_resize_handle_bottom);
 	inset-inline-end: var(--_ui5_dialog_resize_handle_right);
-	cursor: se-resize;
+	cursor: var(--_ui5_dialog_resize_cursor);
 	color: var(--_ui5_dialog_resize_handle_color);
 }

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -37,7 +37,7 @@
 
 }
 :host([actual-placement-type="Bottom"]) .ui5-popover-arrow:after {
-	margin: 0.1875rem 0 0 0.1875rem;
+	margin: var(--_ui5-popover_upward_arrow_margin);
 }
 
 /* pointing right arrow */
@@ -48,19 +48,7 @@
 }
 
 :host([actual-placement-type="Left"]) .ui5-popover-arrow:after {
-	margin: 0.1875rem 0 0 -0.375rem;
-}
-
-:host([actual-placement-type="Left"]) [dir=rtl] .ui5-popover-arrow:after {
-	margin: .1875rem .25rem 0 0;
-}
-
-:host([actual-placement-type="Bottom"]) [dir=rtl] .ui5-popover-arrow:after {
-	margin: .1875rem .125rem 0 0;
-}
-
-:host([actual-placement-type="Top"]) [dir=rtl] .ui5-popover-arrow:after {
-	margin: -0.4375rem .125rem 0 0
+	margin: var(--_ui5-popover_right_arrow_margin);
 }
 
 /* pointing downward arrow */
@@ -71,7 +59,7 @@
 }
 
 :host([actual-placement-type="Top"]) .ui5-popover-arrow:after {
-	margin: -0.375rem 0 0 0.125rem;
+	margin: var(--_ui5-popover_downward_arrow_margin);
 }
 
 /* pointing left arrow */
@@ -85,12 +73,7 @@
 
 :host(:not([actual-placement-type])) .ui5-popover-arrow:after,
 :host([actual-placement-type="Right"]) .ui5-popover-arrow:after {
-	margin: 0.125rem 0 0 0.25rem;
-}
-
-:host(:not([actual-placement-type])) [dir=rtl] .ui5-popover-arrow:after,
-:host([actual-placement-type="Right"]) [dir=rtl] .ui5-popover-arrow:after {
-	margin: .1875rem -.375rem 0 0;
+	margin: var(--_ui5-popover_left_arrow_margin);
 }
 
 :host([hide-arrow]) .ui5-popover-arrow {

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -37,7 +37,7 @@
 
 }
 :host([actual-placement-type="Bottom"]) .ui5-popover-arrow:after {
-	margin: var(--_ui5-popover_upward_arrow_margin);
+	margin: var(--_ui5_popover_upward_arrow_margin);
 }
 
 /* pointing right arrow */
@@ -48,7 +48,7 @@
 }
 
 :host([actual-placement-type="Left"]) .ui5-popover-arrow:after {
-	margin: var(--_ui5-popover_right_arrow_margin);
+	margin: var(--_ui5_popover_right_arrow_margin);
 }
 
 /* pointing downward arrow */
@@ -59,7 +59,7 @@
 }
 
 :host([actual-placement-type="Top"]) .ui5-popover-arrow:after {
-	margin: var(--_ui5-popover_downward_arrow_margin);
+	margin: var(--_ui5_popover_downward_arrow_margin);
 }
 
 /* pointing left arrow */
@@ -73,7 +73,7 @@
 
 :host(:not([actual-placement-type])) .ui5-popover-arrow:after,
 :host([actual-placement-type="Right"]) .ui5-popover-arrow:after {
-	margin: var(--_ui5-popover_left_arrow_margin);
+	margin: var(--_ui5_popover_left_arrow_margin);
 }
 
 :host([hide-arrow]) .ui5-popover-arrow {

--- a/packages/main/src/themes/ResponsivePopover.css
+++ b/packages/main/src/themes/ResponsivePopover.css
@@ -16,10 +16,6 @@
 	width:100%;
 }
 
-:host [dir="rtl"] .ui5-responsive-popover-header {
-	padding: 0 1rem 0 0;
-}
-
 .ui5-responsive-popover-header-text {
 	width: calc(100% - var(--_ui5_button_base_min_width));
 }

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -6,6 +6,11 @@
 	--_ui5_panel_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_timeline_scroll_container_offset: 0.5rem;
+
+	--_ui5-popover_upward_arrow_margin: 0.1875rem 0 0 0.1875rem;
+	--_ui5-popover_right_arrow_margin: 0.1875rem 0 0 -0.375rem;
+	--_ui5-popover_downward_arrow_margin: -0.375rem 0 0 0.125rem;
+	--_ui5-popover_left_arrow_margin: 0.125rem 0 0 0.25rem;
 }
 
 [dir="rtl"] {
@@ -13,4 +18,9 @@
 	--_ui5_panel_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_timeline_scroll_container_offset: -0.5rem;
+
+	--_ui5-popover_upward_arrow_margin: .1875rem .125rem 0 0;
+	--_ui5-popover_right_arrow_margin: .1875rem .25rem 0 0;
+	--_ui5-popover_downward_arrow_margin: -0.4375rem .125rem 0 0;
+	--_ui5-popover_left_arrow_margin: .1875rem -.375rem 0 0;
 }

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -7,10 +7,12 @@
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_90deg);
 	--_ui5_timeline_scroll_container_offset: 0.5rem;
 
-	--_ui5-popover_upward_arrow_margin: 0.1875rem 0 0 0.1875rem;
-	--_ui5-popover_right_arrow_margin: 0.1875rem 0 0 -0.375rem;
-	--_ui5-popover_downward_arrow_margin: -0.375rem 0 0 0.125rem;
-	--_ui5-popover_left_arrow_margin: 0.125rem 0 0 0.25rem;
+	--_ui5_popover_upward_arrow_margin: 0.1875rem 0 0 0.1875rem;
+	--_ui5_popover_right_arrow_margin: 0.1875rem 0 0 -0.375rem;
+	--_ui5_popover_downward_arrow_margin: -0.375rem 0 0 0.125rem;
+	--_ui5_popover_left_arrow_margin: 0.125rem 0 0 0.25rem;
+
+	--_ui5_dialog_resize_cursor: se-resize;
 }
 
 [dir="rtl"] {
@@ -19,8 +21,10 @@
 	--_ui5_li_notification_group_toggle_btn_rotation: var(--_ui5_rotation_minus_90deg);
 	--_ui5_timeline_scroll_container_offset: -0.5rem;
 
-	--_ui5-popover_upward_arrow_margin: .1875rem .125rem 0 0;
-	--_ui5-popover_right_arrow_margin: .1875rem .25rem 0 0;
-	--_ui5-popover_downward_arrow_margin: -0.4375rem .125rem 0 0;
-	--_ui5-popover_left_arrow_margin: .1875rem -.375rem 0 0;
+	--_ui5_popover_upward_arrow_margin: .1875rem .125rem 0 0;
+	--_ui5_popover_right_arrow_margin: .1875rem .25rem 0 0;
+	--_ui5_popover_downward_arrow_margin: -0.4375rem .125rem 0 0;
+	--_ui5_popover_left_arrow_margin: .1875rem -.375rem 0 0;
+
+	--_ui5_dialog_resize_cursor:sw-resize;
 }


### PR DESCRIPTION
Hello https://github.com/orgs/SAP/teams/ui5-webcomponents-topic-rd
this is related to the recently stopped support of IE, allowing us to implement RTL using features, not supported on IE, as the CSS logical properties.

The Browser flips the paddings, margins, etc. automatically based on the direction - there is no need to write specific RTL styles manually. At least for the styles that have CSS logical prop alternative.

In case, there is no CSS logical props alternative or the use-case is very specific as with the Popover's arrow margins, which are different in RTL and LTR (not even mirrored), we extract them as CSS vars and add them to global rtl-parameters.css as we do for the cozy/compact styles.

Doing so, from one hand side we turn more to native implementation and standards, from the other we want to avoid effectiveDir calls as internally getComputedStyle is called, which is slow.


Changes:
- Popover's arrow rtl styles are refactored with the rtl-parameters.css pattern
- This style does not have ltr counter part and did not apply when testing, so I removed it
```css
:host [dir="rtl"] .ui5-responsive-popover-header {
	padding: 0 1rem 0 0;
}
```
- right is replaced with inset-inline-end
```css 
.ui5-popup-resize-handle {
	/* right: var(--_ui5_dialog_resize_handle_right); */
	inset-inline-end:var(--_ui5_dialog_resize_handle_right);
}
```
- The Dialog's resize icon does not need "dir" set