### PR TITLE
chore: upgrade lit-html to 2.2.2

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "lit-html": "2.0.1"
+    "lit-html": "^2.0.1"
   },
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,10 +3899,10 @@ linkify-it@^3.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
-lit-html@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.1.tgz#63241015efa07bc9259b6f96f04abd052d2a1f95"
-  integrity sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==
+lit-html@^2.0.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.2.2.tgz#06ced65dd3fb2d7a214d998c65acc576ae2cb3c4"
+  integrity sha512-cJofCRXuizwyaiGt9pJjJOcauezUlSB6t87VBXsPwRhbzF29MgD8GH6fZ0BuZdXAAC02IRONZBd//VPUuU8QbQ==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 


### PR DESCRIPTION
Set the version as `^2.0.1` so that existing apps don't have to change anything, if running `2.0.1`.
However, internally upgrade to `2.2.2` for our libraries.

With this change apps that use any `lit-html` 2 version (`2.x`) will not bundle the library twice.

closes: #5109