### PR TITLE
feat(ui5-tabcontainer): enable semantic icons in high contrast themes

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-eXc+WUpgN9+EPbUw3gv9VGULGPU=
+sKtI8to12A73DxsbDoXwWKS8MWo=

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -1,7 +1,11 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import executeTemplate from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
+import "@ui5/webcomponents-icons/dist/error.js";
+import "@ui5/webcomponents-icons/dist/alert.js";
+import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import SemanticColor from "./types/SemanticColor.js";
+import ListItemType from "./types/ListItemType.js";
 import TabContainer from "./TabContainer.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
@@ -269,7 +273,7 @@ class Tab extends UI5Element {
 	 * @since 1.0.0-rc.16
 	 */
 	getTabInStripDomRef() {
-		return this._getTabInStripDomRef;
+		return this._tabInStripDomRef;
 	}
 
 	getFocusDomRef() {
@@ -371,11 +375,24 @@ class Tab extends UI5Element {
 		return classes.join(" ");
 	}
 
-	get headerSemanticIconClasses() {
-		const classes = ["ui5-tab-strip-item-semanticIcon"];
+	get semanticIconName() {
+		switch (this.design) {
+		case SemanticColor.Positive:
+			return "sys-enter-2";
+		case SemanticColor.Negative:
+			return "error";
+		case SemanticColor.Critical:
+			return "alert";
+		default:
+			return null;
+		}
+	}
 
-		if (this.design !== SemanticColor.Default) {
-			classes.push(`ui5-tab-strip-item-semanticIcon--${this.design.toLowerCase()}`);
+	get semanticIconClasses() {
+		const classes = ["ui5-tab-semantic-icon"];
+
+		if (this.design !== SemanticColor.Default && this.design !== SemanticColor.Neutral) {
+			classes.push(`ui5-tab-semantic-icon--${this.design.toLowerCase()}`);
 		}
 
 		return classes.join(" ");
@@ -384,7 +401,7 @@ class Tab extends UI5Element {
 	get overflowClasses() {
 		const classes = ["ui5-tab-overflow-item"];
 
-		if (this.design !== SemanticColor.Default) {
+		if (this.design !== SemanticColor.Default && this.design !== SemanticColor.Neutral) {
 			classes.push(`ui5-tab-overflow-item--${this.design.toLowerCase()}`);
 		}
 
@@ -400,7 +417,7 @@ class Tab extends UI5Element {
 	}
 
 	get overflowState() {
-		return (this.disabled || this.isSingleClickArea) ? "Inactive" : "Active";
+		return (this.disabled || this.isSingleClickArea) ? ListItemType.Inactive : ListItemType.Active;
 	}
 }
 

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -11,10 +11,13 @@
 >
 	<div class="ui5-tab-overflow-itemContent-wrapper">
 		<div class="ui5-tab-overflow-itemContent">
+			{{#if this.semanticIconName}}
+				<ui5-icon class="{{this.semanticIconClasses}}" name="{{this.semanticIconName}}"></ui5-icon>
+			{{/if}}
+
 			{{#if this.icon}}
 				<ui5-icon name="{{this.icon}}"></ui5-icon>
 			{{/if}}
-
 			{{this.text}}
 
 			{{#if this.additionalText}}

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -25,7 +25,10 @@
 
 		{{#if this.text}}
 			<span class="ui5-tab-strip-itemText" id="{{this._id}}-text">
-				<span class="{{this.headerSemanticIconClasses}}"></span>
+				{{#if this.semanticIconName}}
+					<ui5-icon class="{{semanticIconClasses}}" name="{{semanticIconName}}"></ui5-icon>
+				{{/if}}
+
 				{{this.displayText}}
 			{{#if this.isSingleClickArea}}
 			<span class="ui5-tab-single-click-icon">
@@ -34,8 +37,8 @@
 			{{/if}}
 			</span>
 		{{/if}}
-
 	</div>
+
 	{{#if this.requiresExpandButton}}
 		<div class="ui5-tab-expand-button" @click="{{_onTabExpandButtonClick}}">
 			<ui5-button
@@ -43,6 +46,7 @@
 				icon="slim-arrow-down"
 				design="Transparent"
 				tabindex="-1"
+				?disabled="{{disabled}}"
 				aria-haspopup="true">
 			</ui5-button>
 		</div>

--- a/packages/main/src/TabSeparator.js
+++ b/packages/main/src/TabSeparator.js
@@ -59,7 +59,7 @@ class TabSeparator extends UI5Element {
 	}
 
 	getTabInStripDomRef() {
-		return this._getTabInStripDomRef;
+		return this._tabInStripDomRef;
 	}
 
 	get stableDomRef() {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -110,32 +110,6 @@
 	display: none;
 }
 
-.ui5-tab-expand-button > [ui5-button] {
-	height: 1.5rem;
-	min-width: 1.5rem;
-	margin-top: 0.25rem;
-	margin-left: 0.625rem;
-	color: var(--_ui5_tc_headerItem_color);
-}
-
-.ui5-tab-strip-item--selected .ui5-tab-expand-button > [ui5-button] {
-	color: var(--_ui5_tc_headeritem_text_selected_color);
-}
-
-.ui5-tab-expand-button > [ui5-button]:hover {
-	color: var(--_ui5_tc_headeritem_text_selected_hover_color);
-}
-
-.ui5-tab-single-click-icon {
-	margin-left: 0.875rem;
-}
-
-.ui5-tab-expand-button>[ui5-button]:hover {
-	background-color: var(--sapButton_Hover_Background);
-}
-.ui5-tab-expand-button>[ui5-button]:active {
-	background-color: var(--sapButton_Active_Background);
-}
 /*** Responsive paddings ***/
 
 :host([media-range="S"]) .ui5-tc__header {

--- a/packages/main/src/themes/TabInOverflow.css
+++ b/packages/main/src/themes/TabInOverflow.css
@@ -1,30 +1,33 @@
+@import "./TabSemanticIcon.css";
+
 .ui5-tab-overflow-item {
 	color: var(--_ui5_tc_overflowItem_default_color);
 }
 
 .ui5-tab-overflow-item--disabled {
 	cursor: default;
-	opacity: 0.5;
+	opacity: var(--sapContent_DisabledOpacity);
 }
 
-.ui5-tab-overflow-item--positive {
+.ui5-tab-overflow-item[hidden] {
+	display: none;
+}
+
+.ui5-tab-semantic-icon {
+	position: absolute;
+	inset-inline-start: -0.25rem;
+}
+
+.ui5-tab-overflow-item--positive:not(.ui5-tab-overflow-item--disabled) .ui5-tab-overflow-itemContent {
 	color: var(--_ui5_tc_overflowItem_positive_color);
-	border-color: var(--_ui5_tc_headerItem_positive_selected_border_color);
 }
 
-.ui5-tab-overflow-item--negative {
+.ui5-tab-overflow-item--negative:not(.ui5-tab-overflow-item--disabled) .ui5-tab-overflow-itemContent {
 	color: var(--_ui5_tc_overflowItem_negative_color);
-	border-color: var(--_ui5_tc_headerItem_negative_selected_border_color);
 }
 
-.ui5-tab-overflow-item--critical {
+.ui5-tab-overflow-item--critical:not(.ui5-tab-overflow-item--disabled) .ui5-tab-overflow-itemContent {
 	color: var(--_ui5_tc_overflowItem_critical_color);
-	border-color: var(--_ui5_tc_headerItem_critical_selected_border_color);
-}
-
-.ui5-tab-overflow-item--neutral {
-	color: var(--_ui5_tc_overflowItem_neutral_color);
-	border-color: var(--_ui5_tc_headerItem_neutral_selected_border_color);
 }
 
 .ui5-tab-overflow-item[active] .ui5-tab-overflow-itemContent {
@@ -34,36 +37,30 @@
 .ui5-tab-overflow-itemContent {
 	display: flex;
 	align-items: center;
-	padding-right: 0.5rem;
+	position: relative;
+	padding-inline: 1rem 0.5rem;
 	height: var(--_ui5_tc_item_text);
 	pointer-events: none;
 	font-size: 0.875rem;
 }
 
 .ui5-tab-overflow-itemContent-wrapper {
-	padding-left: calc(var(--_ui5-indentation-level, 0) * 1rem);
+	padding-inline-start: calc(var(--_ui5-tab-indentation-level) * 0.5rem + var(--_ui5-tab-extra-indent, 0) * var(--_ui5_tc_overflowItem_extraIndent));
 }
 
 .ui5-tab-overflow-item--selectedSubTab {
 	background-color: var(--sapList_SelectionBackgroundColor);
 }
 
-.ui5-tab-overflow-item [ui5-icon] {
+.ui5-tab-overflow-item [ui5-icon]:not(.ui5-tab-semantic-icon) {
 	width: 1.375rem;
 	height: 1.375rem;
-	padding-right: 1rem;
+	padding-inline-end: 0.75rem;
 	color: var(--_ui5_tc_overflowItem_current_color);
 }
 
-.ui5-tab-overflow-item[hidden] {
-	display: none;
-}
-
 .ui5-tab-container-responsive-popover [ui5-li-custom][focused]::part(native-li)::after {
-	top: var(--_ui5_tc_overflowItem_focus_offset);
-	right: var(--_ui5_tc_overflowItem_focus_offset);
-	bottom: var(--_ui5_tc_overflowItem_focus_offset);
-	left: var(--_ui5_tc_overflowItem_focus_offset);
+	inset: var(--_ui5_tc_overflowItem_focus_offset);
 }
 
 .ui5-tab-container-responsive-popover::part(content) {

--- a/packages/main/src/themes/TabInStrip.css
+++ b/packages/main/src/themes/TabInStrip.css
@@ -1,3 +1,5 @@
+@import "./TabSemanticIcon.css";
+
 .ui5-tab-strip-item {
 	height: var(--_ui5_tc_header_height);
 	color: var(--_ui5_tc_headerItem_color);
@@ -41,12 +43,35 @@
 	pointer-events: none;
 	transition: var(--_ui5_tc_headerItem_transition);
 }
+.ui5-tab-expand-button > [ui5-button] {
+	height: 1.5rem;
+	min-width: 1.5rem;
+	margin-top: 0.25rem;
+	margin-left: 0.625rem;
+}
+
+.ui5-tab-expand-button > [ui5-button]:not([active]) {
+	color: var(--_ui5_tc_headerItem_color);
+}
+
+.ui5-tab-strip-item--selected .ui5-tab-expand-button > [ui5-button]:not([active]) {
+	color: var(--_ui5_tc_headerItem_text_selected_color);
+}
+
+.ui5-tab-expand-button > [ui5-button]:hover:not([active]) {
+	color: var(--_ui5_tc_headerItem_text_selected_hover_color);
+}
+
+.ui5-tab-single-click-icon {
+	margin-left: 0.875rem;
+}
 
 .ui5-tab-strip-item--selected.ui5-tab-strip-item--textOnly {
-	color: var(--_ui5_tc_headeritem_text_selected_color);
+	color: var(--_ui5_tc_headerItem_text_selected_color);
 }
-.ui5-tab-strip-item--selected.ui5-tab-strip-item--singleClickArea .ui5-tab-strip-itemText .ui5-tab-single-click-icon>[ui5-icon] {
-	color: var(--_ui5_tc_headeritem_text_selected_color);
+
+.ui5-tab-strip-item--selected.ui5-tab-strip-item--singleClickArea .ui5-tab-strip-itemText .ui5-tab-single-click-icon > [ui5-icon] {
+	color: var(--_ui5_tc_headerItem_text_selected_color);
 }
 
 .ui5-tab-strip-item--singleClickArea .ui5-tab-strip-itemText {
@@ -58,11 +83,11 @@
 	display: flex;
 }
 
-.ui5-tab-strip-item--singleClickArea .ui5-tab-strip-itemText .ui5-tab-single-click-icon>[ui5-icon] {
+.ui5-tab-strip-item--singleClickArea .ui5-tab-strip-itemText .ui5-tab-single-click-icon > [ui5-icon] {
 	color: var(--_ui5_tc_headerItem_color);
 }
-.ui5-tab-strip-item:hover:not(.ui5-tab-strip-item--selected):not(ui5-tab-strip-item--negative).ui5-tab-strip-item--textOnly,
-.ui5-tab-strip-item--singleClickArea.ui5-tab-strip-item:hover:not(.ui5-tab-strip-item--selected) .ui5-tab-single-click-icon>[ui5-icon] {
+.ui5-tab-strip-item:hover:not(.ui5-tab-strip-item--selected):not(.ui5-tab-strip-item--negative).ui5-tab-strip-item--textOnly,
+.ui5-tab-strip-item--singleClickArea.ui5-tab-strip-item:hover:not(.ui5-tab-strip-item--selected):not(.ui5-tab-strip-item--disabled) .ui5-tab-single-click-icon > [ui5-icon] {
 	color: var(--_ui5_tc_headerItem_text_hover_color);
 }
 
@@ -122,7 +147,7 @@
 
 .ui5-tab-strip-item--disabled {
 	cursor: default;
-	opacity: 0.5;
+	opacity: var(--sapContent_DisabledOpacity);
 }
 
 .ui5-tab-strip-item:focus {
@@ -166,27 +191,6 @@
 	border-radius: var(--_ui5_tc_headerItemIcon_focus_border_radius);
 }
 
-.ui5-tab-strip-item-semanticIcon::before {
-	display: var(--_ui5_tc_headerItemSemanticIcon_display);
-	font-family: "SAP-icons";
-	font-size: 0.75rem;
-	margin-right: 0.25rem;
-	speak: none;
-	-webkit-font-smoothing: antialiased;
-}
-
-.ui5-tab-strip-item-semanticIcon--positive::before {
-	content: "\e1ab";
-}
-
-.ui5-tab-strip-item-semanticIcon--negative::before {
-	content: "\e1ac";
-}
-
-.ui5-tab-strip-item-semanticIcon--critical::before {
-	content: "\e1ae";
-}
-
 /*** Icon and text Tab styles ***/
 
 .ui5-tab-strip-item-icon-outer {
@@ -196,7 +200,7 @@
 	position: relative;
 	border: var(--_ui5_tc_headerItemIcon_border);
 	border-radius: 50%;
-	margin-right: 0.25rem;
+	margin-inline-end: 0.25rem;
 	height: var(--_ui5_tc_item_icon_circle_size);
 	width: var(--_ui5_tc_item_icon_circle_size);
 	pointer-events: none;
@@ -221,7 +225,7 @@
 }
 
 .ui5-tab-strip-itemAdditionalText + .ui5-tab-strip-itemText {
-	display: block;
+	display: flex;
 }
 
 .ui5-tab-strip-item--inline .ui5-tab-strip-itemAdditionalText + .ui5-tab-strip-itemText {
@@ -229,7 +233,7 @@
 }
 
 .ui5-tab-strip-item--withIcon .ui5-tab-strip-itemAdditionalText + .ui5-tab-strip-itemText {
-	margin-top: var(--_ui5_tc_item_add_text_margin_top);
+	margin-block-start: var(--_ui5_tc_item_add_text_margin_top);
 }
 
 /*** END Icon and text Tab styles ***/
@@ -269,7 +273,7 @@
 
 .ui5-tab-strip-item--mixedMode .ui5-tab-strip-itemAdditionalText {
 	font-size: 1.5rem;
-	margin-right: 0.5rem;
+	margin-inline-end: 0.5rem;
 }
 
 .ui5-tab-strip-item--mixedMode .ui5-tab-strip-itemText {
@@ -281,8 +285,7 @@
 
 /*** Semantic states ***/
 .ui5-tab-strip-item--positive.ui5-tab-strip-item--textOnly .ui5-tab-strip-itemText,
-.ui5-tab-strip-item--positive .ui5-tab-strip-item-icon-outer,
-.ui5-tab-strip-item-semanticIcon--positive::before {
+.ui5-tab-strip-item--positive .ui5-tab-strip-item-icon-outer {
 	color: var(--sapPositiveColor);
 	border-color: var(--_ui5_tc_headerItem_positive_selected_border_color);
 }
@@ -313,8 +316,7 @@
 }
 
 .ui5-tab-strip-item--negative.ui5-tab-strip-item--textOnly .ui5-tab-strip-itemText,
-.ui5-tab-strip-item--negative .ui5-tab-strip-item-icon-outer,
-.ui5-tab-strip-item-semanticIcon--negative::before {
+.ui5-tab-strip-item--negative .ui5-tab-strip-item-icon-outer {
 	color: var(--sapNegativeColor);
 	border-color: var(--_ui5_tc_headerItem_negative_selected_border_color);
 }
@@ -338,8 +340,7 @@
 }
 
 .ui5-tab-strip-item--critical.ui5-tab-strip-item--textOnly .ui5-tab-strip-itemText,
-.ui5-tab-strip-item--critical .ui5-tab-strip-item-icon-outer,
-.ui5-tab-strip-item-semanticIcon--critical::before {
+.ui5-tab-strip-item--critical .ui5-tab-strip-item-icon-outer {
 	color: var(--sapCriticalColor);
 	border-color: var(--_ui5_tc_headerItem_critical_selected_border_color);
 }
@@ -387,27 +388,11 @@
 }
 
 .ui5-tab-strip-item--withIcon .ui5-tab-strip-itemContent .ui5-tab-strip-itemAdditionalText {
-	padding: 0px;
+	padding: 0;
 }
 
 .ui5-tab-strip-item .ui5-tab-strip-itemAdditionalText {
-	padding: 0px 0.188rem;
-	color: var(--_ui5_tc_headeritem_additional_text_color);
-	font-weight: var(--_ui5_tc_headeritem_additional_text_font_weight);
-}
-/*** RTL ***/
-
-[dir=rtl] .ui5-tab-strip-item-semanticIcon::before {
-	margin-left: 0.25rem;
-	margin-right: 0;
-}
-
-[dir=rtl] .ui5-tab-strip-item-icon-outer {
-	margin-left: 0.25rem;
-	margin-right: 0;
-}
-
-[dir=rtl] .ui5-tab-strip-item--mixedMode .ui5-tab-strip-itemAdditionalText {
-	margin-right: 0;
-	margin-left: 0.5rem;
+	padding: 0 0.188rem;
+	color: var(--_ui5_tc_headerItem_additional_text_color);
+	font-weight: var(--_ui5_tc_headerItem_additional_text_font_weight);
 }

--- a/packages/main/src/themes/TabSemanticIcon.css
+++ b/packages/main/src/themes/TabSemanticIcon.css
@@ -1,0 +1,18 @@
+.ui5-tab-semantic-icon {
+	display: var(--_ui5_tc_headerItemSemanticIcon_display);
+	height: var(--_ui5_tc_headerItemSemanticIcon_size);
+	width: var(--_ui5_tc_headerItemSemanticIcon_size);
+	margin-inline-end: 0.5rem;
+}
+
+.ui5-tab-semantic-icon--positive {
+	color: var(--sapPositiveElementColor);
+}
+
+.ui5-tab-semantic-icon--negative {
+	color: var(--sapNegativeElementColor);
+}
+
+.ui5-tab-semantic-icon--critical {
+	color: var(--sapCriticalElementColor);
+}

--- a/packages/main/src/themes/TabSeparatorInOverflow.css
+++ b/packages/main/src/themes/TabSeparatorInOverflow.css
@@ -1,9 +1,10 @@
 .ui5-tc__separator {
 	min-height: 0.25rem;
 	border-bottom: 0.0625rem solid var(--sapGroup_TitleBorderColor);
-	margin-left: calc(var(--_ui5-indentation-level, 0) * 1rem);
-	margin-right: 0.5rem;
+	margin-inline-start: calc(var(--_ui5-tab-indentation-level) * 0.5rem);
+	margin-inline-end: 0.5rem;
 }
-[ui5-list]>.ui5-tc__separator:first-child {
+
+[ui5-list] > .ui5-tc__separator:first-child {
 	min-height: 0.5rem;
 }

--- a/packages/main/src/themes/base/TabContainer-parameters.css
+++ b/packages/main/src/themes/base/TabContainer-parameters.css
@@ -9,12 +9,12 @@
 	/* Header Item */
 	--_ui5_tc_headeritem_padding: 0 1rem;
 	--_ui5_tc_headerItem_color: var(--sapContent_LabelColor);
-	--_ui5_tc_headeritem_additional_text_color: var(--sapContent_LabelColor);
+	--_ui5_tc_headerItem_additional_text_color: var(--sapContent_LabelColor);
 	--_ui5_tc_headerItem_text_hover_color: var(--_ui5_tc_headerItem_color);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapSelectedColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapSelectedColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapSelectedColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapSelectedColor);
 	--_ui5_tc_headeritem_text_font_weight: normal;
-	--_ui5_tc_headeritem_additional_text_font_weight: normal;
+	--_ui5_tc_headerItem_additional_text_font_weight: normal;
 	--_ui5_tc_headerItem_neutral_color: var(--sapNeutralColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapPositiveColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapNegativeColor);
@@ -57,6 +57,7 @@
 	--_ui5_tc_headerItemContent_default_focus_border: none;
 	--_ui5_tc_headerItemContent_focus_border_radius: 0;
 	--_ui5_tc_headerItemSemanticIcon_display: none;
+	--_ui5_tc_headerItemSemanticIcon_size: 0.75rem;
 	--_ui5_tc_headerItem_focus_border_radius: 0px;
 	--_ui5_tc_mixedMode_itemText_color: var(--sapContent_LabelColor);
 	--_ui5_tc_mixedMode_itemText_font_family: var(--sapFontFamily);
@@ -69,8 +70,8 @@
 	--_ui5_tc_overflowItem_positive_color: var(--sapPositiveColor);
 	--_ui5_tc_overflowItem_negative_color: var(--sapNegativeColor);
 	--_ui5_tc_overflowItem_critical_color: var(--sapCriticalColor);
-	--_ui5_tc_overflowItem_focus_border: 0px;
 	--_ui5_tc_overflowItem_focus_offset: 0.125rem;
+	--_ui5_tc_overflowItem_extraIndent: 0rem;
 
 	/* Header Item icons */
 	--_ui5_tc_headerItemIcon_border: 1px solid var(--sapHighlightColor);

--- a/packages/main/src/themes/sap_belize/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize/TabContainer-parameters.css
@@ -1,6 +1,6 @@
 @import "../base/TabContainer-parameters.css";
 
 :root {
-	--_ui5_tc_headeritem_text_selected_color: #3b6f9a;
+	--_ui5_tc_headerItem_text_selected_color: #3b6f9a;
 	--_ui5_tc_headerItemIcon_selected_background: #3b6f9a;
 }

--- a/packages/main/src/themes/sap_belize_hcb/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/src/themes/sap_belize_hcw/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/src/themes/sap_horizon/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_horizon/TabContainer-parameters.css
@@ -26,9 +26,6 @@
 	--_ui5_tc_headerItemIcon_background_color: var(--sapContent_Selected_Background);
 	--_ui5_tc_headerItemIcon_selected_color: var(--sapContent_ContrastIconColor);
 
-	/* Overflow Item */
-	--_ui5_tc_overflowItem_focus_border: 0.75rem;
-
 	/* Mixed Mode */
 	--_ui5_tc_mixedMode_itemText_color: var(--sapTextColor);
 }

--- a/packages/main/src/themes/sap_horizon_dark/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/TabContainer-parameters.css
@@ -19,7 +19,4 @@
 
 	/* Header Item icons */
 	--_ui5_tc_headerItemIcon_border: 0.125rem solid var(--sapHighlightColor);
-
-	/* Overflow Item */
-	--_ui5_tc_overflowItem_focus_border: 0.75rem;
 }

--- a/packages/main/src/themes/sap_horizon_exp/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/TabContainer-parameters.css
@@ -12,7 +12,7 @@
 	--_ui5_tc_headerItem_color: var(--sapNeutralTextColor); /* #5B738B; */
 	--_ui5_tc_headeritem_text_font_weight: bold;
 	--_ui5_tc_headerItem_text_hover_color: var(--sapTile_TitleTextColor); /* #475E75; */
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapContent_Selected_TextColor); /* #0057D2; */
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapContent_Selected_TextColor); /* #0057D2; */
 	--_ui5_tc_headerItem_focus_border: none;
 	--_ui5_tc_headerItem_transition: all 0.2s ease-in-out;
 	--_ui5_tc_headerItemContent_border_radius: 0.125rem;

--- a/packages/main/src/themes/sap_horizon_hcb/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/TabContainer-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/TabContainer-parameters.css
@@ -6,8 +6,8 @@
 	/* Header Item */
 	--_ui5_tc_headerItemContent_border_bottom: 0.25rem solid var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_focus_border: 0.125rem dotted var(--sapContent_FocusColor);
-	--_ui5_tc_headeritem_text_selected_color: var(--sapPageHeader_BorderColor);
-	--_ui5_tc_headeritem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_color: var(--sapPageHeader_BorderColor);
+	--_ui5_tc_headerItem_text_selected_hover_color: var(--sapPageHeader_BorderColor);
 	--_ui5_tc_headerItem_neutral_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_positive_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_headerItem_negative_color: var(--sapGroup_TitleTextColor);
@@ -41,4 +41,5 @@
 	--_ui5_tc_overflowItem_critical_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_default_color: var(--sapGroup_TitleTextColor);
 	--_ui5_tc_overflowItem_current_color: var(--_ui5_tc_overflowItem_default_color);
+	--_ui5_tc_overflowItem_extraIndent: 1rem;
 }

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -33,23 +33,29 @@
 			<ui5-tab text="One">
 				<ui5-button>Button 1</ui5-button>
 			</ui5-tab>
-				<ui5-tab-separator></ui5-tab-separator>
+
+			<ui5-tab-separator></ui5-tab-separator>
+
 			<ui5-tab text="Two">
-					<ui5-button id="button2">Button 2</ui5-button>
+				<ui5-button id="button2">Button 2</ui5-button>
+
 				<ui5-tab slot="subTabs" text="2.1">
 					<ui5-button id="button21">Button 21</ui5-button>
 
 					<ui5-tab slot="subTabs" text="2.1.1" selected>
 						<ui5-button id="button211">Button 211</ui5-button>
-				<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
 					</ui5-tab>
+
+					<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
 
 					<ui5-tab slot="subTabs" text="2.1.2">
 						<ui5-tab slot="subTabs" text="2.1.2.1">
 							<ui5-button id="button2121">Button 2121</ui5-button>
 						</ui5-tab>
+
 						<ui5-button id="button212">Button 212</ui5-button>
 					</ui5-tab>
+
 				</ui5-tab>
 
 				<ui5-tab text="2.2" slot="subTabs">
@@ -59,23 +65,39 @@
 
 			<ui5-tab text="Three">
 				<ui5-tab slot="subTabs" icon="sap-icon://menu2" text="3.1">
-					<ui5-button>Button 31</ui5-button>
+					<ui5-button>Button 3.1</ui5-button>
+
+					<ui5-tab slot="subTabs" icon="sap-icon://menu2" text="3.1.1">
+						<ui5-button>Button 3.1.1</ui5-button>
+					</ui5-tab>
+					<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+					<ui5-tab slot="subTabs" icon="sap-icon://menu2" text="3.1.2">
+						<ui5-button>Button 3.1.2</ui5-button>
+					</ui5-tab>
 				</ui5-tab>
 			</ui5-tab>
 
-			<ui5-tab text="Four"><ui5-button>Button 4</ui5-button>
-							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+			<ui5-tab text="Four">
+				<ui5-button>Button 4</ui5-button>
 
-				<ui5-tab slot="subTabs" text="Four 1"><ui5-button>Button 41</ui5-button>
-							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+				<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+				<ui5-tab slot="subTabs" text="Four 1">
+					<ui5-button>Button 41</ui5-button>
 
-					<ui5-tab slot="subTabs" text="Four 1.1"><ui5-button>Button 411</ui5-button>
-							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
-						<ui5-tab slot="subTabs" text="Four 1.1.1"><ui5-button>Button 4111</ui5-button>
-							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
-							<ui5-tab slot="subTabs" text="Four 1.1.1.1"><ui5-button>Button 41111</ui5-button></ui5-tab>
-							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+					<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+					<ui5-tab design="Positive" slot="subTabs" text="Four 1.1">
+						<ui5-button>Button 411</ui5-button>
 
+						<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+						<ui5-tab slot="subTabs" text="Four 1.1.1">
+							<ui5-button>Button 4111</ui5-button>
+
+							<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+							<ui5-tab slot="subTabs" text="Four 1.1.1.1">
+								<ui5-button>Button 41111</ui5-button>
+
+								<ui5-tab-separator slot="subTabs"></ui5-tab-separator>
+							</ui5-tab>
 						</ui5-tab>
 					</ui5-tab>
 				</ui5-tab>
@@ -124,26 +146,30 @@
 	<section>
 		<h2>Text only End Overflow</h2>
 		<ui5-tabcontainer id="tabContainerEndOverflow" collapsed fixed>
-			<ui5-tab text="One"></ui5-tab>
-			<ui5-tab text="Two">
-				<ui5-tab text="2.1"><ui5-button>Button 2.1</ui5-button>
-					<ui5-tab text="2.1.1"><ui5-button>Button 2.2</ui5-button>
-						<ui5-tab text="2.1.2"></ui5-tab><ui5-button>Button 2.3</ui5-button>
-				</ui5-tab></ui5-tab>
+			<ui5-tab design="Positive" text="One"></ui5-tab>
+			<ui5-tab design="Negative" text="Two" disabled>
+				<ui5-tab slot="subTabs" text="2.1"></ui5-tab>
 			</ui5-tab>
-			<ui5-tab text="Three">
-				<ui5-tab text="3.1">
+			<ui5-tab design="Critical" text="Three">
+				<ui5-tab slot="subTabs" design="Positive" text="3.1">
 					<ui5-button>Button 3</ui5-button>
 				</ui5-tab>
 			</ui5-tab>
 			<ui5-tab text="Four"></ui5-tab>
-			<ui5-tab text="Five"></ui5-tab>
+
+			<ui5-tab text="Five">
+				<ui5-tab slot="subTabs" text="nested in Five">
+					<ui5-tab slot="subTabs" text="nested deeper in Five">text</ui5-tab>
+					text
+				</ui5-tab>
+			</ui5-tab>
+
 			<ui5-tab text="Six"></ui5-tab>
 			<ui5-tab text="Seven"></ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
-			<ui5-tab text="Eight"></ui5-tab>
-			<ui5-tab text="Nine"></ui5-tab>
-			<ui5-tab text="Ten"></ui5-tab>
+			<ui5-tab design="Positive" text="Eight"></ui5-tab>
+			<ui5-tab design="Negative" text="Nine"></ui5-tab>
+			<ui5-tab design="Critical" text="Ten"></ui5-tab>
 			<ui5-tab text="Eleven"></ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
 			<ui5-tab text="Twelve"></ui5-tab>
@@ -189,9 +215,9 @@
 			<ui5-tab text="Thirteen"></ui5-tab>
 			<ui5-tab text="Fourteen"></ui5-tab>
 			<ui5-tab text="Fifteen"></ui5-tab>
-			<ui5-tab text="Sixteen"></ui5-tab>
-			<ui5-tab text="Seventeen"></ui5-tab>
-			<ui5-tab text="Eighteen"></ui5-tab>
+			<ui5-tab text="Sixteen" design="Positive"></ui5-tab>
+			<ui5-tab text="Seventeen" design="Negative"></ui5-tab>
+			<ui5-tab text="Eighteen" design="Critical"></ui5-tab>
 			<ui5-tab text="Nineteen"></ui5-tab>
 			<ui5-tab text="Twenty" selected></ui5-tab>
 			<ui5-tab text="Twenty One"></ui5-tab>
@@ -223,7 +249,7 @@
 
 	<section>
 		<h2>Tab Container Start And End Overflow</h2>
-		<ui5-tabcontainer id="tabContainer1" fixed collapsed tabs-overflow-mode="StartAndEnd">
+		<ui5-tabcontainer id="tabContainer2" fixed collapsed tabs-overflow-mode="StartAndEnd">
 			<ui5-tab stable-dom-ref="products-ref" text="Products" additional-text="125"></ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
 			<ui5-tab icon="sap-icon://menu2" text="Laptops" design="Positive" additional-text="25"></ui5-tab>
@@ -288,7 +314,7 @@
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
 			</ui5-tab>
-			<ui5-tab text="Avaialability">
+			<ui5-tab text="Availability">
 				<ui5-button>Button 2</ui5-button>
 			</ui5-tab>
 			<ui5-tab text="Date of Expire">
@@ -488,7 +514,7 @@
 				<ui5-button>Button 11</ui5-button>
 				<ui5-button>Button 12</ui5-button>
 			</ui5-tab>
-			<ui5-tab text="Avaialability">
+			<ui5-tab text="Availability">
 				<ui5-button>Button 2</ui5-button>
 			</ui5-tab>
 			<ui5-tab text="Date of Expire">
@@ -709,7 +735,6 @@
 		});
 
 		document.getElementById("densityToggle").addEventListener("click", function (event) {
-			console.log(event);
 			document.body.classList.toggle("sapUiSizeCompact")
 		})
 	</script>

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -129,7 +129,7 @@ describe("TabContainer general interaction", () => {
 
 		const newlySelectedItem = await tabcontainer.$("[selected]");
 
-		assert.strictEqual(await newlySelectedItem.getProperty("text"), "Twelve", "The first item in the overflow is 12");
+		assert.strictEqual(await newlySelectedItem.getProperty("text"), "Eleven", "The first item in the overflow is 11");
 
 	});
 

--- a/packages/theming/hash.txt
+++ b/packages/theming/hash.txt
@@ -1,1 +1,1 @@
-nVDITlsbNpjqxPOZcH0r7oboURo=
+jTxjP4q8ZYzq4ZcbwLrh2rt5ZuI=


### PR DESCRIPTION
- Semantic icons are now displayed using Icon components.
- The design property is no longer visualised when the tab is disabled.

Fixes: #2540
