### PR TITLE
chore: parallelize build tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "ui5"
   ],
   "scripts": {
-    "build": "npm-run-all --sequential build:base build:localization build:theming build:icons build:icons-business-suite build:icons-tnt build:main build:fiori",
+    "build": "npm-run-all --sequential build:non-component-packages build:main build:fiori",
+    "build:non-component-packages": "npm-run-all --parallel build:base build:localization build:theming build:icons build:icons-business-suite build:icons-tnt",
     "build:localization": "yarn workspace @ui5/webcomponents-localization build",
     "build:base": "yarn workspace @ui5/webcomponents-base build",
     "build:theming": "yarn workspace @ui5/webcomponents-theming build",
@@ -31,8 +32,8 @@
     "dev:fiori": "yarn workspace @ui5/webcomponents-fiori nps dev",
     "scopeDev:main": "yarn workspace @ui5/webcomponents nps scope.dev",
     "scopeDev:fiori": "yarn workspace @ui5/webcomponents-fiori nps scope.dev",
-    "start": "npm-run-all --sequential build:base build:localization build:theming build:icons build:icons-business-suite build:icons-tnt prepare:main prepare:fiori copy-css start:all",
-    "startWithScope": "npm-run-all --sequential build:base build:localization build:theming build:icons build:icons-business-suite build:icons-tnt scopePrepare:main scopePrepare:fiori copy-css scopeStart:all",
+    "start": "npm-run-all --sequential build:non-component-packages prepare:main prepare:fiori copy-css start:all",
+    "startWithScope": "npm-run-all --sequential build:non-component-packages scopePrepare:main scopePrepare:fiori copy-css scopeStart:all",
     "start:all": "npm-run-all --parallel dev:base dev:localization dev:main dev:fiori",
     "scopeStart:all": "npm-run-all --parallel dev:base dev:localization scopeDev:main scopeDev:fiori",
     "start:base": "yarn workspace @ui5/webcomponents-base start",

--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,1 @@
-6uF3armWsQqj6RlvG7f/WVGVIdc=
+mUCRKUiEewx+UyYrPGkfoYy4H4I=

--- a/packages/theming/hash.txt
+++ b/packages/theming/hash.txt
@@ -1,1 +1,1 @@
-nVDITlsbNpjqxPOZcH0r7oboURo=
+jTxjP4q8ZYzq4ZcbwLrh2rt5ZuI=

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -18,7 +18,11 @@ const getScripts = (options) => {
 		clean: "rimraf dist && rimraf .port",
 		lint: "eslint . --config config/.eslintrc.js",
 		lintfix: "eslint . --config config/.eslintrc.js --fix",
-		prepare: "nps clean build.templates build.styles build.i18n build.jsonImports copy build.samples build.illustrations",
+		prepare: {
+			default: "nps clean prepare.all",
+			all: 'concurrently "nps build.templates" "nps build.i18n" "nps prepare.styleRelated" "nps copy" "nps build.samples" "nps build.illustrations"',
+			styleRelated: "nps build.styles build.jsonImports",
+		},
 		build: {
 			default: "nps lint prepare build.bundle",
 			templates: `mkdirp dist/generated/templates && node "${LIB}/hbs2ui5/index.js" -d src/ -o dist/generated/templates`,


### PR DESCRIPTION
Parallelize as many tasks as possible, both on **monorepo** level and **components package** (main/fiori) level.

This optimization reduces the build time (from clean state) by *35 sec* on my local machine.

**On the build server:**

Before the change: 
<img width="387" alt="image" src="https://user-images.githubusercontent.com/15844574/165746387-abd2e20a-5d5f-4099-a438-52ddf6ff7bb8.png">
After the change:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/15844574/165746446-cc13ddde-f2b1-4e6f-b41d-93a75fa1e77c.png">
