### PR TITLE
chore: ignore playground package

### DIFF
--- a/.github/actions/pre-release.js
+++ b/.github/actions/pre-release.js
@@ -20,9 +20,7 @@ const OTP = options.otp;
 
 const run = async () => {
 	const { globby } = await import("globby");
-	let FILES = await globby("packages/*/package.json", {
-		"ignoreFiles": ["*/playground/*"],
-	});
+	let FILES = await globby(["packages/*/package.json", "!packages/playground/package.json"]);
 
 	// Step 1: process package.json files
 	const pkgs = await Promise.all(FILES.map(processPackageJSON));


### PR DESCRIPTION
The playground's package.json has not been ignored, now it is excluded. Somehow the [ignoreFiles](https://github.com/sindresorhus/globby#ignorefiles) option did not work as expected. I checked the docs - "ignoreFiles: Glob patterns to look for ignore files, which are then used to ignore globbed files." but could not make it work, so I used the "!" syntax.