### PR TITLE
fix(theming): fix fallback to default theme

### DIFF
--- a/packages/base/src/asset-registries/Themes.js
+++ b/packages/base/src/asset-registries/Themes.js
@@ -38,10 +38,14 @@ const getThemeProperties = async (packageName, themeName) => {
 
 	if (!registeredThemes.has(themeName)) {
 		const regThemesStr = [...registeredThemes.values()].join(", ");
-		console.warn(`You have requested a non-registered theme - falling back to ${DEFAULT_THEME}. Registered themes are: ${regThemesStr}`); /* eslint-disable-line */
-		return themeStyles.get(`${packageName}_${DEFAULT_THEME}`);
+		console.warn(`You have requested a non-registered theme ${themeName} - falling back to ${DEFAULT_THEME}. Registered themes are: ${regThemesStr}`); /* eslint-disable-line */
+		return _getThemeProperties(packageName, DEFAULT_THEME);
 	}
 
+	return _getThemeProperties(packageName, themeName);
+};
+
+const _getThemeProperties = async (packageName, themeName) => {
 	const loader = loaders.get(`${packageName}/${themeName}`);
 	if (!loader) {
 		// no themes for package

--- a/packages/base/test/specs/Theming.spec.js
+++ b/packages/base/test/specs/Theming.spec.js
@@ -30,4 +30,15 @@ describe("Theming works", () => {
 		assert.strictEqual(res, true, "Theme parameters changed");
 	});
 
+	it("Tests fallback to default theme when setting unknown theme", async () => {
+		const unknownTheme = 'sap_unknown_theme';
+		await browser.url(`http://localhost:9191/test-resources/pages/AllTestElements.html?sap-ui-theme=${unknownTheme}`);
+
+		const res = await browser.executeAsync( async (done) => {
+			const cssVarValue = getComputedStyle(document.documentElement).getPropertyValue('--var1');
+			done(cssVarValue);
+		});
+
+		assert.strictEqual(res, ' red', "Default theme parameters loaded");
+	});
 });


### PR DESCRIPTION
When the user sets unknown theme, the fallback does not quite work. The framework correctly displays a warning, but the theme parameters are not returned (as the theme parameters map ends up empty at that point), and the page is left in broken state. Now we use the same flow to fallback to the default theme, as if the user set it.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5136
Closes: https://github.com/SAP/ui5-webcomponents/issues/5136