### PR TITLE
docs(ui5-list): do not use names from @ui5/webcomponents-fiori

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -285,7 +285,7 @@ const metadata = {
 		/**
 		 * Fired when the <code>Close</code> button of any item is clicked
 		 * <br><br>
-		 * <b>Note:</b> This event is applicable to <code>ui5-li-notification</code> items only,
+		 * <b>Note:</b> This event is only applicable to list items that can be closed (such as notification list items),
 		 * not to be confused with <code>item-delete</code>.
 		 *
 		 * @event sap.ui.webcomponents.main.List#item-close
@@ -302,7 +302,7 @@ const metadata = {
 		/**
 		 * Fired when the <code>Toggle</code> button of any item is clicked.
 		 * <br><br>
-		 * <b>Note:</b> This event is applicable to <code>ui5-li-notification-group</code> items only.
+		 * <b>Note:</b> This event is only applicable to list items that can be toggled (such as notification group list items).
 		 *
 		 * @event sap.ui.webcomponents.main.List#item-toggle
 		 * @param {HTMLElement} item the toggled item.


### PR DESCRIPTION
Currently, the `ui5-list` documentation mentions some `@ui5/webcomponents-fiori` components, but `@ui5/webcomponents` does not have a dependency to `@ui5/webcomponents-fiori` (but the other way round).

This creates a "reverse dependency" in the documentation.

When we create OpenUI5 wrappers for the webcomponents, we replace all mentions of tags in the documentation with the OpenUI5 class names. For example, `ui5-li-notification` should be replaced with `sap.ui.webc.fiori.NotificationListItem`. However, since `@ui5/webcomponents` does not have a dependency to `@ui5/webcomponents-fiori`, during the wrappers generation for `sap.ui.webc.main` we don't have the `sap.ui.webc.fiori`  classes loaded, and we cannot match `ui5-li-notification` against anything, thus leaving it unchanged in the final OpenUI5 documentation.

Note: this worked "by chance" until now (hence the OpenUI5 documentation is currently correct on `master`) since the wrappers generation script was hard-coded to build both libraries at once. Now with the new version of the script, dependencies are calculated dynamically (so that the script works for third parties) and for that reason when `sap.ui.webc.main` is generated, we no longer have any references to `sap.ui.webc.fiori`.

To avoid this problem, the wording is changed:
 - first, to be more general (speaking of items that can be closed/toggled in principle, instead of specific classes)
 - second, notification-related items are still mentioned, but not with the technical names