### PR TITLE
fix(ui5-panel): fix typo in css var name

### DIFF
--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -69,7 +69,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-family: "72override", var(--sapFontHeaderFamily);
-	font-size: var(--sapGroup_TitleFontSize);
+	font-size: var(--sapGroup_Title_FontSize);
 	font-weight: normal;
 	color: var(--sapGroup_TitleTextColor);
 	font-weight: normal;

--- a/packages/theming/css-vars-usage.json
+++ b/packages/theming/css-vars-usage.json
@@ -272,7 +272,7 @@
   "--sapGroup_ContentBorderColor",
   "--sapGroup_TitleBackground",
   "--sapGroup_TitleBorderColor",
-  "--sapGroup_TitleFontSize",
+  "--sapGroup_Title_FontSize",
   "--sapGroup_TitleTextColor",
   "--sapHC_ReducedBackground",
   "--sapHC_ReducedForeground",


### PR DESCRIPTION
Use --sapGroup_Title_FontSize, instead of --sapGroup_TitleFontSize

Fixes: https://github.com/SAP/ui5-webcomponents/issues/5201