### PR TITLE
fix(ui5-color-picker): provide meaningful labels for the inner input components

### DIFF
--- a/packages/main/src/ColorPicker.hbs
+++ b/packages/main/src/ColorPicker.hbs
@@ -20,6 +20,7 @@
             min="0"
             max="1530"
             value="{{_hue}}"
+            accessible-name="{{hueSliderLabel}}"
             @ui5-input="{{_handleHueInput}}"
         ></ui5-slider>
         <ui5-slider
@@ -29,6 +30,7 @@
             max="1"
             step="0.01"
             value="{{_alpha}}"
+            accessible-name="{{alphaSliderLabel}}"
             @ui5-input="{{_handleAlphaInput}}"
         ></ui5-slider>
     </div>
@@ -47,6 +49,7 @@
                 class="ui5-color-picker-hex-input"
                 value="{{hex}}"
                 @keydown="{{_onkeydown}}"
+                accessible-name="{{hexInputLabel}}"
                 @ui5-change="{{_handleHEXChange}}"
                 value-state="{{hexInputErrorState}}"
             ></ui5-input>
@@ -62,6 +65,7 @@
                 id="red"
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
+                accessible-name="{{redInputLabel}}"
                 value="{{_color.r}}"
             ></ui5-input>
             <ui5-label>R</ui5-label>
@@ -71,6 +75,7 @@
                 id="green"
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
+                accessible-name="{{greenInputLabel}}"
                 value="{{_color.g}}"
             ></ui5-input>
             <ui5-label>G</ui5-label>
@@ -80,6 +85,7 @@
                 id="blue"
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
+                accessible-name="{{blueInputLabel}}"
                 value="{{_color.b}}"
             ></ui5-input>
             <ui5-label>B</ui5-label>
@@ -90,6 +96,7 @@
                 disabled="{{inputsDisabled}}"
                 class="ui5-color-picker-rgb-input"
                 value="{{_alpha}}"
+                accessible-name="{{alphaInputLabel}}"
                 @ui5-input="{{_handleAlphaInput}}"
                 @ui5-change="{{_handleAlphaChange}}"
             ></ui5-input>

--- a/packages/main/src/ColorPicker.js
+++ b/packages/main/src/ColorPicker.js
@@ -6,6 +6,7 @@ import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
+import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import {
 	getRGBColor,
 	HSLToRGB,
@@ -16,6 +17,16 @@ import ColorPickerTemplate from "./generated/templates/ColorPickerTemplate.lit.j
 import Input from "./Input.js";
 import Slider from "./Slider.js";
 import Label from "./Label.js";
+
+import {
+	COLORPICKER_ALPHA_SLIDER,
+	COLORPICKER_HUE_SLIDER,
+	COLORPICKER_HEX,
+	COLORPICKER_RED,
+	COLORPICKER_GREEN,
+	COLORPICKER_BLUE,
+	COLORPICKER_ALPHA,
+} from "./generated/i18n/i18n-defaults.js";
 
 // Styles
 import ColorPickerCss from "./generated/themes/ColorPicker.css.js";
@@ -177,6 +188,10 @@ class ColorPicker extends UI5Element {
 			Slider,
 			Label,
 		];
+	}
+
+	static async onDefine() {
+		ColorPicker.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 
 	constructor() {
@@ -531,6 +546,34 @@ class ColorPicker extends UI5Element {
 		}
 
 		this._setMainColor(this._hue);
+	}
+
+	get hueSliderLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_HUE_SLIDER);
+	}
+
+	get alphaSliderLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_ALPHA_SLIDER);
+	}
+
+	get hexInputLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_HEX);
+	}
+
+	get redInputLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_RED);
+	}
+
+	get greenInputLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_GREEN);
+	}
+
+	get blueInputLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_BLUE);
+	}
+
+	get alphaInputLabel() {
+		return ColorPicker.i18nBundle.getText(COLORPICKER_ALPHA);
 	}
 
 	get inputsDisabled() {

--- a/packages/main/src/RangeSlider.hbs
+++ b/packages/main/src/RangeSlider.hbs
@@ -34,7 +34,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{startValue}}"
-		aria-labelledby="{{_ariaLabelledByStartHandleReffs}}"
+		aria-labelledby="{{_ariaLabelledByStartHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
 	>
 		<ui5-icon name="source-code" slider-icon></ui5-icon>
@@ -56,7 +56,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{endValue}}"
-		aria-labelledby="{{_ariaLabelledByEndHandleReffs}}"
+		aria-labelledby="{{_ariaLabelledByEndHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
 	>
 		<ui5-icon name="source-code" slider-icon></ui5-icon>

--- a/packages/main/src/RangeSlider.hbs
+++ b/packages/main/src/RangeSlider.hbs
@@ -34,7 +34,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{startValue}}"
-		aria-labelledby="{{_id}}-startHandleDesc"
+		aria-labelledby="{{_ariaLabelledByStartHandleReffs}}"
 		aria-disabled="{{_ariaDisabled}}"
 	>
 		<ui5-icon name="source-code" slider-icon></ui5-icon>
@@ -56,7 +56,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{endValue}}"
-		aria-labelledby="{{_id}}-endHandleDesc"
+		aria-labelledby="{{_ariaLabelledByEndHandleReffs}}"
 		aria-disabled="{{_ariaDisabled}}"
 	>
 		<ui5-icon name="source-code" slider-icon></ui5-icon>

--- a/packages/main/src/RangeSlider.hbs
+++ b/packages/main/src/RangeSlider.hbs
@@ -17,7 +17,7 @@
 			aria-valuemin="{{min}}"
 			aria-valuemax="{{max}}"
 			aria-valuetext="From {{startValue}} to {{endValue}}"
-			aria-labelledby="{{_id}}-sliderDesc"
+			aria-labelledby="{{_ariaLabelledByProgressBarRefs}}"
 			aria-disabled="{{_ariaDisabled}}"
 		></div>
 	</div>

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -768,11 +768,11 @@ class RangeSlider extends SliderBase {
 		return this.shadowRoot.querySelector(".ui5-slider-progress");
 	}
 
-	get _ariaLabelledByStartHandleReffs() {
+	get _ariaLabelledByStartHandleRefs() {
 		return [`${this._id}-accName`, `${this._id}-startHandleDesc`].join(" ").trim();
 	}
 
-	get _ariaLabelledByEndHandleReffs() {
+	get _ariaLabelledByEndHandleRefs() {
 		return [`${this._id}-accName`, `${this._id}-endHandleDesc`].join(" ").trim();
 	}
 

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -768,6 +768,14 @@ class RangeSlider extends SliderBase {
 		return this.shadowRoot.querySelector(".ui5-slider-progress");
 	}
 
+	get _ariaLabelledByStartHandleReffs() {
+		return [`${this._id}-accName`, `${this._id}-startHandleDesc`].join(" ").trim();
+	}
+
+	get _ariaLabelledByEndHandleReffs() {
+		return [`${this._id}-accName`, `${this._id}-endHandleDesc`].join(" ").trim();
+	}
+
 	get styles() {
 		return {
 			progress: {

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -776,6 +776,10 @@ class RangeSlider extends SliderBase {
 		return [`${this._id}-accName`, `${this._id}-endHandleDesc`].join(" ").trim();
 	}
 
+	get _ariaLabelledByProgressBarRefs() {
+		return [`${this._id}-accName`, `${this._id}-sliderDesc`].join(" ").trim();
+	}
+
 	get styles() {
 		return {
 			progress: {

--- a/packages/main/src/Slider.hbs
+++ b/packages/main/src/Slider.hbs
@@ -27,7 +27,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{value}}"
-		aria-labelledby="{{_id}}-sliderDesc"
+		aria-labelledby="{{_ariaLabelledByStartHandleReffs}}"
 		aria-disabled="{{_ariaDisabled}}"
 		data-sap-focus-ref
 		part="handle"

--- a/packages/main/src/Slider.hbs
+++ b/packages/main/src/Slider.hbs
@@ -27,7 +27,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{value}}"
-		aria-labelledby="{{_ariaLabelledByStartHandleRefs}}"
+		aria-labelledby="{{_ariaLabelledByHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
 		data-sap-focus-ref
 		part="handle"

--- a/packages/main/src/Slider.hbs
+++ b/packages/main/src/Slider.hbs
@@ -27,7 +27,7 @@
 		aria-valuemin="{{min}}"
 		aria-valuemax="{{max}}"
 		aria-valuenow="{{value}}"
-		aria-labelledby="{{_ariaLabelledByStartHandleReffs}}"
+		aria-labelledby="{{_ariaLabelledByStartHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
 		data-sap-focus-ref
 		part="handle"

--- a/packages/main/src/SliderBase.hbs
+++ b/packages/main/src/SliderBase.hbs
@@ -36,7 +36,7 @@
 		{{> handles}}
 	</div>
 
-	<span id="{{_id}}-accName" class="ui5-hidden-text">{{ariaLabelStartHandleText}}</span>
+	<span id="{{_id}}-accName" class="ui5-hidden-text">{{accessibleName}}</span>
 	<span id="{{_id}}-sliderDesc" class="ui5-hidden-text">{{_ariaLabelledByText}}</span>
 </div>
 

--- a/packages/main/src/SliderBase.hbs
+++ b/packages/main/src/SliderBase.hbs
@@ -36,6 +36,7 @@
 		{{> handles}}
 	</div>
 
+	<span id="{{_id}}-accName" class="ui5-hidden-text">{{ariaLabelStartHandleText}}</span>
 	<span id="{{_id}}-sliderDesc" class="ui5-hidden-text">{{_ariaLabelledByText}}</span>
 </div>
 

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -807,7 +807,7 @@ class SliderBase extends UI5Element {
 		return this.disabled ? "-1" : "0";
 	}
 
-	get _ariaLabelledByStartHandleRefs() {
+	get _ariaLabelledByHandleRefs() {
 		return [`${this._id}-accName`, `${this._id}-sliderDesc`].join(" ").trim();
 	}
 }

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -8,6 +8,7 @@ import "@ui5/webcomponents-icons/dist/source-code.js";
 import {
 	isEscape, isHome, isEnd, isUp, isDown, isRight, isLeft, isUpCtrl, isDownCtrl, isRightCtrl, isLeftCtrl, isPlus, isMinus, isPageUp, isPageDown,
 } from "@ui5/webcomponents-base/dist/Keys.js";
+import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 
 // Styles
 import styles from "./generated/themes/SliderBase.css.js";
@@ -98,6 +99,17 @@ const metadata = {
 		 */
 		disabled: {
 			type: Boolean,
+		},
+
+		/**
+		 * Defines the accessible aria name of the component.
+		 *
+		 * @type {string}
+		 * @defaultvalue: ""
+		 * @public
+		 */
+		 accessibleName: {
+			type: String,
 		},
 
 		/**
@@ -793,6 +805,14 @@ class SliderBase extends UI5Element {
 
 	get tabIndex() {
 		return this.disabled ? "-1" : "0";
+	}
+
+	get ariaLabelStartHandleText() {
+		return getEffectiveAriaLabelText(this);
+	}
+
+	get _ariaLabelledByStartHandleReffs() {
+		return [`${this._id}-accName`, `${this._id}-sliderDesc`].join(" ").trim();
 	}
 }
 

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -811,7 +811,7 @@ class SliderBase extends UI5Element {
 		return getEffectiveAriaLabelText(this);
 	}
 
-	get _ariaLabelledByStartHandleReffs() {
+	get _ariaLabelledByStartHandleRefs() {
 		return [`${this._id}-accName`, `${this._id}-sliderDesc`].join(" ").trim();
 	}
 }

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -8,7 +8,6 @@ import "@ui5/webcomponents-icons/dist/source-code.js";
 import {
 	isEscape, isHome, isEnd, isUp, isDown, isRight, isLeft, isUpCtrl, isDownCtrl, isRightCtrl, isLeftCtrl, isPlus, isMinus, isPageUp, isPageDown,
 } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 
 // Styles
 import styles from "./generated/themes/SliderBase.css.js";
@@ -806,10 +805,6 @@ class SliderBase extends UI5Element {
 
 	get tabIndex() {
 		return this.disabled ? "-1" : "0";
-	}
-
-	get ariaLabelStartHandleText() {
-		return getEffectiveAriaLabelText(this);
 	}
 
 	get _ariaLabelledByStartHandleRefs() {

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -107,6 +107,7 @@ const metadata = {
 		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public
+		 * @since 1.4.0
 		 */
 		 accessibleName: {
 			type: String,

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -91,6 +91,27 @@ COLOR_PALETTE_DIALOG_TITLE=Change Color
 #XTIT: Color Palette dialog title of the Color Picker
 COLOR_PALETTE_MORE_COLORS_TEXT=More Colors...
 
+#XACT: Aria information for the ColorPicker Alpha slider
+COLORPICKER_ALPHA_SLIDER=Alpha control
+
+#XACT: Aria information for the ColorPicker Hue slider
+COLORPICKER_HUE_SLIDER=Hue control
+
+#XTOL: Six symbol hexadecimal group representing CSS color hex string
+COLORPICKER_HEX=Hexadecimal
+
+#XTOL: Red color for the ColorPicker control
+COLORPICKER_RED=Red
+
+#XTOL: Green color for the ColorPicker control
+COLORPICKER_GREEN=Green
+
+#XTOL: Blue color for the ColorPicker control
+COLORPICKER_BLUE=Blue
+
+#XTOL: Alpha chanel transparency value for RGBA color mode
+COLORPICKER_ALPHA=Alpha
+
 #XACT: DatePicker 'Open Picker' icon title
 DATEPICKER_OPEN_ICON_TITLE=Open Picker
 

--- a/packages/main/test/pages/RangeSlider.html
+++ b/packages/main/test/pages/RangeSlider.html
@@ -28,7 +28,7 @@
 	<body class="rangeslider1auto">
 		<section class="group">
 			<h2>Basic Range Slider</h2>
-			<ui5-range-slider id="basic-range-slider" end-value="20"></ui5-range-slider>
+			<ui5-range-slider id="basic-range-slider" accessible-name="Basic Range Slider" end-value="20"></ui5-range-slider>
 
 			<h2>Range Slider with custom min and max properties and tooltip</h2>
 			<ui5-range-slider id="basic-range-slider-with-tooltip" min="50" max="200" show-tooltip></ui5-range-slider>

--- a/packages/main/test/pages/Slider.html
+++ b/packages/main/test/pages/Slider.html
@@ -28,7 +28,7 @@
 	<body class="slider1auto">
 		<section class="group">
 			<h2>Basic Slider</h2>
-			<ui5-slider id="basic-slider" min="0" max="10"></ui5-slider>
+			<ui5-slider id="basic-slider" accessible-name="Basic Slider" min="0" max="10"></ui5-slider>
 
 			<h2>Basic Slider with tooltip</h2>
 			<ui5-slider id="basic-slider-with-tooltip" min="0" max="20" show-tooltip></ui5-slider>

--- a/packages/main/test/specs/ColorPicker.spec.js
+++ b/packages/main/test/specs/ColorPicker.spec.js
@@ -139,4 +139,22 @@ describe("Color Picker general interaction", () => {
 		assert.strictEqual(await colorPicker.getAttribute("_hue"), hueValue, "Hue value remained unchanged");
 	});
 
+	it("Inner input components accessibility references", async () => {
+		const colorPicker = await browser.$("#cp1");
+		const hueSlider = await colorPicker.shadow$(".ui5-color-picker-hue-slider");
+		const alphaSlider = await colorPicker.shadow$(".ui5-color-picker-alpha-slider");
+		const hexInput = await colorPicker.shadow$(".ui5-color-picker-hex-input");
+		const redInput = await colorPicker.shadow$("#red");
+		const greenInput = await colorPicker.shadow$("#green");
+		const blueInput = await colorPicker.shadow$("#blue");
+		const alphaInput = await colorPicker.shadow$("#alpha");
+
+		assert.strictEqual(await hueSlider.getAttribute("accessible-name"), "Hue control", "Hue slider accessible-name attribute properly set");
+		assert.strictEqual(await alphaSlider.getAttribute("accessible-name"), "Alpha control", "Alpha slider accessible-name attribute properly set");
+		assert.strictEqual(await hexInput.getAttribute("accessible-name"), "Hexadecimal", "Hex input accessible-name attribute properly set");
+		assert.strictEqual(await redInput.getAttribute("accessible-name"), "Red", "Red input accessible-name attribute properly set");
+		assert.strictEqual(await greenInput.getAttribute("accessible-name"), "Green", "Green input accessible-name attribute properly set");
+		assert.strictEqual(await blueInput.getAttribute("accessible-name"), "Blue", "Blue input accessible-name attribute properly set");
+		assert.strictEqual(await alphaInput.getAttribute("accessible-name"), "Alpha", "Alpha input accessible-name attribute properly set");
+	});
 });

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -316,7 +316,7 @@ describe("Accessibility", async () => {
 		const rangeSliderId = await rangeSlider.getProperty("_id");
 
 		assert.strictEqual(await rangeSliderProgressBar.getAttribute("aria-labelledby"),
-			`${rangeSliderId}-sliderDesc`, "aria-labelledby is set correctly");
+			`${rangeSliderId}-accName ${rangeSliderId}-sliderDesc`, "aria-labelledby is set correctly");
 		assert.strictEqual(await rangeSliderProgressBar.getAttribute("aria-valuemin"),
 			`${await rangeSlider.getProperty("min")}`, "aria-valuemin is set correctly");
 		assert.strictEqual(await rangeSliderProgressBar.getAttribute("aria-valuemax"),

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -331,7 +331,7 @@ describe("Accessibility", async () => {
 		const rangeSliderId = await rangeSlider.getProperty("_id");
 
 		assert.strictEqual(await startHandle.getAttribute("aria-labelledby"),
-			`${rangeSliderId}-startHandleDesc`, "aria-labelledby is set correctly");
+			`${rangeSliderId}-accName ${rangeSliderId}-startHandleDesc`, "aria-labelledby is set correctly");
 		assert.strictEqual(await startHandle.getAttribute("aria-valuemin"),
 			`${await rangeSlider.getProperty("min")}`, "aria-valuemin is set correctly");
 		assert.strictEqual(await startHandle.getAttribute("aria-valuemax"),
@@ -346,7 +346,7 @@ describe("Accessibility", async () => {
 		const rangeSliderId = await rangeSlider.getProperty("_id");
 
 		assert.strictEqual(await endHandle.getAttribute("aria-labelledby"),
-			`${rangeSliderId}-endHandleDesc`, "aria-labelledby is set correctly");
+			`${rangeSliderId}-accName ${rangeSliderId}-endHandleDesc`, "aria-labelledby is set correctly");
 		assert.strictEqual(await endHandle.getAttribute("aria-valuemin"),
 			`${await rangeSlider.getProperty("min")}`, "aria-valuemin is set correctly");
 		assert.strictEqual(await endHandle.getAttribute("aria-valuemax"),

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -246,7 +246,7 @@ describe("Accessibility", async () => {
 		const sliderId = await slider.getProperty("_id");
 
 		assert.strictEqual(await sliderHandle.getAttribute("aria-labelledby"),
-			`${sliderId}-sliderDesc`, "aria-labelledby is set correctly");
+			`${sliderId}-accName ${sliderId}-sliderDesc`, "aria-labelledby is set correctly");
 		assert.strictEqual(await sliderHandle.getAttribute("aria-valuemin"),
 			`${await slider.getProperty("min")}`, "aria-valuemin is set correctly");
 		assert.strictEqual(await sliderHandle.getAttribute("aria-valuemax"),


### PR DESCRIPTION
Issue description:
- The screen reader should announce meaningful messages
in relation to the inner input controls of the "ui5-color-picker".

Solution:
- The "accessibleName" property is enabled for the "ui5-slider"
and "ui5-range-slider" components.
- The missing label references for the "ui5-color-picker" inner input
components are added as per specification.

Related to: #5015
Related to: #5023