### PR TITLE
fix(ui5-input): prevent exception if there are suggestion but propert…

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -654,7 +654,7 @@ class Input extends UI5Element {
 	}
 
 	async onAfterRendering() {
-		if (this.Suggestions) {
+		if (this.Suggestions && this.showSuggestions) {
 			this.Suggestions.toggle(this.open, {
 				preventFocusRestore: true,
 			});


### PR DESCRIPTION
- When there is an input with suggestions, but show-suggestions is set to false, if you type in the Input an exception was thrown.