### PR TITLE
fix(ui5-calendar): adjust previous and next button styles

### DIFF
--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -332,17 +332,9 @@ class DayPicker extends CalendarPart {
 	}
 
 	onAfterRendering() {
-		if (this._autoFocus && !this._hidden) {
+		if (!this._hidden) {
 			this.focus();
 		}
-	}
-
-	_onfocusin() {
-		this._autoFocus = true;
-	}
-
-	_onfocusout() {
-		this._autoFocus = false;
 	}
 
 	/**

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -23,6 +23,7 @@
 	white-space: nowrap;
 	padding: 0;
 	font-size: var(--sapFontSize);
+	user-select: none;
 }
 
 .ui5-calheader-arrowbtn.ui5-calheader-arrowbtn-disabled:hover,


### PR DESCRIPTION
- User selection is disabled for the ui5-calendar arrow buttons
- Focus is retrieved back into the ui5-daypicker after navigation

Fixes: #5117
