### PR TITLE
fix(ui5-tabcontainer): provide unique names for each disabled slot

### DIFF
--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -252,7 +252,7 @@ class Tab extends UI5Element {
 	}
 
 	get _effectiveSlotName() {
-		return this.isOnSelectedTabPath ? this._individualSlot : "disabled-slot";
+		return this.isOnSelectedTabPath ? this._individualSlot : `disabled-${this._individualSlot}`;
 	}
 
 	get _defaultSlotName() {


### PR DESCRIPTION
In Firefox, using two or more slots with the same name (i.e. "disabled-slot")
in a shadow root will prevent the other slots from being shown.
Further clicking on a Tab in the strip after the slots are broken will cause
the browser tab to crash.

This change fixes the ui5-tabcontainer to work correctly in Firefox by
ensuring each slot that should be hidden gets a unique name.

Fixes #5178
