### PR TITLE
fix(ui5-calendar): correct header month button text localization

### DIFF
--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -290,7 +290,7 @@ class Calendar extends CalendarPart {
 
 		const yearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this.primaryCalendarType });
 		const localeData = getCachedLocaleDataInstance(getLocale());
-		this._headerMonthButtonText = localeData.getMonths("wide", this.primaryCalendarType)[this._calendarDate.getMonth()];
+		this._headerMonthButtonText = localeData.getMonthsStandAlone("wide", this.primaryCalendarType)[this._calendarDate.getMonth()];
 
 		if (this._currentPicker === "year") {
 			const rangeStart = new CalendarDate(this._calendarDate, this._primaryCalendarType);


### PR DESCRIPTION
This is a follow up on https://github.com/SAP/ui5-webcomponents/pull/5212 where the month selection view has been fixed. We noticed that the header button text should also rely on `getMonthsStandAlone`, instead of `getMonths`.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5242
