### PR TITLE
fix(retrofit): hide busy indicator if owned by the component

### DIFF
--- a/packages/base/src/css/BusyIndicator.css
+++ b/packages/base/src/css/BusyIndicator.css
@@ -59,6 +59,10 @@
 	--ui5_web_components_busy_indicator_display: none;
 }
 
+.busy-indicator-wrapper [ui5-busy-indicator] {
+    display: none;
+}
+
 @keyframes grow {
     0%, 50%, 100% {
         -webkit-transform: scale(0.5);


### PR DESCRIPTION
Problem:
Two busy indicators appear if component has logic for "local" busy indicator.

Fix:
Hide all nested `ui5-busy-indicator` inside busy wrapper.

Part of #5236