### PR TITLE
fix(ui5-table): adjust colspan value in MultiSelect mode

### DIFF
--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -542,6 +542,11 @@ class Table extends UI5Element {
 		this._noDataDisplayed = !this.rows.length && !this.hideNoData;
 		this.visibleColumnsCount = this.visibleColumns.length;
 
+		if (this.isMultiSelect) {
+			// we have to count the selection column as well
+			this.visibleColumnsCount += 1;
+		}
+
 		this._allRowsSelected = selectedRows.length === this.rows.length;
 
 		this._prevFocusedRow = this._prevFocusedRow || this.rows[0];


### PR DESCRIPTION
In MultiSelect mode, we should count the selection column as a visible column as well, since the "growing" row as well as the "no-data-text" row are one column narrower if the value of their colspan attribute is the count of the visible columns without the selection one.

FIXES: #5234 