### PR TITLE
fix(ui5-panel): set pointer cursor only over the header

### DIFF
--- a/packages/main/src/themes/Panel.css
+++ b/packages/main/src/themes/Panel.css
@@ -41,7 +41,7 @@
 	pointer-events: none;
 }
 
-:host(:not([_has-header]):not([fixed])) {
+:host(:not([_has-header]):not([fixed])) .ui5-panel-header {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
When we hover the content of the ui5-panel or not clickable header, the cursor should be the default one instead of pointer.

FIXES: #5248 
