### PR TITLE
fix(ui5-rating-indicator): apply correct styles for focus in HC themes

### DIFF
--- a/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_outline_offset: 0.125rem;
+	--_ui5_rating_indicator_outline_offset: 0.0625rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_border_radius: 0.25rem;
+	--_ui5_rating_indicator_outline_offset: 0.125rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_outline_offset: 0.125rem;
+	--_ui5_rating_indicator_outline_offset: 0.0625rem;;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_border_radius: 0.25rem;
+	--_ui5_rating_indicator_outline_offset: 0.125rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;


### PR DESCRIPTION
The focus border is now according to the spec in HC themes.