### PR TITLE
chore: fix import of theming assets in codesandbox

### DIFF
--- a/packages/tools/lib/generate-json-imports/themes.js
+++ b/packages/tools/lib/generate-json-imports/themes.js
@@ -39,7 +39,7 @@ const loadThemeProperties = async (themeName) => {
 		throw new Error("[themes] Inlined JSON not supported with static imports of assets. Use dynamic imports of assets or configure JSON imports as URLs");
 	}
 	return (await fetch(themeUrlsByName[themeName])).json();
-}
+};
 
 ${availableThemesArray}
   .forEach(themeName => registerThemePropertiesLoader("${packageName}", themeName, loadThemeProperties));
@@ -54,7 +54,7 @@ const loadThemeProperties = async (themeName) => {
 ${dynamicImportLines}
 		default: throw "unknown theme"
 	}
-}
+};
 
 const loadAndCheck = async (themeName) => {
 	const data = await loadThemeProperties(themeName);
@@ -62,7 +62,7 @@ const loadAndCheck = async (themeName) => {
 		throw new Error(\`[themes] Invalid bundling detected - dynamic JSON imports bundled as URLs. Switch to inlining JSON files from the build or use 'import ".../Assets-static.js"'. Check the \"Assets\" documentation for more information.\`);
 	}
 	return data;
-}
+};
 
 ${availableThemesArray}
   .forEach(themeName => registerThemePropertiesLoader("${packageName}", themeName, loadAndCheck));


### PR DESCRIPTION
**Background**
The following assets import fails in codesandbox
```js
import "@ui5/webcomponents/dist/Assets.js";
```
with

```js 
TypeError
Cannot read properties of undefined (reading 'forEach')
```

**Root cause**
It turns out that our JS module below that includes JSON imports was missing couple of ";" at the end of the methods and confused the parcel bundling.
```js
@ui5/webcomponents-theming/dist/generated/json-imports/Themes.js
```

**Fix**
After we added ";" everywhere needed, the theming ис working properly in codesandbox.

- with laters version 1.4.0 without the fix
https://codesandbox.io/s/ui5-webcomponents-forked-7q7f6m
https://7q7f6m.csb.app/?sap-ui-theme=sap_fiori_3_dark

- with preview version 0.0.0-453158269 including the fix
https://codesandbox.io/s/ui5-webcomponents-forked-ofu6xp
https://ofu6xp.csb.app/?sap-ui-theme=sap_fiori_3_dark

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5290

