### PR TITLE
fix(ui5-carousel): correct navigation buttons behavior

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -70,7 +70,7 @@
         class="ui5-carousel-navigation-button {{classes.navPrevButton}}"
         icon="slim-arrow-left"
         tabindex="-1"
-        @click={{navigateLeft}}
+        @click={{_navButtonClick}}
     ></ui5-button>
 {{/inline}}
 
@@ -81,6 +81,6 @@
         class="ui5-carousel-navigation-button {{classes.navNextButton}}"
         icon="slim-arrow-right"
         tabindex="-1"
-        @click={{navigateRight}}
+        @click={{_navButtonClick}}
     ></ui5-button>
 {{/inline}}

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -479,6 +479,16 @@ class Carousel extends UI5Element {
 		}
 	}
 
+	_navButtonClick(event) {
+		if (event.target.hasAttribute("arrow-forward")) {
+			this.navigateRight();
+		} else {
+			this.navigateLeft();
+		}
+
+		this.focus();
+	}
+
 	/**
 	 * Changes the currently displayed page.
 	 * @param {Integer} itemIndex The index of the target page

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -106,6 +106,8 @@
     box-shadow: none;
     cursor: pointer;
     outline-offset: .1rem;
+
+    --_ui5_button_focused_border_radius: 50%;
 }
 
 .ui5-carousel-navigation-arrows .ui5-carousel-navigation-button {


### PR DESCRIPTION
The ui5-carousel's navigation buttons now will focus the carousel after
being clicked. This avoids losing the focus when the first/last button
of the carousel dissapears when reaching the fist/last pages.
With this change, the arrow buttons will no longer retain the focus.

Fixes: #5125