### PR TITLE
fix(ui5-rating-indicator): import ui5-icon as used in template

### DIFF
--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -18,6 +18,7 @@ import {
 	RATING_INDICATOR_TOOLTIP_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
 import RatingIndicatorTemplate from "./generated/templates/RatingIndicatorTemplate.lit.js";
+import Icon from "./Icon.js";
 import "@ui5/webcomponents-icons/dist/favorite.js";
 import "@ui5/webcomponents-icons/dist/unfavorite.js";
 
@@ -192,6 +193,10 @@ class RatingIndicator extends UI5Element {
 
 	static async onDefine() {
 		RatingIndicator.i18nBundle = await getI18nBundle("@ui5/webcomponents");
+	}
+
+	static get dependencies() {
+		return [Icon];
 	}
 
 	constructor() {


### PR DESCRIPTION
The Icon component is not imported, although used. Not marked as dependency.
If someone bundles just the RatingIndicator, the Icon component will be missing and actually the stars won't be displayed.
Also, when we don't mark  it as dependency, we break the scoping, which adds suffixes to the dependencies of the component -  the case with the issue, linked below. The users enabled the scoping feature and used `ui5-rating-indicator-demo`, but in the Shadow DOM, the ui5-icon did not get its suffix (ui5-icon-demo) and thus not rendered.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5318