### PR TITLE
refactor: cleanup IE code part 3: CSS

### DIFF
--- a/packages/base/src/util/Caret.js
+++ b/packages/base/src/util/Caret.js
@@ -6,20 +6,7 @@ const getCaretPosition = field => {
 	// Initialize
 	let caretPos = 0;
 
-	// IE Support
-	if (document.selection) {
-		// Set focus on the element
-		field.focus();
-
-		// To get cursor position, get empty selection range
-		const selection = document.selection.createRange();
-
-		// Move selection start to 0 position
-		selection.moveStart("character", -field.value.length);
-
-		// The caret position is selection length
-		caretPos = selection.text.length;
-	} else if (field.selectionStart || field.selectionStart === "0") { // Firefox support
+	if (field.selectionStart || field.selectionStart === "0") { // Firefox support
 		caretPos = field.selectionDirection === "backward" ? field.selectionStart : field.selectionEnd;
 	}
 

--- a/packages/fiori/src/themes/Bar.css
+++ b/packages/fiori/src/themes/Bar.css
@@ -66,13 +66,7 @@
 	box-shadow: var(--sapContent_Shadow1);
 	border: none;
 }
-  /* This selector works well for all browsers except IE11.
-  After support for IE11 is stopped, the specific selectors added for it can be removed and this selector can be uncommented*/
-/* ::slotted(*) {
-	margin: 0 0.25rem;
-} */
 
-/*Specific selector added for support in IE11*/
-::slotted(.ui5-bar-content) {
+::slotted(*) {
 	margin: 0 0.25rem;
 }

--- a/packages/fiori/src/themes/MediaGalleryItem.css
+++ b/packages/fiori/src/themes/MediaGalleryItem.css
@@ -88,7 +88,6 @@
     bottom: 0;
     -webkit-user-select: none;
     -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 

--- a/packages/fiori/src/themes/ProductSwitchItem.css
+++ b/packages/fiori/src/themes/ProductSwitchItem.css
@@ -43,7 +43,6 @@
 
 .ui5-product-switch-item-root {
 	user-select: none;
-	-ms-user-select: none;
 	width: 100%;
 	height: 100%;
 	flex-direction: column;

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -261,14 +261,12 @@ slot[name="profile"] {
 	cursor: text;
 	-webkit-user-select: text;
 	-moz-user-select: text;
-	-ms-user-select: text;
 	user-select: text;
 }
 
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive {
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	cursor: pointer;
 	border: var(--_ui5_shellbar_button_border);
@@ -432,26 +430,6 @@ slot[name="profile"] {
 	max-height: 2rem;
 	pointer-events: none;
 }
-
-
-/**
-* IE styles
-*/
-[ui5-input][value-state]:not([readonly]) {
-	background: var(--sapShellColor);
-	border: 1px solid var(--sapShell_InteractiveBorderColor);
-}
-
-[ui5-input][value-state]:not([readonly]):hover,
-[ui5-input]:not([value-state]):not([readonly]):hover {
-	background: var(--sapShell_Hover_Background);
-	border: 1px solid var(--sapShell_InteractiveBorderColor);
-}
-
-[ui5-input][value-state]:not([value-state="None"])[focused] {
-	outline: 1px dotted var(--sapContent_ContrastFocusColor);
-}
-/* IE styles end */
 
 .ui5-shellbar-copilot-wrapper {
 	position: relative;

--- a/packages/fiori/src/themes/Wizard.css
+++ b/packages/fiori/src/themes/Wizard.css
@@ -75,7 +75,6 @@
 	padding: 1rem 2rem;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	background-color: var(--sapObjectHeader_Background);
 	font-size: .875rem;

--- a/packages/fiori/src/themes/WizardTab.css
+++ b/packages/fiori/src/themes/WizardTab.css
@@ -162,11 +162,6 @@
 	border-bottom-style: dashed;
 }
 
-/* Workaround for IE to make the focus outline visible */
-[ui5-wizard-tab] .ui5-wiz-step-main {
-	pointer-events: none;
-}
-
 :host([data-ui5-wizard-expanded-tab="false"]) .ui5-wiz-step-root {
 	display: inline;
 	position: absolute;

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -59,11 +59,6 @@
 	color: inherit;
 }
 
-/* IE 11 specific selector */
-[ui5-badge] [ui5-icon][slot="icon"] {
-	display: flex;
-}
-
 :host([_has-icon]) .ui5-badge-text {
 	padding-inline-start: 0.125rem;
 }

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -59,10 +59,6 @@
 	color: inherit;
 }
 
-[ui5-badge] [ui5-icon][slot="icon"] {
-	display: flex;
-}
-
 :host([_has-icon]) .ui5-badge-text {
 	padding-inline-start: 0.125rem;
 }

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -59,6 +59,10 @@
 	color: inherit;
 }
 
+[ui5-badge] [ui5-icon][slot="icon"] {
+	display: flex;
+}
+
 :host([_has-icon]) .ui5-badge-text {
 	padding-inline-start: 0.125rem;
 }

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -120,13 +120,11 @@
 	0%, 50%, 100% {
 		-webkit-transform: scale(0.5);
 		-moz-transform: scale(0.5);
-		-ms-transform: scale(0.5);
 		transform: scale(0.5);
 	}
 	25% {
 		-webkit-transform: scale(1);
 		-moz-transform: scale(1);
-		-ms-transform: scale(1);
 		transform: scale(1);
 	}
 }

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -47,7 +47,6 @@
 	line-height: inherit;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 }
 

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -100,7 +100,6 @@
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 }
 

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -145,15 +145,6 @@
 	box-sizing: border-box;
 }
 
-/* Fixes IE11 bug for flex + min-height
-https://github.com/philipwalton/flexbugs/issues/231
-*/
-.ui5-checkbox-root::after {
-	content: "";
-	min-height: inherit;
-	font-size: 0;
-}
-
 /* focused */
 .ui5-checkbox-root:focus::before {
 	display: var(--_ui5_checkbox_focus_outline_display);
@@ -254,7 +245,6 @@ https://github.com/philipwalton/flexbugs/issues/231
 	overflow: hidden;
 	pointer-events: none;
 	user-select: none;
-	-ms-user-select: none;
 	-webkit-user-select: none;
 	color: var(--_ui5_checkbox_label_color);
 }

--- a/packages/main/src/themes/ColorPicker.css
+++ b/packages/main/src/themes/ColorPicker.css
@@ -21,11 +21,9 @@
     background-image: -webkit-linear-gradient(left, #000, rgba(0,0,0,0)),-webkit-linear-gradient(top, rgba(255,255,255,0), #fff);
     background-image: -moz-linear-gradient(left, #000, rgba(0,0,0,0)),-moz-linear-gradient(top, rgba(255,255,255,0), #fff);
     background-image: linear-gradient(left, #000, rgba(0,0,0,0)),linear-gradient(top, rgba(255,255,255,0), #fff);
-    background-image: -ms-linear-gradient(left, #000, rgba(0,0,0,0)),-ms-linear-gradient(top, rgba(255,255,255,0), #fff);
     background-image: -webkit-linear-gradient(left, #000, rgba(0,0,0,0), #fff),-webkit-linear-gradient(top, rgba(128,128,128,0), #808080);
     background-image: -moz-linear-gradient(left, #000, rgba(0,0,0,0), #fff),-moz-linear-gradient(top, rgba(128,128,128,0), #808080);
     background-image: linear-gradient(left, #000, rgba(0,0,0,0), #fff),linear-gradient(top, rgba(128,128,128,0), #808080);
-    background-image: -ms-linear-gradient(left, #000, rgba(0,0,0,0), #fff),-ms-linear-gradient(top, rgba(128,128,128,0), #808080);
 	user-select: none;
     -moz-user-select: none;
 }
@@ -92,7 +90,6 @@
     background-size: 100%;
     background-image: -webkit-linear-gradient(left, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
     background-image: -moz-linear-gradient(left, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
-    background-image: -ms-linear-gradient(left, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
     background-image: linear-gradient(left, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
     background-color: none;
 }
@@ -221,7 +218,6 @@
 [dir=rtl] [ui5-slider].ui5-color-picker-hue-slider::part(progress-container) {
     background-image: -webkit-linear-gradient(right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
     background-image: -moz-linear-gradient(right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
-    background-image: -ms-linear-gradient(right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
     background-image: linear-gradient(right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
 }
 

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -76,7 +76,6 @@
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 }
 

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -146,14 +146,6 @@
 	visibility: hidden;
 }
 
-:host([disabled]) [inner-input]:-ms-input-placeholder {
-	visibility: hidden;
-}
-
-:host([readonly]) [inner-input]:-ms-input-placeholder {
-	visibility: hidden;
-}
-
 [inner-input]::-webkit-input-placeholder {
 	font-weight: normal;
 	font-style: var(--_ui5_input_placeholder_style);
@@ -164,13 +156,6 @@
 [inner-input]::-moz-placeholder {
 	font-weight: normal;
 	font-style: var(--_ui5_input_placeholder_style);
-	color: var(--_ui5_input_placeholder_color);
-	padding-right: 0.125rem;
-}
-
-[inner-input]:-ms-input-placeholder {
-	font-weight: normal;
-	font-style: italic;
 	color: var(--_ui5_input_placeholder_color);
 	padding-right: 0.125rem;
 }
@@ -353,12 +338,6 @@
 :host([value-state="Information"]:not([readonly]):not([focused]):hover) {
 	background-color: var(--sapField_Hover_Background);
 	box-shadow: var(--_ui5_input_value_state_information_hover_box_shadow);
-}
-
-/* Remove IE's defaut clear button */
-[inner-input]::-ms-clear {
-	height: 0;
-	width: 0;
 }
 
 /* Input Icon */

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -160,7 +160,6 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	pointer-events: none; /* IE specific */
 }
 
 .ui5-li-detailbtn,

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -79,8 +79,6 @@
 
 .ui5-li-content {
 	max-width: 100%;
-	min-height: 1px; /* IE specific: fixes vertical centering with flex  */
 	font-family: "72override", var(--sapFontFamily);
 	color: var(--sapList_TextColor);
-	pointer-events: none;  /* IE specific: fixes focus crrectly applied*/
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -29,7 +29,6 @@
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	cursor: default;
 	outline: none;

--- a/packages/main/src/themes/MultiComboBox.css
+++ b/packages/main/src/themes/MultiComboBox.css
@@ -22,20 +22,6 @@
 	height: 100%;
 }
 
-/* Workaround for IE */
-[ui5-multi-combobox] {
-	width: 100%;
-}
-
-[ui5-multi-combobox] [ui5-tokenizer] {
-	flex: 3;
-}
-
-[ui5-icon] {
-	border-top-right-radius: var(--ui5-multi_bombobox_icon_border_top_right_radius);
-    border-bottom-right-radius: var(--ui5-multi_bombobox_icon_border_bottom_right_radius);
-}
-
 :host([readonly]) .ui5-multi-combobox-tokenizer::part(n-more-text) {
 	color: var(--sapLinkColor);
 }

--- a/packages/main/src/themes/MultiInput.css
+++ b/packages/main/src/themes/MultiInput.css
@@ -8,11 +8,6 @@
 	height: 100%;
 }
 
-/* Workaround for IE */
-[ui5-multi-input] [ui5-tokenizer] {
-	flex: 3;
-}
-
 :host([readonly]) .ui5-multi-input-tokenizer::part(n-more-text) {
 	color: var(--sapLinkColor);
 }

--- a/packages/main/src/themes/PopupsCommon.css
+++ b/packages/main/src/themes/PopupsCommon.css
@@ -20,12 +20,6 @@
     outline: none;
 }
 
-@media screen and (-ms-high-contrast: active) {
-    .ui5-popup-root {
-        border: 1px solid var(--sapPageFooter_BorderColor);
-    }
-}
-
 .ui5-popup-root .ui5-popup-header-root {
     color: var(--sapPageHeader_TextColor);
     box-shadow: var(--sapContent_HeaderShadow);

--- a/packages/main/src/themes/ResponsivePopoverCommon.css
+++ b/packages/main/src/themes/ResponsivePopoverCommon.css
@@ -79,11 +79,6 @@
 	color: var(--sapField_PlaceholderTextColor);
 }
 
-[inner-input]:-ms-input-placeholder {
-	font-style: italic;
-	color: var(--sapField_PlaceholderTextColor);
-}
-
 .input-root-phone[value-state]:not([value-state="None"]) {
 	border-width: var(--_ui5_input_state_border_width);
 }
@@ -159,12 +154,6 @@
 .input-root-phone[value-state="Information"]:not([readonly]) [inner-input]:focus {
 	background-color: var(--_ui5_input_focused_value_state_information_background);
 	border-color: var(--_ui5_input_focused_value_state_information_border_color);
-}
-
-/* Remove IE's defaut clear button */
-[inner-input]::-ms-clear {
-	height: 0;
-	width: 0;
 }
 
 /* MultiComboBox & MultiInput specific */

--- a/packages/main/src/themes/SliderBase.css
+++ b/packages/main/src/themes/SliderBase.css
@@ -24,7 +24,6 @@
 	padding: 1rem 0;
 	outline: none;
 	touch-action: none;
-	-ms-touch-action: pan-y;
 }
 
 .ui5-slider-inner {
@@ -147,7 +146,7 @@
 	outline: var(--_ui5_slider_handle_active_focused_outline);
 }
 
-.ui5-slider-handle.ui5-slider-handle--start:focus, 
+.ui5-slider-handle.ui5-slider-handle--start:focus,
 .ui5-slider-handle--end:focus {
 	border: var(--_ui5_slider_handle_focus_border);
 }

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -110,7 +110,6 @@
 	white-space: nowrap;
 	user-select: none;
 	-webkit-user-select: none;
-	-ms-user-select: none;
 }
 
 .ui5-switch-handle,
@@ -262,7 +261,7 @@
 .ui5-switch-root.ui5-switch--no-label .ui5-switch-text {
 	display: flex;
 	justify-content: center;
-	
+
 }
 
 .ui5-switch--no-label .ui5-switch-no-label-icon-on,
@@ -276,7 +275,7 @@
 .ui5-switch-root.ui5-switch--semantic .ui5-switch-icon-off {
 	width: var(--_ui5_switch_icon_width);
 	height: var(--_ui5_switch_icon_height)
-} 
+}
 
 .ui5-switch-root .ui5-switch-text {
 	font-family: var(--_ui5_switch_text_font_family);
@@ -295,7 +294,7 @@
 
 :host([active]) .ui5-switch-desktop.ui5-switch-root:not(.ui5-switch--disabled) .ui5-switch-track {
 	background: var( --_ui5-switch_track-off-active-background);
-} 
+}
 
 /* active & on */
 

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -145,13 +145,6 @@
 	color: var(--sapField_PlaceholderTextColor);
 }
 
-.ui5-textarea-inner:-ms-input-placeholder {
-	/* IE 10+ */
-	font-weight: normal;
-	font-style: var(--_ui5_textarea_placeholder_font_style);
-	color: var(--sapField_PlaceholderTextColor);
-}
-
 .ui5-textarea-inner:-moz-placeholder {
 	/* Firefox 18- */
 	font-weight: normal;
@@ -168,13 +161,6 @@
 
 :host([value-state="Error"]) .ui5-textarea-inner::-moz-placeholder {
 	/* Firefox 19+ */
-	font-weight: var(--_ui5_textarea_value_state_error_warning_placeholder_font_weight);
-	font-style: var(--_ui5_textarea_error_placeholder_font_style);
-	color: var(--_ui5_textarea_error_placeholder_color);
-}
-
-:host([value-state="Error"]) .ui5-textarea-inner:-ms-input-placeholder {
-	/* IE 10+ */
 	font-weight: var(--_ui5_textarea_value_state_error_warning_placeholder_font_weight);
 	font-style: var(--_ui5_textarea_error_placeholder_font_style);
 	color: var(--_ui5_textarea_error_placeholder_color);

--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -30,12 +30,6 @@
 	white-space: pre-line;
 }
 
-@media screen and (-ms-high-contrast: active) {
-    .ui5-toast-root {
-        border: 1px solid var(--sapPageFooter_BorderColor);
-    }
-}
-
 :host(:not([placement])) .ui5-toast-root {
 	bottom: var(--_ui5_toast_vertical_offset);
 	left: 50%;

--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -2,11 +2,6 @@
 	display: inline-block;
 }
 
-/* this line is also included from the Button.css, but keep it here in case we start using it for automatic IE11 compilation */
-:host([disabled]) {
-	pointer-events: none;
-}
-
 :host([pressed]),
 :host([design="Default"][pressed]),
 :host([design="Transparent"][pressed]),

--- a/packages/main/src/themes/YearPicker.css
+++ b/packages/main/src/themes/YearPicker.css
@@ -36,7 +36,6 @@
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 	cursor: default;
 	outline: none;

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -552,7 +552,7 @@ describe("Input general interaction", () => {
 		const firstListItem = await respPopover.$("ui5-list").$("ui5-li-suggestion-item");
 
 		assert.ok(await respPopover.isDisplayedInViewport(), "The popover is visible");
-		await browser.pause(500);
+		await browser.pause(1000);
 		const firstItemHtml = await firstListItem.getHTML(false);
 		assert.include(firstItemHtml, "<b>Ad</b>am", "The suggestions is highlighted.");
 	});


### PR DESCRIPTION
Remove all IE11-related CSS:
 - denoted by comments
 - starting with the `-ms` prefix

Additionally, remove the code using IE-specific `document.selection` for the inputs.