### PR TITLE
fix(ui5-button): adjust icon role

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -25,6 +25,7 @@
 		<ui5-icon
 			class="ui5-button-icon"
 			name="{{icon}}"
+			accessible-role="{{iconRole}}"
 			part="icon"
 			?show-tooltip={{showIconTooltip}}
 		></ui5-icon>

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -462,6 +462,14 @@ class Button extends UI5Element {
 		return this.design !== ButtonDesign.Default && this.design !== ButtonDesign.Transparent;
 	}
 
+	get iconRole() {
+		if (!this.icon) {
+			return "";
+		}
+
+		return this.isIconOnly ? "img" : "presentation";
+	}
+
 	get isIconOnly() {
 		return !Array.from(this.childNodes).filter(node => {
 			return node.nodeType !== Node.COMMENT_NODE

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -56,7 +56,7 @@
 	<ui5-button design="Positive">Agree</ui5-button>
 	<ui5-button design="Negative">Decline</ui5-button>
 	<ui5-button design="Attention">Warning</ui5-button>
-	<ui5-button design="Attention" icon="message-warning">Warning</ui5-button>
+	<ui5-button id="attentionIconButton" design="Attention" icon="message-warning">Warning</ui5-button>
 	<ui5-button design="Attention" icon="message-warning"></ui5-button>
 	<br/>
 	<br/>

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -100,6 +100,13 @@ describe("Button general interaction", () => {
 		assert.strictEqual(await innerButton.getAttribute("aria-controls"), "registration-dialog", "Attribute is reflected");
 	});
 
+	it("tests button with text icon role", async () => {
+		const button = await browser.$("#attentionIconButton");
+		const icon = await button.shadow$("ui5-icon");
+
+		assert.ok(icon.getAttribute("accessible-role", "presentation"), "icon has proper role");
+	});
+
 	it("setting accessible-name-ref on the host is reflected on the button tag", async () => {
 		const button = await browser.$("#buttonAccNameRef").shadow$("button");
 


### PR DESCRIPTION
Issue:
The ui5-button icon was announced by the screen readers
when there is a text and a icon.

Solution:
The ui5-button icon has role "presentation" when we aren't
in an icon only scenario.

Fixes: #5288