### PR TITLE
fix(ui5-avatar-group): adapt width calculations in composite layouts

### DIFF
--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -382,7 +382,7 @@ class AvatarGroup extends UI5Element {
 				item = button;
 			}
 
-			return this.effectiveDir === "rtl" ? this._getWidthToItem(item) : item.offsetLeft;
+			return this.effectiveDir === "rtl" ? this._getWidthToItem(item) : item.offsetLeft - this.offsetLeft;
 		}
 
 		return button.offsetWidth;
@@ -526,7 +526,7 @@ class AvatarGroup extends UI5Element {
 		}
 
 		// in LTR the width is equal to item.offsetLeft
-		return item.offsetLeft;
+		return item.offsetLeft - this.offsetLeft;
 	}
 
 	/**


### PR DESCRIPTION
The calculations of the main container width have been adjusted to take into account sibling nodes.

Fixes #5333