### PR TITLE
fix(ui5-input): enhance lazy loading

### DIFF
--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -871,6 +871,8 @@ class Input extends UI5Element {
 		const innerInput = this.getInputDOMRefSync();
 		const isAutoCompleted = innerInput.selectionEnd - innerInput.selectionStart > 0;
 
+		this.isTyping = false;
+
 		if (!isOpen) {
 			this.value = this.lastConfirmedValue ? this.lastConfirmedValue : this.previousValue;
 			return;
@@ -1119,7 +1121,6 @@ class Input extends UI5Element {
 			this.focused = false;
 		}
 
-		this.isTyping = false;
 		this.openOnMobile = false;
 		this.open = false;
 		this._forceOpen = false;

--- a/packages/main/test/pages/InputsLazyLoading.html
+++ b/packages/main/test/pages/InputsLazyLoading.html
@@ -66,6 +66,12 @@
     </ui5-input>
   </div>
 
+  <div class="demo-container">
+    <h1>Always show suggestions</h1>
+
+    <ui5-input id="field1" show-suggestions></ui5-input>
+  </div>
+
   <div class="devider"></div>
 
   <div class="demo-container">
@@ -177,6 +183,39 @@
 
       fillItems(data, document.getElementById("preload"), "ui5-suggestion-item");
     };
+
+    const field = document.getElementById("field1");
+    const fetchSuggestions = (el) => {
+      let timeout;
+      return new Promise((resolve) => {
+        if (!timeout) {
+          timeout = setTimeout(() => {
+            Array.from(field.children).forEach((c) => {
+              field.removeChild(c);
+            });
+
+            setTimeout(() => {
+              resolve(Array(el.value.length).fill("Suggestion Item"));
+              timeout = undefined;
+            }, 0);
+          }, 0);
+        }
+      });
+    };
+
+    const addSuggestions = (arr) => {
+      arr.forEach((item, i) => {
+        const el = document.createElement("ui5-input-suggestion");
+        el.innerText = `${item} ${i}`;
+        field.appendChild(el);
+      });
+    };
+
+    field.addEventListener("ui5-input", (event) => {
+      fetchSuggestions(event.target).then((value) => {
+         addSuggestions(value);
+      });
+    });
 
     enableLazyLoadingOnInput();
     enableFirsTypein();

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -1209,4 +1209,24 @@ describe("Lazy loading", () => {
 
 		assert.notOk(await respPopover.getProperty("opened"), "Picker should not be open");
 	});
+
+	it("Should not close picker when items are updated", async () => {
+		const input = await $("#field1");
+		const inner = await input.shadow$("input");
+		const staticAreaClassName = await browser.getStaticAreaItemClassName("#field1");
+		const respPopover = await $(`.${staticAreaClassName}`).shadow$("ui5-responsive-popover");
+
+		await inner.click();
+		await inner.keys("S");
+
+		
+		await browser.waitUntil(() => respPopover.getProperty("opened"), {
+			timeout: 2000,
+			timeoutMsg: "Popover should be displayed"
+		});
+
+		await inner.keys("b");
+
+		assert.strictEqual(await respPopover.getProperty("opened"), true, "Picker should not be open");
+	});
 });


### PR DESCRIPTION
If items are removed and update on input with a delay, the suggestions popover remains open while the items are loading.

FIXES: #5365 