### PR TITLE
chore: fix css-vars-usage-report on Windows

### DIFF
--- a/packages/theming/lib/generate-css-vars-usage-report/index.js
+++ b/packages/theming/lib/generate-css-vars-usage-report/index.js
@@ -16,8 +16,9 @@ const processFile = async file => {
 const generate = async () => {
 	const { globby } = await import("globby");
 
-	const mainFiles = await globby(path.join(__dirname, "../../../main/src/themes/**/*.css"));
-	const fioriFiles = await globby(path.join(__dirname, "../../../fiori/src/themes/**/*.css"));
+	const mainFiles = await globby(path.join(__dirname, "../../../main/src/themes/**/*.css").replace(/\\/g, "/"));
+	const fioriFiles = await globby(path.join(__dirname, "../../../fiori/src/themes/**/*.css").replace(/\\/g, "/"));
+
 	await Promise.all([...mainFiles.map(processFile), ...fioriFiles.map(processFile)]);
 
 	const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});


### PR DESCRIPTION
Glob pattern must contain only forward slashes, which is not the case on Windows. Related issue in globby - https://github.com/sindresorhus/globby/issues/179.

Fixes https://github.com/SAP/ui5-webcomponents/issues/5368
