### PR TITLE
feat(ui5-li): add wrappingType property

### DIFF
--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -2,6 +2,7 @@ import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import ListItem from "./ListItem.js";
 import Icon from "./Icon.js";
 import Avatar from "./Avatar.js";
+import WrappingType from "@ui5/webcomponents/dist/types/WrappingType.js";
 import StandardListItemTemplate from "./generated/templates/StandardListItemTemplate.lit.js";
 
 /**
@@ -96,6 +97,21 @@ const metadata = {
 		 */
 		accessibleName: {
 			type: String,
+		},
+
+		/**
+		 * Defines if the text of the component should wrap, they truncate by default.
+		 *
+		 * <br><br>
+		 * <b>Note:</b> this property takes affect only if text node is provided to default slot of the component
+		 * @type {WrappingType}
+		 * @defaultvalue "None"
+		 * @private
+		 * @since 1.5.0
+		 */
+		 wrappingType: {
+			type: WrappingType,
+			defaultValue: WrappingType.None,
 		},
 
 		/**

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -1,8 +1,8 @@
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
+import WrappingType from "@ui5/webcomponents-base/dist/types/WrappingType.js";
 import ListItem from "./ListItem.js";
 import Icon from "./Icon.js";
 import Avatar from "./Avatar.js";
-import WrappingType from "@ui5/webcomponents/dist/types/WrappingType.js";
 import StandardListItemTemplate from "./generated/templates/StandardListItemTemplate.lit.js";
 
 /**

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -106,11 +106,19 @@
 }
 
 .ui5-li-additional-text,
-.ui5-li-title,
+:host(:not([wrapping-type="Normal"])) .ui5-li-title,
 .ui5-li-desc {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+:host([wrapping-type="Normal"]) {
+	height: auto;
+}
+
+:host([wrapping-type="Normal"]) .ui5-li-content {
+	margin: var(--_ui5_list_item_content_vertical_offset) 0;
 }
 
 .ui5-li-desc {
@@ -157,9 +165,7 @@
 	display: flex;
 	align-items: center;
 	flex: auto;
-	white-space: nowrap;
 	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 .ui5-li-detailbtn,

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -52,6 +52,7 @@
 	--_ui5_list_item_icon_size: 1.125rem;
 	--_ui5_list_item_icon_padding-inline-end: 0.5rem;
 	--_ui5_list_item_selection_btn_margin_top: calc(-1 * var(--_ui5_checkbox_wrapper_padding));
+	--_ui5_list_item_content_vertical_offset: calc((var(--_ui5_list_item_base_height) - var(--_ui5_list_item_title_size)) / 2);
 	--_ui5_group_header_list_item_height: 2.75rem;
 	--_ui5_list_busy_row_height: 3rem;
 	--_ui5_month_picker_item_height: 3rem;
@@ -267,6 +268,7 @@
 	--_ui5_list_item_base_height: 2rem;
 	--_ui5_list_item_icon_size: 1rem;
 	--_ui5_list_item_selection_btn_margin_top: calc(-1 * var(--_ui5_checkbox_wrapper_padding));
+	--_ui5_list_item_content_vertical_offset: calc((var(--_ui5_list_item_base_height) - var(--_ui5_list_item_title_size)) / 2);
 	--_ui5_list_busy_row_height: 2rem;
 	--_ui5_list_buttons_left_space: 0.125rem;
 


### PR DESCRIPTION
Added new private wrappingType property which now is only for internal uses.

Currently it is implemented to support only the scenario where list item has only text.