### PR TITLE
feat(ui5-illustrated-message): implement size property

### DIFF
--- a/packages/fiori/src/IllustratedMessage.js
+++ b/packages/fiori/src/IllustratedMessage.js
@@ -187,7 +187,7 @@ const metadata = {
 		 * </ul>
 		 *
 		 * As <code>IllustratedMessage</code> adapts itself around the <code>Illustration</code>, the other
-		 * elements of the control are displayed differently on the different breakpoints/illustration sizes.
+		 * elements of the component are displayed differently on the different breakpoints/illustration sizes.
 		 *
 		 * @type {IllustrationMessageSize}
 		 * @defaultvalue "Auto"

--- a/packages/fiori/src/IllustratedMessage.js
+++ b/packages/fiori/src/IllustratedMessage.js
@@ -6,6 +6,7 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import IllustratedMessageTemplate from "./generated/templates/IllustratedMessageTemplate.lit.js";
+import IllustrationMessageSize from "./types/IllustrationMessageSize.js";
 import IllustrationMessageType from "./types/IllustrationMessageType.js";
 import "./illustrations/BeforeSearch.js";
 
@@ -173,6 +174,30 @@ const metadata = {
 			type: IllustrationMessageType,
 			defaultValue: IllustrationMessageType.BeforeSearch,
 		},
+		/**
+		 * Determines which illustration breakpoint variant is used.
+		 * <br><br>
+		 * Available options are:
+		 * <ul>
+		 * <li><code>Auto</code></li>
+		 * <li><code>Base</code></li>
+		 * <li><code>Spot</code></li>
+		 * <li><code>Dialog</code></li>
+		 * <li><code>Scene</code></li>
+		 * </ul>
+		 *
+		 * As <code>IllustratedMessage</code> adapts itself around the <code>Illustration</code>, the other
+		 * elements of the control are displayed differently on the different breakpoints/illustration sizes.
+		 *
+		 * @type {IllustrationMessageSize}
+		 * @defaultvalue "Auto"
+		 * @public
+		 * @since 1.5.0
+		 */
+		size: {
+			type: IllustrationMessageSize,
+			defaultValue: IllustrationMessageSize.Auto,
+		},
 	},
 	slots: /** @lends sap.ui.webcomponents.fiori.IllustratedMessage.prototype */ {
 		/**
@@ -316,6 +341,10 @@ class IllustratedMessage extends UI5Element {
 
 		this.illustrationTitle = IllustratedMessage.i18nBundle.getText(illustrationData.title);
 		this.illustrationSubtitle = IllustratedMessage.i18nBundle.getText(illustrationData.subtitle);
+
+		if (this.size !== IllustrationMessageSize.Auto) {
+			this._handleCustomSize();
+		}
 	}
 
 	onEnterDOM() {
@@ -327,6 +356,10 @@ class IllustratedMessage extends UI5Element {
 	}
 
 	handleResize() {
+		if (this.size !== IllustrationMessageSize.Auto) {
+			return;
+		}
+
 		if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.BASE) {
 			this.media = IllustratedMessage.MEDIA.BASE;
 		} else if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.SPOT) {
@@ -334,6 +367,28 @@ class IllustratedMessage extends UI5Element {
 		} else if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.DIALOG) {
 			this.media = IllustratedMessage.MEDIA.DIALOG;
 		} else {
+			this.media = IllustratedMessage.MEDIA.SCENE;
+		}
+	}
+
+	/**
+	 * Modifies the IM styles in accordance to the `size` property's value.
+	 * Note: The resize handler has no effect when size is different than "Auto".
+	 * @private
+	 * @since 1.5.0
+	 */
+	_handleCustomSize() {
+		switch (this.size) {
+		case IllustrationMessageSize.Base:
+			this.media = IllustratedMessage.MEDIA.BASE;
+			return;
+		case IllustrationMessageSize.Spot:
+			this.media = IllustratedMessage.MEDIA.SPOT;
+			return;
+		case IllustrationMessageSize.Dialog:
+			this.media = IllustratedMessage.MEDIA.DIALOG;
+			return;
+		default:
 			this.media = IllustratedMessage.MEDIA.SCENE;
 		}
 	}

--- a/packages/fiori/src/types/IllustrationMessageSize.js
+++ b/packages/fiori/src/types/IllustrationMessageSize.js
@@ -1,0 +1,66 @@
+import DataType from "@ui5/webcomponents-base/dist/types/DataType.js";
+
+/**
+ * Different types of IllustrationMessageSize.
+ * @lends sap.ui.webcomponents.fiori.types.IllustrationMessageSize.prototype
+ * @public
+ * @since 1.5.0
+ */
+const IllustrationMessageSizes = {
+	/**
+	 * Automatically decides the <code>Illustration</code> size (<code>Base</code>, <code>Spot</code>,
+	 * <code>Dialog</code>, or <code>Scene</code>) depending on the <code>IllustratedMessage</code> container width.
+	 *
+	 * <b>Note:</b> <code>Auto</code> is the only option where the illustration size is changed according to
+	 * the available container width. If any other <code>IllustratedMessageSize</code> is chosen, it remains
+	 * until changed by the app developer.
+	 *
+	 * @public
+	 */
+	Auto: "Auto",
+	/**
+	 * Base <code>Illustration</code> size (XS breakpoint). Suitable for cards (two columns).
+	 *
+	 * <b>Note:</b> When <code>Base</code> is in use, no illustration is displayed.
+	 *
+	 * @public
+	 */
+	Base: "Base",
+
+	/**
+	 * Spot <code>Illustration</code> size (S breakpoint). Suitable for cards (four columns).
+	 * @public
+	 */
+	Spot: "Spot",
+
+	/**
+	 * Dialog <code>Illustration</code> size (M breakpoint). Suitable for dialogs.
+	 * @public
+	 */
+	Dialog: "Dialog",
+
+	/**
+	 * Scene <code>Illustration</code> size (L breakpoint). Suitable for a <code>Page</code> or a table.
+	 * @public
+	 */
+	Scene: "Scene",
+};
+
+/**
+ * @class
+ * Different types of IllustrationMessageSize.
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.fiori.types.IllustrationMessageSize
+ * @public
+ * @enum {string}
+ */
+class IllustrationMessageSize extends DataType {
+	static isValid(value) {
+		return !!IllustrationMessageSizes[value];
+	}
+}
+
+IllustrationMessageSize.generateTypeAccessors(IllustrationMessageSizes);
+
+export default IllustrationMessageSize;

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -114,7 +114,7 @@
 		<ui5-option>dialog</ui5-option>
 		<ui5-option selected>scene</ui5-option>
 	</ui5-select>
-	<ui5-illustrated-message class="border">
+	<ui5-illustrated-message id="illustratedMsg1" class="border">
 		<ui5-button>Action 1</ui5-button>
 	</ui5-illustrated-message>
 
@@ -127,7 +127,7 @@
 		</ui5-bar>
 	</ui5-dialog>
 
-	<ui5-illustrated-message name="UnableToUpload" title="Something went wrong...">
+	<ui5-illustrated-message id="illustratedMsg2" name="UnableToUpload" title="Something went wrong...">
 		<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
 		<ui5-button icon="refresh">Try again</ui5-button>
 	</ui5-illustrated-message>

--- a/packages/fiori/test/specs/IllustratedMessage.spec.js
+++ b/packages/fiori/test/specs/IllustratedMessage.spec.js
@@ -1,0 +1,30 @@
+const assert = require("chai").assert;
+
+describe("IllustratedMessage 'size' property", () => {
+	before(async () => {
+		await browser.url(`test/pages/IllustratedMessage.html`);
+	});
+
+	it("should return correct size", async () => {
+		// Arrange
+		const illustratedMsg = await browser.$("#illustratedMsg2");
+		let illustratedMsgSize = await illustratedMsg.getProperty("size");
+
+		// Assert
+		assert.strictEqual(illustratedMsgSize, "Auto", "'size' should be equal to 'Auto' by default");
+
+		// Act
+		await illustratedMsg.setProperty("size", "Base");
+		illustratedMsgSize = await illustratedMsg.getProperty("size");
+
+		// Assert
+		assert.strictEqual(illustratedMsgSize, "Base", "'size' should be equal to 'Base'");
+
+		// Act
+		await illustratedMsg.setProperty("size", "Invalid");
+		illustratedMsgSize = await illustratedMsg.getProperty("size");
+
+		// Assert
+		assert.strictEqual(illustratedMsgSize, "Auto", "'size' should be equal to 'Auto' when invalid value is passed");
+	});
+});


### PR DESCRIPTION
A new `size` property for IllustratedMessage has been implemented.
It determines which illustration breakpoint variant is used.

Available options are:
- `Auto` (default) - Automatically decides the size depending on the component width.
- `Base` (XS breakpoint) - Suitable for cards (two columns).
- `Spot` (S breakpoint) - Suitable for cards (four columns).
- `Dialog` (M breakpoint) - Suitable for dialogs.
- `Scene` (L breakpoint) - Suitable for a `Page` or a table.

Resolves #5221