### PR TITLE
fix(framework): correct use of arrow keys for ItemNavigation in RTL

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.js
+++ b/packages/base/src/delegate/ItemNavigation.js
@@ -133,15 +133,20 @@ class ItemNavigation {
 
 		const horizontalNavigationOn = this._navigationMode === NavigationMode.Horizontal || this._navigationMode === NavigationMode.Auto;
 		const verticalNavigationOn = this._navigationMode === NavigationMode.Vertical || this._navigationMode === NavigationMode.Auto;
+		const isRTL = this.rootWebComponent.effectiveDir === "rtl";
 
-		if (isUp(event) && verticalNavigationOn) {
-			this._handleUp();
-		} else if (isDown(event) && verticalNavigationOn) {
-			this._handleDown();
+		if (isRTL && isLeft(event) && horizontalNavigationOn) {
+			this._handleRight();
+		} else if (isRTL && isRight(event) && horizontalNavigationOn) {
+			this._handleLeft();
 		} else if (isLeft(event) && horizontalNavigationOn) {
 			this._handleLeft();
 		} else if (isRight(event) && horizontalNavigationOn) {
 			this._handleRight();
+		} else if (isUp(event) && verticalNavigationOn) {
+			this._handleUp();
+		} else if (isDown(event) && verticalNavigationOn) {
+			this._handleDown();
 		} else if (isHome(event)) {
 			this._handleHome();
 		} else if (isEnd(event)) {

--- a/packages/main/test/pages/ItemNavigation.html
+++ b/packages/main/test/pages/ItemNavigation.html
@@ -2,18 +2,20 @@
 <html>
 <head>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>Item Navigation</title>
 
-
 	<script src="../../bundle.esm.js" type="module"></script>
-
-
 <link rel="stylesheet" type="text/css" href="./styles/ItemNavigation.css">
 </head>
 
 <body class="itemnavigation1auto">
+	<div>
+		<ui5-label>Manually switch RTL:</ui5-label>
+		<ui5-switch id="sw"></ui5-switch>
+	</div>
+
 	<h2>Focus does not cycle</h2>
 	<ui5-list>
 		<ui5-li id="item1">Option 1</ui5-li>
@@ -26,6 +28,13 @@
 		<ui5-li id="item4">Option 2.2</ui5-li>
 		<ui5-li id="item5">Option 2.3</ui5-li>
 	</ui5-list>
+
+	<h2>Horizontal navigation only</h2>
+	<ui5-breadcrumbs id="horizontalNavigation">
+		<ui5-breadcrumbs-item>First</ui5-breadcrumbs-item>
+		<ui5-breadcrumbs-item>Second</ui5-breadcrumbs-item>
+		<ui5-breadcrumbs-item>Third</ui5-breadcrumbs-item>
+	</ui5-breadcrumbs>
 
 	<h1>Test PAGE UP/DOWN</h1>
 	<br><br>
@@ -64,5 +73,21 @@
 		<ui5-li>29</ui5-li>
 		<ui5-li>30</ui5-li>
 	</ui5-list>
+
+	<script>
+		// Utility function to change RTL and apply the changes
+		function setDir(dir) {
+			document.body.dir = dir;
+			window['sap-ui-webcomponents-bundle'].applyDirection();
+		}
+
+		document.getElementById("sw").addEventListener("ui5-change", (e) => {
+			if (e.target.checked) {
+				setDir("rtl");
+			} else {
+				setDir("ltr");
+			}
+		});
+	</script>
 </body>
 </html>

--- a/packages/main/test/pages/ItemNavigation.html
+++ b/packages/main/test/pages/ItemNavigation.html
@@ -12,7 +12,7 @@
 
 <body class="itemnavigation1auto">
 	<div>
-		<ui5-label>Manually switch RTL:</ui5-label>
+		<ui5-label show-colon>Manually switch RTL</ui5-label>
 		<ui5-switch id="sw"></ui5-switch>
 	</div>
 

--- a/packages/main/test/pages/ItemNavigation.html
+++ b/packages/main/test/pages/ItemNavigation.html
@@ -30,11 +30,11 @@
 	</ui5-list>
 
 	<h2>Horizontal navigation only</h2>
-	<ui5-breadcrumbs id="horizontalNavigation">
-		<ui5-breadcrumbs-item>First</ui5-breadcrumbs-item>
-		<ui5-breadcrumbs-item>Second</ui5-breadcrumbs-item>
-		<ui5-breadcrumbs-item>Third</ui5-breadcrumbs-item>
-	</ui5-breadcrumbs>
+	<ui5-avatar-group type="Individual" id="horizontalNavigation">
+		<ui5-avatar size="S" initials="A"></ui5-avatar>
+		<ui5-avatar size="S" initials="B"></ui5-avatar>
+		<ui5-avatar size="S" initials="C"></ui5-avatar>
+	</ui5-avatar-group>
 
 	<h1>Test PAGE UP/DOWN</h1>
 	<br><br>

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -5,37 +5,6 @@ describe("Item Navigation Tests", () => {
 		await browser.url(`test/pages/ItemNavigation.html`);
 	});
 
-	it("tests left and right arrow keys in LTR", async () => {
-		// Setup
-		const items = await browser.$$("#horizontalNavigation ui5-breadcrumbs-item");
-		await items[0].focus();
-
-		// Act
-		await browser.keys("ArrowRight");
-		await browser.keys("ArrowRight");
-
-		// Assert
-		assert.strictEqual(await items[2].isFocused(), true, "third item is focused");
-	});
-
-	it("tests left and right arrow keys in RTL", async () => {
-		// Setup
-		const switchEl = await browser.$("#sw");
-		await switchEl.click();
-		const items = await browser.$$("#horizontalNavigation ui5-breadcrumbs-item");
-		await items[0].focus();
-
-		// Act
-		await browser.keys("ArrowLeft");
-		await browser.keys("ArrowLeft");
-
-		// Assert
-		assert.strictEqual(await items[2].isFocused(), true, "third item is focused");
-
-		// Clean-up
-		await switchEl.click();
-	});
-
 	it("focus does not cycle", async () => {
 		const firstItem = await browser.$("#item1");
 		const secondItem = await browser.$("#item2");
@@ -96,5 +65,50 @@ describe("Item Navigation Tests", () => {
 		await itemOnFocus2.click();
 		await itemOnFocus2.keys("PageUp");
 		assert.ok(await nextFocusedItem2.isFocused(), "The 6th is focused.");
+	});
+
+	it("tests left and right arrow keys in LTR", async () => {
+		// Setup
+		const items = await browser.$$("#horizontalNavigation ui5-avatar"),
+			first = items[0],
+			third = items[2];
+
+		await first.click();
+
+		// Assert
+		assert.strictEqual(await first.isFocused(), true, "first item is focused");
+
+		// Act
+		await browser.keys("ArrowRight");
+		await browser.keys("ArrowRight");
+
+		// Assert
+		assert.strictEqual(await third.isFocused(), true, "third item is focused");
+		
+	});
+	
+
+	it("tests left and right arrow keys in RTL", async () => {
+		// Setup
+		const switchEl = await browser.$("#sw");
+		await switchEl.click();
+
+		const items = await browser.$$("#horizontalNavigation ui5-avatar"),
+			first = items[0],
+			third = items[2];
+
+		await first.click();
+
+		// Assert
+		assert.strictEqual(await first.isFocused(), true, "first item is focused");
+
+		// Act
+		await browser.keys("ArrowLeft");
+		await browser.keys("ArrowLeft");
+
+		// Assert
+		assert.strictEqual(await third.isFocused(), true, "third item is focused");
+
+		// Clean-up
 	});
 });

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -110,5 +110,6 @@ describe("Item Navigation Tests", () => {
 		assert.strictEqual(await third.isFocused(), true, "third item is focused");
 
 		// Clean-up
+		await switchEl.click();
 	});
 });

--- a/packages/main/test/specs/ItemNavigation.spec.js
+++ b/packages/main/test/specs/ItemNavigation.spec.js
@@ -5,6 +5,37 @@ describe("Item Navigation Tests", () => {
 		await browser.url(`test/pages/ItemNavigation.html`);
 	});
 
+	it("tests left and right arrow keys in LTR", async () => {
+		// Setup
+		const items = await browser.$$("#horizontalNavigation ui5-breadcrumbs-item");
+		await items[0].focus();
+
+		// Act
+		await browser.keys("ArrowRight");
+		await browser.keys("ArrowRight");
+
+		// Assert
+		assert.strictEqual(await items[2].isFocused(), true, "third item is focused");
+	});
+
+	it("tests left and right arrow keys in RTL", async () => {
+		// Setup
+		const switchEl = await browser.$("#sw");
+		await switchEl.click();
+		const items = await browser.$$("#horizontalNavigation ui5-breadcrumbs-item");
+		await items[0].focus();
+
+		// Act
+		await browser.keys("ArrowLeft");
+		await browser.keys("ArrowLeft");
+
+		// Assert
+		assert.strictEqual(await items[2].isFocused(), true, "third item is focused");
+
+		// Clean-up
+		await switchEl.click();
+	});
+
 	it("focus does not cycle", async () => {
 		const firstItem = await browser.$("#item1");
 		const secondItem = await browser.$("#item2");


### PR DESCRIPTION
In RTL, the left and right arrow keys now correctly move the focus for
horizontally navigable items in the absolute direction of Left/Right.

Fixes: #5166