### PR TITLE
feat(ui5-avatar): introduce badge support

### DIFF
--- a/packages/main/src/Avatar.hbs
+++ b/packages/main/src/Avatar.hbs
@@ -17,4 +17,6 @@
 	{{else if initials}}
 		<span class="ui5-avatar-initials">{{validInitials}}</span>
 	{{/if}}
+
+	<slot name="badge"></slot>
 </div>

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -208,6 +208,34 @@ const metadata = {
 			propertyName: "image",
 			type: HTMLElement,
 		},
+		/**
+		 * Defines the optional badge that will be used for visual affordance.
+		 * <b>Note:</b> While the slot allows for custom badges, to achieve
+		 * the Fiori design, please use <code>ui5-badge</code> with <code>ui5-icon</code>
+		 * in the corresponding <code>icon</code> slot, without text nodes.
+		 * <br><br>
+		 * Example:
+		 * <br><br>
+		 * &lt;ui5-avatar><br>
+		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-badge slot="badge"><br>
+		 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-icon slot="icon" name="employee">&lt;/ui5-icon><br>
+		 * &nbsp;&nbsp;&nbsp;&nbsp&lt;/ui5-badge><br>
+		 * &lt;/ui5-avatar>
+		 * <br><br>
+		 * <ui5-avatar initials="AB" color-scheme="Accent1">
+		 * <ui5-badge slot="badge">
+		 * <ui5-icon slot="icon" name="accelerated"></ui5-icon>
+		 * </ui5-badge>
+		 * </ui5-avatar>
+		 *
+		 * @type {HTMLElement}
+		 * @slot badge
+		 * @public
+		 * @since 1.7.0
+		 */
+		badge: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Avatar.prototype */ {
 		/**

--- a/packages/main/src/Badge.js
+++ b/packages/main/src/Badge.js
@@ -99,7 +99,6 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Badge
  * @extends sap.ui.webcomponents.base.UI5Element
- * @implements sap.ui.webcomponents.IBadge
  * @tagname ui5-badge
  * @since 0.12.0
  * @public

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -8,16 +8,6 @@
 const IAvatar = "sap.ui.webcomponents.main.IAvatar";
 
 /**
- * Interface for components that represent a badge,
- * and as such may be optionally slotted inside other components.
- *
- * @name sap.ui.webcomponents.main.IBadge
- * @interface
- * @public
- */
-const IBadge = "sap.ui.webcomponents.main.IBadge";
-
-/**
  * Interface for components that may be slotted inside <code>ui5-breadcrumbs</code> as options
  *
  * @name sap.ui.webcomponents.main.IBreadcrumbsItem
@@ -191,7 +181,6 @@ const ITreeItem = "sap.ui.webcomponents.main.ITreeItem";
 export {
 	IAvatar,
 	IBreadcrumbsItem,
-	IBadge,
 	IButton,
 	ICalendarDate,
 	IColorPaletteItem,

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -1,6 +1,7 @@
 :host(:not([hidden])) {
 	display: inline-block;
 	box-sizing: border-box;
+	position: relative;
 }
 
 /*The ui5_hovered class is set by FileUploader to indicate hover state of the control*/
@@ -210,4 +211,54 @@
 
 .ui5-avatar-initials {
 	color: inherit;
+}
+
+/* Slotted Badge */
+::slotted([slot="badge"]) {
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	width: 1.125rem;
+	height: 1.125rem;
+	background: var(--sapButton_Emphasized_Background);
+	border: var(--sapButton_Emphasized_Background);
+	border-radius: 1rem;
+	color: var(--sapContent_BadgeTextColor);
+	justify-content: center;
+	font-family: "72override", var(--sapFontFamily);
+	font-size: var(--sapFontSmallSize);
+}
+
+::slotted([ui5-badge][slot="badge"]) {
+	padding: 0.1875rem;
+}
+
+:host([_size="L"]) ::slotted([slot="badge"]),
+:host([size="L"]) ::slotted([slot="badge"]) {
+	width: 1.25rem;
+	height: 1.25rem;
+}
+
+:host([_size="XL"]) ::slotted([slot="badge"]),
+:host([size="XL"]) ::slotted([slot="badge"]) {
+	padding: 0.375rem;
+	width: 1.75rem;
+	height: 1.75rem;
+}
+
+:host([shape="Square"]) ::slotted([slot="badge"]) {
+	bottom: -0.125rem;
+	right: -0.125rem;
+}
+
+:host([_size="L"][shape="Square"]) ::slotted([slot="badge"]),
+:host([size="L"][shape="Square"]) ::slotted([slot="badge"]) {
+	bottom: -0.1875rem;
+	right: -0.1875rem;
+}
+
+:host([_size="XL"][shape="Square"]) ::slotted([slot="badge"]),
+:host([size="XL"][shape="Square"]) ::slotted([slot="badge"]) {
+	bottom: -0.25rem;
+	right: -0.25rem;
 }

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -132,3 +132,15 @@
 	border-color: var(--ui5-badge-color-scheme-10-border);
 	color: var(--ui5-badge-color-scheme-10-color);
 }
+
+/* ---Slotted Badges--- */
+/* ui5-avatar - Badge icon styles */
+/* Make icon take full width minus padding.
+ ui5-avatar is the only component using an icon for badge,
+ therefore no additional scoping is needed. */
+:host([slot="badge"]) ::slotted([ui5-icon][slot="icon"]) {
+	width: 100%;
+	height: 100%;
+	min-width: 100%;
+	min-height: 100%;
+}

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -163,6 +163,58 @@
 		<ui5-input id="click-event-2"></ui5-input>
 	</section>
 
+	<section>
+		<h3>Avatar - Visual affordance</h3>
+		<ui5-avatar initials="AB" color-scheme="Accent1">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="accelerated"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+
+		<ui5-avatar interactive size="L" initials="CD" color-scheme="Accent2">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="accept"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+	
+		<ui5-avatar size="XL">
+			<img src="./img/John_Miller.png" alt="John Miller">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="bar-chart"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+
+		<br>
+
+		<ui5-avatar shape="Square" size="XS" initials="EF" color-scheme="Accent3">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="filter"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+
+		<ui5-avatar interactive shape="Square" initials="GH" color-scheme="Accent4">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="add-employee"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+	
+		<ui5-avatar shape="Square" size="L">
+			<img src="./img/John_Miller.png" alt="John Miller">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="document"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+		<br><br>
+	</section>
+
+	<section>
+		<h3>Avatar - Custom visual affordance</h3>
+		<ui5-avatar initials="AB" color-scheme="Accent1">
+			<span slot="badge" class="custom-badge">1</span>
+		</ui5-avatar>
+		<br><br>
+	</section>
+
 	<script>
 		var avatar = document.getElementById("interactive-avatar"),
 			myInteractiveAvatar = document.getElementById("myInteractiveAvatar"),

--- a/packages/main/test/pages/styles/Avatar.css
+++ b/packages/main/test/pages/styles/Avatar.css
@@ -31,3 +31,10 @@
 .avatar5auto {
     object-fit: contain;
 }
+
+.custom-badge {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgb(255, 0, 0);
+}

--- a/packages/main/test/samples/Avatar.sample.html
+++ b/packages/main/test/samples/Avatar.sample.html
@@ -9,6 +9,13 @@
 	ui5-avatar:not(:defined) {
 		visibility: hidden;
 	}
+
+	.custom-badge {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background-color: rgb(255, 0, 0);
+	}
 </style>
 
 <div class="component-package">@ui5/webcomponents</div>
@@ -157,6 +164,64 @@
 </ui5-avatar>
 <ui5-avatar id="myCustomAvatar1" shape="Square" size="XL" style="width: 250px; height: 250px; border: 1px solid var(--sapField_BorderColor)">
 	<img src="../../../assets/images/avatars/Lamp_avatar_01.jpg" alt="Lamp" style="object-fit: contain">
+</ui5-avatar>
+</xmp></pre>
+</section>
+
+<section>
+	<h4>Avatar with Visual Affordance</h4>
+	<div class="snippet">
+		<ui5-avatar shape="Circle">
+			<img src="../../../assets/images/avatars/woman_avatar_3.png" alt="Woman 3">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="filter"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+		<ui5-avatar initials="AB" size="L" shape="Circle">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="document"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+		<ui5-avatar shape="Square">
+			<img src="../../../assets/images/avatars/woman_avatar_4.png" alt="Woman 4">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="accept"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+		<ui5-avatar initials="CD" size="L" shape="Square">
+			<ui5-badge slot="badge">
+				<ui5-icon slot="icon" name="employee"></ui5-icon>
+			</ui5-badge>
+		</ui5-avatar>
+		<ui5-avatar initials="AB" color-scheme="Accent1">
+			<span slot="badge" class="custom-badge">1</span>
+		</ui5-avatar>
+	</div>
+<pre class="prettyprint lang-html"><xmp>
+<ui5-avatar shape="Circle">
+	<img src="../../../assets/images/avatars/woman_avatar_3.png" alt="Woman 3">
+	<ui5-badge slot="badge">
+		<ui5-icon slot="icon" name="filter"></ui5-icon>
+	</ui5-badge>
+</ui5-avatar>
+<ui5-avatar initials="AB" size="L" shape="Circle">
+	<ui5-badge slot="badge">
+		<ui5-icon slot="icon" name="document"></ui5-icon>
+	</ui5-badge>
+</ui5-avatar>
+<ui5-avatar shape="Square">
+	<img src="../../../assets/images/avatars/woman_avatar_4.png" alt="Woman 4">
+	<ui5-badge slot="badge">
+		<ui5-icon slot="icon" name="accept"></ui5-icon>
+	</ui5-badge>
+</ui5-avatar>
+<ui5-avatar initials="CD" size="L" shape="Square">
+	<ui5-badge slot="badge">
+		<ui5-icon slot="icon" name="employee"></ui5-icon>
+	</ui5-badge>
+</ui5-avatar>
+<ui5-avatar initials="AB" color-scheme="Accent1">
+	<span slot="badge" class="custom-badge">1</span>
 </ui5-avatar>
 </xmp></pre>
 </section>

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -8,7 +8,7 @@ describe("Avatar", () => {
 
 	it("tests rendering of image", async () => {
 		const avatar = await browser.$("#myAvatar1");
-		const image = await avatar.shadow$("slot");
+		const image = await avatar.shadow$('slot:not([name="badge"])');
 		const icon = await avatar.shadow$("ui5-avatar-icon");
 
 		// img tag is rendered, ui5-icon - not
@@ -18,7 +18,7 @@ describe("Avatar", () => {
 
 	it("tests rendering of icon", async () => {
 		const avatar = await browser.$("#myAvatar2");
-		const image = await avatar.shadow$("slot");
+		const image = await avatar.shadow$('slot:not([name="badge"])');
 		const icon = await avatar.shadow$(".ui5-avatar-icon");
 
 		// ui5-icon tag is rendered, img - not
@@ -28,7 +28,7 @@ describe("Avatar", () => {
 
 	it("tests rendering of image, when all set", async () => {
 		const avatar = await browser.$("#myAvatar3");
-		const image = await avatar.shadow$("slot");
+		const image = await avatar.shadow$('slot:not([name="badge"])');
 		const icon = await avatar.shadow$(".ui5-avatar-icon");
 		const initials = await avatar.shadow$(".ui5-avatar-initials");
 


### PR DESCRIPTION
The Avatar now supports visual affordance using a new `badge` slot:

```js
<ui5-avatar initials="AB" color-scheme="Accent1">
	<ui5-badge slot="badge">
		<ui5-icon slot="icon" name="accelerated"></ui5-icon>
	</ui5-badge>
</ui5-avatar>
```

**Note:** To achieve the target design, please use only `ui5-icon` in the corresponding slot of `ui5-badge`, without text nodes.

The `IBadge` interface has been removed as it limits the scope of slottable elements and causes issues in the enablement context.

Related to https://github.com/SAP/ui5-webcomponents/issues/4624