### PR TITLE
fix(f6navigation): prevent default behavior on windows OS

### DIFF
--- a/packages/base/src/features/F6Navigation.js
+++ b/packages/base/src/features/F6Navigation.js
@@ -21,6 +21,8 @@ class F6Navigation {
 				return;
 			}
 
+			event.preventDefault();
+
 			const nextIndex = this.groups.indexOf(this.selectedGroup);
 			let nextElement = null;
 
@@ -43,6 +45,8 @@ class F6Navigation {
 			if (this.groups.length < 1) {
 				return;
 			}
+
+			event.preventDefault();
 
 			const nextIndex = this.groups.indexOf(this.selectedGroup);
 			let nextElement = null;

--- a/packages/fiori/test/pages/F6TestPage.html
+++ b/packages/fiori/test/pages/F6TestPage.html
@@ -35,6 +35,11 @@
 		<ui5-button>3</ui5-button>
 		<ui5-button>4</ui5-button>
 	</div>
+	<div>
+		Ensure that typing inside ui5-input works when F6 navigation is enabled
+		<br />
+		<ui5-input id="testInput"></ui5-input>
+	</div>
 	<ui5-panel id="panel-expandable" accessible-role="Complementary" header-text="Both expandable and expanded"
 		header-level="H4">
 		<!-- Content -->


### PR DESCRIPTION
Prevent default browser behaviour only when all conditions for F6 navigation next / back are meet.

Fixes: #5339