### PR TITLE
fix(ui5-popover): avoid dangling aria-labelledby attribute

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -778,7 +778,11 @@ class Popover extends Popup {
 	}
 
 	get _ariaLabelledBy() { // Required by Popup.js
-		return this._ariaLabel ? undefined : "ui5-popup-header";
+		if (!this._ariaLabel && this._displayHeader) {
+			return "ui5-popup-header"
+		}
+
+		return undefined;
 	}
 
 	get _ariaModal() { // Required by Popup.js

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -779,7 +779,7 @@ class Popover extends Popup {
 
 	get _ariaLabelledBy() { // Required by Popup.js
 		if (!this._ariaLabel && this._displayHeader) {
-			return "ui5-popup-header"
+			return "ui5-popup-header";
 		}
 
 		return undefined;

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -354,7 +354,7 @@ describe("Acc", () => {
 		assert.strictEqual(await popover.shadow$(".ui5-popup-root").getAttribute("aria-label"), expectedText, "aria-label should be the text of the label.");
 	});
 
-	it("test that aria-labelledby is not set when there is no header and no accessible-name-ref", async () => {
+	it("tests that aria-labelledby is not set when there is no header and no accessible-name-ref", async () => {
 		const popoverWithoutHeader = await browser.$("#popoverAttr");
 
 		assert.isNull(await popoverWithoutHeader.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "Popover should NOT have aria-labelledby set.");

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -353,4 +353,10 @@ describe("Acc", () => {
 
 		assert.strictEqual(await popover.shadow$(".ui5-popup-root").getAttribute("aria-label"), expectedText, "aria-label should be the text of the label.");
 	});
+
+	it("test that aria-labelledby is not set when there is no header and no accessible-name-ref", async () => {
+		const popoverWithoutHeader = await browser.$("#popoverAttr");
+
+		assert.isNull(await popoverWithoutHeader.shadow$(".ui5-popup-root").getAttribute("aria-labelledby"), "Popover should NOT have aria-labelledby set.");
+	});
 });


### PR DESCRIPTION
Part of #3956
