### PR TITLE
chore: fix event metadata

### DIFF
--- a/packages/fiori/src/DynamicSideContent.js
+++ b/packages/fiori/src/DynamicSideContent.js
@@ -209,7 +209,7 @@ const metadata = {
 		 * @public
 		 */
 		"layout-change": {
-			details: {
+			detail: {
 				currentBreakpoint: {
 					type: String,
 				},

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -119,7 +119,7 @@ const metadata = {
 		 * @param {string} color the selected color
 		 */
 		"item-click": {
-			details: {
+			detail: {
 				color: {
 					type: String,
 				},

--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -87,7 +87,7 @@ const metadata = {
 		 * @param {string} color the selected color
 		 */
 		"item-click": {
-			details: {
+			detail: {
 				color: {
 					type: String,
 				},

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -248,7 +248,7 @@ const metadata = {
 		 * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 		*/
 		change: {
-			details: {
+			detail: {
 				value: {
 					type: String,
 				},
@@ -268,7 +268,7 @@ const metadata = {
 		 * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 		*/
 		input: {
-			details: {
+			detail: {
 				value: {
 					type: String,
 				},


### PR DESCRIPTION
It should be event.detail by spec -> https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail.

Luckily, it's not a breaking change as the framework properly fires the event and assigns the data on the "detail" object.
Also, the "details" does not show up in the API reference.