### PR TITLE
fix(InvisibleMessage): clear announcement after a while

### DIFF
--- a/packages/base/src/util/InvisibleMessage.js
+++ b/packages/base/src/util/InvisibleMessage.js
@@ -55,6 +55,14 @@ const announce = (message, mode) => {
 	if (mode !== InvisibleMessageMode.Assertive && mode !== InvisibleMessageMode.Polite) {
 		console.warn(`You have entered an invalid mode. Valid values are: "Polite" and "Assertive". The framework will automatically set the mode to "Polite".`); // eslint-disable-line
 	}
+
+	// clear the span in order to avoid reading it out while in JAWS reading node
+	setTimeout(() => {
+		// ensure that we clear the text node only if no announce is made in the meantime
+		if (span.textContent === message) {
+			span.textContent = "";
+		}
+	}, 3000);
 };
 
 export default announce;

--- a/packages/main/test/specs/base/InvisibleMessage.spec.js
+++ b/packages/main/test/specs/base/InvisibleMessage.spec.js
@@ -25,9 +25,17 @@ describe("InvisibleMessage", () => {
         await checkBox.click();
         await button.click();
 
-        const politeSpanHtml = await politeSpan.getHTML();
-        const assertiveSpanHtml = await assertiveSpan.getHTML();
+        let politeSpanHtml = await politeSpan.getHTML();
+        let assertiveSpanHtml = await assertiveSpan.getHTML();
         assert.include(politeSpanHtml, "announcement", "Value has been rendered.");
         assert.include(assertiveSpanHtml, "announcement", "Value has been rendered.");
+
+        await browser.pause(3000);
+
+        politeSpanHtml = await politeSpan.getHTML();
+        assertiveSpanHtml = await assertiveSpan.getHTML();
+
+        assert.notInclude(politeSpanHtml, "announcement", "Value should be cleared.");
+        assert.notInclude(assertiveSpanHtml, "announcement", "Value should be cleared.");
     });
 });


### PR DESCRIPTION
In order to avoid reading the span content of the Invisible Message when the Screen Reader is in reading mode, we should clear the span content after a while. Also, we check if there is a new announcement call in order to avoid clearing
the span before the announcement is made.

Related to: #5285 
