### PR TITLE
fix(ui5-combobox): correctly fire change event on item press

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -934,6 +934,7 @@ class ComboBox extends UI5Element {
 		const sameSelectionPerformed = this.value.toLowerCase() === this.filterValue.toLowerCase();
 
 		if (sameItemSelected && sameSelectionPerformed) {
+			this._fireChangeEvent(); // Click on an already typed, but not memoized value shouold also trigger the change event
 			return this._closeRespPopover();
 		}
 

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -283,6 +283,30 @@ describe("General interaction", () => {
 
 	});
 
+	it("should fire change event after the user has typed in value, but also selects it from the popover", async () => {
+        await browser.url(`test/pages/ComboBox.html`);
+
+		// Setup
+		const changeValue = await browser.$("#change-placeholder");
+        const counter = await browser.$("#change-count");
+        const combo = await browser.$("#change-cb");
+		const input = await combo.shadow$("[inner-input]");
+
+
+		// Type something which is in the list
+		await input.click();
+		await input.keys("Bulgaria");
+
+		// Click on the item
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#change-cb");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		await (await popover.$("ui5-list").$$("ui5-li")[0]).click();
+
+
+		assert.strictEqual(await counter.getText(), "1", "Call count should be 1");
+		assert.strictEqual(await changeValue.getText(), "Bulgaria", "The value should be changed accordingly");
+    });
+
 	it ("Value should be reset on ESC key", async () => {
 		await browser.url(`test/pages/ComboBox.html`);
 


### PR DESCRIPTION
There's a case when the user types the full value of some of the items, without any differences, but then clicks on the item itself in the list.
By now, this didn't fire change event as the item selection had its own handler for events. It checks with the value of the input whether it differs from the value of the item. If they differ, then fires a change event. However, in that edge case, this is a false positive and we need to take it into account.

Fixes #5432 
