### PR TITLE
chore: fix local playground start

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "start:all": "npm-run-all --parallel watch:base watch:localization watch:main watch:fiori dev",
     "dev": "node packages/tools/lib/dev-server/dev-server.js",
     "scopeStart:all": "npm-run-all --parallel watch:base watch:localization scopeWatch:main scopeWatch:fiori dev",
-    "start:playground": "yarn build:theming && yarn build:main && yarn build:fiori && yarn copy-css && yarn workspace @ui5/webcomponents-playground start",
+    "start:playground": "yarn build:prerequisites && yarn build:main && yarn build:fiori && yarn copy-css && yarn workspace @ui5/webcomponents-playground start",
     "test:base": "yarn workspace @ui5/webcomponents-base test",
     "test:main": "yarn workspace @ui5/webcomponents test",
     "test:main:suite-1": "yarn workspace @ui5/webcomponents test:suite-1",


### PR DESCRIPTION
run build:prerequisites as quite a lot of projects are not built after a clean