### PR TITLE
fix(ui5-title): use correct font-family for Horizon Themes

### DIFF
--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -7,7 +7,7 @@
 	max-width: 100%;
 	color: var(--sapGroup_TitleTextColor);
 	font-size: var(--sapFontHeader2Size);
-	font-family: "72override", var(--sapFontFamily);
+	font-family: var(--sapFontHeaderFamily);
 	text-shadow: var(--sapContent_TextShadow);
 }
 

--- a/packages/main/src/themes/Title.css
+++ b/packages/main/src/themes/Title.css
@@ -7,7 +7,7 @@
 	max-width: 100%;
 	color: var(--sapGroup_TitleTextColor);
 	font-size: var(--sapFontHeader2Size);
-	font-family: var(--sapFontHeaderFamily);
+	font-family: "72override", var(--sapFontHeaderFamily);
 	text-shadow: var(--sapContent_TextShadow);
 }
 


### PR DESCRIPTION
SAPUI5 is using the bold font family for rendering Titles in the Horizon Themes. I think it would be better to use the `sapFontHeaderFamily` variable.

Compare to: https://ui5.sap.com/#/entity/sap.m.Title/sample/sap.m.sample.TitleWrapping
