### PR TITLE
fix(ui5-date-picker): adjust value help icon role

### DIFF
--- a/packages/main/src/DatePicker.hbs
+++ b/packages/main/src/DatePicker.hbs
@@ -31,6 +31,8 @@
 				name="{{openIconName}}"
 				tabindex="-1"
 				accessible-name="{{openIconTitle}}"
+				interactive="true"
+				aria-hidden="{{_ariaHidden}}"
 				show-tooltip
 				@click="{{togglePicker}}"
 				input-icon

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -705,6 +705,14 @@ class DatePicker extends DateComponentBase {
 		return false;
 	}
 
+	/**
+	 * Defines whether the value help icon is hidden
+	 * @private
+	 */
+	 get _ariaHidden() {
+		return (!this.phone).toString();
+	}
+
 	async _respPopover() {
 		const staticAreaItem = await this.getStaticAreaItemDomRef();
 		return staticAreaItem.querySelector("[ui5-responsive-popover]");


### PR DESCRIPTION
The ui5-date-picker value help icon is now decorative.

Fixes: #5378
