### PR TITLE
docs(ui5-option): update disabled documentation

### DIFF
--- a/packages/main/src/Option.js
+++ b/packages/main/src/Option.js
@@ -21,7 +21,7 @@ const metadata = {
 		/**
 		 * Defines whether the component is in disabled state.
 		 * <br><br>
-		 * <b>Note:</b> A disabled component is noninteractive.
+		 * <b>Note:</b> A disabled component is hidden.
 		 * @type {boolean}
 		 * @defaultvalue false
 		 * @public


### PR DESCRIPTION
According to https://experience.sap.com/fiori-design-web/select/#option-list1, Select options are supposed to be completely hidden when disabled. 
This is why `disabled` hides options instead of altering their appearance.

Related to #5459