### PR TITLE
fix(ui5-date-picker): adjust background color

### DIFF
--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -14,7 +14,7 @@
 	border-radius: var(--_ui5-datepicker_border_radius);
 }
 
-:host([value-state="Error"]) {
+:host([value-state="Error"]):not([disabled]):not([readonly]) {
 	background-color: var(--sapField_InvalidBackground);
 }
 


### PR DESCRIPTION
- The background color is now adjusted when the
component is disabled or readonly and the value
state is set to "Error".

Fixes: #5396