### PR TITLE
feat(InvisibleMessage): make it available for application usage

### DIFF
--- a/docs/2-advanced/07-accessibility.md
+++ b/docs/2-advanced/07-accessibility.md
@@ -36,6 +36,15 @@ By doing so, you receive an input element with `role="combobox"` with all aria a
 In order to ease the setting of aria attributes, we have introduced properties that are available for developers to extend the accessibility support in the context of the application. More information about the available properties could be found in the Accessibility APIs section below.
 
 
+### **Invisible Messaging**
+The Invisible Message provides a way to programmaticaly expose dynamic content changes in a way that can be announced by screen readers. It marks the dynamic content changes as ARIA live regions so that we are able to inform the users of assistive technologies for a change that has happened to the UI.
+
+The Invisible Messaging service is designed to be used both internally in the components logic and from the applications. Using the service, you have to specify the message to be announced by the screen reader and the mode which will be inserted in the `aria-live` attribute via the `InvisibleMessage.announce(message, mode)` method. The possible modes to choose from are ` InvisibleMessageMode.Assertive` and  `InvisibleMessageMode.Polite`. `Assertive` indicates that updates to the region have the highest priority and should be presented to the user immediately. `Polite` indicates that updates to the region should be presented at the next graceful opportunity such as at the end of reading the current sentence, or when the user paused typing.
+
+According to the WAI-ARIA recommendations, the live regions should be initialised empty when the page is loaded. This way screen readers remember them and start to listen for changes of their value. Thus, we recommend to instantiate Invisible Message  as early as possible in the application. Then, you should specify the text, that has to be announced by the screen reader and the live region’s mode using the `announce` method.
+Here is a sample that show an example usage of the invisible messaging service - [Dynamic MessageStrip Generator Sample](https://sap.github.io/ui5-webcomponents/playground/components/MessageStrip/)
+
+
 ### **Keyboard Handling**
 
 All standard UI elements and controls are designed to be keyboard-enabled. All suitable input channels (such as mouse, keyboard, or touch) are treated equally according to the capabilities of the device or the individual preferences of the user. For example, some users may prefer using the keyboard instead of a mouse, which lets them work faster.

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -18,6 +18,7 @@ Contains the base files for all Web Components, most notably `@ui5/webcomponents
  Components    | `@ui5/webcomponents-base/dist/features/F6Navigation.js`   | Adds support for F6 fast group navigation                                                           |
  Components    | `import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js"`| Applies direction ("ltr"/"rtl") - re-renders all RTL-aware components     |
  Components    | `import { setCustomElementsScopingSuffix } from "@ui5/webcomponents-base/dist/CustomElementsScope.js"`| Adds suffix to the tag names of all components          |
+ Components    | `@ui5/webcomponents-base/dist/util/InvisibleMessage.js`   | Provides a way to expose dynamic content changes in a way that can be announced by screen readers   |
  CSP compliance| `import { setPackageCSSRoot } from "@ui5/webcomponents-base/dist/CSP.js"`| Sets directory path where the CSS resources for given package will be served from    |
  CSP compliance| `import { setUseLinks } from "@ui5/webcomponents-base/dist/CSP.js"`      | Enables or disables the usage of `<link>` tags instead of `<style>` tags             |
  CSP compliance| `import { setPreloadLinks } from "@ui5/webcomponents-base/dist/CSP.js"`  | Enables or disables the preloading of `<link>` tags                                  |

--- a/packages/base/src/util/InvisibleMessage.js
+++ b/packages/base/src/util/InvisibleMessage.js
@@ -43,6 +43,7 @@ attachBoot(() => {
  *
  * @param {string} message String to be announced by the screen reader.
  * @param {sap.ui.core.InvisibleMessageMode} mode The mode to be inserted in the aria-live attribute.
+ * @public
  */
 const announce = (message, mode) => {
 	// If no type is presented, fallback to polite announcement.

--- a/packages/main/test/samples/MessageStrip.sample.html
+++ b/packages/main/test/samples/MessageStrip.sample.html
@@ -72,6 +72,68 @@
 </section>
 
 <section>
+	<h3>Dynamic Message Strip Generator</h3>
+	<div class="snippet">
+		<div class="wrapper">
+			<ui5-button id="button1">Generate MessageStrip</ui5-button>
+		</div>
+		<script>
+			const container = document.querySelector(".wrapper");
+			const button =  document.querySelector("#button1");
+			button.addEventListener("click", function(event) {
+				let invisibleMessage =  window["sap-ui-webcomponents-bundle"].invisibleMessage;
+				const messageStrip = document.querySelector("#msgStrip");
+				const types = ["Information", "Warning", "Negative", "Positive"];
+				const text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam, quis nostrud exercitation ullamco.";
+				let type = types[Math.round(Math.random() * 3)];
+		
+				if (messageStrip) {
+					container.removeChild(messageStrip);
+				}
+		
+				let generatedMsgStrip = document.createElement("ui5-message-strip");
+				generatedMsgStrip.id = "msgStrip";
+				generatedMsgStrip.design = type;
+				generatedMsgStrip.textContent = text;
+
+				invisibleMessage.announce(`New Information Bar of type ${type} ${text}`, "Assertive");
+		
+				container.appendChild(generatedMsgStrip);
+			});
+		</script>
+	</div>
+	<pre class="prettyprint lang-html"><xmp>
+		<div class="wrapper">
+			<ui5-button id="button1">Generate MessageStrip</ui5-button>
+		</div>
+		<script>
+			const container = document.querySelector(".wrapper");
+			const button =  document.querySelector("#button1");
+			button.addEventListener("click", function(event) {
+				let invisibleMessage =  window["sap-ui-webcomponents-bundle"].invisibleMessage;
+				const messageStrip = document.querySelector("#msgStrip");
+				const types = ["Information", "Warning", "Negative", "Positive"];
+				const text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam, quis nostrud exercitation ullamco.";
+				let type = types[Math.round(Math.random() * 3)];
+		
+				if (messageStrip) {
+					container.removeChild(messageStrip);
+				}
+		
+				let generatedMsgStrip = document.createElement("ui5-message-strip");
+				generatedMsgStrip.id = "msgStrip";
+				generatedMsgStrip.design = type;
+				generatedMsgStrip.textContent = text;
+
+				invisibleMessage.announce(`New Information Bar of type ${type} ${text}`, "Assertive");
+		
+				container.appendChild(generatedMsgStrip);
+			});
+		</script>
+	</xmp></pre>
+</section>
+
+<section>
 	<h3>Custom MessageStrip</h3>
 	<div class="snippet">
 		<ui5-message-strip class="samples-margin-bottom samples-vertical-align" style="width: 200px;" design="Information" hide-icon hide-close-button>You have new message.</ui5-message-strip>


### PR DESCRIPTION
Now, the Invisible Messaging service can be used within the applications via the "announce" method, in order to be able to expose dynamic content changes in a way that can be announced by screen readers.
FIXES: #5285 
