### PR TITLE
feat(BadgeEnablement): introduce BadgeEnablement feature

### DIFF
--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -28,6 +28,7 @@ import getLocaleData from "@ui5/webcomponents-localization/dist/locale/getLocale
 
 import "./dist/features/InputElementsFormSupport.js";
 import "./dist/features/InputSuggestions.js";
+import "./dist/features/BadgeEnablement.js";
 import "./dist/features/ColorPaletteMoreColors.js";
 
 import Avatar from "./dist/Avatar.js";

--- a/packages/main/src/Avatar.hbs
+++ b/packages/main/src/Avatar.hbs
@@ -17,4 +17,8 @@
 	{{else if initials}}
 		<span class="ui5-avatar-initials">{{validInitials}}</span>
 	{{/if}}
+
+	{{#if showBadge}}
+		{{Badge}}
+	{{/if}}
 </div>

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -3,6 +3,9 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 
 import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
+
+import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+
 // Template
 import AvatarTemplate from "./generated/templates/AvatarTemplate.lit.js";
 
@@ -73,6 +76,33 @@ const metadata = {
 		 * @public
 		 */
 		initials: {
+			type: String,
+		},
+
+		/**
+		 * Defines whether the component should show a badge.
+		 * <br><br>
+		 * <b>Note:</b> You need to import the <code>BadgeEnablement</code> module
+		 * from <code>"@ui5/webcomponents/dist/features/BadgeEnablement.js"</code> to enable this functionality.
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 */
+		showBadge: {
+			type: Boolean,
+		},
+
+		/**
+		 * Defines the unique identifier (icon name) of the icon, slotted in <code>ui5-badge</code>.
+		 * <br>
+		 * To view all supported names, see the documentation for <code>ui5-icon</code>'s <code>name</code> property.
+		 * <br>
+		 * <b>Note</b>: The <code>showBadge</code> property must be set to true
+		 * and <code>BadgeEnablement</code> must be imported.
+		 * @type {string}
+		 * @public
+		 */
+		badgeIconName: {
 			type: String,
 		},
 
@@ -218,6 +248,11 @@ const metadata = {
 		* @since 1.0.0-rc.11
 		*/
 		click: {},
+		"badge-enablement-icon-name-change": {
+			detail: {
+				iconName: { type: String },
+			},
+		},
 	},
 };
 
@@ -340,6 +375,25 @@ class Avatar extends UI5Element {
 
 	onBeforeRendering() {
 		this._onclick = this.interactive ? this._onClickHandler.bind(this) : undefined;
+
+		if (this.showBadge) {
+			this.enableBadge();
+			this.fireEvent(EVENT_BADGE_ENABLEMENT_ICON_NAME_CHANGE, this.badgeIconName);
+		}
+	}
+
+	enableBadge() {
+		if (this.Badge) {
+			return;
+		}
+
+		const BadgeEnablement = getFeature("BadgeEnablement");
+
+		if (BadgeEnablement) {
+			this.Badge = new BadgeEnablement(this).Badge;
+		} else {
+			throw new Error(`You have to import the "@ui5/webcomponents/dist/features/BadgeEnablement.js" module to use a badge.`);
+		}
 	}
 
 	_onClickHandler(event) {
@@ -386,6 +440,8 @@ class Avatar extends UI5Element {
 		return this.ariaHaspopup;
 	}
 }
+
+const EVENT_BADGE_ENABLEMENT_ICON_NAME_CHANGE = "badge-enablement-icon-name-change";
 
 Avatar.define();
 

--- a/packages/main/src/features/BadgeEnablement.js
+++ b/packages/main/src/features/BadgeEnablement.js
@@ -1,0 +1,64 @@
+import { registerFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import Badge from "../Badge.js";
+import Icon from "../Icon.js";
+
+/**
+ * A class to enable badge support for components.
+ *
+ * @class
+ * @private
+ * @author SAP SE
+ */
+class BadgeEnablement {
+	constructor(component) {
+		// The component that BadgeEnablement would plug into.
+		this.component = component;
+
+		// The ui5-badge instance.
+		this.Badge = new Badge();
+
+		/* Used for style scoping in Badge.css, for cases when the slotted ui5-icon should be styled.
+		This is due to inability to expose a ::part for slotted elements and style them from e.g. Button.css.
+		The string prefix CSS selector [attr^=value] should be used to ensure scoping suffix support.
+		For example, to style ui5-avatar's badge icon, the selector used in Badge.css should be:
+		:host([ui5-badge-enablement^="ui5-avatar"]) ::slotted([ui5-icon][slot="icon"]) { ... } */
+		this.Badge.setAttribute("ui5-badge-enablement", this.component.localName);
+
+		this.fnOnChange = this.onChange.bind(this);
+		this.fnOnIconNameChange = this.onIconNameChange.bind(this);
+		this.component.addEventListener("ui5-badge-enablement-change", this.fnOnChange);
+		this.component.addEventListener("ui5-badge-enablement-icon-name-change", this.fnOnIconNameChange);
+	}
+
+	onChange(event) {
+		this.removeChildNodes();
+		this.Badge.append(event.detail);
+	}
+
+	onIconNameChange(event) {
+		const iconName = event.detail;
+
+		this.removeChildNodes();
+
+		if (iconName) {
+			const icon = new Icon();
+			icon.name = iconName;
+			icon.slot = "icon";
+			this.Badge.append(icon);
+		}
+	}
+
+	removeChildNodes() {
+		const badge = this.Badge;
+
+		while (badge.firstChild) {
+			badge.removeChild(badge.firstChild);
+		}
+	}
+
+	get shadowRoot() {
+		return this.Badge.shadowRoot;
+	}
+}
+
+registerFeature("BadgeEnablement", BadgeEnablement);

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -1,6 +1,7 @@
 :host(:not([hidden])) {
 	display: inline-block;
 	box-sizing: border-box;
+	position: relative;
 }
 
 /*The ui5_hovered class is set by FileUploader to indicate hover state of the control*/
@@ -210,4 +211,53 @@
 
 .ui5-avatar-initials {
 	color: inherit;
+}
+
+/* Badge Enablement */
+[ui5-badge-enablement] {
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	width: 1.125rem;
+	height: 1.125rem;
+	background: var(--sapButton_Emphasized_Background);
+	border: var(--sapButton_Emphasized_Background);
+	border-radius: 1rem;
+	color: var(--sapContent_BadgeTextColor);
+	justify-content: center;
+	font-size: var(--sapFontSmallSize);
+}
+
+/* Avatar Badge */
+[ui5-badge-enablement] {
+	padding: 6%;
+}
+
+:host([_size="L"]) [ui5-badge-enablement],
+:host([size="L"]) [ui5-badge-enablement] {
+	width: 1.25rem;
+	height: 1.25rem;
+}
+
+:host([_size="XL"]) [ui5-badge-enablement],
+:host([size="XL"]) [ui5-badge-enablement] {
+	width: 1.75rem;
+	height: 1.75rem;
+}
+
+:host([shape="Square"]) [ui5-badge-enablement] {
+	bottom: -0.125rem;
+	right: -0.125rem;
+}
+
+:host([_size="L"][shape="Square"]) [ui5-badge-enablement],
+:host([size="L"][shape="Square"]) [ui5-badge-enablement] {
+	bottom: -0.1875rem;
+	right: -0.1875rem;
+}
+
+:host([_size="XL"][shape="Square"]) [ui5-badge-enablement],
+:host([size="XL"][shape="Square"]) [ui5-badge-enablement] {
+	bottom: -0.25rem;
+	right: -0.25rem;
 }

--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -132,3 +132,11 @@
 	border-color: var(--ui5-badge-color-scheme-10-border);
 	color: var(--ui5-badge-color-scheme-10-color);
 }
+
+/* ui5-avatar - BadgeEnablement */
+:host([ui5-badge-enablement^="ui5-avatar"]) ::slotted([ui5-icon][slot="icon"]) {
+	width: 100%;
+	height: 100%;
+	min-width: 100%;
+	min-height: 100%;
+}

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -163,6 +163,22 @@
 		<ui5-input id="click-event-2"></ui5-input>
 	</section>
 
+	<section>
+		<h3>Avatar - Visual affordance</h3>
+		<ui5-avatar-demo show-badge badge-icon-name="accelerated" initials="AB" color-scheme="Accent1"></ui5-avatar-demo>
+		<ui5-avatar show-badge badge-icon-name="accept" interactive size="L" initials="CD" color-scheme="Accent2"></ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="bar-chart" size="XL">
+			<img src="./img/John_Miller.png" alt="John Miller">
+		</ui5-avatar>
+		<br>
+		<ui5-avatar show-badge badge-icon-name="filter" shape="Square" size="XS" initials="EF" color-scheme="Accent3"></ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="add-employee" interactive shape="Square" initials="GH" color-scheme="Accent4"></ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="document" shape="Square" size="XL">
+			<img src="./img/John_Miller.png" alt="John Miller">
+		</ui5-avatar>
+		<br><br>
+	</section>
+
 	<script>
 		var avatar = document.getElementById("interactive-avatar"),
 			myInteractiveAvatar = document.getElementById("myInteractiveAvatar"),

--- a/packages/main/test/samples/Avatar.sample.html
+++ b/packages/main/test/samples/Avatar.sample.html
@@ -161,4 +161,30 @@
 </xmp></pre>
 </section>
 
+<section>
+	<h4>Avatar with Visual Affordance</h4>
+	<div class="snippet">
+		<ui5-avatar show-badge badge-icon-name="filter" shape="Circle">
+			<img src="../../../assets/images/avatars/woman_avatar_3.png" alt="Woman 3">
+		</ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="document" initials="AB" size="L" shape="Circle"></ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="accept" shape="Square">
+			<img src="../../../assets/images/avatars/woman_avatar_4.png" alt="Woman 4">
+		</ui5-avatar>
+		<ui5-avatar show-badge badge-icon-name="employee" initials="CD" size="L" shape="Square"></ui5-avatar>
+	</div>
+<pre class="prettyprint lang-html"><xmp>
+<div class="snippet">
+	<ui5-avatar show-badge badge-icon-name="filter" shape="Circle">
+		<img src="../../../assets/images/avatars/woman_avatar_3.png" alt="Woman 3">
+	</ui5-avatar>
+	<ui5-avatar show-badge badge-icon-name="document" initials="AB" size="L" shape="Circle"></ui5-avatar>
+	<ui5-avatar show-badge badge-icon-name="accept" shape="Square">
+		<img src="../../../assets/images/avatars/woman_avatar_4.png" alt="Woman 4">
+	</ui5-avatar>
+	<ui5-avatar show-badge badge-icon-name="employee" initials="CD" size="L" shape="Square"></ui5-avatar>
+</div>
+</xmp></pre>
+</section>
+
 <!-- JSDoc marker -->


### PR DESCRIPTION
This change introduces a new `BadgeEnablement` **feature**, meant to be used by components like `ui5-button` and `ui5-avatar`.

The second variant of the enablement, with a **slot**, is described in #5416

## How to implement

1. Create a `showBadge` property and a method for initializing the Badge.

```js
/**
 * Defines whether the component should show a badge.
 * <br><br>
 * <b>Note:</b> You need to import the <code>BadgeEnablement</code> module
 * from <code>"@ui5/webcomponents/dist/features/BadgeEnablement.js"</code> to enable this functionality.
 * @type {boolean}
 * @defaultvalue false
 * @public
 */
showBadge: {
	type: Boolean,
},
```
```js
onBeforeRendering() {
	if (this.showBadge) {
		this.enableBadge();
	}
}

enableBadge() {
	if (this.Badge) {
		return;
	}

	const BadgeEnablement = getFeature("BadgeEnablement");

	if (BadgeEnablement) {
		this.Badge = new BadgeEnablement(this).Badge;
	} else {
		throw new Error(`You have to import the "@ui5/webcomponents/dist/features/BadgeEnablement.js" module to use a badge.`);
	}
}
```

2. Modify the Handlebars template of the component to include the Badge:
```hbs
...
{{#if showBadge}}
	{{Badge}}
{{/if}}
...
```

3. Create a property for passing in the value (e.g. badgeContent): 
```js
/**
 * The text content of the badge.
 * @type {string}
 * @defaultvalue ""
 * @public
 */
badgeContent: {
	type: String,
},
```

4. As `ui5-badge` has no way of knowing the value of `badgeContent` has changed, we have to implement an event in the code of the consuming component: 
```js
events: /** @lends sap.ui.webcomponents.main.Button.prototype */ {
	"badge-enablement-change": {
		detail: {
			content: { type: String },
		},
	},
},
```
```js
onBeforeRendering() {
...
	if (this.showBadge) {
		this.enableBadge();
		this.fireEvent(EVENT_BADGE_ENABLEMENT_CHANGE, this.badgeContent);
	}
}

...

const EVENT_BADGE_ENABLEMENT_CHANGE = "badge-enablement-change";
```

5. Overstyling can be done in the `.css` file of the consuming component with the following attribute selector. The tag name is omitted to ensure scoping support:
```css
[ui5-badge-enablement] { ... }
```

If custom styles are required for the slotted icon, they can be added at `packages/main/src/themes/Badge.css` with the following selector:
```css
:host([ui5-badge-enablement^="ui5-avatar"]) ::slotted([ui5-icon][slot="icon"]) { ... }
```

Note the use of the `[attr^=value]` attribute value prefix selector. This is to style the slotted icon only for a given consumer of `BadgeEnablement` (e.g. for `ui5-avatar`), while also making sure scoping suffixed tags (like `ui5-avatar-demo`) still work.

## Usage
```js
<ui5-button show-badge badge-content="3">Press</ui5-button>
```

Related to https://github.com/SAP/ui5-webcomponents/issues/4624
