### PR TITLE
fix(ui5-li): correct accessibility attribute to checkbox

### DIFF
--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -80,7 +80,7 @@
 				id="{{_id}}-multiSelectionElement"
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"
-				aria-label="{{_accInfo.ariaLabel}}"
+				accessible-name="{{_accInfo.ariaLabel}}"
 				@click="{{onMultiSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}


### PR DESCRIPTION
Replaced `aria-label` attribute with `accessible-name`, in order to use the public API `ui5-checkbox` which controls its `aria-label` attribute.

Fixes: #5437