### PR TITLE
fix(formEnablement): correct submit event behaviour

### DIFF
--- a/packages/main/src/features/InputElementsFormSupport.js
+++ b/packages/main/src/features/InputElementsFormSupport.js
@@ -82,11 +82,15 @@ class FormSupport {
 
 		if (currentElement) {
 			// eslint-disable-next-line no-undef
-			currentElement.dispatchEvent(new SubmitEvent("submit", {
+			const submitPrevented = !currentElement.dispatchEvent(new SubmitEvent("submit", {
 				bubbles: true,
 				cancelable: true,
 				submitter: element,
 			}));
+
+			if (submitPrevented) {
+				return;
+			}
 
 			currentElement.submit();
 		}

--- a/packages/main/test/pages/FormSupport.html
+++ b/packages/main/test/pages/FormSupport.html
@@ -16,31 +16,43 @@
 <body class="formsupport1auto">
 
 <form method="get">
-
     <ui5-input name="input" value="ok"></ui5-input>
     <ui5-input name="input_disabled" disabled value="ok"></ui5-input>
-	<br><br>
+    <br><br>
     <ui5-textarea name="ta" value="ok"></ui5-textarea>
     <ui5-textarea name="ta_disabled" disabled value="ok"></ui5-textarea>
-	<br><br>
+    <br><br>
     <ui5-date-picker name="dp" value="Apr 10, 2019"></ui5-date-picker>
     <ui5-date-picker name="dp_disabled" disabled value="Apr 10, 2019"></ui5-date-picker>
-	<br><br>
+    <br><br>
     <ui5-checkbox name="cb" checked></ui5-checkbox>
     <ui5-checkbox name="cb_disabled" disabled checked></ui5-checkbox>
-	<br><br>
+    <br><br>
     <ui5-radio-button name="radio" text="A" value="a"></ui5-radio-button>
     <ui5-radio-button name="radio" text="B" value="b" checked></ui5-radio-button>
     <ui5-radio-button name="radio" text="C" value="c"></ui5-radio-button>
-	<br><br>
-	<ui5-step-input class="formsupport2auto" name="si" value="5" min="0" max="10" step="1"></ui5-step-input>
-	<ui5-step-input class="formsupport2auto" name="si_diabled" value="7" min="0" max="10" step="1" disabled></ui5-step-input>
-	<br><br>
+    <br><br>
+    <ui5-step-input class="formsupport2auto" name="si" value="5" min="0" max="10" step="1"></ui5-step-input>
+    <ui5-step-input class="formsupport2auto" name="si_diabled" value="7" min="0" max="10" step="1" disabled></ui5-step-input>
+    <br><br>
     <ui5-button id="b1">Does not submit forms</ui5-button>
     <ui5-button id="b2" submits>Submits forms</ui5-button>
-
 </form>
 
+<form method="get" id="form">
+    <ui5-input name="input" value="notOk"></ui5-input>
+    <ui5-button id="b3" submits>Submits forms</ui5-button>
+</form>
+
+<script>
+    const form = document.getElementById("form");
+
+    form.addEventListener("submit", (e) => {
+        e.preventDefault();
+    })
+
+
+</script>
 
 </body>
 </html>

--- a/packages/main/test/specs/FormSupport.spec.js
+++ b/packages/main/test/specs/FormSupport.spec.js
@@ -27,4 +27,16 @@ describe("Form support", () => {
 		assert.ok(formWasSubmitted, "For was submitted and URL changed");
 	});
 
+	it("Prevent default on submit event", async () => {
+		await browser.url(`test/pages/FormSupport.html`);
+
+		const noSubmitButton = await browser.$("#b3");
+		await noSubmitButton.click();
+
+		const hrefIsSame = await browser.executeAsync(done => {
+			done(location.href.endsWith("FormSupport.html"));
+		});
+		assert.ok(hrefIsSame, "Form is not submitted when prevent default is called");
+	});
+
 });


### PR DESCRIPTION
Form is submitted even if the submit event was prevented. Now, we check if the submit event is prevented and if it's not we submit the form.

Fixes: #5427