### PR TITLE
fix(ui5-list): focus handling on nested lists

### DIFF
--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -888,6 +888,8 @@ class List extends UI5Element {
 	onItemFocused(event) {
 		const target = event.target;
 
+		event.stopPropagation();
+
 		this._itemNavigation.setCurrentItem(target);
 		this.fireEvent("item-focused", { item: target });
 
@@ -937,7 +939,7 @@ class List extends UI5Element {
 	onForwardBefore(event) {
 		this.setPreviouslyFocusedItem(event.target);
 		this.focusBeforeElement();
-		event.stopImmediatePropagation();
+		event.stopPropagation();
 	}
 
 	onForwardAfter(event) {
@@ -949,6 +951,8 @@ class List extends UI5Element {
 			this.focusGrowingButton();
 			event.preventDefault();
 		}
+
+		event.stopPropagation();
 	}
 
 	focusBeforeElement() {

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -232,6 +232,13 @@
 		</ui5-li-custom>
 	</ui5-list>
 
+	<ui5-list growing="Button">
+		<ui5-button slot="header">Header button</ui5-button>
+		<ui5-li >Option 1</ui5-li>
+		<ui5-li >Option 2</ui5-li>
+		<ui5-li >Option 3</ui5-li>
+	</ui5-list>
+
 	<br />
 	Change mode:
 	<ui5-select id="select">


### PR DESCRIPTION
When list item is focused _focused event is fired and the event is handled by each list separately. Now, bubbling is stopped and only first list handles _focused event.

Fixes: #3749