### PR TITLE
feat(ui5-panel): remove header when not used

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -3,56 +3,59 @@
 	role="{{accRole}}"
 	aria-label="{{effectiveAccessibleName}}"
 >
-	{{! header: either header or h1 with header text}}
-	<div
-		@click="{{_headerClick}}"
-		@keydown="{{_headerKeyDown}}"
-		@keyup="{{_headerKeyUp}}"
-		class="ui5-panel-header"
-		tabindex="{{headerTabIndex}}"
-		role="{{accInfo.role}}"
-		aria-expanded="{{accInfo.ariaExpanded}}"
-		aria-controls="{{accInfo.ariaControls}}"
-		aria-labelledby="{{accInfo.ariaLabelledby}}"
-                part="header"
-	>
-		{{#unless fixed}}
-			<div class="ui5-panel-header-button-root">
-				{{#if _hasHeader}}
-					<ui5-button
-						design="Transparent"
-						class="ui5-panel-header-button ui5-panel-header-button-with-icon"
-						@click="{{_toggleButtonClick}}"
-						.accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
-						tooltip="{{accInfo.button.title}}"
-						accessible-name="{{accInfo.button.ariaLabelButton}}"
-					>
-						<div class="ui5-panel-header-icon-wrapper">
-							<ui5-icon class="ui5-panel-header-icon {{classes.headerBtn}}" name="slim-arrow-right"></ui5-icon>
-						</div>
-					</ui5-button>
-				{{else}}
-					<ui5-icon
-						class="ui5-panel-header-button ui5-panel-header-icon {{classes.headerBtn}}"
-						name="slim-arrow-right"
-					></ui5-icon>
-				{{/if}}
-			</div>
-		{{/unless}}
 
-		{{#if _hasHeader}}
-			<slot name="header"></slot>
-		{{else}}
-			<div
-				id="{{_id}}-header-title"
-				role="heading"
-				aria-level="{{headerAriaLevel}}"
-				class="ui5-panel-header-title"
-			>
-				{{headerText}}
-			</div>
-		{{/if}}
-	</div>
+	{{#if hasHeaderOrHeaderText}}
+		{{! header: either header or h1 with header text}}
+		<div
+			@click="{{_headerClick}}"
+			@keydown="{{_headerKeyDown}}"
+			@keyup="{{_headerKeyUp}}"
+			class="ui5-panel-header"
+			tabindex="{{headerTabIndex}}"
+			role="{{accInfo.role}}"
+			aria-expanded="{{accInfo.ariaExpanded}}"
+			aria-controls="{{accInfo.ariaControls}}"
+			aria-labelledby="{{accInfo.ariaLabelledby}}"
+			part="header"
+		>
+			{{#unless fixed}}
+				<div class="ui5-panel-header-button-root">
+					{{#if _hasHeader}}
+						<ui5-button
+							design="Transparent"
+							class="ui5-panel-header-button ui5-panel-header-button-with-icon"
+							@click="{{_toggleButtonClick}}"
+							.accessibilityAttributes={{accInfo.button.accessibilityAttributes}}
+							tooltip="{{accInfo.button.title}}"
+							accessible-name="{{accInfo.button.ariaLabelButton}}"
+						>
+							<div class="ui5-panel-header-icon-wrapper">
+								<ui5-icon class="ui5-panel-header-icon {{classes.headerBtn}}" name="slim-arrow-right"></ui5-icon>
+							</div>
+						</ui5-button>
+					{{else}}
+						<ui5-icon
+							class="ui5-panel-header-button ui5-panel-header-icon {{classes.headerBtn}}"
+							name="slim-arrow-right"
+						></ui5-icon>
+					{{/if}}
+				</div>
+			{{/unless}}
+
+			{{#if _hasHeader}}
+				<slot name="header"></slot>
+			{{else}}
+				<div
+					id="{{_id}}-header-title"
+					role="heading"
+					aria-level="{{headerAriaLevel}}"
+					class="ui5-panel-header-title"
+				>
+					{{headerText}}
+				</div>
+			{{/if}}
+		</div>
+	{{/if}}
 
 	{{! content area}}
 	<div

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -441,6 +441,10 @@ class Panel extends UI5Element {
 		return !this._hasHeader && !this.fixed;
 	}
 
+	get hasHeaderOrHeaderText() {
+		return this._hasHeader || this.headerText;
+	}
+
 	get nonFocusableButton() {
 		return !this.header.length;
 	}

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -146,6 +146,16 @@
 
 	<br>
 
+	<ui5-panel id="panel-expandable">
+		<!-- Content -->
+		<ui5-title>Panel without header and header text</ui5-title>
+		<ui5-label wrapping-type="Normal">
+			The panel consists only of a content part.
+		</ui5-label>
+	</ui5-panel>
+
+	<br>
+
 	<ui5-panel id="panel1" collapsed header-text="Click to expand!" header-level="H3" accessible-role="Form">
 
 		<!-- Content -->


### PR DESCRIPTION
Prevent rendering ui5-panel header part when both header and header text are not set.

FIXES: #5342 
