### PR TITLE
fix: create package bugs

### DIFF
--- a/packages/create-package/index.js
+++ b/packages/create-package/index.js
@@ -6,6 +6,8 @@ const mkdirp = require("mkdirp");
 const prompts = require("prompts");
 const parser = require("npm-config-user-agent-parser");
 
+const version = JSON.parse(fs.readFileSync(path.join(__dirname, "package.json"))).version;
+
 // from where all the files will be copied
 const TEMPLATE_DIR = path.join(`${__dirname}`, `template/`);
 
@@ -129,11 +131,11 @@ const createWebcomponentsPackage = async () => {
 			"./*": "./dist/*",
 		},
 		"dependencies": {
-			"@ui5/webcomponents-base": "1.1.1",
-			"@ui5/webcomponents-theming": "1.1.1",
+			"@ui5/webcomponents-base": version,
+			"@ui5/webcomponents-theming": version,
 		},
 		"devDependencies": {
-			"@ui5/webcomponents-tools": "1.1.1",
+			"@ui5/webcomponents-tools": version,
 			"chromedriver": "*",
 		},
 	};

--- a/packages/create-package/template/src/MyFirstComponent.js
+++ b/packages/create-package/template/src/MyFirstComponent.js
@@ -10,6 +10,9 @@ import INIT_PACKAGE_VAR_CLASS_NAMECss from "./generated/themes/INIT_PACKAGE_VAR_
 
 import { PLEASE_WAIT } from "./generated/i18n/i18n-defaults.js";
 
+/**
+ * @public
+ */
 const metadata = {
 	tag: "INIT_PACKAGE_VAR_TAG",
 	properties: {
@@ -20,6 +23,19 @@ const metadata = {
 	},
 };
 
+/**
+ * @class
+ *
+ * <h3 class="comment-api-title">Overview</h3>
+ *
+ * The <code>INIT_PACKAGE_VAR_TAG</code> component is a demo component that displays some text.
+ *
+ * @constructor
+ * @alias demo.components.INIT_PACKAGE_VAR_CLASS_NAME
+ * @extends UI5Element
+ * @tagname INIT_PACKAGE_VAR_TAG
+ * @public
+ */
 class INIT_PACKAGE_VAR_CLASS_NAME extends UI5Element {
 	static get metadata() {
 		return metadata;

--- a/packages/create-package/template/test/pages/index.html
+++ b/packages/create-package/template/test/pages/index.html
@@ -16,7 +16,7 @@
 		}
 	</script>
 
-	<script src="../../resources/bundle.esm.js" type="module"></script>
+	<script src="../../bundle.esm.js" type="module"></script>
 
     <style>
         code { color: blue; font-size: small; }


### PR DESCRIPTION
This change fixes several bugs in the `create-package` package:
 - path to the `bundle.esm.js` in the test page is now correct after the tooling update
 - the new package is now always created with the same version as the `package.json` of the `create-package` package.
 - added JSDoc to the new component