### PR TITLE
fix(ui5-li-groupheader): use group role on UL nodes only

### DIFF
--- a/packages/main/src/GroupHeaderListItem.hbs
+++ b/packages/main/src/GroupHeaderListItem.hbs
@@ -1,4 +1,4 @@
-<li
+<ul
 	part="native-li"
 	tabindex="{{_tabIndex}}"
 	class="ui5-ghli-root {{classes.main}}"
@@ -12,4 +12,4 @@
 	<div id="{{_id}}-content" class="ui5-li-content">
 		<span class="ui5-ghli-title"><slot></slot></span>
 	</div>
-</li>
+</ul>


### PR DESCRIPTION
Fixes: #5400

With #3869 we override the role of the GroupHeaderListItem node to group.
Role overriding is not allowed for `<li>` items. We may use group role on `<ul>` nodes only as in this ARIA tree example:
https://w3c.github.io/aria-practices/examples/treeview/treeview-navigation.html
