### PR TITLE
fix(ui5-panel): enhance aria-labelledby handling

### DIFF
--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -2,6 +2,7 @@
 	class="ui5-panel-root"
 	role="{{accRole}}"
 	aria-label="{{effectiveAccessibleName}}"
+	aria-labelledby="{{fixedPanelariaLabelledbyReference}}"
 >
 
 	{{#if hasHeaderOrHeaderText}}

--- a/packages/main/src/Panel.hbs
+++ b/packages/main/src/Panel.hbs
@@ -2,7 +2,7 @@
 	class="ui5-panel-root"
 	role="{{accRole}}"
 	aria-label="{{effectiveAccessibleName}}"
-	aria-labelledby="{{fixedPanelariaLabelledbyReference}}"
+	aria-labelledby="{{fixedPanelAriaLabelledbyReference}}"
 >
 
 	{{#if hasHeaderOrHeaderText}}

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -422,7 +422,11 @@ class Panel extends UI5Element {
 	}
 
 	get ariaLabelledbyReference() {
-		return (this.nonFocusableButton && this.headerText) ? `${this._id}-header-title` : undefined;
+		return (this.nonFocusableButton && this.headerText && !this.fixed) ? `${this._id}-header-title` : undefined;
+	}
+
+	get fixedPanelariaLabelledbyReference() {
+		return this.fixed && !this.effectiveAccessibleName ? `${this._id}-header-title` : undefined;
 	}
 
 	get header() {

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -425,7 +425,7 @@ class Panel extends UI5Element {
 		return (this.nonFocusableButton && this.headerText && !this.fixed) ? `${this._id}-header-title` : undefined;
 	}
 
-	get fixedPanelariaLabelledbyReference() {
+	get fixedPanelAriaLabelledbyReference() {
 		return this.fixed && !this.effectiveAccessibleName ? `${this._id}-header-title` : undefined;
 	}
 

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -147,13 +147,23 @@ describe("Panel general interaction", () => {
 			const panelWithNativeHeader = await browser.$("#panel-expandable");
 			const nativeHeader = await panelWithNativeHeader.shadow$(".ui5-panel-header");
 			const panelWithNativeHeaderId = await panelWithNativeHeader.getProperty("_id");
+			const fixedPanel = await browser.$('#panel-fixed');
+			const fixedPanelRoot = await fixedPanel.shadow$(".ui5-panel-root");
+			const fixedPanelHeader = await fixedPanel.shadow$(".ui5-panel-header");
+			const fixedPanelHeaderTitle = await fixedPanel.shadow$(".ui5-panel-header-title");
+			const fixedPanelHeaderTitleId = await fixedPanelHeaderTitle.getProperty("id");
+			
 
 			assert.strictEqual(await nativeHeader.getAttribute("aria-labelledby"),
 				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");
+			assert.notOk(await fixedPanelHeader.getAttribute("aria-labelledby"), "aria-labelledby is not added to the header");
+			assert.strictEqual(await fixedPanelRoot.getAttribute("aria-labelledby"), fixedPanelHeaderTitleId, "aria-labelledby is set correctly");
 
 			await browser.$("#panel-expandable").setAttribute("accessible-name", "New accessible name");
+			fixedPanel.setAttribute("accessible-name", "Accessible name added");
 
 			assert.strictEqual(await panelWithNativeHeader.shadow$(".ui5-panel-root").getAttribute("aria-label"), "New accessible name", "aria-label is set correctly");
+			assert.strictEqual(await fixedPanelRoot.getAttribute("aria-label"), "Accessible name added", "aria-label is set correctly");
 		});
 
 		it("tests whether aria attributes are set correctly with fixed header", async () => {


### PR DESCRIPTION
When the ui5-panel is fixed and accessibleName is not set by the users, we add a reference to the panel's title in order to be announced. If the ui5-panel is fixed but accessibleName is set, then its value take precedence over aria-labelledby referencing the title.

FIXES: #5438
