### PR TITLE
fix(ui5-combobox): now fires change event when ok is pressed on mobile

### DIFF
--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -842,6 +842,10 @@ class ComboBox extends UI5Element {
 		this._isValueStateFocused = false;
 		this._clearFocus();
 
+		if (isPhone() && this.value !== this._lastValue) {
+			this._fireChangeEvent();
+		}
+
 		this.responsivePopover.close();
 	}
 

--- a/packages/main/test/specs/ComboBox.mobile.spec.js
+++ b/packages/main/test/specs/ComboBox.mobile.spec.js
@@ -134,9 +134,11 @@ describe("Eventing", () => {
 
 		const changeCountText = await browser.$("#change-count").getText();
 		assert.strictEqual(changeCountText, "0", "Change was fired once");
-	});
+	});*/
 
 	it("Should fire change event when pressing the picker's OK button", async () => {
+		await browser.url("test/pages/ComboBox.html");
+
 		const combo = await browser.$("#change-cb");
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#change-cb")
 
@@ -159,7 +161,7 @@ describe("Eventing", () => {
 		assert.strictEqual(changeCountText, "1", "Change was fired once");
 
 		assert.strictEqual(await combo.getValue(), "Argentina", "The original value was changed");
-	}); */
+	});
 });
 
 describe("Typeahead", () => {


### PR DESCRIPTION
- On mobile device, when the OK button is pressed, the change event is now fired.

Fixes #5485
