### PR TITLE
fix(MultoComboBox): fix component scoping

### DIFF
--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -50,6 +50,7 @@ import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import MultiComboBoxItem from "./MultiComboBoxItem.js";
 import MultiComboBoxGroupItem from "./MultiComboBoxGroupItem.js";
+import GroupHeaderListItem from "./GroupHeaderListItem.js";
 import Tokenizer from "./Tokenizer.js";
 import Token from "./Token.js";
 import Icon from "./Icon.js";
@@ -470,6 +471,7 @@ class MultiComboBox extends UI5Element {
 			Popover,
 			List,
 			StandardListItem,
+			GroupHeaderListItem,
 			ToggleButton,
 			Button,
 		];

--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -38,7 +38,7 @@
  * as some icons should not be mirrored in RTL (f.e. checkmark, search, etc.).
  * That means, we can have "RTL" set globally and "LTR" set internally for the Icon ShadowDom
   * html dir=rtl
- * 		ui5-icon
+ * 		[ui5-icon]
  * 			#shadowroot
  * 				svg dir=ltr
  * In this case, we need to explicitly check for it as the global CSS definitions (rtl-parameters.css)

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -103,7 +103,7 @@ const getScripts = (options) => {
 				replace: `node "${LIB}/scoping/scope-test-pages.js" test/pages/scoped demo`,
 			},
 			watchWithBundle: 'concurrently "nps scope.watch" "nps scope.bundle" ',
-			watch: 'concurrently "nps watch.templates" "nps watch.api" "nps watch.test" "nps watch.src" "nps watch.props" "nps watch.styles"',
+			watch: 'concurrently "nps watch.templates" "nps watch.api" "nps watch.src" "nps watch.props" "nps watch.styles"',
 			bundle: `node ${LIB}/dev-server/dev-server.js ${viteConfig}`,
 		}
 	};


### PR DESCRIPTION
GroupHeaderListItem is used in the MultiComboboxPopoverTemplate and it should be part of the MultiCombobox dependencies in order to be identified and scoped, when Scoping is turned on.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/5521