### PR TITLE
ci: add auto-close of stale issues

### DIFF
--- a/.github/workflows/auto_close.yaml
+++ b/.github/workflows/auto_close.yaml
@@ -1,0 +1,26 @@
+name: Auto-close stale issues
+
+on:
+  schedule:
+  - cron: "30 17 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v5
+      with:
+        # The number of days old an issue can be before marking it stale.
+        days-before-stale: 21
+        # The number of days to wait to close an issue or pull request after it being marked stale.
+        days-before-close: 7
+        # The message to post on the issue when tagging it.
+        stale-issue-message: >
+          Hello, everyone! 
+          The issue has been inactive for 21 days. If there are still questions or comments, please feel free to continue the discussion. 
+          Inactive issues will be closed after 7 days!
+        # The message to post on the issue when closing it. If none provided, will not comment when closing an issue.
+        close-issue-message: >
+          Hello, everyone!
+          The issue has been inactive for 28 days, so I am closing the issue. 
+        any-of-issue-labels: 'author action,wontfix,stale'

--- a/.github/workflows/auto_close.yaml
+++ b/.github/workflows/auto_close.yaml
@@ -2,7 +2,7 @@ name: Auto-close stale issues
 
 on:
   schedule:
-  - cron: "30 17 * * *"
+  - cron: "30 13 * * *"
 
 jobs:
   stale:

--- a/.github/workflows/auto_close.yaml
+++ b/.github/workflows/auto_close.yaml
@@ -2,7 +2,7 @@ name: Auto-close stale issues
 
 on:
   schedule:
-  - cron: "30 13 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
The action is scheduled to run every day at 17:30 UTC and mark inactive issues for 21 days as "Stale" and close "author action", "wontfix" and "stale" issues after 28 days of inactivity.