### PR TITLE
ci: use ui5-webc-bot for releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Publish
       env:
-        NPM_USERNAME: ${{ secrets.NPM_USERNAME }}
-        NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_AUTH_TOKEN }}
       run: |
         node ./.github/actions/pre-release.js


### PR DESCRIPTION
Make use of the ui5-webc-bot NPM Release token