### PR TITLE
fix(ui5-breadcrumbs): current location misalignment is fixed

### DIFF
--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -22,6 +22,9 @@
     -webkit-flex: 1;
     -webkit-box-flex: 1;
     flex: 1 1 auto;
+    /* Fix extra height in ul -> li element */
+    font-size: 0;
+    align-self: center;
 }
 
 .ui5-breadcrumbs-current-location > span:focus {


### PR DESCRIPTION
Breadcrumbs \<li\> element contains initial padding, which is not visible, but gets inherited by the <span> element, which is visible when the focus style is applied.

Fixes: #5492