### PR TITLE
fix: regenarete base styles on change

### DIFF
--- a/packages/base/lib/generate-styles/index.js
+++ b/packages/base/lib/generate-styles/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const CleanCSS = require('clean-css');
 
 const generate = async () => {
-	await fs.mkdir("dist/generated/css/");
+	await fs.mkdir("dist/generated/css/", {recursive: true});
 
 	const files = (await fs.readdir("src/css/")).filter(file => file.endsWith(".css"));
 	const filesPromises = files.map(async file => {


### PR DESCRIPTION
Using recursive option of mkdir method ensures that each folder from path will be created and if any of the folders exist error is not thrown.