### PR TITLE
feat(ui5-popover): new type DOMReference for opener

### DIFF
--- a/packages/base/src/UI5Element.js
+++ b/packages/base/src/UI5Element.js
@@ -409,7 +409,12 @@ class UI5Element extends HTMLElement {
 				this.removeAttribute(attrName);
 			}
 		} else if (isDescendantOf(propertyTypeClass, DataType)) {
-			this.setAttribute(attrName, propertyTypeClass.propertyToAttribute(newValue));
+			const newAttrValue = propertyTypeClass.propertyToAttribute(newValue);
+			if (newAttrValue === null) {
+				this.removeAttribute(attrName);
+			} else {
+				this.setAttribute(attrName, newAttrValue);
+			}
 		} else if (typeof newValue !== "object") {
 			if (attrValue !== newValue) {
 				this.setAttribute(attrName, newValue);

--- a/packages/base/src/types/DOMReference.js
+++ b/packages/base/src/types/DOMReference.js
@@ -1,0 +1,24 @@
+import DataType from "./DataType.js";
+
+/**
+ * @class
+ * DOM Element reference or ID.
+ * <b>Note:</b> If an ID is passed, it is expected to be part of the same <code>document</code> element as the consuming component.
+ *
+ * @public
+ */
+class DOMReference extends DataType {
+	static isValid(value) {
+		return (typeof value === "string" || value instanceof HTMLElement);
+	}
+
+	static propertyToAttribute(propertyValue) {
+		if (propertyValue instanceof HTMLElement) {
+			return null;
+		}
+
+		return propertyValue;
+	}
+}
+
+export default DOMReference;

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -1,5 +1,6 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { isIOS } from "@ui5/webcomponents-base/dist/Device.js";
+import DOMReference from "@ui5/webcomponents-base/dist/types/DOMReference.js";
 import { getClosedPopupParent } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import clamp from "@ui5/webcomponents-base/dist/util/clamp.js";
 import Popup from "./Popup.js";
@@ -145,14 +146,14 @@ const metadata = {
 		},
 
 		/**
-		 * Defines the opener id of the element that the popover is shown at
+		 * Defines the ID or DOM Reference of the element that the popover is shown at
 		 * @public
-		 * @type {String}
+		 * @type {DOMReference}
 		 * @defaultvalue ""
 		 * @since 1.2.0
 		 */
 		opener: {
-			type: String,
+			type: DOMReference,
 		},
 
 		/**
@@ -305,7 +306,7 @@ class Popover extends Popup {
 
 	onAfterRendering() {
 		if (!this.isOpen() && this.open) {
-			const opener = document.getElementById(this.opener);
+			const opener = this.opener instanceof HTMLElement ? this.opener : document.getElementById(this.opener);
 			if (!opener) {
 				console.warn("Valid opener id is required."); // eslint-disable-line
 				return;

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -306,7 +306,7 @@ class Popover extends Popup {
 
 	onAfterRendering() {
 		if (!this.isOpen() && this.open) {
-			const opener = this.opener instanceof HTMLElement ? this.opener : document.getElementById(this.opener);
+			const opener = this.opener instanceof HTMLElement ? this.opener : this.getRootNode().getElementById(this.opener);
 			if (!opener) {
 				console.warn("Valid opener id is required."); // eslint-disable-line
 				return;


### PR DESCRIPTION
Changes:
 - new custom type `DOMReference` defined (accepts a string or DOM element)
 - `opener` is now of type `DOMReference`
 - The framework gets new functionality:`attributeChangedCallback` can be skipped for an attribute that is being mutated internally (in order to avoid the property being synchronized back)
 - the opener ID is now queried from the same HTML document as the `ui5-popover` instance itself, rather than `window.document`.

**Why the opener type change?**

There are use cases where the popover and opener are _in different documents_ which makes it impossible to pass an ID. At the same time calling the public method to open the popover is not a good option either, because it is not declarative-friendly. The most convenient solution is to be able to pass a DOM Reference directly (which is bindable in React and other frameworks despite being an object). For simpler use cases, we want to retain the string ID option as it is declarative-friendly and does not require a framework.

Therefore, the proposed solution is to use a custom type that allows you to pass either.

**Why the opener document change?**

There are cases where the opener and popover are _in the same document_ (so the ID can be passed as a string), but this is not the main document.

The change to where `opener` is queried is due to the fact that currently the property works only if the opener HTML element is in the top-level document. However, there are many different possibilities - both the popover and its opener might be in another document (f.e. in an iframe), or they might both be in a shadow root (f.e. in a new web component that composes a popover and a button to open it). Therefore, what probably makes the most sense is to search for the opener element in the same document as the popover.

**Why the changes in the framework?**

Properties and attributes are always synchronized. This makes it impossible to have a custom type with object values that don't have a string representation. We've had similar use cases in the past (geomap) and we've solved them by stringifying the object value and setting it as an attribute, so we don't violate the "attribute always matches the property" idea. However in this use case we truly must allow to have **no attribute** if the property is of type object.