### PR TITLE
feat(ui5-illustrated-message): introduce title slot

### DIFF
--- a/packages/fiori/src/IllustratedMessage.hbs
+++ b/packages/fiori/src/IllustratedMessage.hbs
@@ -3,7 +3,11 @@
 		{{{effectiveIllustration}}}
 	</div>
 	{{#if hasTitle}}
-	<ui5-title level="H2" class="ui5-illustrated-message-title" wrapping-type="Normal">{{effectiveTitleText}}</ui5-title>
+			{{#if hasFormattedTitle}}
+				<slot name="title"></slot>
+			{{else}}
+				<ui5-title level="H2" class="ui5-illustrated-message-title" wrapping-type="Normal">{{effectiveTitleText}}</ui5-title>
+			{{/if}}
 	{{/if}}
 
 	{{#if hasSubtitle}}

--- a/packages/fiori/src/IllustratedMessage.js
+++ b/packages/fiori/src/IllustratedMessage.js
@@ -222,6 +222,18 @@ const metadata = {
 		subtitle: {
 			type: HTMLElement,
 		},
+		/**
+		 * Defines the title of the component.
+		 * <br><br>
+		 * <b>Note:</b> Using this slot, the default title text of illustration and the value of <code>title</code> property will be overwritten.
+		 * @type {HTMLElement}
+		 * @slot title
+		 * @public
+		 * @since 1.7.0
+		 */
+		title: {
+			type: HTMLElement,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.fiori.IllustratedMessage.prototype */ {
 		//
@@ -410,6 +422,10 @@ class IllustratedMessage extends UI5Element {
 		return !!this.subtitle.length;
 	}
 
+	get hasFormattedTitle() {
+		return !!this.title.length;
+	}
+
 	get effectiveTitleText() {
 		return this.titleText ? this.titleText : this.illustrationTitle;
 	}
@@ -419,11 +435,11 @@ class IllustratedMessage extends UI5Element {
 	}
 
 	get hasTitle() {
-		return this.titleText || this.illustrationTitle;
+		return this.hasFormattedTitle || this.titleText || this.illustrationTitle;
 	}
 
 	get hasSubtitle() {
-		return this.subtitleText || this.illustrationSubtitle;
+		return this.hasFormattedSubtitle || this.subtitleText || this.illustrationSubtitle;
 	}
 
 	get hasActions() {

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -132,6 +132,10 @@
 		<ui5-button icon="refresh">Try again</ui5-button>
 	</ui5-illustrated-message>
 
+	<ui5-illustrated-message id="illustratedMsg3" name="UnableToUpload">
+		<ui5-title slot="title" level="H1">This is a slotted title</ui5-title>
+	</ui5-illustrated-message>
+
 	<script>
 		const illustrationSelect = document.getElementById("illustrationSelect");
 		const sizeSelect = document.getElementById("sizeSelect");

--- a/packages/fiori/test/samples/IllustratedMessage.sample.html
+++ b/packages/fiori/test/samples/IllustratedMessage.sample.html
@@ -65,15 +65,17 @@
 </section>
 
 <section>
-	<h3>Illustrated message with link in subtitle</h3>
+	<h3>Illustrated message with custom title and link in subtitle</h3>
 	<div class="snippet">
-		<ui5-illustrated-message name="UnableToUpload" title="Something went wrong...">
+		<ui5-illustrated-message name="UnableToUpload"">
+			<ui5-title slot="title" level="H1">Something went wrong</ui5-title>
 			<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
 			<ui5-button icon="refresh">Try again</ui5-button>
 		</ui5-illustrated-message>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-illustrated-message name="UnableToUpload" title="Something went wrong...">
+<ui5-illustrated-message name="UnableToUpload"">
+	<ui5-title slot="title" level="H1">Something went wrong</ui5-title>
 	<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
 	<ui5-button icon="refresh">Try again</ui5-button>
 </ui5-illustrated-message>


### PR DESCRIPTION
Introduced new title slot, that allows custom title levels.

```html
<ui5-illustrated-message name="UnableToUpload">
    <ui5-title slot="title" level="H1">This is a slotted title</ui5-title>
</ui5-illustrated-message>
```
Closes: #5503