### PR TITLE
feat(ui5-popover): openerRef property added

### DIFF
--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -146,6 +146,9 @@ const metadata = {
 
 		/**
 		 * Defines the opener id of the element that the popover is shown at
+		 * <b>Node:</b> The supplied id must belong to the same HTML <code>document</code> as the <code>ui5-popover</code>
+		 * <b>Note:</b> If both <code>opener</code> and <code>openerRef</code> properties are set,
+		 * <code>openerRef</code> will be used and <code>opener</code> will be ignored
 		 * @public
 		 * @type {String}
 		 * @defaultvalue ""
@@ -153,6 +156,20 @@ const metadata = {
 		 */
 		opener: {
 			type: String,
+		},
+
+		/**
+		 * Defines the opener DOM reference of the element that the popover is shown at.
+		 * Use this property whenever the opener element is in a different HTML <code>document</code>
+		 * compared to the <code>ui5-popover</code>.
+		 * <b>Note:</b> If both <code>opener</code> and <code>openerRef</code> properties are set,
+		 * <code>openerRef</code> will be used and <code>opener</code> will be ignored
+		 * @public
+		 * @type {Object}
+		 * @since 1.7.0
+		 */
+		openerRef: {
+			type: Object,
 		},
 
 		/**
@@ -305,7 +322,7 @@ class Popover extends Popup {
 
 	onAfterRendering() {
 		if (!this.isOpen() && this.open) {
-			const opener = document.getElementById(this.opener);
+			const opener = this.openerRef || this.getRootNode().getElementById(this.opener);
 			if (!opener) {
 				console.warn("Valid opener id is required."); // eslint-disable-line
 				return;


### PR DESCRIPTION
WIP

This change:
 - introduces a new `openerRef` property that is an alternative to `opener`, and with higher priority than it. Being of type `Object`, it is not declarative-style-friendly, however it allows you to pass an arbitrary DOM element from any HTML document.
 - changes the way `opener` works: namely, the opener ID is now queried from the same HTML document as the `ui5-popover` instance itself, rather than `window.document`.

The change to `opener` is due to the fact that currently the property works only if the opener HTML element is in the top-level document. However, there are many different possibilities - both the popover and its opener might be in another document (f.e. in an iframe), or they might both be in a shadow root (f.e. in a new web component that composes a popover and a button to open it). Therefore, what probably makes the most sense is to search for the opener element in the same document as the popover.

The introduction of a second property, `openerRef`, instead of having `opener` handle both cases (string or object, as a custom type for example) is due to our synchronization mechanism inside `UI5Element.js`.  Imagine `opener` could accept both `String` and `Object`. You set the property to a string, f.e. `popover.opener = "buttonId"`. This will automatically synchronize the attribute: `opener="buttonId"`. Next, imagine you set the `opener` property to an object: `popover.opener = buttonRef`. The attribute still holds the old value (`buttonId`), so the framework must make a choice:
 - does it leave the attribute with the now outdated string value? It cannot, as this introduces ambiguity, since we don't have any information which was set first and which second, so we can't know if the property or attribute is more recent.
 - or does it remove the attribute, as it can't update it to an object-like value? But if we remove the attribute, this triggers the web component's lifecycle hook `attributeChangedCallback`, which is handled by the browser and we have no influence over. And when `attributeChangedCallback` gets executed, we cannot know if we triggered this by removing the attribute in response to `opener` getting an object value, or the user explicitly calling `removeAttribute("opener")`, in which case we must synchronize the property with the attribute, effectively setting it to `null` (since the attribute was removed). 