### PR TITLE
fix(i18n): usage of quotes in texts

### DIFF
--- a/packages/base/src/i18nBundle.js
+++ b/packages/base/src/i18nBundle.js
@@ -37,7 +37,7 @@ class I18nBundle {
 		}
 		const messageText = bundle && bundle[textObj.key] ? bundle[textObj.key] : (textObj.defaultText || textObj.key);
 
-		return formatMessage(messageText, params);
+		return !!params.length ? formatMessage(messageText, params) : messageText;
 	}
 }
 


### PR DESCRIPTION
Formatter function should invoked if parameters for placeholders exist.

If parameters exist the output should be:
`Text  '{0}` => `Text {placeholder's text}`
`Text  ''{0}` => `Text '{placeholder's text}`
`Text  ''{0}''` =>  `Text '{placeholder's text}'`

If parameters don't exist the output should be:
`Text`   => `Text `
`Text  '` => `Text '`
`Text  ''` => `Text '`
`Text  {0}` => `Text {0}`

Fixes: #5626