### PR TITLE
fix(ui5-panel): toggle ui5-panel correctly on Enter key

### DIFF
--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -322,7 +322,7 @@ class Panel extends UI5Element {
 		}
 
 		if (isEnter(event)) {
-			this._toggleOpen();
+			event.preventDefault();
 		}
 
 		if (isSpace(event)) {
@@ -333,6 +333,10 @@ class Panel extends UI5Element {
 	_headerKeyUp(event) {
 		if (!this.shouldToggle(event.target)) {
 			return;
+		}
+
+		if (isEnter(event)) {
+			this._toggleOpen();
 		}
 
 		if (isSpace(event)) {


### PR DESCRIPTION
Previously in Safari, when the ui5-panel expand/collapsed button was activated via Enter key, the component did not remain open but closed instantly.

FIXES: #5579
