### PR TITLE
feat(ui5-tabcontainer): make tab-select event preventable

### DIFF
--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -264,7 +264,7 @@ const metadata = {
 		 *
 		 * @event sap.ui.webcomponents.main.TabContainer#tab-select
 		 * @param {HTMLElement} tab The selected <code>tab</code>.
-		 * @param {Integer} tabIndex The selected <code>tab</code> index. This index is valid for an array containing all tabs and their subTabs.
+		 * @param {Integer} tabIndex The selected <code>tab</code> index in the flattened array of all tabs and their subTabs, provided by the <code>allItems</code> getter.
 		 * @public
 		 * @allowPreventDefault
 		 */

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -313,7 +313,7 @@
 			<ui5-tab text="Availability">
 				<ui5-button>Button 2</ui5-button>
 			</ui5-tab>
-			<ui5-tab text="Date of Expire">
+			<ui5-tab text="Expiration Date">
 				<ui5-button>Button 3</ui5-button>
 			</ui5-tab>
 			<ui5-tab text="Date of Delivery">
@@ -328,10 +328,10 @@
 			<ui5-tab text="Price">
 				<ui5-button>Button 4</ui5-button>
 			</ui5-tab>
-			<ui5-tab text="Net profit">
+			<ui5-tab text="Net Profit">
 				<ui5-button>Button 4</ui5-button>
 			</ui5-tab>
-			<ui5-tab text="Company name">
+			<ui5-tab text="Company Name">
 				<ui5-button>Button 4</ui5-button>
 			</ui5-tab>
 			<ui5-tab text="Warehouse Location">
@@ -513,7 +513,7 @@
 				<ui5-tab text="Availability">
 					<ui5-button>Button 2</ui5-button>
 				</ui5-tab>
-				<ui5-tab text="Date of Expire">
+				<ui5-tab text="Expiration Date">
 					<ui5-button>Button 3</ui5-button>
 				</ui5-tab>
 				<ui5-tab text="Date of Delivery">
@@ -528,10 +528,10 @@
 				<ui5-tab text="Price">
 					<ui5-button>Button 4</ui5-button>
 				</ui5-tab>
-				<ui5-tab text="Net profit">
+				<ui5-tab text="Net Profit">
 					<ui5-button>Button 4</ui5-button>
 				</ui5-tab>
-				<ui5-tab text="Company name">
+				<ui5-tab text="Company Name">
 					<ui5-button>Button 4</ui5-button>
 				</ui5-tab>
 				<ui5-tab text="Warehouse Location">

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -12,11 +12,7 @@
 			"language": "EN"
 		}
 	</script>
-
-
 	<script src="../../bundle.esm.js" type="module"></script>
-
-
 	<link rel="stylesheet" type="text/css" href="./styles/TabContainer.css">
 </head>
 
@@ -127,7 +123,7 @@
 					<ui5-tab slot="subTabs" text="Fourteen 1.1">1.1</ui5-tab>
 				</ui5-tab>
 				<ui5-tab slot="subTabs" text="Fourteen 2">2
-					<ui5-tab  slot="subTabs" text="Fourteen 2.1">2.1
+					<ui5-tab slot="subTabs" text="Fourteen 2.1">2.1
 						<ui5-tab slot="subTabs" text="Fourteen 2.1.1">2.1.1</ui5-tab>
 					</ui5-tab>
 					<ui5-tab slot="subTabs" text="Fourteen 2.2">2.2</ui5-tab>
@@ -234,6 +230,7 @@
 
 	<section>
 		<h2>Tab Container</h2>
+		<ui5-checkbox text="prevent tab-select event" id="cbPrevent"></ui5-checkbox>
 		<ui5-tabcontainer id="tabContainer1" fixed collapsed>
 			<ui5-tab stable-dom-ref="products-ref" text="Products" additional-text="125"></ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
@@ -509,44 +506,44 @@
 		<h3>TabContainer in Compact</h3>
 		<div>
 			<ui5-tabcontainer>
-			<ui5-tab text="Products ID">
-				<ui5-button>Button 11</ui5-button>
-				<ui5-button>Button 12</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Availability">
-				<ui5-button>Button 2</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Date of Expire">
-				<ui5-button>Button 3</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Date of Delivery">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Date of Manufacture">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Value">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Price">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Net profit">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Company name">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Warehouse Location">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Address">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-			<ui5-tab text="Country">
-				<ui5-button>Button 4</ui5-button>
-			</ui5-tab>
-		</ui5-tabcontainer>
+				<ui5-tab text="Products ID">
+					<ui5-button>Button 11</ui5-button>
+					<ui5-button>Button 12</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Availability">
+					<ui5-button>Button 2</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Date of Expire">
+					<ui5-button>Button 3</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Date of Delivery">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Date of Manufacture">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Value">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Price">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Net profit">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Company name">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Warehouse Location">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Address">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+				<ui5-tab text="Country">
+					<ui5-button>Button 4</ui5-button>
+				</ui5-tab>
+			</ui5-tabcontainer>
 
 			<ui5-tabcontainer id="tabContainer1Compact" fixed collapsed>
 				<ui5-tab stable-dom-ref="products-ref" text="Products" additional-text="125"></ui5-tab>
@@ -758,7 +755,7 @@
 					<ui5-button>Button 1</ui5-button>
 				</ui5-tab>
 			</ui5-tabcontainer>
-		
+
 			<ui5-button id="selectFirst">Select First Tab</ui5-button>
 			<ui5-button id="selectLast">Select Last Tab</ui5-button>
 			<ui5-button id="selectNested">Select a Nested Tab</ui5-button>
@@ -766,9 +763,20 @@
 	</section>
 
 	<script>
-		document.getElementById("tabContainer1").addEventListener("ui5-tabSelect", function (event) {
+		document.getElementById("tabContainer1").addEventListener("ui5-tab-select", async function (event) {
 			result.innerHTML = event.detail.tab.text;
 			resultIdx.innerHTML = event.detail.tabIndex;
+		});
+
+		let preventTabSelect = false;
+		document.getElementById("cbPrevent").addEventListener("ui5-change", event => {
+			preventTabSelect = event.target.checked;
+		});
+
+		document.getElementById("tabContainer1").addEventListener("ui5-tab-select", event => {
+			if (preventTabSelect) {
+				event.preventDefault();
+			}
 		});
 
 		document.getElementById("densityToggle").addEventListener("ui5-click", function (event) {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -30,6 +30,27 @@ describe("TabContainer general interaction", () => {
 		assert.strictEqual(await resultIdx.getText(), SELECTED_TAB_INDEX, "Tab index is retrieved correctly.");
 	});
 
+	it("tests preventing tabSelect", async() => {
+		// Setup
+		const cbPrevent = await browser.$("#cbPrevent");
+		await cbPrevent.click();
+
+		const selectedTab = await browser.$("#tabContainer1").shadow$(".ui5-tab-strip-item--selected");
+		const newTab = await browser.$("#tabContainer1").shadow$(".ui5-tab-strip-item:nth-child(1)");
+
+		assert.notStrictEqual(await newTab.getProperty("id"), await selectedTab.getProperty("id"), "tabs to test are different");
+
+		// Act
+		await newTab.click();
+
+		// Assert
+		assert.ok(await selectedTab.hasClass("ui5-tab-strip-item--selected"), "previously selected tab is still selected");
+		assert.notOk(await newTab.hasClass("ui5-tab-strip-item--selected"), "clicked tab is not selected");
+	
+		// Clean-up
+		await cbPrevent.click();
+	});
+
 	it("tests custom media ranges", async () => {
 		await browser.setWindowSize(520, 1080);
 		assert.strictEqual(await browser.$("#tabContainerIconOnly").getAttribute("media-range"), "S", "media-range=S");


### PR DESCRIPTION
The `tab-select` event can now be prevented.

Added new public getter `allItems` that returns an array which includes all
slotted tabs and their subTabs. The reason for the addition is that
the `tab-select` event returns a `tabIndex` of the selected tab, but if that selected tab is
nested, then `tabIndex` will not correspond to the `items` property,
which includes only the top-level tabs.

Fixes #5116