### PR TITLE
chore: remove 'X-UA-Compatible' meta element

### DIFF
--- a/packages/base/test/pages/AllTestElements.html
+++ b/packages/base/test/pages/AllTestElements.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
 
     <title>Base package default test page</title>

--- a/packages/base/test/pages/Configuration.html
+++ b/packages/base/test/pages/Configuration.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
 
     <title>Base package default test page</title>

--- a/packages/base/test/pages/ConfigurationScript.html
+++ b/packages/base/test/pages/ConfigurationScript.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
 
     <title>Base package default test page</title>

--- a/packages/base/test/pages/i18n.html
+++ b/packages/base/test/pages/i18n.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>i18n</title>

--- a/packages/create-package/template/test/pages/index.html
+++ b/packages/create-package/template/test/pages/index.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>INIT_PACKAGE_VAR_TAG</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/fiori/test/pages/Bar.html
+++ b/packages/fiori/test/pages/Bar.html
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Bar test page</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 

--- a/packages/fiori/test/pages/BarcodeScannerDialog.html
+++ b/packages/fiori/test/pages/BarcodeScannerDialog.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/Components.html
+++ b/packages/fiori/test/pages/Components.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/fiori/test/pages/DynamicSideContent.html
+++ b/packages/fiori/test/pages/DynamicSideContent.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/F6TestPage.html
+++ b/packages/fiori/test/pages/F6TestPage.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/FCLApp.html
+++ b/packages/fiori/test/pages/FCLApp.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/FCLCustom.html
+++ b/packages/fiori/test/pages/FCLCustom.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/fiori/test/pages/MediaGallery.html
+++ b/packages/fiori/test/pages/MediaGallery.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ui5-media-gallery</title>
 
 

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>NotificationListGroupItem</title>
 
 

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>NotificationListItem</title>
 
 

--- a/packages/fiori/test/pages/NotificationList_test_page.html
+++ b/packages/fiori/test/pages/NotificationList_test_page.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>NotificationListItem and NotificationListGroupItem</title>
 
 

--- a/packages/fiori/test/pages/Page.html
+++ b/packages/fiori/test/pages/Page.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Page</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/fiori/test/pages/ProductSwitch.html
+++ b/packages/fiori/test/pages/ProductSwitch.html
@@ -2,7 +2,6 @@
 <html class="productswitch1auto">
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<title>ui5-product-switch</title>

--- a/packages/fiori/test/pages/ProductSwitchItem.html
+++ b/packages/fiori/test/pages/ProductSwitchItem.html
@@ -2,7 +2,6 @@
 <html class="productswitchitem1auto">
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<title>ui5-product-switch-item</title>

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Shell Bar</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Side Navigation</title>
 	<script>
 		// delete Document.prototype.adoptedStyleSheets

--- a/packages/fiori/test/pages/Timeline.html
+++ b/packages/fiori/test/pages/Timeline.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Timeline</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/fiori/test/pages/ViewSettingsDialog.html
+++ b/packages/fiori/test/pages/ViewSettingsDialog.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
 	<title>ViewSettingsDialog test page</title>
 

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Wizard</title>
 
 	<script data-ui5-config type="application/json">

--- a/packages/fiori/test/pages/Wizard_test.html
+++ b/packages/fiori/test/pages/Wizard_test.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Wizard Test Page</title>
 
 

--- a/packages/fiori/test/pages/Wizard_test_mobile.html
+++ b/packages/fiori/test/pages/Wizard_test_mobile.html
@@ -5,7 +5,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Wizard Test Page - small widths</title>
 
 	<script src="../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/72override.html
+++ b/packages/main/test/pages/72override.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/AnimanitionOff.html
+++ b/packages/main/test/pages/AnimanitionOff.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<title>Animations off</title>

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Avatar</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>avatar-group</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Badge.html
+++ b/packages/main/test/pages/Badge.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Badge</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Breadcrumbs</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script>// delete Document.prototype.adoptedStyleSheets;</script>

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Color Palette</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Color Palette Popover</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/ColorPicker.html
+++ b/packages/main/test/pages/ColorPicker.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -5,7 +5,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ComboBox test page</title>
 	<script>
 		// delete Document.prototype.adoptedStyleSheets

--- a/packages/main/test/pages/Components.html
+++ b/packages/main/test/pages/Components.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/CoreControls.html
+++ b/packages/main/test/pages/CoreControls.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/CoreControls_exp.html
+++ b/packages/main/test/pages/CoreControls_exp.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/CustomCSS.html
+++ b/packages/main/test/pages/CustomCSS.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>DatePicker test page</title>
 
 	<script>

--- a/packages/main/test/pages/DatePicker_test_page.html
+++ b/packages/main/test/pages/DatePicker_test_page.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/DateRangePicker.html
+++ b/packages/main/test/pages/DateRangePicker.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>DateRangePicker test page</title>
 
 	<script>

--- a/packages/main/test/pages/DateTimePicker.html
+++ b/packages/main/test/pages/DateTimePicker.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>DateTimePicker Test Page</title>
 
     <script>

--- a/packages/main/test/pages/DayPicker.html
+++ b/packages/main/test/pages/DayPicker.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script>

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 	<title>Dialog</title>

--- a/packages/main/test/pages/DialogLifecycle.html
+++ b/packages/main/test/pages/DialogLifecycle.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/DialogSemantic.html
+++ b/packages/main/test/pages/DialogSemantic.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 	<title>Dialog</title>

--- a/packages/main/test/pages/DurationPicker.html
+++ b/packages/main/test/pages/DurationPicker.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>DurationPicker</title>

--- a/packages/main/test/pages/Eventing.html
+++ b/packages/main/test/pages/Eventing.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/FileUploader.html
+++ b/packages/main/test/pages/FileUploader.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>FileUploader test page</title>
 
 

--- a/packages/main/test/pages/FormSupport.html
+++ b/packages/main/test/pages/FormSupport.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
     <title>Form support</title>

--- a/packages/main/test/pages/HCB.html
+++ b/packages/main/test/pages/HCB.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Icon.html
+++ b/packages/main/test/pages/Icon.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Icon_custom.html
+++ b/packages/main/test/pages/Icon_custom.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ui5-input</title>
 
 

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Input Quick View</title>
 
 	<script src="../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/InputsAlignment.html
+++ b/packages/main/test/pages/InputsAlignment.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Inputs Alignment</title>
 
 

--- a/packages/main/test/pages/InputsLazyLoading.html
+++ b/packages/main/test/pages/InputsLazyLoading.html
@@ -4,7 +4,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Input Lazy Loading</title>
 
   <script src="../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/ItemNavigation.html
+++ b/packages/main/test/pages/ItemNavigation.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>Item Navigation</title>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -4,7 +4,6 @@
 <head>
 	<title>ui5 webcomponents</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<link rel="stylesheet" type="text/css" href="./kitchen-styles.css">

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -4,7 +4,6 @@
 <head>
 	<title>ui5 webcomponents</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<link rel="stylesheet" type="text/css" href="./kitchen-styles.css">

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Label</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
 	<script data-ui5-config type="application/json">
 		{

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Playground</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script>// delete Document.prototype.adoptedStyleSheets;</script>

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>

--- a/packages/main/test/pages/ListGrowing_Button.html
+++ b/packages/main/test/pages/ListGrowing_Button.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>

--- a/packages/main/test/pages/ListGrowing_Scroll.html
+++ b/packages/main/test/pages/ListGrowing_Scroll.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>

--- a/packages/main/test/pages/List_keyboard_support.html
+++ b/packages/main/test/pages/List_keyboard_support.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>ui5-list / ui5-li</title>

--- a/packages/main/test/pages/LitKeyFunction.html
+++ b/packages/main/test/pages/LitKeyFunction.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>LitHTML key function test page</title>
 	<script>
 		// delete Document.prototype.adoptedStyleSheets

--- a/packages/main/test/pages/MemoryLeak.html
+++ b/packages/main/test/pages/MemoryLeak.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Menu</title>
 
 	<script src="../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/MessagePage.html
+++ b/packages/main/test/pages/MessagePage.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/MessageStrip.html
+++ b/packages/main/test/pages/MessageStrip.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html role="application">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/MultiComboBox.html
+++ b/packages/main/test/pages/MultiComboBox.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>MultiComboBox test page</title>
 	<script>
 		// delete Document.prototype.adoptedStyleSheets

--- a/packages/main/test/pages/MultiInput.html
+++ b/packages/main/test/pages/MultiInput.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ui5-multi-input</title>
 
 

--- a/packages/main/test/pages/MultiInput_Suggestions.html
+++ b/packages/main/test/pages/MultiInput_Suggestions.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ui5-multi-input</title>
 
 

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/Panel.html
+++ b/packages/main/test/pages/Panel.html
@@ -3,7 +3,6 @@
 
 <head>
 	<title>Panel</title>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Popover</title>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<title>Popups</title>

--- a/packages/main/test/pages/ProgressIndicator.html
+++ b/packages/main/test/pages/ProgressIndicator.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/RTL.html
+++ b/packages/main/test/pages/RTL.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/RadioButton.html
+++ b/packages/main/test/pages/RadioButton.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/RangeSlider.html
+++ b/packages/main/test/pages/RangeSlider.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>UI5 Range Slider</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/ResizeHandler.html
+++ b/packages/main/test/pages/ResizeHandler.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ResponsivePopover</title>
 
 	<script src="../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>ui5-select</title>
 
 	<script>

--- a/packages/main/test/pages/Simple.html
+++ b/packages/main/test/pages/Simple.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 

--- a/packages/main/test/pages/Slider.html
+++ b/packages/main/test/pages/Slider.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>UI5 Slider</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/StepInput.html
+++ b/packages/main/test/pages/StepInput.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>StepInput test page</title>
 
 	<script>

--- a/packages/main/test/pages/Switch.html
+++ b/packages/main/test/pages/Switch.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Tab Container</title>
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Table-perf-pure.html
+++ b/packages/main/test/pages/Table-perf-pure.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Web components Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script data-config type="application/json">

--- a/packages/main/test/pages/Table-perf.html
+++ b/packages/main/test/pages/Table-perf.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Web components Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Web components Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/Table2.html
+++ b/packages/main/test/pages/Table2.html
@@ -3,7 +3,6 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Web components Table</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TableAllPopin.html
+++ b/packages/main/test/pages/TableAllPopin.html
@@ -3,7 +3,6 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Web components Table</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TableCustomStyling.html
+++ b/packages/main/test/pages/TableCustomStyling.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Web components Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TableGrouping.html
+++ b/packages/main/test/pages/TableGrouping.html
@@ -3,7 +3,6 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Web components Table</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TableGrowingWithButton.html
+++ b/packages/main/test/pages/TableGrowingWithButton.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script>// delete Document.prototype.adoptedStyleSheets</script>

--- a/packages/main/test/pages/TableGrowingWithScroll.html
+++ b/packages/main/test/pages/TableGrowingWithScroll.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script>// delete Document.prototype.adoptedStyleSheets</script>

--- a/packages/main/test/pages/TableSelection.html
+++ b/packages/main/test/pages/TableSelection.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Web components Table</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -2,12 +2,10 @@
 <html xmlns="http://www.w3.org/1999/html">
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>TextArea</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script data-ui5-config type="application/json">

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta charset="utf-8">
 
 		<script>

--- a/packages/main/test/pages/TimeSelection.html
+++ b/packages/main/test/pages/TimeSelection.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta charset="utf-8">
 
 		<script>

--- a/packages/main/test/pages/Title.html
+++ b/packages/main/test/pages/Title.html
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>Title test page</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 

--- a/packages/main/test/pages/Toast.html
+++ b/packages/main/test/pages/Toast.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>ui5-toast</title>

--- a/packages/main/test/pages/ToggleButton.html
+++ b/packages/main/test/pages/ToggleButton.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>ToggleButton</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script>

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>ui5-tree</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<script>// delete Document.prototype.adoptedStyleSheets;</script>

--- a/packages/main/test/pages/WheelSlider_Test_Page.html
+++ b/packages/main/test/pages/WheelSlider_Test_Page.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta charset="utf-8">
 
 		<script>

--- a/packages/main/test/pages/base/DOMObserver.html
+++ b/packages/main/test/pages/base/DOMObserver.html
@@ -2,12 +2,10 @@
 <html>
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
 
     <title>DOMObserver</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
 
     <script src="../../../bundle.esm.js" type="module"></script>

--- a/packages/main/test/pages/base/InvisibleMessage.html
+++ b/packages/main/test/pages/base/InvisibleMessage.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 

--- a/packages/main/test/pages/form.html
+++ b/packages/main/test/pages/form.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>Form support</title>

--- a/packages/main/test/pages/i18n-defaultLang.html
+++ b/packages/main/test/pages/i18n-defaultLang.html
@@ -2,12 +2,10 @@
 <html xmlns="http://www.w3.org/1999/html">
 
 <head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<title>i18n default language test page</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta charset="utf-8">
 
 	<!-- The "fetchDefaultLanguage" is enabled,

--- a/packages/main/test/pages/i18n-demo.html
+++ b/packages/main/test/pages/i18n-demo.html
@@ -3,7 +3,6 @@
 
 <head>
 	<script>// delete Document.prototype.adoptedStyleSheets;</script>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 	<title>i18n Demo</title>

--- a/packages/playground/_includes/head.html
+++ b/packages/playground/_includes/head.html
@@ -1,6 +1,5 @@
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta name="keywords" content="ui5-webcomponents,ui5 webcomponents,ui5 web components,webcomponents,web components,ui5,api,docs,documentation,sample,usage,examples,demo,Fiori 3">
 
   {% if site.plugins.jekyll-seo == nil %}


### PR DESCRIPTION
Element `<meta http-equiv="X-UA-Compatible" content="IE=edge">` has been
removed from all files.

See https://github.com/SAP/openui5/commit/e07ec6797746b7a286a39264579ae923cb404e2a