### PR TITLE
fix: correct imports of horizon Badge CSS files

### DIFF
--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -2,7 +2,7 @@
 @import "../base/rtl-parameters.css";
 @import "./Avatar-parameters.css";
 @import "./AvatarGroup-parameters.css";
-@import "../base/Badge-parameters.css";
+@import "./Badge-parameters.css";
 @import "./Breadcrumbs-parameters.css";
 @import "../base/BrowserScrollbar-parameters.css";
 @import "./BusyIndicator-parameters.css";

--- a/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -2,7 +2,7 @@
 @import "../base/rtl-parameters.css";
 @import "./Avatar-parameters.css";
 @import "../sap_horizon/AvatarGroup-parameters.css";
-@import "../base/Badge-parameters.css";
+@import "./Badge-parameters.css";
 @import "./Breadcrumbs-parameters.css";
 @import "../base/BrowserScrollbar-parameters.css";
 @import "./BusyIndicator-parameters.css";


### PR DESCRIPTION
Related to: #5667

Since #5171, the badge css files are uncorrectly imported and are now causing deviations from the design specification.