### PR TITLE
fix(ui5-textarea): show exceeded text when maxLength is 0

### DIFF
--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -534,7 +534,7 @@ class TextArea extends UI5Element {
 			leftCharactersCount;
 
 		if (this.showExceededText) {
-			const maxLength = this.maxlength || 0;
+			const maxLength = this.maxlength;
 
 			if (maxLength !== null) {
 				leftCharactersCount = maxLength - this.value.length;

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -536,7 +536,7 @@ class TextArea extends UI5Element {
 		if (this.showExceededText) {
 			const maxLength = this.maxlength || 0;
 
-			if (maxLength) {
+			if (maxLength !== null) {
 				leftCharactersCount = maxLength - this.value.length;
 
 				if (leftCharactersCount >= 0) {

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -134,6 +134,11 @@
 	</section>
 
 	<section class="group">
+		<ui5-title>Text Area: showExceededText with maxlength '0'</ui5-title>
+		<ui5-textarea id="show-max-length-0" class="fixed-width fixed-height" maxlength="0" show-exceeded-text placeholder="Max length and Show Exceeded Text"></ui5-textarea>
+	</section>
+
+	<section class="group">
 		<ui5-title>Text Area: change event</ui5-title>
 		<ui5-textarea id="textarea-change" class="fixed-width fixed-height" placeholder="Test change event"></ui5-textarea>
 	</section>

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -242,11 +242,11 @@ describe("when enabled", () => {
 				const textAreaInner = await browser.$("#show-max-length-0").shadow$("textarea");
 				const counter = await browser.$("#show-max-length-0").shadow$(".ui5-textarea-exceeded-text");
 
+				let count = parseInt(await counter.getText());
 				assert.strictEqual(count, 4, "0 characters remaining");
 
 				await textAreaInner.setValue(`1234`);
-
-				const count = parseInt(await counter.getText());
+				count = parseInt(await counter.getText());
 
 				assert.strictEqual(count, 4, "4 symbols should exceed");
 			});

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -237,6 +237,19 @@ describe("when enabled", () => {
 
 				assert.strictEqual(count, 4, "4 symbols should exceed");
 			});
+
+			it("Shows exceeded text when maxLength is 0", async () => {
+				const textAreaInner = await browser.$("#show-max-length-0").shadow$("textarea");
+				const counter = await browser.$("#show-max-length-0").shadow$(".ui5-textarea-exceeded-text");
+
+				assert.strictEqual(count, 4, "0 characters remaining");
+
+				await textAreaInner.setValue(`1234`);
+
+				const count = parseInt(await counter.getText());
+
+				assert.strictEqual(count, 4, "4 symbols should exceed");
+			});
 		});
 	});
 });

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -243,7 +243,7 @@ describe("when enabled", () => {
 				const counter = await browser.$("#show-max-length-0").shadow$(".ui5-textarea-exceeded-text");
 
 				let count = parseInt(await counter.getText());
-				assert.strictEqual(count, 4, "0 characters remaining");
+				assert.strictEqual(count, 0, "0 characters remaining");
 
 				await textAreaInner.setValue(`1234`);
 				count = parseInt(await counter.getText());


### PR DESCRIPTION
related to #5384


