### PR TITLE
fix(ui5-button): correct calculation of the min width of an icon button

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -103,7 +103,7 @@
 
 :host([has-icon]:not([icon-only])) .ui5-button-text{
 	/* calculating the minimum width by removing the icon size  */
-	min-width: calc(var(--_ui5_button_base_min_width) - 1rem);
+	min-width: calc(var(--_ui5_button_base_min_width) - var(--_ui5_button_base_icon_margin) - 1rem);
 }
 
 :host([focused]) .ui5-button-root:after {

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -101,6 +101,11 @@
 	pointer-events: none;
 }
 
+:host([has-icon]:not([icon-only])) .ui5-button-text{
+	/* calculating the minimum width by removing the icon size  */
+	min-width: calc(var(--_ui5_button_base_min_width) - 1rem);
+}
+
 :host([focused]) .ui5-button-root:after {
 	content: "";
 	position: absolute;


### PR DESCRIPTION
* When using a segment button placed in a container with display flex a minimum width setting is necessary
FIXES: #5027