### PR TITLE
refactor(ui5-card-header): add new CSS Shadow part

### DIFF
--- a/packages/main/src/CardHeader.hbs
+++ b/packages/main/src/CardHeader.hbs
@@ -6,6 +6,7 @@
 	@click="{{_click}}"
 	@keydown="{{_keydown}}"
 	@keyup="{{_keyup}}"
+	part="root"
 >
 	<div
 		class="ui5-card-header-focusable-element"

--- a/packages/main/src/CardHeader.js
+++ b/packages/main/src/CardHeader.js
@@ -133,6 +133,7 @@ const metadata = {
  * <br>
  * The <code>ui5-card</code> exposes the following CSS Shadow Parts:
  * <ul>
+ * <li>root - Used to style the root DOM element of the CardHeader</li>
  * <li>title - Used to style the title of the CardHeader</li>
  * <li>subtitle - Used to style the subtitle of the CardHeader</li>
  * <li>status - Used to style the status of the CardHeader</li>


### PR DESCRIPTION
Recently we got a request from the MDK colleagues to customize the background of the CardHeader and to make this possible we add a new shadow part (as we have for the title, status and sub-status texts).