### PR TITLE
fix(ui5-li-notification): align actions' texts to the left

### DIFF
--- a/packages/fiori/src/NotificationOverflowActionsPopover.hbs
+++ b/packages/fiori/src/NotificationOverflowActionsPopover.hbs
@@ -13,6 +13,7 @@
 				?disabled="{{this.disabled}}"
 				design="{{this.design}}"
 				data-ui5-external-action-item-id="{{this.refItemid}}"
+				class="ui5-notification-overflow-list-btn"
 				>{{this.text}}
 			</ui5-button>
 		{{/each}}

--- a/packages/fiori/src/themes/NotificationOverflowActionsPopover.css
+++ b/packages/fiori/src/themes/NotificationOverflowActionsPopover.css
@@ -6,3 +6,7 @@
 .ui5-notification-overflow-popover::part(content) {
 	padding: var(--_ui5-notification-overflow-popover-padding);
 }
+
+.ui5-notification-overflow-list-btn::part(button) {
+	justify-content: flex-start;
+}

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -70,6 +70,7 @@
 
 			<ui5-notification-action icon="accept" text="Accept All Requested Information" slot="actions"></ui5-notification-action>
 			<ui5-notification-action icon="decline" design="Negative" text="Reject All Requested Information" slot="actions"></ui5-notification-action>
+			<ui5-notification-action icon="decline" design="Negative" text="Reject More" slot="actions"></ui5-notification-action>
 		</ui5-li-notification>
 
 		<ui5-li-notification title-text="New order (#2523)">


### PR DESCRIPTION
The change aligns actions' texts to the left.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5704

Before:
<img width="645" alt="Screenshot 2022-08-23 at 14 23 14" src="https://user-images.githubusercontent.com/15702139/186156913-5da85c13-2d0c-4cc1-81d6-c53d6b5fb17f.png">

After:
<img width="417" alt="Screenshot 2022-08-23 at 15 22 31" src="https://user-images.githubusercontent.com/15702139/186156921-d371d530-18f5-4a2c-be42-e8637455d746.png">
<img width="417" alt="Screenshot 2022-08-23 at 15 22 31" src="https://user-images.githubusercontent.com/15702139/186156977-34634b20-0b78-4fe8-a593-1fb5a6f1b7bb.png">

