### PR TITLE
fix(ui5-button): adjust icon role

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -25,7 +25,7 @@
 		<ui5-icon
 			class="ui5-button-icon"
 			name="{{icon}}"
-			accessible-role="{{iconRole}}"
+			accessible-role="presentation"
 			part="icon"
 			?show-tooltip={{showIconTooltip}}
 		></ui5-icon>

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -461,14 +461,6 @@ class Button extends UI5Element {
 		return this.design !== ButtonDesign.Default && this.design !== ButtonDesign.Transparent;
 	}
 
-	get iconRole() {
-		if (!this.icon) {
-			return "";
-		}
-
-		return this.showIconTooltip ? "img" : "presentation";
-	}
-
 	get isIconOnly() {
 		return !isDefaultSlotProvided(this);
 	}


### PR DESCRIPTION
- The ui5-button icon has role "presentation"
in all cases as per specification.

Fixes: #5505
Fixes: #5596
Fixes: #5687