### PR TITLE
Revert "fix(ui5-button): adjust icon role"

### DIFF
--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -25,7 +25,7 @@
 		<ui5-icon
 			class="ui5-button-icon"
 			name="{{icon}}"
-			accessible-role="presentation"
+			accessible-role="{{iconRole}}"
 			part="icon"
 			?show-tooltip={{showIconTooltip}}
 		></ui5-icon>

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -461,6 +461,14 @@ class Button extends UI5Element {
 		return this.design !== ButtonDesign.Default && this.design !== ButtonDesign.Transparent;
 	}
 
+	get iconRole() {
+		if (!this.icon) {
+			return "";
+		}
+
+		return this.showIconTooltip ? "img" : "presentation";
+	}
+
 	get isIconOnly() {
 		return !isDefaultSlotProvided(this);
 	}


### PR DESCRIPTION
The default tooltip announcement coming from the inner ui5-button icon is not
present.

Reverts SAP/ui5-webcomponents#5714