### PR TITLE
fix(ui5-list): unexpected spaces between group items

### DIFF
--- a/packages/main/src/themes/GroupHeaderListItem.css
+++ b/packages/main/src/themes/GroupHeaderListItem.css
@@ -16,6 +16,7 @@
 	font-size: var(--sapFontHeader6Size);
 	font-weight: normal;
 	line-height: 2rem;
+	margin: 0;
 }
 
 .ui5-ghli-title {


### PR DESCRIPTION
Fixes #5720 

Bug description:
There are spaces that should not be, between the items with different GroupHeaders. It is caused by #3869.

Fix:
Removed the spaces between the items.

### Before fix:
![image](https://user-images.githubusercontent.com/88034608/186705578-b19c33d3-b60a-4f4a-9c5d-9afe79a8c404.png)

### After fix:
![image](https://user-images.githubusercontent.com/88034608/186705817-a5581055-ac53-4e37-9934-2614454914ef.png)

