### PR TITLE
feat(ui5-menu-item): add new `accessibleName` property

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -57,6 +57,7 @@
 				class="ui5-menu-item"
 				id="{{../_id}}-menu-item-{{@index}}"
 				icon="{{this.item.icon}}"
+				accessible-name={{this.item.ariaLabelledByText}}
 				accessible-role="menuitem"
 				._ariaHasPopup={{this.ariaHasPopup}}
 				?disabled={{this.item.disabled}}

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -61,14 +61,14 @@ const metadata = {
 		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
-		 * @since 1.6.0
+		 * @since 1.7.0
 		 */
 		 accessibleName: {
 			type: String,
 		},
 
 		/**
-		 * Indicates if any of the element siblings have children items.
+		 * Indicates whether any of the element siblings have children items.
 		 * @type {boolean}
 		 * @private
 		 */
@@ -78,7 +78,7 @@ const metadata = {
 		},
 
 		/**
-		 * Indicates if any of the element siblings have icon.
+		 * Indicates whether any of the element siblings have icon.
 		 * @type {boolean}
 		 * @private
 		 */

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -78,7 +78,7 @@ const metadata = {
 		},
 
 		/**
-		 * Indicates if the any of the element siblings have icon.
+		 * Indicates if any of the element siblings have icon.
 		 * @type {boolean}
 		 * @private
 		 */

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -56,7 +56,19 @@ const metadata = {
 		},
 
 		/**
-		 * Indicates if the any of the element siblings have children items.
+		 * Defines the accessible ARIA name of the component.
+		 *
+		 * @type {string}
+		 * @defaultvalue ""
+		 * @public
+		 * @since 1.6.0
+		 */
+		 accessibleName: {
+			type: String,
+		},
+
+		/**
+		 * Indicates if any of the element siblings have children items.
 		 * @type {boolean}
 		 * @private
 		 */
@@ -153,6 +165,10 @@ class MenuItem extends UI5Element {
 
 	get subMenuOpened() {
 		return !!Object.keys(this._subMenu).length;
+	}
+
+	get ariaLabelledByText() {
+		return `${this.text} ${this.accessibleName}`.trim();
 	}
 }
 

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -15,7 +15,7 @@
 <body class="responsivepopover2auto">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
-		<ui5-menu-item text="New File" icon="add-document"></ui5-menu-item>
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" icon="add-document"></ui5-menu-item>
 		<ui5-menu-item text="New Folder" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section>
 			<ui5-menu-item text="Open Locally" icon="open-folder">

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -118,5 +118,9 @@ describe("Menu Accessibility", () => {
 
 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
+		assert.strictEqual(
+			await listItems[0].getAttribute("accessible-name"),
+			"New File Opens a file explorer",
+			"There is additional description added");
 	});
 });


### PR DESCRIPTION
The ui5-menu-items can now have an additional description provided
by the application developer.

Fixes: #5514
Fixes: #5656