### PR TITLE
fix(ui5-button): provide tooltip for icon-only buttons

### DIFF
--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -114,7 +114,7 @@ const metadata = {
 		/**
 		 * Defines the tooltip of the component.
 		 * <br>
-		 * <b>Note:</b> A tooltip attribute should be provided for an icon-only buttons, in order to represent their exact meaning/function.
+		 * <b>Note:</b> A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
 		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -114,7 +114,7 @@ const metadata = {
 		/**
 		 * Defines the tooltip of the component.
 		 * <br>
-		 * <b>Note:</b> We recommend setting tooltip to icon-only components.
+		 * <b>Note:</b> A tooltip attribute should be provided for an icon-only buttons, in order to represent their exact meaning/function.
 		 * @type {string}
 		 * @defaultvalue: ""
 		 * @public

--- a/packages/main/test/samples/Button.sample.html
+++ b/packages/main/test/samples/Button.sample.html
@@ -74,16 +74,16 @@
 			<ui5-button class="samples-margin" icon="cart" design="Transparent" accessible-name-ref="lblCart"></ui5-button>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-button icon="away" accessible-name-ref="lblAway"></ui5-button>
-<ui5-button icon="action-settings" accessible-name-ref="lblSettings" ></ui5-button>
-<ui5-button icon="add" accessible-name-ref="lblAdd"></ui5-button>
-<ui5-button icon="alert" accessible-name-ref="lblAlert"></ui5-button>
-<ui5-button icon="accept" design="Positive" accessible-name-ref="lblAccept"></ui5-button>
-<ui5-button icon="bookmark" design="Positive" accessible-name-ref="lblBookmark"></ui5-button>
-<ui5-button icon="cancel" design="Negative" accessible-name-ref="lblCancel" ></ui5-button>
-<ui5-button icon="call" design="Negative" accessible-name-ref="lblCall" ></ui5-button>
-<ui5-button icon="camera" design="Transparent" accessible-name-ref="lblCamera"></ui5-button>
-<ui5-button icon="cart" design="Transparent" accessible-name-ref="lblCart"></ui5-button>
+<ui5-button icon="away" tooltip="Away" accessible-name-ref="lblAway"></ui5-button>
+<ui5-button icon="action-settings" tooltip="Action settings" accessible-name-ref="lblSettings" ></ui5-button>
+<ui5-button icon="add" tooltip="Add" accessible-name-ref="lblAdd"></ui5-button>
+<ui5-button icon="alert"tooltip="Alert"  accessible-name-ref="lblAlert"></ui5-button>
+<ui5-button icon="accept" tooltip="Accept" design="Positive" accessible-name-ref="lblAccept"></ui5-button>
+<ui5-button icon="bookmark" tooltip="Bookmark" design="Positive" accessible-name-ref="lblBookmark"></ui5-button>
+<ui5-button icon="cancel" tooltip="Cancel" design="Negative" accessible-name-ref="lblCancel" ></ui5-button>
+<ui5-button icon="call" tooltip="Call" design="Negative" accessible-name-ref="lblCall" ></ui5-button>
+<ui5-button icon="camera" tooltip="Camera" design="Transparent" accessible-name-ref="lblCamera"></ui5-button>
+<ui5-button icon="cart" tooltip="Cart" design="Transparent" accessible-name-ref="lblCart"></ui5-button>
 	</xmp></pre>
 </section>
 


### PR DESCRIPTION
According to UX guidelines, every instance of an icon-only button needs a tooltip.
When the inner ui5-icon element doesn't have a default one, the tooltip property
should be provided at the application side.

Related to: #5687
Related to: #5596
Related to: #5505
