### PR TITLE
feat(icons): create type-definitions for icon imports

### DIFF
--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -56,6 +56,14 @@ declare const _default: "${collection}/${name}";
 export default _default;
 export { pathData, ltr, accData };`
 
+const collectionTypeDefinitionTemplate = (name, accData) => `declare const pathData: string;
+declare const ltr: boolean;
+declare const accData: ${accData ? '{ key: string; defaultText: string; }' : null}
+declare const _default: "${name}";
+
+export default _default;
+export { pathData, ltr, accData };`
+
 
 const svgTemplate = (pathData) => `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
 	<path d="${pathData}"/>
@@ -81,7 +89,7 @@ const createIcons = async (file) => {
 
 		if (json.version) {
 			promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.js`), collectionTemplate(name)));
-            promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.d.ts`), typeDefinitionTemplate(name, acc, json.collection)));
+            promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.d.ts`), collectionTypeDefinitionTemplate(name, acc)));
 		}
 	}
 

--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -54,9 +54,7 @@ declare const accData: ${accData ? '{ key: string; defaultText: string; }' : nul
 declare const _default: "${collection}/${name}";
 
 export default _default;
-export { pathData, ltr, accData };
-
-`
+export { pathData, ltr, accData };`
 
 
 const svgTemplate = (pathData) => `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -48,6 +48,17 @@ export default "${name}";
 export { pathData, ltr, accData };`;
 
 
+const typeDefinitionTemplate = (name, accData, collection) => `declare const pathData: string;
+declare const ltr: boolean;
+declare const accData: ${accData ? '{ key: string; defaultText: string; }' : null}
+declare const _default: "${collection}/${name}";
+
+export default _default;
+export { pathData, ltr, accData };
+
+`
+
+
 const svgTemplate = (pathData) => `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
 	<path d="${pathData}"/>
 </svg>`;
@@ -68,9 +79,11 @@ const createIcons = async (file) => {
 
 		promises.push(fs.writeFile(path.join(destDir, `${name}.js`), content));
 		promises.push(fs.writeFile(path.join(destDir, `${name}.svg`), svgTemplate(pathData)));
+		promises.push(fs.writeFile(path.join(destDir, `${name}.d.ts`), typeDefinitionTemplate(name, acc, json.collection)));
 
 		if (json.version) {
 			promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.js`), collectionTemplate(name)));
+            promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.d.ts`), typeDefinitionTemplate(name, acc, json.collection)));
 		}
 	}
 


### PR DESCRIPTION
Created TypeDefinitions for all icon packages. This helps TypeScript users to better use the Icon Name Export feature which was introduced with #5747

Fixes #5335 