### PR TITLE
refactor: add collection to icons' name export

### DIFF
--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -17,7 +17,7 @@ const packageName = "${packageName}";
 
 registerIcon(name, { pathData, ltr, collection, packageName });
 
-export default "${name}";
+export default "${collection}/${name}";
 export { pathData, ltr, accData };`;
 
 
@@ -33,7 +33,7 @@ const packageName = "${packageName}";
 
 registerIcon(name, { pathData, ltr, accData, collection, packageName });
 
-export default "${name}";
+export default "${collection}/${name}";
 export { pathData, ltr, accData };`;
 
 


### PR DESCRIPTION
With 1.6.0 we provided default exports for all icons in all collections.  However we export the icon name without the collection and for `@ui5/webcomponents-icons-tnt` and `@ui5/webcomponents-icons-business-suite` packages it makes it not that convenient

**For example,** 
let's take the "actor" icon from "tnt" (source code: https://unpkg.com/browse/@ui5/webcomponents-icons-tnt@1.6.0/dist/actor.js), where we export the string "actor"
```js
// actor.js
import { registerIcon } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
const name = "actor";
const pathData = "..."

registerIcon(name, { pathData, ltr, collection, packageName });

export default "actor";
export { pathData, ltr, accData };
```


**Example from usage point of view:**

```js
import "@ui5/webcomponents/dist/Icon.js";
import iconHome from "@ui5/webcomponents-icons/dist/home.js";
import iconActor from "@ui5/webcomponents-icons-tnt/dist/actor.js";

// The "home" icon will be rendered as it's from the default collection, but "actor" will not.
document.body.innerHTML = `
<ui5-icon name=${iconHome}></ui5-icon>
<br />
<ui5-icon name=${iconActor}></ui5-icon>
`

// To make it work developers must specify the collection manually
<ui5-icon name=`tnt/${iconActor}`></ui5-icon>

```

FIXES: https://github.com/SAP/ui5-webcomponents/issues/5747