### PR TITLE
feat(ui5-illustrated-message): accessible-name-ref added

### DIFF
--- a/packages/fiori/src/IllustratedMessage.js
+++ b/packages/fiori/src/IllustratedMessage.js
@@ -1,6 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { getIllustrationDataSync } from "@ui5/webcomponents-base/dist/asset-registries/Illustrations.js";
+import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
@@ -23,6 +24,19 @@ const metadata = {
 	languageAware: true,
 	managedSlots: true,
 	properties: /** @lends sap.ui.webcomponents.fiori.IllustratedMessage.prototype */ {
+
+		/**
+		 * Receives id(or many ids) of the elements that label the component.
+		 *
+		 * @type {String}
+		 * @defaultvalue ""
+		 * @public
+		 * @since 1.7.0
+		 */
+		 accessibleNameRef: {
+			type: String,
+			defaultValue: "",
+		},
 		/**
 		 * Defines the title of the component.
 		 * <br><br>
@@ -383,6 +397,17 @@ class IllustratedMessage extends UI5Element {
 		}
 	}
 
+	_setSVGAccAttrs() {
+		const svg = this.shadowRoot.querySelector(".ui5-illustrated-message-illustration svg");
+		if (svg && this.ariaLabelText !== "") {
+			svg.setAttribute("aria-label", this.ariaLabelText);
+		}
+	}
+
+	onAfterRendering() {
+		this._setSVGAccAttrs();
+	}
+
 	/**
 	 * Modifies the IM styles in accordance to the `size` property's value.
 	 * Note: The resize handler has no effect when size is different than "Auto".
@@ -403,6 +428,10 @@ class IllustratedMessage extends UI5Element {
 		default:
 			this.media = IllustratedMessage.MEDIA.SCENE;
 		}
+	}
+
+	get ariaLabelText() {
+		return getEffectiveAriaLabelText(this);
 	}
 
 	get effectiveIllustration() {

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -126,8 +126,8 @@
 		</ui5-bar>
 	</ui5-dialog>
 
-	<ui5-illustrated-message id="illustratedMsg2" name="UnableToUpload" title="Something went wrong...">
-		<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
+	<ui5-illustrated-message id="illustratedMsg2" name="UnableToUpload" title="Something went wrong..." accessible-name-ref="lbl">
+		<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link> <br><label id="lbl">Text from aria-labelledby</label></div>
 		<ui5-button icon="refresh">Try again</ui5-button>
 	</ui5-illustrated-message>
 

--- a/packages/fiori/test/specs/IllustratedMessage.spec.js
+++ b/packages/fiori/test/specs/IllustratedMessage.spec.js
@@ -27,4 +27,37 @@ describe("IllustratedMessage 'size' property", () => {
 		// Assert
 		assert.strictEqual(illustratedMsgSize, "Auto", "'size' should be equal to 'Auto' when invalid value is passed");
 	});
+
+
+});
+
+describe("Accessibility", () => {
+	before(async () => {
+		await browser.url(`test/pages/IllustratedMessage.html`);
+	});
+
+
+	it("accessible-name-ref", async () => {
+		// Arrange
+		const illustratedMsg = await browser.$("#illustratedMsg2"),
+			  illustratedMsgSVG = await browser.$("#illustratedMsg2").shadow$('.ui5-illustrated-message-illustration svg'),
+			  EXPECTED_ARIA_LABEL_NAME = "Text from aria-labelledby";
+
+		// Assert
+		assert.strictEqual(await illustratedMsgSVG.getAttribute("aria-label"), EXPECTED_ARIA_LABEL_NAME, "aria-label is set");
+
+		// Act
+		await illustratedMsg.removeAttribute("accessible-name-ref");
+
+		// Assert
+		assert.strictEqual(await illustratedMsgSVG.getAttribute("aria-label"), 'undefined' , "aria-label is removed");
+
+		// Act
+		await illustratedMsg.setAttribute("accessible-name-ref", "lbl");
+
+		// Assert
+		assert.strictEqual(await illustratedMsgSVG.getAttribute("aria-label"), EXPECTED_ARIA_LABEL_NAME, "aria-label is set");
+
+	});
+
 });


### PR DESCRIPTION
AriaLabelledBy association is introduced to IllustratedMessage.