### PR TITLE
fix(ui5-daterange-picker): handle single date value

### DIFF
--- a/packages/main/src/DateRangePicker.js
+++ b/packages/main/src/DateRangePicker.js
@@ -294,8 +294,14 @@ class DateRangePicker extends DatePicker {
 		const valuesArray = [];
 		const partsArray = value.split(this._prevDelimiter || this._effectiveDelimiter);
 
-		valuesArray[0] = partsArray.slice(0, partsArray.length / 2).join(this._effectiveDelimiter);
-		valuesArray[1] = partsArray.slice(partsArray.length / 2).join(this._effectiveDelimiter);
+		// if format successfully parse the value, the value contains only single date
+		if (this.getFormat().parse(value)) {
+			valuesArray[0] = partsArray.join(this._effectiveDelimiter);
+			valuesArray[1] = "";
+		} else {
+			valuesArray[0] = partsArray.slice(0, partsArray.length / 2).join(this._effectiveDelimiter);
+			valuesArray[1] = partsArray.slice(partsArray.length / 2).join(this._effectiveDelimiter);
+		}
 
 		return valuesArray;
 	}

--- a/packages/main/test/pages/DateRangePicker.html
+++ b/packages/main/test/pages/DateRangePicker.html
@@ -28,6 +28,7 @@
 	<div style='width:500px;'>
 		<div>
 			<label id='labelChange'>0</label>
+			<label id='labelDate'></label>
 		</div>
 		<ui5-daterange-picker id="daterange-picker1"></ui5-daterange-picker>
 		<h3>daterange-picker with delimiter @</h3>
@@ -51,6 +52,7 @@
 	<script>
 		document.getElementById('daterange-picker1').addEventListener('ui5-change', function(e) {
 			document.getElementById("labelChange").innerHTML = Number(document.getElementById("labelChange").innerHTML) + 1;
+			document.getElementById("labelDate").innerHTML = e.detail.value;
 		});
 	</script>
 </body>

--- a/packages/main/test/pages/DateRangePicker.html
+++ b/packages/main/test/pages/DateRangePicker.html
@@ -52,6 +52,9 @@
 	<script>
 		document.getElementById('daterange-picker1').addEventListener('ui5-change', function(e) {
 			document.getElementById("labelChange").innerHTML = Number(document.getElementById("labelChange").innerHTML) + 1;
+		});
+
+		document.getElementById('daterange-picker4').addEventListener('ui5-change', function(e) {
 			document.getElementById("labelDate").innerHTML = e.detail.value;
 		});
 	</script>

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -215,4 +215,16 @@ describe("DateRangePicker general interaction", () => {
 		assert.strictEqual(monthButton.innerHTML, monthName, "The month is not changed after selecting the first date in the future");
 	});
 
+
+
+	it("Month is not changed in multiselect mode", async () => {
+		await browser.url(`test/pages/DateRangePicker.html`);
+		const daterangepicker = await browser.$("#daterange-picker1");
+		await daterangepicker.click();
+		await daterangepicker.keys(["7 Sep 2022", "Enter"]);
+		browser.saveScreenshot('screenshot.jpg');
+		assert.equal(await daterangepicker.getProperty("value"), "7 Sep 2022", "works with one date");
+		assert.equal(await browser.$("#labelDate").getHTML(false), "7 Sep 2022", "works with one date");
+	});
+
 });

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -215,15 +215,26 @@ describe("DateRangePicker general interaction", () => {
 		assert.strictEqual(monthButton.innerHTML, monthName, "The month is not changed after selecting the first date in the future");
 	});
 
-	it("Change event is fired with single value", async () => {
+	it("startDateValue and endDateValue getters when single value", async () => {
 		await browser.url(`test/pages/DateRangePicker.html`);
-		const daterangepicker = await browser.$("#daterange-picker1");
+		const daterangepicker = await browser.$("#daterange-picker4");
 
 		await daterangepicker.click();
-		await daterangepicker.keys("7 Sep 2022")
-		await daterangepicker.keys("Enter");
+		await browser.keys("27/09/2019");
+		await browser.keys("Enter");
 
-		assert.equal(await daterangepicker.getProperty("value"), "7 Sep 2022", "value is updated");
-		assert.equal(await browser.$("#labelDate").getHTML(false), "7 Sep 2022", "works with single date in value");
+		await daterangepicker.waitForClickable({ timeout: 1000 });
+		const res = await browser.executeAsync(done => {
+			const myDRP = document.getElementById("daterange-picker4");
+			const startDateValue = myDRP.startDateValue;
+			const endDateValue = myDRP.endDateValue;
+			const drpValue = myDRP.value;
+
+			done({startDateValue, endDateValue, drpValue});
+		});
+
+		assert.deepEqual(new Date(res.startDateValue), new Date(2019, 8, 27), "First date is correct");
+		assert.equal(res.endDateValue, null, "Second date is correct");
+		assert.equal(res.drpValue, await (await browser.$("#labelDate")).getHTML(false), "Event value is correct");
 	});
 });

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -215,16 +215,15 @@ describe("DateRangePicker general interaction", () => {
 		assert.strictEqual(monthButton.innerHTML, monthName, "The month is not changed after selecting the first date in the future");
 	});
 
-
-
-	it("Month is not changed in multiselect mode", async () => {
+	it("Change event is fired with single value", async () => {
 		await browser.url(`test/pages/DateRangePicker.html`);
 		const daterangepicker = await browser.$("#daterange-picker1");
-		await daterangepicker.click();
-		await daterangepicker.keys(["7 Sep 2022", "Enter"]);
-		browser.saveScreenshot('screenshot.jpg');
-		assert.equal(await daterangepicker.getProperty("value"), "7 Sep 2022", "works with one date");
-		assert.equal(await browser.$("#labelDate").getHTML(false), "7 Sep 2022", "works with one date");
-	});
 
+		await daterangepicker.click();
+		await daterangepicker.keys("7 Sep 2022")
+		await daterangepicker.keys("Enter");
+
+		assert.equal(await daterangepicker.getProperty("value"), "7 Sep 2022", "value is updated");
+		assert.equal(await browser.$("#labelDate").getHTML(false), "7 Sep 2022", "works with single date in value");
+	});
 });


### PR DESCRIPTION
When the ui5-date-range-picker tries to split its values by delimiter there was no handle for the case with single date in the values.

Fixes: #5738