### PR TITLE
fix(ItemNavigation): get slotted elements when slot is included as item

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.js
+++ b/packages/base/src/delegate/ItemNavigation.js
@@ -9,6 +9,7 @@ import {
 	isPageUp,
 } from "../Keys.js";
 import getActiveElement from "../util/getActiveElement.js";
+import { isSlot, getSlottedElements } from "../util/SlotsHelper.js";
 
 import NavigationMode from "../types/NavigationMode.js";
 import ItemNavigationBehavior from "../types/ItemNavigationBehavior.js";
@@ -335,7 +336,13 @@ class ItemNavigation {
 			this._currentIndex = 0;
 		}
 
-		const currentItem = items[this._currentIndex];
+		let currentItem = items[this._currentIndex];
+
+		if (isSlot(currentItem)) {
+			currentItem = getSlottedElements(currentItem)[0];
+		} else {
+			currentItem = items[this._currentIndex];
+		}
 
 		if (!currentItem) {
 			return;


### PR DESCRIPTION
Example:

`Wrapper.hbs`

```html
<ui5-table>
  {{#each items}}
    <slot name="{{this._individualSlot}}"></slot>
  {{/each}}
</ui5-table>
```

`Child.hbs`

```html
<ui5-table-row>
  <ui5-table-cell>
    ...
  </ui5-table-cell>
  <ui5-table-cell>
    ...
  </ui5-table-cell>
</ui5-table-row>
```

`Example.html`

```html
<wrapper>
  <child></child>
</wrapper>
```

This way the child is passed as slot of the Parent which renders a table and forwards the items via slot again.
Which means that the table does not receive its rows directly but items which render the rows.

That confuses the current implementation of the Item Navigation and an error is thrown:

<img width="906" alt="image" src="https://user-images.githubusercontent.com/5821279/188414982-744282c9-038a-469e-9ea5-31e6fce8ef30.png">
