### PR TITLE
refactor: use the UMD bundle for zxing

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.js
+++ b/packages/fiori/src/BarcodeScannerDialog.js
@@ -4,7 +4,7 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Dialog from "@ui5/webcomponents/dist/Dialog.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
-import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library";
+import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library/umd/index.js";
 
 // Template
 import BarcodeScannerDialogTemplate from "./generated/templates/BarcodeScannerDialogTemplate.lit.js";


### PR DESCRIPTION
The `zxing` library does not provide sourcemaps which causes Webpack 5 to produce enormous amounts of warnings when starting or building a project that imports the `BarCodeScannerDialog` component:

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/15844574/190083941-1d8ca552-f684-4e16-80f2-39a04fee842c.png">

The proposed solution is to use the UMD bundle instead, in which case there are no errors:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/15844574/190084488-679f29d1-f404-4f4e-8f70-cf89a9ad1744.png">

Additionally, using the UMD bundle seems to improve bundle size by about 2KB:

**Webpack (demo app from the ticket)**
Before: 198.06 kB (+1.8 kB)    build/static/js/main.fa6690d4.js
After: 196.26 kB (-1.8 kB)  build/static/js/main.301eeacc.js

**Vite (UI5 Web Components' own build task)**
Before: dist/assets/bundle.esm.070a07f0.js     5043.94 KiB / gzip: 1548.36 KiB
After: dist/assets/bundle.esm.ed0a9f80.js  4989.66 KiB / gzip: 1546.88 KiB

closes: https://github.com/SAP/ui5-webcomponents/issues/5648