### PR TITLE
fix(ui5-static-area-item): add tag as attr on the host

### DIFF
--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -16,6 +16,7 @@ class StaticAreaItem extends HTMLElement {
 		super();
 		this._rendered = false;
 		this.attachShadow({ mode: "open" });
+		this.pureTagName = "ui5-static-area-item";
 	}
 
 	/**
@@ -36,6 +37,7 @@ class StaticAreaItem extends HTMLElement {
 	 */
 	update() {
 		if (this._rendered) {
+			this.setAttribute(this.pureTagName, "");
 			this._updateContentDensity();
 			this._updateDirection();
 			updateShadowRoot(this.ownerElement, true);


### PR DESCRIPTION
The change was done upon stakeholder's request (via internal communication channel) and the use case is the same as with the standard components - to have stable query selectors no matter the scoping suffix that is set.
