### PR TITLE
chore: remove CLDR warning and ENABLE_CLDR usage

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -18,8 +18,6 @@ jobs:
 
     - name: Build
       run: yarn build
-      env:
-        ENABLE_CLDR: 1
 
     - name: Publish
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,6 @@ jobs:
 
     - name: Build
       run: yarn build
-      env:
-        ENABLE_CLDR: 1
 
     - name: Publish
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Build
       run: yarn build
-      env:
-        ENABLE_CLDR: 1
 
     - name: Test
       run: yarn test:${{ matrix.suite }}

--- a/packages/base/src/asset-registries/LocaleData.js
+++ b/packages/base/src/asset-registries/LocaleData.js
@@ -15,18 +15,12 @@ const M_ISO639_OLD_TO_NEW = {
 	"in": "id",
 };
 
-const DEV_MODE = false;
-
 const _showAssetsWarningOnce = localeId => {
 	if (warningShown) {
 		return;
 	}
 
-	if (!DEV_MODE) {
-		console.warn(`[LocaleData] Supported locale "${localeId}" not configured, import the "Assets.js" module from the webcomponents package you are using.`); /* eslint-disable-line */
-	} else {
-		console.warn(`[LocaleData] Note: in dev mode, CLDR assets might be disabled for performance reasons. Try running "ENABLE_CLDR=1 yarn start" to test CLDR assets.`); /* eslint-disable-line */
-	}
+	console.warn(`[LocaleData] Supported locale "${localeId}" not configured, import the "Assets.js" module from the webcomponents package you are using.`); /* eslint-disable-line */
 
 	warningShown = true;
 };


### PR DESCRIPTION
ENABLE_CLDR variable does not have any effect since the rollup to vite switch so it should be removed. DEV_MODE does not exist as well.