### PR TITLE
build: improve i18n texts update at dev time

### DIFF
--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -134,7 +134,7 @@ FILEUPLOADER_TITLE=Upload File
 GROUP_HEADER_TEXT=Group Header
 
 #XACT: ARIA announcement for the Select`s roledescription attribute
-SELECT_ROLE_DESCRIPTION=Select ComboBox
+SELECT_ROLE_DESCRIPTION=Select Combo Box
 
 #XTXT: MultiComboBox and ComboBox icon accessible name
 SELECT_OPTIONS=Select Options

--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -22,6 +22,15 @@ const generate = async () => {
 	} catch (e) {
 	}
 
+	// Merge messagebundle.properties and messagebundle_en.properties files to generate the default texts.
+	// Note:
+	// (1) at DEV time, it's intuituve to work with the source bundle file - the messagebundle.properties,
+	// and see the changes there take effect.
+	// (2) as the messagebundle.properties file is always written in English,
+	// it makes sense to consider the messagebundle.properties content only when the default language is "en".
+	if (defaultLanguage === "en") {
+		defaultLanguageProperties = Object.assign({}, defaultLanguageProperties, properties);  
+	}
 
 	/*
 	 * Returns the single text object to enable single export.


### PR DESCRIPTION
**Prior to this PR**, changing the `messagebundle.properties` file does not take effect as the default i18n texts are generated based on the locale specific file (for "en" - messagebundle_en.properties).
**Now,** the output is based on both the source `messagebundle.properties` and the locale specific files. As a result, changing the `messagebundle.properties` file will take immediate effect.

**Note:**  as the  `messagebundle.properties` file is always written in English, this improvement only makes sense for the "en" locale.

