### PR TITLE
feat(ui5-menu-item): implement additional text

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -81,13 +81,11 @@
 						part="icon"
 						name="slim-arrow-right"
 						class="ui5-menu-item-icon-end"
-						?rtl="{{../isRtl}}"
 					>
 					</ui5-icon>
 				{{else if this.item._siblingsWithChildren}}
 					<div
 						class="ui5-menu-item-no-icon-end"
-						?rtl="{{../isRtl}}"
 					>
 					</div>
 				{{/if}}

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -56,9 +56,10 @@
 				.associatedItem="{{this.item}}"
 				class="ui5-menu-item"
 				id="{{../_id}}-menu-item-{{@index}}"
-				icon="{{this.item.icon}}"
+				.icon="{{this.item.icon}}"
 				accessible-name={{this.item.ariaLabelledByText}}
 				accessible-role="menuitem"
+				.additionalText="{{this.item._additionalText}}"
 				._ariaHasPopup={{this.ariaHasPopup}}
 				?disabled={{this.item.disabled}}
 				?starts-section={{this.item.startsSection}}
@@ -80,11 +81,13 @@
 						part="icon"
 						name="slim-arrow-right"
 						class="ui5-menu-item-icon-end"
+						?rtl="{{../isRtl}}"
 					>
 					</ui5-icon>
 				{{else if this.item._siblingsWithChildren}}
 					<div
 						class="ui5-menu-item-no-icon-end"
+						?rtl="{{../isRtl}}"
 					>
 					</div>
 				{{/if}}

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -19,8 +19,7 @@ const metadata = {
 
 		/**
 		 * Defines the <code>additionalText</code>, displayed in the end of the menu item.
-		 * <b>Note:</b> The additional text would not be displayed if the <code>hideAdditionalText</code>
-		 * property is set to <code>true</code>.
+		 * <b>Note:</b> The additional text would not be displayed if the item has a submenu.
 		 *
 		 * @type {string}
 		 * @public
@@ -28,21 +27,6 @@ const metadata = {
 		 */
 		additionalText: {
 			type: String,
-		},
-
-		/**
-		 * Defines whether an additional text should be hidden.
-		 * <b>Note:</b> This property might be useful when the additional text must be hidden in some
-		 * situations - for example to hide additional text on mobile devices when it is used for
-		 * displaying of keyboard shortcuts.
-		 *
-		 * @type {boolean}
-		 * @defaultvalue false
-		 * @public
-		 * @since 1.8.0
-		 */
-		 hideAdditionalText: {
-			type: Boolean,
 		},
 
 		/**
@@ -196,7 +180,7 @@ class MenuItem extends UI5Element {
 	}
 
 	get _additionalText() {
-		return this.hasChildren || this.hideAdditionalText ? "" : this.additionalText;
+		return this.hasChildren ? "" : this.additionalText;
 	}
 
 	get ariaLabelledByText() {

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -18,6 +18,28 @@ const metadata = {
 		},
 
 		/**
+		 * Defines the <code>additionalText</code>, displayed in the end of the menu item.
+		 * @type {string}
+		 * @public
+		 * @since 1.8.0
+		 */
+		additionalText: {
+			type: String,
+		},
+
+		/**
+		 * Defines whether an additional text should be hidden.
+		 *
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 * @since 1.8.0
+		 */
+		 hideAdditionalText: {
+			type: Boolean,
+		},
+
+		/**
 		 * Defines the icon to be displayed as graphical element within the component.
 		 * The SAP-icons font provides numerous options.
 		 * <br><br>
@@ -165,6 +187,10 @@ class MenuItem extends UI5Element {
 
 	get subMenuOpened() {
 		return !!Object.keys(this._subMenu).length;
+	}
+
+	get _additionalText() {
+		return this.hasChildren || this.hideAdditionalText ? "" : this.additionalText;
 	}
 
 	get ariaLabelledByText() {

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -19,6 +19,9 @@ const metadata = {
 
 		/**
 		 * Defines the <code>additionalText</code>, displayed in the end of the menu item.
+		 * <b>Note:</b> The additional text would not be displayed if the <code>hideAdditionalText</code>
+		 * property is set to <code>true</code>.
+		 *
 		 * @type {string}
 		 * @public
 		 * @since 1.8.0
@@ -29,6 +32,9 @@ const metadata = {
 
 		/**
 		 * Defines whether an additional text should be hidden.
+		 * <b>Note:</b> This property might be useful when the additional text must be hidden in some
+		 * situations - for example to hide additional text on mobile devices when it is used for
+		 * displaying of keyboard shortcuts.
 		 *
 		 * @type {boolean}
 		 * @defaultvalue false

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -17,8 +17,7 @@
 	padding-inline-start: 0.5rem;
 	pointer-events: none;
 	position: absolute;
-	right: var(--_ui5_menu_item_submenu_icon_right);
- 	/* float: var(--_ui5-menu_item_icon_float); /* TODO: refactor icon positioning as float and inline-block are incompatible */
+	inset-inline-end: var(--_ui5_menu_item_submenu_icon_right);
 }
 
 .ui5-menu-item-no-icon-end {
@@ -28,17 +27,11 @@
 	vertical-align: middle;
 	padding-inline-start: 0.5rem;
 	pointer-events: none;
-	right: var(--_ui5_menu_item_submenu_icon_right);
+	inset-inline-end: var(--_ui5_menu_item_submenu_icon_right);
 }
 
 .ui5-menu-item[additional-text] .ui5-menu-item-no-icon-end {
 	display: none;
-}
-
-[rtl].ui5-menu-item-icon-end,
-[rtl].ui5-menu-item-no-icon-end {
-	right: initial;
-	left:  var(--_ui5_menu_item_submenu_icon_right);
 }
 
 .ui5-menu-item-dummy-icon {
@@ -113,7 +106,7 @@
 }
 
 .ui5-menu-item::part(additional-text) {
-	margin: 0 0 0 1rem;
+	margin-inline-start: var(--_ui5_menu_item_additional_text_start_margin);
 	color: var(--sapContent_LabelColor);
 	min-width: max-content;
 }

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -16,7 +16,9 @@
 	vertical-align: middle;
 	padding-inline-start: 0.5rem;
 	pointer-events: none;
-	float: var(--_ui5-menu_item_icon_float); /* TODO: refactor icon positioning as float and inline-block are incompatible */
+	position: absolute;
+	right: var(--_ui5_menu_item_submenu_icon_right);
+ 	/* float: var(--_ui5-menu_item_icon_float); /* TODO: refactor icon positioning as float and inline-block are incompatible */
 }
 
 .ui5-menu-item-no-icon-end {
@@ -25,7 +27,18 @@
 	display: inline-block;
 	vertical-align: middle;
 	padding-inline-start: 0.5rem;
-	float: var(--_ui5-menu_item_icon_float); /* TODO: refactor icon positioning a float and inline-block are incompatible */
+	pointer-events: none;
+	right: var(--_ui5_menu_item_submenu_icon_right);
+}
+
+.ui5-menu-item[additional-text] .ui5-menu-item-no-icon-end {
+	display: none;
+}
+
+[rtl].ui5-menu-item-icon-end,
+[rtl].ui5-menu-item-no-icon-end {
+	right: initial;
+	left:  var(--_ui5_menu_item_submenu_icon_right);
 }
 
 .ui5-menu-item-dummy-icon {
@@ -34,6 +47,7 @@
 	display: inline-block;
 	vertical-align: middle;
 	padding-inline-end: 0.5rem;
+	pointer-events: none;
 }
 
 .ui5-menu-dialog-header {
@@ -67,6 +81,16 @@
 	margin-right: 1rem;
 }
 
+.ui5-menu-item::part(title) {
+    font-size: var(--sapFontSize);
+	padding-top: 0.125rem;
+}
+
+.ui5-menu-item[icon]:not([is-phone])::part(title),
+.ui5-menu-item[is-phone]:not([icon=""])::part(title) {
+	padding-top: 0;
+}
+
 .ui5-menu-item:not([is-phone])::part(native-li) {
 	padding: var(--_ui5_menu_item_padding);
 }
@@ -86,4 +110,10 @@
 .ui5-menu-rp[sub-menu] {
 	margin-top: 0.25rem;
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);
+}
+
+.ui5-menu-item::part(additional-text) {
+	margin: 0 0 0 1rem;
+	color: var(--sapContent_LabelColor);
+	min-width: max-content;
 }

--- a/packages/main/src/themes/base/Menu-parameters.css
+++ b/packages/main/src/themes/base/Menu-parameters.css
@@ -1,4 +1,6 @@
 :root {
 	--_ui5_menu_popover_border_radius: var(--sapElement_BorderCornerRadius);
 	--_ui5_menu_item_padding: 0 1rem 0 0.75rem;
+	--_ui5_menu_item_submenu_icon_right: 1rem;
+	--_ui5_menu_item_additional_text_start_margin: 1rem;
 }

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -247,6 +247,7 @@
 
 	/* Menu */
 	--_ui5_menu_item_padding: 0 0.75rem 0 0.5rem;
+	--_ui5_menu_item_submenu_icon_right: 0.75rem;
 
 	/* Notifications */
 	--_ui5-notification-overflow-popover-padding: 0.25rem 0.5rem;

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -34,7 +34,7 @@
 			</ui5-menu-item>
 			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
 		</ui5-menu-item>
-		<ui5-menu-item text="Close" additional-text="Ctrl+W" hide-additional-text></ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W"></ui5-menu-item>
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -15,15 +15,16 @@
 <body class="responsivepopover2auto">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
-		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" icon="add-document"></ui5-menu-item>
-		<ui5-menu-item text="New Folder" icon="add-folder" disabled></ui5-menu-item>
+
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section>
-			<ui5-menu-item text="Open Locally" icon="open-folder">
+			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
 				<ui5-menu-item text="Open from C"></ui5-menu-item>
 				<ui5-menu-item text="Open from D"></ui5-menu-item>
 				<ui5-menu-item text="Open from E"></ui5-menu-item>
 			</ui5-menu-item>
-			<ui5-menu-item text="Open from Cloud"></ui5-menu-item>
+			<ui5-menu-item text="Open from Cloud" additional-text="Ctrl+L"></ui5-menu-item>
 		</ui5-menu-item>
 		<ui5-menu-item text="Save" icon="save">
 			<ui5-menu-item text="Save Locally" icon="save">
@@ -34,7 +35,7 @@
 			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
 		</ui5-menu-item>
 		<ui5-menu-item text="Close"></ui5-menu-item>
-		<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
+		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
 

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -34,7 +34,7 @@
 			</ui5-menu-item>
 			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
 		</ui5-menu-item>
-		<ui5-menu-item text="Close"></ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W" hide-additional-text></ui5-menu-item>
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -111,4 +111,41 @@
 	</xmp></pre>
 </section>
 
+<section>
+	<h3>Menu with additional text on menu items</h3>
+	<div class="snippet">
+		<ui5-button id="btnOpenAdditionalText" class="samples-margin">Open Menu</ui5-button> <br/>
+		<ui5-menu id="menuAdditionalText">
+			<ui5-menu-item text="New File" icon="add-document" additional-text="Ctrl+N"></ui5-menu-item>
+			<ui5-menu-item text="New Folder" icon="add-folder" additional-text="Ctrl+F" disabled></ui5-menu-item>
+			<ui5-menu-item text="Open" icon="open-folder" starts-section></ui5-menu-item>
+			<ui5-menu-item text="Close"></ui5-menu-item>
+			<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
+			<ui5-menu-item text="Exit" icon="journey-arrive" additional-text="Ctrl+X"></ui5-menu-item>
+		</ui5-menu>
+		<script>
+			btnOpenAdditionalText.addEventListener("click", function(event) {
+				menuAdditionalText.showAt(btnOpenAdditionalText);
+			});
+		</script>
+	</div>
+	<pre class="prettyprint lang-html"><xmp>
+<ui5-button id="btnOpenAdditionalText">Open Menu</ui5-button> <br/>
+<ui5-menu id="menuAdditionalText">
+	<ui5-menu-item text="New File" icon="add-document" additional-text="Ctrl+N"></ui5-menu-item>
+	<ui5-menu-item text="New Folder" icon="add-folder" additional-text="Ctrl+F" disabled></ui5-menu-item>
+	<ui5-menu-item text="Open" icon="open-folder" starts-section></ui5-menu-item>
+	<ui5-menu-item text="Close"></ui5-menu-item>
+	<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
+	<ui5-menu-item text="Exit" icon="journey-arrive" additional-text="Ctrl+X"></ui5-menu-item>
+</ui5-menu>
+<script>
+	btnOpenAdditionalText.addEventListener("click", function(event) {
+		menuAdditionalText.showAt(btnOpenAdditionalText);
+	});
+</script>
+	</xmp></pre>
+</section>
+
+
 <!-- JSDoc marker -->

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -26,6 +26,7 @@ describe("Menu interaction", () => {
 
 		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
 		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
+		assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
 		assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
 		assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
 		assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -27,7 +27,6 @@ describe("Menu interaction", () => {
 		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
 		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
 		assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
-		assert.notOk(await listItems[4].getAttribute("additional-text"), "The list item with hideAdditionalText property set doesn't display additional text");
 		assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
 		assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
 		assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -27,6 +27,7 @@ describe("Menu interaction", () => {
 		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
 		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
 		assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
+		assert.notOk(await listItems[4].getAttribute("additional-text"), "The list item with hideAdditionalText property set doesn't display additional text");
 		assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
 		assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
 		assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");


### PR DESCRIPTION
The newly implemented additional text of the menu item provides a way to display additional texts such as shortcut combinations in the menu items via the additionalText proprty. In addition, there is another property hideAdditionalText which can be used to hide defined additional texts in some situations (on mobile devices for example).

related to: #5369