### PR TITLE
fix(ui5-shellbar): outline buttons color on focus fixed for quartz

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.js
+++ b/packages/fiori/src/BarcodeScannerDialog.js
@@ -4,7 +4,7 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Dialog from "@ui5/webcomponents/dist/Dialog.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
-import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library";
+import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library/umd/index.js";
 
 // Template
 import BarcodeScannerDialogTemplate from "./generated/templates/BarcodeScannerDialogTemplate.lit.js";

--- a/packages/fiori/src/themes/sap_fiori_3/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+[ui5-shellbar] {
+	--_ui5_button_focused_border: 0.0625rem dotted var(--sapContent_ContrastFocusColor);
+}

--- a/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
@@ -5,7 +5,7 @@
 @import "../base/MediaGalleryItem-parameters.css";
 @import "../base/Page-parameters.css";
 @import "../base/ProductSwitchItem-parameters.css";
-@import "../base/ShellBar-parameters.css";
+@import "./ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
 @import "../base/TimelineItem-parameters.css";
 @import "../base/UploadCollection-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_dark/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_dark/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_logo_outline_color: var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -5,7 +5,7 @@
 @import "../base/MediaGalleryItem-parameters.css";
 @import "../base/Page-parameters.css";
 @import "../base/ProductSwitchItem-parameters.css";
-@import "../base/ShellBar-parameters.css";
+@import "./ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
 @import "../base/TimelineItem-parameters.css";
 @import "../base/UploadCollection-parameters.css";


### PR DESCRIPTION
There were mismatch in outline color for focused buttons/elements in ui5-shellbar for Quartz light and dark themes.
It is corrected in this change.

Fixes: #5795 