### PR TITLE
feat(ui5-avatar): support of 3 letters is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
+    "chromedriver": "^106.0.1",
     "command-line-args": "^5.1.1",
     "copy-and-watch": "^0.1.5",
     "globby": "^13.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "chromedriver": "^106.0.1",
     "command-line-args": "^5.1.1",
     "copy-and-watch": "^0.1.5",
     "globby": "^13.1.1",

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -387,7 +387,7 @@ class Avatar extends UI5Element {
 		// an icon should be shown inside the avatar
 		const avatar = this.getDomRef(),
 			avatarInitials = avatar.querySelector(".ui5-avatar-initials");
-		if (this.initials && this.initials.length === 3 && this.size === "XS") {
+		if (this.initials && this.initials.length === 3) {
 			if (avatarInitials.scrollWidth > avatar.scrollWidth) {
 				this.icon = "employee";
 			}

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -348,10 +348,7 @@ class Avatar extends UI5Element {
 		const validInitials = /^[a-zA-Z]{1,3}$/,
 			  areInitialsValid = this.initials && validInitials.test(this.initials);
 
-		if (!areInitialsValid) {
-			// if initials are not valid,an icon should be shown inside the avatar
-			this._setFallbackIcon();
-		} else {
+		if (areInitialsValid) {
 			return this.initials;
 		}
 
@@ -377,9 +374,14 @@ class Avatar extends UI5Element {
 
 	onEnterDOM() {
 		this._checkInitialsWidth();
+
+		if (!this.validInitials) {
+			// if initials are not valid,an icon should be shown inside the avatar
+			this._setFallbackIcon();
+		}
 	}
 
-	_setFallbackIcon () {
+	_setFallbackIcon() {
 		// the default icon shown inside the avatar,
 		// when the initials are not valid
 		this.icon = "employee";

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -352,13 +352,9 @@ class Avatar extends UI5Element {
 			return this.initials;
 		}
 
-		if (!areInitialsValid) {
-			// if initials are not valid,an icon should be shown inside the avatar
-			this.icon = "employee";
-			return this.icon;
-		}
-
-		return this;
+		// if initials are not valid,an icon should be shown inside the avatar
+		this.icon = "employee";
+		return this.icon;
 	}
 
 	get accessibleNameText() {
@@ -388,7 +384,7 @@ class Avatar extends UI5Element {
 		const avatar = this.getDomRef(),
 			avatarInitials = avatar.querySelector(".ui5-avatar-initials");
 		if (this.initials && this.initials.length === 3) {
-			if (avatarInitials.scrollWidth > avatar.scrollWidth) {
+			if (avatarInitials.scrollWidth >= avatar.scrollWidth) {
 				this.icon = "employee";
 			}
 		}

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -344,13 +344,21 @@ class Avatar extends UI5Element {
 	}
 
 	get validInitials() {
-		const validInitials = /^[a-zA-Z]{1,2}$/;
+		// initials should consist of only 1,2 or 3 latin letters
+		const validInitials = /^[a-zA-Z]{1,3}$/,
+			  areInitialsValid = this.initials && validInitials.test(this.initials);
 
-		if (this.initials && validInitials.test(this.initials)) {
+		if (areInitialsValid) {
 			return this.initials;
 		}
 
-		return null;
+		if (!areInitialsValid) {
+			// if initials are not valid,an icon should be shown inside the avatar
+			this.icon = "employee";
+			return this.icon;
+		}
+
+		return this;
 	}
 
 	get accessibleNameText() {
@@ -368,6 +376,23 @@ class Avatar extends UI5Element {
 
 	onBeforeRendering() {
 		this._onclick = this.interactive ? this._onClickHandler.bind(this) : undefined;
+	}
+
+	onEnterDOM() {
+		this._checkInitialsWidth();
+	}
+
+	_checkInitialsWidth() {
+		// if initials` width is bigger than the avatar,
+		// an icon should be shown inside the avatar
+		const avatar = this.getDomRef(),
+			avatarInitials = avatar.querySelector(".ui5-avatar-initials");
+		if (this.initials && this.initials.length === 3 && this.size === "XS") {
+			if (avatarInitials.scrollWidth > avatar.scrollWidth) {
+				this.icon = "employee";
+			}
+		}
+		return this.icon;
 	}
 
 	_onClickHandler(event) {

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -348,13 +348,14 @@ class Avatar extends UI5Element {
 		const validInitials = /^[a-zA-Z]{1,3}$/,
 			  areInitialsValid = this.initials && validInitials.test(this.initials);
 
-		if (areInitialsValid) {
+		if (!areInitialsValid) {
+			// if initials are not valid,an icon should be shown inside the avatar
+			this._setFallbackIcon();
+		} else {
 			return this.initials;
 		}
 
-		// if initials are not valid,an icon should be shown inside the avatar
-		this.icon = "employee";
-		return this.icon;
+		return null;
 	}
 
 	get accessibleNameText() {
@@ -376,6 +377,13 @@ class Avatar extends UI5Element {
 
 	onEnterDOM() {
 		this._checkInitialsWidth();
+	}
+
+	_setFallbackIcon () {
+		// the default icon shown inside the avatar,
+		// when the initials are not valid
+		this.icon = "employee";
+		return this.icon;
 	}
 
 	_checkInitialsWidth() {

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -174,7 +174,7 @@
 				<ui5-icon slot="icon" name="accept"></ui5-icon>
 			</ui5-badge>
 		</ui5-avatar>
-	
+
 		<ui5-avatar size="XL">
 			<img src="./img/John_Miller.png" alt="John Miller">
 			<ui5-badge slot="badge">
@@ -195,7 +195,7 @@
 				<ui5-icon slot="icon" name="add-employee"></ui5-icon>
 			</ui5-badge>
 		</ui5-avatar>
-	
+
 		<ui5-avatar shape="Square" size="L">
 			<img src="./img/John_Miller.png" alt="John Miller">
 			<ui5-badge slot="badge">
@@ -244,6 +244,17 @@
 	<ui5-avatar size="XL" shape="Square">
 		<img src="./img/Lamp_avatar_01.jpg" alt="Woman 1" class="avatar-image1">
 	</ui5-avatar>
+
+	<section>
+		<h3>Avatar with three initials</h3>
+		<ui5-avatar initials="ABC" color-scheme="Accent1"></ui5-avatar>
+		<ui5-avatar initials="ABC" color-scheme="Accent2" size="M"></ui5-avatar>
+
+
+		<h3>Avatar with three overflowing initials - icon should be shown</h3>
+		<ui5-avatar initials="ABC" color-scheme="Accent1" size="XS"></ui5-avatar>
+
+	</section>
 
 
 </body>

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -248,11 +248,12 @@
 	<section>
 		<h3>Avatar with three initials</h3>
 		<ui5-avatar initials="ABC" color-scheme="Accent1"></ui5-avatar>
-		<ui5-avatar initials="ABC" color-scheme="Accent2" size="M"></ui5-avatar>
+		<ui5-avatar initials="ABC" color-scheme="Accent2" size="XL"></ui5-avatar>
 
 
 		<h3>Avatar with three overflowing initials - icon should be shown</h3>
-		<ui5-avatar initials="ABC" color-scheme="Accent1" size="XS"></ui5-avatar>
+		<ui5-avatar initials="WWW" color-scheme="Accent1" size="XS"></ui5-avatar>
+		<ui5-avatar initials="WWW" color-scheme="Accent2" size="XL"></ui5-avatar>
 
 	</section>
 

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -148,6 +148,7 @@
 			<img src="./img/woman_avatar_5.png" alt="Woman image">
 		</ui5-avatar>
 		<ui5-avatar id="myAvatar4" initials="SF" shape="Square" size="M"></ui5-avatar>
+		<ui5-avatar id="myAvatar5" initials="WWW" shape="Square" size="M"></ui5-avatar>
 	</section>
 
 	<section>

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -46,6 +46,14 @@ describe("Avatar", () => {
 		assert.ok(await initials.isExisting(), "initials are rendered");
 	});
 
+	it("tests rendering of icon when initials are overflowing ", async () => {
+		const avatar = await browser.$("#myAvatar5");
+		const icon = await avatar.shadow$(".ui5-avatar-icon");
+
+		// icon is rendered
+		assert.ok(await icon.isExisting(), "icon should be rendered, when the initials are overflowing");
+	});
+
 	it("Tests noConflict 'ui5-click' event is thrown for interactive avatars", async () => {
 		const avatarRoot = await browser.$("#interactive-avatar").shadow$(".ui5-avatar-root");
 		const input = await browser.$("#click-event");


### PR DESCRIPTION
Now, the ui5-avatar control supports three letters initials. If the initials are not valid or they are overflowing the control, an icon should be shown.