### PR TITLE
fix(ui5-icon): visualize the icons properly in Safari

### DIFF
--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -29,6 +29,8 @@
 
 .ui5-icon-root {
 	display:flex;
+	height: 100%;
+	width: 100%;
 	outline: none;
 	vertical-align: top;
 }


### PR DESCRIPTION
In Safari, the svg does not occupy 100% of the Icon's height and that causes the issue. The svg needs to take full width and height of the root in order to be visualised correctly. Setting the width and height of the svg to 100%, I tested many different samples and components that use ui5-icon and I did not find any side effects from the change. Something more, the ui5-icon has a predefined width and height of 1rem, so that has to prevent unexpected changes in the svg size.

FIXES: #5842
