### PR TITLE
docs: set sap_horizon as default theme in playground

### DIFF
--- a/packages/playground/_layouts/sample.html
+++ b/packages/playground/_layouts/sample.html
@@ -26,14 +26,14 @@ layout: default
             <div class="setting">
                 <ui5-label for="themeSwitch">Theme:</ui5-label>
                 <ui5-select id="themeSwitch">
-                    <ui5-option value="sap_fiori_3">Quartz Light</ui5-option>
-                    <ui5-option value="sap_fiori_3_dark">Quartz Dark</ui5-option>
-                    <ui5-option value="sap_fiori_3_hcb">Quartz High Contrast Black</ui5-option>
-                    <ui5-option value="sap_fiori_3_hcw">Quartz High Contrast White</ui5-option>
                     <ui5-option value="sap_horizon">Morning Horizon (Light)</ui5-option>
                     <ui5-option value="sap_horizon_dark">Evening Horizon (Dark)</ui5-option>
                     <ui5-option value="sap_horizon_hcb">Horizon High Contrast Black</ui5-option>
                     <ui5-option value="sap_horizon_hcw">Horizon High Contrast White</ui5-option>
+                    <ui5-option value="sap_fiori_3">Quartz Light</ui5-option>
+                    <ui5-option value="sap_fiori_3_dark">Quartz Dark</ui5-option>
+                    <ui5-option value="sap_fiori_3_hcb">Quartz High Contrast Black</ui5-option>
+                    <ui5-option value="sap_fiori_3_hcw">Quartz High Contrast White</ui5-option>
                 </ui5-select>
             </div>
             <div class="setting">
@@ -59,6 +59,13 @@ layout: default
 </ui5-dialog>
 
 <!-- UI5 Web Components Assests -->
+
+<script data-ui5-config type="application/json">
+    {
+      "theme": "sap_horizon"
+    }
+</script>
+
 <script type="module" src="{{ "/assets/js/ui5-webcomponents/bundle.esm.js" | absolute_url }}"></script>
 
 <link rel="stylesheet" href="{{ "/assets/css/api.css" | absolute_url }}">

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -13,10 +13,11 @@ nav_exclude: true
     <meta name="keywords" content="ui5-webcomponents,ui5 webcomponents,ui5 web components,webcomponents,web components,ui5,api,docs,documentation,sample,usage,examples,demo,Fiori 3,react,angular,vue">
     <link type="image/x-icon" href="{{"assets/images/favicon.ico" | absolute_url}}" rel="shortcut icon">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.25.0/themes/prism.css">
-    <script id="sap-ui-config" type="application/json">
+
+    <script data-ui5-config type="application/json">
         {
-            "theme": "sap_fiori_3",
-            "language": "EN"
+          "theme": "sap_horizon",
+          "language": "EN"
         }
     </script>
 


### PR DESCRIPTION
Change default display theme to "sap_horizon" + re-order the theme options in the settings view.