### PR TITLE
feat(ui5-link): make acceessibleRole property public

### DIFF
--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -129,7 +129,7 @@ const metadata = {
 		/**
 		 * Defines the ARIA role of the component.
 		 *
-		 * <b>Note:</b> Use "button" role in cases when navigation isn't expected to occur and the <code>href</code> property isn't defined.
+		 * <b>Note:</b> Use the "button" role in cases when navigation is not expected to occur and the href property is not defined.
 		 *
 		 * @type {string}
 		 * @defaultvalue "link"

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -128,9 +128,9 @@ const metadata = {
 
 		/**
 		 * Defines the ARIA role of the component.
-		 * 
+		 *
 		 * <b>Note:</b> Use "button" role in cases when navigation isn't expected to occur and the <code>href</code> property isn't defined.
-		 * 
+		 *
 		 * @type {string}
 		 * @defaultvalue "link"
 		 * @public
@@ -138,7 +138,7 @@ const metadata = {
 		 */
 		accessibleRole: {
 			type: String,
-			defaultValue: "link"
+			defaultValue: "link",
 		},
 
 		/**

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -128,12 +128,17 @@ const metadata = {
 
 		/**
 		 * Defines the ARIA role of the component.
-		 * @defaultvalue ""
-		 * @private
-		 * @since 1.0.0-rc.15
+		 * 
+		 * <b>Note:</b> Use "button" role in cases when navigation isn't expected to occur and the <code>href</code> property isn't defined.
+		 * 
+		 * @type {string}
+		 * @defaultvalue "link"
+		 * @public
+		 * @since 1.9.0
 		 */
-		 accessibleRole: {
+		accessibleRole: {
 			type: String,
+			defaultValue: "link"
 		},
 
 		/**
@@ -334,7 +339,7 @@ class Link extends UI5Element {
 	}
 
 	get effectiveAccRole() {
-		return this.accessibleRole || "link";
+		return this.accessibleRole.toLowerCase();
 	}
 
 	static async onDefine() {

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -98,7 +98,7 @@
 
 	<section class="group">
 		<h2>Link opens a dialog</h2>
-		<ui5-link id="signInLink">Sign in</ui5-link>
+		<ui5-link accessible-role="button" id="signInLink">Sign in</ui5-link>
 		<ui5-dialog id="signInDialog" header-text="Sign in form">
 			<section class="login-form">
 				<div>
@@ -121,7 +121,7 @@
 
 	<section class="group">
 		<h2>Link with prevent default and modifiers</h2>
-		<ui5-link id="modifierLink">Link 1</ui5-link>
+		<ui5-link accessible-role="button" id="modifierLink">Link 1</ui5-link>
 		<span id="modifierResult"></span>
 	</section>
 


### PR DESCRIPTION
- The previously private `accessibleRole` property is now made public, in order to enable
application developers to configure a given ui5-link element to be interpreted as button
by the accessibility tools.

Fixes: #5686