### PR TITLE
chore: remove obsolete hash file

### DIFF
--- a/packages/base/hash.txt
+++ b/packages/base/hash.txt
@@ -1,1 +1,0 @@
-XeoUDYYqmjUwnJg4dGNgbPltSMo=


### PR DESCRIPTION
Not needed as we don't make use of hashes build time any more.
