### PR TITLE
fix: make static are items recognizable to openui5 dialogs

### DIFF
--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -17,6 +17,7 @@ class StaticAreaItem extends HTMLElement {
 		this._rendered = false;
 		this.attachShadow({ mode: "open" });
 		this.pureTagName = "ui5-static-area-item";
+		this.popupIntegrationAttr = "data-sap-ui-integration-popup-content";
 	}
 
 	/**
@@ -37,9 +38,9 @@ class StaticAreaItem extends HTMLElement {
 	 */
 	update() {
 		if (this._rendered) {
-			this.setAttribute(this.pureTagName, "");
 			this._updateContentDensity();
 			this._updateDirection();
+			this._updateAdditionalAttrs();
 			updateShadowRoot(this.ownerElement, true);
 		}
 	}
@@ -65,6 +66,11 @@ class StaticAreaItem extends HTMLElement {
 		} else {
 			this.removeAttribute("dir");
 		}
+	}
+
+	_updateAdditionalAttrs() {
+		this.setAttribute(this.pureTagName, "");
+		this.toggleAttribute(this.popupIntegrationAttr, this.ownerElement.hasAttribute(this.popupIntegrationAttr));
 	}
 
 	/**

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -70,7 +70,7 @@ class StaticAreaItem extends HTMLElement {
 
 	_updateAdditionalAttrs() {
 		this.setAttribute(this.pureTagName, "");
-		this.toggleAttribute(this.popupIntegrationAttr, this.ownerElement.hasAttribute(this.popupIntegrationAttr));
+		this.setAttribute(this.popupIntegrationAttr, "");
 	}
 
 	/**

--- a/packages/base/src/StaticAreaItem.js
+++ b/packages/base/src/StaticAreaItem.js
@@ -38,9 +38,9 @@ class StaticAreaItem extends HTMLElement {
 	 */
 	update() {
 		if (this._rendered) {
+			this._updateAdditionalAttrs();
 			this._updateContentDensity();
 			this._updateDirection();
-			this._updateAdditionalAttrs();
 			updateShadowRoot(this.ownerElement, true);
 		}
 	}

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -4,23 +4,54 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
 
-    <title>Button</title>
+    <title>OpenUI5 + UI5 Web Components</title>
 
     <script id='sap-ui-bootstrap'
             src='https://sdk.openui5.org/resources/sap-ui-core.js'
             data-sap-ui-theme='sap_belize_hcb'
-            data-sap-ui-libs='sap.m'
+            data-sap-ui-libs='sap.m, sap.ui.core'
             data-sap-ui-preload="async"
     ></script>
+
     <script>
         sap.ui.getCore().attachInit(function() {
-			var btn = new sap.m.Button({
-				text:'OpenUI5',
+			const dialog = new sap.m.Dialog({
+                content: [
+                    new sap.ui.core.HTML({
+                        content: '<ui5-date-picker id="myDatepicker" value="Aug 14, 2018" data-sap-ui-integration-popup-content></ui5-date-picker>'
+                    }),
+                ]
+            });
+
+            const dialog2 = new sap.m.Dialog({
+                content: [
+                    new sap.ui.core.HTML({
+                        content: '<ui5-calendar id="myCalendar" value="Aug 14, 2018"></ui5-calendar>'
+                    }),
+                ]
+            });
+
+			const btn = new sap.m.Button({
+				text: "DialogWithDatePicker",
 				press: function() {
-					alert("Hello!")
-				}
+					dialog.open();
+				},
 			});
-			btn.placeAt('content');
+
+			const btn2 = new sap.m.Button({
+				text: "DialogWithCalendar",
+				press: function() {
+					dialog2.open();
+				},
+			});
+
+            const page = new sap.m.Page({
+                content: [
+                    dialog, dialog2, btn, btn2
+                ],
+            });
+
+			page.placeAt('content');
         });
     </script>
 
@@ -35,18 +66,16 @@
         }
     </script>
 
-
     <script src="../../bundle.esm.js" type="module"></script>
 
-<link rel="stylesheet" type="text/css" href="./styles/OpenUI5.css">
+	<link rel="stylesheet" type="text/css" href="./styles/OpenUI5.css">
 </head>
 
 <body class="openui51auto">
 
-<ui5-button icon="download">Web Component</ui5-button>
-<ui5-datepicker></ui5-datepicker>
+	<ui5-button icon="download">Web Component</ui5-button>
+	<ui5-datepicker></ui5-datepicker>
 
-<div id='content'></div>
-
+	<div id='content'></div>
 </body>
 </html>

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -7,7 +7,7 @@
     <title>OpenUI5 + UI5 Web Components</title>
 
     <script id='sap-ui-bootstrap'
-            src='https://sdk.openui5.org/resources/sap-ui-core.js'
+            src='https://openui5.hana.ondemand.com/resources/sap-ui-core.js'
             data-sap-ui-theme='sap_belize_hcb'
             data-sap-ui-libs='sap.m, sap.ui.core'
             data-sap-ui-preload="async"

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -7,7 +7,7 @@
     <title>OpenUI5 + UI5 Web Components</title>
 
     <script id='sap-ui-bootstrap'
-            src='https://openui5.hana.ondemand.com/resources/sap-ui-core.js'
+            src='https://sdk.openui5.org/resources/sap-ui-core.js'
             data-sap-ui-theme='sap_belize_hcb'
             data-sap-ui-libs='sap.m, sap.ui.core'
             data-sap-ui-preload="async"

--- a/packages/main/test/pages/styles/OpenUI5.css
+++ b/packages/main/test/pages/styles/OpenUI5.css
@@ -1,3 +1,7 @@
+html, body, #content {
+    height: 100%;
+}
+
 .openui51auto {
     background-color: var(--sapBackgroundColor);
 }


### PR DESCRIPTION
**Issue**
When UI5WC ui5-date-picker is opened inside UI5 dialog, click "ESC" wrongly close whole dialog.

**Root cause** 
It's an integration issue between UI5WC Popups and OpenUI5 Popups - the focus never gets to the DatePicker's popover as it's not recognized as an external content by the sap.m.Dialog.

**Solution**
While we are working on more general, out of the box solution by integrating UI5WC Popups and OpenUI5 Popups, we would like to provide the following solution for the time being:

Forwarding the `"data-sap-ui-integration-popup-content"` attribute from the component that opens popup to its the static are item, which makes the static are item an external content for the sap.m.Dialog (as the aforementioned attribute is already part of the OpenUI5 logic). When the attribute is present, the focus goes inside the DatePicker's popover and the ESC behaviour works as expected.

Related to: https://github.com/SAP/ui5-webcomponents/issues/5634