### PR TITLE
docs: fix bad nbsp

### DIFF
--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -220,7 +220,6 @@ const metadata = {
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-badge slot="badge"><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-icon slot="icon" name="employee">&lt;/ui5-icon><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;/ui5-badge><br>
-		 *
 		 * &lt;/ui5-avatar>
 		 * <br><br>
 		 * <ui5-avatar initials="AB" color-scheme="Accent1">

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -52,7 +52,7 @@ const metadata = {
 		 * <br><br>
 		 * import "@ui5/webcomponents-icons/dist/{icon_name}.js"
 		 * <br>
-		 * <pre>&lt;ui5-avatar icon="employee"> </pre>
+		 * <pre>&lt;ui5-avatar icon="employee"></pre>
 		 *
 		 * See all the available icons in the <ui5-link target="_blank" href="https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 * @type {string}

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -219,7 +219,7 @@ const metadata = {
 		 * &lt;ui5-avatar><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-badge slot="badge"><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-icon slot="icon" name="employee">&lt;/ui5-icon><br>
-		 * &nbsp;&nbsp;&nbsp;&nbsp&lt;/ui5-badge><br>
+		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;/ui5-badge><br>
 		 * &lt;/ui5-avatar>
 		 * <br><br>
 		 * <ui5-avatar initials="AB" color-scheme="Accent1">

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -52,7 +52,7 @@ const metadata = {
 		 * <br><br>
 		 * import "@ui5/webcomponents-icons/dist/{icon_name}.js"
 		 * <br>
-		 * <pre>&lt;ui5-avatar icon="employee"></pre>
+		 * <pre>&lt;ui5-avatar icon="employee"> </pre>
 		 *
 		 * See all the available icons in the <ui5-link target="_blank" href="https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html" class="api-table-content-cell-link">Icon Explorer</ui5-link>.
 		 * @type {string}

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -220,6 +220,7 @@ const metadata = {
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-badge slot="badge"><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ui5-icon slot="icon" name="employee">&lt;/ui5-icon><br>
 		 * &nbsp;&nbsp;&nbsp;&nbsp;&lt;/ui5-badge><br>
+		 *
 		 * &lt;/ui5-avatar>
 		 * <br><br>
 		 * <ui5-avatar initials="AB" color-scheme="Accent1">


### PR DESCRIPTION
One `&nbsp` in `Avatar.js` is missing the `;` which causes it to not be replaced by the `@uit/tooling-webc` wrapper generator, ultimately breaking the UI5 Enablement for Web Components build