### PR TITLE
fix(BarcodeScannerDialog): imports of UMD modules work in all kinds o…

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.js
+++ b/packages/fiori/src/BarcodeScannerDialog.js
@@ -4,8 +4,7 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Dialog from "@ui5/webcomponents/dist/Dialog.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
-import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library/umd/index.js";
-
+import * as ZXing from "@zxing/library/umd/index.js";
 // Template
 import BarcodeScannerDialogTemplate from "./generated/templates/BarcodeScannerDialogTemplate.lit.js";
 
@@ -17,6 +16,11 @@ import {
 	BARCODE_SCANNER_DIALOG_CANCEL_BUTTON_TXT,
 	BARCODE_SCANNER_DIALOG_LOADING_TXT,
 } from "./generated/i18n/i18n-defaults.js";
+
+// some tools handle named exports from UMD files and the window object is not assigned but the imports work (vitejs)
+// other tools do not handle named exports (they are undefined after the import), but the window global is assigned and can be used (web dev server)
+const effectiveZXing = { ...ZXing, ...window.ZXing };
+const { BrowserMultiFormatReader, NotFoundException } = effectiveZXing;
 
 const defaultMediaConstraints = {
 	audio: false,


### PR DESCRIPTION
The ZXing ES module import provides source maps, but does not ship the actual sources so some tools print a lot of warnings. A previous change switched to the UMD module of ZXing, but this turns out is not universally supported by all dev tools.

Some tools (like vitejs, rollup plugin commonjs) correctly handle the UMD exports and find out the named exports.

Other tools like web dev server however, do not recognise the exported values of UMD modules and suggest to make an ES wrapper that reexports the names from the window object assigned by the UMD module.

Vitejs however does not provide the window object as it handles the named exports correctly.

This change merges both approaches - a named import, and in case it doesn't have values it takes them from the window object.

Fixes: #5884 