### PR TITLE
fix(ui5-shellbar): enable title for shellbar items

### DIFF
--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -25,6 +25,7 @@
 				icon="{{this.icon}}"
 				type="Active"
 				@ui5-_press="{{this.press}}"
+				title="{{this.text}}"
 			>{{this.text}}
 			</ui5-li>
 		{{/each}}


### PR DESCRIPTION
Title (tooltip) is now shown for items inside the shellbar's popover.

Fixes: #5885