### PR TITLE
[for discussion] docs: add Form related tags to components API

### DIFF
--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -126,6 +126,7 @@ const metadata = {
 		 *
 		 * @type {boolean}
 		 * @defaultvalue false
+		 * @controlledByEvents change
 		 * @public
 		 */
 		checked: {
@@ -279,7 +280,9 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.CheckBox
  * @extends sap.ui.webcomponents.base.UI5Element
+ * @implements sap.ui.webcomponents.main.IFormComponent
  * @tagname ui5-checkbox
+ * @formProperties value name
  * @public
  */
 class CheckBox extends UI5Element {

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -259,6 +259,7 @@ const metadata = {
 		 *
 		 * @type {string}
 		 * @defaultvalue ""
+		 * @controlledByEvents change input
 		 * @public
 		 */
 		value: {
@@ -566,8 +567,9 @@ const metadata = {
  * @alias sap.ui.webcomponents.main.Input
  * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-input
+ * @formProperties value
  * @appenddocs SuggestionItem SuggestionGroupItem
- * @implements sap.ui.webcomponents.main.IInput
+ * @implements sap.ui.webcomponents.main.IFormComponent sap.ui.webcomponents.main.IInput
  * @public
  */
 class Input extends UI5Element {

--- a/packages/main/src/Interfaces.js
+++ b/packages/main/src/Interfaces.js
@@ -53,6 +53,15 @@ const IComboBoxItem = "sap.ui.webcomponents.main.IComboBoxItem";
 const IColorPaletteItem = "sap.ui.webcomponents.main.IColorPaletteItem";
 
 /**
+ * Interface for form components.
+ *
+ * @name sap.ui.webcomponents.main.IFormComponent
+ * @interface
+ * @public
+ */
+const IFormComponent = "sap.ui.webcomponents.main.IFormComponent";
+
+/**
  * Interface for components that represent an icon, usable in numerous higher-order components
  *
  * @name sap.ui.webcomponents.main.IIcon
@@ -185,6 +194,7 @@ export {
 	ICalendarDate,
 	IColorPaletteItem,
 	IComboBoxItem,
+	IFormComponent,
 	IIcon,
 	IInput,
 	IInputSuggestionItem,

--- a/packages/tools/lib/jsdoc/plugin.js
+++ b/packages/tools/lib/jsdoc/plugin.js
@@ -34,6 +34,10 @@
  *   native
  *
  *   noattribute
+ * 
+ *   controlledByEvents
+ * 
+ *   formProperties
  *
  *   allowPreventDefault
  *
@@ -2106,6 +2110,34 @@ exports.defineTags = function(dictionary) {
 		mustHaveValue: false,
 		onTagged: function(doclet, tag) {
 			doclet.noattribute = true;
+		}
+	});
+
+	dictionary.defineTag('controlledByEvents', {
+		mustHaveValue: false,
+		onTagged: function(doclet, tag) {
+			if (tag.value) {
+				doclet.controlledByEvents = doclet.controlledByEvents || [];
+				tag.value.split(" ").forEach(function($) {
+					if ( doclet.controlledByEvents.indexOf($) < 0 ) {
+						doclet.controlledByEvents.push($);
+					}
+				});
+			}
+		}
+	});
+
+	dictionary.defineTag('formProperties', {
+		mustHaveValue: false,
+		onTagged: function(doclet, tag) {
+			if (tag.value) {
+				doclet.formProperties = doclet.formProperties || [];
+				tag.value.split(/\s*,\s*/g).forEach(function($) {
+					if ( doclet.formProperties.indexOf($) < 0 ) {
+						doclet.formProperties.push($);
+					}
+				});
+			}
 		}
 	});
 };

--- a/packages/tools/lib/jsdoc/template/publish.js
+++ b/packages/tools/lib/jsdoc/template/publish.js
@@ -2657,6 +2657,10 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 	if (symbol.appenddocs) {
 		attrib("appenddocs", symbol.appenddocs);
 	}
+	if ( symbol.formProperties ) {
+		attrib("formProperties", symbol.formProperties);
+	}
+
 	if ( symbol.__ui5.resource ) {
 		attrib("resource", symbol.__ui5.resource);
 	}
@@ -2818,6 +2822,10 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 					}
 					if ( member.since ) {
 						attrib("since", extractVersion(member.since));
+					}
+
+					if ( member.controlledByEvents ) {
+						attrib("controlledByEvents", member.controlledByEvents);
 					}
 
 					var type = listTypes(member.type);
@@ -3865,7 +3873,7 @@ function createAPIJS(symbols, filename) {
 
 	var output = [];
 
-	var rkeywords = /^(?:abstract|as|boolean|break|byte|case|catch|char|class|continue|const|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|is|long|namespace|native|new|null|noattribute|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|use|var|void|volatile|while|with)$/;
+	var rkeywords = /^(?:abstract|as|boolean|break|byte|case|catch|char|class|continue|controlledByEvents|const|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|formProperties|goto|if|implements|import|in|instanceof|int|interface|is|long|namespace|native|new|null|noattribute|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|use|var|void|volatile|while|with)$/;
 
 	function isNoKeyword($) { return !rkeywords.test($.name); }
 


### PR DESCRIPTION
To enable easier generation of Angular wrappers in terms of Angular Form support, we might need to append more information to our existing API JSDoc, such as which component is a Form Component, the properties that are form related, the events that related to the change of those properties.
(Names are subject to change)

**Class level:**
- New interface `IFormComponent`
- New class level tag `@formProperties` -  describes the form related properties 

Example:
```js
/**
* @implements sap.ui.webcomponents.main.IFormComponent
* @formProperties value
```

**Property level**
- New tag `@controlledByEvent` - describes the event, fired when a form property changes 

Example:
```js
/**
* @controlledByEvent change input
value: {},
```