### PR TITLE
fix(f6navigation): correct activeElement when shadow root doesn't exist

### DIFF
--- a/packages/base/src/features/F6Navigation.js
+++ b/packages/base/src/features/F6Navigation.js
@@ -54,24 +54,20 @@ class F6Navigation {
 			const nextIndex = this.groups.indexOf(this.selectedGroup);
 			let nextElement = null;
 
-			if (nextIndex > -1) {
-				if (nextIndex - 1 < 0) {
-					nextElement = this.groups[this.groups.length - 1];
-				} else {
-					// Handle the situation where the first focusable element of two neighbor groups is the same
-					// For example:
-					// <ui5-flexible-column-layout>
-					//     <ui5-list>
-					//         <ui5-li>List Item</ui5-li>
-					//     </ui5-list>
-					// </ui5-flexible-column-layout>
-					// Here for both FCL & List the firstFoccusableElement is the same (the ui5-li)
+			if (nextIndex > 0) {
+				// Handle the situation where the first focusable element of two neighbor groups is the same
+				// For example:
+				// <ui5-flexible-column-layout>
+				//     <ui5-list>
+				//         <ui5-li>List Item</ui5-li>
+				//     </ui5-list>
+				// </ui5-flexible-column-layout>
+				// Here for both FCL & List the firstFoccusableElement is the same (the ui5-li)
 
-					const firstFocusable = await getFirstFocusableElement(this.groups[nextIndex - 1], true);
-					const shouldSkipParent = firstFocusable === await getFirstFocusableElement(this.groups[nextIndex], true);
+				const firstFocusable = await getFirstFocusableElement(this.groups[nextIndex - 1], true);
+				const shouldSkipParent = firstFocusable === await getFirstFocusableElement(this.groups[nextIndex], true);
 
-					nextElement = this.groups[shouldSkipParent ? nextIndex - 2 : nextIndex - 1];
-				}
+				nextElement = this.groups[shouldSkipParent ? nextIndex - 2 : nextIndex - 1];
 			} else {
 				nextElement = this.groups[this.groups.length - 1];
 			}
@@ -86,26 +82,27 @@ class F6Navigation {
 	}
 
 	updateGroups() {
-		this.setSelectedGroup(document.activeElement);
+		this.setSelectedGroup();
 		this.groups = getFastNavigationGroups(document.body);
 	}
 
-	setSelectedGroup(element) {
+	setSelectedGroup(element = document) {
+		const htmlElement = document.querySelector("html");
 		element = this.deepActive(element);
 
-		while (element && element.getAttribute("data-sap-ui-fastnavgroup") !== "true" && element !== document.querySelector("html")) {
+		while (element && element.getAttribute("data-sap-ui-fastnavgroup") !== "true" && element !== htmlElement) {
 			element = element.parentElement ? element.parentNode : element.parentNode.host;
 		}
 
 		this.selectedGroup = element;
 	}
 
-	deepActive(element) {
-		if (element.shadowRoot) {
-			return this.deepActive(element.shadowRoot);
+	deepActive(root) {
+		if (root.activeElement && root.activeElement.shadowRoot) {
+			return this.deepActive(root.activeElement.shadowRoot);
 		}
 
-		return element.activeElement;
+		return root.activeElement;
 	}
 
 	destroy() {


### PR DESCRIPTION
I have found that deepActive won't work if `document.active` does not have shadowRoot (it's returning undefined), which I suppose is not intended.

I am part of SAP CX, please for faster communication reach out in Slack/Teams
My name is Zsolt Deák

## Pull Request Checklist
- [✅ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [✅ ] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
    + Bugfixes should generally include a test to cover the issue.
