### PR TITLE
fix(ui5-time-picker): enable text spacing

### DIFF
--- a/packages/main/src/themes/StepInput.css
+++ b/packages/main/src/themes/StepInput.css
@@ -4,6 +4,9 @@
 :host(:not([hidden])) {
 	display: inline-block;
 	width: 100%;
+	line-height: normal;
+	letter-spacing: normal;
+	word-spacing: normal;
 }
 
 :host {
@@ -150,6 +153,9 @@
 	position: relative;
 	padding: 0px 2.5rem 0px 2.4375rem;
 	outline: none;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 :host .ui5-step-input-input[readonly] { 
@@ -163,6 +169,9 @@
 
 :host .ui5-step-input-root {
 	white-space: nowrap;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 :host .ui5-step-input-input[text-align=left] {

--- a/packages/main/src/themes/TimePicker.css
+++ b/packages/main/src/themes/TimePicker.css
@@ -3,6 +3,9 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
+	line-height: normal;
+	letter-spacing: normal;
+	word-spacing: normal;
 }
 
 :host {
@@ -19,10 +22,19 @@
 	background: var(--sapField_Hover_Background);
 }
 
+.ui5-time-picker-root {
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
+}
+
 :host .ui5-time-picker-input {
 	width: 100%;
 	color: inherit;
 	background-color: inherit;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 .ui5-time-picker-input-icon-button {


### PR DESCRIPTION
- Text spacing is now applied when custom styles are provided to the parent element.

Fixes: #5792
