### PR TITLE
feat(ui5-switch): provide tooltip property

### DIFF
--- a/packages/main/src/Switch.hbs
+++ b/packages/main/src/Switch.hbs
@@ -9,6 +9,7 @@
 	@keydown="{{_onkeydown}}"
 	tabindex="{{tabIndex}}"
 	dir="{{effectiveDir}}"
+	title="{{tooltip}}"
 >
 	<div class="ui5-switch-inner">
 		<div class="ui5-switch-track" part="slider">

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -120,6 +120,19 @@ const metadata = {
 			type: String,
 			defaultValue: "",
 		},
+
+		/**
+		 * Defines the tooltip of the component.
+		 * <br>
+		 * <b>Note:</b> If applicable an external label reference should always be the preferred option to provide context to the <code>ui5-switch</code> component over a tooltip.
+		 * @type {string}
+		 * @defaultvalue: ""
+		 * @public
+		 * @since 1.9.0
+		 */
+		 tooltip: {
+			type: String,
+		},
 	},
 	events: /** @lends sap.ui.webcomponents.main.Switch.prototype */ {
 

--- a/packages/main/test/pages/Switch.html
+++ b/packages/main/test/pages/Switch.html
@@ -21,6 +21,7 @@
 	</div>
 
 	<div class="switch2auto">
+		<ui5-switch id="switchTooltip" tooltip="Use GPS location" class="switch3auto" text-on="Yes" text-off="No"></ui5-switch>
 		<ui5-switch id="switchAccName" accessible-name="Geographical location" class="switch3auto" text-on="Yes" text-off="No"></ui5-switch>
 		<ui5-label id="descriptionText">Use GPS location</ui5-label>
 		<ui5-switch id="switchAccNameRef" accessible-name-ref="descriptionText" class="switch3auto" text-on="Yes" text-off="No"></ui5-switch>

--- a/packages/main/test/specs/Switch.spec.js
+++ b/packages/main/test/specs/Switch.spec.js
@@ -27,18 +27,24 @@ describe("Switch general interaction", async () => {
 		assert.strictEqual(await field.getProperty("value"), "3", "Change event should not be called any more");
 	});
 
-	it("setting accessible-name on the host is reflected on the button tag", async () => {
+	it("setting accessible-name on the host is reflected on the root element", async () => {
 		const switchEl = await browser.$("#switchAccName").shadow$("div");
 
 		assert.strictEqual(await switchEl.getAttribute("role"), "switch", "Proper role attribute is set");
 		assert.strictEqual(await switchEl.getAttribute("aria-label"), "Geographical location No", "Attribute is reflected");
 	});
 
-	it("setting accessible-name-ref on the host is reflected on the button tag", async () => {
+	it("setting accessible-name-ref on the host is reflected on the root element", async () => {
 		const switchEl = await browser.$("#switchAccNameRef").shadow$("div");
 
 		assert.strictEqual(await switchEl.getAttribute("role"), "switch", "Proper role attribute is set");
 		assert.strictEqual(await switchEl.getAttribute("aria-label"), "Use GPS location No", "Attribute is reflected");
+	});
+
+	it("setting tooltip on the host is reflected on the root element", async () => {
+		const switchEl = await browser.$("#switchTooltip").shadow$("div");
+
+		assert.strictEqual(await switchEl.getAttribute("title"), "Use GPS location", "Attribute is reflected");
 	});
 
 	it("aria-label attribute is properly set when text-on and text-off attributes aren't set", async () => {


### PR DESCRIPTION
- Application developers are enabled to use the new tooltip property in cases when referring
an external label is not wanted.

Fixes: #5552