### PR TITLE
fix(framework): fix contexts management in hbs-2-lit compiler

### DIFF
--- a/packages/base/bundle.esm.js
+++ b/packages/base/bundle.esm.js
@@ -10,6 +10,7 @@ import "./test/elements/NoShadowDOM.js";
 import "./test/elements/Parent.js";
 import "./test/elements/Child.js";
 import "./test/elements/WithStaticArea.js";
+import "./test/elements/WithComplexTemplate.js";
 import "./test/elements/GenericExt.js";
 
 // Test themes - CSS Vars for the sap_fiori_3, sap_fiori_3_dark, sap_belize and sap_belize_hcb themes

--- a/packages/base/package-scripts.js
+++ b/packages/base/package-scripts.js
@@ -15,7 +15,7 @@ const eslintConfig = `--config ${require.resolve("@ui5/webcomponents-tools/compo
 const scripts = {
 	clean: "rimraf dist && rimraf .port",
 	lint: `eslint . ${eslintConfig}`,
-	prepare: "nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles",
+	prepare: "nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles generateTemplates",
 	integrate: {
 		default: "nps integrate.copy-used-modules integrate.replace-amd integrate.amd-to-es6 integrate.esm-abs-to-rel integrate.third-party",
 		"copy-used-modules": `node "${copyUsedModules}" ./used-modules.txt dist/`,
@@ -39,6 +39,7 @@ const scripts = {
 	generateAssetParameters: `node "${assetParametersScript}"`,
 	generateVersionInfo: `node "${versionScript}"`,
 	generateStyles: `node "${stylesScript}"`,
+	generateTemplates: `mkdirp dist/generated/templates && node "${LIB}/hbs2ui5/index.js" -d test/elements -o dist/generated/templates`,
 	watch: {
 		default: 'concurrently "nps watch.src" "nps watch.styles"',
 		withBundle: 'concurrently "nps watch.src" "nps watch.bundle" "nps watch.styles"',

--- a/packages/base/test/elements/WithComplexTemplate.hbs
+++ b/packages/base/test/elements/WithComplexTemplate.hbs
@@ -1,0 +1,25 @@
+<div>
+	Root text: {{text}}
+	{{#each items}}
+			<h3>Item-{{@index}}</h3>
+
+			{{#if text}}
+				<div class="before-each-content--start--{{@index}}">Root text: {{../text}}, Item text: {{text}}</div>
+			{{/if}}
+
+			<ul>
+				{{#each words}}
+						<li>
+							<h3>Word-{{@index}}</h3>
+							<div class="nested-each-content--{{@index}}--0">Root Text: {{../../text}}, Word text: {{text}}</div>
+							<div class="nested-each-content--{{@index}}--1">Root Text: {{@root.text}}, Word text: {{text}}</div>
+						</li>
+				{{/each}}
+			</ul>
+
+			{{#if text}}
+				<div class="after-each-content--end--{{@index}}">Root text: {{../text}}, Item text: {{text}}</div>
+			{{/if}}
+	{{/each}}
+	Root text: {{text}}
+ </div>

--- a/packages/base/test/elements/WithComplexTemplate.js
+++ b/packages/base/test/elements/WithComplexTemplate.js
@@ -1,0 +1,46 @@
+import UI5Element from "../../dist/UI5Element.js";
+import litRender from "../../dist/renderer/LitRenderer.js";
+import WithComplexTemplateTemplate from "../../dist/generated/templates/elements/WithComplexTemplateTemplate.lit.js";
+
+class WithComplexTemplate extends UI5Element {
+	static get metadata() {
+		return {
+			tag: "ui5-test-complex-template",
+		};
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	static get template() {
+		return WithComplexTemplateTemplate;
+	}
+
+    get text() {
+		return "root";
+	}
+
+    get items() {
+		return [
+			{
+				text: "positives",
+				words: [
+					{ text: "word1_good" },
+					{ text: "word2_nice" },
+					{ text: "word3_kind" },
+				],
+			},
+			{
+				text: "negatives",
+				words:[
+						{ text: "word4_bad"},
+						{ text: "word5_rude"},
+						{ text: "word6_unpolite"},
+					],
+			},
+		];
+	}
+}
+
+WithComplexTemplate.define();

--- a/packages/base/test/pages/WithComplexTemplate.html
+++ b/packages/base/test/pages/WithComplexTemplate.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Compex Template Test Page</title>
+	<script src="../../bundle.esm.js" type="module"></script>
+</head>
+
+<body>
+
+    <h3>Legend</h3>
+    <ul>
+        <li>Root text is "root"</li>
+        <li>Item text are "positives" and "negatives"</li>
+        <li>Word text are "good", "nice", "kind", "bad", "unpolite"...</li>
+    </ul>
+
+    <h3>Component</h3>
+    <ui5-test-complex-template id="testComplexTemplate"></ui5-test-complex-template>
+</body>
+</html>

--- a/packages/base/test/specs/WithComplexTemplate.spec.js
+++ b/packages/base/test/specs/WithComplexTemplate.spec.js
@@ -1,0 +1,31 @@
+const assert = require("chai").assert;
+
+describe("Theming works", () => {
+	before(async () => {
+		await browser.url("test/pages/WithComplexTemplate.html");
+	});
+
+	it("Tests context maintained in the HBS template before, after and inside 'each' statements", async () => {
+		// Expected order of the rendered texts, which depends on correct context within the template
+		const EXPTECTED_LOOP_CONTENT = "Root text: root, Item text: positives";
+		const EXPTECTED_NESTED_LOOP_CONTENT = "Root Text: root, Word text: word1_good";
+		
+		const ACTUAL_TEXT_CONTENT = await browser.executeAsync( async (done) => {
+			const beforeLoopContent = document.querySelector("#testComplexTemplate").shadowRoot.querySelector('.before-each-content--start--0').textContent;
+			const nestedLoopContent1 = document.querySelector("#testComplexTemplate").shadowRoot.querySelector('.nested-each-content--0--0').textContent;
+			const nestedLoopContent2 = document.querySelector("#testComplexTemplate").shadowRoot.querySelector('.nested-each-content--0--1').textContent;
+			const afterLoopContent = document.querySelector("#testComplexTemplate").shadowRoot.querySelector('.after-each-content--end--0').textContent;
+			done({
+				beforeLoopContent,
+				nestedLoopContent1,
+				nestedLoopContent2,
+				afterLoopContent,
+			});
+		}, );
+
+		assert.strictEqual(ACTUAL_TEXT_CONTENT.beforeLoopContent, EXPTECTED_LOOP_CONTENT, "The template has been built correctly.");
+		assert.strictEqual(ACTUAL_TEXT_CONTENT.nestedLoopContent1, EXPTECTED_NESTED_LOOP_CONTENT, "The template has been built correctly.");
+		assert.strictEqual(ACTUAL_TEXT_CONTENT.nestedLoopContent2, EXPTECTED_NESTED_LOOP_CONTENT, "The template has been built correctly.");
+		assert.strictEqual(ACTUAL_TEXT_CONTENT.afterLoopContent, EXPTECTED_LOOP_CONTENT, "The template has been built correctly.");
+	});
+});


### PR DESCRIPTION
The PR addresses several issues with context setting within the lit templates by the HBS-2-lit compiler.

**Note:** There is one downside - to test it out, I have created a dummy component in "base", I created an HBS template and test, but I needed to enable the lit template generation. So, I guess we can find a smarter way to test it out - to pass templates to the compiler and check the output (I will look into that).

**Issues that are resolved with this change:**
- when "@root" is used in HBS template - it will throw an error: invalid or unexpected token
- when trying to access root context from nested loop with "{{../../text}}", it will compile to "{{text}}" ("context.text" would have been correct) and will throw an error
```hbs
<div>
{{#each items}}
	<ul>
		{{#each words}}
			<li>
			<div>{{../../text}}</div> {{!-- compiles to "text" (throws an error) --}}
			<div>{{@root.text}}</div> {{!--"@root" throws an error"--}}
			</li>
		{{/each}}
	</ul>
{{/each}}
</div>
```

- After the nested each (level 2) completes, the default context is set the root one "context", but it should be "item" as the execution continues in the top level loop.

```hbs
<div>
	{{#each items}}
			{{#each words}}
					
			{{/each}}

                       <div> item text: {{text}}</div>{{!-- compiles to "context.text", but should be "item.text"--}} 
	{{/each}}
</div>
```

- After the nested each (level 2) completes and trying to access the root context with "{{../text}}" from the top level loop fails as it compiles to "item.text", instead of "context.text":

```hbs
<div>
	{{#each items}}
			{{#each words}}
					
			{{/each}}

                       <div> item text: {{../text}}</div>{{!-- compiles to "item.text", but should be "context.text"--}} 
	{{/each}}
</div>
```

**Note:** one major issue still remains with the "../" syntax. Even after the change "../" syntax only works when trying to access the root context, as we have only one root context represented by the "context" variable. But when it comes to moving between different levels of loops - it still does not work.


After the change,  parsing {../text}} generates properly "item.text", but "item" points to the wrong object - points to current object not the object of the outer array as shown below:

```hbs
<div>
{{#each items}}
		{{#each words}}
			<div> item text: {{../text}}</div>{{!-- compiles to "item.text" properly, but "item" refers to the item in "words", not in "items" array--}} 
		{{/each}}
{{/each}}
</div>
```
There is another [BLI](https://github.com/SAP/ui5-webcomponents/issues/4997) for refactoring, where this is described. We need to maintain a stack of contexts and use it when generating the templates to pass the correct one.


FIXES: https://github.com/SAP/ui5-webcomponents/issues/4701