### PR TITLE
docs(framework): align jsdoc types

### DIFF
--- a/packages/base/src/types/CSSColor.js
+++ b/packages/base/src/types/CSSColor.js
@@ -4,7 +4,7 @@ import DataType from "./DataType.js";
  * @class
  * CSSColor data type.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.CSSColor

--- a/packages/base/src/types/CSSSize.js
+++ b/packages/base/src/types/CSSSize.js
@@ -4,7 +4,7 @@ import DataType from "./DataType.js";
  * @class
  * CSSSize data type.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.CSSSize

--- a/packages/base/src/types/CalendarType.js
+++ b/packages/base/src/types/CalendarType.js
@@ -41,7 +41,7 @@ const CalendarTypes = {
  * @class
  * Different calendar types.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.CalendarType

--- a/packages/base/src/types/DOMReference.js
+++ b/packages/base/src/types/DOMReference.js
@@ -5,6 +5,10 @@ import DataType from "./DataType.js";
  * DOM Element reference or ID.
  * <b>Note:</b> If an ID is passed, it is expected to be part of the same <code>document</code> element as the consuming component.
  *
+ * @constructor
+ * @extends sap.ui.webcomponents.base.types.DataType
+ * @author SAP SE
+ * @alias sap.ui.webcomponents.base.types.DOMReference
  * @public
  */
 class DOMReference extends DataType {

--- a/packages/base/src/types/Float.js
+++ b/packages/base/src/types/Float.js
@@ -5,7 +5,7 @@ import DataType from "./DataType.js";
  * Float data type.
  *
  * @constructor
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.Float
  * @public

--- a/packages/base/src/types/Integer.js
+++ b/packages/base/src/types/Integer.js
@@ -5,7 +5,7 @@ import DataType from "./DataType.js";
  * Integer data type.
  *
  * @constructor
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.Integer
  * @public

--- a/packages/base/src/types/InvisibleMessageMode.js
+++ b/packages/base/src/types/InvisibleMessageMode.js
@@ -28,7 +28,7 @@ const InvisibleMessageModes = {
  * @class
  * Different types of InvisibleMessageMode.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.InvisibleMessageMode

--- a/packages/base/src/types/PopupState.js
+++ b/packages/base/src/types/PopupState.js
@@ -39,7 +39,7 @@ const PopupStates = {
  * @class
  * Different types of PopupState.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.PopupState

--- a/packages/base/src/types/ValueState.js
+++ b/packages/base/src/types/ValueState.js
@@ -46,7 +46,7 @@ const ValueStates = {
  * @class
  * Different types of ValueState.
  *
- * @extends DataType
+ * @extends sap.ui.webcomponents.base.types.DataType
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.base.types.ValueState

--- a/packages/create-package/template/src/MyFirstComponent.js
+++ b/packages/create-package/template/src/MyFirstComponent.js
@@ -32,7 +32,7 @@ const metadata = {
  *
  * @constructor
  * @alias demo.components.INIT_PACKAGE_VAR_CLASS_NAME
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname INIT_PACKAGE_VAR_TAG
  * @public
  */

--- a/packages/fiori/src/Bar.js
+++ b/packages/fiori/src/Bar.js
@@ -28,7 +28,7 @@ const metadata = {
 		 * <li><code>FloatingFooter</code></li>
 		 * </ul>
 		 *
-		 * @type {BarDesign}
+		 * @type {sap.ui.webcomponents.fiori.types.BarDesign}
 		 * @defaultvalue "Header"
 		 * @public
 		 */
@@ -117,7 +117,7 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.Bar
  * @implements sap.ui.webcomponents.fiori.IBar
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-bar
  * @public
  * @since 1.0.0-rc.11

--- a/packages/fiori/src/BarcodeScannerDialog.js
+++ b/packages/fiori/src/BarcodeScannerDialog.js
@@ -106,7 +106,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.BarcodeScannerDialog
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-barcode-scanner-dialog
  * @public
  * @since 1.0.0-rc.15

--- a/packages/fiori/src/DynamicSideContent.js
+++ b/packages/fiori/src/DynamicSideContent.js
@@ -65,7 +65,7 @@ const metadata = {
 		 * <li><code>End</code></li>
 		 * </ul>
 		 *
-		 * @type {SideContentPosition}
+		 * @type {sap.ui.webcomponents.fiori.types.SideContentPosition}
 		 * @defaultvalue "End"
 		 * @public
 		 *
@@ -89,7 +89,7 @@ const metadata = {
 		 * <li><code>NeverShow</code></li>
 		 * </ul>
 		 *
-		 * @type {SideContentVisibility}
+		 * @type {sap.ui.webcomponents.fiori.types.SideContentVisibility}
 		 * @defaultvalue "ShowAboveS"
 		 * @public
 		 *
@@ -112,7 +112,7 @@ const metadata = {
 		 * <li><code>OnMinimumWidth</code></li>
 		 * </ul>
 		 *
-		 * @type {SideContentFallDown}
+		 * @type {sap.ui.webcomponents.fiori.types.SideContentFallDown}
 		 * @defaultvalue "OnMinimumWidth"
 		 * @public
 		 *
@@ -300,7 +300,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.DynamicSideContent
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-dynamic-side-content
  * @public
  * @since 1.1.0

--- a/packages/fiori/src/FilterItem.js
+++ b/packages/fiori/src/FilterItem.js
@@ -61,7 +61,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.FilterItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @since 1.0.0-rc.16
  * @tagname ui5-filter-item
  * @implements sap.ui.webcomponents.fiori.IFilterItem

--- a/packages/fiori/src/FilterItemOption.js
+++ b/packages/fiori/src/FilterItemOption.js
@@ -52,7 +52,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.FilterItemOption
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @since 1.0.0-rc.16
  * @tagname ui5-filter-item-option
  * @implements sap.ui.webcomponents.fiori.IFilterItemOption

--- a/packages/fiori/src/FlexibleColumnLayout.js
+++ b/packages/fiori/src/FlexibleColumnLayout.js
@@ -61,7 +61,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>For example:</b> layout=<code>TwoColumnsStartExpanded</code> means the layout will display up to two columns
 		 * in 67%/33% proportion.
-		 * @type {FCLLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.FCLLayout}
 		 * @defaultvalue "OneColumn"
 		 * @public
 		 */
@@ -126,7 +126,7 @@ const metadata = {
 		/**
 		* Defines the component width in px.
 		*
-		* @type {Float}
+		* @type {sap.ui.webcomponents.base.types.Float}
 		* @defaultvalue 0
 		* @private
 		*/
@@ -140,7 +140,7 @@ const metadata = {
 		* based on both the <code>layout</code> property and the screen size.
 		* Example: [67%, 33%, 0], [25%, 50%, 25%], etc.
 		*
-		* @type {Object}
+		* @type {object}
 		* @defaultvalue undefined
 		* @private
 		*/
@@ -152,7 +152,7 @@ const metadata = {
 		/**
 		* Defines the visible columns count - 1, 2 or 3.
 		*
-		* @type {Integer}
+		* @type {sap.ui.webcomponents.base.types.Integer}
 		* @defaultvalue 1
 		* @private
 		*/
@@ -164,7 +164,7 @@ const metadata = {
 		/**
 		 * Allows the user to replace the whole layouts configuration
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 * @sap-restricted
 		 */
@@ -209,8 +209,8 @@ const metadata = {
 		 * Fired when the layout changes via user interaction by clicking the arrows
 		 * or by changing the component size due to resizing.
 		 *
-		 * @param {FCLLayout} layout The current layout
-		 * @param {Array} columnLayout The effective column layout, f.e [67%, 33%, 0]
+		 * @param {sap.ui.webcomponents.fiori.types.FCLLayout} layout The current layout
+		 * @param {array} columnLayout The effective column layout, f.e [67%, 33%, 0]
 		 * @param {boolean} startColumnVisible Indicates if the start column is currently visible
 		 * @param {boolean} midColumnVisible Indicates if the middle column is currently visible
 		 * @param {boolean} endColumnVisible Indicates if the end column is currently visible
@@ -276,7 +276,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.FlexibleColumnLayout
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-flexible-column-layout
  * @public
  * @since 1.0.0-rc.8
@@ -493,7 +493,7 @@ class FlexibleColumnLayout extends UI5Element {
 	 * <b>For example:</b> ["67%", "33%", 0], ["100%", 0, 0], ["25%", "50%", "25%"], etc,
 	 * where the numbers represents the width of the start, middle and end columns.
 	 * @readonly
-	 * @type { Array }
+	 * @type {array}
 	 * @defaultvalue ["100%", 0, 0]
 	 * @public
 	 */
@@ -505,7 +505,7 @@ class FlexibleColumnLayout extends UI5Element {
 	 * Returns if the <code>start</code> column is visible.
 	 * @readonly
 	 * @defaultvalue true
-	 * @type { boolean }
+	 * @type {boolean}
 	 * @public
 	 */
 	get startColumnVisible() {
@@ -519,7 +519,7 @@ class FlexibleColumnLayout extends UI5Element {
 	/**
 	 * Returns if the <code>middle</code> column is visible.
 	 * @readonly
-	 * @type { boolean }
+	 * @type {boolean}
 	 * @defaultvalue false
 	 * @public
 	 */
@@ -534,7 +534,7 @@ class FlexibleColumnLayout extends UI5Element {
 	/**
 	 * Returns if the <code>end</code> column is visible.
 	 * @readonly
-	 * @type { boolean }
+	 * @type {boolean}
 	 * @defaultvalue false
 	 * @public
 	 */
@@ -549,7 +549,7 @@ class FlexibleColumnLayout extends UI5Element {
 	/**
 	 * Returns the number of currently visible columns.
 	 * @readonly
-	 * @type { Integer }
+	 * @type {sap.ui.webcomponents.base.types.Integer}
 	 * @defaultvalue 1
 	 * @public
 	 */

--- a/packages/fiori/src/IllustratedMessage.js
+++ b/packages/fiori/src/IllustratedMessage.js
@@ -28,7 +28,7 @@ const metadata = {
 		/**
 		 * Receives id(or many ids) of the elements that label the component.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultvalue ""
 		 * @public
 		 * @since 1.7.0
@@ -180,7 +180,7 @@ const metadata = {
 		 * You can import them removing the <code>Tnt</code> prefix like this:
 		 * <br>
 		 * <code>import "@ui5/webcomponents-fiori/dist/illustrations/tnt/SessionExpired.js";</code>
-		 * @type {IllustrationMessageType}
+		 * @type {sap.ui.webcomponents.fiori.types.IllustrationMessageType}
 		 * @defaultvalue "BeforeSearch"
 		 * @public
 		 */
@@ -203,7 +203,7 @@ const metadata = {
 		 * As <code>IllustratedMessage</code> adapts itself around the <code>Illustration</code>, the other
 		 * elements of the component are displayed differently on the different breakpoints/illustration sizes.
 		 *
-		 * @type {IllustrationMessageSize}
+		 * @type {sap.ui.webcomponents.fiori.types.IllustrationMessageSize}
 		 * @defaultvalue "Auto"
 		 * @public
 		 * @since 1.5.0
@@ -296,7 +296,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.IllustratedMessage
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-illustrated-message
  * @public
  * @since 1.0.0-rc.15

--- a/packages/fiori/src/MediaGallery.js
+++ b/packages/fiori/src/MediaGallery.js
@@ -133,7 +133,7 @@ const metadata = {
 		 * <li><code>Bottom</code></li>
 		 * </ul>
 		 *
-		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryMenuVerticalAlign.prototype}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryMenuVerticalAlign}
 		 * @defaultvalue "Bottom"
 		 * @public
 		 */

--- a/packages/fiori/src/MediaGallery.js
+++ b/packages/fiori/src/MediaGallery.js
@@ -95,7 +95,7 @@ const metadata = {
 		 * <li><code>Horizontal</code></li>
 		 * </ul>
 		 *
-		 * @type {MediaGalleryLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryLayout}
 		 * @defaultvalue "Auto"
 		 * @public
 		 */
@@ -114,7 +114,7 @@ const metadata = {
 		 * <li><code>Right</code></li>
 		 * </ul>
 		 *
-		 * @type {MediaGalleryMenuHorizontalAlign}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryMenuHorizontalAlign}
 		 * @defaultvalue "Left"
 		 * @public
 		 */
@@ -133,7 +133,7 @@ const metadata = {
 		 * <li><code>Bottom</code></li>
 		 * </ul>
 		 *
-		 * @type {MediaGalleryMenuVerticalAlign}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryMenuVerticalAlign.prototype}
 		 * @defaultvalue "Bottom"
 		 * @public
 		 */
@@ -153,7 +153,7 @@ const metadata = {
 		 * <li><code>Horizontal</code></li>
 		 * </ul>
 		 *
-		 * @type {MediaGalleryLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryLayout}
 		 * @defaultvalue "Vertical"
 		 * @private
 		 */
@@ -254,7 +254,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.MediaGallery
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-media-gallery
  * @appenddocs MediaGalleryItem
  * @public

--- a/packages/fiori/src/MediaGalleryItem.js
+++ b/packages/fiori/src/MediaGalleryItem.js
@@ -49,7 +49,7 @@ const metadata = {
 		 * <li><code>Wide</code></li>
 		 * </ul>
 		 *
-		 * @type {MediaGalleryItemLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.MediaGalleryItemLayout}
 		 * @defaultvalue "Square"
 		 * @public
 		 */

--- a/packages/fiori/src/NotificationAction.js
+++ b/packages/fiori/src/NotificationAction.js
@@ -44,7 +44,7 @@ const metadata = {
 		 * <li><code>Transparent</code></li>
 		 * </ul>
 		 *
-		 * @type {ButtonDesign}
+		 * @type {sap.ui.webcomponents.main.types.ButtonDesign}
 		 * @defaultvalue "Transparent"
 		 * @public
 		 */
@@ -83,7 +83,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.NotificationAction
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-notification-action
  * @implements sap.ui.webcomponents.fiori.INotificationAction
  * @public

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -125,7 +125,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.NotificationListGroupItem
- * @extends NotificationListItemBase
+ * @extends sap.ui.webcomponents.fiori.NotificationListItemBase
  * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
  * @appenddocs NotificationAction

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -50,7 +50,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> by default the <code>titleText</code> and <code>decription</code>,
 		 * and a <code>ShowMore/Less</code> button would be displayed.
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -168,7 +168,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.NotificationListItem
- * @extends NotificationListItemBase
+ * @extends sap.ui.webcomponents.fiori.NotificationListItemBase
  * @tagname ui5-li-notification
  * @appenddocs NotificationAction
  * @since 1.0.0-rc.8

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -52,7 +52,7 @@ const metadata = {
 		 * <li><code>Medium</code></li>
 		 * <li><code>High</code></li>
 		 * </ul>
-		 * @type {Priority}
+		 * @type {sap.ui.webcomponents.main.types.Priority}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -98,7 +98,7 @@ const metadata = {
 		/**
 		 * Defines the delay in milliseconds, after which the busy indicator will show up for this component.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue 1000
 		 * @public
 		 */
@@ -142,7 +142,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.NotificationListItemBase
- * @extends ListItemBase
+ * @extends sap.ui.webcomponents.main.ListItemBase
  * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
  * @appenddocs NotificationAction

--- a/packages/fiori/src/Page.js
+++ b/packages/fiori/src/Page.js
@@ -30,12 +30,12 @@ const metadata = {
 		 * <li><code>Transparent</code></li>
 		 * <li><code>List</code></li>
 		 * </ul>
-		 * @type {PageBackgroundDesign}
+		 * @type {sap.ui.webcomponents.fiori.types.PageBackgroundDesign}
 		 * @defaultvalue "Solid"
 		 * @public
 		 */
 		backgroundDesign: {
-			type: String,
+			type: PageBackgroundDesign,
 			defaultValue: PageBackgroundDesign.Solid,
 		},
 
@@ -154,7 +154,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.Page
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-page
  * @since 1.0.0-rc.12
  * @public

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -812,7 +812,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>logo</code> DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16
@@ -823,7 +823,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>copilot</code> DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16
@@ -834,7 +834,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>notifications</code> icon DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16
@@ -845,7 +845,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>overflow</code> icon DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16
@@ -856,7 +856,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>profile</code> icon DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16
@@ -867,7 +867,7 @@ class ShellBar extends UI5Element {
 
 	/**
 	 * Returns the <code>product-switch</code> icon DOM ref.
-	 * @type { HTMLElement }
+	 * @type {HTMLElement}
 	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.16

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -141,7 +141,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.SideNavigation
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-side-navigation
  * @since 1.0.0-rc.8
  * @appenddocs SideNavigationItem SideNavigationSubItem

--- a/packages/fiori/src/SideNavigationItem.js
+++ b/packages/fiori/src/SideNavigationItem.js
@@ -115,7 +115,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.SideNavigationItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-side-navigation-item
  * @public
  * @since 1.0.0-rc.8

--- a/packages/fiori/src/SideNavigationSubItem.js
+++ b/packages/fiori/src/SideNavigationSubItem.js
@@ -73,7 +73,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.SideNavigationSubItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-side-navigation-sub-item
  * @public
  * @since 1.0.0-rc.8

--- a/packages/fiori/src/SortItem.js
+++ b/packages/fiori/src/SortItem.js
@@ -51,7 +51,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.SortItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @since 1.0.0-rc.16
  * @tagname ui5-sort-item
  * @implements sap.ui.webcomponents.fiori.ISortItem

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -34,7 +34,7 @@ const metadata = {
 	 	* <li><code>Horizontal</code></li>
 		 * </ul>
 		 *
-		 * @type {TimelineLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.TimelineLayout}
 		 * @defaultvalue "Vertical"
 		 * @since 1.0.0-rc.15
 		 * @public
@@ -87,7 +87,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.Timeline
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-timeline
  * @appenddocs TimelineItem
  * @public

--- a/packages/fiori/src/TimelineItem.js
+++ b/packages/fiori/src/TimelineItem.js
@@ -95,7 +95,7 @@ const metadata = {
 		/**
 		 * Defines the items orientation.
 		 *
-		 * @type {TimelineLayout}
+		 * @type {sap.ui.webcomponents.fiori.types.TimelineLayout}
 		 * @defaultvalue "Vertical"
 		 * @private
 		 */
@@ -139,7 +139,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.TimelineItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-timeline-item
  * @implements sap.ui.webcomponents.fiori.ITimelineItem
  * @public

--- a/packages/fiori/src/UploadCollection.js
+++ b/packages/fiori/src/UploadCollection.js
@@ -47,7 +47,7 @@ const metadata = {
 		 * <li><code>Delete</code></li>
 		 * </ul>
 		 *
-		 * @type {ListMode}
+		 * @type {sap.ui.webcomponents.main.types.ListMode}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -96,12 +96,12 @@ const metadata = {
 		/**
 		 * Indicates what overlay to show when files are being dragged.
 		 *
-		 * @type {UploadCollectionDnDOverlayMode}
+		 * @type {sap.ui.webcomponents.fiori.types.UploadCollectionDnDOverlayMode}
 		 * @defaultvalue "None"
 		 * @private
 		 */
 		_dndOverlayMode: {
-			type: String,
+			type: UploadCollectionDnDOverlayMode,
 			defaultValue: UploadCollectionDnDOverlayMode.None,
 		},
 
@@ -207,7 +207,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.UploadCollection
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-upload-collection
  * @appenddocs UploadCollectionItem
  * @public

--- a/packages/fiori/src/UploadCollectionItem.js
+++ b/packages/fiori/src/UploadCollectionItem.js
@@ -121,7 +121,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Expected values are in the interval [0, 100].
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -135,7 +135,7 @@ const metadata = {
 		 * Also if set to <code>Error</code>, a refresh button is shown. When this icon is pressed <code>retry</code> event is fired.
 		 * If set to <code>Uploading</code>, a terminate button is shown. When this icon is pressed <code>terminate</code> event is fired.
 		 *
-		 * @type {UploadState}
+		 * @type {sap.ui.webcomponents.fiori.types.UploadState}
 		 * @defaultvalue "Ready"
 		 * @public
 		 */
@@ -243,7 +243,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.UploadCollectionItem
- * @extends ListItem
+ * @extends sap.ui.webcomponents.main.ListItem
  * @tagname ui5-upload-collection-item
  * @public
  * @implements sap.ui.webcomponents.fiori.IUploadCollectionItem

--- a/packages/fiori/src/ViewSettingsDialog.js
+++ b/packages/fiori/src/ViewSettingsDialog.js
@@ -56,7 +56,7 @@ const metadata = {
 		/**
 		 * Keeps recently focused list in order to focus it on next dialog open.
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		 _recentlyFocused: {
@@ -66,7 +66,7 @@ const metadata = {
 		/**
 		 * Stores settings of the dialog before the initial open.
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		 _initialSettings: {
@@ -76,7 +76,7 @@ const metadata = {
 		/**
 		 * Stores settings of the dialog after confirmation.
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		 _confirmedSettings: {
@@ -86,7 +86,7 @@ const metadata = {
 		/**
 		 * Stores current settings of the dialog.
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		 _currentSettings: {
@@ -220,7 +220,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.ViewSettingsDialog
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-view-settings-dialog
  * @appenddocs SortItem FilterItem FilterItemOption
  * @since 1.0.0-rc.16

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -79,7 +79,7 @@ const metadata = {
 		 * <b>Note:</b> Supported values are between 0.5 and 1
 		 * and values out of the range will be normalized to 0.5 and 1 respectively.
 		 * @private
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0.7
 		 * @since 1.0.0-rc.13
 		 */
@@ -224,7 +224,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.Wizard
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-wizard
  * @since 1.0.0-rc.10
  * @appenddocs WizardStep

--- a/packages/fiori/src/WizardStep.js
+++ b/packages/fiori/src/WizardStep.js
@@ -138,7 +138,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.WizardStep
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-wizard-step
  * @since 1.0.0-rc.10
  * @implements sap.ui.webcomponents.fiori.IWizardStep

--- a/packages/fiori/src/WizardTab.js
+++ b/packages/fiori/src/WizardTab.js
@@ -147,7 +147,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.fiori.WizardTab
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-wizard-tab
  * @private
  */

--- a/packages/main/src/Avatar.js
+++ b/packages/main/src/Avatar.js
@@ -84,7 +84,7 @@ const metadata = {
 		 * <li><code>Circle</code></li>
 		 * <li><code>Square</code></li>
 		 * </ul>
-		 * @type {AvatarShape}
+		 * @type {sap.ui.webcomponents.main.types.AvatarShape}
 		 * @defaultvalue "Circle"
 		 * @public
 		 */
@@ -104,7 +104,7 @@ const metadata = {
 		 * <li><code>L</code></li>
 		 * <li><code>XL</code></li>
 		 * </ul>
-		 * @type {AvatarSize}
+		 * @type {sap.ui.webcomponents.main.types.AvatarSize}
 		 * @defaultvalue "S"
 		 * @public
 		 */
@@ -138,7 +138,7 @@ const metadata = {
 		 * <li><code>Accent10</code></li>
 		 * <li><code>Placeholder</code></li>
 		 * </ul>
-		 * @type {AvatarColorScheme}
+		 * @type {sap.ui.webcomponents.main.types.AvatarColorScheme}
 		 * @defaultvalue "Accent6"
 		 * @public
 		 */
@@ -276,7 +276,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Avatar
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-avatar
  * @since 1.0.0-rc.6
  * @implements sap.ui.webcomponents.main.IAvatar
@@ -314,7 +314,7 @@ class Avatar extends UI5Element {
 	/**
 	 * Returns the effective avatar size.
 	 * @readonly
-	 * @type { String }
+	 * @type {string}
 	 * @defaultValue "S"
 	 * @private
 	 */
@@ -326,7 +326,7 @@ class Avatar extends UI5Element {
 	/**
 	 * Returns the effective background color.
 	 * @readonly
-	 * @type { String }
+	 * @type {string}
 	 * @defaultValue "Accent6"
 	 * @private
 	 */

--- a/packages/main/src/AvatarGroup.js
+++ b/packages/main/src/AvatarGroup.js
@@ -71,12 +71,12 @@ const metadata = {
 		 * <li><code>Group</code></li>
 		 * <li><code>Individual</code></li>
 		 * </ul>
-		 * @type {AvatarGroupType}
+		 * @type {sap.ui.webcomponents.main.types.AvatarGroupType}
 		 * @defaultValue "Group"
 		 * @public
 		 */
 		type: {
-			type: String,
+			type: AvatarGroupType,
 			defaultValue: AvatarGroupType.Group,
 		},
 
@@ -229,7 +229,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.AvatarGroup
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-avatar-group
  * @since 1.0.0-rc.11
  * @public
@@ -278,7 +278,7 @@ class AvatarGroup extends UI5Element {
 	/**
 	 * Returns an array containing the <code>ui5-avatar</code> instances that are currently not displayed due to lack of space.
 	 * @readonly
-	 * @type { HTMLElement[] }
+	 * @type {HTMLElement[]}
 	 * @defaultValue []
 	 * @public
 	 */
@@ -289,7 +289,7 @@ class AvatarGroup extends UI5Element {
 	/**
 	 * Returns an array containing the <code>AvatarColorScheme</code> values that correspond to the avatars in the component.
 	 * @readonly
-	 * @type { AvatarColorScheme[] }
+	 * @type {sap.ui.webcomponents.main.types.AvatarColorScheme[]}
 	 * @defaultValue []
 	 * @public
 	 */

--- a/packages/main/src/Breadcrumbs.js
+++ b/packages/main/src/Breadcrumbs.js
@@ -69,7 +69,7 @@ const metadata = {
 		 * <b>Note:</b> The <code>Standard</code> breadcrumbs show the current page as the last item in the trail.
 		 * The last item contains only plain text and is not a link.
 		 *
-		 * @type {BreadcrumbsDesign}
+		 * @type {sap.ui.webcomponents.main.types.BreadcrumbsDesign}
 		 * @defaultvalue "Standard"
 		 * @public
 		*/
@@ -92,7 +92,7 @@ const metadata = {
 		 * <li><code>GreaterThan</code></li>
 		 * </ul>
 		 *
-		 * @type {BreadcrumbsSeparatorStyle}
+		 * @type {sap.ui.webcomponents.main.types.BreadcrumbsSeparatorStyle}
 		 * @defaultvalue "Slash"
 		 * @public
 		 */
@@ -104,7 +104,7 @@ const metadata = {
 		/**
 		 * Holds the number of items in the overflow.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @private
 		 */
@@ -172,7 +172,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Breadcrumbs
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-breadcrumbs
  * @appenddocs BreadcrumbsItem
  * @public

--- a/packages/main/src/BusyIndicator.js
+++ b/packages/main/src/BusyIndicator.js
@@ -59,7 +59,7 @@ const metadata = {
 		 * <li><code>Large</code></li>
 		 * </ul>
 		 *
-		 * @type {BusyIndicatorSize}
+		 * @type {sap.ui.webcomponents.main.types.BusyIndicatorSize}
 		 * @defaultvalue "Medium"
 		 * @public
 		 */
@@ -82,7 +82,7 @@ const metadata = {
 		/**
 		 * Defines the delay in milliseconds, after which the busy indicator will be visible on the screen.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue 1000
 		 * @public
 		 */
@@ -139,7 +139,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.BusyIndicator
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-busy-indicator
  * @public
  * @since 0.12.0

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -47,7 +47,7 @@ const metadata = {
 		 * <li><code>Attention</code></li>
 		 * </ul>
 		 *
-		 * @type {ButtonDesign}
+		 * @type {sap.ui.webcomponents.main.types.ButtonDesign}
 		 * @defaultvalue "Default"
 		 * @public
 		 */
@@ -315,7 +315,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Button
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-button
  * @implements sap.ui.webcomponents.main.IButton
  * @public

--- a/packages/main/src/Calendar.js
+++ b/packages/main/src/Calendar.js
@@ -41,7 +41,7 @@ const metadata = {
 		 * <li><code>CalendarSelectionMode.Range</code> - enables selection of a date range.</li>
 		 * <li><code>CalendarSelectionMode.Multiple</code> - enables selection of multiple dates.</li>
 		 * </ul>
-		 * @type {CalendarSelectionMode}
+		 * @type {sap.ui.webcomponents.main.types.CalendarSelectionMode}
 		 * @defaultvalue "Single"
 		 * @public
 		 */
@@ -240,7 +240,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Calendar
- * @extends CalendarPart
+ * @extends sap.ui.webcomponents.main.CalendarPart
  * @tagname ui5-calendar
  * @appenddocs CalendarDate
  * @public

--- a/packages/main/src/CalendarHeader.js
+++ b/packages/main/src/CalendarHeader.js
@@ -22,7 +22,7 @@ const metadata = {
 	properties: {
 		/**
 		 * Already normalized by Calendar
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @public
 		 */
 		timestamp: {
@@ -31,7 +31,7 @@ const metadata = {
 
 		/**
 		 * Already normalized by Calendar
-		 * @type {CalendarType}
+		 * @type {sap.ui.webcomponents.base.types.CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {
@@ -42,7 +42,7 @@ const metadata = {
 		 * Already normalized by Calendar
 		 * @sience 1.0.0-rc.16
 		 * @defaultvalue undefined
-		 * @type {CalendarType}
+		 * @type {sap.ui.webcomponents.base.types.CalendarType}
 		 * @public
 		 */
 		secondaryCalendarType: {
@@ -51,7 +51,7 @@ const metadata = {
 
 		/**
 		 * Stores information for month button for secondary calendar type
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		*/
 		buttonTextForSecondaryCalendarType: {

--- a/packages/main/src/CalendarPart.js
+++ b/packages/main/src/CalendarPart.js
@@ -12,7 +12,7 @@ const metadata = {
 		/**
 		 * The timestamp of the currently focused date. Set this property to move the component's focus to a certain date.
 		 * <b>Node:</b> Timestamp is 10-digit Integer representing the seconds (not milliseconds) since the Unix Epoch.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @protected
 		 */
 		timestamp: {
@@ -31,7 +31,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.CalendarPart
- * @extends DateComponentBase
+ * @extends sap.ui.webcomponents.main.DateComponentBase
  * @public
  */
 class CalendarPart extends DateComponentBase {

--- a/packages/main/src/CardHeader.js
+++ b/packages/main/src/CardHeader.js
@@ -90,7 +90,7 @@ const metadata = {
 		 * Define the <code>aria-level</code> attribute of the component
 		 * <b>Note: </b> If the interactive property is set, <code>aria-level</code> attribute is not rendered at all.
 		 * @private
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue 3
 		 */
 		ariaLevel: {

--- a/packages/main/src/Carousel.js
+++ b/packages/main/src/Carousel.js
@@ -52,7 +52,7 @@ const metadata = {
 
 		/**
 		 * Defines the number of items per page on small size (up to 640px). One item per page shown by default.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 1
 		 * @public
 		 */
@@ -63,7 +63,7 @@ const metadata = {
 
 		/**
 		 * Defines the number of items per page on medium size (from 640px to 1024px). One item per page shown by default.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 1
 		 * @public
 		 */
@@ -74,7 +74,7 @@ const metadata = {
 
 		/**
 		 * Defines the number of items per page on large size (more than 1024px). One item per page shown by default.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 1
 		 * @public
 		 */
@@ -112,7 +112,7 @@ const metadata = {
 
 		/**
 		 * Defines the index of the initially selected item.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @private
 		 */
@@ -133,7 +133,7 @@ const metadata = {
 		 * When set to "Content", the arrows are placed on the sides of the current page.
 		 * <br>
 		 * When set to "Navigation", the arrows are placed on the sides of the page indicator.
-		 * @type {CarouselArrowsPlacement}
+		 * @type {sap.ui.webcomponents.main.types.CarouselArrowsPlacement}
 		 * @defaultvalue "Content"
 		 * @public
 		 */
@@ -265,7 +265,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Carousel
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-carousel
  * @since 1.0.0-rc.6
  * @public

--- a/packages/main/src/CheckBox.js
+++ b/packages/main/src/CheckBox.js
@@ -157,7 +157,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -175,7 +175,7 @@ const metadata = {
 		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
 		 * </ul>
 		 *
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/ColorPalette.js
+++ b/packages/main/src/ColorPalette.js
@@ -69,7 +69,7 @@ const metadata = {
 		/**
 		 * Defines the default color of the color palette
 		 * <b>Note:</b> The default color should be a part of the ColorPalette colors</code>
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @private
 		 * @since 1.0.0-rc.16
 		 */
@@ -79,7 +79,7 @@ const metadata = {
 
 		/**
 		 * Defines the selected color.
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @private
 		 */
 		_selectedColor: {
@@ -88,7 +88,7 @@ const metadata = {
 
 		/**
 		 * Defines if the palette is in Popup or Embeded mode.
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @private
 		 */
 		popupMode: {
@@ -146,7 +146,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ColorPalette
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-color-palette
  * @since 1.0.0-rc.12
  * @appenddocs ColorPaletteItem

--- a/packages/main/src/ColorPaletteItem.js
+++ b/packages/main/src/ColorPaletteItem.js
@@ -23,7 +23,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> The value should be a valid CSS color.
 		 *
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @public
 		 */
 		value: {

--- a/packages/main/src/ColorPalettePopover.js
+++ b/packages/main/src/ColorPalettePopover.js
@@ -58,7 +58,7 @@ const metadata = {
 		/**
 		 * Defines the default color of the component.
 		 * <b>Note:</b> The default color should be a part of the ColorPalette colors</code>
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @public
 		 */
 		defaultColor: {
@@ -120,7 +120,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ColorPalettePopover
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-color-palette-popover
  * @public
  * @since 1.0.0-rc.16

--- a/packages/main/src/ColorPicker.js
+++ b/packages/main/src/ColorPicker.js
@@ -40,7 +40,7 @@ const metadata = {
 		 * Defines the currently selected color of the component.
 		 * <br><br>
 		 * <b>Note</b>: use HEX, RGB, RGBA, HSV formats or a CSS color name when modifying this property.
-		 * @type {CSSColor}
+		 * @type {sap.ui.webcomponents.base.types.CSSColor}
 		 * @public
 		 */
 		color: {
@@ -159,7 +159,7 @@ const metadata = {
  * @author SAP SE
  * @since 1.0.0-rc.12
  * @alias sap.ui.webcomponents.main.ColorPicker
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-color-picker
  * @public
  */

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -141,7 +141,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -375,7 +375,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ComboBox
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-combobox
  * @appenddocs ComboBoxItem ComboBoxGroupItem
  * @public

--- a/packages/main/src/ComboBoxGroupItem.js
+++ b/packages/main/src/ComboBoxGroupItem.js
@@ -39,7 +39,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ComboBoxGroupItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-cb-group-item
  * @public
  * @implements sap.ui.webcomponents.main.IComboBoxItem

--- a/packages/main/src/ComboBoxItem.js
+++ b/packages/main/src/ComboBoxItem.js
@@ -33,7 +33,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ComboBoxItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-cb-item
  * @implements sap.ui.webcomponents.main.IComboBoxItem
  * @public

--- a/packages/main/src/CustomListItem.js
+++ b/packages/main/src/CustomListItem.js
@@ -49,7 +49,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.CustomListItem
- * @extends ListItem
+ * @extends sap.ui.webcomponents.main.ListItem
  * @tagname ui5-li-custom
  * @implements sap.ui.webcomponents.main.IListItem
  * @public

--- a/packages/main/src/DateComponentBase.js
+++ b/packages/main/src/DateComponentBase.js
@@ -19,7 +19,7 @@ const metadata = {
 		/**
 		 * Sets a calendar type used for display.
 		 * If not set, the calendar type of the global configuration is used.
-		 * @type {CalendarType}
+		 * @type {sap.ui.webcomponents.base.types.CalendarType}
 		 * @public
 		 */
 		primaryCalendarType: {
@@ -29,7 +29,7 @@ const metadata = {
 		/**
 		 * Defines the secondary calendar type.
 		 * If not set, the calendar will only show the primary calendar type.
-		 * @type {CalendarType}
+		 * @type {sap.ui.webcomponents.base.types.CalendarType}
 		 * @since 1.0.0-rc.16
 		 * @defaultvalue undefined
 		 * @public

--- a/packages/main/src/DatePicker.js
+++ b/packages/main/src/DatePicker.js
@@ -75,7 +75,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -368,7 +368,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.DatePicker
- * @extends DateComponentBase
+ * @extends sap.ui.webcomponents.main.DateComponentBase
  * @tagname ui5-date-picker
  * @public
  */
@@ -811,7 +811,7 @@ class DatePicker extends DateComponentBase {
 	 * Currently selected date represented as a Local JavaScript Date instance.
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get dateValue() {

--- a/packages/main/src/DateRangePicker.js
+++ b/packages/main/src/DateRangePicker.js
@@ -70,7 +70,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.DateRangePicker
- * @extends DatePicker
+ * @extends sap.ui.webcomponents.main.DatePicker
  * @tagname ui5-daterange-picker
  * @since 1.0.0-rc.8
  * @public
@@ -93,7 +93,7 @@ class DateRangePicker extends DatePicker {
 	 * <b>Note:</b> The getter method is inherited and not supported. If called it will return an empty value.
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get dateValue() {
@@ -104,7 +104,7 @@ class DateRangePicker extends DatePicker {
 	 * <b>Note:</b> The getter method is inherited and not supported. If called it will return an empty value.
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get dateValueUTC() {
@@ -157,7 +157,7 @@ class DateRangePicker extends DatePicker {
 	 * Returns the start date of the currently selected range as JavaScript Date instance.
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get startDateValue() {
@@ -168,7 +168,7 @@ class DateRangePicker extends DatePicker {
 	 * Returns the end date of the currently selected range as JavaScript Date instance.
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get endDateValue() {

--- a/packages/main/src/DateTimePicker.js
+++ b/packages/main/src/DateTimePicker.js
@@ -148,7 +148,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.DateTimePicker
- * @extends DatePicker
+ * @extends sap.ui.webcomponents.main.DatePicker
  * @tagname ui5-datetime-picker
  * @since 1.0.0-rc.7
  * @public

--- a/packages/main/src/DayPicker.js
+++ b/packages/main/src/DayPicker.js
@@ -47,7 +47,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.DayPicker.prototype */ {
 		/**
 		 * An array of UTC timestamps representing the selected date or dates depending on the capabilities of the picker component.
-		 * @type {Array}
+		 * @type {array}
 		 * @public
 		 */
 		selectedDates: {
@@ -64,7 +64,7 @@ const metadata = {
 		 * <li><code>CalendarSelectionMode.Range</code> - enables selection of a date range.</li>
 		 * <li><code>CalendarSelectionMode.Multiple</code> - enables selection of multiple dates.</li>
 		 * </ul>
-		 * @type {CalendarSelectionMode}
+		 * @type {sap.ui.webcomponents.main.types.CalendarSelectionMode}
 		 * @defaultvalue "Single"
 		 * @public
 		 */
@@ -90,7 +90,7 @@ const metadata = {
 		},
 
 		/**
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		_weeks: {
@@ -149,7 +149,7 @@ const DAYS_IN_WEEK = 7;
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.DayPicker
- * @extends CalendarPart
+ * @extends sap.ui.webcomponents.main.CalendarPart
  * @tagname ui5-daypicker
  * @public
  */

--- a/packages/main/src/Dialog.js
+++ b/packages/main/src/Dialog.js
@@ -146,7 +146,7 @@ const metadata = {
 		 * Defines the state of the <code>Dialog</code>.
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Error"</code>.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -206,7 +206,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Dialog
- * @extends Popup
+ * @extends sap.ui.webcomponents.main.Popup
  * @tagname ui5-dialog
  * @public
  */

--- a/packages/main/src/DurationPicker.js
+++ b/packages/main/src/DurationPicker.js
@@ -26,7 +26,7 @@ const metadata = {
 
 		/**
 		 * Defines the selection step for the minutes
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @public
 		 * @defaultValue 1
 		 * @since 1.0.0-rc.8
@@ -38,7 +38,7 @@ const metadata = {
 
 		/**
 		 * Defines the selection step for the seconds
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @public
 		 * @defaultValue 1
 		 * @since 1.0.0-rc.8
@@ -162,7 +162,7 @@ const pad = number => {
  * @since 1.0.0-rc.7
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.DurationPicker
- * @extends TimePickerBase
+ * @extends sap.ui.webcomponents.main.TimePickerBase
  * @tagname ui5-duration-picker
  * @private
  */

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -130,7 +130,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -229,7 +229,7 @@ const metadata = {
  * @since 1.0.0-rc.6
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.FileUploader
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-file-uploader
  * @public
  */
@@ -310,7 +310,7 @@ class FileUploader extends UI5Element {
 	/**
 	 * FileList of all selected files.
 	 * @readonly
-	 * @type { FileList }
+	 * @type {FileList}
 	 * @public
 	 */
 	get files() {

--- a/packages/main/src/GroupHeaderListItem.js
+++ b/packages/main/src/GroupHeaderListItem.js
@@ -54,7 +54,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.GroupHeaderListItem
- * @extends ListItemBase
+ * @extends sap.ui.webcomponents.main.ListItemBase
  * @tagname ui5-li-groupheader
  * @implements sap.ui.webcomponents.main.IListItem
  * @public

--- a/packages/main/src/Input.js
+++ b/packages/main/src/Input.js
@@ -243,7 +243,7 @@ const metadata = {
 		 * that use different soft keyboard layouts depending on the given input type.</li>
 		 * </ul>
 		 *
-		 * @type {InputType}
+		 * @type {sap.ui.webcomponents.main.types.InputType}
 		 * @defaultvalue "Text"
 		 * @public
 		 */
@@ -337,7 +337,7 @@ const metadata = {
 		 * Sets the maximum number of characters available in the input field.
 		 * <br><br>
 		 * <b>Note:</b> This property is not compatible with the ui5-input type InputType.Number. If the ui5-input type is set to Number, the maxlength value is ignored.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @since 1.0.0-rc.5
 		 * @public
 		 */
@@ -1263,7 +1263,7 @@ class Input extends UI5Element {
 
 	/**
 	 * The suggestion item on preview.
-	 * @type { sap.ui.webcomponents.main.IInputSuggestionItem }
+	 * @type {sap.ui.webcomponents.main.IInputSuggestionItem}
 	 * @readonly
 	 * @public
 	 */

--- a/packages/main/src/Label.js
+++ b/packages/main/src/Label.js
@@ -39,7 +39,7 @@ const metadata = {
 		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
 		 * </ul>
 		 *
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -76,7 +76,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> Avaialble options are <code>Default</code>, <code>Subtle</code>, and <code>Emphasized</code>.
 		 *
-		 * @type {LinkDesign}
+		 * @type {sap.ui.webcomponents.main.types.LinkDesign}
 		 * @defaultvalue "Default"
 		 * @public
 		 */
@@ -93,7 +93,7 @@ const metadata = {
 		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
 		 * </ul>
 		 *
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/List.js
+++ b/packages/main/src/List.js
@@ -120,7 +120,7 @@ const metadata = {
 		 * <b>Note:</b> Available options are <code>None</code>, <code>SingleSelect</code>, <code>SingleSelectBegin</code>,
 		 * <code>SingleSelectEnd</code>, <code>MultiSelect</code>, and <code>Delete</code>.
 		 *
-		 * @type {ListMode}
+		 * @type {sap.ui.webcomponents.main.types.ListMode}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -151,7 +151,7 @@ const metadata = {
 		 * item doesn't have a bottom separator.</li>
 		 * </ul>
 		 *
-		 * @type {ListSeparators}
+		 * @type {sap.ui.webcomponents.main.types.ListSeparators}
 		 * @defaultvalue "All"
 		 * @public
 		 */
@@ -177,7 +177,7 @@ const metadata = {
 		 *
 		 * <b>Restrictions:</b> <code>growing="Scroll"</code> is not supported for Internet Explorer,
 		 * on IE the component will fallback to <code>growing="Button"</code>.
-		 * @type {ListGrowingMode}
+		 * @type {sap.ui.webcomponents.main.types.ListGrowingMode}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.13
 		 * @public
@@ -202,7 +202,7 @@ const metadata = {
 		/**
 		 * Defines the delay in milliseconds, after which the busy indicator will show up for this component.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue 1000
 		 * @public
 		 */
@@ -424,7 +424,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.List
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-list
  * @appenddocs StandardListItem CustomListItem GroupHeaderListItem
  * @public

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -33,7 +33,7 @@ const metadata = {
 		 * <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press and hover,
 		 * while with type <code>Inactive</code> and <code>Detail</code> - will not.
 		 *
-		 * @type {ListItemType}
+		 * @type {sap.ui.webcomponents.main.types.ListItemType}
 		 * @defaultvalue "Active"
 		 * @public
 		*/
@@ -133,7 +133,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ListItem
- * @extends ListItemBase
+ * @extends sap.ui.webcomponents.main.ListItemBase
  * @public
  */
 class ListItem extends ListItemBase {

--- a/packages/main/src/ListItemBase.js
+++ b/packages/main/src/ListItemBase.js
@@ -72,7 +72,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ListItemBase
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @public
  */
 class ListItemBase extends UI5Element {

--- a/packages/main/src/Menu.js
+++ b/packages/main/src/Menu.js
@@ -185,7 +185,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Menu
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-menu
  * @appenddocs MenuItem
  * @since 1.3.0

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -9,7 +9,7 @@ const metadata = {
 		/**
 		 * Defines the text of the tree item.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultValue ""
 		 * @public
 		 */
@@ -156,7 +156,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MenuItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-menu-item
  * @implements sap.ui.webcomponents.main.IMenuItem
  * @since 1.3.0

--- a/packages/main/src/MessageStrip.js
+++ b/packages/main/src/MessageStrip.js
@@ -38,7 +38,7 @@ const metadata = {
 		 * <b>Note:</b> Available options are <code>"Information"</code>, <code>"Positive"</code>, <code>"Negative"</code>,
 		 * and <code>"Warning"</code>.
 		 *
-		 * @type {MessageStripDesign}
+		 * @type {sap.ui.webcomponents.main.types.MessageStripDesign}
 		 * @defaultvalue "Information"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -147,7 +147,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MessageStrip
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-message-strip
  * @public
  * @since 0.9.0

--- a/packages/main/src/MonthPicker.js
+++ b/packages/main/src/MonthPicker.js
@@ -30,7 +30,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.MonthPicker.prototype */ {
 		/**
 		 * An array of UTC timestamps representing the selected date or dates depending on the capabilities of the picker component.
-		 * @type {Array}
+		 * @type {array}
 		 * @public
 		 */
 		selectedDates: {
@@ -79,7 +79,7 @@ const ROW_SIZE = 3; // Months per row (4 rows of 3 months each)
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MonthPicker
- * @extends CalendarPart
+ * @extends sap.ui.webcomponents.main.CalendarPart
  * @tagname ui5-monthpicker
  * @public
  */

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -212,7 +212,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -429,7 +429,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MultiComboBox
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-multi-combobox
  * @public
  * @appenddocs MultiComboBoxItem MultiComboBoxGroupItem

--- a/packages/main/src/MultiComboBoxGroupItem.js
+++ b/packages/main/src/MultiComboBoxGroupItem.js
@@ -32,7 +32,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MultiComboBoxGroupItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-mcb-group-item
  * @public
  * @implements sap.ui.webcomponents.main.IMultiComboBoxItem

--- a/packages/main/src/MultiComboBoxItem.js
+++ b/packages/main/src/MultiComboBoxItem.js
@@ -23,7 +23,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MultiComboBoxItem
- * @extends ComboBoxItem
+ * @extends sap.ui.webcomponents.main.ComboBoxItem
  * @tagname ui5-mcb-item
  * @implements sap.ui.webcomponents.main.IMultiComboBoxItem
  * @public

--- a/packages/main/src/MultiInput.js
+++ b/packages/main/src/MultiInput.js
@@ -99,7 +99,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MultiInput
- * @extends Input
+ * @extends sap.ui.webcomponents.main.Input
  * @tagname ui5-multi-input
  * @appenddocs Token
  * @since 1.0.0-rc.9

--- a/packages/main/src/Panel.js
+++ b/packages/main/src/Panel.js
@@ -109,7 +109,7 @@ const metadata = {
 		 * Depending on the usage, you can change the role from the default <code>Form</code>
 		 * to <code>Region</code> or <code>Complementary</code>.
 		 *
-		 * @type {PanelAccessibleRole}
+		 * @type {sap.ui.webcomponents.main.types.PanelAccessibleRole}
 		 * @defaultvalue "Form"
 		 * @public
 		 */
@@ -123,7 +123,7 @@ const metadata = {
 		 * set by the <code>headerText</code>.
 		 * <br><br>
 		 * Available options are: <code>"H6"</code> to <code>"H1"</code>.
-		 * @type {TitleLevel}
+		 * @type {sap.ui.webcomponents.main.types.TitleLevel}
 		 * @defaultvalue "H2"
 		 * @public
 		*/

--- a/packages/main/src/Popover.js
+++ b/packages/main/src/Popover.js
@@ -48,7 +48,7 @@ const metadata = {
 		 * <li><code>Bottom</code></li>
 		 * </ul>
 		 *
-		 * @type {PopoverPlacementType}
+		 * @type {sap.ui.webcomponents.main.types.PopoverPlacementType}
 		 * @defaultvalue "Right"
 		 * @public
 		 */
@@ -68,7 +68,7 @@ const metadata = {
 		 * <li><code>Stretch</code></li>
 		 * </ul>
 		 *
-		 * @type {PopoverHorizontalAlign}
+		 * @type {sap.ui.webcomponents.main.types.PopoverHorizontalAlign}
 		 * @defaultvalue "Center"
 		 * @public
 		 */
@@ -88,7 +88,7 @@ const metadata = {
 		 * <li><code>Stretch</code></li>
 		 * </ul>
 		 *
-		 * @type {PopoverVerticalAlign}
+		 * @type {sap.ui.webcomponents.main.types.PopoverVerticalAlign}
 		 * @defaultvalue "Center"
 		 * @public
 		 */
@@ -148,7 +148,7 @@ const metadata = {
 		/**
 		 * Defines the ID or DOM Reference of the element that the popover is shown at
 		 * @public
-		 * @type {DOMReference}
+		 * @type {sap.ui.webcomponents.base.types.DOMReference}
 		 * @defaultvalue ""
 		 * @since 1.2.0
 		 */
@@ -278,7 +278,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Popover
- * @extends Popup
+ * @extends sap.ui.webcomponents.main.Popup
  * @tagname ui5-popover
  * @since 1.0.0-rc.6
  * @public

--- a/packages/main/src/ProgressIndicator.js
+++ b/packages/main/src/ProgressIndicator.js
@@ -48,7 +48,7 @@ const metadata = {
 		 *
 		 * <b>Note:</b>
 		 * If a value greater than 100 is provided, the percentValue is set to 100. In other cases of invalid value, percentValue is set to its default of 0.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -83,7 +83,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -117,7 +117,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ProgressIndicator
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-progress-indicator
  * @public
  * @since 1.0.0-rc.8

--- a/packages/main/src/RadioButton.js
+++ b/packages/main/src/RadioButton.js
@@ -121,7 +121,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -184,7 +184,7 @@ const metadata = {
 		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
 		 * </ul>
 		 *
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 */

--- a/packages/main/src/RangeSlider.js
+++ b/packages/main/src/RangeSlider.js
@@ -31,7 +31,7 @@ const metadata = {
 		 * Defines start point of a selection - position of a first handle on the slider.
 		 * <br><br>
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -43,7 +43,7 @@ const metadata = {
 		 * Defines end point of a selection - position of a second handle on the slider.
 		 * <br><br>
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 100
 		 * @public
 		 */
@@ -111,7 +111,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.RangeSlider
- * @extends SliderBase
+ * @extends sap.ui.webcomponents.main.SliderBase
  * @tagname ui5-range-slider
  * @since 1.0.0-rc.11
  * @public

--- a/packages/main/src/RatingIndicator.js
+++ b/packages/main/src/RatingIndicator.js
@@ -42,7 +42,7 @@ const metadata = {
 		 * <li>1.3 - 1.7 -> 1.5</li>
 		 * <li>1.8 - 1.9 -> 2</li>
 		 * <ul>
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -53,7 +53,7 @@ const metadata = {
 
 		/**
 		 * The number of displayed rating symbols.
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 5
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -169,7 +169,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.RatingIndicator
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-rating-indicator
  * @public
  * @since 1.0.0-rc.8

--- a/packages/main/src/ResponsivePopover.js
+++ b/packages/main/src/ResponsivePopover.js
@@ -74,7 +74,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ResponsivePopover
- * @extends Popover
+ * @extends sap.ui.webcomponents.main.Popover
  * @tagname ui5-responsive-popover
  * @since 1.0.0-rc.6
  * @public

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -273,7 +273,7 @@ class SegmentedButton extends UI5Element {
 	 * Currently selected item.
 	 *
 	 * @readonly
-	 * @type { sap.ui.webcomponents.main.ISegmentedButtonItem }
+	 * @type {sap.ui.webcomponents.main.ISegmentedButtonItem}
 	 * @public
 	 */
 	get selectedItem() {

--- a/packages/main/src/SegmentedButtonItem.js
+++ b/packages/main/src/SegmentedButtonItem.js
@@ -14,7 +14,7 @@ const metadata = {
 		/**
 		 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
 		 *
-		 * @type {ButtonDesign}
+		 * @type {sap.ui.webcomponents.main.types.ButtonDesign}
 		 * @defaultvalue "Default"
 		 * @public
 		 */
@@ -86,7 +86,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SegmentedButtonItem
- * @extends ToggleButton
+ * @extends sap.ui.webcomponents.main.ToggleButton
  * @tagname ui5-segmented-button-item
  * @implements sap.ui.webcomponents.main.ISegmentedButtonItem
  * @public

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -161,7 +161,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -360,7 +360,7 @@ class Select extends UI5Element {
 	/**
 	 * Currently selected option.
 	 * @readonly
-	 * @type { sap.ui.webcomponents.main.ISelectOption }
+	 * @type {sap.ui.webcomponents.main.ISelectOption}
 	 * @public
 	 */
 	get selectedOption() {

--- a/packages/main/src/Slider.js
+++ b/packages/main/src/Slider.js
@@ -23,7 +23,7 @@ const metadata = {
 		/**
 		 * Current value of the slider
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -99,7 +99,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Slider
- * @extends SliderBase
+ * @extends sap.ui.webcomponents.main.SliderBase
  * @tagname ui5-slider
  * @since 1.0.0-rc.11
  * @public

--- a/packages/main/src/SliderBase.js
+++ b/packages/main/src/SliderBase.js
@@ -20,7 +20,7 @@ const metadata = {
 		/**
 		 * Defines the minimum value of the slider.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -31,7 +31,7 @@ const metadata = {
 		/**
 		 * Defines the maximum value of the slider.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 100
 		 * @public
 		 */
@@ -44,7 +44,7 @@ const metadata = {
 		 * <br><br>
 		 * <b>Note:</b> If set to 0 the slider handle movement is disabled. When negative number or value other than a number, the component fallbacks to its default value.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 1
 		 * @public
 		 */
@@ -59,7 +59,7 @@ const metadata = {
 		 * Example - if the step value is set to 2 and the label interval is also specified to 2 - then every second
 		 * tickmark will be labelled, which means every 4th value number.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */

--- a/packages/main/src/SplitButton.js
+++ b/packages/main/src/SplitButton.js
@@ -73,7 +73,7 @@ const metadata = {
 		 * <li><code>Attention</code></li>
 		 * </ul>
 		 *
-		 * @type {ButtonDesign}
+		 * @type {sap.ui.webcomponents.main.types.ButtonDesign}
 		 * @defaultvalue "Default"
 		 * @public
 		 */
@@ -120,7 +120,7 @@ const metadata = {
 		/**
 		 * Accessibility-related properties for inner elements of the Split Button
 		 *
-		 * @type {Object}
+		 * @type {object}
 		 * @private
 		 */
 		_splitButtonAccInfo: {
@@ -272,7 +272,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SplitButton
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-split-button
  * @public
  * @since 1.1.0

--- a/packages/main/src/StandardListItem.js
+++ b/packages/main/src/StandardListItem.js
@@ -76,7 +76,7 @@ const metadata = {
 		 * Defines the state of the <code>additionalText</code>.
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Error"</code>.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -104,7 +104,7 @@ const metadata = {
 		 *
 		 * <br><br>
 		 * <b>Note:</b> this property takes affect only if text node is provided to default slot of the component
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @private
 		 * @since 1.5.0
@@ -162,7 +162,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.StandardListItem
- * @extends ListItem
+ * @extends sap.ui.webcomponents.main.ListItem
  * @tagname ui5-li
  * @implements sap.ui.webcomponents.main.IListItem
  * @public

--- a/packages/main/src/StepInput.js
+++ b/packages/main/src/StepInput.js
@@ -42,7 +42,7 @@ const metadata = {
 		/**
 		 * Defines a value of the component.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -54,7 +54,7 @@ const metadata = {
 		/**
 		 * Defines a minimum value of the component.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @public
 		 */
 		min: {
@@ -64,7 +64,7 @@ const metadata = {
 		/**
 		 * Defines a maximum value of the component.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @public
 		 */
 		max: {
@@ -74,7 +74,7 @@ const metadata = {
 		/**
 		 * Defines a step of increasing/decreasing the value of the component.
 		 *
-		 * @type {Float}
+		 * @type {sap.ui.webcomponents.base.types.Float}
 		 * @defaultvalue 1
 		 * @public
 		 */
@@ -95,7 +95,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -177,7 +177,7 @@ const metadata = {
 		/**
 		 * Determines the number of digits after the decimal point of the component.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -356,7 +356,7 @@ const INITIAL_SPEED = 120; // milliseconds
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.StepInput
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-step-input
  * @since 1.0.0-rc.13
  * @public

--- a/packages/main/src/SuggestionGroupItem.js
+++ b/packages/main/src/SuggestionGroupItem.js
@@ -32,7 +32,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SuggestionGroupItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-suggestion-group-item
  * @implements sap.ui.webcomponents.main.IInputSuggestionItem
  * @public

--- a/packages/main/src/SuggestionItem.js
+++ b/packages/main/src/SuggestionItem.js
@@ -28,7 +28,7 @@ const metadata = {
 		 * <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press and hover,
 		 * while when <code>Inactive</code> or <code>Detail</code> - will not.
 		 *
-		 * @type {ListItemType}
+		 * @type {sap.ui.webcomponents.main.types.ListItemType}
 		 * @defaultvalue "Active"
 		 * @public
 		 * @since 1.0.0-rc.8
@@ -101,7 +101,7 @@ const metadata = {
 		 * Defines the state of the <code>additionalText</code>.
 		 * <br><br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Information"</code>, <code>"Warning"</code> and <code>"Error"</code>.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.15
 		 * @public
@@ -124,7 +124,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SuggestionItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-suggestion-item
  * @implements sap.ui.webcomponents.main.IInputSuggestionItem
  * @public

--- a/packages/main/src/SuggestionListItem.js
+++ b/packages/main/src/SuggestionListItem.js
@@ -45,7 +45,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.SuggestionListItem
- * @extends StandardListItem
+ * @extends sap.ui.webcomponents.main.StandardListItem
  * @tagname ui5-li-suggestion-item
  */
 class SuggestionListItem extends StandardListItem {

--- a/packages/main/src/Switch.js
+++ b/packages/main/src/Switch.js
@@ -31,7 +31,7 @@ const metadata = {
 		 * positive and negative icons will replace the <code>textOn</code> and <code>textOff</code>.
 		 *
 		 * @public
-		 * @type {SwitchDesign}
+		 * @type {sap.ui.webcomponents.main.types.SwitchDesign}
 		 * @defaultValue "Textual"
 		 */
 		design: {

--- a/packages/main/src/Tab.js
+++ b/packages/main/src/Tab.js
@@ -139,7 +139,7 @@ const metadata = {
 		 *
 		 * <br><br>
 		 * <b>Note:</b> The design depends on the current theme.
-		 * @type {SemanticColor}
+		 * @type {sap.ui.webcomponents.main.types.SemanticColor}
 		 * @defaultvalue "Default"
 		 * @public
 		 */
@@ -184,7 +184,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Tab
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-tab
  * @implements sap.ui.webcomponents.main.ITab
  * @public

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -140,7 +140,7 @@ const metadata = {
 		 * <li><code>Bottom</code></li>
 		 * </ul>
 		 *
-		 * @type {TabContainerTabsPlacement}
+		 * @type {sap.ui.webcomponents.main.types.TabContainerTabsPlacement}
 		 * @defaultvalue "Top"
 		 * @since 1.0.0-rc.7
 		 * @private
@@ -181,7 +181,7 @@ const metadata = {
 		 * <li><code>Inline</code></li>
 		 * </ul>
 		 *
-		 * @type {TabLayout}
+		 * @type {sap.ui.webcomponents.main.types.TabLayout}
 		 * @defaultvalue "Standard"
 		 * @public
 		 */
@@ -206,7 +206,7 @@ const metadata = {
 		 * <li><code>StartAndEnd</code></li>
 		 * </ul>
 		 *
-		 * @type {TabsOverflowMode}
+		 * @type {sap.ui.webcomponents.main.types.TabsOverflowMode}
 		 * @defaultvalue "End"
 		 * @since 1.1.0
 		 * @public

--- a/packages/main/src/TabSeparator.js
+++ b/packages/main/src/TabSeparator.js
@@ -26,7 +26,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TabSeparator
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-tab-separator
  * @implements sap.ui.webcomponents.main.ITab
  * @public

--- a/packages/main/src/Table.js
+++ b/packages/main/src/Table.js
@@ -166,7 +166,7 @@ const metadata = {
 		 *
 		 * <b>Restrictions:</b> <code>growing="Scroll"</code> is not supported for Internet Explorer,
 		 * and the component will fallback to <code>growing="Button"</code>.
-		 * @type {TableGrowingMode}
+		 * @type {sap.ui.webcomponents.main.types.TableGrowingMode}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.12
 		 * @public
@@ -194,7 +194,7 @@ const metadata = {
 		/**
 		 * Defines the delay in milliseconds, after which the busy indicator will show up for this component.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue 1000
 		 * @public
 		 */
@@ -242,7 +242,7 @@ const metadata = {
 		 * <li><code>SingleSelect</code></li>
 		 * <li><code>None</code></li>
 		 * <ul>
-		 * @type {TableMode}
+		 * @type {sap.ui.webcomponents.main.types.TableMode}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.15
 		 * @public

--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -31,7 +31,7 @@ const metadata = {
 		 * <br>
 		 * For further responsive design options, see <code>demandPopin</code> property.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue Infinity
 		 * @public
 		 */

--- a/packages/main/src/TableGroupRow.js
+++ b/packages/main/src/TableGroupRow.js
@@ -44,7 +44,7 @@ const metadata = {
 		 * <li><code>SingleSelect</code></li>
 		 * <li><code>MultiSelect</code></li>
 		 * </ul>
-		 * @type {TableMode}
+		 * @type {sap.ui.webcomponents.main.types.TableMode}
 		 * @defaultvalue "None"
 		 * @private
 		 */

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -48,7 +48,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.TableRow.prototype */ {
 		/**
 		 * Defines the mode of the row (None, SingleSelect, MultiSelect).
-		 * @type {TableMode}
+		 * @type {sap.ui.webcomponents.main.types.TableMode}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.15
 		 * @private
@@ -69,7 +69,7 @@ const metadata = {
 		 * <b>Note:</b> When set to <code>Active</code>, the item will provide visual response upon press,
 		 * while with type <code>Inactive</code> - will not.
 		 *
-		 * @type {TableRowType}
+		 * @type {sap.ui.webcomponents.main.types.TableRowType}
 		 * @defaultvalue "Inactive"
 		 * @since 1.0.0-rc.15
 		 * @public

--- a/packages/main/src/TextArea.js
+++ b/packages/main/src/TextArea.js
@@ -120,7 +120,7 @@ const metadata = {
 		 * <b>Note:</b> If <code>maxlength</code> property is set,
 		 * the component turns into "Warning" state once the characters exceeds the limit.
 		 * In this case, only the "Error" state is considered and can be applied.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @since 1.0.0-rc.7
 		 * @public
@@ -140,7 +140,7 @@ const metadata = {
 		 * <li>The CSS <code>height</code> property wins over the <code>rows</code> property, if both are set.</li>
 		 * </ul>
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */
@@ -152,7 +152,7 @@ const metadata = {
 		/**
 		 * Defines the maximum number of characters that the <code>value</code> can have.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultValue null
 		 * @public
 		 */
@@ -193,7 +193,7 @@ const metadata = {
 		/**
 		 * Defines the maximum number of lines that the component can grow.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 0
 		 * @public
 		 */

--- a/packages/main/src/TimePicker.js
+++ b/packages/main/src/TimePicker.js
@@ -108,7 +108,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TimePicker
- * @extends TimePickerBase
+ * @extends sap.ui.webcomponents.main.TimePickerBase
  * @tagname ui5-time-picker
  * @public
  * @since 1.0.0-rc.6
@@ -138,7 +138,7 @@ class TimePicker extends TimePickerBase {
 	 * Currently selected time represented as JavaScript Date instance
 	 *
 	 * @readonly
-	 * @type { Date }
+	 * @type {Date}
 	 * @public
 	 */
 	get dateValue() {

--- a/packages/main/src/TimePickerBase.js
+++ b/packages/main/src/TimePickerBase.js
@@ -69,7 +69,7 @@ const metadata = {
 		 * <li><code>Information</code></li>
 		 * </ul>
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -151,7 +151,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TimePickerBase
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @public
  * @since 1.0.0-rc.6
  */

--- a/packages/main/src/TimeSelection.js
+++ b/packages/main/src/TimeSelection.js
@@ -160,7 +160,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TimeSelection
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-time-selection
  * @private
  * @since 1.0.0-rc.12

--- a/packages/main/src/Title.js
+++ b/packages/main/src/Title.js
@@ -24,7 +24,7 @@ const metadata = {
 		 * <li><code>Normal</code> - The text will wrap. The words will not be broken based on hyphenation.</li>
 		 * </ul>
 		 *
-		 * @type {WrappingType}
+		 * @type {sap.ui.webcomponents.main.types.WrappingType}
 		 * @defaultvalue "None"
 		 * @public
 		 */
@@ -37,7 +37,7 @@ const metadata = {
 		 * Defines the component level.
 		 * Available options are: <code>"H6"</code> to <code>"H1"</code>.
 		 *
-		 * @type {TitleLevel}
+		 * @type {sap.ui.webcomponents.main.types.TitleLevel}
 		 * @defaultvalue "H2"
 		 * @public
 		*/

--- a/packages/main/src/Toast.js
+++ b/packages/main/src/Toast.js
@@ -28,7 +28,7 @@ const metadata = {
 		 * <b>Note:</b> The minimum supported value is <code>500</code> ms
 		 * and even if a lower value is set, the duration would remain <code>500</code> ms.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @defaultvalue 3000
 		 * @public
 		 */
@@ -53,7 +53,7 @@ const metadata = {
 		 * <li><code>BottomEnd</code></li>
 		 * </ul>
 		 *
-		 * @type {ToastPlacement}
+		 * @type {sap.ui.webcomponents.main.types.ToastPlacement}
 		 * @defaultvalue "BottomCenter"
 		 * @public
 		 */
@@ -137,7 +137,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Toast
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-toast
  * @public
  * @since 1.0.0-rc.6

--- a/packages/main/src/ToggleButton.js
+++ b/packages/main/src/ToggleButton.js
@@ -47,7 +47,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.ToggleButton
- * @extends Button
+ * @extends sap.ui.webcomponents.main.Button
  * @tagname ui5-toggle-button
  * @public
  */

--- a/packages/main/src/Tokenizer.js
+++ b/packages/main/src/Tokenizer.js
@@ -96,7 +96,7 @@ const metadata = {
 		/**
 		 * Indicates the value state of the related input component.
 		 *
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @private
 		 */
@@ -132,7 +132,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Tokenizer
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-tokenizer
  * @usestextcontent
  * @private

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -35,7 +35,7 @@ const metadata = {
 		 * </ul>
 		 *
 		 * @public
-		 * @type {ListMode}
+		 * @type {sap.ui.webcomponents.main.types.ListMode}
 		 * @defaultValue "None"
 		 */
 		mode: {
@@ -307,7 +307,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.Tree
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-tree
  * @appenddocs TreeItem
  * @public

--- a/packages/main/src/TreeItem.js
+++ b/packages/main/src/TreeItem.js
@@ -103,7 +103,7 @@ const metadata = {
 		 * Defines the state of the <code>additionalText</code>.
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Error"</code>.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -172,7 +172,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TreeItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-tree-item
  * @public
  * @implements sap.ui.webcomponents.main.ITreeItem

--- a/packages/main/src/TreeListItem.js
+++ b/packages/main/src/TreeListItem.js
@@ -29,7 +29,7 @@ const metadata = {
 		/**
 		 * Defines the indentation of the tree list item. Use level 1 for tree list items, representing top-level tree nodes.
 		 *
-		 * @type {Integer}
+		 * @type {sap.ui.webcomponents.base.types.Integer}
 		 * @public
 		 * @defaultValue 1
 		 */
@@ -93,7 +93,7 @@ const metadata = {
 		 * Defines the state of the <code>additionalText</code>.
 		 * <br>
 		 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Error"</code>.
-		 * @type {ValueState}
+		 * @type {sap.ui.webcomponents.base.types.ValueState}
 		 * @defaultvalue "None"
 		 * @public
 		 * @since 1.0.0-rc.15
@@ -233,7 +233,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.TreeListItem
- * @extends ListItem
+ * @extends sap.ui.webcomponents.main.ListItem
  * @tagname ui5-li-tree
  * @public
  * @since 1.0.0-rc.8

--- a/packages/main/src/WheelSlider.js
+++ b/packages/main/src/WheelSlider.js
@@ -134,7 +134,7 @@ const CELL_SIZE_COZY = 46;
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.WheelSlider
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-wheelslider
  * @public
  * @since 1.0.0-rc.6

--- a/packages/main/src/YearPicker.js
+++ b/packages/main/src/YearPicker.js
@@ -30,7 +30,7 @@ const metadata = {
 	properties: /** @lends sap.ui.webcomponents.main.YearPicker.prototype */ {
 		/**
 		 * An array of UTC timestamps representing the selected date or dates depending on the capabilities of the picker component.
-		 * @type {Array}
+		 * @type {array}
 		 * @public
 		 */
 		selectedDates: {
@@ -74,7 +74,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.YearPicker
- * @extends CalendarPart
+ * @extends sap.ui.webcomponents.main.CalendarPart
  * @tagname ui5-yearpicker
  * @public
  */

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -40,7 +40,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.${library}.${componentName}
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ${tagName}
  * @public
  */


### PR DESCRIPTION
Fixes:

- @extends tag now shows the full namespace of the superclass
- @type tag now shows the full namespace of the DataType
- Changed properties type from String to the corresponding custom data type 
