### PR TITLE
Fix #5978 - Typo in ShellBar example for UI5 Input used as Search

### DIFF
--- a/packages/fiori/test/samples/ShellBar.sample.html
+++ b/packages/fiori/test/samples/ShellBar.sample.html
@@ -167,7 +167,7 @@
 				<img src="../../../assets/images/avatars/woman_avatar_5.png" />
 			</ui5-avatar>
 			<img slot="logo" src="../../../assets/images/sap-logo-svg.svg"/>
-			<ui5-input slot="searchField" placeholer="Enter service..."></ui5-input>
+			<ui5-input slot="searchField" placeholder="Enter service..."></ui5-input>
 		</ui5-shellbar>
 	</div>
 
@@ -182,7 +182,7 @@
 			<img src="../../../assets/images/avatars/woman_avatar_5.png" />
 		</ui5-avatar>
 		<img slot="logo" src="../../../assets/images/sap-logo-svg.svg"/>
-		<ui5-input slot="searchField" placeholer="Enter service..."></ui5-input>
+		<ui5-input slot="searchField" placeholder="Enter service..."></ui5-input>
 </ui5-shellbar>
 	</xmp></pre>
 </section>


### PR DESCRIPTION
The word `placeholder` had a typo, it was `placeholer`, missing the letter `d`.

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
    + Bugfixes should generally include a test to cover the issue.
