### PR TITLE
feat(ui5-menu): add open/opener functionality and open/close events

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -7,10 +7,10 @@
 	hide-arrow
 	allow-target-overlap
 	?sub-menu={{_isSubMenu}}
-	@before-open={{_beforePopoverOpen}}
-	@after-open={{_afterPopoverOpen}}
-	@before-close={{_beforePopoverClose}}
-	@after-close={{_afterPopoverClose}}
+	@ui5-before-open={{_beforePopoverOpen}}
+	@ui5-after-open={{_afterPopoverOpen}}
+	@ui5-before-close={{_beforePopoverClose}}
+	@ui5-after-close={{_afterPopoverClose}}
 >
 {{#if isPhone}}
 	<div

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -7,7 +7,10 @@
 	hide-arrow
 	allow-target-overlap
 	?sub-menu={{_isSubMenu}}
+	@before-open={{_beforePopoverOpen}}
+	@after-open={{_afterPopoverOpen}}
 	@before-close={{_beforePopoverClose}}
+	@after-close={{_afterPopoverClose}}
 >
 {{#if isPhone}}
 	<div

--- a/packages/main/src/Menu.js
+++ b/packages/main/src/Menu.js
@@ -50,7 +50,7 @@ const metadata = {
 		 * @public
 		 * @type {boolean}
 		 * @defaultvalue false
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		open: {
 			type: Boolean,
@@ -61,7 +61,7 @@ const metadata = {
 		 * @public
 		 * @type {DOMReference}
 		 * @defaultvalue ""
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		opener: {
 			type: DOMReference,
@@ -181,7 +181,7 @@ const metadata = {
 		 * @public
 		 * @event sap.ui.webcomponents.main.Menu#before-open
 		 * @allowPreventDefault
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		"before-open": {},
 
@@ -190,7 +190,7 @@ const metadata = {
 		 *
 		 * @public
 		 * @event sap.ui.webcomponents.main.Menu#after-open
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		"after-open": {},
 
@@ -201,7 +201,7 @@ const metadata = {
 		 * @event sap.ui.webcomponents.main.Menu#before-close
 		 * @allowPreventDefault
 		 * @param {boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		"before-close": {
 			detail: {
@@ -214,7 +214,7 @@ const metadata = {
 		 *
 		 * @public
 		 * @event sap.ui.webcomponents.main.Menu#after-close
-		 * @since 1.9.0
+		 * @since 1.10.0
 		 */
 		"after-close": {},
 	},

--- a/packages/main/src/MenuItem.js
+++ b/packages/main/src/MenuItem.js
@@ -9,7 +9,7 @@ const metadata = {
 		/**
 		 * Defines the text of the tree item.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @defaultValue ""
 		 * @public
 		 */
@@ -156,7 +156,7 @@ const metadata = {
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webcomponents.main.MenuItem
- * @extends UI5Element
+ * @extends sap.ui.webcomponents.base.UI5Element
  * @tagname ui5-menu-item
  * @implements sap.ui.webcomponents.main.IMenuItem
  * @since 1.3.0

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -82,7 +82,7 @@
 		<h3 class="header-title">Event logger</h3>
 	</header>
 	<div class="samples-margin">
-		<ui5-textarea id="eventLogger" style="width: 500px; height: 100px;"></ui5-textarea>
+		<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
 	</div>
 
 	<script>
@@ -113,24 +113,24 @@
 		menu.addEventListener("ui5-before-open", function(event) {
 			eventLogger.value = "";
 			preventBeforeOpen.checked && event.preventDefault();
-			eventLogger.value = "* [before-open]" + (preventBeforeOpen.checked ? "[prevented]" : "") + "\n";
+			eventLogger.value = "* [before-open]" + (preventBeforeOpen.checked ? "[prevented]" : "") + " ";
 		});
 
 		menu.addEventListener("ui5-after-open", function() {
 			var opener = menu.opener.id ? menu.opener.id : menu.opener;
 			openerInput.value = opener;
-			eventLogger.value += "* [after-open]\n";
+			eventLogger.value += "* [after-open] ";
 		});
 
 		menu.addEventListener("ui5-before-close", function(event) {
 			preventBeforeClose.checked && event.preventDefault();
-			eventLogger.value += "* [before-close]" + (event.detail.escPressed ? "[Esc]" : "") + (preventBeforeClose.checked ? "[prevented]" : "") + "\n";
+			eventLogger.value += "* [before-close]" + (event.detail.escPressed ? "[Esc]" : "") + (preventBeforeClose.checked ? "[prevented]" : "") + " ";
 		});
 
 		menu.addEventListener("ui5-after-close", function() {
 			openerInput.value = "";
 			btnToggleOpen.pressed = false;
-			eventLogger.value += "* [after-close]\n";
+			eventLogger.value += "* [after-close]";
 		});
 
 		direction.addEventListener("change", function() {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -54,17 +54,83 @@
 		<ui5-switch id="direction" text-on="RTL" text-off="LTR"></ui5-switch>
 	</div>
 
+	<header class="header">
+		<h3 class="header-title">Prevent "before-open" event</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-switch id="preventBeforeOpen" text-on="Yes" text-off="No"></ui5-switch>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Prevent "before-close" event</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-switch id="preventBeforeClose" text-on="Yes" text-off="No"></ui5-switch>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">open/opener</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-button id="btnAddOpener">Add opener</ui5-button>
+		<ui5-button id="btnRemoveOpener">Remove opener</ui5-button>
+		<ui5-toggle-button id="btnToggleOpen">Toggle open</ui5-toggle-button> <br/>
+		<ui5-input id="openerInput"></ui5-input>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Event logger</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-textarea id="eventLogger" style="width: 500px; height: 100px;"></ui5-textarea>
+	</div>
+
 	<script>
 		btnOpen.accessibilityAttributes = {
 			hasPopup: "Menu",
 		};
 
-		btnOpen.addEventListener("click", function(event) {
+		btnOpen.addEventListener("click", function() {
 			menu.showAt(btnOpen);
 		});
 
-		menu.addEventListener("ui5-item-click", function(event){
+		btnAddOpener.addEventListener("click", function() {
+			menu.opener="btnToggleOpen";
+		});
+
+		btnRemoveOpener.addEventListener("click", function() {
+			menu.opener = "";
+		});
+
+		btnToggleOpen.addEventListener("click", function() {
+			menu.open = btnToggleOpen.pressed;
+		});
+
+		menu.addEventListener("ui5-item-click", function(event) {
 			selectionInput.value = event.detail.text;
+		});
+
+		menu.addEventListener("ui5-before-open", function(event) {
+			eventLogger.value = "";
+			preventBeforeOpen.checked && event.preventDefault();
+			eventLogger.value = "* [before-open]" + (preventBeforeOpen.checked ? "[prevented]" : "") + "\n";
+		});
+
+		menu.addEventListener("ui5-after-open", function() {
+			var opener = menu.opener.id ? menu.opener.id : menu.opener;
+			openerInput.value = opener;
+			eventLogger.value += "* [after-open]\n";
+		});
+
+		menu.addEventListener("ui5-before-close", function(event) {
+			preventBeforeClose.checked && event.preventDefault();
+			eventLogger.value += "* [before-close]" + (event.detail.escPressed ? "[Esc]" : "") + (preventBeforeClose.checked ? "[prevented]" : "") + "\n";
+		});
+
+		menu.addEventListener("ui5-after-close", function() {
+			openerInput.value = "";
+			btnToggleOpen.pressed = false;
+			eventLogger.value += "* [after-close]\n";
 		});
 
 		direction.addEventListener("change", function() {

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -125,10 +125,11 @@ describe("Menu interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const eventLogger = await browser.$("#eventLogger");
 
 		await browser.keys("Esc");
 
-		const eventLoggerValue = await browser.$("#eventLogger").getAttribute("value");
+		const eventLoggerValue = eventLogger.getAttribute("value");
 
 		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
 		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -129,7 +129,7 @@ describe("Menu interaction", () => {
 
 		await browser.keys("Esc");
 
-		const eventLoggerValue = eventLogger.getAttribute("value");
+		const eventLoggerValue = await eventLogger.getAttribute("value");
 
 		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
 		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -13,6 +13,19 @@ describe("Menu interaction", () => {
 		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
 	});
 
+	it("Menu opens after setting of opener and open", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openerButton = await browser.$("#btnAddOpener");
+		const openButton = await browser.$("#btnToggleOpen");
+
+		openerButton.click();
+		openButton.click();
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	});
+
 	it("Top level menu items appearance", async () => {
 		await browser.url(`test/pages/Menu.html`);
 		const openButton = await browser.$("#btnOpen");
@@ -101,6 +114,26 @@ describe("Menu interaction", () => {
 		await browser.keys("Enter");
 
 		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
+	});
+
+	it("Events firing on open/close of the menu", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
+
+		openButton.click();
+
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
+
+		await browser.keys("Esc");
+
+		const eventLoggerValue = await browser.$("#EventLogger").getAttribute("value");
+
+		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("before-close"), -1, "'before-close' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
 	});
 });
 

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -128,7 +128,7 @@ describe("Menu interaction", () => {
 
 		await browser.keys("Esc");
 
-		const eventLoggerValue = await browser.$("#EventLogger").getAttribute("value");
+		const eventLoggerValue = await browser.$("#eventLogger").getAttribute("value");
 
 		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
 		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -129,7 +129,7 @@ describe("Menu interaction", () => {
 
 		await browser.keys("Esc");
 
-		const eventLoggerValue = await eventLogger.getAttribute("value");
+		const eventLoggerValue = await eventLogger.getValue();
 
 		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
 		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -1,7 +1,6 @@
 const assert = require("chai").assert;
 
 describe("Menu interaction", () => {
-
 	it("Menu opens after button click", async () => {
 		await browser.url(`test/pages/Menu.html`);
 		const openButton = await browser.$("#btnOpen");
@@ -119,15 +118,11 @@ describe("Menu interaction", () => {
 	it("Events firing on open/close of the menu", async () => {
 		await browser.url(`test/pages/Menu.html`);
 		const openButton = await browser.$("#btnOpen");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
 		const eventLogger = await browser.$("#eventLogger");
 
-		await browser.keys("Esc");
+		openButton.click();
+		await browser.pause(100);
+		await browser.keys("Escape");
 
 		const eventLoggerValue = await eventLogger.getValue();
 


### PR DESCRIPTION
There are new properties defined: **opener** and **open**, and by setting them the menu can be opened and closed declaratively.

Also there are new events provided: **before-open** (can be prevented), **after-open**, **before-close** (can be prevented) and **after-close** that are fired on opening and closing of the menu.

Fixes https://github.com/SAP/ui5-webcomponents/issues/5558
Fixes https://github.com/SAP/ui5-webcomponents/issues/5440
Fixes https://github.com/SAP/ui5-webcomponents/issues/5653