### PR TITLE
fix(framework): fix paths for generating illustration imports in nps

### DIFF
--- a/packages/fiori/package-scripts.js
+++ b/packages/fiori/package-scripts.js
@@ -3,6 +3,7 @@ const getScripts = require("@ui5/webcomponents-tools/components-package/nps.js")
 const options = {
 	port: 8081,
 	portStep: 2,
+	fioriPackage: true,
 	illustrationsData: [
 		{
 			path: "src/illustrations",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -1,14 +1,16 @@
 const path = require("path");
 const fs = require("fs");
 const LIB = path.join(__dirname, `../lib/`);
-const FIORI = path.join(__dirname, `../../fiori/`);
-
 
 const getScripts = (options) => {
 
-	let illustrations = options.illustrationsData || [];
+	let illustrations = illustrationsImports = options.illustrationsData || [];
 	illustrations = illustrations.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
 	let illustrationsScript = illustrations.join(" && ");
+
+	// create file with all illustrations' imports
+	illustrationsImports = illustrationsImports.map(illustrations => `node ${LIB}/generate-js-imports/illustrations.js ${illustrations.destinationPath.replace("/tnt", "")} ${illustrations.destinationPath} dist/generated/js-imports`);
+	let illustrationsImportsScript = illustrationsImports.join(" && ");
 
 	let viteConfig;
 	if (fs.existsSync("config/vite.config.js")) {
@@ -63,11 +65,11 @@ const getScripts = (options) => {
 			},
 			jsImports: {
 				default: "mkdirp dist/generated/js-imports && nps build.jsImports.illustrations",
-				illustrations: `node "${LIB}/generate-js-imports/illustrations.js" ${FIORI}/dist/illustrations ${FIORI}/dist/illustrations/tnt dist/generated/js-imports`,
+				illustrations: illustrationsImportsScript,
 			},
 			bundle: `vite build ${viteConfig}`,
 			api: `jsdoc -c "${LIB}/jsdoc/config.json"`,
-			illustrations: illustrationsScript
+			illustrations: illustrationsScript,
 		},
 		copy: {
 			default: "nps copy.src copy.props",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -8,9 +8,8 @@ const getScripts = (options) => {
 	illustrations = illustrations.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
 	let illustrationsScript = illustrations.join(" && ");
 
-	// create file with all illustrations' imports
-	illustrationsImports = illustrationsImports.map(illustrations => `node ${LIB}/generate-js-imports/illustrations.js ${illustrations.destinationPath.replace("/tnt", "")} ${illustrations.destinationPath} dist/generated/js-imports`);
-	let illustrationsImportsScript = illustrationsImports.join(" && ");
+	// the generated illustrations' paths
+	let illustrationPaths = illustrationsImports.map(illustrations => illustrations.destinationPath);
 
 	let viteConfig;
 	if (fs.existsSync("config/vite.config.js")) {
@@ -65,7 +64,7 @@ const getScripts = (options) => {
 			},
 			jsImports: {
 				default: "mkdirp dist/generated/js-imports && nps build.jsImports.illustrations",
-				illustrations: illustrationsImportsScript,
+				illustrations: options.fioriPackage ? `node ${LIB}/generate-js-imports/illustrations.js ${illustrationPaths[0]} ${illustrationPaths[1]} dist/generated/js-imports` : "",
 			},
 			bundle: `vite build ${viteConfig}`,
 			api: `jsdoc -c "${LIB}/jsdoc/config.json"`,

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -4,12 +4,13 @@ const LIB = path.join(__dirname, `../lib/`);
 
 const getScripts = (options) => {
 
-	let illustrations = illustrationsImports = options.illustrationsData || [];
+	// The script creates all JS modules (dist/illustrations/{illustrationName}.js) out of the existing SVGs
+	let illustrations = illustrationsData = options.illustrationsData || [];
 	illustrations = illustrations.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
-	let illustrationsScript = illustrations.join(" && ");
+	let createIllustrationsJSImportsScript = illustrations.join(" && ");
 
-	// the generated illustrations' paths
-	let illustrationPaths = illustrationsImports.map(illustrations => illustrations.destinationPath);
+	// The script creates the "dist/generated/js-imports/Illustration.js" file that registers loaders (dynamic JS imports) for each illustration
+	const illustrationDestinationPaths = illustrationsData.map(illustrations => illustrations.destinationPath);
 
 	let viteConfig;
 	if (fs.existsSync("config/vite.config.js")) {
@@ -63,12 +64,12 @@ const getScripts = (options) => {
 				i18n: `node "${LIB}/generate-json-imports/i18n.js" dist/generated/assets/i18n dist/generated/json-imports`,
 			},
 			jsImports: {
-				default: "mkdirp dist/generated/js-imports && nps build.jsImports.illustrations",
-				illustrations: options.fioriPackage ? `node ${LIB}/generate-js-imports/illustrations.js ${illustrationPaths[0]} ${illustrationPaths[1]} dist/generated/js-imports` : "",
+				default: "mkdirp dist/generated/js-imports && nps build.jsImports.createIllustrationsLoadersScript",
+				createIllustrationsLoadersScript: options.fioriPackage ? `node ${LIB}/generate-js-imports/illustrations.js ${illustrationDestinationPaths[0]} ${illustrationDestinationPaths[1]} dist/generated/js-imports` : "",
 			},
 			bundle: `vite build ${viteConfig}`,
 			api: `jsdoc -c "${LIB}/jsdoc/config.json"`,
-			illustrations: illustrationsScript,
+			illustrations: createIllustrationsJSImportsScript,
 		},
 		copy: {
 			default: "nps copy.src copy.props",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -5,12 +5,13 @@ const LIB = path.join(__dirname, `../lib/`);
 const getScripts = (options) => {
 
 	// The script creates all JS modules (dist/illustrations/{illustrationName}.js) out of the existing SVGs
-	let illustrationsData = options.illustrationsData || [];
+	const illustrationsData = options.illustrationsData || [];
 	illustrations = illustrationsData.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
-	let createIllustrationsJSImportsScript = illustrations.join(" && ");
+	const createIllustrationsJSImportsScript = illustrations.join(" && ");
 
 	// The script creates the "dist/generated/js-imports/Illustration.js" file that registers loaders (dynamic JS imports) for each illustration
 	const illustrationDestinationPaths = illustrationsData.map(illustrations => illustrations.destinationPath);
+	const createIllustrationsLoadersScript = options.fioriPackage ? `node ${LIB}/generate-js-imports/illustrations.js ${illustrationDestinationPaths[0]} ${illustrationDestinationPaths[1]} dist/generated/js-imports` : "";
 
 	let viteConfig;
 	if (fs.existsSync("config/vite.config.js")) {
@@ -64,8 +65,8 @@ const getScripts = (options) => {
 				i18n: `node "${LIB}/generate-json-imports/i18n.js" dist/generated/assets/i18n dist/generated/json-imports`,
 			},
 			jsImports: {
-				default: "mkdirp dist/generated/js-imports && nps build.jsImports.createIllustrationsLoadersScript",
-				createIllustrationsLoadersScript: options.fioriPackage ? `node ${LIB}/generate-js-imports/illustrations.js ${illustrationDestinationPaths[0]} ${illustrationDestinationPaths[1]} dist/generated/js-imports` : "",
+				default: "mkdirp dist/generated/js-imports && nps build.jsImports.illustrationsLoaders",
+				illustrationsLoaders: createIllustrationsLoadersScript,
 			},
 			bundle: `vite build ${viteConfig}`,
 			api: `jsdoc -c "${LIB}/jsdoc/config.json"`,

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -5,8 +5,8 @@ const LIB = path.join(__dirname, `../lib/`);
 const getScripts = (options) => {
 
 	// The script creates all JS modules (dist/illustrations/{illustrationName}.js) out of the existing SVGs
-	let illustrations = illustrationsData = options.illustrationsData || [];
-	illustrations = illustrations.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
+	let illustrationsData = options.illustrationsData || [];
+	illustrations = illustrationsData.map(illustration => `node "${LIB}/create-illustrations/index.js" ${illustration.path} ${illustration.defaultText} ${illustration.illustrationsPrefix} ${illustration.set} ${illustration.destinationPath}`);
 	let createIllustrationsJSImportsScript = illustrations.join(" && ");
 
 	// The script creates the "dist/generated/js-imports/Illustration.js" file that registers loaders (dynamic JS imports) for each illustration


### PR DESCRIPTION
### **_Issue:_** 
In order to be generated file, with all of the illustrations imported in it, it was hardcoded that the illustrations to be taken from **specific path**. But when they were requested from npm, which has different path names for the packages, an error is thrown.

### **_Fix:_** 
Paths are now dynamic.

Fixes: #5992
