### PR TITLE
docs: fix "Blog" link's href

### DIFF
--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -38,7 +38,7 @@ nav_exclude: true
         <div class="navbar-right-container">
             <a href="{{"/playground/getting-started/first-steps" | absolute_url}}" class="item link">Documentation</a>
             <a href="{{"/playground/components" | absolute_url}}" class="item link">Components</a>
-            <a href="{{" page.blog" | absolute_url}}" class="item navbar-button">Blog</a>
+            <a href="https://blogs.sap.com/tag/ui5-web-components/" class="item navbar-button">Blog</a>
             <a href="https://github.com/SAP/ui5-webcomponents" class="item">
                 <img src="{{"/assets/icons/github-icon.svg" | absolute_url}}" alt="GithHub Repository">
             </a>


### PR DESCRIPTION
The "Blog" link opens non-existing page, now points to blog.sap.com and ui5-webcomponents blogs