### PR TITLE
fix(ui5-dynamic-side-content): fix tab order when side content position is 'Start'

### DIFF
--- a/packages/fiori/src/DynamicSideContent.hbs
+++ b/packages/fiori/src/DynamicSideContent.hbs
@@ -2,12 +2,27 @@
 	class="ui5-dsc-root"
 	style="{{styles.root}}"
 >
+
+	{{#if _isSideContentFirst}}
+		{{> sideContent}}
+		{{> mainContent}}
+	{{else}}
+		{{> mainContent}}
+		{{> sideContent}}
+	{{/if}}
+
+</div>
+
+{{#*inline "mainContent"}}
 	<div
 		class="{{classes.main}}"
 		style="{{styles.main}}"
 	>
 		<slot></slot>
 	</div>
+{{/inline}}
+
+{{#*inline "sideContent"}}
 	<aside
 		role="complementary"
 		aria-label="{{accInfo.label}}"
@@ -16,5 +31,4 @@
 	>
 		<slot name="sideContent"></slot>
 	</aside>
-
-</div>
+{{/inline}}

--- a/packages/fiori/src/DynamicSideContent.js
+++ b/packages/fiori/src/DynamicSideContent.js
@@ -384,11 +384,9 @@ class DynamicSideContent extends UI5Element {
 			},
 			main: {
 				"height": mcSpan === this.span12 ? contentHeight : "100%",
-				"order": this.sideContentPosition === SideContentPosition.Start ? 2 : 1,
 			},
 			side: {
 				"height": scSpan === this.span12 ? contentHeight : "100%",
-				"order": this.sideContentPosition === SideContentPosition.Start ? 1 : 2,
 			},
 		};
 	}
@@ -465,6 +463,10 @@ class DynamicSideContent extends UI5Element {
 		}
 
 		return size;
+	}
+
+	get _isSideContentFirst() {
+		return this.sideContentPosition === SideContentPosition.Start;
 	}
 
 	handleResize() {

--- a/packages/fiori/test/pages/styles/DynamicSideContent.css
+++ b/packages/fiori/test/pages/styles/DynamicSideContent.css
@@ -9,7 +9,7 @@ body, html {
 	background-color: var(--sapBackgroundColor);
 }
 
-.content-padding * {
+.content-padding > * {
 	padding: 0.5rem;
 }
 

--- a/packages/fiori/test/specs/DynamicSideContent.spec.js
+++ b/packages/fiori/test/specs/DynamicSideContent.spec.js
@@ -4,19 +4,21 @@ describe("'sideContentPosition' property: ", () => {
 	it("set to 'End'", async () => {
 		await browser.url(`test/pages/DynamicSideContent.html`);
 		const dynamicSideContent = await browser.$("ui5-dynamic-side-content");
+		const dynamicSideContentRoot = await dynamicSideContent.shadow$(".ui5-dsc-root");
 
 		await dynamicSideContent.setAttribute("side-content-position", "End");
-		assert.strictEqual((await dynamicSideContent.shadow$(".ui5-dsc-main").getCSSProperty("order")).value, 1, "The main content have order 1");
-		assert.strictEqual((await dynamicSideContent.shadow$(".ui5-dsc-side").getCSSProperty("order")).value, 2, "The side content have order 2");
+
+		assert.notEqual((await dynamicSideContentRoot.$("*").getAttribute("class")).indexOf("ui5-dsc-main"), -1, "The main content container is the first element in the shadow root");
 	});
 
 	it("set to 'Start'", async () => {
 		await browser.url(`test/pages/DynamicSideContent.html`);
 		const dynamicSideContent = await browser.$("ui5-dynamic-side-content");
+		const dynamicSideContentRoot = await dynamicSideContent.shadow$(".ui5-dsc-root");
 
 		await dynamicSideContent.setAttribute("side-content-position", "Start");
-		assert.strictEqual((await dynamicSideContent.shadow$(".ui5-dsc-main").getCSSProperty("order")).value, 2, "The main content have order 2");
-		assert.strictEqual((await dynamicSideContent.shadow$(".ui5-dsc-side").getCSSProperty("order")).value, 1, "The side content have order 1");
+
+		assert.notEqual((await dynamicSideContentRoot.$("*").getAttribute("class")).indexOf("ui5-dsc-side"), -1, "The side content container is the first element in the shadow root");
 	});
 });
 


### PR DESCRIPTION
When side content position is set to 'Start', the side content container is now rendered before the main content container, which effectively fixes the tab order.

Fixes https://github.com/SAP/ui5-webcomponents/issues/6012