### PR TITLE
fix(ui5-textarea): fix the minimum width of the component

### DIFF
--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -6,6 +6,7 @@
 
 :host {
 	width: 100%;
+	min-width: 6rem;
 	color: var(--sapField_TextColor);
 	min-height: var(--__ui5_textarea_min_height);
 	font-size: var(--sapFontSize);
@@ -104,7 +105,6 @@
 	border: none;
 	box-sizing: border-box;
 	width: 100%;
-	min-width: 6rem;
 	margin: 0;
 	padding-top: var(--_ui5_textarea_padding_top);
 	padding-bottom: var(--_ui5_textarea_padding_bottom);


### PR DESCRIPTION
The min-width CSS prop was set to the incorrect element making the component not respecting it, I moved it to the host.