### PR TITLE
chore: update ruby version on deploy

### DIFF
--- a/.github/workflows/deploy_latest.yaml
+++ b/.github/workflows/deploy_latest.yaml
@@ -13,6 +13,9 @@ jobs:
       with:
         node-version: 16
         cache: 'yarn'
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7.6'
 
     - name: Install and Build
       run: |


### PR DESCRIPTION
Playground is not deploying since a few days

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/5821279/203440922-96a78f20-5c3d-4160-afa4-062ad84f06f7.png">

I suspect that the build has been broken with a recent update of the `Gemfile` coming from https://github.com/SAP/ui5-webcomponents/commit/e1b02714a79c30001af99b7ed689f723610d43a3#diff-6f7aab33e75ae07ef9e183f84b74b8755e9aa05c4dde9824902dc5da2aca98be

Not really familiar with how gh actions work but I suggest you to bump the ruby version to `2.7.6` as `2.2` is quite old.


P.S. change of the `Gemfile` was required to get the playground running.