### PR TITLE
chore: refactor ItemNav and I18nBundle types

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.ts
+++ b/packages/base/src/delegate/ItemNavigation.ts
@@ -16,16 +16,19 @@ import ItemNavigationBehavior from "../types/ItemNavigationBehavior.js";
 import type UI5Element from "../UI5Element.js";
 import { instanceOfUI5Element } from "../UI5Element.js";
 
-type TabbableObject = {id?: string, _tabIndex: string};
+interface Tabbable {
+	id?: string,
+	_tabIndex?: string,
+}
 
 type ItemNavigationOptions = {
-	currentIndex: number,
-	navigationMode: NavigationMode,
-	rowSize: number
-	skipItemsSize: number,
-	behavior: ItemNavigationBehavior,
-	getItemsCallback: () => Array<TabbableObject>,
-	affectedPropertiesNames: Array<string>,
+	currentIndex?: number,
+	navigationMode?: NavigationMode,
+	rowSize?: number
+	skipItemsSize?: number,
+	behavior?: ItemNavigationBehavior,
+	getItemsCallback: () => Array<Tabbable>,
+	affectedPropertiesNames?: Array<string>,
 };
 
 /**
@@ -64,7 +67,7 @@ type ItemNavigationOptions = {
 class ItemNavigation {
 	rootWebComponent: UI5Element;
 
-	_getItems: () => Array<TabbableObject>;
+	_getItems: () => Array<Tabbable>;
 
 	_currentIndex: number;
 
@@ -123,7 +126,7 @@ class ItemNavigation {
 	 * @public
 	 * @param current the new selected item
 	 */
-	setCurrentItem(current: TabbableObject) {
+	setCurrentItem(current: Tabbable) {
 		const currentItemIndex = this._getItems().indexOf(current);
 
 		if (currentItemIndex === -1) {
@@ -384,3 +387,7 @@ class ItemNavigation {
 }
 
 export default ItemNavigation;
+
+export {
+	Tabbable,
+};

--- a/packages/base/src/i18nBundle.ts
+++ b/packages/base/src/i18nBundle.ts
@@ -9,8 +9,8 @@ type I18nText = {
 	key: string,
 	defaultText: string,
 };
-type GetText = (textObj: I18nText, ...params: Array<number | string>) => string;
-type I18nBundleGetter = (packageName: string) => Promise<{ getText: GetText }>;
+
+type I18nBundleGetter = (packageName: string) => Promise<I18nBundle>;
 
 /**
  * @class
@@ -50,7 +50,14 @@ class I18nBundle {
 	}
 }
 
-const getI18nBundleSync = (packageName: string) => {
+/**
+ * Returns the I18nBundle instance for the given package synchronously.
+ *
+ * @public
+ * @param packageName
+ * @returns { I18nBundle }
+ */
+const getI18nBundleSync = (packageName: string): I18nBundle => {
 	if (I18nBundleInstances.has(packageName)) {
 		return I18nBundleInstances.get(packageName)!;
 	}
@@ -58,6 +65,22 @@ const getI18nBundleSync = (packageName: string) => {
 	const i18nBundle = new I18nBundle(packageName);
 	I18nBundleInstances.set(packageName, i18nBundle);
 	return i18nBundle;
+};
+
+/**
+ * Fetches and returns the I18nBundle instance for the given package.
+ *
+ * @public
+ * @param packageName
+ * @returns { Promise<I18nBundle> }
+ */
+const getI18nBundle = async (packageName: string): Promise<I18nBundle> => {
+	if (customGetI18nBundle) {
+		return customGetI18nBundle(packageName);
+	}
+
+	await fetchI18nBundle(packageName);
+	return getI18nBundleSync(packageName);
 };
 
 /**
@@ -72,21 +95,7 @@ const registerCustomI18nBundleGetter = (customGet: I18nBundleGetter) => {
 	customGetI18nBundle = customGet;
 };
 
-/**
- * Fetches and returns the I18nBundle instance for the given package
- *
- * @public
- * @param packageName
- * @returns {Promise<I18nBundle>}
- */
-const getI18nBundle = async (packageName: string) => {
-	if (customGetI18nBundle) {
-		return customGetI18nBundle(packageName);
-	}
-
-	await fetchI18nBundle(packageName);
-	return getI18nBundleSync(packageName);
-};
+export default I18nBundle;
 
 export {
 	registerI18nLoader,


### PR DESCRIPTION
- new interface Tabbable that child components, subject to item navigation need to implement
- fix return type of getI18nBundle and getI18nBundleSync to Promise {I18nBundle} and I18nBundle respectively.