### PR TITLE
feat(ui5-shellbar): programmatically show search field

### DIFF
--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -116,7 +116,7 @@ const metadata = {
 		},
 
 		/**
-		 * Defines, if the Search Field would be displayed if there is a valid <code>searchField</code> slot.
+		 * Defines, if the Search Field would be displayed when there is a valid <code>searchField</code> slot.
 		 * <br><b>Note:</b> By default the Search Field is not displayed.
 		 * @type {boolean}
 		 * @defaultvalue false

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -116,6 +116,17 @@ const metadata = {
 		},
 
 		/**
+		 * Defines, if the Search Field would be displayed if there is a valid <code>searchField</code> slot.
+		 * <br><b>Note:</b> By default the Search Field is not displayed.
+		 * @type {boolean}
+		 * @defaultvalue false
+		 * @public
+		 */
+		showSearchField: {
+			type: Boolean,
+		},
+
+		/**
 		 * An object of strings that defines additional accessibility roles for further customization.
 		 *
 		 * It supports the following fields:

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -166,13 +166,6 @@ const metadata = {
 		/**
 		 * @private
 		 */
-		showSearchField: {
-			type: Boolean,
-		},
-
-		/**
-		 * @private
-		 */
 		coPilotActive: {
 			type: Boolean,
 		},

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -404,6 +404,17 @@ describe("Component Behavior", () => {
 				await searchIcon.click();
 				assert.notOk(await searchField.isDisplayed(), "Search is hidden after clicking again on the icon");
 			});
+
+			it("tests if searchfield toggles when altering the showSearchField property", async () => {
+				const searchField = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-field");
+				const shellBar = await browser.$("#shellbar");
+				
+				assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden by default");
+
+				await shellBar.setProperty('showSearchField', true);
+				assert.ok(await searchField.isDisplayed(), "Search is visible after altering the showSearchField property of the ShellBar");
+				await shellBar.setProperty('showSearchField', false); // Clean Up
+			});
 		});
 
 		describe("Small screen", () => {
@@ -492,7 +503,18 @@ describe("Component Behavior", () => {
 				assert.ok(await searchField.isDisplayed(), "Search is visible after clicking on the search icon within the overflow");
 
 				await cancelButton.click();
-				assert.notOk(await searchField.isDisplayed(), "Search is hidden after clicking on the search icon agian");
+				assert.notOk(await searchField.isDisplayed(), "Search is hidden after clicking on the search icon again");
+			});
+
+			it("tests if searchfield toggles when altering the showSearchField property", async () => {
+				const searchField = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-full-width-wrapper");
+				const shellBar = await browser.$("#shellbar");
+				
+				assert.notOk(await searchField.isDisplayed(), "Search is hidden by default");
+
+				await shellBar.setProperty('showSearchField', true);
+				assert.ok(await searchField.isDisplayed(), "Search is visible after altering the showSearchField property of the ShellBar");
+				await shellBar.setProperty('showSearchField', false); // Clean Up
 			});
 		});
 	});


### PR DESCRIPTION
Now there is option to programmatically toggle the display of the search field (if there is a valid slot in use).

Part of #5818

**Thank you for your contribution!** 👏

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
    + Bugfixes should generally include a test to cover the issue.
