### PR TITLE
refactor(ui5-table): renaming tablecellpopindisplaytype

### DIFF
--- a/packages/main/src/TableColumn.js
+++ b/packages/main/src/TableColumn.js
@@ -2,7 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import TableColumnTemplate from "./generated/templates/TableColumnTemplate.lit.js";
-import TableCellPopinDisplay from "./types/TableCellPopinDisplay.js";
+import TableColumnPopinDisplay from "./types/TableColumnPopinDisplay.js";
 
 // Styles
 import styles from "./generated/themes/TableColumn.css.js";
@@ -77,13 +77,13 @@ const metadata = {
 		 * <li><code>Inline</code></li>
 		 * </ul>
 		 *
-		 * @type {TableCellPopinDisplay}
+		 * @type {TableColumnPopinDisplay}
 		 * @defaultvalue "Block"
 		 * @public
 		 */
 		popinDisplay: {
-			type: TableCellPopinDisplay,
-			defaultValue: TableCellPopinDisplay.Block,
+			type: TableColumnPopinDisplay,
+			defaultValue: TableColumnPopinDisplay.Block,
 		},
 
 		/**

--- a/packages/main/src/types/TableColumnPopinDisplay.ts
+++ b/packages/main/src/types/TableColumnPopinDisplay.ts
@@ -5,9 +5,9 @@
  * @enum {string}
  * @public
  * @author SAP SE
- * @alias sap.ui.webcomponents.main.types.TableCellPopinDisplay
+ * @alias sap.ui.webcomponents.main.types.TableColumnPopinDisplay
  */
-enum TableCellPopinDisplay {
+enum TableColumnPopinDisplay {
 	/**
 	 * default type
 	 * @public
@@ -23,4 +23,4 @@ enum TableCellPopinDisplay {
 	Inline = "Inline",
 }
 
-export default TableCellPopinDisplay;
+export default TableColumnPopinDisplay;


### PR DESCRIPTION
In order to fulfill the naming conventions we renamed TableCellPopinDisplayType to TableColumnPopinDisplay. This does not affect the end users, API stays the same. 