### PR TITLE
chore(item-navigation): simplify return type of _getCurrentItem

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.ts
+++ b/packages/base/src/delegate/ItemNavigation.ts
@@ -353,7 +353,7 @@ class ItemNavigation {
 		const items = this._getItems();
 
 		if (!items.length) {
-			return null;
+			return;
 		}
 
 		// normalize the index


### PR DESCRIPTION
Simplified return type of _getCurrentItem function of ItemNavigation. Previously it was returning null | HTMLElement | undefined. Now, it only returns HTMLElement | undefined

Related to: #6080