### PR TITLE
refactor: use global map for event marking

### DIFF
--- a/packages/base/src/MarkedEvents.ts
+++ b/packages/base/src/MarkedEvents.ts
@@ -1,0 +1,20 @@
+const markedEvents = new WeakMap<Event, string>();
+
+/**
+ * Marks the given event with random marker.
+ */
+const markEvent = (event: Event, value: string) => {
+	markedEvents.set(event, value);
+};
+
+/**
+ * Returns the marker for the given event.
+ */
+const getEventMark = (event: Event): string | undefined => {
+	return markedEvents.get(event);
+};
+
+export {
+	markEvent,
+	getEventMark,
+};

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -1,6 +1,6 @@
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import Priority from "@ui5/webcomponents/dist/types/Priority.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
@@ -365,7 +365,7 @@ class NotificationListItem extends NotificationListItemBase {
 
 		const space = isSpace(event);
 
-		if (space && event.isMarked === "link") {
+		if (space && getEventMark(event) === "link") {
 			this._onShowMoreClick(event);
 			return;
 		}
@@ -379,7 +379,7 @@ class NotificationListItem extends NotificationListItemBase {
 	 * Private
 	 */
 	fireItemPress(event) {
-		if (event.isMarked === "button" || event.isMarked === "link") {
+		if (getEventMark(event) === "button" || getEventMark(event) === "link") {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -1,5 +1,6 @@
 import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import Priority from "@ui5/webcomponents/dist/types/Priority.js";
@@ -236,7 +237,7 @@ class NotificationListItemBase extends ListItemBase {
 	_onkeydown(event) {
 		super._onkeydown(event);
 
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			return;
 		}
 

--- a/packages/fiori/src/Timeline.js
+++ b/packages/fiori/src/Timeline.js
@@ -4,6 +4,7 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { TIMELINE_ARIA_LABEL } from "./generated/i18n/i18n-defaults.js";
 import TimelineTemplate from "./generated/templates/TimelineTemplate.lit.js";
 import TimelineItem from "./TimelineItem.js";
@@ -153,7 +154,7 @@ class Timeline extends UI5Element {
 
 	_onkeydown(event) {
 		if (isTabNext(event)) {
-			if (!event.target.nameClickable || event.isMarked === "link") {
+			if (!event.target.nameClickable || getEventMark(event) === "link") {
 				this._handleTabNextOrPrevious(event, isTabNext(event));
 			}
 		} else if (isTabPrevious(event)) {

--- a/packages/main/src/Button.js
+++ b/packages/main/src/Button.js
@@ -4,6 +4,8 @@ import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { markEvent } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
+
 import {
 	isPhone,
 	isTablet,
@@ -357,7 +359,8 @@ class Button extends UI5Element {
 		}
 
 		const handleTouchStartEvent = event => {
-			event.isMarked = "button";
+			markEvent(event, "button");
+
 			if (this.nonInteractive) {
 				return;
 			}
@@ -389,7 +392,7 @@ class Button extends UI5Element {
 		if (this.nonInteractive) {
 			return;
 		}
-		event.isMarked = "button";
+		markEvent(event, "button");
 		const FormSupport = getFeature("FormSupport");
 		if (FormSupport && this.submits) {
 			FormSupport.triggerFormSubmit(this);
@@ -405,7 +408,7 @@ class Button extends UI5Element {
 			return;
 		}
 
-		event.isMarked = "button";
+		markEvent(event, "button");
 		this.active = true;
 		activeButton = this; // eslint-disable-line
 	}
@@ -419,11 +422,11 @@ class Button extends UI5Element {
 	}
 
 	_onmouseup(event) {
-		event.isMarked = "button";
+		markEvent(event, "button");
 	}
 
 	_onkeydown(event) {
-		event.isMarked = "button";
+		markEvent(event, "button");
 
 		if (isSpace(event) || isEnter(event)) {
 			this.active = true;
@@ -451,7 +454,7 @@ class Button extends UI5Element {
 			return;
 		}
 
-		event.isMarked = "button";
+		markEvent(event, "button");
 		if (isDesktop()) {
 			this.focused = true;
 		}

--- a/packages/main/src/FileUploader.js
+++ b/packages/main/src/FileUploader.js
@@ -3,6 +3,7 @@ import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import {
 	FILEUPLOAD_BROWSE,
@@ -282,7 +283,7 @@ class FileUploader extends UI5Element {
 	}
 
 	_onclick(event) {
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			this._input.click(event);
 		}
 	}

--- a/packages/main/src/Link.js
+++ b/packages/main/src/Link.js
@@ -3,6 +3,7 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { markEvent } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import LinkDesign from "./types/LinkDesign.js";
 import WrappingType from "./types/WrappingType.js";
 
@@ -355,7 +356,7 @@ class Link extends UI5Element {
 		} = event;
 
 		event.stopImmediatePropagation();
-		event.isMarked = "link";
+		markEvent(event, "link");
 
 		const executeEvent = this.fireEvent("click", {
 			altKey,
@@ -370,7 +371,7 @@ class Link extends UI5Element {
 	}
 
 	_onfocusin(event) {
-		event.isMarked = "link";
+		markEvent(event, "link");
 		this.focused = true;
 	}
 
@@ -385,12 +386,12 @@ class Link extends UI5Element {
 			event.preventDefault();
 		}
 
-		event.isMarked = "link";
+		markEvent(event, "link");
 	}
 
 	_onkeyup(event) {
 		if (!isSpace(event)) {
-			event.isMarked = "link";
+			markEvent(event, "link");
 			return;
 		}
 

--- a/packages/main/src/ListItem.js
+++ b/packages/main/src/ListItem.js
@@ -1,4 +1,5 @@
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { isSpace, isEnter, isDelete } from "@ui5/webcomponents-base/dist/Keys.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/edit.js";
@@ -284,14 +285,14 @@ class ListItem extends ListItemBase {
 	}
 
 	_onmousedown(event) {
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			return;
 		}
 		this.activate();
 	}
 
 	_onmouseup(event) {
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			return;
 		}
 		this.deactivate();
@@ -307,7 +308,7 @@ class ListItem extends ListItemBase {
 	}
 
 	_onclick(event) {
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			return;
 		}
 		this.fireItemPress(event);

--- a/packages/main/src/SplitButton.js
+++ b/packages/main/src/SplitButton.js
@@ -11,6 +11,7 @@ import {
 	isShift,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 import SplitButtonTemplate from "./generated/templates/SplitButtonTemplate.lit.js";
@@ -326,7 +327,7 @@ class SplitButton extends UI5Element {
 	}
 
 	_onFocusOut(event) {
-		if (this.disabled || event.isMarked) {
+		if (this.disabled || getEventMark(event)) {
 			return;
 		}
 		this._shiftOrEscapePressed = false;
@@ -335,7 +336,7 @@ class SplitButton extends UI5Element {
 	}
 
 	_onFocusIn(event) {
-		if (this.disabled || event.isMarked) {
+		if (this.disabled || getEventMark(event)) {
 			return;
 		}
 		this._shiftOrEscapePressed = false;

--- a/packages/main/src/TableRow.js
+++ b/packages/main/src/TableRow.js
@@ -10,6 +10,7 @@ import {
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import { getLastTabbableElement } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
+import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import CheckBox from "./CheckBox.js";
 import TableMode from "./types/TableMode.js";
 import TableRowType from "./types/TableRowType.js";
@@ -292,7 +293,7 @@ class TableRow extends UI5Element {
 		// If the user tab over a button on IOS device, the document.activeElement
 		// is the ui5-table-row. The check below ensure that, if a button within the row is pressed,
 		// the row will not be selected.
-		if (event.isMarked === "button") {
+		if (getEventMark(event) === "button") {
 			return;
 		}
 


### PR DESCRIPTION
Use global map for event marking, instead of marking the event instances:
- don't use `event.isMarked === "link"`, use `getEventMark(event)`
- don't use  `event.isMarked = "button"`, use `mark(event, "button")`