### PR TITLE
fix(infra): set Content-Type header on testsuite

### DIFF
--- a/packages/tools/lib/dev-server/virtual-index-html-plugin.js
+++ b/packages/tools/lib/dev-server/virtual-index-html-plugin.js
@@ -33,6 +33,7 @@ const virtualIndexPlugin = async () => {
 					const folders = Object.keys(pagesPerFolder);
 
 					res.statusCode = 200;
+					res.setHeader("Content-Type", "text/html; charset=utf-8");
 					res.end(`${folders.map(folder => {
 						const pages = pagesPerFolder[folder];
 						return `<h1>${folder}</h1>


### PR DESCRIPTION
Adding a Content-Type=text/html header to the testsuite index.html will hint to Safari to correctly display the content as HTML.

Fixes #6107