### PR TITLE
refactor: change type and methods in `MediaRange.ts`

### DIFF
--- a/packages/base/src/MediaRange.ts
+++ b/packages/base/src/MediaRange.ts
@@ -3,9 +3,9 @@ type Range = Map<string, Array<number>>;
 const mediaRanges = new Map<string, Range>();
 
 const DEAFULT_RANGE_SET: Range = new Map<string, Array<number>>();
-DEAFULT_RANGE_SET.set("S", [0, 600]);
-DEAFULT_RANGE_SET.set("M", [600, 1024]);
-DEAFULT_RANGE_SET.set("L", [1024, 1440]);
+DEAFULT_RANGE_SET.set("S", [0, 599]);
+DEAFULT_RANGE_SET.set("M", [600, 1023]);
+DEAFULT_RANGE_SET.set("L", [1024, 1439]);
 DEAFULT_RANGE_SET.set("XL", [1440, 2560]);
 
 /**

--- a/packages/base/src/MediaRange.ts
+++ b/packages/base/src/MediaRange.ts
@@ -6,7 +6,7 @@ const DEAFULT_RANGE_SET: Range = new Map<string, Array<number>>();
 DEAFULT_RANGE_SET.set("S", [0, 599]);
 DEAFULT_RANGE_SET.set("M", [600, 1023]);
 DEAFULT_RANGE_SET.set("L", [1024, 1439]);
-DEAFULT_RANGE_SET.set("XL", [1440, 2560]);
+DEAFULT_RANGE_SET.set("XL", [1440, Infinity]);
 
 /**
  * Enumeration containing the names and settings of predefined screen width media query range sets.
@@ -83,7 +83,7 @@ const getCurrentRange = (name: string, width = window.innerWidth): string => {
 	let currentRangeName;
 
 	rangeSet.forEach((value, key) => {
-		if (width >= value[0] && width <= value[1]) {
+		if (Math.floor(width) >= value[0] && Math.floor(width) <= value[1]) {
 			currentRangeName = key;
 		}
 	});

--- a/packages/base/src/MediaRange.ts
+++ b/packages/base/src/MediaRange.ts
@@ -80,15 +80,15 @@ const getCurrentRange = (name: string, width = window.innerWidth): string => {
 		rangeSet = mediaRanges.get(RANGESETS.RANGE_4STEPS)!;
 	}
 
-	let currentRangeName = [...rangeSet.keys()][0];
+	let currentRangeName;
 
 	rangeSet.forEach((value, key) => {
-		if (width > value[0] && width < value[1]) {
+		if (width >= value[0] && width <= value[1]) {
 			currentRangeName = key;
 		}
 	});
 
-	return currentRangeName;
+	return currentRangeName || [...rangeSet.keys()][0];
 };
 
 /**

--- a/packages/base/src/MediaRange.ts
+++ b/packages/base/src/MediaRange.ts
@@ -81,9 +81,10 @@ const getCurrentRange = (name: string, width = window.innerWidth): string => {
 	}
 
 	let currentRangeName;
+	const effectiveWidth = Math.floor(width);
 
 	rangeSet.forEach((value, key) => {
-		if (Math.floor(width) >= value[0] && Math.floor(width) <= value[1]) {
+		if (effectiveWidth >= value[0] && effectiveWidth <= value[1]) {
 			currentRangeName = key;
 		}
 	});

--- a/packages/base/src/MediaRange.ts
+++ b/packages/base/src/MediaRange.ts
@@ -1,8 +1,36 @@
-const querySets = new Map<string, RangeSet>();
+type Range = Map<string, Array<number>>;
 
-type RangeSet = {
-	borders: Array<number>,
-	names: Array<string>,
+const mediaRanges = new Map<string, Range>();
+
+const DEAFULT_RANGE_SET: Range = new Map<string, Array<number>>();
+DEAFULT_RANGE_SET.set("S", [0, 600]);
+DEAFULT_RANGE_SET.set("M", [600, 1024]);
+DEAFULT_RANGE_SET.set("L", [1024, 1440]);
+DEAFULT_RANGE_SET.set("XL", [1440, 2560]);
+
+/**
+ * Enumeration containing the names and settings of predefined screen width media query range sets.
+ *
+ * @namespace
+ * @name MediaRange.RANGESETS
+ * @public
+ */
+ enum RANGESETS {
+	/**
+	 * A 4-step range set (S-M-L-XL).
+	 *
+	 * The ranges of this set are:
+	 * <ul>
+	 * <li><code>"S"</code>: For screens smaller than 600 pixels.</li>
+	 * <li><code>"M"</code>: For screens greater than or equal to 600 pixels and smaller than 1024 pixels.</li>
+	 * <li><code>"L"</code>: For screens greater than or equal to 1024 pixels and smaller than 1440 pixels.</li>
+	 * <li><code>"XL"</code>: For screens greater than or equal to 1440 pixels.</li>
+	 * </ul>
+	 *
+	 * @name MediaRange.RANGESETS.RANGE_4STEPS
+	 * @public
+	 */
+	RANGE_4STEPS = "4Step",
 }
 
 /**
@@ -23,15 +51,11 @@ type RangeSet = {
  *
  * @param {string} name The name of the range set to be initialized.
  * The name must be a valid id and consist only of letters and numeric digits.
- * @param {int[]} [borders] The range borders
- * @param {string[]} [names] The names of the ranges. The names must be a valid id and consist only of letters and digits.
+ * @param {Range} [range] The given range set.
  * @name MediaRange.initRangeSet
  */
-const _initRangeSet = (name: string, borders: Array<number>, names: Array<string>) => {
-	querySets.set(name, {
-		borders,
-		names,
-	});
+const initRangeSet = (name: string, range: Range) => {
+	mediaRanges.set(name, range);
 };
 
 /**
@@ -41,55 +65,31 @@ const _initRangeSet = (name: string, borders: Array<number>, names: Array<string
  * otherwise it is determined for the current window size.
  *
  * @param {string} name The name of the range set. The range set must be initialized beforehand ({@link MediaRange.initRangeSet})
- * @param {int} [width] An optional width, based on which the range should be determined;
- *             If <code>width</code> is not provided, the window size will be used.
+ * @param {number} [width] An optional width, based on which the range should be determined;
+ * If <code>width</code> is not provided, the window size will be used.
  * @returns {string} The name of the current active interval of the range set.
  *
  * @name MediaRange.getCurrentRange
  * @function
  * @public
  */
-const _getCurrentRange = (name: string, width = window.innerWidth) => {
-	const querySet = querySets.get(name);
-	let i = 0;
+const getCurrentRange = (name: string, width = window.innerWidth): string => {
+	let rangeSet = mediaRanges.get(name);
 
-	if (!querySet) {
-		return null;
+	if (!rangeSet) {
+		rangeSet = mediaRanges.get(RANGESETS.RANGE_4STEPS)!;
 	}
 
-	for (; i < querySet.borders.length; i++) {
-		if (width < querySet.borders[i]) {
-			return querySet.names[i];
+	let currentRangeName = [...rangeSet.keys()][0];
+
+	rangeSet.forEach((value, key) => {
+		if (width > value[0] && width < value[1]) {
+			currentRangeName = key;
 		}
-	}
+	});
 
-	return querySet.names[i];
+	return currentRangeName;
 };
-
-/**
- * Enumeration containing the names and settings of predefined screen width media query range sets.
- *
- * @namespace
- * @name MediaRange.RANGESETS
- * @public
- */
-enum RANGESETS {
-	/**
-	 * A 4-step range set (S-M-L-XL).
-	 *
-	 * The ranges of this set are:
-	 * <ul>
-	 * <li><code>"S"</code>: For screens smaller than 600 pixels.</li>
-	 * <li><code>"M"</code>: For screens greater than or equal to 600 pixels and smaller than 1024 pixels.</li>
-	 * <li><code>"L"</code>: For screens greater than or equal to 1024 pixels and smaller than 1440 pixels.</li>
-	 * <li><code>"XL"</code>: For screens greater than or equal to 1440 pixels.</li>
-	 * </ul>
-	 *
-	 * @name MediaRange.RANGESETS.RANGE_4STEPS
-	 * @public
-	 */
-	RANGE_4STEPS = "4Step",
-}
 
 /**
  * API for screen width changes.
@@ -100,10 +100,10 @@ enum RANGESETS {
 
 const MediaRange = {
 	RANGESETS,
-	initRangeSet: _initRangeSet,
-	getCurrentRange: _getCurrentRange,
+	initRangeSet,
+	getCurrentRange,
 };
 
-MediaRange.initRangeSet(MediaRange.RANGESETS.RANGE_4STEPS, [600, 1024, 1440], ["S", "M", "L", "XL"]);
+MediaRange.initRangeSet(MediaRange.RANGESETS.RANGE_4STEPS, DEAFULT_RANGE_SET);
 
 export default MediaRange;

--- a/packages/base/src/util/FocusableElements.ts
+++ b/packages/base/src/util/FocusableElements.ts
@@ -2,13 +2,13 @@ import isElementHidden from "./isElementHidden.js";
 import isElementClickable from "./isElementClickable.js";
 import { instanceOfUI5Element } from "../UI5Element.js";
 
-type FocusableElement = Promise<HTMLElement | null>;
+type FocusableElementPromise = Promise<HTMLElement | null>;
 
 const isFocusTrap = (el: HTMLElement) => {
 	return el.hasAttribute("data-ui5-focus-trap");
 };
 
-const getFirstFocusableElement = async (container: HTMLElement, startFromContainer: boolean): FocusableElement => {
+const getFirstFocusableElement = async (container: HTMLElement, startFromContainer?: boolean): FocusableElementPromise => {
 	if (!container || isElementHidden(container)) {
 		return null;
 	}
@@ -16,7 +16,7 @@ const getFirstFocusableElement = async (container: HTMLElement, startFromContain
 	return findFocusableElement(container, true, startFromContainer);
 };
 
-const getLastFocusableElement = async (container: HTMLElement, startFromContainer: boolean): FocusableElement => {
+const getLastFocusableElement = async (container: HTMLElement, startFromContainer?: boolean): FocusableElementPromise => {
 	if (!container || isElementHidden(container)) {
 		return null;
 	}
@@ -28,7 +28,7 @@ const isElemFocusable = (el: HTMLElement) => {
 	return el.hasAttribute("data-ui5-focus-redirect") || !isElementHidden(el);
 };
 
-const findFocusableElement = async (container: HTMLElement, forward: boolean, startFromContainer?: boolean): FocusableElement => {
+const findFocusableElement = async (container: HTMLElement, forward: boolean, startFromContainer?: boolean): FocusableElementPromise => {
 	let child: HTMLElement | undefined;
 
 	if (container.shadowRoot) {

--- a/packages/base/src/util/FocusableElements.ts
+++ b/packages/base/src/util/FocusableElements.ts
@@ -16,7 +16,7 @@ const getFirstFocusableElement = async (container: HTMLElement, startFromContain
 	return findFocusableElement(container, true, startFromContainer);
 };
 
-const getLastFocusableElement = async (container: HTMLElement, startFromContainer: boolean) => {
+const getLastFocusableElement = async (container: HTMLElement, startFromContainer: boolean): FocusableElement => {
 	if (!container || isElementHidden(container)) {
 		return null;
 	}

--- a/packages/base/src/util/FocusableElements.ts
+++ b/packages/base/src/util/FocusableElements.ts
@@ -2,11 +2,13 @@ import isElementHidden from "./isElementHidden.js";
 import isElementClickable from "./isElementClickable.js";
 import { instanceOfUI5Element } from "../UI5Element.js";
 
+type FocusableElement = Promise<HTMLElement | null>;
+
 const isFocusTrap = (el: HTMLElement) => {
 	return el.hasAttribute("data-ui5-focus-trap");
 };
 
-const getFirstFocusableElement = async (container: HTMLElement, startFromContainer: boolean): Promise<HTMLElement | null> => {
+const getFirstFocusableElement = async (container: HTMLElement, startFromContainer: boolean): FocusableElement => {
 	if (!container || isElementHidden(container)) {
 		return null;
 	}
@@ -26,7 +28,7 @@ const isElemFocusable = (el: HTMLElement) => {
 	return el.hasAttribute("data-ui5-focus-redirect") || !isElementHidden(el);
 };
 
-const findFocusableElement = async (container: HTMLElement, forward: boolean, startFromContainer?: boolean): Promise<HTMLElement | null> => {
+const findFocusableElement = async (container: HTMLElement, forward: boolean, startFromContainer?: boolean): FocusableElement => {
 	let child: HTMLElement | undefined;
 
 	if (container.shadowRoot) {


### PR DESCRIPTION
We did the following changes: 

- `getCurrentRange` now always returns a result, because it fallbacks to the default `rangeSet`, previously it was returning "null";
- `initRangeSet` method now expects 2 params, instead of 3. 
- We completely changed the usage of the `initRangeSet`, instead of `initRangeSet(name: string, borders: [600, 1100, 1400], names: [S, L, M])`, we now use it like: 

```js
initRangeSet(name: string, range: Map<string, Array<number>>);
```

Related to: #6080 