### PR TITLE
chore: use a better regex for types parsing

### DIFF
--- a/packages/fiori/src/types/BarDesign.ts
+++ b/packages/fiori/src/types/BarDesign.ts
@@ -1,4 +1,6 @@
 /**
+ * Different types of Bar design
+ *
  * @class
  * @enum {string}
  * @public

--- a/packages/main/src/types/BreadcrumbsSeparatorStyle.ts
+++ b/packages/main/src/types/BreadcrumbsSeparatorStyle.ts
@@ -10,7 +10,7 @@
 enum BreadcrumbsSeparatorStyle {
 
 	/**
-	 * The separator appears as a slash.
+	 * The separator appears as "/".
 	 * @public
 	 * @type {Slash}
 	 */
@@ -38,7 +38,7 @@ enum BreadcrumbsSeparatorStyle {
 	DoubleGreaterThan = "DoubleGreaterThan",
 
 	/**
-	 * The separator appears as double slash.
+	 * The separator appears as "//" .
 	 * @public
 	 * @type {DoubleSlash}
 	 */

--- a/packages/main/src/types/TableGrowingMode.ts
+++ b/packages/main/src/types/TableGrowingMode.ts
@@ -9,7 +9,7 @@
  */
 enum TableGrowingMode {
 	/**
-	 * Component "load-more" is fired
+	 * Component <code>load-more</code> is fired
 	 * upon pressing a "More" button at the bottom.
 	 * @public
 	 * @type {Button}
@@ -17,7 +17,7 @@ enum TableGrowingMode {
 	Button = "Button",
 
 	/**
-	 * Component "load-more" is fired upon scroll.
+	 * Component <code>load-more</code> is fired upon scroll.
 	 * @public
 	 * @type {Scroll}
 	 */

--- a/packages/main/src/types/TitleLevel.ts
+++ b/packages/main/src/types/TitleLevel.ts
@@ -9,42 +9,42 @@
  */
 enum TitleLevel {
 	/**
-	 * Renders h1 tag.
+	 * Renders <code>h1</code> tag.
 	 * @public
 	 * @type {H1}
 	 */
 	H1 = "H1",
 
 	/**
-	 * Renders h2 tag.
+	 * Renders <code>h2</code> tag.
 	 * @public
 	 * @type {H2}
 	 */
 	H2 = "H2",
 
 	/**
-	 * Renders h3 tag.
+	 * Renders <code>h3</code> tag.
 	 * @public
 	 * @type {H3}
 	 */
 	H3 = "H3",
 
 	/**
-	 * Renders h4 tag.
+	 * Renders <code>h4</code> tag.
 	 * @public
 	 * @type {H4}
 	 */
 	H4 = "H4",
 
 	/**
-	 * Renders h5 tag.
+	 * Renders <code>h5</code> tag.
 	 * @public
 	 * @type {H5}
 	 */
 	H5 = "H5",
 
 	/**
-	 * Renders h6 tag.
+	 * Renders <code>h6</code> tag.
 	 * @public
 	 * @type {H6}
 	 */

--- a/packages/main/src/types/ToastPlacement.ts
+++ b/packages/main/src/types/ToastPlacement.ts
@@ -10,56 +10,56 @@
 enum ToastPlacement {
 
 	/**
-	 * Toast is placed at the "TopStart" position of its container.
+	 * Toast is placed at the <code>TopStart</code> position of its container.
 	 * @public
 	 * @type {TopStart}
 	 */
 	TopStart = "TopStart",
 
 	/**
-	 * Toast is placed at the "TopCenter" position of its container.
+	 * Toast is placed at the <code>TopCenter</code> position of its container.
 	 * @public
 	 * @type {TopCenter}
 	 */
 	TopCenter = "TopCenter",
 
 	/**
-	 * Toast is placed at the "TopEnd" position of its container.
+	 * Toast is placed at the <code>TopEnd</code> position of its container.
 	 * @public
 	 * @type {TopEnd}
 	 */
 	TopEnd = "TopEnd",
 
 	/**
-	 * Toast is placed at the "MiddleStart" position of its container.
+	 * Toast is placed at the <code>MiddleStart</code> position of its container.
 	 * @public
 	 * @type {MiddleStart}
 	 */
 	MiddleStart = "MiddleStart",
 
 	/**
-	 * Toast is placed at the "MiddleCenter" position of its container.
+	 * Toast is placed at the <code>MiddleCenter</code> position of its container.
 	 * @public
 	 * @type {MiddleCenter}
 	 */
 	MiddleCenter = "MiddleCenter",
 
 	/**
-	 * Toast is placed at the "MiddleEnd" position of its container.
+	 * Toast is placed at the <code>MiddleEnd</code> position of its container.
 	 * @public
 	 * @type {MiddleEnd}
 	 */
 	MiddleEnd = "MiddleEnd",
 
 	/**
-	 * Toast is placed at the "BottomStart" position of its container.
+	 * Toast is placed at the <code>BottomStart</code> position of its container.
 	 * @public
 	 * @type {BottomStart}
 	 */
 	BottomStart = "BottomStart",
 
 	/**
-	 * Toast is placed at the "BottomCenter" position of its container.
+	 * Toast is placed at the <code>BottomCenter</code> position of its container.
 	 * Default placement (no selection)
 	 * @public
 	 * @type {BottomCenter}
@@ -67,7 +67,7 @@ enum ToastPlacement {
 	BottomCenter = "BottomCenter",
 
 	/**
-	 * Toast is placed at the "BottomEnd" position of its container.
+	 * Toast is placed at the <code>BottomEnd</code> position of its container.
 	 * @public
 	 * @type {BottomEnd}
 	 */

--- a/packages/tools/lib/jsdoc/preprocess.js
+++ b/packages/tools/lib/jsdoc/preprocess.js
@@ -19,15 +19,15 @@ const preprocessTypes = async () => {
 const processTypeFile = async (fileName) => {
 	let fileContent = `${await fs.readFile(fileName)}`;
 
-	const re = new RegExp(`(\\/\\*\\*[^\\/]+\\s+\\*\\/)?\\s+\\s+.*?\\["([\\w\\d]+)"\\].*?"([\\w\\d]+)";`, "gm")
+	const re = new RegExp(`(\\/\\*\\*\\s*\\n([^\\*]|(\\*(?!\\/)))*\\*\\/)\\s+[\\w\\d]+\\[\\"([\\w\\d]+)\\"\\]\\s*=\\s*\\"([\\w\\d]+)\\";`, "gm")
 	let matches = [...fileContent.matchAll(re)];
 
 	// Get all type values
 	const typeData = matches.map(match => {
 		return {
 			comment: match[1],
-			key: match[2],
-			value: match[3],
+			key: match[4],
+			value: match[5],
 		};
 	});
 	if (typeData.length === 0) {
@@ -36,7 +36,7 @@ const processTypeFile = async (fileName) => {
 
 	const typeName = path.parse(fileName).name;
 
-	matches = fileContent.match(/^\/\*\*[^\/]+\//gm);
+	matches = fileContent.match(/\/\*\*\s*\n([^\*]|(\*(?!\/)))*\*\//gm);
 	const comment = matches[0];
 
 	const propsCode = typeData.map(item => {


### PR DESCRIPTION
It's now once again possible to use `/` in `types/**/*.ts` files comments. Before this fix, the regular expression used to parse comments for JSDoc had a bug that prevented the usage of slashes.