### PR TITLE
feat(ui5-shellbar): use header semantic element

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -1,6 +1,5 @@
-<div
+<header
 	class="{{classes.wrapper}}"
-	role="banner"
 	aria-label="{{_shellbarText}}"
 	part="root"
 >
@@ -203,7 +202,7 @@
 			{{/if}}
 		</div>
 	</div>
-</div>
+</header>
 
 {{#*inline "profileButton"}}
 	<ui5-button


### PR DESCRIPTION
`<header>` semantic element is now supported by modern browsers, so it is used instead of `<div role="banner">` 
