### PR TITLE
fix(ui5-date-picker): align styles to input

### DIFF
--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -16,7 +16,7 @@
 	border-radius: var(--_ui5-datepicker_border_radius);
 }
 
-:host([value-state="Error"]):not([disabled]):not([readonly]) {
+:host([value-state="Error"]:not([readonly]):not([disabled])) {
 	background-color: var(--sapField_InvalidBackground);
 }
 
@@ -50,6 +50,12 @@
 
 :host(:not([disabled]):not([readonly])) .ui5-date-picker-input[focused] {
 	background-color: var(--_ui5-datepicker-hover-background);
+}
+
+:host([readonly]) {
+	border-color: var(--_ui5_input_readonly_border_color);
+	background: var(--sapField_ReadOnly_BackgroundStyle);
+	background-color: var(--_ui5_input_readonly_background);
 }
 
 [slot="icon"] {


### PR DESCRIPTION
- The proper background color is now set to the ui5-datepicker element when there is a value state configured or the component is in read only mode.

fixes: https://github.com/SAP/ui5-webcomponents/issues/5699
fixes: https://github.com/SAP/ui5-webcomponents/issues/5698
fixes: https://github.com/SAP/ui5-webcomponents/issues/5913