### PR TITLE
chore: correct openui5 imports after upgrade to 1.109

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",
-    "@openui5/sap.ui.core": "1.101.0",
+    "@openui5/sap.ui.core": "1.109.0",
     "@ui5/webcomponents-tools": "1.9.1",
     "chromedriver": "107.0.3",
     "clean-css": "^5.2.2",

--- a/packages/localization/src/sap/ui/core/Configuration.ts
+++ b/packages/localization/src/sap/ui/core/Configuration.ts
@@ -1,0 +1,22 @@
+import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
+import getDesigntimePropertyAsArray from "@ui5/webcomponents-base/dist/util/getDesigntimePropertyAsArray.js";
+// @ts-ignore
+import TimezoneUtil from "./format/TimezoneUtil.js";
+import FormatSettings from "./FormatSettings.js";
+
+const emptyFn = () => {};
+
+/**
+ * OpenUI5 Configuration Shim
+ */
+const Configuration = {
+	getLanguage,
+	getCalendarType,
+	getSupportedLanguages: () => getDesigntimePropertyAsArray("$core-i18n-locales:,ar,bg,ca,cs,da,de,el,en,es,et,fi,fr,hi,hr,hu,it,iw,ja,ko,lt,lv,nl,no,pl,pt,ro,ru,sh,sk,sl,sv,th,tr,uk,vi,zh_CN,zh_TW$"),
+	getOriginInfo: emptyFn,
+	getFormatSettings: () => FormatSettings,
+	getTimezone: () => TimezoneUtil.getLocalTimezone() as string,
+};
+
+export default Configuration;

--- a/packages/localization/src/sap/ui/core/Core.ts
+++ b/packages/localization/src/sap/ui/core/Core.ts
@@ -1,33 +1,7 @@
-import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
-import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
-import getDesigntimePropertyAsArray from "@ui5/webcomponents-base/dist/util/getDesigntimePropertyAsArray.js";
-import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
-// @ts-ignore
-import TimezoneUtil from "./format/TimezoneUtil.js";
+import FormatSettings from "./FormatSettings.js";
+import Configuration from "./Configuration.js";
 
 const emptyFn = () => {};
-
-/**
- * OpenUI5 FormatSettings shim
- */
-const FormatSettings = {
-	getFormatLocale: getLocale,
-	getLegacyDateFormat: emptyFn,
-	getLegacyDateCalendarCustomizing: emptyFn,
-	getCustomLocaleData: emptyFn,
-};
-
-/**
- * OpenUI5 Configuration Shim
- */
-const Configuration = {
-	getLanguage,
-	getCalendarType,
-	getSupportedLanguages: () => getDesigntimePropertyAsArray("$core-i18n-locales:,ar,bg,ca,cs,da,de,el,en,es,et,fi,fr,hi,hr,hu,it,iw,ja,ko,lt,lv,nl,no,pl,pt,ro,ru,sh,sk,sl,sv,th,tr,uk,vi,zh_CN,zh_TW$"),
-	getOriginInfo: emptyFn,
-	getFormatSettings: () => FormatSettings,
-	getTimezone: () => TimezoneUtil.getLocalTimezone() as string,
-};
 
 /**
  * OpenUI5 Core shim

--- a/packages/localization/src/sap/ui/core/FormatSettings.ts
+++ b/packages/localization/src/sap/ui/core/FormatSettings.ts
@@ -1,0 +1,15 @@
+import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
+
+const emptyFn = () => {};
+
+/**
+ * OpenUI5 FormatSettings shim
+ */
+const FormatSettings = {
+	getFormatLocale: getLocale,
+	getLegacyDateFormat: emptyFn,
+	getLegacyDateCalendarCustomizing: emptyFn,
+	getCustomLocaleData: emptyFn,
+};
+
+export default FormatSettings;

--- a/packages/localization/used-modules.txt
+++ b/packages/localization/used-modules.txt
@@ -17,6 +17,8 @@ sap/ui/core/CalendarType.js
 sap/ui/core/Locale.js
 sap/ui/core/LocaleData.js
 sap/ui/core/date/Buddhist.js
+sap/ui/core/date/CalendarUtils.js
+sap/ui/core/date/CalendarWeekNumbering.js
 sap/ui/core/date/Gregorian.js
 sap/ui/core/date/Islamic.js
 sap/ui/core/date/Japanese.js

--- a/packages/main/src/TimeSelection.js
+++ b/packages/main/src/TimeSelection.js
@@ -236,7 +236,7 @@ class TimeSelection extends UI5Element {
 	}
 
 	get periodsArray() {
-		return this.getFormat().aDayPeriods.map(x => x.toUpperCase());
+		return this.getFormat().aDayPeriodsAbbrev.map(x => x.toUpperCase());
 	}
 
 	get _hoursSliderFocused() {

--- a/packages/tools/lib/copy-list/index.js
+++ b/packages/tools/lib/copy-list/index.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const fileList = process.argv[2];
 const dest = process.argv[3];
-const src = "../../node_modules/@openui5/sap.ui.core/src/";
+const src = "@openui5/sap.ui.core/src/";
 
 const generate = async () => {
 	const filesToCopy = (await fs.readFile(fileList)).toString();
@@ -15,7 +15,7 @@ const generate = async () => {
 	const trimFile = file => file.trim();
 
 	return filesToCopy.split("\n").map(trimFile).filter(shouldCopy).map(async moduleName => {
-		const srcPath = path.join(src, moduleName);
+		const srcPath = require.resolve(path.join(src, moduleName), {paths: [process.cwd()]});
 		const destPath = path.join(dest, moduleName);
 
 		await fs.mkdir(path.dirname(destPath), { recursive: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,11 +480,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openui5/sap.ui.core@1.101.0":
-  version "1.101.0"
-  resolved "https://registry.yarnpkg.com/@openui5/sap.ui.core/-/sap.ui.core-1.101.0.tgz#02a834f1f395df60fdbd64ab78e8d2fa82222dfd"
-  integrity sha512-cwOBvs4ZuOM6h5yo64vqdHSi1DcNDVDqyb9PserwnQILh6c/CfOWxeihv5HyW/c1de9/9GdRKJu3dv/lR9B5BQ==
-
 "@openui5/sap.ui.core@1.109.0":
   version "1.109.0"
   resolved "https://registry.yarnpkg.com/@openui5/sap.ui.core/-/sap.ui.core-1.109.0.tgz#bd4e70eecb1e1a7fbe79942fa42b5958d344f8c2"


### PR DESCRIPTION
- fix build script to take proper location of openui5 for copying files
- add new files coming from upgrade as used modules

TimeSelection.js uses a field from DateFormat that was changed in openui5
https://github.com/SAP/openui5/commit/166f2dc05599e4dd94097e76dad3738832bbd780

previously it was `aDayPeriods`, now the equivalent seems to be `aDayPeriodsAbbrev`