### PR TITLE
chore: make TS dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "husky": "^7.0.4",
     "npm-run-all": "^4.1.3",
     "nps": "^5.10.0",
+    "typescript": "^4.9.4",
     "wsrun": "^5.2.4",
     "yarnhook": "^0.6.0"
   },

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,7 +44,6 @@
     "eslint": "^7.22.0",
     "mkdirp": "^1.0.4",
     "replace-in-file": "^6.3.5",
-    "resolve": "^1.20.0",
-    "typescript": "^4.9.3"
+    "resolve": "^1.20.0"
   }
 }

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -44,11 +44,11 @@
     "@ui5/webcomponents-base": "1.9.1",
     "@ui5/webcomponents-icons": "1.9.1",
     "@ui5/webcomponents-theming": "1.9.1",
-    "@zxing/library": "^0.17.1",
-    "typescript": "^4.9.3"
+    "@zxing/library": "^0.17.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3"
+    "chromedriver": "107.0.3",
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3",
-    "typescript": "^4.9.3"
+    "chromedriver": "107.0.3"
   }
 }

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3",
-    "typescript": "^4.9.3"
+    "chromedriver": "107.0.3"
   }
 }

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -26,11 +26,11 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3"
+    "chromedriver": "107.0.3",
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -26,11 +26,11 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3"
+    "chromedriver": "107.0.3",
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3",
-    "typescript": "^4.9.3"
+    "chromedriver": "107.0.3"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -26,11 +26,11 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3"
+    "chromedriver": "107.0.3",
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3",
-    "typescript": "^4.9.3"
+    "chromedriver": "107.0.3"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -32,10 +32,10 @@
     "@ui5/webcomponents-tools": "1.9.1",
     "chromedriver": "107.0.3",
     "mkdirp": "^1.0.4",
-    "resolve": "^1.20.0"
+    "resolve": "^1.20.0",
+    "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-base": "1.9.1"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -32,8 +32,7 @@
     "@ui5/webcomponents-tools": "1.9.1",
     "chromedriver": "107.0.3",
     "mkdirp": "^1.0.4",
-    "resolve": "^1.20.0",
-    "typescript": "^4.9.3"
+    "resolve": "^1.20.0"
   },
   "dependencies": {
     "@ui5/webcomponents-base": "1.9.1"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -45,11 +45,11 @@
     "@ui5/webcomponents-base": "1.9.1",
     "@ui5/webcomponents-icons": "1.9.1",
     "@ui5/webcomponents-localization": "1.9.1",
-    "@ui5/webcomponents-theming": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-theming": "1.9.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3"
+    "chromedriver": "107.0.3",
+    "typescript": "^4.9.3"
   }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
-    "chromedriver": "107.0.3",
-    "typescript": "^4.9.3"
+    "chromedriver": "107.0.3"
   }
 }

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -40,8 +40,7 @@
     "nps": "^5.10.0",
     "postcss": "^8.4.5",
     "postcss-import": "^14.0.2",
-    "resolve": "^1.20.0",
-    "typescript": "^4.9.3"
+    "resolve": "^1.20.0"
   },
   "resolutions": {}
 }

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.1.44",
-    "@ui5/webcomponents-base": "1.9.1",
-    "typescript": "^4.9.3"
+    "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.9.1",
@@ -41,7 +40,8 @@
     "nps": "^5.10.0",
     "postcss": "^8.4.5",
     "postcss-import": "^14.0.2",
-    "resolve": "^1.20.0"
+    "resolve": "^1.20.0",
+    "typescript": "^4.9.3"
   },
   "resolutions": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7635,10 +7635,10 @@ typescript@^4.4.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-typescript@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Make Typescript a dev dependency of the root and bump typescript from 4.9.3 to 4.9.4
