### PR TITLE
fix(ui5-avatar): visual alignment

### DIFF
--- a/packages/main/src/themes/sap_horizon/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Avatar-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/Avatar-parameters.css";
 
 :root {
-	--ui5-avatar-initials-border: 0.0625rem solid var(--sapAvatar_1_BorderColor);
+	--ui5-avatar-initials-border: none;
 	--ui5-avatar-border-radius: var(--sapElement_BorderCornerRadius);
 	--_ui5_avatar_fontsize_XS: 1rem;
 	--_ui5_avatar_fontsize_S: 1.125rem;

--- a/packages/main/src/themes/sap_horizon_dark/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Avatar-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/Avatar-parameters.css";
 
 :root {
-	--ui5-avatar-initials-border: 0.0625rem solid var(--sapAvatar_1_BorderColor);
+	--ui5-avatar-initials-border: none;
 	--ui5-avatar-border-radius: var(--sapElement_BorderCornerRadius);
 	--_ui5_avatar_fontsize_XS: 1rem;
 	--_ui5_avatar_fontsize_S: 1.125rem;


### PR DESCRIPTION
Avatar should have border only on High Contrast White and Black, so it is removed in other Horizon themes.

Fixes: #5860
