### PR TITLE
fix(ui5-input): fix typo in renderer

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -40,7 +40,7 @@
 		/>
 
 		{{#if effectiveShowClearIcon}}
-			<div @click={{_clear}} @mousedown={{_iconMouseDown}} class="ui5-input-clear-icon-wrapper" input-icon tabindex="-1>
+			<div @click={{_clear}} @mousedown={{_iconMouseDown}} class="ui5-input-clear-icon-wrapper" input-icon tabindex="-1">
 				<ui5-icon tabindex="-1" class="ui5-input-clear-icon" name="decline"></ui5-icon>
 			</div>
 		{{/if}}


### PR DESCRIPTION
There is a typo in input's renderer introduced with #5908 