### PR TITLE
fix(ui5-calendar): adjust displayed width

### DIFF
--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -1,7 +1,7 @@
 :root {
 	/* Calendar */
 	--_ui5_calendar_height: 24.5rem;
-	--_ui5_calendar_width: 20.5rem;
+	--_ui5_calendar_width: 20rem;
 	--_ui5_calendar_padding: 1rem;
 	--_ui5_calendar_left_right_padding:  0.5rem;
 	--_ui5_calendar_top_bottom_padding: 1rem;


### PR DESCRIPTION
- Component's width is now 20rem as per visual specification. This would result in not displaying a horizontal scrollbar on 320px screen size.

Fixes: #5641
