### PR TITLE
refactor(ui5-illustrated-message): deprecate the title slot

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -982,8 +982,8 @@ abstract class UI5Element extends HTMLElement {
 		if (slotsAreManaged) {
 			const slots = this.getMetadata().getSlots();
 			for (const [slotName, slotData] of Object.entries(slots)) { // eslint-disable-line
-				if (!isValidPropertyName(slotName)) {
-					console.warn(`"${slotName}" is not a valid property name. Use a name that does not collide with DOM APIs`); /* eslint-disable-line */
+				if (!isValidPropertyName(slotName, true)) {
+					console.warn(`"${slotName}" is not a valid property name for a slot. Use a name that does not collide with DOM APIs`); /* eslint-disable-line */
 				}
 
 				const propertyName = slotData.propertyName || slotName;

--- a/packages/fiori/src/IllustratedMessage.hbs
+++ b/packages/fiori/src/IllustratedMessage.hbs
@@ -4,7 +4,7 @@
 	</div>
 	{{#if hasTitle}}
 			{{#if hasFormattedTitle}}
-				<slot name="title"></slot>
+				<slot name="titleContent"></slot><slot name="title"></slot>
 			{{else}}
 				<ui5-title level="H2" class="ui5-illustrated-message-title" wrapping-type="Normal">{{effectiveTitleText}}</ui5-title>
 			{{/if}}
@@ -13,7 +13,7 @@
 	{{#if hasSubtitle}}
 		<div class="ui5-illustrated-message-subtitle">
 			{{#if hasFormattedSubtitle}}
-				<slot name="subtitle"></slot>
+				<slot name="subtitleContent"></slot><slot name="subtitle"></slot>
 			{{else}}
 				{{effectiveSubitleText}}
 			{{/if}}

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -286,7 +286,7 @@ class IllustratedMessage extends UI5Element {
 	media!: string;
 
 	/**
-	* Defines the title of the component.
+	* Defines the title of the component. <b>Note:</b> Deprecated in favor of <code>titleContent</code>
 	* <br><br>
 	* <b>Note:</b> Using this slot, the default title text of illustration and the value of <code>title</code> property will be overwritten.
 	* @type {HTMLElement}
@@ -294,22 +294,50 @@ class IllustratedMessage extends UI5Element {
 	* @name sap.ui.webc.fiori.IllustratedMessage.prototype.title
 	* @public
 	* @since 1.7.0
+	* @deprecated
 	*/
 	@slot({ type: HTMLElement })
 	title!: Array<HTMLElement> & string; // Note: since title collides with HTMLElement's title attribute and it's a String, we're adding the "& string" to the type Array<HTMLElement> to avoid ts complains. In the future we will rename/deprecate this slot name, so that it doesn't collide with HTMLElement's title attribute.
 
 	/**
-	* Defines the subtitle of the component.
+	 * Defines the title of the component.
+	 * <br><br>
+	 * <b>Note:</b> Using this slot, the default title text of illustration and the value of <code>title</code> property will be overwritten.
+	 * @type {HTMLElement}
+	 * @slot title
+	 * @name sap.ui.webc.fiori.IllustratedMessage.prototype.titleContent
+	 * @public
+	 * @since 1.10
+	 */
+	@slot({ type: HTMLElement })
+	titleContent!: Array<HTMLElement>;
+
+	/**
+	* Defines the subtitle of the component. <b>Note:</b> Deprecated in favor of <code>subtitleContent</code>
 	* <br><br>
 	* <b>Note:</b> Using this slot, the default subtitle text of illustration and the value of <code>subtitleText</code> property will be overwritten.
 	* @type {HTMLElement}
 	* @slot subtitle
 	* @name sap.ui.webc.fiori.IllustratedMessage.prototype.subtitle
 	* @public
+	* @deprecated
 	* @since 1.0.0-rc.16
 	*/
 	@slot({ type: HTMLElement })
 	subtitle!: Array<HTMLElement>;
+
+	/**
+	 * Defines the subtitle of the component.
+	 * <br><br>
+	 * <b>Note:</b> Using this slot, the default subtitle text of illustration and the value of <code>subtitleText</code> property will be overwritten.
+	 * @type {HTMLElement}
+	 * @slot subtitle
+	 * @name sap.ui.webc.fiori.IllustratedMessage.prototype.subtitleContent
+	 * @public
+	 * @since 1.10
+	 */
+	@slot({ type: HTMLElement })
+	subtitleContent!: Array<HTMLElement>;
 
 	/**
 	* Defines the component actions.
@@ -489,12 +517,20 @@ class IllustratedMessage extends UI5Element {
 		}
 	}
 
+	get _effectiveTitle() {
+		return this.titleContent || this.title;
+	}
+
+	get _effectiveSubtitle() {
+		return this.subtitleContent || this.subtitle;
+	}
+
 	get hasFormattedSubtitle(): boolean {
-		return !!this.subtitle.length;
+		return !!this._effectiveSubtitle.length;
 	}
 
 	get hasFormattedTitle(): boolean {
-		return !!this.title.length;
+		return !!this._effectiveTitle.length;
 	}
 
 	get effectiveTitleText(): string | undefined {

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -130,12 +130,12 @@
 	</ui5-dialog>
 
 	<ui5-illustrated-message id="illustratedMsg2" name="UnableToUpload" title="Something went wrong..." accessible-name-ref="lbl">
-		<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link> <br><label id="lbl">Text from aria-labelledby</label></div>
+		<div slot="subtitleContent">Please try again or contact us at <ui5-link>example@example.com</ui5-link> <br><label id="lbl">Text from aria-labelledby</label></div>
 		<ui5-button icon="refresh">Try again</ui5-button>
 	</ui5-illustrated-message>
 
 	<ui5-illustrated-message id="illustratedMsg3" name="UnableToUpload">
-		<ui5-title slot="title" level="H1">This is a slotted title</ui5-title>
+		<ui5-title slot="titleContent" level="H1">This is a slotted title</ui5-title>
 	</ui5-illustrated-message>
 
 	<script>

--- a/packages/fiori/test/samples/IllustratedMessage.sample.html
+++ b/packages/fiori/test/samples/IllustratedMessage.sample.html
@@ -67,16 +67,16 @@
 <section>
 	<h3>Illustrated message with custom title and link in subtitle</h3>
 	<div class="snippet">
-		<ui5-illustrated-message name="UnableToUpload"">
-			<ui5-title slot="title" level="H1">Something went wrong</ui5-title>
-			<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
+		<ui5-illustrated-message name="UnableToUpload">
+			<ui5-title slot="titleContent" level="H1">Something went wrong</ui5-title>
+			<div slot="subtitleContent">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
 			<ui5-button icon="refresh">Try again</ui5-button>
 		</ui5-illustrated-message>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-illustrated-message name="UnableToUpload"">
-	<ui5-title slot="title" level="H1">Something went wrong</ui5-title>
-	<div slot="subtitle">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
+<ui5-illustrated-message name="UnableToUpload">
+	<ui5-title slot="titleContent" level="H1">Something went wrong</ui5-title>
+	<div slot="subtitleContent">Please try again or contact us at <ui5-link>example@example.com</ui5-link></div>
 	<ui5-button icon="refresh">Try again</ui5-button>
 </ui5-illustrated-message>
 	</xmp></pre>


### PR DESCRIPTION
Currently the `IllustratedMessage` component has:
 - `title` slot and `titleText` property
 - `subtitle` slot and `subtitleText` property

However, we didn't take into account the fact that `title` already exists as a Global HTML attribute of type `String` for any HTML Element. And while we override `title` in multiple other components, it's always used as a property accessor, which is fine, as it is still of type `String`. In this particular component, however, we use `title` as a slot accessor, which is of type `Array<HTMLElement>`, which is incompatible with `String`. 

To correct this, both `title` and `subtitle` are deprecated as slot names (only `title` is problematic, but `subtitle` has also been changed for consistency).

Here is the new API:
 - `titleContent` slot and `titleText` property
 - `subtitleContent` slot and `subtitleText` property

The old slot names will be marked as deprecated, but will continue to work until version `2.0`, when they will be deleted.

Note: to support this change, the framework's `isValidPropertyName` function now differentiates between property and slot accessors - the rules for slots are stricter and require no overlap with native HTML names at all, while for property accessors we still allow some names to be overridden.