### PR TITLE
fix(ui5-select): change roledescription to Listbox

### DIFF
--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -134,7 +134,7 @@ FILEUPLOADER_TITLE=Upload File
 GROUP_HEADER_TEXT=Group Header
 
 #XACT: ARIA announcement for the Select`s roledescription attribute
-SELECT_ROLE_DESCRIPTION=Select Combo Box
+SELECT_ROLE_DESCRIPTION=Listbox
 
 #XTXT: MultiComboBox and ComboBox icon accessible name
 SELECT_OPTIONS=Select Options

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -417,7 +417,7 @@ describe("Select general interaction", () => {
 		const select2 = await browser.$("#textAreaAriaLabelledBy").shadow$(".ui5-select-label-root");
 		const EXPECTED_ARIA_LABEL1 = "Hello World";
 		const EXPECTED_ARIA_LABEL2 = "info text";
-		const EXPECTER_ARIA_ROLEDESCRIPTION = "Select Combo Box";
+		const EXPECTER_ARIA_ROLEDESCRIPTION = "Listbox";
 
 		assert.strictEqual(await select1.getAttribute("aria-label"), EXPECTED_ARIA_LABEL1,
 			"The aria-label is correctly set internally.");


### PR DESCRIPTION
Based on feedback and consultation with the accessibility team, the term "combobox" used for the select's `aria-roledescription` means that there may be multiple ways to change the selected value. The term "Listbox" is the more appropriate one for the ui5-select. 

Related to #2910