### PR TITLE
refactor(ui5-progress-indicator): migrate to TS

### DIFF
--- a/packages/main/src/ProgressIndicator.ts
+++ b/packages/main/src/ProgressIndicator.ts
@@ -1,104 +1,27 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
-import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import I18nBundle, { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Icon from "./Icon.js";
-import ProgressIndicatorTemplate from "./generated/templates/ProgressIndicatorTemplate.lit.js";
 import {
 	VALUE_STATE_ERROR,
 	VALUE_STATE_WARNING,
 	VALUE_STATE_SUCCESS,
 	VALUE_STATE_INFORMATION,
+// @ts-ignore
 } from "./generated/i18n/i18n-defaults.js";
+
+// Template
+import ProgressIndicatorTemplate from "./generated/templates/ProgressIndicatorTemplate.lit.js";
 
 // Styles
 import ProgressIndicatorCss from "./generated/themes/ProgressIndicator.css.js";
-
-/**
- * @public
- */
-const metadata = {
-	tag: "ui5-progress-indicator",
-	properties: /** @lends sap.ui.webc.main.ProgressIndicator.prototype */ {
-		/**
-		 * Defines whether component is in disabled state.
-		 *
-		 * @type {boolean}
-		 * @defaultvalue false
-		 * @public
-		 */
-		disabled: {
-			type: Boolean,
-		},
-		/**
-		 * Defines whether the component value is shown.
-		 *
-		 * @type {boolean}
-		 * @defaultvalue false
-		 * @public
-		 */
-		hideValue: {
-			type: Boolean,
-		},
-		/**
-		 * Specifies the numerical value in percent for the length of the component.
-		 *
-		 * <b>Note:</b>
-		 * If a value greater than 100 is provided, the percentValue is set to 100. In other cases of invalid value, percentValue is set to its default of 0.
-		 * @type {sap.ui.webc.base.types.Integer}
-		 * @defaultvalue 0
-		 * @public
-		 */
-		value: {
-			type: Integer,
-			defaultValue: 0,
-		},
-		/**
-		 * Specifies the text value to be displayed in the bar.
-		 *
-		 * <b>Note:</b>
-		 * <ul>
-		 * <li>If there is no value provided or the value is empty, the default percentage value is shown.</li>
-		 * <li>If <code>hideValue</code> property is <code>true</code> both the <code>displayValue</code> and <code>value</code> property values are not shown.</li>
-		 * </ul>
-		 *
-		 * @type {string}
-		 * @public
-		 */
-		displayValue: {
-			type: String,
-		},
-		/**
-		 * Defines the value state of the component.
-		 * <br><br>
-		 * Available options are:
-		 * <ul>
-		 * <li><code>None</code></li>
-		 * <li><code>Error</code></li>
-		 * <li><code>Warning</code></li>
-		 * <li><code>Success</code></li>
-		 * <li><code>Information</code></li>
-		 * </ul>
-		 *
-		 * @type {sap.ui.webc.base.types.ValueState}
-		 * @defaultvalue "None"
-		 * @public
-		 */
-		valueState: {
-			type: ValueState,
-			defaultValue: ValueState.None,
-		},
-	},
-	slots: /** @lends sap.ui.webc.main.ProgressIndicator.prototype */ {
-		//
-	},
-	events: /** @lends sap.ui.webc.main.ProgressIndicator.prototype */ {
-		//
-	},
-};
 
 /**
  * @class
@@ -122,10 +45,82 @@ const metadata = {
  * @public
  * @since 1.0.0-rc.8
  */
+@customElement("ui5-progress-indicator")
 class ProgressIndicator extends UI5Element {
-	static get metadata() {
-		return metadata;
-	}
+	/**
+	 * Defines whether component is in disabled state.
+	 *
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.ProgressIndicator.prototype.disabled
+	 * @defaultvalue false
+	 * @public
+	 */
+	@property({ type: Boolean })
+	disabled!: boolean;
+
+	/**
+	 * Defines whether the component value is shown.
+	 *
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.ProgressIndicator.prototype.hideValue
+	 * @defaultvalue false
+	 * @public
+	 */
+	@property({ type: Boolean })
+	hideValue!: boolean;
+
+	/**
+	 * Specifies the numerical value in percent for the length of the component.
+	 *
+	 * <b>Note:</b>
+	 * If a value greater than 100 is provided, the percentValue is set to 100. In other cases of invalid value, percentValue is set to its default of 0.
+	 * @type {sap.ui.webc.base.types.Integer}
+	 * @name sap.ui.webc.main.ProgressIndicator.prototype.value
+	 * @defaultvalue 0
+	 * @public
+	 */
+	@property({ validator: Integer, defaultValue: 0 })
+	value!: number;
+
+	/**
+	 * Specifies the text value to be displayed in the bar.
+	 *
+	 * <b>Note:</b>
+	 * <ul>
+	 * <li>If there is no value provided or the value is empty, the default percentage value is shown.</li>
+	 * <li>If <code>hideValue</code> property is <code>true</code> both the <code>displayValue</code> and <code>value</code> property values are not shown.</li>
+	 * </ul>
+	 *
+	 * @type {string}
+	 * @name sap.ui.webc.main.ProgressIndicator.prototype.displayValue
+	 * @public
+	 */
+	@property()
+	displayValue!: string;
+
+	/**
+	 * Defines the value state of the component.
+	 * <br><br>
+	 * Available options are:
+	 * <ul>
+	 * <li><code>None</code></li>
+	 * <li><code>Error</code></li>
+	 * <li><code>Warning</code></li>
+	 * <li><code>Success</code></li>
+	 * <li><code>Information</code></li>
+	 * </ul>
+	 *
+	 * @type {sap.ui.webc.base.types.ValueState}
+	 * @name sap.ui.webc.main.ProgressIndicator.prototype.valueState
+	 * @defaultvalue "None"
+	 * @public
+	 */
+	@property({ type: ValueState, defaultValue: ValueState.None })
+	valueState!: ValueState;
+
+	static i18nBundle: I18nBundle;
+	_previousValue: number;
+	_transitionDuration: number;
 
 	static get render() {
 		return litRender;
@@ -155,16 +150,16 @@ class ProgressIndicator extends UI5Element {
 		this._previousValue = this.validatedValue;
 	}
 
-	valueStateTextMappings() {
+	valueStateTextMappings(): Record<string, string> {
 		return {
-			"Error": ProgressIndicator.i18nBundle.getText(VALUE_STATE_ERROR),
-			"Warning": ProgressIndicator.i18nBundle.getText(VALUE_STATE_WARNING),
-			"Success": ProgressIndicator.i18nBundle.getText(VALUE_STATE_SUCCESS),
-			"Information": ProgressIndicator.i18nBundle.getText(VALUE_STATE_INFORMATION),
+			"Error": ProgressIndicator.i18nBundle.getText(VALUE_STATE_ERROR as I18nText),
+			"Warning": ProgressIndicator.i18nBundle.getText(VALUE_STATE_WARNING as I18nText),
+			"Success": ProgressIndicator.i18nBundle.getText(VALUE_STATE_SUCCESS as I18nText),
+			"Information": ProgressIndicator.i18nBundle.getText(VALUE_STATE_INFORMATION as I18nText),
 		};
 	}
 
-	valueStateIconMappings() {
+	valueStateIconMappings(): Record<string, string> {
 		return {
 			"Error": "status-negative",
 			"Warning": "status-critical",

--- a/packages/main/src/ProgressIndicator.ts
+++ b/packages/main/src/ProgressIndicator.ts
@@ -6,7 +6,8 @@ import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
-import I18nBundle, { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Icon from "./Icon.js";
 import {


### PR DESCRIPTION
The **ProgressIndicator** component have been migrated to Typescript as part of the TS migration initiative.
**Note:** The `@name sap.ui.webc.main.ProgressIndicator.prototype.{propertyName}` added to all properties

Related to: https://github.com/SAP/ui5-webcomponents/issues/6080