### PR TITLE
fix(ui5-select): correct typo in --_ui5_select_label_color

### DIFF
--- a/packages/main/src/themes/Select.css
+++ b/packages/main/src/themes/Select.css
@@ -22,7 +22,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	color: var(--_ui5_select_label_olor);
+	color: var(--_ui5_select_label_color);
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;

--- a/packages/main/src/themes/base/Select-parameters.css
+++ b/packages/main/src/themes/base/Select-parameters.css
@@ -5,5 +5,5 @@
 	--_ui5_select_state_error_warning_border_width: 0.125rem;
 	--_ui5_select_hover_icon_left_border: 1px solid transparent;
 	--_ui5_select_focus_width: 1px;
-	--_ui5_select_label_olor: var(--sapField_TextColor);
+	--_ui5_select_label_color: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/sap_horizon_exp/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/Select-parameters.css
@@ -1,5 +1,5 @@
 @import "../base/Select-parameters.css";
 
 :root {
-	--_ui5_select_label_olor: var(--sapTitleColor); /* #223548; */
+	--_ui5_select_label_color: var(--sapTitleColor); /* #223548; */
 }


### PR DESCRIPTION
There is a little typo in the css-variable `--_ui5_select_label_color`. 

Changed it from `--_ui5_select_label_olor` -> `--_ui5_select_label_color` with this PR 

