### PR TITLE
fix: peerDependencies instead of dependencies

### DIFF
--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -39,11 +39,13 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/fiori"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents": "1.9.1",
     "@ui5/webcomponents-base": "1.9.1",
     "@ui5/webcomponents-icons": "1.9.1",
-    "@ui5/webcomponents-theming": "1.9.1",
+    "@ui5/webcomponents-theming": "1.9.1"
+  },
+  "dependencies": {
     "@zxing/library": "^0.17.1"
   },
   "devDependencies": {

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/icons-business-suite"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/icons-tnt"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/icons"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents-base": "1.9.1"
   },
   "devDependencies": {

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -34,7 +34,7 @@
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents-base": "1.9.1"
   }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/main"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@ui5/webcomponents-base": "1.9.1",
     "@ui5/webcomponents-icons": "1.9.1",
     "@ui5/webcomponents-localization": "1.9.1",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/SAP/ui5-webcomponents.git",
     "directory": "packages/theming"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@sap-theming/theming-base-content": "11.1.48",
     "@ui5/webcomponents-base": "1.9.1"
   },


### PR DESCRIPTION
## Referenced issues

None.

## Description

There was an issue when you had different versions of base package and others which are dependent on it, so the sharing wasn't working (for example icon registries). The root of the issue was that package managers were creating nested node_modules for the packages because base was dep, not peerDep.

![CleanShot 2022-12-23 at 16 15 47@2x](https://user-images.githubusercontent.com/20265336/209358699-88c82116-4b42-4c10-ace2-be61e83dd288.png)


## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [X] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
    + Bugfixes should generally include a test to cover the issue.
