### PR TITLE
feat(ui5-range-slider): implement shadow parts

### DIFF
--- a/packages/main/src/RangeSlider.hbs
+++ b/packages/main/src/RangeSlider.hbs
@@ -6,7 +6,7 @@
 {{/inline}}
 
 {{#*inline "progressBar"}}
-	<div class="ui5-slider-progress-container">
+	<div class="ui5-slider-progress-container" part="progress-container">
 		<div class="ui5-slider-progress"
 			style="{{styles.progress}}"
 			@focusin="{{_onfocusin}}"
@@ -19,6 +19,7 @@
 			aria-valuetext="From {{startValue}} to {{endValue}}"
 			aria-labelledby="{{_ariaLabelledByProgressBarRefs}}"
 			aria-disabled="{{_ariaDisabled}}"
+			part="progress-bar"
 		></div>
 	</div>
 {{/inline}}
@@ -36,6 +37,7 @@
 		aria-valuenow="{{startValue}}"
 		aria-labelledby="{{_ariaLabelledByStartHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
+		part="handle-start"
 	>
 		<ui5-icon name="direction-arrows" slider-icon></ui5-icon>
 
@@ -58,6 +60,7 @@
 		aria-valuenow="{{endValue}}"
 		aria-labelledby="{{_ariaLabelledByEndHandleRefs}}"
 		aria-disabled="{{_ariaDisabled}}"
+		part="handle-end"
 	>
 		<ui5-icon name="direction-arrows" slider-icon></ui5-icon>
 


### PR DESCRIPTION
Currently, `ui5-slider` has the following shadow parts:
 - `progress-container`
 - `progress-bar`
 - `handle`

Similarly, for `ui5-range-slider` the following have been added:
 - `progress-container`
 - `progress-bar`
 - `handle-start`
 - `handle-end`

closes: https://github.com/SAP/ui5-webcomponents/issues/6125