### PR TITLE
fix(ui5-textarea): adjust styles according to the visual specification

### DIFF
--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -412,7 +412,7 @@
 	display: none;
 }
 
-:host:not([disabled]) :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {
+:host(:not([disabled])) :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {
 	background: var(--sapField_BackgroundStyle);
 	background-color: var(--sapScrollBar_TrackColor);
 	border-top-right-radius: var(--sapField_BorderCornerRadius);

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -19,7 +19,7 @@
 	margin: var(--_ui5_textarea_margin);
 }
 
-:host(:not([value-state]):not([readonly]):not([focused])) .ui5-textarea-wrapper, :host([value-state][disabled]) .ui5-textarea-wrapper {
+:host(:not([value-state]):not([readonly]):not([disabled]):not([focused])) .ui5-textarea-wrapper {
 	background: var(--sapField_BackgroundStyle);
 	background-color: var(--sapField_Background);
 }
@@ -92,6 +92,13 @@
 	right: var(--_ui5_textarea_focus_offset);
 }
 
+:host([focused][readonly]) .ui5-textarea-wrapper::after {
+	top: var(--_ui5_textarea_readonly_focus_offset);
+	bottom: var(--_ui5_textarea_readonly_focus_offset);
+	left: var(--_ui5_textarea_readonly_focus_offset);
+	right: var(--_ui5_textarea_readonly_focus_offset);
+}
+
 :host([focused][value-state="Error"]:not([disabled])) .ui5-textarea-wrapper::after,
 :host([focused][value-state="Warning"]:not([disabled])) .ui5-textarea-wrapper::after,
 :host([focused][value-state="Information"]:not([disabled])) .ui5-textarea-wrapper::after {
@@ -106,10 +113,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	margin: 0;
-	padding-top: var(--_ui5_textarea_padding_top);
-	padding-bottom: var(--_ui5_textarea_padding_bottom);
-	padding-left: var(--_ui5_textarea_padding_left);
-	padding-right: var(--_ui5_textarea_padding_right);
+	padding: var(--_ui5_textarea_padding_top) var(--_ui5_textarea_padding_right_and_left) var(--_ui5_textarea_padding_bottom);
 	color: inherit;
 	font-size: inherit;
 	font-family: inherit;
@@ -224,14 +228,14 @@
 	border-color: var(--sapField_ReadOnly_BorderColor);
 }
 
-:host([readonly][focused]) .ui5-textarea-root .ui5-textarea-wrapper {
-	background-image: none;
+:host([readonly]) .ui5-textarea-inner {
+	padding: var(--_ui5_textarea_padding_top_readonly) var(--_ui5_textarea_padding_right_and_left_readonly) var(--_ui5_textarea_padding_bottom_readonly);
 }
 
 :host([readonly]) .ui5-textarea-root .ui5-textarea-wrapper {
-	background: var(--sapField_ReadOnly_BackgroundStyle);
 	background-color: var(--sapField_ReadOnly_Background);
 	border-color: var(--sapField_ReadOnly_BorderColor);
+	border-style: var(--_ui5_textarea_readonly_border_style);
 }
 
 :host([show-exceeded-text]) .ui5-textarea-root {
@@ -310,13 +314,8 @@
 :host([value-state="Warning"]:not([readonly]):not([disabled])) .ui5-textarea-inner {
 	font-style: var(--_ui5_textarea_error_warning_font_style);
 	font-weight: var(--_ui5_textarea_error_warning_font_weight);
-	padding-top: var(--_ui5_textarea_padding_top_error_warning);
+	padding: var(--_ui5_textarea_padding_top_error_warning) var(--_ui5_textarea_padding_right_and_left_error_warning) var(--_ui5_textarea_padding_bottom_error_warning);
 }
-
-:host([value-state="Error"]:not([disabled]):not([readonly])) .ui5-textarea-inner,
-:host([value-state="Warning"]:not([disabled]):not([readonly])) .ui5-textarea-inner {
-	padding-bottom: var(--_ui5_textarea_padding_bottom_error_warning);
-}	
 
 :host([value-state="Error"]:not([readonly]):not([disabled])) .ui5-textarea-wrapper,
 :host([value-state="Warning"]:not([readonly]):not([disabled])) .ui5-textarea-wrapper {
@@ -377,8 +376,7 @@
 }
 
 :host([value-state="Information"]:not([readonly]):not([disabled])) .ui5-textarea-inner {
-	padding-top: var(--_ui5_textarea_padding_top_information);
-	padding-bottom: var(--_ui5_textarea_padding_bottom_information);
+	padding: var(--_ui5_textarea_padding_top_information) var(--_ui5_textarea_padding_right_and_left_information) var(--_ui5_textarea_padding_bottom_information);
 }
 
 :host([value-state="Information"]:not([readonly]):not([disabled])) .ui5-textarea-wrapper {
@@ -414,16 +412,11 @@
 	display: none;
 }
 
-:host :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {
+:host:not([disabled]) :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {
 	background: var(--sapField_BackgroundStyle);
 	background-color: var(--sapScrollBar_TrackColor);
 	border-top-right-radius: var(--sapField_BorderCornerRadius);
 	border-bottom-right-radius: var(--sapField_BorderCornerRadius);
-}
-
-:host([readonly]) :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {
-	background: var(--sapField_ReadOnly_BackgroundStyle);
-	background-color: var(--sapScrollBar_TrackColor);
 }
 
 :host([value-state="Error"]) :not(.ui5-content-native-scrollbars) ::-webkit-scrollbar {

--- a/packages/main/src/themes/base/TextArea-parameters.css
+++ b/packages/main/src/themes/base/TextArea-parameters.css
@@ -20,20 +20,38 @@
 	--_ui5_textarea_focused_value_state_warning_focus_outline_color: var(--sapContent_FocusColor);
 	--_ui5_textarea_focused_value_state_success_focus_outline_color: var(--sapContent_FocusColor);
 	--_ui5_textarea_focus_offset: 1px;
+	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_value_state_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapContent_FocusColor);
 	--__ui5_textarea_min_height: 2.25rem;
+	--_ui5_textarea_padding_right_and_left: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.5625rem;
+	--_ui5_textarea_padding_top: 0.4375rem;
+	--_ui5_textarea_padding_bottom: 0.4375rem;
+	--_ui5_textarea_padding_top_readonly: 0.4375rem;
+	--_ui5_textarea_padding_bottom_readonly:0.4375rem;
 	--_ui5_textarea_padding_top_error_warning: 0.375rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.375rem;
 	--_ui5_textarea_padding_top_information: 0.375rem;
 	--_ui5_textarea_padding_bottom_information: 0.375rem;
 	--_ui5_textarea_margin: 0.25rem 0;
 	--_ui5_textarea_exceeded_text_height: 1rem;
+	--_ui5_textarea_readonly_border_style: var(--sapField_BorderStyle);
 }
 
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	--_ui5_textarea_padding_right_and_left: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.4375rem;
+	--_ui5_textarea_padding_top: 0.125rem;
+	--_ui5_textarea_padding_bottom: 0.125rem;
+	--_ui5_textarea_padding_top_readonly: 0.125rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.125rem;
 	--_ui5_textarea_padding_top_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_top_information: 0.0625rem;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -119,10 +119,6 @@
 	--_ui5_tc_item_add_text_margin_top: 0.375rem;
 
 	/* TextArea */
-	--_ui5_textarea_padding_top: 0.4375rem;
-	--_ui5_textarea_padding_bottom:0.4375rem;
-	--_ui5_textarea_padding_left: 0.625rem;
-	--_ui5_textarea_padding_right: 0.625rem;
 	--_ui5_textarea_margin: .25rem 0;
 
 	/* Panel */
@@ -291,10 +287,6 @@
 	--_ui5_token_wrapper_right_padding: 0.25rem;
 	--_ui5_token_wrapper_left_padding: 0;
 	--_ui5_token_outline_offset: -0.125rem;
-	--_ui5_textarea_padding_top: 0.125rem;
-	--_ui5_textarea_padding_bottom: 0.125rem;
-	--_ui5_textarea_padding_left: 0.5rem;
-	--_ui5_textarea_padding_right: 0.5rem;
 
 	--_ui5_tl_bubble_padding: .5rem;
 	--_ui5_tl_indicator_before_bottom: -.5rem;

--- a/packages/main/src/themes/sap_belize/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize/TextArea-parameters.css
@@ -2,10 +2,18 @@
 
 :root {
 	--__ui5_textarea_min_height: 2.5rem;
+	--_ui5_textarea_padding_top: 0.5625rem;
+	--_ui5_textarea_padding_bottom:0.5625rem;
+	--_ui5_textarea_padding_top_readonly: 0.5625rem;
+	--_ui5_textarea_padding_bottom_readonly:0.5625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.5rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.5rem;
 	--_ui5_textarea_padding_top_information: 0.5rem;
 	--_ui5_textarea_padding_bottom_information: 0.5rem;
+	--_ui5_textarea_padding_right_and_left: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.6875rem;
 }
 
 [data-ui5-compact-size],

--- a/packages/main/src/themes/sap_belize_hcb/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/TextArea-parameters.css
@@ -15,10 +15,16 @@
 	--_ui5_textarea_error_placeholder_color: var(--sapField_TextColor);
 	--_ui5_textarea_padding_top: 0.5625rem;
 	--_ui5_textarea_padding_bottom: 0.5625rem;
+	--_ui5_textarea_padding_top_readonly: 0.5625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.5625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.5625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.5625rem;
 	--_ui5_textarea_padding_top_information: 0.5625rem;
 	--_ui5_textarea_padding_bottom_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.6875rem;
 }
 
 [data-ui5-compact-size],
@@ -28,4 +34,6 @@
 	--_ui5_textarea_padding_bottom_error_warning: 0.125rem;
 	--_ui5_textarea_padding_top_information: 0.125rem;
 	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_belize_hcw/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/TextArea-parameters.css
@@ -15,10 +15,16 @@
 	--_ui5_textarea_error_placeholder_color: var(--sapField_TextColor);
 	--_ui5_textarea_padding_top: 0.5625rem;
 	--_ui5_textarea_padding_bottom: 0.5625rem;
+	--_ui5_textarea_padding_top_readonly: 0.5625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.5625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.5625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.5625rem;
 	--_ui5_textarea_padding_top_information: 0.5625rem;
 	--_ui5_textarea_padding_bottom_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.6875rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.6875rem;
 }
 
 [data-ui5-compact-size],
@@ -28,4 +34,6 @@
 	--_ui5_textarea_padding_bottom_error_warning: 0.125rem;
 	--_ui5_textarea_padding_top_information: 0.125rem;
 	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/TextArea-parameters.css
@@ -8,12 +8,17 @@
 	--_ui5_textarea_error_warning_font_weight: bold;
 	--_ui5_textarea_error_warning_font_style: italic;
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
-	--_ui5_textarea_information_border_width: var(--sapField_BorderWidth);
+	--_ui5_textarea_information_border_width: var(--sapField_InformationBorderWidth);
 	--_ui5_textarea_error_warning_border_style: dashed;
 	--_ui5_textarea_padding_top_information: 0.4375rem;
 	--_ui5_textarea_padding_bottom_information: 0.4375rem;
 	--_ui5_textarea_padding_top: 0.375rem;
 	--_ui5_textarea_padding_bottom: 0.375rem;
+	--_ui5_textarea_padding_top_readonly: 0.375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.375rem;
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.5rem;
 }
 
 [data-ui5-compact-size],
@@ -21,8 +26,13 @@
 .sapUiSizeCompact {
 	--_ui5_textarea_padding_top: 0.0625rem;
 	--_ui5_textarea_padding_bottom: 0.0625rem;
+	--_ui5_textarea_padding_top_readonly: 0.0625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.0625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.0625rem;
-	--_ui5_textarea_padding_top_information: 0.0625rem;
-	--_ui5_textarea_padding_bottom_information: 0.0625rem;
+	--_ui5_textarea_padding_top_information: 0.125rem;
+	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.375rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/TextArea-parameters.css
@@ -8,12 +8,17 @@
 	--_ui5_textarea_error_warning_font_weight: bold;
 	--_ui5_textarea_error_warning_font_style: italic;
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
-	--_ui5_textarea_information_border_width: var(--sapField_BorderWidth);
+	--_ui5_textarea_information_border_width: var(--sapField_InformationBorderWidth);
 	--_ui5_textarea_error_warning_border_style: dashed;
 	--_ui5_textarea_padding_top_information: 0.4375rem;
 	--_ui5_textarea_padding_bottom_information: 0.4375rem;
 	--_ui5_textarea_padding_top: 0.375rem;
 	--_ui5_textarea_padding_bottom: 0.375rem;
+	--_ui5_textarea_padding_top_readonly: 0.375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.375rem;
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.5rem;
 }
 
 [data-ui5-compact-size],
@@ -21,8 +26,13 @@
 .sapUiSizeCompact {
 	--_ui5_textarea_padding_top: 0.0625rem;
 	--_ui5_textarea_padding_bottom: 0.0625rem;
+	--_ui5_textarea_padding_top_readonly: 0.0625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.0625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.0625rem;
-	--_ui5_textarea_padding_top_information: 0.0625rem;
-	--_ui5_textarea_padding_bottom_information: 0.0625rem;
+	--_ui5_textarea_padding_top_information: 0.125rem;
+	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.375rem;
 }

--- a/packages/main/src/themes/sap_horizon/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon/TextArea-parameters.css
@@ -18,19 +18,33 @@
 	--_ui5_textarea_focused_value_state_warning_focus_outline_color: var(--sapField_WarningColor);
 	--_ui5_textarea_focused_value_state_success_focus_outline_color: var(--sapField_SuccessColor);
 	--_ui5_textarea_focus_offset: 0;
+	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapField_Active_BorderColor);
 	--_ui5_textarea_value_state_focus_offset: 0;
+	--_ui5_textarea_padding_top: 0.5rem;
+	--_ui5_textarea_padding_bottom: 0.4375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.375rem;
 	--_ui5_textarea_padding_top_error_warning: 0.5rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.4375rem;
 	--_ui5_textarea_padding_top_information: 0.5rem;
 	--_ui5_textarea_padding_bottom_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.625rem;
+	--_ui5_textarea_readonly_border_style: dashed;
 }
 
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	--_ui5_textarea_padding_top: 0.1875rem;
+	--_ui5_textarea_padding_bottom: 0.125rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.0625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.1875rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.125rem;
 	--_ui5_textarea_padding_top_information: 0.1875rem;
 	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5rem;
 }

--- a/packages/main/src/themes/sap_horizon_dark/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/TextArea-parameters.css
@@ -18,19 +18,33 @@
 	--_ui5_textarea_focused_value_state_warning_focus_outline_color: var(--sapField_WarningColor);
 	--_ui5_textarea_focused_value_state_success_focus_outline_color: var(--sapField_SuccessColor);
 	--_ui5_textarea_focus_offset: 0;
+	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapField_Active_BorderColor);
 	--_ui5_textarea_value_state_focus_offset: 0;
+	--_ui5_textarea_padding_top: 0.5rem;
+	--_ui5_textarea_padding_bottom: 0.4375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.375rem;
 	--_ui5_textarea_padding_top_error_warning: 0.5rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.4375rem;
 	--_ui5_textarea_padding_top_information: 0.5rem;
 	--_ui5_textarea_padding_bottom_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.625rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.625rem;
+	--_ui5_textarea_readonly_border_style: dashed;
 }
 
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	--_ui5_textarea_padding_top: 0.1875rem;
+	--_ui5_textarea_padding_bottom: 0.125rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.0625rem;
 	--_ui5_textarea_padding_top_error_warning: 0.1875rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.125rem;
 	--_ui5_textarea_padding_top_information: 0.1875rem;
 	--_ui5_textarea_padding_bottom_information: 0.125rem;
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_error_warning: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/TextArea-parameters.css
@@ -10,15 +10,19 @@
 	--_ui5_textarea_error_placeholder_font_style: normal;
 	--_ui5_textarea_error_placeholder_color: var(--sapField_TextColor);
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
+	--_ui5_textarea_information_border_width: var(--sapField_InformationBorderWidth);
 	--_ui5_textarea_error_warning_border_style: dashed;
-	--_ui5_textarea_padding_top_information: 0.375rem;
-	--_ui5_textarea_padding_bottom_information: 0.3125rem;
+	--_ui5_textarea_padding_top_information: 0.4375rem;
+	--_ui5_textarea_padding_bottom_information: 0.375rem;
 	--_ui5_textarea_padding_top: 0.375rem;
 	--_ui5_textarea_padding_bottom: 0.3125rem;
+	--_ui5_textarea_padding_top_readonly: 0.375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.3125rem;
 	--_ui5_textarea_padding_top_error_warning: 0.375rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.3125rem;
-	--_ui5_textarea_padding_top_information: 0.375rem;
-	--_ui5_textarea_padding_bottom_information: 0.3125rem;	
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.5rem;
 }
 
 [data-ui5-compact-size],
@@ -26,8 +30,13 @@
 .sapUiSizeCompact {
 	--_ui5_textarea_padding_top: 0.0625rem;
 	--_ui5_textarea_padding_bottom: 0rem;
+	--_ui5_textarea_padding_top_readonly: 0.0625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0rem;
 	--_ui5_textarea_padding_top_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0rem;
-	--_ui5_textarea_padding_top_information: 0.0625rem;
-	--_ui5_textarea_padding_bottom_information: 0rem;
+	--_ui5_textarea_padding_top_information: 0.125rem;
+	--_ui5_textarea_padding_bottom_information: 0.0625rem;
+	--_ui5_textarea_padding_right_and_left: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.375rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/TextArea-parameters.css
@@ -10,15 +10,19 @@
 	--_ui5_textarea_placeholder_font_style: normal;
 	--_ui5_textarea_error_placeholder_color: var(--sapField_TextColor);
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
+	--_ui5_textarea_information_border_width: var(--sapField_InformationBorderWidth);
 	--_ui5_textarea_error_warning_border_style: dashed;
-	--_ui5_textarea_padding_top_information: 0.375rem;
-	--_ui5_textarea_padding_bottom_information: 0.3125rem;
+	--_ui5_textarea_padding_top_information: 0.4375rem;
+	--_ui5_textarea_padding_bottom_information: 0.375rem;
 	--_ui5_textarea_padding_top: 0.375rem;
 	--_ui5_textarea_padding_bottom: 0.3125rem;
+	--_ui5_textarea_padding_top_readonly: 0.375rem;
+	--_ui5_textarea_padding_bottom_readonly: 0.3125rem;
 	--_ui5_textarea_padding_top_error_warning: 0.375rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0.3125rem;
-	--_ui5_textarea_padding_top_information: 0.375rem;
-	--_ui5_textarea_padding_bottom_information: 0.3125rem;
+	--_ui5_textarea_padding_right_and_left: 0.5rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.5625rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.5rem;
 }
 
 [data-ui5-compact-size],
@@ -26,8 +30,13 @@
 .sapUiSizeCompact {
 	--_ui5_textarea_padding_top: 0.0625rem;
 	--_ui5_textarea_padding_bottom: 0rem;
+	--_ui5_textarea_padding_top_readonly: 0.0625rem;
+	--_ui5_textarea_padding_bottom_readonly: 0rem;
 	--_ui5_textarea_padding_top_error_warning: 0.0625rem;
 	--_ui5_textarea_padding_bottom_error_warning: 0rem;
-	--_ui5_textarea_padding_top_information: 0.0625rem;
-	--_ui5_textarea_padding_bottom_information: 0rem;
+	--_ui5_textarea_padding_top_information: 0.125rem;
+	--_ui5_textarea_padding_bottom_information: 0.0625rem;
+	--_ui5_textarea_padding_right_and_left: 0.375rem;
+	--_ui5_textarea_padding_right_and_left_information: 0.4375rem;
+	--_ui5_textarea_padding_right_and_left_readonly: 0.375rem;
 }


### PR DESCRIPTION
1. New readonly design is Horizon Light and Dark applied.
2. Background image for disabled state in Horizon Light and Dark removed.
3. Paddings are updated according to the specification in all supported themes.
