### PR TITLE
chore: remove ts-ignore on migrated components imports

### DIFF
--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -10,7 +10,6 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Icon from "@ui5/webcomponents/dist/Icon.js";
 import Label from "@ui5/webcomponents/dist/Label.js";
-// @ts-ignore: ignore will no longer be required, when List is migrated to TS
 import List from "@ui5/webcomponents/dist/List.js";
 import ListMode from "@ui5/webcomponents/dist/types/ListMode.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
@@ -239,7 +238,7 @@ class UploadCollection extends UI5Element {
 			Label,
 			List,
 			Title,
-		] as Array<typeof UI5Element>; // Note: casting will no longer be required, when List is migrated to TS
+		];
 	}
 
 	static async onDefine() {

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -8,11 +8,9 @@ import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-// @ts-ignore
 import Dialog from "@ui5/webcomponents/dist/Dialog.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import Label from "@ui5/webcomponents/dist/Label.js";
-// @ts-ignore
 import GroupHeaderListItem from "@ui5/webcomponents/dist/GroupHeaderListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
 import type { ClickEventDetail } from "@ui5/webcomponents/dist/List.js";
@@ -74,12 +72,6 @@ type VSDInternalSettings = {
 	sortOrder: Array<VSDItem>,
 	sortBy: Array<VSDItem & {index: number}>,
 	filters: Array<VSDItem & {filterOptions: Array<VSDItem>}>,
-}
-
-type DialogTemp = UI5Element & { // Delete after Dialog is done
-	isOpen: () => boolean,
-	show: (preventInitialFocus: boolean) => void,
-	close: () => void,
 }
 
 /**
@@ -254,7 +246,7 @@ class ViewSettingsDialog extends UI5Element {
 	@slot()
 	filterItems!: Array<FilterItem>;
 
-	_dialog?: DialogTemp;
+	_dialog?: Dialog;
 	_sortOrder?: List;
 	_sortBy?: List;
 
@@ -302,11 +294,11 @@ class ViewSettingsDialog extends UI5Element {
 			Bar,
 			Button,
 			Title,
-			Dialog as typeof UI5Element,
+			Dialog,
 			Label,
 			List,
 			StandardListItem,
-			GroupHeaderListItem as typeof UI5Element,
+			GroupHeaderListItem,
 			SegmentedButton as typeof UI5Element,
 			SegmentedButtonItem as typeof UI5Element,
 		];
@@ -502,7 +494,7 @@ class ViewSettingsDialog extends UI5Element {
 	}
 
 	get _dialogDomRef() {
-		return this.shadowRoot!.querySelector<DialogTemp>("[ui5-dialog]")!;
+		return this.shadowRoot!.querySelector<Dialog>("[ui5-dialog]")!;
 	}
 
 	/**

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -23,6 +23,7 @@ import ColorPaletteTemplate from "./generated/templates/ColorPaletteTemplate.lit
 import ColorPaletteDialogTemplate from "./generated/templates/ColorPaletteDialogTemplate.lit.js";
 import ColorPaletteItem from "./ColorPaletteItem.js";
 import Button from "./Button.js";
+import type Dialog from "./Dialog.js";
 import type ColorPaletteMoreColors from "./features/ColorPaletteMoreColors.js";
 import type ColorPicker from "./ColorPicker.js";
 
@@ -35,12 +36,6 @@ import {
 // Styles
 import ColorPaletteCss from "./generated/themes/ColorPalette.css.js";
 import ColorPaletteStaticAreaCss from "./generated/themes/ColorPaletteStaticArea.css.js";
-
-type DialogTemp = HTMLElement & {
-	content: Array<HTMLElement>,
-	close: () => void,
-	show: () => void,
-}
 
 type ColorPaletteNavigationItem = ColorPaletteItem | Button;
 
@@ -503,7 +498,7 @@ class ColorPalette extends UI5Element {
 
 	async _getDialog() {
 		const staticAreaItem = await this.getStaticAreaItemDomRef();
-		return staticAreaItem!.querySelector<DialogTemp>("[ui5-dialog]")!;
+		return staticAreaItem!.querySelector<Dialog>("[ui5-dialog]")!;
 	}
 
 	async getColorPicker() {

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -22,7 +22,6 @@ import type {
 } from "@ui5/webcomponents-base/dist/util/ColorConversion.js";
 import ColorPickerTemplate from "./generated/templates/ColorPickerTemplate.lit.js";
 import Input from "./Input.js";
-// @ts-ignore
 import Slider from "./Slider.js";
 import Label from "./Label.js";
 
@@ -39,10 +38,6 @@ import {
 
 // Styles
 import ColorPickerCss from "./generated/themes/ColorPicker.css.js";
-
-type TempSlider = HTMLElement & {
-	value: number;
-}
 
 const PICKER_POINTER_WIDTH = 6.5;
 
@@ -290,7 +285,7 @@ class ColorPicker extends UI5Element {
 	}
 
 	_handleHueInput(e: CustomEvent) {
-		this.selectedHue = (e.target as TempSlider).value;
+		this.selectedHue = (e.target as Slider).value;
 		this._hue = this.selectedHue;
 		this._setMainColor(this._hue);
 		// Idication that changes to the hue value triggered as a result of user pressing over the hue slider.

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -22,9 +22,7 @@ import {
 // @ts-ignore
 } from "./generated/i18n/i18n-defaults.js";
 
-// @ts-ignore
 import Input from "./Input.js";
-// @ts-ignore
 import Popover from "./Popover.js";
 import Icon from "./Icon.js";
 
@@ -510,7 +508,7 @@ class FileUploader extends UI5Element implements IFormElement {
 	}
 
 	get ui5Input() {
-		return this.shadowRoot!.querySelector<HTMLElement>(".ui5-file-uploader-input");
+		return this.shadowRoot!.querySelector<Input>(".ui5-file-uploader-input");
 	}
 
 	static get dependencies() {

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1329,7 +1329,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	async getInputDOMRef() {
 		if (isPhone() && this.Suggestions) {
 			await this.Suggestions._getSuggestionPopover();
-			return this.Suggestions && this.Suggestions.responsivePopover!.querySelector<Input>(".ui5-input-inner-phone")!;
+			return this.Suggestions.responsivePopover!.querySelector<Input>(".ui5-input-inner-phone")!;
 		}
 
 		return this.nativeInput;

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -36,16 +36,11 @@ import "@ui5/webcomponents-icons/dist/less.js";
 import "@ui5/webcomponents-icons/dist/add.js";
 
 import Icon from "./Icon.js";
-// @ts-ignore
 import Input from "./Input.js";
 import InputType from "./types/InputType.js";
 
 // Styles
 import StepInputCss from "./generated/themes/StepInput.css.js";
-
-type TempInput = HTMLElement & {
-	value: string,
-}
 
 // Spin variables
 const INITIAL_WAIT_TIMEOUT = 500; // milliseconds
@@ -425,8 +420,8 @@ class StepInput extends UI5Element implements IFormElement {
 		}
 	}
 
-	get input(): TempInput {
-		return this.shadowRoot!.querySelector<TempInput>("[ui5-input]")!;
+	get input(): Input {
+		return this.shadowRoot!.querySelector<Input>("[ui5-input]")!;
 	}
 
 	get inputOuter() {

--- a/packages/main/src/TimePickerBase.ts
+++ b/packages/main/src/TimePickerBase.ts
@@ -31,7 +31,6 @@ import Icon from "./Icon.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import TimePickerTemplate from "./generated/templates/TimePickerTemplate.lit.js";
 import TimePickerPopoverTemplate from "./generated/templates/TimePickerPopoverTemplate.lit.js";
-// @ts-ignore
 import Input from "./Input.js";
 import Button from "./Button.js";
 import TimeSelection from "./TimeSelection.js";
@@ -53,11 +52,6 @@ type TempResponsivePopover = HTMLElement & {
 	showAt: (opener: HTMLElement) => Promise<void>,
 	close: () => void,
 	resetFocus: () => void,
-}
-
-type TempInput = HTMLElement & {
-	value: string,
-	getInputDOMRef: () => Promise<HTMLInputElement>,
 }
 
 /**
@@ -254,7 +248,7 @@ class TimePickerBase extends UI5Element {
 		const inputField = await this._getInputField();
 
 		if (inputField) {
-			inputField.select();
+			(inputField as HTMLInputElement).select();
 		}
 	}
 
@@ -289,12 +283,12 @@ class TimePickerBase extends UI5Element {
 	}
 
 	_handleInputChange(e: CustomEvent) {
-		const target = e.target as TempInput;
+		const target = e.target as Input;
 		this._updateValueAndFireEvents(target.value, true, ["change", "value-changed"]);
 	}
 
 	_handleInputLiveChange(e: CustomEvent) {
-		const target = e.target as TempInput;
+		const target = e.target as Input;
 		this._updateValueAndFireEvents(target.value, false, ["input"]);
 	}
 
@@ -347,8 +341,8 @@ class TimePickerBase extends UI5Element {
 		return staticAreaItem!.querySelector<TempResponsivePopover>("[ui5-responsive-popover]")!;
 	}
 
-	_getInput() {
-		return this.shadowRoot!.querySelector<TempInput>("[ui5-input]")!;
+	_getInput(): Input {
+		return this.shadowRoot!.querySelector<Input>("[ui5-input]")!;
 	}
 
 	_getInputField() {


### PR DESCRIPTION
We used to have temp types for components that haven't been migrated to TS. Now as they are in TS, we can directly use them and remove the "ts-ignore" comments on those component imports any temp types created meanwhile.