### PR TITLE
refactor(i18n): add mapping for norwegian locale

### DIFF
--- a/packages/base/src/locale/normalizeLocale.ts
+++ b/packages/base/src/locale/normalizeLocale.ts
@@ -7,7 +7,7 @@ const SAPSupportabilityLocales = /(?:^|-)(saptrc|sappsd)(?:-|$)/i;
 const M_ISO639_NEW_TO_OLD = {
 	"he": "iw",
 	"yi": "ji",
-	"id": "in",
+	"nb": "no",
 	"sr": "sh",
 };
 


### PR DESCRIPTION
The change adds "nb": "no" to fallback to "no" locale, when "nb" is set.
In addition the mapping from the old ISO639 language code "in" to "id" removed to align with SAPUI5/OpenUI5 mappings, where "in" to "id" mapping has been also removed with https://github.com/SAP/openui5/commit/b4efdf14404c2cff51f8b5af5b3b2b257b54c58d

Fixes: https://github.com/SAP/ui5-webcomponents/issues/6283
