### PR TITLE
chore: fix copy-and-watch usage

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -121,7 +121,7 @@ const getScripts = (options) => {
 		},
 		generateAPI: {
 			default: "nps generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup",
-			prepare: `copy-and-watch "dist/**/*.js" jsdoc-dist/`,
+			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,
 			jsdoc: `jsdoc -c "${LIB}/jsdoc/configTypescript.json"`,
 			cleanup: "rimraf jsdoc-dist/"


### PR DESCRIPTION
This fixes the bug for third-party packages that don't have a dependency to  `copy-and-watch`.