### PR TITLE
docs: fix jsdoc preprocessing of default slot

### DIFF
--- a/packages/tools/lib/jsdoc/preprocess.js
+++ b/packages/tools/lib/jsdoc/preprocess.js
@@ -75,9 +75,8 @@ const isClass = text => {
 	return text.includes("@abstract") || text.includes("@class");
 };
 
-const isAnnotationComment = (comment, fileContent) =>  {
-	const index = fileContent.indexOf(comment);
-	return fileContent.substr(index + comment.length).trim().charAt(0) === "@";
+const isAnnotationComment = (comment) =>  {
+	return comment.includes("@name");
 }
 
 const processComponentFile = async (fileName) => {


### PR DESCRIPTION
Previously, JSDoc preprocessor was looking for comments followed by @decorator to mark them as a comment that should be moved to the end of the file. Now, we append at the end of the file each JSDoc comment that has @name tag inside it.

Related to: https://github.com/SAP/ui5-webcomponents/issues/6300