### PR TITLE
docs: fix jsdoc of StepInput valuStateMessage slot

### DIFF
--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -261,8 +261,6 @@ class Dialog extends Popup {
 	 *
 	 * @param {boolean} preventInitialFocus Prevents applying the focus inside the popup
 	 * @public
-	 * @method
-	 * @name sap.ui.webc.main.Dialog#show
 	 * @async
 	 * @method
 	 * @name sap.ui.webc.main.Dialog#show

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -303,13 +303,13 @@ class StepInput extends UI5Element implements IFormElement {
 	 * Defines the value state message that will be displayed as pop up under the component.
 	 * <br><br>
 	 *
-	 * @name sap.ui.webc.main.StepInput.prototype.valueStateMessage
 	 * <b>Note:</b> If not specified, a default text (in the respective language) will be displayed.
 	 * <br>
 	 * <b>Note:</b> The <code>valueStateMessage</code> would be displayed,
 	 * when the component is in <code>Information</code>, <code>Warning</code> or <code>Error</code> value state.
 	 * @type {HTMLElement}
 	 * @slot
+	 * @name sap.ui.webc.main.StepInput.prototype.valueStateMessage
 	 * @public
 	 */
 	@slot()


### PR DESCRIPTION
There are two more issues to tackle, then it would be ready for code review.

- [ ] Dialog - show() has now a mandatory parameter 'preventInitialFocus'
- [ ] the Popover showAt has now also a required second parameter preventInitialFocus
- [x] the step input is missing the valueStateMessage

Part of: https://github.com/SAP/ui5-webcomponents/issues/6300