### PR TITLE
chore: mark JSdoc function parameters as optional

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -620,7 +620,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.DatePicker#isValid
-	 * @param { string } value A value to be tested against the current date format
+	 * @param { string } [value=""] A value to be tested against the current date format
 	 * @returns { boolean }
 	 */
 	isValid(value = ""): boolean {
@@ -638,7 +638,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.DatePicker#isInValidRange
-	 * @param { string } value A value to be checked
+	 * @param { string } [value=""] A value to be checked
 	 * @returns { boolean }
 	 */
 	isInValidRange(value = ""): boolean {

--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -259,7 +259,7 @@ class Dialog extends Popup {
 	/**
 	 * Shows the dialog.
 	 *
-	 * @param {boolean} preventInitialFocus Prevents applying the focus inside the popup
+	 * @param {boolean} [preventInitialFocus=false] Prevents applying the focus inside the popup
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.Dialog#show

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -343,7 +343,7 @@ class Popover extends Popup {
 	/**
 	 * Shows the popover.
 	 * @param {HTMLElement} opener the element that the popover is shown at
-	 * @param {boolean} preventInitialFocus prevents applying the focus inside the popover
+	 * @param {boolean} [preventInitialFocus=false] prevents applying the focus inside the popover
 	 * @public
 	 * @async
 	 * @method

--- a/packages/main/src/ResponsivePopover.ts
+++ b/packages/main/src/ResponsivePopover.ts
@@ -118,7 +118,7 @@ class ResponsivePopover extends Popover {
 	/**
 	 * Shows popover on desktop and dialog on mobile.
 	 * @param {HTMLElement} opener the element that the popover is shown at
-	 * @param {boolean} preventInitialFocus Prevents applying the focus inside the popup
+	 * @param {boolean} [preventInitialFocus=false] Prevents applying the focus inside the popup
 	 * @public
 	 * @async
 	 * @method


### PR DESCRIPTION
Mark parameters with default value as optional on all public methods in Typescript files.

Related to: #6300 