### PR TITLE
chore(ui5-wizard): provide a better fix

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -668,7 +668,7 @@ abstract class UI5Element extends HTMLElement {
 				}
 				res = `${res}: ${x.name}`;
 				if (x.type === "property") {
-					res = `${res} ${x.oldValue} => ${x.newValue}`;
+					res = `${res} ${JSON.stringify(x.oldValue)} => ${JSON.stringify(x.newValue)}`;
 				}
 
 				return res;

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -485,9 +485,6 @@ class Wizard extends UI5Element {
 	 */
 	onStepResize() {
 		this.width = this.getBoundingClientRect().width;
-		if (this.width === 0) {
-			return; // Do not re-calculate steps and render until the wizard has non-zero width
-		}
 		this.contentHeight = this.getContentHeight();
 
 		if (this._prevWidth !== this.width || this.contentHeight !== this._prevContentHeight) {
@@ -496,7 +493,7 @@ class Wizard extends UI5Element {
 
 		this._prevWidth = this.width;
 		this._prevContentHeight = this.contentHeight;
-		this._breakpoint = RESPONSIVE_BREAKPOINTS[Object.keys(RESPONSIVE_BREAKPOINTS).findLast(size => Number(size) < this.width)];
+		this._breakpoint = RESPONSIVE_BREAKPOINTS[Object.keys(RESPONSIVE_BREAKPOINTS).findLast(size => Number(size) < this.width)] || RESPONSIVE_BREAKPOINTS["0"];
 	}
 
 	attachStepsResizeObserver() {


### PR DESCRIPTION
The underlying issue was that `_breakpoint` is of type `String`, however when `this.width` is `0`, the following expression:

```js
RESPONSIVE_BREAKPOINTS[Object.keys(RESPONSIVE_BREAKPOINTS).findLast(size => Number(size) < this.width)]
```

does not return a string, but rather `undefined`. Since `_breakpoint` does not have a default value, it becomes the string `"undefined"` which triggers the infinite invalidation loop of `undefined` vs `"undefined"`.

The solution is to always use a string for `_breakpoint`. For zero-width, this is the smallest breakpoint ("S").

Additionally, improved the invalidation debug code that is normally commented out to work better with objects.