### PR TITLE
docs: fix type annotation for `icon` slot

### DIFF
--- a/packages/main/src/Badge.ts
+++ b/packages/main/src/Badge.ts
@@ -90,7 +90,7 @@ class Badge extends UI5Element {
 	/**
 	 * Defines the icon to be displayed in the component.
 	 *
-	 * @type {sap.ui.webc.main.IIcon}
+	 * @type {sap.ui.webc.main.IIcon[]}
 	 * @name sap.ui.webc.main.Badge.prototype.icon
 	 * @slot
 	 * @public

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -292,7 +292,7 @@ const metadata = {
 		/**
 		 * Defines the icon to be displayed in the input field.
 		 *
-		 * @type {sap.ui.webc.main.IIcon}
+		 * @type {sap.ui.webc.main.IIcon[]}
 		 * @slot
 		 * @public
 		 * @since 1.0.0-rc.9

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -111,7 +111,7 @@ const metadata = {
 		/**
 		* Defines the icon to be displayed in the component.
 		*
-		* @type {sap.ui.webc.main.IIcon}
+		* @type {sap.ui.webc.main.IIcon[]}
 		* @slot
 		* @public
 		* @since 1.0.0-rc.9


### PR DESCRIPTION
This PR changes the JSDoc annotation of the `icon` slot for the `Badge`, `ComboBox` and `MultiComboBox` component.

For the `Badge` I changed it because the TypeScript type accepts an array of `HTMLElement`s and not only a single element. For the `ComboBox` and the `MultiComboBox` I changed it because the type of the [Input](https://github.com/SAP/ui5-webcomponents/blob/eea1822a1a72811521eace8d7548d7f3fd48e1b0/packages/main/src/Input.ts#L567) accepts an array as well and since (at least in my opinion) these components should behave in the same way, they should also accept an array.

Additionally I believe that the TypeScript type of the [MessageStrip](https://github.com/SAP/ui5-webcomponents/blob/eea1822a1a72811521eace8d7548d7f3fd48e1b0/packages/main/src/MessageStrip.ts#L166) is wrong. When multiple icons are rendered inside the slot it overflows the text:
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/9749730/214062807-790d088f-a8ff-4ad0-baba-51e6ec517f5e.png">

If you still want me to change the JSDoc type for the MessageStrip, please let me know.