### PR TITLE
docs(CheckBox): typo red-only -> read-only

### DIFF
--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -131,7 +131,7 @@ class CheckBox extends UI5Element implements IFormElement {
 	/**
 	 * Defines whether the component is read-only.
 	 * <br><br>
-	 * <b>Note:</b> A red-only component is not editable,
+	 * <b>Note:</b> A read-only component is not editable,
 	 * but still provides visual feedback upon user interaction.
 	 *
 	 * @type {boolean}


### PR DESCRIPTION
Hi,
please correct this typo.
Thanks!
Oliver