### PR TITLE
chore: change all src imports to dist

### DIFF
--- a/packages/base/package-scripts.js
+++ b/packages/base/package-scripts.js
@@ -36,7 +36,7 @@ const scripts = {
 	},
 	copy: {
 		default: "nps copy.src",
-		src: `copy-and-watch "src/**/*.{js,css}" dist/`,
+		src: `copy-and-watch "src/**/*.{js,css,d.ts}" dist/`,
 	},
 	generateAssetParameters: `node "${assetParametersScript}"`,
 	generateVersionInfo: `node "${versionScript}"`,

--- a/packages/base/src/global.d.ts
+++ b/packages/base/src/global.d.ts
@@ -1,4 +1,4 @@
-import { StyleData } from "./src/types.js";
+import { StyleData } from "./types.js";
 
 export {};
 

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src/**/*", "global.d.ts"],
+    "include": ["src/**/*", "src/global.d.ts"],
     "compilerOptions": {
       "target": "ES2021",
       // Generate d.ts files

--- a/packages/fiori/global.d.ts
+++ b/packages/fiori/global.d.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
-import "@ui5/webcomponents-base/global";
-import { TemplateFunction } from "@ui5/webcomponents-base/src/renderer/executeTemplate.js";
+import "@ui5/webcomponents-base/dist/global";
+import { TemplateFunction } from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
 
 export {};
 

--- a/packages/main/global.d.ts
+++ b/packages/main/global.d.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
-import "@ui5/webcomponents-base/global";
-import { TemplateFunction } from "@ui5/webcomponents-base/src/renderer/executeTemplate.js";
+import "@ui5/webcomponents-base/dist/global";
+import { TemplateFunction } from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
 
 export {};
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -9,7 +9,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import languageAware from "@ui5/webcomponents-base/dist/decorators/languageAware.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
-import type UI5Element from "@ui5/webcomponents-base/src/UI5Element.js";
+import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/edit.js";
 import ListItemType from "./types/ListItemType.js";


### PR DESCRIPTION
this change moves all TS related imports to the dist path

1. `base/global.d.ts` is moved to the `src` folder and contains a manual copy to `dist` as the typescript compiler does not touch .d.ts files
2. the remaining `src` imports are changed to `dist`