### PR TITLE
chore: fix API tables in playground

### DIFF
--- a/packages/fiori/src/MediaGallery.js
+++ b/packages/fiori/src/MediaGallery.js
@@ -256,7 +256,7 @@ const metadata = {
  * @alias sap.ui.webc.fiori.MediaGallery
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-media-gallery
- * @appenddocs MediaGalleryItem
+ * @appenddocs sap.ui.webc.fiori.MediaGalleryItem
  * @public
  * @since 1.1.0
  */

--- a/packages/fiori/src/NotificationListGroupItem.js
+++ b/packages/fiori/src/NotificationListGroupItem.js
@@ -128,7 +128,7 @@ const metadata = {
  * @extends sap.ui.webc.fiori.NotificationListItemBase
  * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
- * @appenddocs NotificationAction
+ * @appenddocs sap.ui.webc.fiori.NotificationAction
  * @implements sap.ui.webc.main.IListItem
  * @public
  */

--- a/packages/fiori/src/NotificationListItem.js
+++ b/packages/fiori/src/NotificationListItem.js
@@ -170,7 +170,7 @@ const metadata = {
  * @alias sap.ui.webc.fiori.NotificationListItem
  * @extends sap.ui.webc.fiori.NotificationListItemBase
  * @tagname ui5-li-notification
- * @appenddocs NotificationAction
+ * @appenddocs sap.ui.webc.fiori.NotificationAction
  * @since 1.0.0-rc.8
  * @implements sap.ui.webc.fiori.INotificationListItem, sap.ui.webc.main.IListItem
  * @public

--- a/packages/fiori/src/NotificationListItemBase.js
+++ b/packages/fiori/src/NotificationListItemBase.js
@@ -151,7 +151,7 @@ const metadata = {
  * @extends sap.ui.webc.main.ListItemBase
  * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
- * @appenddocs NotificationAction
+ * @appenddocs sap.ui.webc.fiori.NotificationAction
  * @public
  */
 class NotificationListItemBase extends ListItemBase {

--- a/packages/fiori/src/ProductSwitch.ts
+++ b/packages/fiori/src/ProductSwitch.ts
@@ -56,7 +56,7 @@ import type ProductSwitchItem from "./ProductSwitchItem.js";
  * @alias sap.ui.webc.fiori.ProductSwitch
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-product-switch
- * @appenddocs ProductSwitchItem
+ * @appenddocs sap.ui.webc.fiori.ProductSwitchItem
  * @public
  * @since 1.0.0-rc.5
  */

--- a/packages/fiori/src/ShellBar.js
+++ b/packages/fiori/src/ShellBar.js
@@ -455,7 +455,7 @@ const metadata = {
  * @alias sap.ui.webc.fiori.ShellBar
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-shellbar
- * @appenddocs ShellBarItem
+ * @appenddocs sap.ui.webc.fiori.ShellBarItem
  * @public
  * @since 0.8.0
  */

--- a/packages/fiori/src/SideNavigation.js
+++ b/packages/fiori/src/SideNavigation.js
@@ -152,7 +152,7 @@ const metadata = {
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-side-navigation
  * @since 1.0.0-rc.8
- * @appenddocs SideNavigationItem SideNavigationSubItem
+ * @appenddocs sap.ui.webc.fiori.SideNavigationItem sap.ui.webc.fiori.SideNavigationSubItem
  * @public
  */
 class SideNavigation extends UI5Element {

--- a/packages/fiori/src/Timeline.ts
+++ b/packages/fiori/src/Timeline.ts
@@ -39,7 +39,7 @@ const LARGE_LINE_WIDTH = "LargeLineWidth";
  * @alias sap.ui.webc.fiori.Timeline
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-timeline
- * @appenddocs TimelineItem
+ * @appenddocs sap.ui.webc.fiori.TimelineItem
  * @public
  * @since 0.8.0
  */

--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -62,7 +62,7 @@ type ItemDeleteEventDetail = {
  * @alias sap.ui.webc.fiori.UploadCollection
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-upload-collection
- * @appenddocs UploadCollectionItem
+ * @appenddocs sap.ui.webc.fiori.UploadCollectionItem
  * @public
  * @since 1.0.0-rc.7
  */

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -102,7 +102,7 @@ type VSDInternalSettings = {
  * @alias sap.ui.webc.fiori.ViewSettingsDialog
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-view-settings-dialog
- * @appenddocs SortItem FilterItem FilterItemOption
+ * @appenddocs sap.ui.webc.fiori.SortItem sap.ui.webc.fiori.FilterItem sap.ui.webc.fiori.FilterItemOption
  * @since 1.0.0-rc.16
  * @public
  */

--- a/packages/fiori/src/Wizard.js
+++ b/packages/fiori/src/Wizard.js
@@ -248,7 +248,7 @@ const metadata = {
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-wizard
  * @since 1.0.0-rc.10
- * @appenddocs WizardStep
+ * @appenddocs sap.ui.webc.fiori.WizardStep
  * @public
  */
 class Wizard extends UI5Element {

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -91,7 +91,7 @@ type FocusAdaptor = ITabbable & {
  * @alias sap.ui.webc.main.Breadcrumbs
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-breadcrumbs
- * @appenddocs BreadcrumbsItem
+ * @appenddocs sap.ui.webc.main.BreadcrumbsItem
  * @public
  * @since 1.0.0-rc.15
  */

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -161,7 +161,7 @@ type CalendarChangeEventDetail = {
  * @alias sap.ui.webc.main.Calendar
  * @extends sap.ui.webc.main.CalendarPart
  * @tagname ui5-calendar
- * @appenddocs CalendarDate
+ * @appenddocs sap.ui.webc.main.CalendarDate
  * @public
  * @since 1.0.0-rc.11
  */

--- a/packages/main/src/Card.ts
+++ b/packages/main/src/Card.ts
@@ -47,7 +47,7 @@ import cardCss from "./generated/themes/Card.css.js";
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-card
  * @public
- * @appenddocs CardHeader
+ * @appenddocs sap.ui.webc.main.CardHeader
  */
 @customElement("ui5-card")
 @languageAware

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -64,7 +64,7 @@ type ColorPaletteItemClickEventDetail = {
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-color-palette
  * @since 1.0.0-rc.12
- * @appenddocs ColorPaletteItem
+ * @appenddocs sap.ui.webc.main.ColorPaletteItem
  * @public
  */
 @customElement("ui5-color-palette")

--- a/packages/main/src/ComboBox.js
+++ b/packages/main/src/ComboBox.js
@@ -379,7 +379,7 @@ const metadata = {
  * @alias sap.ui.webc.main.ComboBox
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-combobox
- * @appenddocs ComboBoxItem ComboBoxGroupItem
+ * @appenddocs sap.ui.webc.main.ComboBoxItem sap.ui.webc.main.ComboBoxGroupItem
  * @public
  * @since 1.0.0-rc.6
  */

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -173,7 +173,7 @@ type SuggestionScrollEventDetail = {
  * @alias sap.ui.webc.main.Input
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-input
- * @appenddocs SuggestionItem SuggestionGroupItem
+ * @appenddocs sap.ui.webc.main.SuggestionItem sap.ui.webc.main.SuggestionGroupItem
  * @implements sap.ui.webc.main.IInput
  * @public
  */

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -140,7 +140,7 @@ type ClickEventDetail = CloseEventDetail;
  * @alias sap.ui.webc.main.List
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-list
- * @appenddocs StandardListItem CustomListItem GroupHeaderListItem
+ * @appenddocs sap.ui.webc.main.StandardListItem sap.ui.webc.main.CustomListItem sap.ui.webc.main.GroupHeaderListItem
  * @public
  */
 @customElement("ui5-list")

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -79,7 +79,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @alias sap.ui.webc.main.Menu
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-menu
- * @appenddocs MenuItem
+ * @appenddocs sap.ui.webc.main.MenuItem
  * @since 1.3.0
  * @public
  */

--- a/packages/main/src/MultiComboBox.js
+++ b/packages/main/src/MultiComboBox.js
@@ -434,7 +434,7 @@ const metadata = {
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-multi-combobox
  * @public
- * @appenddocs MultiComboBoxItem MultiComboBoxGroupItem
+ * @appenddocs sap.ui.webc.main.MultiComboBoxItem sap.ui.webc.main.MultiComboBoxGroupItem
  * @since 0.11.0
  */
 class MultiComboBox extends UI5Element {

--- a/packages/main/src/MultiInput.js
+++ b/packages/main/src/MultiInput.js
@@ -101,7 +101,7 @@ const metadata = {
  * @alias sap.ui.webc.main.MultiInput
  * @extends sap.ui.webc.main.Input
  * @tagname ui5-multi-input
- * @appenddocs Token
+ * @appenddocs sap.ui.webc.main.Token
  * @since 1.0.0-rc.9
  * @public
  */

--- a/packages/main/src/SegmentedButton.js
+++ b/packages/main/src/SegmentedButton.js
@@ -93,7 +93,7 @@ const metadata = {
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-segmented-button
  * @since 1.0.0-rc.6
- * @appenddocs SegmentedButtonItem
+ * @appenddocs sap.ui.webc.main.SegmentedButtonItem
  * @public
  */
 class SegmentedButton extends UI5Element {

--- a/packages/main/src/Select.js
+++ b/packages/main/src/Select.js
@@ -282,7 +282,7 @@ const metadata = {
  * @alias sap.ui.webc.main.Select
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-select
- * @appenddocs Option
+ * @appenddocs sap.ui.webc.main.Option
  * @public
  * @since 0.8.0
  */

--- a/packages/main/src/TabContainer.js
+++ b/packages/main/src/TabContainer.js
@@ -355,7 +355,7 @@ const metadata = {
  * @author SAP SE
  * @alias sap.ui.webc.main.TabContainer
  * @extends sap.ui.webc.base.UI5Element
- * @appenddocs Tab TabSeparator
+ * @appenddocs sap.ui.webc.main.Tab sap.ui.webc.main.TabSeparator
  * @tagname ui5-tabcontainer
  * @public
  */

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -178,7 +178,7 @@ enum TableFocusTargetElement {
  * @alias sap.ui.webc.main.Table
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-table
- * @appenddocs TableColumn TableRow TableGroupRow TableCell
+ * @appenddocs sap.ui.webc.main.TableColumn sap.ui.webc.main.TableRow sap.ui.webc.main.TableGroupRow sap.ui.webc.main.TableCell
  * @public
  */
 @customElement("ui5-table")

--- a/packages/main/src/Tree.js
+++ b/packages/main/src/Tree.js
@@ -323,7 +323,7 @@ const metadata = {
  * @alias sap.ui.webc.main.Tree
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-tree
- * @appenddocs TreeItem
+ * @appenddocs sap.ui.webc.main.TreeItem
  * @public
  * @since 1.0.0-rc.8
  */

--- a/packages/playground/build-scripts/api-for-sample/index.js
+++ b/packages/playground/build-scripts/api-for-sample/index.js
@@ -19,7 +19,7 @@ const enrichSampleWihAPI = async (name, api, rawSampleContent) => {
 
 	const getComponentByName = name => {
 		return entries.find(element => {
-			return element.basename === name;
+			return element.name === name;
 		})
 	};
 
@@ -51,7 +51,7 @@ const enrichSampleWihAPI = async (name, api, rawSampleContent) => {
 	let entriesAPI = [];
 
 	const appendCSSVarsAPI = entry => {
-		entry.cssVariables = getCSSVarsByName(entry.basename);
+		entry.cssVariables = getCSSVarsByName(entry.name);
 		return entry;
 	}
 
@@ -61,7 +61,7 @@ const enrichSampleWihAPI = async (name, api, rawSampleContent) => {
 	const removeEmpty = arr => arr.filter(x => x);
 
 	const calculateAPI = component => {
-		if (entriesAPI.indexOf(component.basename) !== -1) {
+		if (entriesAPI.indexOf(component.name) !== -1) {
 			return component;
 		}
 		const entities = ["properties", "slots", "events", "methods", "cssVariables"];
@@ -85,7 +85,7 @@ const enrichSampleWihAPI = async (name, api, rawSampleContent) => {
 			});
 		}
 
-		entriesAPI.push(component.basename);
+		entriesAPI.push(component.name);
 
 		return component;
 	};

--- a/packages/playground/build-scripts/samples-prepare.js
+++ b/packages/playground/build-scripts/samples-prepare.js
@@ -35,16 +35,17 @@ const main = async () => {
 
 		files.forEach(async (file) => {
 			const currentSampleName = file.slice(0, file.indexOf('.'));
+			const currentNameWithNamespace = `sap.ui.webc.${package}.${currentSampleName}`
 
 			// read file
 			let result = (await fs.readFile(path.join(samplesPath, file))).toString();
-			
+
 			// replace pre
 			result = result.replaceAll(`<pre class="prettyprint lang-html"><xmp>`, '<pre class="highlight">{% highlight html %}');
 			result = result.replaceAll(`</xmp></pre>`, '{% endhighlight %}</pre>');
-			
+
 			// add api
-			result = await enrichSampleWihAPI(currentSampleName, api, result);
+			result = await enrichSampleWihAPI(currentNameWithNamespace, api, result);
 
 			// prepend front matter
 			result = `---


### PR DESCRIPTION
API Tables weren't fully complete because enriching the documentation with parent props wasn't correct. Previously build documentation was working with base name (Button) and name (sap.ui.webc.main.Button) of the component which was leading to not found / missing documentation. Now, we build documentation based on name (sap.ui.webc.main.Button) in order to display it correctly. Also switched @appenddocs from basename to name.