### PR TITLE
chore: generate custom element manifest when package is build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ui5"
   ],
   "scripts": {
-    "build": "npm-run-all --sequential build:prerequisitesWithLint build:bundles build:customElementsManifest",
+    "build": "npm-run-all --sequential build:prerequisitesWithLint build:bundles",
     "build:bundles": "npm-run-all --parallel bundle:main bundle:fiori",
     "build:prerequisitesWithLint": "npm-run-all build:base build:prerequisites prepare:main prepare:fiori lint:main lint:fiori",
     "build:prerequisites": "npm-run-all --parallel build:localization build:theming build:icons build:icons-business-suite build:icons-tnt",
@@ -21,7 +21,6 @@
     "build:icons-tnt": "yarn workspace @ui5/webcomponents-icons-tnt build",
     "build:main": "yarn workspace @ui5/webcomponents build",
     "build:fiori": "yarn workspace @ui5/webcomponents-fiori build",
-    "build:customElementsManifest": "node packages/tools/lib/generate-custom-elements-manifest/index.js",
     "lint:main": "yarn workspace @ui5/webcomponents lint",
     "lint:fiori": "yarn workspace @ui5/webcomponents-fiori lint",
     "lint:scope": "npm-run-all --parallel lint:scope:main lint:scope:fiori",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -122,7 +122,7 @@ const getScripts = (options) => {
 		generateAPI: {
 			default: "nps generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup generateAPI.prepareManifest",
 			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
-			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" "dist/api.json" "dist/"`,
+			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" dist dist`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,
 			jsdoc: `jsdoc -c "${LIB}/jsdoc/configTypescript.json"`,
 			cleanup: "rimraf jsdoc-dist/"

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -120,8 +120,9 @@ const getScripts = (options) => {
 			bundle: `node ${LIB}/dev-server/dev-server.js ${viteConfig}`,
 		},
 		generateAPI: {
-			default: "nps generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup",
+			default: "nps generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup generateAPI.prepareManifest",
 			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
+			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" "dist/api.json" "dist/"`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,
 			jsdoc: `jsdoc -c "${LIB}/jsdoc/configTypescript.json"`,
 			cleanup: "rimraf jsdoc-dist/"

--- a/packages/tools/lib/generate-custom-elements-manifest/index.js
+++ b/packages/tools/lib/generate-custom-elements-manifest/index.js
@@ -1,9 +1,11 @@
 const fs = require("fs").promises;
 // https://github.com/webcomponents/custom-elements-manifest/blob/main/schema.json
 
+const apiIndexFilePath = process.argv[2];
+const outputDir = process.argv[3];
+
 const camelToKebabMap = new Map();
 const apiIndex = new Map();
-const processedApiIndex = new Set();
 const forbiddenAttributeTypes = ["object", "array"];
 
 const camelToKebabCase = string => {
@@ -16,7 +18,7 @@ const camelToKebabCase = string => {
 
 const generateJavaScriptExport = entity => {
 	return {
-		declaration: generateRefenrece(entity),
+		declaration: generateRefenrece(entity.name),
 		deprecated: !!entity.deprecated,
 		kind: "js",
 		name: "default",
@@ -226,8 +228,6 @@ const generateSlots = slots => {
 };
 
 const generateCustomElementDeclaration = entity => {
-	entity = generateFullComponentApi(entity);
-
 	let generatedCustomElementDeclaration = {
 		deprecated: !!entity.deprecated,
 		customElement: true,
@@ -265,63 +265,39 @@ const generateCustomElementDeclaration = entity => {
 	}
 
 	if (entity.extends && entity.extends !== "HTMLElement") {
-		generatedCustomElementDeclaration.superclass = generateRefenrece(apiIndex.get(entity.extends));
+		generatedCustomElementDeclaration.superclass = generateRefenrece(entity.extends);
 	}
 
 	return generatedCustomElementDeclaration;
 };
 
-const generateRefenrece = (entity) => {
+const generateRefenrece = (entityName) => {
 	let packageName;
+	let basename;
 
-	if (!entity.name) {
+	if (!entityName) {
 		throw new Error("JSDoc error: entity not found in api.json.");
 	}
 
-	if (entity.name.includes("sap.ui.webc.main")) {
+	if (entityName.includes(".")) {
+		basename = entityName.split(".").pop();
+	} else {
+		basename = entityName
+	}
+
+	if (entityName.includes("sap.ui.webc.main")) {
 		packageName = "@ui5/webcomponents";
-	} else if (entity.name.includes("sap.ui.webc.fiori")) {
+	} else if (entityName.includes("sap.ui.webc.fiori")) {
 		packageName = "@ui5/webcomponents-fiori";
-	} else if (entity.name.includes("sap.ui.webc.base")) {
+	} else if (entityName.includes("sap.ui.webc.base")) {
 		packageName = "@ui5/webcomponents-base";
 	}
 
 	return {
-		module: `${entity.module}.js`,
-		name: `${entity.basename}`,
+		module: `${basename}.js`,
+		name: `${basename}`,
 		package: packageName,
 	};
-};
-
-const generateFullComponentApi = entity => {
-	const componentProps = ["properties", "slots", "events", "methods"];
-	let parent = apiIndex.get(entity.extends);
-
-	if (!parent) {
-		processedApiIndex.add(entity.name);
-
-		return entity;
-	}
-
-	parent = processedApiIndex.has(entity.extends) ? apiIndex.get(entity.extends) : generateFullComponentApi(parent);
-
-	componentProps.forEach(prop => {
-		if (parent[prop] && parent[prop].length) {
-			if (entity[prop] && entity[prop].length) {
-				const uniqueParentState = parent[prop].filter(pSlot => {
-					return !entity[prop].some(eSlot => eSlot.name === pSlot.name);
-				});
-
-				entity[prop] = entity[prop].concat(uniqueParentState);
-			} else {
-				entity[prop] = [...parent[prop]];
-			}
-		}
-	});
-
-	processedApiIndex.add(entity.name);
-
-	return entity;
 };
 
 const filterPublicApi = array => {
@@ -329,53 +305,21 @@ const filterPublicApi = array => {
 };
 
 const generate = async () => {
-	const apiFilesPaths = [
-		require.resolve("@ui5/webcomponents-base/dist/api.json"),
-		require.resolve("@ui5/webcomponents/dist/api.json"),
-		require.resolve("@ui5/webcomponents-fiori/dist/api.json"),
-];
+	const file = JSON.parse(await fs.readFile(apiIndexFilePath));
+	let customElementsManifest = {
+		schemaVersion: "1.0.0",
+		readme: "",
+		modules: [],
+	};
 
-	console.warn("Base", apiFilesPaths[0]);
-	console.warn("Main", apiFilesPaths[1]);
-	console.warn("Main", await fs.readdir(apiFilesPaths[1].replace("/api.json", "")));
-	console.warn("Fiori", apiFilesPaths[2]);
-
-	let apiFiles = new Map();
-
-	await Promise.all(apiFilesPaths.map(async (apiFilePath) => {
-		const file = JSON.parse(await fs.readFile(apiFilePath));
-
-		apiFiles.set(apiFilePath, file);
-
-		file.symbols.forEach(symbol => {
-			apiIndex.set(symbol.name, symbol);
-		});
-	}));
-
-	await Promise.all(apiFilesPaths.map(async (apiFilePath) => {
-		if (apiFilePath.includes("base")) {
-			return;
+	file.symbols.forEach(entity => {
+		if (entity.tagname) {
+			customElementsManifest.modules.push(generateJavaScriptModule(entity));
 		}
+	});
 
-		let customElementsManifest = {
-			schemaVersion: "1.0.0",
-			readme: "",
-			modules: [],
-		};
-
-		apiFiles.get(apiFilePath).symbols.forEach(entity => {
-			if (entity.tagname) {
-				customElementsManifest.modules.push(generateJavaScriptModule(entity));
-			}
-		});
-
-		console.warn(apiFilePath.replace("api.json", "custom-elements.json"));
-
-		await fs.writeFile(apiFilePath.replace("api.json", "custom-elements.json"), JSON.stringify(customElementsManifest));
-	}));
+	await fs.writeFile(`${outputDir}custom-elements.json`, JSON.stringify(customElementsManifest));
 };
-
-console.warn(process.cwd());
 
 generate().then(() => {
 	console.log("Custom elements manifest generated.");

--- a/packages/tools/lib/generate-custom-elements-manifest/index.js
+++ b/packages/tools/lib/generate-custom-elements-manifest/index.js
@@ -335,6 +335,10 @@ const generate = async () => {
 		require.resolve("@ui5/webcomponents-fiori/dist/api.json"),
 	];
 
+	console.warn("Base", apiFilesPaths[0]);
+	console.warn("Main", apiFilesPaths[1]);
+	console.warn("Fiori", apiFilesPaths[2]);
+
 	let apiFiles = new Map();
 
 	await Promise.all(apiFilesPaths.map(async (apiFilePath) => {
@@ -363,6 +367,8 @@ const generate = async () => {
 				customElementsManifest.modules.push(generateJavaScriptModule(entity));
 			}
 		});
+
+		console.warn(apiFilePath.replace("api.json", "custom-elements.json"));
 
 		await fs.writeFile(apiFilePath.replace("api.json", "custom-elements.json"), JSON.stringify(customElementsManifest));
 	}));

--- a/packages/tools/lib/generate-custom-elements-manifest/index.js
+++ b/packages/tools/lib/generate-custom-elements-manifest/index.js
@@ -1,7 +1,8 @@
 const fs = require("fs").promises;
+const path = require("path");
 // https://github.com/webcomponents/custom-elements-manifest/blob/main/schema.json
 
-const apiIndexFilePath = process.argv[2];
+const inputDir = process.argv[2];
 const outputDir = process.argv[3];
 
 const camelToKebabMap = new Map();
@@ -305,7 +306,7 @@ const filterPublicApi = array => {
 };
 
 const generate = async () => {
-	const file = JSON.parse(await fs.readFile(apiIndexFilePath));
+	const file = JSON.parse(await fs.readFile(path.join(inputDir, "api.json")));
 	let customElementsManifest = {
 		schemaVersion: "1.0.0",
 		readme: "",
@@ -318,7 +319,7 @@ const generate = async () => {
 		}
 	});
 
-	await fs.writeFile(`${outputDir}custom-elements.json`, JSON.stringify(customElementsManifest));
+	await fs.writeFile(path.join(outputDir, "custom-elements.json"), JSON.stringify(customElementsManifest));
 };
 
 generate().then(() => {

--- a/packages/tools/lib/generate-custom-elements-manifest/index.js
+++ b/packages/tools/lib/generate-custom-elements-manifest/index.js
@@ -333,10 +333,11 @@ const generate = async () => {
 		require.resolve("@ui5/webcomponents-base/dist/api.json"),
 		require.resolve("@ui5/webcomponents/dist/api.json"),
 		require.resolve("@ui5/webcomponents-fiori/dist/api.json"),
-	];
+];
 
 	console.warn("Base", apiFilesPaths[0]);
 	console.warn("Main", apiFilesPaths[1]);
+	console.warn("Main", await fs.readdir(apiFilesPaths[1].replace("/api.json", "")));
 	console.warn("Fiori", apiFilesPaths[2]);
 
 	let apiFiles = new Map();
@@ -373,6 +374,8 @@ const generate = async () => {
 		await fs.writeFile(apiFilePath.replace("api.json", "custom-elements.json"), JSON.stringify(customElementsManifest));
 	}));
 };
+
+console.warn(process.cwd());
 
 generate().then(() => {
 	console.log("Custom elements manifest generated.");


### PR DESCRIPTION
Generate custom element when api.json of the package is generated and use only references to the related components instead of merging their metadata (and making them as dependencies when the command is executed).