### PR TITLE
chore: release 1.10.2 to keep all packages in sync

### DIFF
--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 **Note:** Version bump only for package @ui5/webcomponents-base

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-base",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",
     "@openui5/sap.ui.core": "1.109.0",
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/create-webcomponents-package",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: create package",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -40,14 +40,14 @@
     "directory": "packages/fiori"
   },
   "dependencies": {
-    "@ui5/webcomponents": "^1.10.1",
-    "@ui5/webcomponents-base": "^1.10.1",
-    "@ui5/webcomponents-icons": "^1.10.1",
-    "@ui5/webcomponents-theming": "^1.10.1",
+    "@ui5/webcomponents": "1.10.2",
+    "@ui5/webcomponents-base": "1.10.2",
+    "@ui5/webcomponents-icons": "1.10.2",
+    "@ui5/webcomponents-theming": "1.10.2",
     "@zxing/library": "^0.17.1"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0"
   }
 }

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-business-suite",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -26,10 +26,10 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0"
   }
 }

--- a/packages/icons-tnt/CHANGELOG.md
+++ b/packages/icons-tnt/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-tnt

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-tnt",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -26,10 +26,10 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0"
   }
 }

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: webcomponents.SAP-icons",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -26,10 +26,10 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0"
   }
 }

--- a/packages/localization/CHANGELOG.md
+++ b/packages/localization/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-localization",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Localization for UI5 Web Components",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -28,13 +28,13 @@
   },
   "devDependencies": {
     "@openui5/sap.ui.core": "1.109.0",
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },
   "dependencies": {
     "@types/openui5": "^1.109.0",
-    "@ui5/webcomponents-base": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2"
   }
 }

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: webcomponents.main",
   "ui5": {
     "webComponentsPackage": true
@@ -42,13 +42,13 @@
     "directory": "packages/main"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "^1.10.1",
-    "@ui5/webcomponents-icons": "^1.10.1",
-    "@ui5/webcomponents-localization": "^1.10.1",
-    "@ui5/webcomponents-theming": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2",
+    "@ui5/webcomponents-icons": "1.10.2",
+    "@ui5/webcomponents-localization": "1.10.2",
+    "@ui5/webcomponents-theming": "1.10.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0"
   }
 }

--- a/packages/theming/CHANGELOG.md
+++ b/packages/theming/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 **Note:** Version bump only for package @ui5/webcomponents-theming

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-theming",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: webcomponents.theming",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.1.48",
-    "@ui5/webcomponents-base": "^1.10.1"
+    "@ui5/webcomponents-base": "1.10.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "^1.10.1",
+    "@ui5/webcomponents-tools": "1.10.2",
     "chromedriver": "109.0.0",
     "cssnano": "^4.1.11",
     "globby": "^13.1.1",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.2](https://github.com/SAP/ui5-webcomponents/compare/v1.10.1...v1.10.2) (2023-01-25)
+
+**Note:** Version bump only for package ui5-webcomponents
+
 ## [1.10.1](https://github.com/SAP/ui5-webcomponents/compare/v0.0.0-7b49a7ff1...v1.10.1) (2023-01-24)
 
 **Note:** Version bump only for package @ui5/webcomponents-tools

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-tools",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI5 Web Components: webcomponents.tools",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",


### PR DESCRIPTION
The auto releases did not force version bump to all packages (pushed some to 1.10.2, kept some on 1.10.1), so with this change we fix this to keep all packages in sync and we need to force lerna to bump all packages even if they are not changed.