### PR TITLE
feat(framework): add option to define port, tag and typescript support from command line

### DIFF
--- a/packages/create-package/README.md
+++ b/packages/create-package/README.md
@@ -14,6 +14,7 @@ with `npm`
 - `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME>` (the user will be asked for **port**, **tag** and **typescript support** only).
 - `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT>` (the user will be asked for **tag** and **typescript support** only).
 - `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG>` (the user will be asked for **typescript support** only).
+- `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG> <NEW-PACKAGE-TYPESCRIPT-SUPPORT>` (the user will not be asked for anything).
 
 And with `yarn`
 
@@ -21,6 +22,7 @@ And with `yarn`
 - `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME>`.
 - `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT>`.
 - `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG>`.
+- `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG> <NEW-PACKAGE-TYPESCRIPT-SUPPORT>`.
 
 The script creates a new directory, and fills it with a `package.json` file and all necessary source files, and resources for a new
 components package.

--- a/packages/create-package/README.md
+++ b/packages/create-package/README.md
@@ -10,13 +10,17 @@ Provides an `npm init` script for creating new "UI5 Web Components" packages.
 
 with `npm`
 
-- `npm init @ui5/webcomponents-package` (the user will be asked for **name**, **port**, **tag**);
-- `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME>` (the user will be asked for **port** and **tag** only).
+- `npm init @ui5/webcomponents-package` (the user will be asked for **name**, **port**, **tag**, **typescript support**);
+- `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME>` (the user will be asked for **port**, **tag** and **typescript support** only).
+- `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT>` (the user will be asked for **tag** and **typescript support** only).
+- `npm init @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG>` (the user will be asked for **typescript support** only).
 
 And with `yarn`
 
 - `yarn create @ui5/webcomponents-package`
 - `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME>`.
+- `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT>`.
+- `yarn create @ui5/webcomponents-package <NEW-PACKAGE-NAME> <NEW-PACKAGE-PORT> <NEW-PACKAGE-TAG>`.
 
 The script creates a new directory, and fills it with a `package.json` file and all necessary source files, and resources for a new
 components package.

--- a/packages/create-package/index.js
+++ b/packages/create-package/index.js
@@ -75,6 +75,10 @@ const createWebcomponentsPackage = async () => {
 
 	// Get the name
 	let name = process.argv[2];
+	// Get the port
+	let port = process.argv[3];
+	// Get the tag
+	let tag = process.argv[4];
 
 	if (!isNameValid(name)) {
 		response = await prompts({
@@ -104,25 +108,27 @@ const createWebcomponentsPackage = async () => {
 	});
 	const typescript = response.language === "ts";
 
-	// Get the port
-	response = await prompts({
-		type: "text",
-		name: "port",
-		message: "Dev server port:",
-		validate: isPortValid,
-		initial: "8080",
-	});
-	const port = response.port;
+	if (!isPortValid(port)) {
+		response = await prompts({
+			type: "text",
+			name: "port",
+			message: "Dev server port:",
+			validate: isPortValid,
+			initial: "8080",
+		});
+		port = response.port;
+	}
 
-	// Get the tag
-	response = await prompts({
-		type: "text",
-		name: "tag",
-		message: "Demo component name:",
-		initial: "my-first-component",
-		validate: isTagValid,
-	});
-	const tag = response.tag;
+	if (!isTagValid(port)) {
+		response = await prompts({
+			type: "text",
+			name: "tag",
+			message: "Demo component name:",
+			initial: "my-first-component",
+			validate: isTagValid,
+		});
+		tag = response.tag;
+	}
 
 	const className = capitalizeFirst(kebabToCamelCase(tag));
 

--- a/packages/create-package/index.js
+++ b/packages/create-package/index.js
@@ -72,6 +72,7 @@ const copyFiles = (vars, sourcePath, destPath) => {
 // Main function
 const createWebcomponentsPackage = async () => {
 	let response;
+	let typescript = false;
 
 	// Get the name
 	let name = process.argv[2];
@@ -79,6 +80,8 @@ const createWebcomponentsPackage = async () => {
 	let port = process.argv[3];
 	// Get the tag
 	let tag = process.argv[4];
+	// Get the TypeScript support
+	let typescriptSupport = process.argv[5];
 
 	if (!isNameValid(name)) {
 		response = await prompts({
@@ -90,23 +93,24 @@ const createWebcomponentsPackage = async () => {
 		name = response.name;
 	}
 
-	// Add TypeScript support
-	response = await prompts({
-		type: "select",
-		name: "language",
-		message: "Support TypeScript:",
-		choices: [
-			{
-				title: "JavaScript",
-				value: "js",
-			},
-			{
-				title: "TypeScript",
-				value: "ts",
-			},
-		]
-	});
-	const typescript = response.language === "ts";
+	if (!typescriptSupport) {
+		response = await prompts({
+			type: "select",
+			name: "language",
+			message: "Support TypeScript:",
+			choices: [
+				{
+					title: "JavaScript",
+					value: "js",
+				},
+				{
+					title: "TypeScript",
+					value: "ts",
+				},
+			]
+		});
+		typescript = response.language === "ts";
+	}
 
 	if (!isPortValid(port)) {
 		response = await prompts({


### PR DESCRIPTION
Add option to configure the new package package from command line in order to skip configuration wizard.