### PR TITLE
fix(ui5-input): fire change event on enter

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1010,8 +1010,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		}
 
 		if (this.previousValue !== this.getInputDOMRefSync()!.value) {
-			this.previousValue = this.getInputDOMRefSync()!.value;
 			this.fireEvent(INPUT_EVENTS.CHANGE);
+			this.previousValue = this.value;
 		}
 	}
 

--- a/packages/main/test/pages/MultiInput.html
+++ b/packages/main/test/pages/MultiInput.html
@@ -258,6 +258,13 @@
 	</div>
 
 	<div class="sample-container">
+		<ui5-multi-input show-suggestions id="token-unique" style="width: 50%">
+			<div slot="valueStateMessage" id="value-state-wrapper">Token is already in the list</div>
+			<ui5-suggestion-item text="Argentina"></ui5-suggestion-item>
+		</ui5-multi-input>
+	</div>
+
+	<div class="sample-container">
 		<h1>Test value-help-trigger with F4 and Alt + ArrowUp/Down</h1>
 
 		<ui5-multi-input id="multi-with-value-help-icon" show-value-help-icon>
@@ -401,6 +408,35 @@
 			}
 		}
 		document.getElementById("mi-event").addEventListener("ui5-token-delete", handleTokenDelete2);
+
+		document.getElementById("token-unique").addEventListener("ui5-token-delete", function (event) {
+				const token = event.detail?.token;
+				token && token.remove();
+			});
+		
+			document.getElementById("token-unique").addEventListener("ui5-change", function (event) {
+				if (!event.target.value) {
+					return;
+				}
+		
+				var isDuplicate = event.target.tokens.some(function(token) {
+					return token.text === event.target.value
+				});
+		
+				if (isDuplicate) {
+					event.target.valueState = "Error";
+		
+					setTimeout(function () {
+						event.target.valueState = "None";
+					}, 2000);
+		
+					return;
+				}
+		
+				event.target.appendChild(createTokenFromText(event.target.value));
+		
+				event.target.value = "";
+			});
 	</script>
 </body>
 

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -476,4 +476,26 @@ describe("Keyboard handling", () => {
 
 		assert.ok(await mi.getProperty("focused"), "input field should be focused");
 	});
+
+	it("should trigger change event on enter", async () => {
+		const mi = await $("#token-unique");
+		const inner = await mi.shadow$("input");
+		const valueState = await $("#value-state-wrapper");
+
+		await mi.scrollIntoView();
+
+		// populate new token
+		await inner.click();
+		await inner.keys("a");
+		await inner.keys("Enter");
+
+		await inner.click();
+		await inner.keys("a");
+		await inner.keys("Enter");
+
+		assert.strictEqual(await mi.getProperty("valueState"), "Error", "Value state is Error");
+
+		await browser.pause(2500);
+		assert.strictEqual(await mi.getProperty("valueState"), "None", "Value state is None");
+	});
 });


### PR DESCRIPTION
when the user types something then hits enter the value is set to the input field value. If the user change the value in the change handler, internals used to be not updated correctly and prevented correct future firing of the change event.

FIXES: #6262
