### PR TITLE
fix(ui5-input): prevent setSelectionRange on number input

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -861,7 +861,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 			}
 		}
 
-		if (this._isPhone && !this.suggestionItems.length) {
+		if (this._isPhone && !this.suggestionItems.length && !this.isTypeNumber) {
 			innerInput.setSelectionRange(this.value.length, this.value.length);
 		}
 


### PR DESCRIPTION
setSelectionRange method is not supported by input with type "number" and throws an error

FIXES: #6386
