### PR TITLE
fix(ui5-select, ui5-suggestion-item, ui5-shellbar): color of icon inside options is according to spec

### DIFF
--- a/packages/fiori/src/themes/ShellBarPopover.css
+++ b/packages/fiori/src/themes/ShellBarPopover.css
@@ -3,3 +3,6 @@
 	padding: 0;
 }
 
+.ui5-shellbar-overflow-popover [ui5-li]::part(icon) {
+	color: var(--sapList_TextColor);
+}

--- a/packages/main/src/themes/SelectPopover.css
+++ b/packages/main/src/themes/SelectPopover.css
@@ -6,3 +6,7 @@
 .ui5-select-popover [ui5-li] {
 	height: var(--_ui5_list_item_dropdown_base_height);
 }
+
+.ui5-select-popover [ui5-li]::part(icon) {
+	color: var(--sapList_TextColor);
+}

--- a/packages/main/src/themes/Suggestions.css
+++ b/packages/main/src/themes/Suggestions.css
@@ -15,3 +15,8 @@
 .ui5-suggestions-popover [ui5-li-suggestion-item] {
 	height: var(--_ui5_list_item_dropdown_base_height);
 }
+
+.ui5-suggestions-popover [ui5-li]::part(icon),
+.ui5-suggestions-popover [ui5-li-suggestion-item]::part(icon) {
+	color: var(--sapList_TextColor);
+}


### PR DESCRIPTION
Color of the icons (of list items/options) isnide dropdown should be the same as the  text color of the options.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/6068