### PR TITLE
chore: change snapshot npm tag to @experimental

### DIFF
--- a/.github/actions/release.js
+++ b/.github/actions/release.js
@@ -13,7 +13,7 @@ const options = commandLineArgs([
 	{ name: 'otp', alias: 'p', type: String },
 ]);
 
-const DEFAULT_TAG = "next";
+const DEFAULT_TAG = "experimental";
 const TAG = options.tag || DEFAULT_TAG;
 const NEW_VERSION = options.version;
 const OTP = options.otp;
@@ -72,5 +72,5 @@ const publishPackage = pkg => {
 };
 
 run().catch(error => {
-	console.error("Release of @next version failed", error); // eslint-disable-line
+	console.error("Release of @experimental version failed", error); // eslint-disable-line
 });


### PR DESCRIPTION
Prior to this change the snapshot releases (0.0.0-{commit_id}), triggered via the **Release Snapshot** action used to be published as "@next" tag.
Recently we setup weekly auto releases - RC versions, such as 1.10.3-rc.0, 1.11.0-rc.0, etc. to also be published as "@next" versions, the versions look weird and mixed up.
So we either 
- option 1 - need to publish those types of  versions as two different tags
 f.e. 1.11.0-rc.0 as "@next" and "0.0.0-dae342da" as "@experimental"
- option 2 - or need to align **Release-weekly-auto** and the **Release Snapshot** to both create the next "rc" and both publish as "@next" tag.

In this PR, the first option is implemented, because sometimes we want to release a state that's not actually the "next" thing, but something to try out, adn experiment with.
