### PR TITLE
refactor(ui5-tabcontainer): Simplify _handleResize

### DIFF
--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -389,6 +389,7 @@ class TabContainer extends UI5Element {
 	_itemNavigation: ItemNavigation;
 	_allItemsAndSubItems?: Array<ITab>;
 	responsivePopover?: ResponsivePopover;
+	_handleResizeBound: () => void;
 
 	static get styles() {
 		return [tabStyles, tabContainerCss];
@@ -423,7 +424,7 @@ class TabContainer extends UI5Element {
 	constructor() {
 		super();
 
-		this._handleResize = this._handleResize.bind(this);
+		this._handleResizeBound = this._handleResize.bind(this);
 
 		// Init ItemNavigation
 		this._itemNavigation = new ItemNavigation(this, {
@@ -473,11 +474,11 @@ class TabContainer extends UI5Element {
 	}
 
 	onEnterDOM() {
-		ResizeHandler.register(this._getHeader(), this._handleResize);
+		ResizeHandler.register(this._getHeader(), this._handleResizeBound);
 	}
 
 	onExitDOM() {
-		ResizeHandler.deregister(this._getHeader(), this._handleResize);
+		ResizeHandler.deregister(this._getHeader(), this._handleResizeBound);
 	}
 
 	_handleResize() {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -486,12 +486,12 @@ class TabContainer extends UI5Element {
 			this.responsivePopover.close();
 		}
 
-		this._updateMediaRange();
 		this._width = this.offsetWidth;
+		this._updateMediaRange(this._width);
 	}
 
-	_updateMediaRange() {
-		this.mediaRange = MediaRange.getCurrentRange(MediaRange.RANGESETS.RANGE_4STEPS, this.getDomRef()!.offsetWidth);
+	_updateMediaRange(width: number) {
+		this.mediaRange = MediaRange.getCurrentRange(MediaRange.RANGESETS.RANGE_4STEPS, width);
 	}
 
 	_setItemsPrivateProperties(items: Array<ITab>) {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -11,6 +11,7 @@ import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.j
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import slideDown from "@ui5/webcomponents-base/dist/animations/slideDown.js";
 import slideUp from "@ui5/webcomponents-base/dist/animations/slideUp.js";
+import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
 import { getAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
@@ -335,6 +336,9 @@ class TabContainer extends UI5Element {
 	@property({ type: Object, multiple: true })
 	_overflowItems!: Array<ITab>;
 
+	@property({ validator: Integer, noAttribute: true })
+	_width?: number;
+
 	/**
 	 * Defines the tabs.
 	 * <br><br>
@@ -469,25 +473,20 @@ class TabContainer extends UI5Element {
 	}
 
 	onEnterDOM() {
-		// eslint-disable-next-line
-		// TODO: handleResize is promise, it shouldn't be
-		ResizeHandler.register(this._getHeader(), this._handleResize); /* eslint-disable-line */
+		ResizeHandler.register(this._getHeader(), this._handleResize);
 	}
 
 	onExitDOM() {
-		// eslint-disable-next-line
-		// TODO: handleResize is promise, it shouldn't be
-		ResizeHandler.deregister(this._getHeader(), this._handleResize); /* eslint-disable-line */
+		ResizeHandler.deregister(this._getHeader(), this._handleResize);
 	}
 
-	async _handleResize() {
+	_handleResize() {
 		if (this.responsivePopover && this.responsivePopover.opened) {
 			this.responsivePopover.close();
 		}
-		this._updateMediaRange();
 
-		await renderFinished(); // await the tab container to have rendered its representation of tabs
-		this._setItemsForStrip();
+		this._updateMediaRange();
+		this._width = this.offsetWidth;
 	}
 
 	_updateMediaRange() {


### PR DESCRIPTION
Reasons:
- `_handleResize` was async function, which is not supported type of callback by the ResizeHandler
- It awaited the rendering of the TabContainer, which is unnecessary. The logic is already in the onAfterRendering hook
- Rarely (when the media range changed), `_setItemsForStrip` was called twice - once onAfterRendering and once in `_handleResize`

Solution:
- Simplify the logic by always invalidating on resize
