### PR TITLE
chore(ResizeHandler): accept async resize handlers

### DIFF
--- a/packages/base/src/delegate/ResizeHandler.ts
+++ b/packages/base/src/delegate/ResizeHandler.ts
@@ -1,6 +1,6 @@
 import { instanceOfUI5Element } from "../UI5Element.js";
 
-type ResizeObserverCallback = () => void;
+type ResizeObserverCallback = () => Promise<void> | void;
 
 let resizeObserver: ResizeObserver;
 const observedElements = new Map<HTMLElement, Array<ResizeObserverCallback>>();
@@ -10,7 +10,9 @@ const getResizeObserver = () => {
 		resizeObserver = new window.ResizeObserver(entries => {
 			entries.forEach(entry => {
 				const callbacks = observedElements.get(entry.target as HTMLElement);
-				callbacks?.forEach((callback: ResizeObserverCallback) => callback());
+				// Callbacks could be async and we need to handle returned promises to comply with the eslint "no-misused-promises" rule.
+				// Although Promise.all awaits all, we don't additonal task after calling the callbacks and should not make any difference.
+				callbacks && Promise.all(callbacks.map((callback: ResizeObserverCallback) => callback()));
 			});
 		});
 	}
@@ -93,3 +95,6 @@ class ResizeHandler {
 }
 
 export default ResizeHandler;
+export type {
+	ResizeObserverCallback,
+};

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -4,6 +4,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import languageAware from "@ui5/webcomponents-base/dist/decorators/languageAware.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { getIllustrationDataSync, getIllustrationData } from "@ui5/webcomponents-base/dist/asset-registries/Illustrations.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import I18nBundle, { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -327,7 +328,7 @@ class IllustratedMessage extends UI5Element {
 	static i18nBundle: I18nBundle;
 	_lastKnownOffsetWidthForMedia: Record<string, number>;
 	_lastKnownMedia: string;
-	_handleResize: () => void;
+	_handleResize: ResizeObserverCallback;
 
 	constructor() {
 		super();

--- a/packages/fiori/src/Page.ts
+++ b/packages/fiori/src/Page.ts
@@ -5,6 +5,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import MediaRange from "@ui5/webcomponents-base/dist/MediaRange.js";
 import PageBackgroundDesign from "./types/PageBackgroundDesign.js";
 
@@ -147,7 +148,7 @@ class Page extends UI5Element {
 	@slot()
 	footer!: Array<HTMLElement>;
 
-	_updateMediaRange: () => void;
+	_updateMediaRange: ResizeObserverCallback;
 
 	static get render() {
 		return litRender;

--- a/packages/fiori/src/ProductSwitch.ts
+++ b/packages/fiori/src/ProductSwitch.ts
@@ -6,6 +6,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 
@@ -95,7 +96,7 @@ class ProductSwitch extends UI5Element {
 	_itemNavigation: ItemNavigation;
 	_currentIndex: number;
 	_rowSize: number;
-	_handleResizeBound: () => void;
+	_handleResizeBound: ResizeObserverCallback;
 
 	static i18nBundle: I18nBundle;
 

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -17,6 +17,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
 import BreadcrumbsDesign from "./types/BreadcrumbsDesign.js";
 import BreadcrumbsSeparatorStyle from "./types/BreadcrumbsSeparatorStyle.js";
@@ -180,7 +181,7 @@ class Breadcrumbs extends UI5Element {
 	items!: Array<BreadcrumbsItem>;
 
 	_itemNavigation: ItemNavigation
-	_onResizeHandler: () => void;
+	_onResizeHandler: ResizeObserverCallback;
 
 	// maps items to their widths
 	_breadcrumbItemWidths = new WeakMap<BreadcrumbsItem, number>();

--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -19,6 +19,7 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ScrollEnablement from "@ui5/webcomponents-base/dist/delegate/ScrollEnablement.js";
 import type { ScrollEnablementEventListenerParam } from "@ui5/webcomponents-base/dist/delegate/ScrollEnablement.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
@@ -270,7 +271,7 @@ class Carousel extends UI5Element {
 	_visibleNavigationArrows!: boolean;
 
 	_scrollEnablement: ScrollEnablement;
-	_onResizeBound: () => void;
+	_onResizeBound: ResizeObserverCallback;
 	_resizing: boolean;
 	_lastFocusedElements: Array<HTMLElement>;
 	_orderOfLastFocusedPages: Array<number>;

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -1,6 +1,7 @@
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
@@ -154,7 +155,7 @@ class DateTimePicker extends DatePicker {
 	@property({ defaultValue: "hours" })
 	_currentTimeSlider!: string;
 
-	_handleResizeBound: () => void;
+	_handleResizeBound: ResizeObserverCallback;
 
 	static get staticAreaTemplate() {
 		return DateTimePickerPopoverTemplate;

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -7,6 +7,7 @@ import languageAware from "@ui5/webcomponents-base/dist/decorators/languageAware
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import {
 	isPhone,
 	isAndroid,
@@ -609,7 +610,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	lastConfirmedValue: string
 	isTyping: boolean
 	suggestionsTexts: Array<InputSuggestionText>;
-	_handleResizeBound: () => void;
+	_handleResizeBound: ResizeObserverCallback;
 	_keepInnerValue: boolean;
 	_shouldAutocomplete?: boolean;
 	_keyDown?: boolean;

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1,6 +1,7 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import fastNavigation from "@ui5/webcomponents-base/dist/decorators/fastNavigation.js";
@@ -466,7 +467,7 @@ class List extends UI5Element {
 	_forwardingFocus: boolean;
 	resizeListenerAttached: boolean;
 	listEndObserved: boolean;
-	_handleResize: () => void;
+	_handleResize: ResizeObserverCallback;
 	initialIntersection: boolean;
 	_selectionRequested?: boolean;
 	growingIntersectionObserver?: IntersectionObserver | null;

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -13,6 +13,7 @@ import { hasStyle, createStyle } from "@ui5/webcomponents-base/dist/ManagedStyle
 import { isEnter, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getNextZIndex, getFocusedElement, isFocusedElementWithinNode } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import MediaRange from "@ui5/webcomponents-base/dist/MediaRange.js";
 import PopupTemplate from "./generated/templates/PopupTemplate.lit.js";
 import PopupBlockLayer from "./generated/templates/PopupBlockLayerTemplate.lit.js";
@@ -245,7 +246,7 @@ abstract class Popup extends UI5Element {
 	@slot({ type: HTMLElement, "default": true })
 	content!: Array<HTMLElement>
 
-	_resizeHandler: () => void;
+	_resizeHandler: ResizeObserverCallback;
 	_shouldFocusRoot?: boolean;
 	_zIndex?: number;
 	_focusedElementBeforeOpen?: HTMLElement | null;

--- a/packages/main/src/SliderBase.ts
+++ b/packages/main/src/SliderBase.ts
@@ -5,6 +5,7 @@ import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import type { ComponentStylesData, PassiveEventListenerObject } from "@ui5/webcomponents-base/dist/types.js";
 import "@ui5/webcomponents-icons/dist/direction-arrows.js";
@@ -160,7 +161,7 @@ class SliderBase extends UI5Element {
 	@property({ type: Boolean })
 	_hiddenTickmarks!: boolean;
 
-	_resizeHandler: () => void;
+	_resizeHandler: ResizeObserverCallback;
 	_moveHandler: (e: TouchEvent | MouseEvent) => void;
 	_upHandler: () => void;
 	_stateStorage: StateStorage;

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -6,6 +6,7 @@ import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
@@ -513,7 +514,7 @@ class Table extends UI5Element {
 
 	fnHandleF7: (e: CustomEvent) => void;
 	fnOnRowFocused: (e: CustomEvent) => void;
-	_handleResize: () => void;
+	_handleResize: ResizeObserverCallback;
 
 	moreDataText?: string;
 	tableEndObserved: boolean;


### PR DESCRIPTION
There are use-cases to register an async resize handler in several components (SegmentedButton, TabContainer) and currently the ResizeHandler.register accepts only sync ones. In order to allow registration of async functions:
- change **ResizeObserverCallback** type to accept async functions
- export the **ResizeObserverCallback** type and adopt ResizeObserverCallback in all components using the ResizeHandler

To Discuss:
- Does it worth using the "Promise.all" workaround to fix eslint "no-misused-promises" rule or just "eslint-disable-line"