### PR TITLE
fix(ui5-date-picker): align value state

### DIFF
--- a/packages/main/src/DatePicker.hbs
+++ b/packages/main/src/DatePicker.hbs
@@ -19,6 +19,7 @@
 			@ui5-input="{{_onInputInput}}"
 			@ui5-submit="{{_onInputSubmit}}"
 			@keydown="{{_onkeydown}}"
+			@focusout="{{_onInputFocusOut}}"
 	>
 
 		{{#if valueStateMessage.length}}

--- a/packages/main/src/DatePicker.hbs
+++ b/packages/main/src/DatePicker.hbs
@@ -19,7 +19,6 @@
 			@ui5-input="{{_onInputInput}}"
 			@ui5-submit="{{_onInputSubmit}}"
 			@keydown="{{_onkeydown}}"
-			@focusout="{{_onInputFocusOut}}"
 	>
 
 		{{#if valueStateMessage.length}}

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -594,6 +594,14 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	}
 
 	/**
+	 * The ui5-input "focusout" event handler
+	 * @protected
+	 */
+	 _onInputFocusOut(e: Event) {
+		this._updateValueAndFireEvents((e.target as DatePicker).value, true, ["change", "value-changed"]);
+	}
+
+	/**
 	 * Checks if the provided value is valid and within valid range.
 	 * @protected
 	 * @param { string } value

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -543,11 +543,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 		}
 
 		if (updateValue) {
-			this._getInput().getInputDOMRef().then((innerInput: Input | HTMLInputElement | null) => {
-				if (innerInput) {
-					innerInput.value = value;
-				}
-			});
+			this._getInput().value = value;
 			this.value = value;
 			this._updateValueState(); // Change the value state to Error/None, but only if needed
 		}
@@ -591,14 +587,6 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	 */
 	_onInputInput(e: KeyboardEvent) {
 		this._updateValueAndFireEvents((e.target as DatePicker).value, false, ["input"], false);
-	}
-
-	/**
-	 * The ui5-input "focusout" event handler
-	 * @protected
-	 */
-	 _onInputFocusOut(e: Event) {
-		this._updateValueAndFireEvents((e.target as DatePicker).value, true, ["change", "value-changed"]);
 	}
 
 	/**

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1161,4 +1161,37 @@ describe("Date Picker Tests", () => {
 
 		assert.equal(await input.getProperty("value"), "Invalid value", "the value isn't changed");
 	});
+
+	it("Maximum or minimum date changes value state to none", async () => {
+		await browser.url(`test/pages/DatePicker_test_page.html?sap-ui-language=en`);
+		datepicker.id = "#dp33";
+
+		const input = await datepicker.getInput();
+		const innerInput = await datepicker.getInnerInput();
+		await input.click();
+		while(await innerInput.getValue() !== ""){
+			await innerInput.keys("Backspace");
+		}
+
+		await innerInput.keys("asd");
+		const root = await datepicker.getRoot();
+		await root.keys("Enter");
+
+		assert.equal(await input.getProperty("valueState"), "Error", "value state of the input is valid (1)");
+
+		await datepicker.openPicker();
+
+		const displayedDay = await datepicker.getDisplayedDay(15);
+		displayedDay.click();
+
+
+		assert.equal(await input.getProperty("valueState"), "None", "value state of the input is valid (2)");
+
+		await input.click();
+		await innerInput.keys("asd");
+		await root.keys("Enter");
+
+
+		assert.equal(await input.getProperty("valueState"), "Error", "value state of the input is valid (3)");
+	});
 });

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1162,34 +1162,32 @@ describe("Date Picker Tests", () => {
 		assert.equal(await input.getProperty("value"), "Invalid value", "the value isn't changed");
 	});
 
-	it("Maximum or minimum date changes value state to none", async () => {
+	it("Invalid state is refreshed after a value is picked by Calendar and set again", async () => {
 		await browser.url(`test/pages/DatePicker_test_page.html?sap-ui-language=en`);
 		datepicker.id = "#dp33";
 
 		const input = await datepicker.getInput();
 		const innerInput = await datepicker.getInnerInput();
 		await input.click();
-		while(await innerInput.getValue() !== ""){
-			await innerInput.keys("Backspace");
-		}
 
-		await innerInput.keys("asd");
-		const root = await datepicker.getRoot();
-		await root.keys("Enter");
+		await innerInput.keys("asd")
+		await innerInput.keys("Enter");
 
 		assert.equal(await input.getProperty("valueState"), "Error", "value state of the input is valid (1)");
 
 		await datepicker.openPicker();
 
 		const displayedDay = await datepicker.getDisplayedDay(15);
-		displayedDay.click();
-
+		await displayedDay.click();
 
 		assert.equal(await input.getProperty("valueState"), "None", "value state of the input is valid (2)");
 
 		await input.click();
+		while(await innerInput.getValue() !== ""){
+			await innerInput.keys("Backspace");
+		}
 		await innerInput.keys("asd");
-		await root.keys("Enter");
+		await innerInput.keys("Enter");
 
 
 		assert.equal(await input.getProperty("valueState"), "Error", "value state of the input is valid (3)");


### PR DESCRIPTION
The issue was occuring only when you write wrong value in input, focus out, then select something and without focusing out write the same wrong value in the input and then focus out. This was not triggering the change event of the input, hence we were not validating the value, because the input would have same value before and after the selection.
Now we set the value to the input when we select, so the input would react to every value change.

fixes: https://github.com/SAP/ui5-webcomponents/issues/6303
fixes: https://github.com/SAP/ui5-webcomponents/issues/5963
