### PR TITLE
fix(ui5-segmented-button): press item programatically works properly

### DIFF
--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -184,7 +184,7 @@ class SegmentedButton extends UI5Element {
 	}
 
 	normalizeSelection() {
-		let selectedItems = this.items.filter(item => item.pressed);
+		const selectedItems = this.items.filter(item => item.pressed);
 		const selectedIndex = this._selectedItem ? selectedItems.indexOf(this._selectedItem) : -1;
 
 		if (this._selectedItem && selectedItems.length > 1) {

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -91,7 +91,7 @@ class SegmentedButton extends UI5Element {
 	 * @slot items
 	 * @public
 	 */
-	@slot({ type: HTMLElement, "default": true })
+	@slot({ type: HTMLElement, invalidateOnChildChange: true, "default": true })
 	items!: Array<SegmentedButtonItem>;
 
 	static i18nBundle: I18nBundle;
@@ -184,7 +184,13 @@ class SegmentedButton extends UI5Element {
 	}
 
 	normalizeSelection() {
-		this._selectedItem = this.items.filter(item => item.pressed).pop();
+		let selectedItems = this.items.filter(item => item.pressed);
+		const selectedIndex = this._selectedItem ? selectedItems.indexOf(this._selectedItem) : -1;
+
+		if (this._selectedItem && selectedItems.length > 1) {
+			selectedItems.splice(selectedIndex, 1);
+		}
+		this._selectedItem = selectedItems.pop();
 
 		if (this._selectedItem) {
 			this.items.forEach(item => {

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -120,7 +120,8 @@
 		</ui5-segmented-button>
 		<ui5-button id="progSetButton1">Press second item</ui5-button>
 		<ui5-button id="progSetButton2">Press multiple items</ui5-button>
-		<ui5-button id="progSetButton3">Press pressed items</ui5-button>
+		<ui5-button id="progSetButton3">Press pressed item</ui5-button>
+		<ui5-button id="progSetButton4">Press first item</ui5-button>
 	</section>
 
 	<script>
@@ -136,6 +137,10 @@
 
 		progSetButton3.addEventListener("click", function() {
 			segButtonProg.selectedItem.pressed = true;
+		});
+
+		progSetButton4.addEventListener("click", function() {
+			segButtonProg.items[0].pressed = true;
 		});
 
 	</script>

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -110,5 +110,35 @@
 			<ui5-segmented-button-item icon="accept"></ui5-segmented-button-item>
 		</ui5-segmented-button>
 	</section>
+
+	<section>
+		<h3>Programatical change test</h3>
+		<ui5-segmented-button id="segButtonProg">
+			<ui5-segmented-button-item id="sbpItem1" pressed>First</ui5-segmented-button-item>
+			<ui5-segmented-button-item id="sbpItem2">Second</ui5-segmented-button-item>
+			<ui5-segmented-button-item id="sbpItem3">Third</ui5-segmented-button-item>
+		</ui5-segmented-button>
+		<ui5-button id="progSetButton1">Press second item</ui5-button>
+		<ui5-button id="progSetButton2">Press multiple items</ui5-button>
+		<ui5-button id="progSetButton3">Press pressed items</ui5-button>
+	</section>
+
+	<script>
+
+		progSetButton1.addEventListener("click", function() {
+			segButtonProg.items[1].pressed = true;
+		});
+
+		progSetButton2.addEventListener("click", function() {
+			segButtonProg.items[0].pressed = true;
+			segButtonProg.items[2].pressed = true;
+		});
+
+		progSetButton3.addEventListener("click", function() {
+			segButtonProg.selectedItem.pressed = true;
+		});
+
+	</script>
+
 </body>
 </html>

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -76,4 +76,30 @@ describe("SegmentedButton general interaction", () => {
 		await button2.keys("Tab");
 		assert.ok(await segmentedButtonItem2.isFocused(), "The selected SegmentedButtonItem should be focused.");
 	});
+
+	it("tests programatical item pressing", async () => {
+		const button1 =  await browser.$("#progSetButton1");
+		const button2 =  await browser.$("#progSetButton2");
+		const button3 =  await browser.$("#progSetButton3");
+		const segmentedButtonItem1 =  await browser.$("#sbpItem1");
+		const segmentedButtonItem2 =  await browser.$("#sbpItem2");
+		const segmentedButtonItem3 =  await browser.$("#sbpItem3");
+
+		await button1.click();
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+
+		await button2.click();
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
+
+		await button3.click();
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
+	});
+
+
 });

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -81,24 +81,35 @@ describe("SegmentedButton general interaction", () => {
 		const button1 =  await browser.$("#progSetButton1");
 		const button2 =  await browser.$("#progSetButton2");
 		const button3 =  await browser.$("#progSetButton3");
+		const button4 =  await browser.$("#progSetButton4");
 		const segmentedButtonItem1 =  await browser.$("#sbpItem1");
 		const segmentedButtonItem2 =  await browser.$("#sbpItem2");
 		const segmentedButtonItem3 =  await browser.$("#sbpItem3");
 
 		await button1.click();
-		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
-		assert.ok(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
-		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "[step 1] The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem2.getProperty("pressed"), "[step 1] The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "[step 1] The first SegmentedButtonItem should not be pressed.");
 
 		await button2.click();
-		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
-		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
-		assert.ok(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "[step 2] The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "[step 2] The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem3.getProperty("pressed"), "[step 2] The first SegmentedButtonItem should be pressed.");
+
+		await button4.click();
+		assert.ok(await segmentedButtonItem1.getProperty("pressed"), "[step 3] The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "[step 3] The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "[step 3] The first SegmentedButtonItem should not be pressed.");
+
+		await button1.click();
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "[step 4] The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem2.getProperty("pressed"), "[step 4] The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "[step 4] The first SegmentedButtonItem should not be pressed.");
 
 		await button3.click();
-		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
-		assert.notOk(await segmentedButtonItem2.getProperty("pressed"), "The first SegmentedButtonItem should not be pressed.");
-		assert.ok(await segmentedButtonItem3.getProperty("pressed"), "The first SegmentedButtonItem should be pressed.");
+		assert.notOk(await segmentedButtonItem1.getProperty("pressed"), "[step 5] The first SegmentedButtonItem should not be pressed.");
+		assert.ok(await segmentedButtonItem2.getProperty("pressed"), "[step 5] The first SegmentedButtonItem should not be pressed.");
+		assert.notOk(await segmentedButtonItem3.getProperty("pressed"), "[step 5] The first SegmentedButtonItem should be pressed.");
 	});
 
 


### PR DESCRIPTION
The slot where segmented button items are placed, was not set to invalidate the component when some of the child items was changed ("pressed" to be exact). So setting directly "pressed" attribute of any item did not tell the parent control that something was changed. In addition, the logic that removes the pressed state of other segmented button items when another one was set as "pressed" worked partially, so there were scenarios where more than one segmented button item can be in "pressed" state. This PR fixes the issue by setting a slot to invsalidate when children are changed, and the logic for updating "pressed" states of the items is fixed too.

Fixes: #5890 
Fixes: #4969