### PR TITLE
docs(ui5-color-palette-popover): fix tag in Playground page

### DIFF
--- a/packages/main/test/samples/ColorPalettePopover.sample.html
+++ b/packages/main/test/samples/ColorPalettePopover.sample.html
@@ -4,7 +4,7 @@
 
 <div class="component-package">@ui5/webcomponents</div>
 
-<div class="control-tag">&lt;ui5-color-palette&gt;</div>
+<div class="control-tag">&lt;ui5-color-palette-popover&gt;</div>
 
 <section>
 	<h3>Color Palette Popover with recent colors, default color and more colors features</h3>


### PR DESCRIPTION
There was wrong tag mentioned in the Playground page of ui5-color-palette-popover. Now it is fixed.

Fixes: #6496