### PR TITLE
fix(playground): use relative path for storybook assets

### DIFF
--- a/packages/playground/.storybook/main.ts
+++ b/packages/playground/.storybook/main.ts
@@ -40,7 +40,7 @@ const config = {
     ...config,
     // static assets loaded inside preview-head.html are located in the root
     // of the gh-pages branch and not in the _playground folder
-    STORYBOOK_ASSETS_BASE: isProd ? "/ui5-webcomponents/" : "./"
+    STORYBOOK_ASSETS_BASE: isProd ? "../" : "./"
   }),
   docs: {
     autodocs: true


### PR DESCRIPTION
Deployed assets are always one directory back in the `gh-pages` branch. The storybook build is in the `./_playground` dir. Changing the assets path to relative `../` ensures storybook assets are loaded successfully in the `main` sub directory as well.