### PR TITLE
chore: fix tnt icons export value

### DIFF
--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -117,6 +117,19 @@ import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.j
 import * as defaultTexts from "./dist/generated/i18n/i18n-defaults.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
 
+// SAP Icons
+import accept from "@ui5/webcomponents-icons/dist/accept.js";
+import acceptv4 from "@ui5/webcomponents-icons/dist/v4/accept.js";
+import acceptv5 from "@ui5/webcomponents-icons/dist/v5/accept.js";
+// SAP TNT Icons
+import actor from "@ui5/webcomponents-icons-tnt/dist/actor.js";
+import actorv2 from "@ui5/webcomponents-icons-tnt/dist/v2/actor.js";
+import actorv3 from "@ui5/webcomponents-icons-tnt/dist/v3/actor.js";
+// SAP BS Icons
+import polygone from "@ui5/webcomponents-icons-business-suite/dist/add-polygone.js";
+
+const icons = [accept, acceptv4, acceptv5, actor, actorv2, actorv3, polygone];
+
 const testAssets = {
 	configuration : {
 		getAnimationMode,
@@ -142,6 +155,7 @@ const testAssets = {
 	getIconNames,
 	renderFinished,
 	defaultTexts,
+	getExportedIconsValues: () => icons,
 };
 
 // The SAP Icons V4 icon collection is set by default in sap_fiori_3,

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -88,4 +88,13 @@ describe("Icon general interaction", () => {
 		const iconPathValueAfter = await iconPathAfter.getAttribute("d");
 		assert.ok(iconPathValueAfter.startsWith(V5_PATH_START), "Icon's path changed in sap_horizon.");
 	});
+
+	it("Tests icon modules' exported values", async () => {
+		const expectedExportedValues = "accept|SAP-icons-v4/accept|SAP-icons-v5/accept|tnt/actor|tnt-v2/actor|tnt-v3/actor|business-suite/add-polygone";
+		const actualExportedValues = await browser.executeAsync(done => {
+			const exportedIconValues = window["sap-ui-webcomponents-bundle"].getExportedIconsValues();
+			done(exportedIconValues.join("|"));
+		});
+		assert.strictEqual(actualExportedValues, expectedExportedValues, "Exported values are correct.");
+	});
 });

--- a/packages/tools/lib/create-icons/index.js
+++ b/packages/tools/lib/create-icons/index.js
@@ -38,13 +38,13 @@ export { pathData, ltr, accData };`;
 
 
 
-const collectionTemplate = (name, versions) => `import { isThemeFamily } from "@ui5/webcomponents-base/dist/config/Theme.js";
+const collectionTemplate = (name, versions, fullName) => `import { isThemeFamily } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import { pathData as pathData${versions[0]}, ltr, accData } from "./${versions[0]}/${name}.js";
 import { pathData as pathData${versions[1]} } from "./${versions[1]}/${name}.js";
 
 const pathData = isThemeFamily("sap_horizon") ? pathData${versions[1]} : pathData${versions[0]};
 
-export default "${name}";
+export default "${fullName}";
 export { pathData, ltr, accData };`;
 
 
@@ -80,20 +80,43 @@ const createIcons = async (file) => {
 		const pathData = iconData.path;
 		const ltr = !!iconData.ltr;
 		const acc = iconData.acc;
+		const packageName =  json.packageName;
+		const collection =  json.collection;
 
-		const content = acc ? iconAccTemplate(name, pathData, ltr, acc, json.collection, json.packageName) : iconTemplate(name, pathData, ltr, json.collection, json.packageName);
+		const content = acc ? iconAccTemplate(name, pathData, ltr, acc, collection, packageName) : iconTemplate(name, pathData, ltr, collection, packageName);
 
 		promises.push(fs.writeFile(path.join(destDir, `${name}.js`), content));
 		promises.push(fs.writeFile(path.join(destDir, `${name}.svg`), svgTemplate(pathData)));
-		promises.push(fs.writeFile(path.join(destDir, `${name}.d.ts`), typeDefinitionTemplate(name, acc, json.collection)));
+		promises.push(fs.writeFile(path.join(destDir, `${name}.d.ts`), typeDefinitionTemplate(name, acc, collection)));
+
+		// For versioned icons collections, the script creates top level (unversioned) module that internally imports the versioned ones.
+		// For example, the top level "@ui5/ui5-webcomponents-icons/dist/accept.js" imports:
+		// - "@ui5/ui5-webcomponents-icons/dist/v5/accept.js" 
+		// - "@ui5/ui5-webcomponents-icons/dist/v4/accept.js"
 
 		if (json.version) {
-			promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.js`), collectionTemplate(name, json.versions)));
-            promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.d.ts`), collectionTypeDefinitionTemplate(name, acc)));
+			// The exported value from the top level (unversioned) icon module depends on whether the collection is the default,
+			// to add or not the collection name to the exported value:
+			// For the default collection (SAPIcons) we export just the icon name - "export default { 'accept' }"
+			// For non-default collections (SAPTNTIcons and SAPBSIcons) we export the full name - "export default { 'tnt/actor' }"
+			const effectiveName = isDefaultCollection(collection) ? name : getUnversionedFullIconName(name, collection);
+			promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.js`), collectionTemplate(name, json.versions, effectiveName)));
+            promises.push(fs.writeFile(path.join(path.normalize("dist/"), `${name}.d.ts`), collectionTypeDefinitionTemplate(effectiveName, acc)));
 		}
 	}
 
 	return Promise.all(promises);
+};
+
+const isDefaultCollection = collectionName => collectionName === "SAP-icons-v4"  || collectionName === "SAP-icons-v5";
+const getUnversionedFullIconName = (name, collection) => `${getUnversionedCollectionName(collection)}/${name}`;
+const getUnversionedCollectionName = collectionName => CollectionVersionedToUnversionedMap[collectionName] || collectionName;
+
+const CollectionVersionedToUnversionedMap = {
+	"tnt-v2": "tnt",
+	"tnt-v3": "tnt",
+	"business-suite-v1": "business-suite",
+	"business-suite-v2": "business-suite",
 };
 
 createIcons(srcFile).then(() => {


### PR DESCRIPTION
**Background**
After splitting the SAP TNT icons to support 2 version - v2 and v3, we now have a top level module , that refers to and imports the versioned ones.
Before the split, the top level module used to export the icon name, including the collection ("tnt/actor"). 
After the split, the top level module (built from different flow) includes only the icon name ("actor").

```js
// In recent RC release the exported value is "actor"
import actor from "@ui5/webcomponents-icons-tnt/dist/actor.js";
```
 [RC release](https://unpkg.com/browse/@ui5/webcomponents-icons-tnt@1.11.0-rc.2/dist/actor.js) 

```js
// In our latest release the exported value is "tnt/actor"
import actor from "@ui5/webcomponents-icons-tnt/dist/actor.js";
```
[latest release](https://unpkg.com/browse/@ui5/webcomponents-icons-tnt@1.10.0/dist/actor.d.ts) 

**Changes**
- fixes this incompatible change.
- adds test for the exported value per collection.
Note: for the default collection, as before, we keep exporting just the icon name ("accept" from SAP Icons).

