### PR TITLE
docs: add ui5-tree-item-custom API docs

### DIFF
--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -91,7 +91,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @alias sap.ui.webc.main.Tree
  * @extends sap.ui.webc.base.UI5Element
  * @tagname ui5-tree
- * @appenddocs sap.ui.webc.main.TreeItem
+ * @appenddocs sap.ui.webc.main.TreeItem sap.ui.webc.main.TreeItemCustom
  * @public
  * @since 1.0.0-rc.8
  */


### PR DESCRIPTION
The `TreeItemCustom` is a public component, but the API reference is not available - let's add it.