### PR TITLE
fix(ui5-toggle-button): fix Emphasized Toggle Button text shadow in Belize theme

### DIFF
--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -2,6 +2,10 @@
 	display: inline-block;
 }
 
+:host([design="Emphasized"]:not([pressed])) {
+	text-shadow: var(--_ui5_toggle_button_emphasized_text_shadow);
+}
+
 :host([pressed]),
 :host([design="Default"][pressed]),
 :host([design="Transparent"][pressed]),
@@ -9,6 +13,7 @@
 	background: var(--sapButton_Selected_Background);
 	border-color: var(--sapButton_Selected_BorderColor);
 	color: var(--sapButton_Selected_TextColor);
+	text-shadow: none;
 }
 
 :host([pressed]:hover),

--- a/packages/main/src/themes/base/ToggleButton-parameters.css
+++ b/packages/main/src/themes/base/ToggleButton-parameters.css
@@ -5,4 +5,5 @@
 	--_ui5_toggle_button_selected_negative_text_color: var(--sapButton_Selected_TextColor);
 	--_ui5_toggle_button_selected_attention_text_color: var(--sapButton_Selected_TextColor);
 	--_ui5_toggle_button_emphasized_pressed_focussed_hovered: var(--sapContent_FocusColor);
+	--_ui5_toggle_button_emphasized_text_shadow: none;
 }

--- a/packages/main/src/themes/sap_belize/ToggleButton-parameters.css
+++ b/packages/main/src/themes/sap_belize/ToggleButton-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ToggleButton-parameters.css";
+
+:root {
+	--_ui5_toggle_button_emphasized_text_shadow: 0 0 0.125rem rgb(0 0 0 / 50%);
+}

--- a/packages/main/src/themes/sap_belize/parameters-bundle.css
+++ b/packages/main/src/themes/sap_belize/parameters-bundle.css
@@ -33,6 +33,7 @@
 @import "../base/SegmentedButtton-parameters.css";
 @import "../base/Select-parameters.css";
 @import "./SplitButton-parameters.css";
+@import "./ToggleButton-parameters.css";
 @import "../base/Switch-parameters.css";
 @import "./TabContainer-parameters.css";
 @import "./Table-parameters.css";

--- a/packages/main/test/pages/ToggleButton.html
+++ b/packages/main/test/pages/ToggleButton.html
@@ -45,6 +45,8 @@
 			<ui5-toggle-button class="toggleButton" design="Negative" pressed>Reject ToggleButton</ui5-toggle-button>
 			<ui5-toggle-button class="toggleButton" design="Transparent">Transparent ToggleButton</ui5-toggle-button>
 			<ui5-toggle-button class="toggleButton" design="Transparent" pressed>Transparent ToggleButton</ui5-toggle-button>
+			<ui5-toggle-button class="toggleButton" design="Emphasized">Emphasized ToggleButton</ui5-toggle-button>
+			<ui5-toggle-button class="toggleButton" design="Emphasized" pressed>Emphasized ToggleButton</ui5-toggle-button>
 		</div>
 	</div>
 	<div class="result">


### PR DESCRIPTION
There was not applied text-shadow of the non-pressed Emphasized Toggle Button in Belize theme.
This PR fixes it.
In fact the issue is reported for sap.ui.webc.main.ToggleButton
Internal incident: 2270135209