### PR TITLE
fix(ui5-tree): correctly pass mode to sub items

### DIFF
--- a/packages/main/src/TreeList.ts
+++ b/packages/main/src/TreeList.ts
@@ -34,7 +34,7 @@ const flattenTree = (items: Array<TreeItemBase>, result: Array<TreeItemBase>, in
 		result.push(item);
 
 		if ((item.expanded || includeCollapsed) && item.items) {
-			flattenTree(item.items, result);
+			flattenTree(item.items, result, includeCollapsed);
 		}
 	});
 };

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -178,6 +178,27 @@
 			</ui5-tree-item-custom>
 		</ui5-tree-item-custom>
 	</ui5-tree>
+
+	<ui5-tree mode="MultiSelect" id="allItemsMultiSelect">
+		<ui5-tree-item text="Should have checkbox">
+			<ui5-tree-item text="Should have checkbox">
+				<ui5-tree-item text="Should have checkbox">
+					<ui5-tree-item text="Should have checkbox">
+						<ui5-tree-item text="Should have checkbox">
+							<ui5-tree-item
+								class="lastItem"
+								text="Should have checkbox"
+							></ui5-tree-item>
+							<ui5-tree-item
+								text="Should have checkbox"
+							></ui5-tree-item>
+						</ui5-tree-item>
+					</ui5-tree-item>
+				</ui5-tree-item>
+			</ui5-tree-item>
+			<ui5-tree-item text="Should have checkbox"></ui5-tree-item>
+		</ui5-tree-item>
+	</ui5-tree>
 	
 	<script>
 		const mouseOverInput = document.getElementById("mouseover-counter");

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -182,19 +182,11 @@
 	<ui5-tree mode="MultiSelect" id="allItemsMultiSelect">
 		<ui5-tree-item text="Should have checkbox">
 			<ui5-tree-item text="Should have checkbox">
-				<ui5-tree-item text="Should have checkbox">
-					<ui5-tree-item text="Should have checkbox">
-						<ui5-tree-item text="Should have checkbox">
-							<ui5-tree-item
-								class="lastItem"
-								text="Should have checkbox"
-							></ui5-tree-item>
-							<ui5-tree-item
-								text="Should have checkbox"
-							></ui5-tree-item>
-						</ui5-tree-item>
-					</ui5-tree-item>
-				</ui5-tree-item>
+				<ui5-tree-item
+					class="lastItem"
+					text="Should have checkbox"
+				></ui5-tree-item>
+				<ui5-tree-item text="Should have checkbox"></ui5-tree-item>
 			</ui5-tree-item>
 			<ui5-tree-item text="Should have checkbox"></ui5-tree-item>
 		</ui5-tree-item>

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -81,7 +81,7 @@ describe("Tree proxies properties to list", () => {
 		});
 	});
 
-	it.only("Mode works recursively", async () => {
+	it("Mode works recursively", async () => {
 		const lastItem = await browser.$(">>>#allItemsMultiSelect .lastItem");
 		assert.strictEqual(await lastItem.getAttribute("_mode"), "MultiSelect", "Mode applied to the last tree item");
 	});

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -81,6 +81,11 @@ describe("Tree proxies properties to list", () => {
 		});
 	});
 
+	it.only("Mode works recursively", async () => {
+		const lastItem = await browser.$(">>>#allItemsMultiSelect .lastItem");
+		assert.strictEqual(await lastItem.getAttribute("_mode"), "MultiSelect", "Mode applied to the last tree item");
+	});
+
 	it("headerText, footerText, noDataText work", async () => {
 		const tree = await browser.$("#tree");
 		const list = await tree.shadow$("ui5-tree-list");


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/6571

The flag `includeCollapsed` was not passed to the recursive call of `flattenTree` function, causing it not to work pass the the second level of sub nodes. 