### PR TITLE
chore: return result from fireEvent call

### DIFF
--- a/packages/fiori/src/NotificationAction.ts
+++ b/packages/fiori/src/NotificationAction.ts
@@ -98,8 +98,16 @@ class NotificationAction extends UI5Element {
 	@property()
 	icon!: string;
 
-	fireClickEvent(e: MouseEvent) {
-		this.fireEvent<NotificationActionClickEventDetail>("click", {
+	/**
+	 * Fires a custom event "click".
+	 * <b>Note:</b> Called by NotificationListItem and NotificationListGroupItem components.
+	 *
+	 * @param { MouseEvent } e
+	 * @protected
+	 * @returns { boolean } false, if the event was cancelled (preventDefault called), true otherwise
+	 */
+	fireClickEvent(e: MouseEvent): boolean {
+		return this.fireEvent<NotificationActionClickEventDetail>("click", {
 			targetRef: (e.target as Button),
 		}, true);
 	}


### PR DESCRIPTION
In previous change, part of the TS migration, `fireClickEvent` has been introduced, to wrap a call to `fireEvent`.
Since fireEvent returns boolean (event has been prevented or not), we need to also return that result, so that consumers of fireClickEvent can use it.