### PR TITLE
chore(ui5-li): fix `selection-change` event detail

### DIFF
--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -346,7 +346,7 @@ abstract class ListItem extends ListItemBase {
 			return;
 		}
 
-		this.fireEvent<SelectionRequestEventDetail>("_selection-requested", { item: this, selected: (e.target as HTMLInputElement).checked, selectionComponentPressed: true }); // Switch HTMLInputElement to CheckBox when ui5-check is migrated to TypeScript
+		this.fireEvent<SelectionRequestEventDetail>("_selection-requested", { item: this, selected: (e.target as CheckBox).checked, selectionComponentPressed: true });
 	}
 
 	onSingleSelectionComponentPress(e: MouseEvent) {
@@ -354,7 +354,7 @@ abstract class ListItem extends ListItemBase {
 			return;
 		}
 
-		this.fireEvent<SelectionRequestEventDetail>("_selection-requested", { item: this, selected: !(e.target as ListItemBase).selected, selectionComponentPressed: true });
+		this.fireEvent<SelectionRequestEventDetail>("_selection-requested", { item: this, selected: !(e.target as RadioButton).checked, selectionComponentPressed: true });
 	}
 
 	activate() {

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -48,6 +48,7 @@
 	</ui5-list>
 	<ui5-input id="itemClickResultField" placeholder="itemClick result"></ui5-input>
 	<ui5-input id="selectionChangeResultField" placeholder="selectionChange result"></ui5-input>
+	<ui5-input id="selectionChangeResultFieldRadio" placeholder="selectionComponentPressed result "></ui5-input>
 	<ui5-input id="selectionChangeResultPreviousItemsParameter" placeholder="selectionChange previousSelection result"></ui5-input>
 
 	<br><br><br>
@@ -282,6 +283,7 @@
 		listEvents.addEventListener("ui5-selection-change", function (event) {
 			selectionChangeCounter += 1;
 			selectionChangeResultField.value = selectionChangeCounter;
+			selectionChangeResultFieldRadio.value = event.detail.selectionComponentPressed;
 		});
 
 		listEvents.addEventListener("ui5-selection-change", function(event) {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -37,7 +37,7 @@ describe("List Tests", () => {
 		const itemClickResultField = await browser.$("#itemClickResultField");
 		const selectionChangeResultField = await browser.$("#selectionChangeResultField");
 		const firstItem = await browser.$("#listEvents #country1");
-		const secondItemRadio = await browser.$("#listEvents #country2").shadow$("ui5-radio-buttom");
+		const secondItemRadio = await browser.$("#listEvents #country2").shadow$("ui5-radio-button");
 
 		await firstItem.click();
 

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -37,11 +37,18 @@ describe("List Tests", () => {
 		const itemClickResultField = await browser.$("#itemClickResultField");
 		const selectionChangeResultField = await browser.$("#selectionChangeResultField");
 		const firstItem = await browser.$("#listEvents #country1");
+		const secondItemRadio = await browser.$("#listEvents #country2").shadow$("ui5-radio-buttom");
 
 		await firstItem.click();
 
 		assert.strictEqual(await itemClickResultField.getProperty("value"), "1", "itemClick event has been fired once");
 		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "1", "selectionChange event has been fired.");
+
+		await secondItemRadio.click();
+		assert.strictEqual(await itemClickResultField.getProperty("value"), "2", "itemClick event has been fired second time");
+		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "2", "selectionChange event has been fired second time.");
+		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "true", "selectionChange event correct detail - selectionComponentPressed.");
+
 	});
 
 	it("itemClick and selectionChange events are fired in Multi selection", async () => {

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -36,6 +36,7 @@ describe("List Tests", () => {
 	it("itemClick and selectionChange events are fired in Single selection", async () => {
 		const itemClickResultField = await browser.$("#itemClickResultField");
 		const selectionChangeResultField = await browser.$("#selectionChangeResultField");
+		const selectionChangeResultFieldRadio = await browser.$("#selectionChangeResultFieldRadio");
 		const firstItem = await browser.$("#listEvents #country1");
 		const secondItemRadio = await browser.$("#listEvents #country2").shadow$("ui5-radio-button");
 
@@ -47,7 +48,7 @@ describe("List Tests", () => {
 		await secondItemRadio.click();
 		assert.strictEqual(await itemClickResultField.getProperty("value"), "2", "itemClick event has been fired second time");
 		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "2", "selectionChange event has been fired second time.");
-		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "true", "selectionChange event correct detail - selectionComponentPressed.");
+		assert.strictEqual(await selectionChangeResultFieldRadio.getProperty("value"), "true", "selectionChange event correct detail - selectionComponentPressed.");
 
 	});
 


### PR DESCRIPTION
Fix `selection-change` private event detail  `selectionComponentPressed`:
- event target type `HTMLInputElement` replaced with `CheckBox`
- event target type is `RadioButton`, not `ListItemBase`
- the property of the RadioButton is `checked` (after 1.0), not `selected` (prior to 1.0) (due to this - actually the logic was not working for a long time)
- add a test to cover the click on a radio button