### PR TITLE
fix(framework): generate unique names individual slots

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -318,7 +318,7 @@ abstract class UI5Element extends HTMLElement {
 			if (slotData.individualSlots) {
 				const nextIndex = (autoIncrementMap.get(slotName) || 0) + 1;
 				autoIncrementMap.set(slotName, nextIndex);
-				(child as Record<string, any>)._individualSlot = `${slotName}-${nextIndex}`;
+				(child as Record<string, any>)._individualSlot = `${this._id}-${slotName}-${nextIndex}`;
 			}
 
 			// Await for not-yet-defined custom elements

--- a/packages/base/test/specs/UI5ElementSlots.js
+++ b/packages/base/test/specs/UI5ElementSlots.js
@@ -28,9 +28,12 @@ describe("Slots work properly", () => {
 	});
 
 	it("Tests that individualSlots modifies the slot property of slotted children", async () => {
-		assert.strictEqual((await browser.$$("#withContent>[slot=individual]")).length, 0, "There are no children with slot=individual");
-		assert.strictEqual((await browser.$$("#withContent>[slot=individual-1]")).length, 1, "The slot of the first child became individual-1");
-		assert.strictEqual((await browser.$$("#withContent>[slot=individual-2]")).length, 1, "The slot of the second child became individual-2");
+		const parent = await browser.$("#withContent");
+		const internalId = await parent.getProperty("_id");
+
+		assert.strictEqual((await parent.$$(`[slot=${internalId}-individual]`)).length, 0, "There are no children with slot=individual");
+		assert.strictEqual((await parent.$$(`[slot=${internalId}-individual-1]`)).length, 1, `The slot of the first child became ${internalId}-individual-1`);
+		assert.strictEqual((await parent.$$(`[slot=${internalId}-individual-2]`)).length, 1, `The slot of the second child became ${internalId}-individual-2`);
 	});
 
 });


### PR DESCRIPTION
Many components use `_individualSlots` to name the slots of their children.
This will lead to a duplication of slot names in a page that uses many ui5-webcomponents.
See https://github.com/SAP/ui5-webcomponents/issues/6591#issuecomment-1447736483
To avoid browser crashes due to slot name collision, the framework will now generate unique `_individualSlot` slot names based on the parent's internal id.
Fixes: #6591 