### PR TITLE
feat: enhance create-ui5-element command to create component in TS

### DIFF
--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -65,7 +65,7 @@ const generateFiles = (componentName, tagName, library, packageName, isTypeScrip
 	console.log(`Successfully generated ${filePaths.template}`);
 
 	// Change the color of the output
-		console.warn('\x1b[33m%s\x1b[0m', `
+	console.warn('\x1b[33m%s\x1b[0m', `
 	Make sure to import the component in your bundle by using:
 	import ${componentName} from "./dist/${componentName}.js";`);
 }
@@ -74,7 +74,7 @@ const generateFiles = (componentName, tagName, library, packageName, isTypeScrip
 const createWebComponent = async () => {
 	const packageName = getPackageName();
 	const library = getLibraryName(packageName);
-	
+
 	const consoleArguments = process.argv.slice(2);
 	let componentName = consoleArguments[0];
 	let tagName = consoleArguments[1];
@@ -145,7 +145,7 @@ const createWebComponent = async () => {
 		isTypeScript = false;
 	}
 
-		generateFiles(componentName, tagName, library, packageName, isTypeScript);
+	generateFiles(componentName, tagName, library, packageName, isTypeScript);
 };
 
 createWebComponent();

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -106,16 +106,16 @@ const createWebComponent = async () => {
 			choices: [
 				{
 					title: "TypeScript (recommended)",
-					value: "ts" 
+					value: true,
 				},
 				{
 					title: "JavaScript",
-					value: "js" 
+					value: false,
 				},
 			],
 		});
-		language = response.language;
-	} else if (language === "ts" || language === "typescript") {
+		isTypeScript = response.language;
+	} else if (language === "typescript" || language === "ts") {
 		isTypeScript = true;
 	} else {
 		isTypeScript = false;

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -43,42 +43,37 @@ const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.
 const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
 
 const generateFiles = (componentName, tagName, library, packageName, isTypeScript) => {
-	const correctComponentName = capitalizeFirstLetter(componentName);
+	componentName = capitalizeFirstLetter(componentName);
 	const filePaths = {
-		"extension": isTypeScript 
-			? `./src/${correctComponentName}.ts` 
-			: `./src/${correctComponentName}.js`,
-		"css": `./src/themes/${correctComponentName}.css`,
-		"hbs": `./src/${correctComponentName}.hbs`,
+		"main": isTypeScript 
+			? `./src/${componentName}.ts` 
+			: `./src/${componentName}.js`,
+		"css": `./src/themes/${componentName}.css`,
+		"template": `./src/${componentName}.hbs`,
 	};
 
 	const FileContentTemplate = isTypeScript 
-		? tsFileContentTemplate(correctComponentName, tagName, library, packageName) 
-		: jsFileContentTemplate(correctComponentName, tagName, library, packageName);
+		? tsFileContentTemplate(componentName, tagName, library, packageName) 
+		: jsFileContentTemplate(componentName, tagName, library, packageName);
 
-	// The .extension determines if the file is .js or .ts with the help of the isTypeScript check
-	fs.writeFileSync(filePaths.extension, FileContentTemplate, { flag: "wx+" });
+	fs.writeFileSync(filePaths.main, FileContentTemplate, { flag: "wx+" });
 	fs.writeFileSync(filePaths.css, "", { flag: "wx+" });
-	fs.writeFileSync(filePaths.hbs, "<div>Hello World</div>", { flag: "wx+" });
+	fs.writeFileSync(filePaths.template, "<div>Hello World</div>", { flag: "wx+" });
 
-	console.log(isTypeScript 
-		? `Successfully generated ${correctComponentName}.ts` 
-		: `Successfully generated ${correctComponentName}.js`);
-	console.log(`Successfully generated ${correctComponentName}.css`);
-	console.log(`Successfully generated ${correctComponentName}.hbs`);
+	console.log(`Successfully generated ${filePaths.main}`);
+	console.log(`Successfully generated ${filePaths.css}`);
+	console.log(`Successfully generated ${filePaths.template}`);
 
 	// Change the color of the output
 		console.warn('\x1b[33m%s\x1b[0m', `
-	Make sure to import the component in the bundle.common.js file by using:
-	Import ${correctComponentName} from "./dist/${correctComponentName}.js";
-	Do NOT forget to sort the file in alphabetical order.`);
+	Make sure to import the component in your bundle by using:
+	import ${componentName} from "./dist/${componentName}.js";`);
 }
 
 // Main function
 const createWebComponent = async () => {
 	const consoleArguments = process.argv.slice(2);
 	let componentName = consoleArguments[0];
-	let isTypeScript = false;
 
 	if (!componentName) {
 		const response = await prompts({
@@ -117,7 +112,7 @@ const createWebComponent = async () => {
 	const packageName = getPackageName();
 	const library = getLibraryName(packageName);
 
-	if (componentName.match(/^[a-zA-Z][a-zA-Z0-9_-]*$/)) {
+	if (isNameValid(componentName)) {
 		generateFiles(componentName, tagName, library, packageName, isTypeScript);
 	} else {
 		console.warn('\x1b[33m%s\x1b[0m',"Invalid component name. Please use only letters, numbers, dashes and underscores. The first character must be a letter.");

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -40,8 +40,7 @@ const camelToKebabCase = string => string.replace(/([a-z])([A-Z])/g, "$1-$2").to
 const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.slice(1);
 
 // Validation of user input
-const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z0-9\-_]+$/);
-const isNameStartingWithNumber = name => typeof name === "string" && name.match(/^[0-9]/);
+const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
 
 const generateFiles = (componentName, tagName, library, packageName, isTypeScript) => {
 	const correctComponentName = capitalizeFirstLetter(componentName);
@@ -68,17 +67,10 @@ const generateFiles = (componentName, tagName, library, packageName, isTypeScrip
 	console.log(`Successfully generated ${correctComponentName}.css`);
 	console.log(`Successfully generated ${correctComponentName}.hbs`);
 
-	const bundleLogger = fs.createWriteStream("./bundle.common.js", {
-		flags: "a" // appending
-	});
-
-	bundleLogger.write(`
-	// TODO: Move this line in order to keep the file sorted alphabetically
-	import ${correctComponentName} from "./dist/${correctComponentName}.js";`);
-
 	// Change the color of the output
 		console.warn('\x1b[33m%s\x1b[0m', `
-	Component is imported in bundle.common.js.
+	Make sure to import the component in the bundle.common.js file by using:
+	Import ${correctComponentName} from "./dist/${correctComponentName}.js";
 	Do NOT forget to sort the file in alphabetical order.`);
 }
 
@@ -98,11 +90,6 @@ const createWebComponent = async () => {
 		componentName = response.componentName;
 	}
 
-	if (!isNameValid(componentName)) {
-		console.error(`The component name "${componentName}" is not valid. Please use only letters, numbers, dashes and underscores.`);
-		return;
-	}
-
 	if (consoleArguments.length === 2) {
 		let language = consoleArguments[1];
 		isTypeScript = language === "typescript";
@@ -113,15 +100,15 @@ const createWebComponent = async () => {
 		message: "Component type:",
 		choices: [
 			{
-			title: "TypeScript (recommended)",
-			value: true,
+				title: "TypeScript (recommended)",
+				value: true,
 			},
 			{
-			title: "JavaScript",
-			value: false,
+				title: "JavaScript",
+				value: false,
 			},
 		],
-		initial: 0,
+			initial: 0,
 		});
 		isTypeScript = response.language;
 	}
@@ -129,11 +116,11 @@ const createWebComponent = async () => {
 	const tagName = `ui5-${camelToKebabCase(componentName)}`;
 	const packageName = getPackageName();
 	const library = getLibraryName(packageName);
-	
-	if (!isNameStartingWithNumber(componentName)) {
+
+	if (componentName.match(/^[a-zA-Z][a-zA-Z0-9_-]*$/)) {
 		generateFiles(componentName, tagName, library, packageName, isTypeScript);
 	} else {
-		console.error(`The component name "${componentName}" is not valid. Please use only letters, dashes and underscores.`);
+		console.warn('\x1b[33m%s\x1b[0m',"Invalid component name. Please use only letters, numbers, dashes and underscores. The first character must be a letter.");
 	}
 };
 

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -40,7 +40,7 @@ const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.
 
 // Validation of user input
 const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
-const isTagNameValid = tagName => tagName.match(/^[a-z]+-[a-z0-9]*(-[a-z0-9]+)*$/);
+const isTagNameValid = tagName => tagName.match(/^[a-z][a-z0-9]+-[a-z0-9]*(-[a-z0-9]+)*$/);
 
 const generateFiles = (componentName, tagName, library, packageName, isTypeScript) => {
 	componentName = capitalizeFirstLetter(componentName);
@@ -74,8 +74,9 @@ const generateFiles = (componentName, tagName, library, packageName, isTypeScrip
 const createWebComponent = async () => {
 	const consoleArguments = process.argv.slice(2);
 	let componentName = consoleArguments[0];
-	let language = consoleArguments[1];
-	let tagName = consoleArguments[2];
+	let tagName = consoleArguments[1];
+	let language = consoleArguments[2];
+	let isTypeScript;
 
 	if (!componentName) {
 		const response = await prompts({
@@ -87,35 +88,7 @@ const createWebComponent = async () => {
 		componentName = response.componentName;
 	}
 
-	if (consoleArguments.length === 2) {
-		language = consoleArguments[1];
-		isTypeScript = language === "typescript" || language === "ts";
-	} else if (consoleArguments.length === 3 && (tagName && !isTagNameValid(tagName))) {
-		console.warn('\x1b[33m%s\x1b[0m',"Invalid tag name. The tag name should only contain lowercase letters, numbers, dashes, and underscores. The first character must be a letter, and it should follow the pattern 'tag-name'.");
-		return;
-	} else {
-		const response = await prompts({
-		type: "select",
-		name: "language",
-		message: "Component type:",
-		choices: [
-			{
-				title: "TypeScript (recommended)",
-				value: true,
-			},
-			{
-				title: "JavaScript",
-				value: false,
-			},
-		],
-			initial: 0,
-		});
-		isTypeScript = response.language;
-	}
-
-	if (consoleArguments.length === 3 && tagName) {
-		tagName = consoleArguments[2];
-	} else {
+	if (!tagName) {
 		const response = await prompts({
 			type: "text",
 			name: "tagName",
@@ -123,6 +96,29 @@ const createWebComponent = async () => {
 			validate: (value) => isTagNameValid(value),
 		});
 		tagName = response.tagName;
+	}
+
+	if (!language && isTagNameValid(tagName)) {
+		const response = await prompts({
+			type: "select",
+			name: "language",
+			message: "Please select a language:",
+			choices: [
+				{
+					title: "TypeScript (recommended)",
+					value: "ts" 
+				},
+				{
+					title: "JavaScript",
+					value: "js" 
+				},
+			],
+		});
+		language = response.language;
+	} else if (language === "ts" || language === "typescript") {
+		isTypeScript = true;
+	} else {
+		isTypeScript = false;
 	}
 
 	const packageName = getPackageName();

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -1,11 +1,7 @@
 const fs = require("fs");
 const prompts = require("prompts");
-const yargs = require("yargs/yargs");
-const { hideBin } = require("yargs/helpers");
 const jsFileContentTemplate = require("./jsFileContentTemplate.js");
 const tsFileContentTemplate = require("./tsFileContentTemplate.js");
-
-const argv = yargs(hideBin(process.argv)).argv;
 
 const getPackageName = () => {
 	if (!fs.existsSync("./package.json")) {
@@ -90,7 +86,7 @@ const generateFiles = (componentName, tagName, library, packageName, isTypeScrip
 const createWebComponent = async () => {
 	const consoleArguments = process.argv.slice(2);
 	let componentName = consoleArguments[0];
-	let isTypeScript = !!argv.enableTypescript;
+	let isTypeScript = false;
 
 	if (!componentName) {
 		const response = await prompts({
@@ -107,24 +103,28 @@ const createWebComponent = async () => {
 		return;
 	}
 
-	let response = await prompts({
+	if (consoleArguments.length === 2) {
+		let language = consoleArguments[1];
+		isTypeScript = language === "typescript";
+	} else {
+		const response = await prompts({
 		type: "select",
 		name: "language",
 		message: "Component type:",
 		choices: [
 			{
-				title: "TypeScript (recommended)",
-				value: true,
+			title: "TypeScript (recommended)",
+			value: true,
 			},
 			{
-				title: "JavaScript",
-				value: false,
+			title: "JavaScript",
+			value: false,
 			},
 		],
-		initial: isTypeScript ? 1 : 0,
-	});
-
-	isTypeScript = response.language;
+		initial: 0,
+		});
+		isTypeScript = response.language;
+	}
 
 	const tagName = `ui5-${camelToKebabCase(componentName)}`;
 	const packageName = getPackageName();

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -1,80 +1,11 @@
 const fs = require("fs");
+const prompts = require("prompts");
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+const jsFileContentTemplate = require("./jsFileContentTemplate.js");
+const tsFileContentTemplate = require("./tsFileContentTemplate.js");
 
-const jsFileContentTemplate = componentName => {
-	return `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import ${componentName}Template from "./generated/templates/${componentName}Template.lit.js";
-
-// Styles
-import ${componentName}Css from "./generated/themes/${componentName}.css.js";
-
-/**
- * @public
- */
-const metadata = {
-	tag: "${tagName}",
-	properties: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
-		//
-	},
-	slots: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
-		//
-	},
-	events: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
-		//
-	},
-};
-
-/**
- * @class
- *
- * <h3 class="comment-api-title">Overview</h3>
- *
- *
- * <h3>Usage</h3>
- *
- * For the <code>${tagName}</code>
- * <h3>ES6 Module Import</h3>
- *
- * <code>import ${packageName}/dist/${componentName}.js";</code>
- *
- * @constructor
- * @author SAP SE
- * @alias sap.ui.webc.${library}.${componentName}
- * @extends sap.ui.webc.base.UI5Element
- * @tagname ${tagName}
- * @public
- */
-class ${componentName} extends UI5Element {
-	static get metadata() {
-		return metadata;
-	}
-
-	static get render() {
-		return litRender;
-	}
-
-	static get styles() {
-		return ${componentName}Css;
-	}
-
-	static get template() {
-		return ${componentName}Template;
-	}
-
-	static get dependencies() {
-		return [];
-	}
-
-	static async onDefine() {
-
-	}
-}
-
-${componentName}.define();
-
-export default ${componentName};
-`;
-};
+const argv = yargs(hideBin(process.argv)).argv;
 
 const getPackageName = () => {
 	if (!fs.existsSync("./package.json")) {
@@ -108,47 +39,102 @@ const getLibraryName = packageName => {
 	return packageName.substr("webcomponents-".length);
 };
 
+// String manipulation
 const camelToKebabCase = string => string.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.slice(1);
 
-const packageName = getPackageName();
-const library = getLibraryName(packageName);
+// Validation of user input
+const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z0-9\-_]+$/);
+const isNameStartingWithNumber = name => typeof name === "string" && name.match(/^[0-9]/);
 
-const consoleArguments = process.argv.slice(2);
-const componentName = consoleArguments[0];
+const generateFiles = (componentName, tagName, library, packageName, isTypeScript) => {
+	const correctComponentName = capitalizeFirstLetter(componentName);
+	const filePaths = {
+		"extension": isTypeScript 
+			? `./src/${correctComponentName}.ts` 
+			: `./src/${correctComponentName}.js`,
+		"css": `./src/themes/${correctComponentName}.css`,
+		"hbs": `./src/${correctComponentName}.hbs`,
+	};
 
-if (!componentName){
-	console.error("Please enter component name.");
-	return;
+	const FileContentTemplate = isTypeScript 
+		? tsFileContentTemplate(correctComponentName, tagName, library, packageName) 
+		: jsFileContentTemplate(correctComponentName, tagName, library, packageName);
+
+	// The .extension determines if the file is .js or .ts with the help of the isTypeScript check
+	fs.writeFileSync(filePaths.extension, FileContentTemplate, { flag: "wx+" });
+	fs.writeFileSync(filePaths.css, "", { flag: "wx+" });
+	fs.writeFileSync(filePaths.hbs, "<div>Hello World</div>", { flag: "wx+" });
+
+	console.log(isTypeScript 
+		? `Successfully generated ${correctComponentName}.ts` 
+		: `Successfully generated ${correctComponentName}.js`);
+	console.log(`Successfully generated ${correctComponentName}.css`);
+	console.log(`Successfully generated ${correctComponentName}.hbs`);
+
+	const bundleLogger = fs.createWriteStream("./bundle.common.js", {
+		flags: "a" // appending
+	});
+
+	bundleLogger.write(`
+	// TODO: Move this line in order to keep the file sorted alphabetically
+	import ${correctComponentName} from "./dist/${correctComponentName}.js";`);
+
+	// Change the color of the output
+		console.warn('\x1b[33m%s\x1b[0m', `
+	Component is imported in bundle.common.js.
+	Do NOT forget to sort the file in alphabetical order.`);
 }
 
-const tagName = `ui5-${camelToKebabCase(componentName)}`;
+// Main function
+const createWebComponent = async () => {
+	const consoleArguments = process.argv.slice(2);
+	let componentName = consoleArguments[0];
+	let isTypeScript = !!argv.enableTypescript;
 
-const filePaths = {
-	"js": `./src/${componentName}.js`,
-	"css": `./src/themes/${componentName}.css`,
-	"hbs": `./src/${componentName}.hbs`,
+	if (!componentName) {
+		const response = await prompts({
+			type: "text",
+			name: "componentName",
+			message: "Please enter a component name:",
+			validate: (value) => isNameValid(value),
+		});
+		componentName = response.componentName;
+	}
+
+	if (!isNameValid(componentName)) {
+		console.error(`The component name "${componentName}" is not valid. Please use only letters, numbers, dashes and underscores.`);
+		return;
+	}
+
+	let response = await prompts({
+		type: "select",
+		name: "language",
+		message: "Component type:",
+		choices: [
+			{
+				title: "TypeScript (recommended)",
+				value: true,
+			},
+			{
+				title: "JavaScript",
+				value: false,
+			},
+		],
+		initial: isTypeScript ? 1 : 0,
+	});
+
+	isTypeScript = response.language;
+
+	const tagName = `ui5-${camelToKebabCase(componentName)}`;
+	const packageName = getPackageName();
+	const library = getLibraryName(packageName);
+	
+	if (!isNameStartingWithNumber(componentName)) {
+		generateFiles(componentName, tagName, library, packageName, isTypeScript);
+	} else {
+		console.error(`The component name "${componentName}" is not valid. Please use only letters, dashes and underscores.`);
+	}
 };
-const sJsFileContentTemplate = jsFileContentTemplate(componentName);
 
-fs.writeFileSync(filePaths.js, sJsFileContentTemplate, { flag: "wx+" });
-fs.writeFileSync(filePaths.css, "", { flag: "wx+" });
-fs.writeFileSync(filePaths.hbs, "<div>Hello World</div>", { flag: "wx+" });
-
-
-console.log(`Successfully generated ${componentName}.js`);
-console.log(`Successfully generated ${componentName}.css`);
-console.log(`Successfully generated ${componentName}.hbs`);
-
-const bundleLogger = fs.createWriteStream("./bundle.common.js", {
-	flags: "a" // appending
-});
-
-bundleLogger.write(`
-// TODO: Move this line in order to keep the file sorted alphabetically
-import ${componentName} from "./dist/${componentName}.js";`);
-
-// Change the color of the output
-	console.warn('\x1b[33m%s\x1b[0m', `
-Component is imported in bundle.common.js.
-Do NOT forget to sort the file in alphabeticall order.
-`);
+createWebComponent();

--- a/packages/tools/lib/create-new-component/jsFileContentTemplate.js
+++ b/packages/tools/lib/create-new-component/jsFileContentTemplate.js
@@ -1,0 +1,77 @@
+const jsFileContentTemplate = (componentName, tagName, library, packageName) => {
+	return `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import ${componentName}Template from "./generated/templates/${componentName}Template.lit.js";
+
+// Styles
+import ${componentName}Css from "./generated/themes/${componentName}.css.js";
+
+/**
+ * @public
+ */
+const metadata = {
+	tag: "${tagName}",
+	properties: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
+		//
+	},
+	slots: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
+		//
+	},
+	events: /** @lends sap.ui.webc.${library}.${componentName}.prototype */ {
+		//
+	},
+};
+
+/**
+ * @class
+ *
+ * <h3 class="comment-api-title">Overview</h3>
+ *
+ *
+ * <h3>Usage</h3>
+ *
+ * For the <code>${tagName}</code>
+ * <h3>ES6 Module Import</h3>
+ *
+ * <code>import ${packageName}/dist/${componentName}.js";</code>
+ *
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webc.${library}.${componentName}
+ * @extends sap.ui.webc.base.UI5Element
+ * @tagname ${tagName}
+ * @public
+ */
+class ${componentName} extends UI5Element {
+	static get metadata() {
+		return metadata;
+	}
+
+	static get render() {
+		return litRender;
+	}
+
+	static get styles() {
+		return ${componentName}Css;
+	}
+
+	static get template() {
+		return ${componentName}Template;
+	}
+
+	static get dependencies() {
+		return [];
+	}
+
+	static async onDefine() {
+
+	}
+}
+
+${componentName}.define();
+
+export default ${componentName};
+`;
+};
+
+module.exports = jsFileContentTemplate;

--- a/packages/tools/lib/create-new-component/tsFileContentTemplate.js
+++ b/packages/tools/lib/create-new-component/tsFileContentTemplate.js
@@ -33,15 +33,15 @@ import ${componentName}Css from "./generated/themes/${componentName}.css.js";
  */
 @customElement({
 	tag: "${tagName}",
-	renderer: litRender, /* optional */
-	styles: ${componentName}Css, /* optional */
-	template: ${componentName}Template, /* optional */
+	renderer: litRender,
+	styles: ${componentName}Css,
+	template: ${componentName}Template,
 	dependencies: [
-		// Add dependencies here if needed (e.g. Icon, Button, etc.)
+		
 	],
-	languageAware: true, /* optional */
-	themeAware: true, /* optional */
-	fastNavigation: true, /* optional */
+	languageAware: true,
+	themeAware: true,
+	fastNavigation: true,
 })
 
 /**
@@ -53,11 +53,27 @@ import ${componentName}Css from "./generated/themes/${componentName}.css.js";
  */
 @event("click", { detail: { /* event payload ( optional ) */ } })
 class ${componentName} extends UI5Element {
-	/** @lends sap.ui.webc.${library}.${componentName}.prototype */
+	/**
+	 * Defines the value of the component.
+	 *
+	 * @type {string}
+	 * @name sap.ui.webc.${library}.${componentName}.prototype.value
+	 * @defaultvalue ""
+	 * @public
+	 */
 	@property()
+	value!: string;
 
-	/** @lends sap.ui.webc.${library}.${componentName}.prototype */
-	@slot()
+	/**
+	 * Defines the text of the component.
+	 *
+	 * @type {Node[]}
+	 * @name sap.ui.webc.${library}.${componentName}.prototype.default
+	 * @slot
+	 * @public
+	 */
+	@slot({ type: Node, "default": true })
+	text!: Array<Node>;
 
 	static async onDefine() {
 

--- a/packages/tools/lib/create-new-component/tsFileContentTemplate.js
+++ b/packages/tools/lib/create-new-component/tsFileContentTemplate.js
@@ -37,19 +37,16 @@ import ${componentName}Css from "./generated/themes/${componentName}.css.js";
 	styles: ${componentName}Css,
 	template: ${componentName}Template,
 	dependencies: [],
-	languageAware: true,
-	themeAware: true,
-	fastNavigation: true,
 })
 
 /**
  * Example custom event.
  * Please keep in mind that all public events should be documented in the API Reference as shown below.
  *
- * @event sap.ui.webc.${library}.${componentName}#click
+ * @event sap.ui.webc.${library}.${componentName}#interact
  * @public
  */
-@event("click", { detail: { /* event payload ( optional ) */ } })
+@event("interact", { detail: { /* event payload ( optional ) */ } })
 class ${componentName} extends UI5Element {
 	/**
 	 * Defines the value of the component.

--- a/packages/tools/lib/create-new-component/tsFileContentTemplate.js
+++ b/packages/tools/lib/create-new-component/tsFileContentTemplate.js
@@ -1,0 +1,73 @@
+const tsFileContentTemplate = (componentName, tagName, library, packageName) => {
+	return `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import event from "@ui5/webcomponents-base/dist/decorators/event.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+
+import ${componentName}Template from "./generated/templates/${componentName}Template.lit.js";
+
+// Styles
+import ${componentName}Css from "./generated/themes/${componentName}.css.js";
+
+/**
+ * @class
+ *
+ * <h3 class="comment-api-title">Overview</h3>
+ *
+ *
+ * <h3>Usage</h3>
+ *
+ * For the <code>${tagName}</code>
+ * <h3>ES6 Module Import</h3>
+ *
+ * <code>import ${packageName}/dist/${componentName}.js";</code>
+ *
+ * @constructor
+ * @author SAP SE
+ * @alias sap.ui.webc.${library}.${componentName}
+ * @extends sap.ui.webc.base.UI5Element
+ * @tagname ${tagName}
+ * @public
+ */
+@customElement({
+	tag: "${tagName}",
+	renderer: litRender, /* optional */
+	styles: ${componentName}Css, /* optional */
+	template: ${componentName}Template, /* optional */
+	dependencies: [
+		// Add dependencies here if needed (e.g. Icon, Button, etc.)
+	],
+	languageAware: true, /* optional */
+	themeAware: true, /* optional */
+	fastNavigation: true, /* optional */
+})
+
+/**
+ * Example custom event.
+ * Please keep in mind that all public events should be documented in the API Reference as shown below.
+ *
+ * @event sap.ui.webc.${library}.${componentName}#click
+ * @public
+ */
+@event("click", { detail: { /* event payload ( optional ) */ } })
+class ${componentName} extends UI5Element {
+	/** @lends sap.ui.webc.${library}.${componentName}.prototype */
+	@property()
+
+	/** @lends sap.ui.webc.${library}.${componentName}.prototype */
+	@slot()
+
+	static async onDefine() {
+
+	}
+}
+
+${componentName}.define();
+
+export default ${componentName};
+`;
+};
+
+module.exports = tsFileContentTemplate;

--- a/packages/tools/lib/create-new-component/tsFileContentTemplate.js
+++ b/packages/tools/lib/create-new-component/tsFileContentTemplate.js
@@ -36,9 +36,7 @@ import ${componentName}Css from "./generated/themes/${componentName}.css.js";
 	renderer: litRender,
 	styles: ${componentName}Css,
 	template: ${componentName}Template,
-	dependencies: [
-		
-	],
+	dependencies: [],
 	languageAware: true,
 	themeAware: true,
 	fastNavigation: true,


### PR DESCRIPTION
Previously the component package level command `create-ui5-element` was producing skeleton files for a new web component with only **JavaScript** as a possible and **_default_** option. 
Within this change since we support TypeScript for development and even more, 3rd parties can now create custom web component in **TypeScript.**

#

Additionally the following is implemented as well:

- Now when a user is executing the `yarn create-ui5-element`, could specify up to **three** arguments:
  - **component name** 
  ` yarn create-ui5-element myComponent `
  - **custom tag name** 
  `yarn create-ui5-element myComponent my-component`
  - **language** 
  `yarn create-ui5-element myComponent my-component typescript`

Each argument is independent from one another, which means if:
- One argument is provided, a wizard for providing the rest of the arguments would occur
E.g:
`yarn create-ui5-element MyComponent`

```sh
? Please enter a tag name: »
```
and after that

```sh
? Please select a language: » - Use arrow-keys. Return to submit.
>   TypeScript (recommended)
    JavaScript
```
Same pattern goes for the other arguments provided.

At the end, when all the steps are followed and executed properly, in the following package `./src` folder, three files are created based on the language the user has chosen: 

```
./src/MyComponent.ts (for TypeScript) or ./src/MyComponent.js (for JavaScript)
./src/MyComponent.hbs
./src/themes/MyComponent.css
```

Fixes: #6530