### PR TITLE
fix(framework): fix boot, interfering theme load

### DIFF
--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -18,7 +18,11 @@ let booted = false;
  * @param { Function } listener
  */
 const attachBoot = (listener: () => void) => {
-	eventProvider.attachEvent("boot", listener);
+	if (!booted) {
+		eventProvider.attachEvent("boot", listener);
+	}
+
+	listener();
 };
 
 const boot = async (): Promise<void> => {

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -39,29 +39,29 @@ const boot = async (): Promise<void> => {
 			resolve();
 			return;
 		}
-	
+
 		registerCurrentRuntime();
-	
+
 		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
 		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isLoaded() : false;
 		const f6Navigation = getFeature<typeof F6Navigation>("F6Navigation");
-	
+
 		if (openUI5Support) {
 			await openUI5Support.init();
 		}
-	
+
 		if (f6Navigation && !isOpenUI5Loaded) {
 			f6Navigation.init();
 		}
-	
+
 		await whenDOMReady();
 		await applyTheme(getTheme());
 		openUI5Support && openUI5Support.attachListeners();
 		insertFontFace();
 		insertSystemCSSVars();
-	
+
 		resolve();
-	
+
 		booted = true;
 		await eventProvider.fireEventAsync("boot");
 	};

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -8,12 +8,15 @@ import { registerCurrentRuntime } from "./Runtimes.js";
 import { getFeature } from "./FeaturesRegistry.js";
 import type OpenUI5Support from "./features/OpenUI5Support.js";
 import type F6Navigation from "./features/F6Navigation.js";
+import { PromiseResolve } from "./types.js";
 
-const eventProvider = new EventProvider<void, void>();
 let booted = false;
+let bootPromise: Promise<void>;
+const eventProvider = new EventProvider<void, void>();
 
 /**
  * Attaches a callback that will be executed after boot finishes.
+ * <b>Note:</b> If the framework already booted, the callback will be immediately executed.
  * @public
  * @param { Function } listener
  */
@@ -27,36 +30,44 @@ const attachBoot = (listener: () => void) => {
 };
 
 const boot = async (): Promise<void> => {
-	if (booted) {
-		return;
+	if (bootPromise !== undefined) {
+		return bootPromise;
 	}
 
-	if (typeof document === "undefined") {
-		return;
-	}
+	const bootExecutor = async (resolve: PromiseResolve) => {
+		if (typeof document === "undefined") {
+			resolve();
+			return;
+		}
+	
+		registerCurrentRuntime();
+	
+		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
+		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isLoaded() : false;
+		const f6Navigation = getFeature<typeof F6Navigation>("F6Navigation");
+	
+		if (openUI5Support) {
+			await openUI5Support.init();
+		}
+	
+		if (f6Navigation && !isOpenUI5Loaded) {
+			f6Navigation.init();
+		}
+	
+		await whenDOMReady();
+		await applyTheme(getTheme());
+		openUI5Support && openUI5Support.attachListeners();
+		insertFontFace();
+		insertSystemCSSVars();
+	
+		resolve();
+	
+		booted = true;
+		await eventProvider.fireEventAsync("boot");
+	};
 
-	registerCurrentRuntime();
-
-	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	const isOpenUI5Loaded = openUI5Support ? openUI5Support.isLoaded() : false;
-	const f6Navigation = getFeature<typeof F6Navigation>("F6Navigation");
-
-	if (openUI5Support) {
-		await openUI5Support.init();
-	}
-
-	if (f6Navigation && !isOpenUI5Loaded) {
-		f6Navigation.init();
-	}
-
-	await whenDOMReady();
-	await applyTheme(getTheme());
-	openUI5Support && openUI5Support.attachListeners();
-	insertFontFace();
-	insertSystemCSSVars();
-
-	await eventProvider.fireEventAsync("boot");
-	booted = true;
+	bootPromise = new Promise(bootExecutor as (resolve: PromiseResolve) => void);
+	return bootPromise;
 };
 
 export {

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -13,7 +13,7 @@ const eventProvider = new EventProvider<void, void>();
 let booted = false;
 
 /**
- * Attach  a callback that will be executed on boot
+ * Attaches a callback that will be executed after boot finishes.
  * @public
  * @param { Function } listener
  */

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -20,6 +20,7 @@ let booted = false;
 const attachBoot = (listener: () => void) => {
 	if (!booted) {
 		eventProvider.attachEvent("boot", listener);
+		return;
 	}
 
 	listener();

--- a/packages/base/test/assets/bundle.light.js
+++ b/packages/base/test/assets/bundle.light.js
@@ -3,9 +3,16 @@ import { boot } from "../../dist/Boot.js";
 
 // Call attachBoot early
 attachBoot(() => {
-    console.log("framework booted!")
+    console.log("Listener1: after framework booted!")
 })
 
+attachBoot(() => {
+    console.log("Listener2: after framework booted!")
+})
+
+attachBoot(() => {
+    console.log("Listener3: after framework booted!")
+})
 import { registerThemePropertiesLoader } from "../../dist/AssetRegistry.js";
 
 const testAssets = {
@@ -17,7 +24,19 @@ const testAssets = {
                 fileName: "",
             };
         });
+        // call "boot" multiple times as if multiple web components start upgrading
+        console.log("Booting...");
         boot();
+        boot();
+        boot();
+        boot();
+        boot();
+        boot();
+    },
+    attachBootAfterBoot: () => {
+        attachBoot(() => {
+            console.log("Listener4: after framework booted!")
+        })
     }
 }
 window["sap-ui-webcomponents-bundle"] = testAssets;

--- a/packages/base/test/assets/bundle.light.js
+++ b/packages/base/test/assets/bundle.light.js
@@ -16,7 +16,7 @@ attachBoot(() => {
 import { registerThemePropertiesLoader } from "../../dist/AssetRegistry.js";
 
 const testAssets = {
-    registerThemePropsAndReboot: () => {
+    registerThemePropsAndBoot: () => {
         registerThemePropertiesLoader("@ui5/webcomponents-theming", "sap_fiori_3", () => {
             return {
                 content: `:root{ --var1: red; }`,
@@ -33,10 +33,5 @@ const testAssets = {
         boot();
         boot();
     },
-    attachBootAfterBoot: () => {
-        attachBoot(() => {
-            console.log("Listener4: after framework booted!")
-        })
-    }
 }
 window["sap-ui-webcomponents-bundle"] = testAssets;

--- a/packages/base/test/assets/bundle.light.js
+++ b/packages/base/test/assets/bundle.light.js
@@ -1,0 +1,23 @@
+import { attachBoot } from "../../dist/Boot.js";
+import { boot } from "../../dist/Boot.js";
+
+// Call attachBoot early
+attachBoot(() => {
+    console.log("framework booted!")
+})
+
+import { registerThemePropertiesLoader } from "../../dist/AssetRegistry.js";
+
+const testAssets = {
+    registerThemePropsAndReboot: () => {
+        registerThemePropertiesLoader("@ui5/webcomponents-theming", "sap_fiori_3", () => {
+            return {
+                content: `:root{ --var1: red; }`,
+                packageName: "",
+                fileName: "",
+            };
+        });
+        boot();
+    }
+}
+window["sap-ui-webcomponents-bundle"] = testAssets;

--- a/packages/base/test/assets/styles/Boot.css
+++ b/packages/base/test/assets/styles/Boot.css
@@ -1,0 +1,3 @@
+.content {
+    color: var(--var1);
+}

--- a/packages/base/test/pages/Boot.html
+++ b/packages/base/test/pages/Boot.html
@@ -5,7 +5,10 @@
     <title>Test theme loading and attachBoot</title>
     <script>delete Document.prototype.adoptedStyleSheets</script>
 	<script src="../assets/bundle.light.js" type="module"></script>
+    <link rel="stylesheet" type="text/css" href="../assets/styles/Boot.css">
 </head>
 <body>
+
+    <div class="content">When styles are applied, this text shoul be red.</div>
 </body>
 </html>

--- a/packages/base/test/pages/Boot.html
+++ b/packages/base/test/pages/Boot.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test theme loading and attachBoot</title>
+    <script>delete Document.prototype.adoptedStyleSheets</script>
+	<script src="../assets/bundle.light.js" type="module"></script>
+</head>
+<body>
+</body>
+</html>

--- a/packages/base/test/specs/Boot.spec.js
+++ b/packages/base/test/specs/Boot.spec.js
@@ -1,0 +1,20 @@
+const assert = require("chai").assert;
+
+describe("Framework boot", async () => {
+	before(async () => {
+		await browser.url("test/pages/Boot.html");
+	});
+
+	it("Tests theme loading, when attachBoot is called before theme is registered", async () => {
+		await browser.executeAsync(done => {
+			window['sap-ui-webcomponents-bundle'].registerThemePropsAndReboot();
+			done();
+		});
+
+		const styleElement = await browser.executeAsync(done => {
+			return done(document.querySelector("head>style[data-ui5-theme-properties]"));
+		});
+
+		assert.ok(styleElement, "style[data-ui5-theme-properties] tag is successfully created");
+	});
+});

--- a/packages/base/test/specs/Boot.spec.js
+++ b/packages/base/test/specs/Boot.spec.js
@@ -7,7 +7,7 @@ describe("Framework boot", async () => {
 
 	it("Tests theme loading, when attachBoot is called before theme is registered", async () => {
 		await browser.executeAsync(done => {
-			window['sap-ui-webcomponents-bundle'].registerThemePropsAndReboot();
+			window['sap-ui-webcomponents-bundle'].registerThemePropsAndBoot();
 			done();
 		});
 


### PR DESCRIPTION
Previously calling `attachBoot` used to trigger `boot`, which was causing unexpected issues.
```js
const attachBoot = async (listener: () => void) => {
	await boot();
	listener();
};
```

One effect of this was that theme properties were not loading properly. This happens when the theme registration (triggered by component define call) comes after someone calls `attachBoot`. In this case, our logic looks for a registered theme properties, can't find any and continues without loading. 
```js
// applyTheme.js
const loadThemeBase = async (theme: string) => {
    if (!isThemeBaseRegistered()) {
        return; // no theme props are registered at this point
    }
}
```

Later when the registration happens and boot is called again, we reuse the created promise and just return,
and we no longer reach to the point to check and continue with the theme properties loading:

```js
// Boot.js
const boot = async (): Promise<void> => {
    if (bootPromise !== undefined) {
        return bootPromise;
    }
```
The PR fixes exactly the described problem:
- `attachBoot` does not trigger `boot` anymore - only registers listeners, called after boot finishes.
- adds a test to cover the use-case

Closes: https://github.com/SAP/ui5-webcomponents/issues/6607