### PR TITLE
fix(ui5-combobox): fire selection-change correctly

### DIFF
--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -630,7 +630,7 @@ class ComboBox extends UI5Element {
 			const item = this._getFirstMatchingItem(value);
 			item && this._applyAtomicValueAndSelection(item, value, true);
 
-			if (value !== "" && !this._selectionChanged && (item && !item.selected && !item.isGroupItem)) {
+			if (value !== "" && (item && !item.selected && !item.isGroupItem)) {
 				this.fireEvent<ComboBoxSelectionChangeEventDetail>("selection-change", {
 					item,
 				});

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -420,7 +420,6 @@ class ComboBox extends UI5Element {
 
 	_initialRendering: boolean;
 	_itemFocused: boolean;
-	_selectionChanged: boolean;
 	// used only for Safari fix (check onAfterRendering)
 	_autocomplete: boolean;
 	_isKeyNavigation: boolean;
@@ -439,7 +438,6 @@ class ComboBox extends UI5Element {
 		this._filteredItems = [];
 		this._initialRendering = true;
 		this._itemFocused = false;
-		this._selectionChanged = false;
 		this._autocomplete = false;
 		this._isKeyNavigation = false;
 		this._lastValue = "";
@@ -634,8 +632,6 @@ class ComboBox extends UI5Element {
 				this.fireEvent<ComboBoxSelectionChangeEventDetail>("selection-change", {
 					item,
 				});
-
-				this._selectionChanged = false;
 			}
 		}
 
@@ -744,7 +740,6 @@ class ComboBox extends UI5Element {
 		}
 
 		this._isValueStateFocused = false;
-		this._selectionChanged = true;
 
 		this._announceSelectedItem(indexOfItem);
 
@@ -1038,8 +1033,6 @@ class ComboBox extends UI5Element {
 			this.fireEvent<ComboBoxSelectionChangeEventDetail>("selection-change", {
 				item: listItem.mappedItem,
 			});
-
-			this._selectionChanged = true;
 		}
 
 		this._filteredItems.map(item => {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -475,11 +475,29 @@ describe("General interaction", () => {
 
 		await arrow.click();
 
-		const listItem = listItems[8];
+		const listItem = listItems[7];
+		const listItemText = await listItem.shadow$(".ui5-li-title").getText();
 
 		await listItem.click();
 
-		assert.strictEqual(await label.getText(), await listItem.shadow$(".ui5-li-title").getText(), "event is fired correctly");
+		assert.strictEqual(await label.getText(), listItemText, "event is fired correctly");
+	});
+
+	it ("Tests selection-change event when type text after selection", async () => {
+		const combo = await browser.$("#combo");
+		let label = await browser.$("#selection-change-event-result");
+		const arrow = await combo.shadow$("[input-icon]");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#combo");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		let listItems = await popover.$("ui5-list").$$("ui5-li");
+
+		await arrow.click();
+		await combo.keys("Backspace");
+		await combo.keys("A");
+
+		const fisrtListItem = listItems[0];
+
+		assert.strictEqual(await label.getText(), await fisrtListItem.shadow$(".ui5-li-title").getText(), "event is fired correctly");
 	});
 
 	it ("Tests focused property when clicking on the arrow", async () => {


### PR DESCRIPTION
Previously, when a suggestion was selected and then a value matching another suggestion was entered, the selection-change event was not fired which is not correct.

FIXES: #6560 
