### PR TITLE
fix(ui5-input, ui5-textarea): remove redundant styles

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -17,9 +17,6 @@
 	border: var(--_ui5-input-border);
 	border-radius: var(--_ui5_input_border_radius);
 	box-sizing: border-box;
-	line-height: normal;
-	letter-spacing: normal;
-	word-spacing: normal;
 	text-align: start;
 	transition: var(--_ui5_input_transition);
 }

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -14,8 +14,6 @@
 	font-style: normal;
 	box-sizing: border-box;
 	line-height: var(--_ui5_textarea_line_height);
-	letter-spacing: normal;
-	word-spacing: normal;
 	margin: var(--_ui5_textarea_margin);
 }
 


### PR DESCRIPTION
Having these styles applied, the text styles relevant to the text spacing accessibility standard were not applied when an input component was placed within a shadow DOM. As they are not needed and not specified in the visual specification, they are removed.

FIXES: #5792
