### PR TITLE
docs: fix side navigation items interfaces

### DIFF
--- a/packages/fiori/src/SideNavigationItem.ts
+++ b/packages/fiori/src/SideNavigationItem.ts
@@ -26,6 +26,7 @@ import type SideNavigationSubItem from "./SideNavigationSubItem.js";
  * @abstract
  * @tagname ui5-side-navigation-item
  * @public
+ * @implements sap.ui.webc.fiori.ISideNavigationItem
  * @since 1.0.0-rc.8
  */
 @customElement("ui5-side-navigation-item")

--- a/packages/fiori/src/SideNavigationSubItem.ts
+++ b/packages/fiori/src/SideNavigationSubItem.ts
@@ -21,6 +21,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
  * @tagname ui5-side-navigation-sub-item
  * @public
  * @abstract
+ * @implements sap.ui.webc.fiori.ISideNavigationSubItem
  * @since 1.0.0-rc.8
  */
 @customElement("ui5-side-navigation-sub-item")


### PR DESCRIPTION
The lack of these 2 interfaces breaks the OpenUI5 Retrofit build when trying to upgrade.