### PR TITLE
chore: add missing type description in fiori

### DIFF
--- a/packages/fiori/src/types/IllustrationMessageType.ts
+++ b/packages/fiori/src/types/IllustrationMessageType.ts
@@ -1,4 +1,6 @@
 /**
+ * Different illustration types of Illustrated Message.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/MediaGalleryItemLayout.ts
+++ b/packages/fiori/src/types/MediaGalleryItemLayout.ts
@@ -1,4 +1,6 @@
 /**
+ * Defines the layout of the content displayed in the <code>ui5-media-gallery-item</code>.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/MediaGalleryLayout.ts
+++ b/packages/fiori/src/types/MediaGalleryLayout.ts
@@ -1,4 +1,6 @@
 /**
+ * Defines the layout type of the thumbnails list of the <code>ui5-media-gallery</code> component.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/MediaGalleryMenuHorizontalAlign.ts
+++ b/packages/fiori/src/types/MediaGalleryMenuHorizontalAlign.ts
@@ -1,4 +1,6 @@
 /**
+ * Defines the horizontal alignment of the thumbnails menu of the <code>ui5-media-gallery</code> component.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/MediaGalleryMenuVerticalAlign.ts
+++ b/packages/fiori/src/types/MediaGalleryMenuVerticalAlign.ts
@@ -1,4 +1,6 @@
 /**
+ * Types for the vertical alignment of the thumbnails menu of the <code>ui5-media-gallery</code> component.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/SideContentFallDown.ts
+++ b/packages/fiori/src/types/SideContentFallDown.ts
@@ -1,4 +1,6 @@
 /**
+ * SideContent FallDown options.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/SideContentPosition.ts
+++ b/packages/fiori/src/types/SideContentPosition.ts
@@ -1,4 +1,6 @@
 /**
+ * Side Content position options.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/SideContentVisibility.ts
+++ b/packages/fiori/src/types/SideContentVisibility.ts
@@ -1,4 +1,6 @@
 /**
+ * Side Content visibility options.
+ *
  * @readonly
  * @enum {string}
  * @public

--- a/packages/fiori/src/types/ViewSettingsDialogMode.ts
+++ b/packages/fiori/src/types/ViewSettingsDialogMode.ts
@@ -1,4 +1,6 @@
 /**
+ * Different types of Bar.
+ *
  * @readonly
  * @enum {string}
  * @public


### PR DESCRIPTION
After refactoring to TypeScript, in the `fiori`'s types folder, few types' descriptions were missing. 
We are adding them within this change.