### PR TITLE
fix(icons): use strings instead of template literal for imports

### DIFF
--- a/packages/icons-business-suite/src/json-imports/Icons.ts
+++ b/packages/icons-business-suite/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
 	let iconData: CollectionData;
 
 	if (collection === "business-suite-v1") {
-		iconData = (await import(`../generated/assets/v1/SAP-icons-business-suite.json`)).default;
+		iconData = (await import("../generated/assets/v1/SAP-icons-business-suite.json")).default;
 	} else {
-		iconData = (await import(`../generated/assets/v2/SAP-icons-business-suite.json`)).default;
+		iconData = (await import("../generated/assets/v2/SAP-icons-business-suite.json")).default;
 	}
 
 	if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {

--- a/packages/icons-tnt/src/json-imports/Icons.ts
+++ b/packages/icons-tnt/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
 	let iconData: CollectionData;
 
 	if (collection === "tnt-v3") {
-		iconData = (await import(`../generated/assets/v3/SAP-icons-TNT.json`)).default;
+		iconData = (await import("../generated/assets/v3/SAP-icons-TNT.json")).default;
 	} else {
-		iconData = (await import(`../generated/assets/v2/SAP-icons-TNT.json`)).default;
+		iconData = (await import("../generated/assets/v2/SAP-icons-TNT.json")).default;
 	}
 
 	if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {

--- a/packages/icons/src/json-imports/Icons.ts
+++ b/packages/icons/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
     let iconData: CollectionData;
 
 	if (collection === "SAP-icons-v5") {
-		iconData = (await import(`../generated/assets/v5/SAP-icons.json`)).default;
+		iconData = (await import("../generated/assets/v5/SAP-icons.json")).default;
 	} else {
-		iconData = (await import(`../generated/assets/v4/SAP-icons.json`)).default;
+		iconData = (await import("../generated/assets/v4/SAP-icons.json")).default;
 	}
 
     if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {


### PR DESCRIPTION
vitejs complains when using a template literal (even a static one) in an import