### PR TITLE
feat(ui5-product-switch): enable alignment of items

### DIFF
--- a/packages/fiori/src/themes/ProductSwitch.css
+++ b/packages/fiori/src/themes/ProductSwitch.css
@@ -6,6 +6,8 @@
 .ui5-product-switch-root {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: inherit;
+	align-items: inherit;
 	width: 752px; /* 4 * item size */
 	padding: 1.25rem .75rem;
 }

--- a/packages/fiori/test/pages/ProductSwitch.html
+++ b/packages/fiori/test/pages/ProductSwitch.html
@@ -48,6 +48,11 @@
 		<ui5-product-switch-item title-text="S/4HANA" icon="batch-payments"></ui5-product-switch-item>
 	</ui5-product-switch>
 
+	<ui5-product-switch id="productSwitchFlex" style="display: flex; justify-content: center; align-items: center;">
+		<ui5-product-switch-item title-text="Home" subtitle-text="Central Home" icon="home"></ui5-product-switch-item>
+		<ui5-product-switch-item title-text="Analytics Cloud" subtitle-text="Analytics Cloud" icon="business-objects-experience"></ui5-product-switch-item>
+	</ui5-product-switch>
+
 	<ui5-input id="eventTest"></ui5-input>
 
 	<script>

--- a/packages/fiori/test/specs/ProductSwitch.spec.js
+++ b/packages/fiori/test/specs/ProductSwitch.spec.js
@@ -33,14 +33,20 @@ describe("ARIA attributes", () => {
 		assert.strictEqual(await productSwitchRoot.getAttribute("role"), "list", "should have role list");
 		assert.strictEqual(await productSwitchRoot.getAttribute("aria-label"), "Products", "aria-label reference is correct");
 	});
+});
 
-	it ("items attributes set correctly", async () => {
-		let items = $$("#productSwitchThreeColumn > ui5-product-switch-item");
+describe("ProductSwitch styles", async () => {
+	before(async () => {
+		await browser.url(`test/pages/ProductSwitch.html`);
+	});
 
-		items.forEach(async item => {
-			const itemDom = await item.shadow$(".ui5-product-switch-item-root");
+	it("tests root element inherit styles", async () => {
+		const productSwitch = await browser.$("#productSwitchFlex");
+		const productSwitchRoot = await productSwitch.shadow$(".ui5-product-switch-root");
+		const justifyContent = await productSwitchRoot.getCSSProperty("justify-content");
+		const alignItems = await productSwitchRoot.getCSSProperty("align-items");
 
-			assert.strictEqual(await itemDom.getAttribute("role"), "listitem", "should have role list");
-		})
+		assert.strictEqual(justifyContent.value, "center", "style is inherited");
+		assert.strictEqual(alignItems.value, "center", "style is inherited");
 	});
 });

--- a/packages/fiori/test/specs/ProductSwitchItem.spec.js
+++ b/packages/fiori/test/specs/ProductSwitchItem.spec.js
@@ -13,3 +13,12 @@ describe("ProductSwitchItem general interaction", async () => {
 		assert.ok(await productSwitchItem.shadow$(".ui5-product-switch-item-subtitle"), "SubTitle is rendered.");
 	});
 });
+
+describe("ARIA attributes", () => {
+	it("items role set correctly", async () => {
+		const productSwitchItem = await browser.$("#productSwitchItem");
+		const root = await productSwitchItem.shadow$(".ui5-product-switch-item-root");
+		const role = await root.getAttribute("role");
+		assert.strictEqual(role, "listitem", "should have role listitem");
+	});
+});


### PR DESCRIPTION
With this change, the root element of `ui5-product-switch` inherits the following css properties from it parent (the custom element)
in order to allow aligment: 
- `justiy-content`
- `align-items`

```html
<ui5-product-switch  style="justify-content: center;">
```

Closes: #6594 
