### PR TITLE
fix(ui5-breadcrumbs): import used arrow-down icon

### DIFF
--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -36,6 +36,7 @@ import type { SelectionChangeEventDetail } from "./List.js";
 import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
+import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 
 // Templates
 import BreadcrumbsTemplate from "./generated/templates/BreadcrumbsTemplate.lit.js";


### PR DESCRIPTION
The icon is used in the template but not imported -  this means that won't be displayed in productive app, when not all the icons are available (as in the playground or our test pages).