### PR TITLE
refactor(InputsElementFormSupport): add file extension to import

### DIFF
--- a/packages/main/src/features/InputElementsFormSupport.ts
+++ b/packages/main/src/features/InputElementsFormSupport.ts
@@ -1,5 +1,5 @@
 import { registerFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
-import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element";
+import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 
 interface IFormElement extends UI5Element {
 	value?: string | number,


### PR DESCRIPTION
Without the `.js` file extension, projects building in ESM mode will fail due do an import error:
```bash
node_modules/@ui5/webcomponents/dist/features/InputElementsFormSupport.d.ts:1:29 - error TS2307: Cannot find module '@ui5/webcomponents-base/dist/UI5Element' or its corresponding type declarations.

1 import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element";
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```