### PR TITLE
fix(ui5-split-button): align styles in icon only mode

### DIFF
--- a/packages/main/src/SplitButton.hbs
+++ b/packages/main/src/SplitButton.hbs
@@ -24,7 +24,9 @@
 		@focusin={{_setTabIndexValue}}
 		@focusout={{_onFocusOut}}
 	>
-		<slot></slot>
+		{{#if isTextButton}}
+			<slot></slot>
+		{{/if}}
 	</ui5-button>
 
 	<div

--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -381,6 +381,10 @@ class SplitButton extends UI5Element {
 		return this.textContent;
 	}
 
+	get isTextButton() {
+		return !!this.textContent;
+	}
+
 	get textButton() {
 		return this.getDomRef()?.querySelector<Button>(".ui5-split-text-button");
 	}

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -50,6 +50,7 @@
 		<ui5-split-button id="sbTextIcon" icon="add">Icon</ui5-split-button>
 		<ui5-split-button id="sbTextActiveIcon" active-icon="accept">Active Icon</ui5-split-button>
 		<ui5-split-button id="sbTextIconActiveIcon" icon="add" active-icon="accept">Icon + Active Icon</ui5-split-button>
+		<ui5-split-button icon="text-color"></ui5-split-button>
 	</div>
 
 	<header class="header">


### PR DESCRIPTION
Solution: We don't create slot for text if we don't have text.
fixes: https://github.com/SAP/ui5-webcomponents/issues/6688
