### PR TITLE
chore: strip CLDRs of unused fields

### DIFF
--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -47,8 +47,7 @@ const removeFields = object => {
 		"scientificFormat",
 		"percentFormat",
 		"miscPattern",
-		"lenient-scope-number",
-		"dayPeriodRules"
+		"lenient-scope-number"
 	].forEach(field => {
 		delete object[field];
 	});

--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -41,7 +41,6 @@ const removeFields = object => {
 		"decimalFormat-short",
 		"decimalFormat-long",
 		"units",
-		"dateFields",
 		"timezoneNamesFormats",
 		"decimalFormat",
 		"scientificFormat",

--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -1,0 +1,44 @@
+const fs = require("fs").promises;
+const path = require("path");
+
+const stripCLDR = async () => {
+	const inputDir = process.argv[2];
+	const outputDir = process.argv[3];
+
+	const files = await fs.readdir(inputDir);
+	const promises = files.map(async fileName => {
+		if (!fileName.endsWith("json")) {
+			return; // skip the license .txt file
+		}
+
+		const inputFilePath = path.join(inputDir, fileName);
+		const fileContent = `${await fs.readFile(inputFilePath, "utf8")}`;
+		let fileContentObject = JSON.parse(fileContent);
+		fileContentObject = removeFields(fileContentObject);
+		const fileContentReduced = JSON.stringify(fileContentObject, null, 2);
+
+		await fs.mkdir(outputDir, { recursive: true });
+		const outputFilePath = path.join(outputDir, fileName);
+		return fs.writeFile(outputFilePath, fileContentReduced);
+	});
+	return Promise.all(promises);
+}
+
+const removeFields = object => {
+	for (const field in object) {
+		if (field.includes("currency")) { // remove all fields related to currency
+			delete object[field];
+		}
+	}
+
+	// remove all deny-listed fields
+	["timezoneNames", "decimalFormat-short", "decimalFormat-long", "units"].forEach(field => {
+		delete object[field];
+	})
+
+	return object;
+}
+
+stripCLDR().then(() => {
+	console.log("CLDR files copied and reduced in size.");
+});

--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -1,7 +1,7 @@
 const fs = require("fs").promises;
 const path = require("path");
 
-const stripCLDR = async () => {
+const copyAndStripCLDR = async () => {
 	const inputDir = process.argv[2];
 	const outputDir = process.argv[3];
 
@@ -25,20 +25,40 @@ const stripCLDR = async () => {
 }
 
 const removeFields = object => {
+	// remove all fields related to currency
 	for (const field in object) {
-		if (field.includes("currency")) { // remove all fields related to currency
+		if (field.includes("currency")) {
 			delete object[field];
 		}
 	}
 
 	// remove all deny-listed fields
-	["timezoneNames", "decimalFormat-short", "decimalFormat-long", "units"].forEach(field => {
+	[
+		"languages",
+		"territories",
+		"scripts",
+		"timezoneNames",
+		"decimalFormat-short",
+		"decimalFormat-long",
+		"units"
+	].forEach(field => {
 		delete object[field];
+	});
+
+
+	["ca-gregorian", "ca-islamic", "ca-japanese", "ca-buddhist", "ca-persian"].forEach(calendar => {
+		// remove all deny-listed fields from the calendar objects
+		[
+			"quarters",
+			"flexibleDayPeriods"
+		].forEach(field => {
+			delete object[calendar][field];
+		});
 	})
 
 	return object;
 }
 
-stripCLDR().then(() => {
+copyAndStripCLDR().then(() => {
 	console.log("CLDR files copied and reduced in size.");
 });

--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -25,9 +25,9 @@ const copyAndStripCLDR = async () => {
 }
 
 const removeFields = object => {
-	// remove all fields related to currency
+	// remove all fields related to currency or listPattern
 	for (const field in object) {
-		if (field.includes("currency")) {
+		if (field.includes("currency") || field.includes("listPattern")) {
 			delete object[field];
 		}
 	}
@@ -40,7 +40,15 @@ const removeFields = object => {
 		"timezoneNames",
 		"decimalFormat-short",
 		"decimalFormat-long",
-		"units"
+		"units",
+		"dateFields",
+		"timezoneNamesFormats",
+		"decimalFormat",
+		"scientificFormat",
+		"percentFormat",
+		"miscPattern",
+		"lenient-scope-number",
+		"dayPeriodRules"
 	].forEach(field => {
 		delete object[field];
 	});

--- a/packages/localization/lib/copy-and-strip-cldr/index.js
+++ b/packages/localization/lib/copy-and-strip-cldr/index.js
@@ -5,6 +5,7 @@ const stripCLDR = async () => {
 	const inputDir = process.argv[2];
 	const outputDir = process.argv[3];
 
+	await fs.mkdir(outputDir, { recursive: true });
 	const files = await fs.readdir(inputDir);
 	const promises = files.map(async fileName => {
 		if (!fileName.endsWith("json")) {
@@ -17,7 +18,6 @@ const stripCLDR = async () => {
 		fileContentObject = removeFields(fileContentObject);
 		const fileContentReduced = JSON.stringify(fileContentObject, null, 2);
 
-		await fs.mkdir(outputDir, { recursive: true });
 		const outputFilePath = path.join(outputDir, fileName);
 		return fs.writeFile(outputFilePath, fileContentReduced);
 	});

--- a/packages/localization/package-scripts.js
+++ b/packages/localization/package-scripts.js
@@ -20,7 +20,7 @@ const scripts = {
 	typescript: "tsc",
 	copy: {
 		"used-modules": `node "${copyUsedModules}" ./used-modules.txt dist/`,
-		cldr: `copy-and-watch "../../node_modules/@openui5/sap.ui.core/src/sap/ui/core/cldr/*.json" dist/generated/assets/cldr/`,
+		cldr: `node ./lib/copy-and-strip-cldr/index.js "../../node_modules/@openui5/sap.ui.core/src/sap/ui/core/cldr/" dist/generated/assets/cldr/`,
 		overlay: `copy-and-watch "overlay/**/*.js" dist/`,
 		src: `copy-and-watch "src/**/*.js" dist/`,
 	},


### PR DESCRIPTION
CLDR files have grown a lot lately after updating to the recent OpenUI5 version. This change aims to reduce their size by stripping all fields that are not used by any of our components.

With this change CLDR .json files are around 55% smaller.

The only components that import files from `@ui5/webcomponents-localization` are:
 - `ui5-calendar`
 - `ui5-date-picker` (and its parts)
 - `ui5-time-picker` (and its parts)
 - `ui5-datetime-picker`

closes: https://github.com/SAP/ui5-webcomponents/issues/6692