### PR TITLE
fix: fix eslint for JS 3rd party projects

### DIFF
--- a/packages/base/package-scripts.js
+++ b/packages/base/package-scripts.js
@@ -15,7 +15,7 @@ const eslintConfig = `--config ${require.resolve("@ui5/webcomponents-tools/compo
 
 const scripts = {
 	clean: "rimraf jsdoc-dist && rimraf src/generated && rimraf dist && rimraf .port",
-	lint: `eslint . ${eslintConfig}`,
+	lint: `cross-env UI5_TS=true eslint . ${eslintConfig}`,
 	prepare: "cross-env UI5_TS=true nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles generateTemplates typescript generateAPI",
 	typescript: "tsc",
 	integrate: {

--- a/packages/localization/package-scripts.js
+++ b/packages/localization/package-scripts.js
@@ -5,7 +5,7 @@ const esmAbsToRel = resolve.sync("@ui5/webcomponents-tools/lib/esm-abs-to-rel/in
 
 const scripts = {
 	clean: "rimraf dist",
-	lint: "eslint . --config config/.eslintrc.js",
+	lint: "cross-env UI5_TS=true eslint . --config config/.eslintrc.js",
 	build: {
 		"default": "nps lint clean copy.used-modules copy.cldr copy.overlay build.replace-amd build.replace-export-true build.replace-export-false build.amd-to-es6 build.replace-global-core-usage build.esm-abs-to-rel build.jsonImports build.typescript copy.src",
 		"replace-amd": "replace-in-file sap.ui.define define dist/**/*.js",

--- a/packages/tools/components-package/eslint.js
+++ b/packages/tools/components-package/eslint.js
@@ -1,3 +1,34 @@
+const tsMode = process.env.UI5_TS === "true";
+
+/**
+ * Typescript Rules
+ */
+const overrides = true ? [{
+	files: ["*.ts"],
+	parser: "@typescript-eslint/parser",
+	plugins: ["@typescript-eslint"],
+	extends: [
+		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/recommended-requiring-type-checking"
+	],
+	parserOptions: {
+	  "project": ["./tsconfig.json", "./packages/*/tsconfig.json"],
+	},
+	rules: {
+		"no-shadow": "off",
+		"@typescript-eslint/no-shadow": ["error"],
+		"@typescript-eslint/no-unsafe-member-access": "off",
+		"@typescript-eslint/no-floating-promises": "off",
+		"@typescript-eslint/no-explicit-any": "off",
+		"@typescript-eslint/no-unsafe-assignment": "off",
+		"@typescript-eslint/ban-ts-comment": "off",
+		"@typescript-eslint/no-unsafe-call": "off",
+		"@typescript-eslint/no-non-null-assertion": "off",
+		"@typescript-eslint/no-empty-function": "off",
+		"lines-between-class-members": "off",
+	}
+}] : [];
+
 module.exports = {
 	"env": {
 		"browser": true,
@@ -5,34 +36,7 @@ module.exports = {
 	},
 	"root": true,
 	"extends": "airbnb-base",
-	overrides: [{
-		files: ["*.ts"],
-		parser: "@typescript-eslint/parser",
-		plugins: ["@typescript-eslint"],
-		extends: [
-			"plugin:@typescript-eslint/recommended",
-			"plugin:@typescript-eslint/recommended-requiring-type-checking"
-		],
-		parserOptions: {
-		  "project": ["./tsconfig.json", "./packages/*/tsconfig.json"],
-		},
-		/**
-		 * Typescript Rules
-		 */
-		rules: {
-			"no-shadow": "off",
-			"@typescript-eslint/no-shadow": ["error"],
-			"@typescript-eslint/no-unsafe-member-access": "off",
-			"@typescript-eslint/no-floating-promises": "off",
-			"@typescript-eslint/no-explicit-any": "off",
-			"@typescript-eslint/no-unsafe-assignment": "off",
-			"@typescript-eslint/ban-ts-comment": "off",
-			"@typescript-eslint/no-unsafe-call": "off",
-			"@typescript-eslint/no-non-null-assertion": "off",
-			"@typescript-eslint/no-empty-function": "off",
-			"lines-between-class-members": "off",
-		}
-	}],
+	overrides,
 	"parserOptions": {
 		"ecmaVersion": 2018,
 		"sourceType": "module"

--- a/packages/tools/components-package/eslint.js
+++ b/packages/tools/components-package/eslint.js
@@ -3,7 +3,7 @@ const tsMode = process.env.UI5_TS === "true";
 /**
  * Typescript Rules
  */
-const overrides = true ? [{
+const overrides = tsMode ? [{
 	files: ["*.ts"],
 	parser: "@typescript-eslint/parser",
 	plugins: ["@typescript-eslint"],

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -46,8 +46,8 @@ const getScripts = (options) => {
 
 	const scripts = {
 		clean: 'rimraf jsdoc-dist && rimraf src/generated && rimraf dist && rimraf .port && nps "scope.testPages.clean"',
-		lint: `eslint . ${eslintConfig}`,
-		lintfix: `eslint . ${eslintConfig} --fix`,
+		lint: `${tsCrossEnv} eslint . ${eslintConfig}`,
+		lintfix: `${tsCrossEnv} eslint . ${eslintConfig} --fix`,
 		prepare: {
 			default: `${tsCrossEnv} nps clean prepare.all typescript generateAPI`,
 			all: 'concurrently "nps build.templates" "nps build.i18n" "nps prepare.styleRelated" "nps copy" "nps build.illustrations"',


### PR DESCRIPTION
When creating a JS type of components package via the `yarn create @ui5/webcomponents-package` command, the `@typescript-eslint` package that is used by the eslint config requires `typescript `and the lint command fails. Now the TS overrides are added only for TS  projects and JS Projects lint works properly.