### PR TITLE
feat(framework): add default values for language/theme

### DIFF
--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -52,7 +52,12 @@ Example:
 import { setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 setTheme("sap_belize_hcb");
 ```
-   
+
+- To reset the theme to the default one:
+```js
+import { setTheme, getDefaultTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
+setTheme(getDefaultTheme());
+```
 
 ### language
 <a name="language"></a>
@@ -86,6 +91,12 @@ Example:
 ```js
 import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 setLanguage("fr");
+```
+
+- To reset the langauge to the default one:
+```js
+import { setLanguage, getDefaultLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+setLanguage(getDefaultLanguage());
 ```
 
 

--- a/packages/base/src/config/Language.ts
+++ b/packages/base/src/config/Language.ts
@@ -4,6 +4,7 @@ import {
 } from "../InitialConfiguration.js";
 import { fireLanguageChange } from "../locale/languageChange.js";
 import { reRenderAllUI5Elements } from "../Render.js";
+import { DEFAULT_LANGUAGE } from "../generated/AssetParameters.js";
 
 let curLanguage: string | undefined;
 let fetchDefaultLanguage: boolean;
@@ -40,6 +41,18 @@ const setLanguage = async (language: string): Promise<void> => {
 };
 
 /**
+ * Returns the default languague.
+ *
+ * Note: Default language might be different than the configurated one.
+ *
+ * @public
+ * @returns {string}
+ */
+const getDefaultLanguage = (): string => {
+	return DEFAULT_LANGUAGE;
+};
+
+/**
  * Defines if the default language, that is inlined, should be
  * fetched over the network instead of using the inlined one.
  * <b>Note:</b> By default the language will not be fetched.
@@ -67,6 +80,7 @@ const getFetchDefaultLanguage = (): boolean => {
 export {
 	getLanguage,
 	setLanguage,
+	getDefaultLanguage,
 	setFetchDefaultLanguage,
 	getFetchDefaultLanguage,
 };

--- a/packages/base/src/config/Theme.ts
+++ b/packages/base/src/config/Theme.ts
@@ -1,6 +1,7 @@
 import { getTheme as getConfiguredTheme } from "../InitialConfiguration.js";
 import { reRenderAllUI5Elements } from "../Render.js";
 import applyTheme from "../theming/applyTheme.js";
+import { DEFAULT_THEME } from "../generated/AssetParameters.js";
 
 let curTheme: string;
 
@@ -36,6 +37,18 @@ const setTheme = async (theme: string): Promise<void> => {
 };
 
 /**
+ * Returns the default theme.
+ *
+ * Note: Default theme might be different than the configurated one.
+ *
+ * @public
+ * @returns {string}
+ */
+const getDefaultTheme = (): string => {
+	return DEFAULT_THEME;
+};
+
+/**
  * Returns if the given theme name is the one currently applied.
  * @private
  * @param {string} theme
@@ -61,4 +74,5 @@ export {
 	setTheme,
 	isTheme,
 	isThemeFamily,
+	getDefaultTheme,
 };


### PR DESCRIPTION
Currently, users are not able to set language and theme to their default values because there is no mechanics for that.

With this PR we are introducing new `getDefaultLanguage` / `getDefaultTheme` method which returns the default value for language / theme.

To reset your language to the default value:
```ts
import { setLanguage, getDefaultLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
setLanguage(getDefaultLanguage());
```

To reset your theme to the default value:
```ts
import { setTheme, getDefaultTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
setTheme(getDefaultTheme());
```

Fixes: #6712 