### PR TITLE
docs: fix NotificationListItemBase's jsdoc

### DIFF
--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -49,9 +49,7 @@ type NotificationListItemBaseCloseEventDetail = {
  * @author SAP SE
  * @alias sap.ui.webc.fiori.NotificationListItemBase
  * @extends sap.ui.webc.main.ListItemBase
- * @tagname ui5-li-notification-group
  * @since 1.0.0-rc.8
- * @appenddocs sap.ui.webc.fiori.NotificationAction
  * @public
  */
 


### PR DESCRIPTION
NotificationListItemBase's appears to be `ui5-li-notification-group` but should not:
```json
{
"kind": "class",
"name": "sap.ui.webc.fiori.NotificationListItemBase",
"basename": "NotificationListItemBase",
"tagname": "ui5-li-notification-group",
}
```
 Also, no need to append docs, as this is done by the NotificationListItem and NotificationListGroupItem.