### PR TITLE
chore: improve DatePicker/TimePickerBase types (brought over from OpenUI5)

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -794,7 +794,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.DatePicker#formatValue
-	 * @param {object} date A Java Script date object to be formatted as string
+	 * @param {Date} date A Java Script date object to be formatted as string
 	 * @returns {string} The date as string
 	 */
 	formatValue(date: Date) {

--- a/packages/main/src/TimePickerBase.ts
+++ b/packages/main/src/TimePickerBase.ts
@@ -409,7 +409,7 @@ class TimePickerBase extends UI5Element {
 	/**
 	 * Formats a Java Script date object into a string representing a locale date and time
 	 * according to the <code>formatPattern</code> property of the TimePicker instance
-	 * @param {object} date A Java Script date object to be formatted as string
+	 * @param {Date} date A Java Script date object to be formatted as string
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.TimePickerBase#formatValue


### PR DESCRIPTION
## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [Correct commit message style](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)
    + Bugfixes should generally include a test to cover the issue.

Hi, those types were in the meantime improved in the copy in the OpenUI5 repo, but reverted by the latest copy.
I redid the improvements in I9663c71d80280bb0841fb8a2e36c44a174378955, but they would be overridden again. Am I right assuming that the DateTimePicker etc. get the types from these two base classes?

The commit message mimics the one of https://github.com/SAP/ui5-webcomponents/commit/e50e00cddcba575d61442a9f87b48523369c8d51