### PR TITLE
chore: add `getIconAccessibleName` base method

### DIFF
--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -1,8 +1,9 @@
 import getSharedResource from "../getSharedResource.js";
 import { getIconCollectionByAlias } from "../assets-meta/IconCollectionsAlias.js";
 import { getEffectiveIconCollection } from "../config/Icons.js";
-import { I18nText } from "../i18nBundle.js";
-import { TemplateFunction } from "../renderer/executeTemplate.js";
+import { getI18nBundle } from "../i18nBundle.js";
+import type { I18nText } from "../i18nBundle.js";
+import type { TemplateFunction } from "../renderer/executeTemplate.js";
 
 type IconLoader = (collectionName: string) => Promise<CollectionData>;
 
@@ -138,6 +139,37 @@ const getIconData = async (name: string) => {
 	return registry.get(registryKey);
 };
 
+/**
+ * Returns the accessibility name for the given icon name,
+ * or undefined if accessibility name is not present.
+ *
+ * @param { string } name
+ * @return { Promise }
+ */
+const getIconA11yName = async (name: string) => {
+	let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);
+	if (!iconData) {
+		iconData = await getIconData(name);
+	}
+
+	if (!iconData) {
+		/* eslint-disable-next-line */
+		console.warn(`Required icon is not registered. Invalid icon name: ${name}`);
+		return;
+	}
+
+	if (iconData === ICON_NOT_FOUND) {
+		/* eslint-disable-next-line */
+		console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents-icons/dist/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/AllIcons.js".`);
+		return;
+	}
+
+	if (iconData && iconData.accData) {
+		const i18nBundle = await getI18nBundle(iconData.packageName);
+		return i18nBundle.getText(iconData.accData) || undefined;
+	}
+};
+
 // test page usage only
 const _getRegisteredNames = async () => {
 	// fetch one icon of each collection to trigger the bundle load
@@ -151,6 +183,7 @@ export {
 	registerIconLoader,
 	getIconData,
 	getIconDataSync,
+	getIconA11yName,
 	registerIcon,
 	_getRegisteredNames,
 };

--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -148,19 +148,12 @@ const getIconData = async (name: string) => {
  */
 const getIconAccessibleName = async (name: string): Promise<string | undefined> => {
 	let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);
+
 	if (!iconData) {
 		iconData = await getIconData(name);
 	}
 
-	if (!iconData) {
-		return;
-	}
-
-	if (iconData === ICON_NOT_FOUND) {
-		return;
-	}
-
-	if (iconData.accData) {
+	if (iconData && iconData !== ICON_NOT_FOUND && iconData.accData) {
 		const i18nBundle = await getI18nBundle(iconData.packageName);
 		return i18nBundle.getText(iconData.accData);
 	}

--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -146,27 +146,23 @@ const getIconData = async (name: string) => {
  * @param { string } name
  * @return { Promise }
  */
-const getIconAccessibleName = async (name: string) => {
+const getIconAccessibleName = async (name: string): Promise<string | undefined> => {
 	let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);
 	if (!iconData) {
 		iconData = await getIconData(name);
 	}
 
 	if (!iconData) {
-		/* eslint-disable-next-line */
-		console.warn(`Required icon is not registered. Invalid icon name: ${name}`);
 		return;
 	}
 
 	if (iconData === ICON_NOT_FOUND) {
-		/* eslint-disable-next-line */
-		console.warn(`Required icon is not registered. You can either import the icon as a module in order to use it e.g. "@ui5/webcomponents-icons/dist/${name.replace("sap-icon://", "")}.js", or setup a JSON build step and import "@ui5/webcomponents-icons/dist/AllIcons.js".`);
 		return;
 	}
 
-	if (iconData && iconData.accData) {
+	if (iconData.accData) {
 		const i18nBundle = await getI18nBundle(iconData.packageName);
-		return i18nBundle.getText(iconData.accData) || undefined;
+		return i18nBundle.getText(iconData.accData);
 	}
 };
 

--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -140,13 +140,13 @@ const getIconData = async (name: string) => {
 };
 
 /**
- * Returns the accessibility name for the given icon name,
- * or undefined if accessibility name is not present.
+ * Returns the accessible name for the given icon,
+ * or undefined if accessible name is not present.
  *
  * @param { string } name
  * @return { Promise }
  */
-const getIconA11yName = async (name: string) => {
+const getIconAccessibleName = async (name: string) => {
 	let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);
 	if (!iconData) {
 		iconData = await getIconData(name);
@@ -183,7 +183,7 @@ export {
 	registerIconLoader,
 	getIconData,
 	getIconDataSync,
-	getIconA11yName,
+	getIconAccessibleName,
 	registerIcon,
 	_getRegisteredNames,
 };

--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -110,7 +110,7 @@ import { getLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/La
 import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
-import { _getRegisteredNames as getIconNames, getIconA11yName } from  "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
+import { _getRegisteredNames as getIconNames, getIconAccessibleName } from  "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
 import { attachDirectionChange } from "@ui5/webcomponents-base/dist/locale/directionChange.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
@@ -155,7 +155,7 @@ const testAssets = {
 	attachThemeLoaded,
 	detachThemeLoaded,
 	getIconNames,
-	getIconA11yName,
+	getIconAccessibleName,
 	renderFinished,
 	defaultTexts,
 	getExportedIconsValues: () => icons,

--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -110,7 +110,7 @@ import { getLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/La
 import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
 import { getRTL } from "@ui5/webcomponents-base/dist/config/RTL.js";
 import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
-import { _getRegisteredNames as getIconNames } from  "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
+import { _getRegisteredNames as getIconNames, getIconA11yName } from  "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
 import { attachDirectionChange } from "@ui5/webcomponents-base/dist/locale/directionChange.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
@@ -155,6 +155,7 @@ const testAssets = {
 	attachThemeLoaded,
 	detachThemeLoaded,
 	getIconNames,
+	getIconA11yName,
 	renderFinished,
 	defaultTexts,
 	getExportedIconsValues: () => icons,

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -97,8 +97,8 @@ describe("Icon general interaction", () => {
 		});
 		assert.strictEqual(actualExportedValues, expectedExportedValues, "Exported values are correct.");
 	});
-	it("Icon svg aria-label cleaned after name change", async () => {
 
+	it("Icon svg aria-label cleaned after name change", async () => {
 		// assert - initial SVG aria-label
 		let iconEl = await browser.$("#iconError");
 		let iconSVG = await browser.$("#iconError").shadow$(".ui5-icon-root");
@@ -119,6 +119,19 @@ describe("Icon general interaction", () => {
 		iconEl = await browser.$("#iconError");
 		iconSVG = await browser.$("#iconError").shadow$(".ui5-icon-root");
 		assert.equal(await iconSVG.getAttribute("aria-label"), null);
+	});
 
+	it("Tests getIconA11yName", async () => {
+		const icons = ["add", "back-to-top", "collapse", "download"];
+		const expectedAccNames = ["Add", "Back to Top", "Collapse", "Download"];
+		const actualAccNames = await browser.executeAsync(async done => {
+			const values = await Promise.all(icons.map(iconName => {
+				return window["sap-ui-webcomponents-bundle"].getIconA11yName(iconName);
+			}));
+			done(values);
+		});
+
+		assert.strictEqual(actualAccNames.join(), expectedAccNames.join(),
+			"getIconA11yName returns the correct icon a11y names.");
 	});
 });

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -126,7 +126,7 @@ describe("Icon general interaction", () => {
 		const expectedAccNames = ["Add", "Back to Top", "Collapse", "Download"];
 		const actualAccNames = await browser.executeAsync(async done => {
 			const values = await Promise.all(icons.map(iconName => {
-				return window["sap-ui-webcomponents-bundle"].getIconA11yName(iconName);
+				return window["sap-ui-webcomponents-bundle"].getIconAccessibleName(iconName);
 			}));
 			done(values);
 		});

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -121,7 +121,7 @@ describe("Icon general interaction", () => {
 		assert.equal(await iconSVG.getAttribute("aria-label"), null);
 	});
 
-	it("Tests getIconA11yName", async () => {
+	it("Tests getIconAccessibleName", async () => {
 		const icons = ["add", "back-to-top", "collapse", "download"];
 		const expectedAccNames = ["Add", "Back to Top", "Collapse", "Download"];
 		const actualAccNames = await browser.executeAsync(async done => {
@@ -132,6 +132,6 @@ describe("Icon general interaction", () => {
 		});
 
 		assert.strictEqual(actualAccNames.join(), expectedAccNames.join(),
-			"getIconA11yName returns the correct icon a11y names.");
+			"getIconAccessibleName returns the correct icon a11y names.");
 	});
 });

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -122,10 +122,9 @@ describe("Icon general interaction", () => {
 	});
 
 	it("Tests getIconAccessibleName", async () => {
-		const icons = ["add", "back-to-top", "collapse", "download"];
 		const expectedAccNames = ["Add", "Back to Top", "Collapse", "Download"];
 		const actualAccNames = await browser.executeAsync(async done => {
-			const values = await Promise.all(icons.map(iconName => {
+			const values = await Promise.all(["add", "back-to-top", "collapse", "download"].map(iconName => {
 				return window["sap-ui-webcomponents-bundle"].getIconAccessibleName(iconName);
 			}));
 			done(values);


### PR DESCRIPTION
The Button component needs to set the icon's accessible name as its "tooltip". And for that we introduce the `getIconAccessibleName` method to return the accessible name for the given icon name:

```js
import { getIconAccessibleName } from  "@ui5/webcomponents-base/dist/asset-registries/Icons.js";

getIconAccessibleName("back-to-top") // returns "Back To Top"
```

Related to: https://github.com/SAP/ui5-webcomponents/pull/6719