### PR TITLE
fix(ui5-radio-button): fix 2-way db issue in angular

### DIFF
--- a/packages/main/src/RadioButton.ts
+++ b/packages/main/src/RadioButton.ts
@@ -444,6 +444,7 @@ class RadioButton extends UI5Element implements IFormElement {
 		if (!this.name) {
 			this.checked = !this.checked;
 			this.fireEvent("change");
+			this.fireEvent("value-changed"); // added for Angular two way data binding
 			return this;
 		}
 

--- a/packages/main/src/RadioButtonGroup.ts
+++ b/packages/main/src/RadioButtonGroup.ts
@@ -159,6 +159,7 @@ class RadioButtonGroup {
 			radioBtn.checked = true;
 			radioBtn._checked = true;
 			radioBtn.fireEvent("change");
+			radioBtn.fireEvent("value-changed"); // added for Angular two-way data binding
 		}
 	}
 

--- a/packages/main/test/pages/RadioButton.html
+++ b/packages/main/test/pages/RadioButton.html
@@ -85,6 +85,7 @@
 		<br/>
 		<ui5-radio-button id="wrappingRb" wrapping-type="Normal" text="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s." class="radiobutton2auto"></ui5-radio-button>
 		<ui5-input id="field"></ui5-input>
+		<ui5-input id="field2"></ui5-input>
 	</div>
 
 	<ui5-title level="H2">accessibleName</ui5-title>
@@ -164,12 +165,17 @@
 
 	<script>
 		var counter = 0;
+		var counterValueChanged = 0;
 		var groupEventCounter = 0;
 
 		[window["rb1"], window["rb2"], window["rb3"], window["rb4"]].forEach(function (radio) {
 			radio.addEventListener("ui5-change", function (event) {
 				counter += 1;
 				window["field"].value = counter;
+			});
+			radio.addEventListener("value-changed", function (event) {
+				counterValueChanged += 1;
+				window["field2"].value = counterValueChanged;
 			});
 		})
 

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -39,15 +39,17 @@ describe("RadioButton general interaction", () => {
 		await browser.url(`test/pages/RadioButton.html`);
 	});
 
-	it("tests change event", async () => {
+	it("tests change and value-changed events", async () => {
 		const radioButton = await browser.$("#rb1").shadow$(".ui5-radio-root");
 		const field = await browser.$("#field");
 
 		await radioButton.click();
-		assert.strictEqual(await field.getProperty("value"), "1", "Change event should be fired 1 time.");
+		assert.strictEqual(await field.getProperty("value"), "1", "change event should be fired 1 time.");
+		assert.strictEqual(await field2.getProperty("value"), "1", "value-changed event should be fired 1 time.");
 
 		await radioButton.click();
-		assert.strictEqual(await field.getProperty("value"), "1", "Change event should not be called any more, as radio is already selected.");
+		assert.strictEqual(await field.getProperty("value"), "1", "change event should not be called any more, as radio is already selected.");
+		assert.strictEqual(await field.getProperty("value"), "1", "value-changed event should not be called any more, as radio is already selected.");
 	});
 
 	it("tests change event upon ENTER", async () => {

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -42,6 +42,7 @@ describe("RadioButton general interaction", () => {
 	it("tests change and value-changed events", async () => {
 		const radioButton = await browser.$("#rb1").shadow$(".ui5-radio-root");
 		const field = await browser.$("#field");
+		const field2 = await browser.$("#field2");
 
 		await radioButton.click();
 		assert.strictEqual(await field.getProperty("value"), "1", "change event should be fired 1 time.");


### PR DESCRIPTION
Origami (the util we and the community recommend as glue between custom elements and Angular) listens for "value-changed" events to trigger 2way db functionality. A lot of components already fire it, but the RadioButton  used to not until now.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/6749