### PR TITLE
chore: improve wdio config of wc generated project

### DIFF
--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -89,6 +89,9 @@ const generateFilesContent = (name, tag, typescript) => {
 		ui5: {
 			webComponentsPackage: true,
 		},
+		repository: {
+			"directory": "/"
+		},
 		scripts: {
 			"clean": "wc-dev clean",
 			"lint": "wc-dev lint",

--- a/packages/create-package/template/.npmrc
+++ b/packages/create-package/template/.npmrc
@@ -1,0 +1,2 @@
+# Auto detect the chromedriver version
+detect_chromedriver_version=true

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -56,8 +56,15 @@ exports.config = {
 		'goog:chromeOptions': {
 			// to run chrome headless the following flags are required
 			// (see https://developers.google.com/web/updates/2017/04/headless-chrome)
-			args: ['--headless', '--disable-gpu'],
-			// args: ['--disable-gpu'],
+			args: [
+				'headless',             // start in headless mode
+				'start-maximized',      // maximize the window
+				'no-sandbox',           // disable sandbox isolation
+				'disable-infobars',     // disable the infos
+				'disable-gpu',          // on windows disable gpu hw acceleration
+				'disable-extensions',   // disable extensions
+				'disable-dev-shm-usage' // disable /dev/shm in CI
+			],
 		}
 	}],
 	//


### PR DESCRIPTION
- add `detect_chromedriver_version=true` flag to install the matching chromedriver of the installed chrome (useful for CI executions)
- add more `chromeOptions` to the wdio config after some issues when running wdio in Linux dockers
- add `repository` field in the package.json, required by the tests (to be checked if needed any more)