### PR TITLE
fix(ui5-text-area): revert removed CSS var

### DIFF
--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -121,7 +121,8 @@
 	--_ui5_tc_item_add_text_margin_top: 0.375rem;
 
 	/* TextArea */
-	--_ui5_textarea_padding: 0.5rem 0.625rem; /* deprecated since 1.10.0 */
+	/* --_ui5_textarea_padding is deprecated since 1.10.0 (to be removed 1.16.0) */
+	--_ui5_textarea_padding: var(--_ui5_textarea_padding_top) var(--_ui5_textarea_padding_right_and_left) var(--_ui5_textarea_padding_bottom);
 	--_ui5_textarea_margin: .25rem 0;
 
 	/* Panel */
@@ -261,7 +262,6 @@
 	--_ui5_popup_default_header_height: 2.5rem;
 
 	/* TextArea */
-	--_ui5_textarea_padding: .1875rem .5rem; /* deprecated since 1.10.0 */
 	--_ui5_textarea_margin: .1875rem 0;
 
 	/* List */

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -121,6 +121,7 @@
 	--_ui5_tc_item_add_text_margin_top: 0.375rem;
 
 	/* TextArea */
+	--_ui5_textarea_padding: 0.5rem 0.625rem; /* deprecated since 1.10.0 */
 	--_ui5_textarea_margin: .25rem 0;
 
 	/* Panel */
@@ -260,6 +261,7 @@
 	--_ui5_popup_default_header_height: 2.5rem;
 
 	/* TextArea */
+	--_ui5_textarea_padding: .1875rem .5rem; /* deprecated since 1.10.0 */
 	--_ui5_textarea_margin: .1875rem 0;
 
 	/* List */

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -121,7 +121,11 @@
 	--_ui5_tc_item_add_text_margin_top: 0.375rem;
 
 	/* TextArea */
-	/* --_ui5_textarea_padding is deprecated since 1.10.0 (to be removed 1.16.0) */
+	/* 
+	The "--_ui5_textarea_padding" CSS var is not used, but left for compatitability
+	when multiple ui5 webc versions are used on same page and will be removed with 1.16.0
+	@deprecated since 1.10.0.
+	*/
 	--_ui5_textarea_padding: var(--_ui5_textarea_padding_top) var(--_ui5_textarea_padding_right_and_left) var(--_ui5_textarea_padding_bottom);
 	--_ui5_textarea_margin: .25rem 0;
 


### PR DESCRIPTION
We removed the `--_ui5_textarea_padding` css var as part of TextArea styles refactoring.
However, when there are multiple versions of UI5 Web Components this removal becomes an issue as we don't support multiple version of the CSS vars. 
In the newer  UI5 Web Components version the  `--_ui5_textarea_padding`  is missing, and when this newer UI5 Web Components version loads, it updates the CSS vars on the page and  the Text Area of the already loaded older UI5 Web Components version, visible on the same page and still using `--_ui5_textarea_padding`, looks broken.

The solutions we discussed and suggested also by this FR https://github.com/SAP/ui5-webcomponents/issues/6806 are all complex, and we finally decided not to remove CSS Vars (the changes in the CSS Vars is rarely a problem and too difficult to catch) and deprecate them, or so to say - to treat them as public stuff. Regularly, we will clean them couple of times during the year, giving enough time to stakeholders to upgrade to newer versions.

Related to: https://github.com/SAP/ui5-webcomponents/issues/6797