### PR TITLE
feat(framework): re-export all public imports from index.js

### DIFF
--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,5 +1,3 @@
-import UI5Element from "./dist/UI5Element.js";
-
 // animations/
 import scroll from "./dist/animations/scroll.js";
 import slideDown from "./dist/animations/slideDown.js";
@@ -8,7 +6,7 @@ import slideUp from "./dist/animations/slideup.js";
 // config/
 import { getAnimationMode, setAnimationMode } from "./dist/config/AnimationMode.js";
 import { getCalendarType } from "./dist/config/CalendarType.js";
-import { getFirstDayOfWeek,	getLegacyDateCalendarCustomizing } from "./dist/config/FormatSettings.js";
+import { getFirstDayOfWeek, getLegacyDateCalendarCustomizing } from "./dist/config/FormatSettings.js";
 import {
 	setDefaultIconCollection,
 	getDefaultIconCollection,
@@ -22,7 +20,7 @@ import {
 	setFetchDefaultLanguage,
 	getFetchDefaultLanguage,
 } from "./dist/config/Language.js";
-import { getNoConflict,	setNoConflict } from "./dist/config/NoConflict.js";
+import { getNoConflict, setNoConflict } from "./dist/config/NoConflict.js";
 import { getRTL } from "./dist/config/RTL.js";
 import {
 	getTheme,
@@ -43,7 +41,7 @@ import ScrollEnablement from "./dist/delegate/ScrollEnablement.js";
 
 // locale/
 import applyDirection from "./dist/locale/applyDirection.js";
-import { attachDirectionChange,	detachDirectionChange } from "./dist/locale/directionChange.js";
+import { attachDirectionChange, detachDirectionChange } from "./dist/locale/directionChange.js";
 import getEffectiveDir from "./dist/locale/getEffectiveDir.js";
 import { attachLanguageChange, detachLanguageChange } from "./dist/locale/languageChange.js";
 
@@ -72,6 +70,7 @@ import {
 	getCustomElementsScopingSuffix,
 	setCustomElementsScopingRules,
 	getCustomElementsScopingRules,
+	getEffectiveScopingSuffixForTag,
 } from "./dist/CustomElementsScope.js";
 
 // Device.ts
@@ -89,8 +88,14 @@ import {
 	isAndroid,
 } from "./dist/Device.js";
 
+// EventProvider.ts
+import EventProvider from "./dist/EventProvider.js";
+
 // i18nBundle.ts
-import { getI18nBundle,	registerCustomI18nBundleGetter } from "./dist/i18nBundle.js";
+import I18nBundle, { getI18nBundle, registerCustomI18nBundleGetter } from "./dist/i18nBundle.js";
+
+// MediaRange.ts
+import MediaRange from "./dist/MediaRange.js";
 
 // PropertiesFileFormat.ts
 import parseProperties from "./dist/PropertiesFileFormat.js";
@@ -105,6 +110,9 @@ import {
 
 // Theming.ts
 import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "./dist/Theming.js";
+
+// UI5Element.ts
+import UI5Element from "./dist/UI5Element.js";
 
 export default UI5Element;
 export {
@@ -177,6 +185,7 @@ export {
 	getCustomElementsScopingSuffix,
 	setCustomElementsScopingRules,
 	getCustomElementsScopingRules,
+	getEffectiveScopingSuffixForTag,
 
 	// Device.ts
 	supportsTouch,
@@ -191,9 +200,16 @@ export {
 	isIOS,
 	isAndroid,
 
+	// EventProvider.ts
+	EventProvider,
+
 	// i18nBundle.ts
+	I18nBundle,
 	getI18nBundle,
 	registerCustomI18nBundleGetter,
+
+	// MediaRange.ts
+	MediaRange,
 
 	// PropertiesFileFormat.ts
 	parseProperties,

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,4 +1,214 @@
 import UI5Element from "./dist/UI5Element.js";
 
+// animations/
+import scroll from "./dist/animations/scroll.js";
+import slideDown from "./dist/animations/slideDown.js";
+import slideUp from "./dist/animations/slideup.js";
+
+// config/
+import { getAnimationMode, setAnimationMode } from "./dist/config/AnimationMode.js";
+import { getCalendarType } from "./dist/config/CalendarType.js";
+import { getFirstDayOfWeek,	getLegacyDateCalendarCustomizing } from "./dist/config/FormatSettings.js";
+import {
+	setDefaultIconCollection,
+	getDefaultIconCollection,
+	getEffectiveIconCollection,
+	RegisteredIconCollection,
+} from "./dist/config/Icons.js";
+import {
+	getLanguage,
+	setLanguage,
+	getDefaultLanguage,
+	setFetchDefaultLanguage,
+	getFetchDefaultLanguage,
+} from "./dist/config/Language.js";
+import { getNoConflict,	setNoConflict } from "./dist/config/NoConflict.js";
+import { getRTL } from "./dist/config/RTL.js";
+import {
+	getTheme,
+	setTheme,
+	getDefaultTheme,
+} from "./dist/config/Theme.js";
+
+// decorators/
+import customElement from "./dist/decorators/customElement.js";
+import event from "./dist/decorators/event.js";
+import property from "./dist/decorators/property.js";
+import slot from "./dist/decorators/slot.js";
+
+// delegate/
+import ItemNavigation from "./dist/delegate/ItemNavigation.js";
+import ResizeHandler from "./dist/delegate/ResizeHandler.js";
+import ScrollEnablement from "./dist/delegate/ScrollEnablement.js";
+
+// locale/
+import applyDirection from "./dist/locale/applyDirection.js";
+import { attachDirectionChange,	detachDirectionChange } from "./dist/locale/directionChange.js";
+import getEffectiveDir from "./dist/locale/getEffectiveDir.js";
+import { attachLanguageChange, detachLanguageChange } from "./dist/locale/languageChange.js";
+
+// util/
+import { URLListValidator, sanitizeHTML } from "./dist/util/HTMLSanitizer.js";
+
+// Assets.ts
+import { registerI18nLoader } from "./dist/asset-registries/i18n.js";
+import { registerLocaleDataLoader } from "./dist/asset-registries/LocaleData.js";
+import { registerThemePropertiesLoader } from "./dist/asset-registries/Themes.js";
+import { registerIconLoader } from "./dist/asset-registries/Icons.js";
+
+// Boot.ts
+import { attachBoot } from "./dist/Boot.js";
+
+// CSP.ts
+import {
+	setPackageCSSRoot,
+	setUseLinks,
+	setPreloadLinks,
+} from "./dist/CSP.js";
+
+// CustomElementsScope.ts
+import {
+	setCustomElementsScopingSuffix,
+	getCustomElementsScopingSuffix,
+	setCustomElementsScopingRules,
+	getCustomElementsScopingRules,
+} from "./dist/CustomElementsScope.js";
+
+// Device.ts
+import {
+	supportsTouch,
+	isIE,
+	isSafari,
+	isChrome,
+	isFirefox,
+	isPhone,
+	isTablet,
+	isDesktop,
+	isCombi,
+	isIOS,
+	isAndroid,
+} from "./dist/Device.js";
+
+// i18nBundle.ts
+import { getI18nBundle,	registerCustomI18nBundleGetter } from "./dist/i18nBundle.js";
+
+// PropertiesFileFormat.ts
+import parseProperties from "./dist/PropertiesFileFormat.js";
+
+// Render.ts
+import {
+	renderDeferred,
+	renderImmediately,
+	cancelRender,
+	renderFinished,
+} from "./dist/Render.js";
+
+// Theming.ts
+import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "./dist/Theming.js";
+
 export default UI5Element;
-export { UI5Element };
+export {
+	// animations/
+	scroll,
+	slideDown,
+	slideUp,
+
+	// config/
+	getAnimationMode,
+	setAnimationMode,
+	getCalendarType,
+	getFirstDayOfWeek,
+	getLegacyDateCalendarCustomizing,
+	setDefaultIconCollection,
+	getDefaultIconCollection,
+	getEffectiveIconCollection,
+	RegisteredIconCollection,
+	getLanguage,
+	setLanguage,
+	getDefaultLanguage,
+	setFetchDefaultLanguage,
+	getFetchDefaultLanguage,
+	getNoConflict,
+	setNoConflict,
+	getRTL,
+	getTheme,
+	setTheme,
+	getDefaultTheme,
+
+	// decorators/
+	customElement,
+	event,
+	property,
+	slot,
+
+	// delegate/
+	ItemNavigation,
+	ResizeHandler,
+	ScrollEnablement,
+
+	// locale/
+	applyDirection,
+	attachDirectionChange,
+	detachDirectionChange,
+	getEffectiveDir,
+	attachLanguageChange,
+	detachLanguageChange,
+
+	// util/
+	URLListValidator,
+	sanitizeHTML,
+
+	// Assets.ts
+	registerI18nLoader,
+	registerLocaleDataLoader,
+	registerThemePropertiesLoader,
+	registerIconLoader,
+
+	// Boot.ts
+	attachBoot,
+
+	// CSP.ts
+	setPackageCSSRoot,
+	setUseLinks,
+	setPreloadLinks,
+
+	// CustomElementsScope.ts
+	setCustomElementsScopingSuffix,
+	getCustomElementsScopingSuffix,
+	setCustomElementsScopingRules,
+	getCustomElementsScopingRules,
+
+	// Device.ts
+	supportsTouch,
+	isIE,
+	isSafari,
+	isChrome,
+	isFirefox,
+	isPhone,
+	isTablet,
+	isDesktop,
+	isCombi,
+	isIOS,
+	isAndroid,
+
+	// i18nBundle.ts
+	getI18nBundle,
+	registerCustomI18nBundleGetter,
+
+	// PropertiesFileFormat.ts
+	parseProperties,
+
+	// Render.ts
+	renderDeferred,
+	renderImmediately,
+	cancelRender,
+	renderFinished,
+
+	// Theming.ts
+	addCustomCSS,
+	attachThemeLoaded,
+	detachThemeLoaded,
+
+	// UI5Element.ts
+	UI5Element,
+};

--- a/packages/base/src/decorators/slot.ts
+++ b/packages/base/src/decorators/slot.ts
@@ -22,11 +22,11 @@ const slot = (slotData?: Slot): PropertyDecorator => {
 
 		const slotMetadata = metadata.slots;
 
-		if (slotData?.default && slotMetadata.default) {
+		if (slotData && slotData.default && slotMetadata.default) {
 			throw new Error("Only one slot can be the default slot.");
 		}
 
-		const key = slotData?.default ? "default" : slotKey as string;
+		const key = slotData && slotData.default ? "default" : slotKey as string;
 		slotData = slotData || { type: HTMLElement };
 
 		if (!slotData.type) {


### PR DESCRIPTION
Notes:
 - the change to `slot.ts` was needed, because when I re-export `slot`, I get eslint errors regarding the combination of the `?` operator and the `default` keyword. This is most probably a glitch with eslint.
 - modules with side effects (all modules from `features/`) are **not re-exported** in order to avoid potential complications with build tools (if they are not tree-shaken, thus all features unnecessarily registered)
 - the order of exports is following the directory structure of `src/`: sub-directories first, and then the files in `src/` itself, and not alphabetically for the exported entities.

*Not all re-exported functions are documented (with `@public`) - let me know if others are considered public and needed*

closes: https://github.com/SAP/ui5-webcomponents/issues/6739