### PR TITLE
chore(framework): fix build

### DIFF
--- a/packages/main/test/specs/base/IconCollection.spec.js
+++ b/packages/main/test/specs/base/IconCollection.spec.js
@@ -1,4 +1,4 @@
-const assert = require("chai").assert;
+import { assert } from "chai";
 
 describe("Icon collection", () => {
 	before(async () => {

--- a/packages/tools/lib/dev-server/virtual-index-html-plugin.js
+++ b/packages/tools/lib/dev-server/virtual-index-html-plugin.js
@@ -1,6 +1,5 @@
-import path from "path";
-
 const virtualIndexPlugin = async () => {
+	const path = await import("path");
 	const { globby } = await import("globby");
 	const files = await globby(["test/pages/**/*.html", "packages/*/test/pages/**/*.html"]);
 

--- a/packages/tools/lib/dev-server/virtual-index-html-plugin.mjs
+++ b/packages/tools/lib/dev-server/virtual-index-html-plugin.mjs
@@ -1,3 +1,0 @@
-import virtualIndexPlugin from "./virtual-index-html-plugin.js";
-
-export default virtualIndexPlugin;

--- a/packages/tools/lib/dev-server/virtual-index-html-plugin.mjs
+++ b/packages/tools/lib/dev-server/virtual-index-html-plugin.mjs
@@ -1,0 +1,3 @@
+import virtualIndexPlugin from "./virtual-index-html-plugin.js";
+
+export default virtualIndexPlugin;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,1 +1,11 @@
-module.exports = require("@ui5/webcomponents-tools/components-package/vite.config.js");
+const { defineConfig } = require('vite');
+const virtualIndex = require("@ui5/webcomponents-tools/lib/dev-server/virtual-index-html-plugin.js");
+
+module.exports = defineConfig(async () => {
+	return {
+		build: {
+			emptyOutDir: false,
+		},
+		plugins: [await virtualIndex()],
+	}
+});


### PR DESCRIPTION
When `yarn start` is executed inside root folder the vite config file is not found because of an error. Packages have `type: module` config and based on that setting vite requires ESM modules and the root folder doesn't have that setting so when vite is started there CJS module is required which leads to an error when shared config is used.