### PR TITLE
fix(framework): remove invalid element from head

### DIFF
--- a/packages/base/src/getSharedResource.ts
+++ b/packages/base/src/getSharedResource.ts
@@ -4,12 +4,12 @@ const getSharedResourcesInstance = (): Record<string, unknown> | null => {
 	if (typeof document === "undefined") {
 		return null;
 	}
-	return getSingletonElementInstance("ui5-shared-resources", document.head) as unknown as Record<string, unknown>;
+	return getSingletonElementInstance("ui5-shared-resources") as unknown as Record<string, unknown>;
 };
 
 /**
  * Use this method to initialize/get resources that you would like to be shared among UI5 Web Components runtime instances.
- * The data will be accessed via a singleton "ui5-shared-resources" HTML element in the "head" element of the page.
+ * The data will be accessed via a singleton "ui5-shared-resources" HTML element in the "body" element of the page.
  *
  * @public
  * @param namespace Unique ID of the resource, may contain "." to denote hierarchy


### PR DESCRIPTION
The **"ui5-shared-resources"** elements used to be created in the **"head"**. However, this turns out to be invalid markup as per the [HTML standard](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head): **title**, **meta**, **link**, **script**, **style**, **base**, **noscript** and **template** tags are allowed only. With this change, it becomes part of the **body**.

**Note:** `document.querySelector("ui5-shared-resources")` continues working, however accessing via the head, f.e `document.querySelector("head>ui5-shared-resources")`, won't work anymore.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/6748