### PR TITLE
fix: fix components metadata calculation

### DIFF
--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -33,15 +33,21 @@ const customElement = (tagNameOrComponentSettings: string | {
 
 		const {
 			tag,
-			languageAware = false,
-			themeAware = false,
-			fastNavigation = false,
+			languageAware,
+			themeAware,
+			fastNavigation,
 		 } = tagNameOrComponentSettings;
 
 		target.metadata.tag = tag;
-		target.metadata.languageAware = languageAware;
-		target.metadata.themeAware = themeAware;
-		target.metadata.fastNavigation = fastNavigation;
+		if (languageAware) {
+			target.metadata.languageAware = languageAware;
+		}
+		if (themeAware) {
+			target.metadata.themeAware = themeAware;
+		}
+		if (fastNavigation) {
+			target.metadata.fastNavigation = fastNavigation;
+		}
 
 		["render", "renderer", "template", "staticAreaTemplate", "styles", "staticAreaStyles", "dependencies"].forEach((customElementEntity: string) => {
 			const _customElementEntity = customElementEntity === "render" ? "renderer" : customElementEntity;


### PR DESCRIPTION
The `customElement` decorator used to set default values for `languageAware = false`, `themeAware = false`, `fastNavigation = false` when the fields are not provided. However, this leads to a wrong metadata in case the field is set by a parent class. Then, the value set by the parent class won't be considered as the child class already set it to "false" and as expected the values set by the child class are taken with precedence.

**For Example:**
- `Calendar` component `does not set languageAware` at all (but gets  languageAware: false by default)
- Calendar's parent class `DateComponentsBase` has `languageAware: true`
- When merging the metadata of the inheritance chain to get the resulting metadata, the Calendar's metadata is taken with precedence and languageAware is false at the end, but should be true.
- As a consequence, when we call setLanguage, the Calendar won't be re-rendered, but should.