### PR TITLE
fix(ui5-color-picker): fix incorrect input state after invalid values

### DIFF
--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -289,20 +289,29 @@ class ColorPicker extends UI5Element {
 	}
 
 	_handleHEXChange(e: CustomEvent | KeyboardEvent) {
-		let newValue: string = (e.target as Input).value.toLowerCase();
 		const hexRegex = new RegExp("^[<0-9 abcdef]+$");
+		const input: Input = (e.target as Input);
+		let inputValueLowerCase = input.value.toLowerCase();
 
 		// Shorthand Syntax
-		if (newValue.length === 3) {
-			newValue = `${newValue[0]}${newValue[0]}${newValue[1]}${newValue[1]}${newValue[2]}${newValue[2]}`;
+		if (inputValueLowerCase.length === 3) {
+			inputValueLowerCase = `${inputValueLowerCase[0]}${inputValueLowerCase[0]}${inputValueLowerCase[1]}${inputValueLowerCase[1]}${inputValueLowerCase[2]}${inputValueLowerCase[2]}`;
 		}
 
-		if (newValue === this.hex) {
+		const isNewValueValid = inputValueLowerCase.length === 6 && hexRegex.test(inputValueLowerCase);
+
+		if (isNewValueValid && input.value !== inputValueLowerCase) {
+			this._wrongHEX = false;
+			input.value = inputValueLowerCase;
+		}
+
+		if (inputValueLowerCase === this.hex) {
 			return;
 		}
 
-		this.hex = newValue;
-		if (newValue.length !== 6 || !hexRegex.test(newValue)) {
+		this.hex = inputValueLowerCase;
+
+		if (!isNewValueValid) {
 			this._wrongHEX = true;
 		} else {
 			this._wrongHEX = false;
@@ -426,8 +435,12 @@ class ColorPicker extends UI5Element {
 
 	_setColor(color: ColorRGB = { r: 0, g: 0, b: 0 }) {
 		this.color = `rgba(${color.r}, ${color.g}, ${color.b}, ${this._alpha})`;
-
+		this._wrongHEX = !this.isValidRGBColor(color);
 		this.fireEvent("change");
+	}
+
+	isValidRGBColor(color: ColorRGB) {
+		return color.r >= 0 && color.r <= 255 && color.g >= 0 && color.g <= 255 && color.b >= 0 && color.b <= 255;
 	}
 
 	_setHex() {


### PR DESCRIPTION
Fixed **`<ui5-color-picker>`** component behaviour.

### Before:
![2023-04-05_16-52-32](https://user-images.githubusercontent.com/88034608/230102010-42f3f20b-986a-4eb8-9d0c-d83db3159864.gif)

#### Case 1:
After providing a 3-digit value to the `Hex` input, after clicking `Enter` ( or firing `ui5-change` event ), the value was beign automatically transformed into a **Hexadecimal** value.

For example, typing `'0ab'`, and pressing `Enter` would lead to transforming the string in the input into `'00aabb'`. 
Which is the **correct** behaviour. 
However, if after that the value is being changed to a invalid one - f.e `00aaxx`, and then the user tries to change the value from the ColorPicker by dragging, the value is being changed correctly, but the state of the Input wasnt changing ( in other words it was staying "Error" instead of "None" ).

#### Case 2: 
After typing a correct value, then deleting some text to invalid value for example ( from `aa00aa` -> `aa`), and then typing a valid one ( from `aa` -> `aa0` ), the value is transforming to a valid **Hexadecimal** only after the **first** time. ( Following these steps the result in the Input should be `aaaa00 )`. After the value is changed to `aaaa00` and if we perform the same actions again f.e `aaaa00` -> `aa` -> *clicks* Enter -> `a2a` -> *clicks* Enter again -> the value should become `aa22aa`, but instead stays to `a2a`.

### After:
The behaviour is now correct.

![2023-04-05_17-05-36](https://user-images.githubusercontent.com/88034608/230105730-19b60d61-ec56-4210-b353-48076b07451f.gif)


Fixes: #5794