### PR TITLE
fix(ui5-timeline*): fix chronological line not displaying in vertical or default layout

### DIFF
--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -10,7 +10,7 @@
 	flex-direction: column;
 }
 
-:host([layout="Vertical"]) .ui5-tli-indicator {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator {
 	position: relative;
 	width: 2rem;
 }
@@ -22,7 +22,7 @@
 	align-items: center;
 }
 
-:host([layout="Vertical"]) .ui5-tli-indicator::before {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator::before {
 	content: "";
 	display: inline-block;
 	background-color: var(--sapContent_ForegroundBorderColor);
@@ -43,7 +43,7 @@
 	left: 2.0625rem;
 	right: var(--_ui5_timeline_tli_indicator_before_right);
 }
-:host([layout="Vertical"]) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 }
 
@@ -52,7 +52,7 @@
 }
 
 /* Line when no Icon is provided */
-:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator::before {
+:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 	top: 1.875rem;
 }
@@ -64,7 +64,7 @@
 	left: 1.6875rem;
 }
 
-:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
+:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_bottom);
 }
 
@@ -84,13 +84,13 @@
 	height: 0.375rem;
 	position: absolute;
 	top: 0.9375rem;
-	left: 50%;
+	left: 51.75%;
 	transform: translateX(-50%);
 }
 
 /* No Icon Dot in Hotizontal */
 :host([layout="Horizontal"]:not([icon])) .ui5-tli-indicator::after {
-	top: 0.78125rem;
+	top: 0.84rem;
 	left: 0.9625rem;
 }
 


### PR DESCRIPTION
While `layout` property/attribute of the `ui5-timeline` component is being not set, or set to `layout="Vertical"` the chronological line, wasnt rendering. With this change is now being rendered properly. 

Also the **dot** which is being rendered when there is no `icon` set, is now positioned with pixel-perfect vertical and horizontal alignment.

### Before (In vertical):

![image](https://user-images.githubusercontent.com/88034608/230128977-d1bbc9dc-8002-4848-9e28-a9199ae657d4.png)

### After (In vertical):

![image](https://user-images.githubusercontent.com/88034608/230129332-de5e022e-27a3-4b0d-9e7b-a1609d23b7d4.png)

### Before (In horizontal):

![image](https://user-images.githubusercontent.com/88034608/230129459-480b912d-6482-4a9f-b108-382b66834545.png)


### After (In horizontal):

![image](https://user-images.githubusercontent.com/88034608/230129805-6ab7606e-344b-4b61-b2ed-d6f8deccdec6.png)

Fixes: #6827
