### PR TITLE
fix(u5-tree-item): correct text alignment on truncation

### DIFF
--- a/packages/main/src/TreeItem.hbs
+++ b/packages/main/src/TreeItem.hbs
@@ -1,13 +1,12 @@
 {{>include "./TreeItemBase.hbs"}}
 
 {{#*inline "listItemContent"}}
-	<div class="ui5-li-tree-text-wrapper">
+	<div class="ui5-li-text-wrapper">
 		{{#if _showTitle}}
 			<div part="title" class="ui5-li-title">{{text}}</div>
 		{{/if}}
-
-		{{#if additionalText}}
-			<span part="additional-text" class="ui5-li-additional-text">{{additionalText}}</span>
-		{{/if}}
 	</div>
+	{{#if additionalText}}
+		<span part="additional-text" class="ui5-li-additional-text">{{additionalText}}</span>
+	{{/if}}
 {{/inline}}

--- a/packages/main/src/themes/TreeItem.css
+++ b/packages/main/src/themes/TreeItem.css
@@ -32,7 +32,7 @@
 	bottom: 0.125rem;
 }
 
-:host([_minimal]) .ui5-li-tree-text-wrapper {
+:host([_minimal]) .ui5-li-text-wrapper {
 	display: none;
 }
 
@@ -92,12 +92,6 @@
 
 :host([active][actionable]) .ui5-li-tree-toggle-icon {
 	color: var(--sapList_Active_TextColor);
-}
-
-.ui5-li-tree-text-wrapper {
-	display: flex;
-	justify-content: space-between;
-	width: 100%;
 }
 
 /* move host styles to .ui5-li-root as the focused element of [ui5-tree-item]


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/6757

Similarly to the `ListItem` components, the `additionalText` element is now rendered outside the `.ui5-li-text-wrapper` container, preventing alignment issue when the main text truncates.