### PR TITLE
 fix(framework): return correct element when getLastFocusableElement is used

### DIFF
--- a/packages/base/src/util/FocusableElements.ts
+++ b/packages/base/src/util/FocusableElements.ts
@@ -74,10 +74,10 @@ const findFocusableElement = async (container: HTMLElement, forward: boolean, st
 		child = forward ? originalChild.nextSibling as HTMLElement : originalChild.previousSibling as HTMLElement;
 
 		// If the child element is not part of the currently assigned element,
-		// we have to check the next element assigned to the slot or continue with the next sibling of the slot,
-		// otherwise, the nextSibling is the next element inside the light DOM
+		// we have to check the next/previous element assigned to the slot or continue with the next/previous sibling of the slot,
+		// otherwise, the nextSibling/previousSibling is the next element inside the light DOM
 		if (assignedElements && !assignedElements[currentIndex].contains(child)) {
-			child = assignedElements[++currentIndex] as HTMLElement;
+			child = forward ? assignedElements[++currentIndex] as HTMLElement : assignedElements[--currentIndex] as HTMLElement;
 		}
 	}
 

--- a/packages/base/src/util/FocusableElements.ts
+++ b/packages/base/src/util/FocusableElements.ts
@@ -77,7 +77,9 @@ const findFocusableElement = async (container: HTMLElement, forward: boolean, st
 		// we have to check the next/previous element assigned to the slot or continue with the next/previous sibling of the slot,
 		// otherwise, the nextSibling/previousSibling is the next element inside the light DOM
 		if (assignedElements && !assignedElements[currentIndex].contains(child)) {
-			child = forward ? assignedElements[++currentIndex] as HTMLElement : assignedElements[--currentIndex] as HTMLElement;
+			currentIndex = forward ? currentIndex + 1 : currentIndex - 1;
+
+			child = assignedElements[currentIndex] as HTMLElement;
 		}
 	}
 

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -451,6 +451,17 @@
 	<br>
 	<br>
 	<div>
+		<ui5-label>Focus circularity</ui5-label>
+		<ui5-button id="btn-focus-circ">Dialog focus circularity</ui5-button>
+		<ui5-dialog id="focus-circ">
+			<ui5-busy-indicator slot="header">
+				<ui5-button id="active-btn-1">1</ui5-button>
+			</ui5-busy-indicator>
+			<ui5-busy-indicator slot="footer">
+				<ui5-button id="active-btn-2">2</ui5-button>
+			</ui5-busy-indicator>
+		</ui5-dialog>
+	</div>
 		<div>
 			<ui5-label>Dialog states</ui5-label>
 		</div>
@@ -603,6 +614,13 @@
 
 		btnOpenDialog.addEventListener("click", function () {
 			dialog.show();
+		});
+
+		const focusCirBtn = document.getElementById("btn-focus-circ");
+		const focusCircDialog = document.getElementById("focus-circ");
+
+		focusCirBtn.addEventListener("click", function () {
+			focusCircDialog.show();
 		});
 
 		btnOpenDialogNoPaddings.addEventListener("click", function () {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -330,28 +330,47 @@ describe("Dialog general interaction", () => {
 		assert.notOk(await dialog.isDisplayedInViewport(), "Dialog is closed");
 	});
 
-	it("Test focus circularity", async () => {
-			const opener = await browser.$("#btn-focus-circ");
-		const dialog = await browser.$("#focus-circ");
-		const firstActiveBtn = await browser.$("#active-btn-1");
-		const secondActiveBtn = await browser.$("#active-btn-2");
+	it("Test initial focus when content is provided before the header", async () => {
+		const listContainerItem = await browser.$("#dialogFocus");
+		await listContainerItem.scrollIntoView();
+		await listContainerItem.click();
 
-		await opener.click();
-		await dialog.isDisplayed();
+		const closeButton = await browser.$("#closeDialogFocusButton");
 
-		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
-		await browser.keys("Tab");
-		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
-		await browser.keys("Tab");
-		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.waitUntil(async () => {
+			const activeElement = await browser.$(await browser.getActiveElement());
+			return await activeElement.getProperty("id") === "fistButtonInDialog";
+		}, {
+			timeout: 500,
+			timeoutMsg: "the active element must be the button in the content of the dialog"
+		});
 
-		await browser.keys(["Shift", "Tab"]);
-		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
-		await browser.keys(["Shift", "Tab"]);
-		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
-		await browser.keys(["Shift", "Tab"]);
-		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+		await closeButton.click();
+
 	});
+
+	it("Test focus circularity", async () => {
+		const opener = await browser.$("#btn-focus-circ");
+	const dialog = await browser.$("#focus-circ");
+	const firstActiveBtn = await browser.$("#active-btn-1");
+	const secondActiveBtn = await browser.$("#active-btn-2");
+
+	await opener.click();
+	await dialog.isDisplayed();
+
+	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+	await browser.keys("Tab");
+	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+	await browser.keys("Tab");
+	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+
+	await browser.keys(["Shift", "Tab"]);
+	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+	await browser.keys(["Shift", "Tab"]);
+	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+	await browser.keys(["Shift", "Tab"]);
+	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+});
 });
 
 describe("Acc", () => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -330,26 +330,29 @@ describe("Dialog general interaction", () => {
 		assert.notOk(await dialog.isDisplayedInViewport(), "Dialog is closed");
 	});
 
-	it("Test initial focus when content is provided before the header", async () => {
-		const listContainerItem = await browser.$("#dialogFocus");
-		await listContainerItem.scrollIntoView();
-		await listContainerItem.click();
+	it("Test focus circularity", async () => {
+			const opener = await browser.$("#btn-focus-circ");
+		const dialog = await browser.$("#focus-circ");
+		const firstActiveBtn = await browser.$("#active-btn-1");
+		const secondActiveBtn = await browser.$("#active-btn-2");
 
-		const closeButton = await browser.$("#closeDialogFocusButton");
+		await opener.click();
+		await dialog.isDisplayed();
 
-		await browser.waitUntil(async () => {
-			const activeElement = await browser.$(await browser.getActiveElement());
-			return await activeElement.getProperty("id") === "fistButtonInDialog";
-		}, {
-			timeout: 500,
-			timeoutMsg: "the active element must be the button in the content of the dialog"
-		});
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys("Tab");
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys("Tab");
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
 
-		await closeButton.click();
-
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
 	});
 });
-
 
 describe("Acc", () => {
 	before(async () => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -351,26 +351,26 @@ describe("Dialog general interaction", () => {
 
 	it("Test focus circularity", async () => {
 		const opener = await browser.$("#btn-focus-circ");
-	const dialog = await browser.$("#focus-circ");
-	const firstActiveBtn = await browser.$("#active-btn-1");
-	const secondActiveBtn = await browser.$("#active-btn-2");
+		const dialog = await browser.$("#focus-circ");
+		const firstActiveBtn = await browser.$("#active-btn-1");
+		const secondActiveBtn = await browser.$("#active-btn-2");
 
-	await opener.click();
-	await dialog.isDisplayed();
+		await opener.click();
+		await dialog.isDisplayed();
 
-	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
-	await browser.keys("Tab");
-	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
-	await browser.keys("Tab");
-	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys("Tab");
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys("Tab");
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
 
-	await browser.keys(["Shift", "Tab"]);
-	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
-	await browser.keys(["Shift", "Tab"]);
-	assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
-	await browser.keys(["Shift", "Tab"]);
-	assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
-});
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await firstActiveBtn.isFocused(), true, "Correct element is focused");
+		await browser.keys(["Shift", "Tab"]);
+		assert.strictEqual(await secondActiveBtn.isFocused(), true, "Correct element is focused");
+	});
 });
 
 describe("Acc", () => {


### PR DESCRIPTION
getLastFocusableElement returns wrong element when it looks for previous focus element. It's because when we go over assigned elements to slot we only check forward. Now, we go over elements based on the direction of the traversing.

Fixes: #6858