### PR TITLE
fix(ui5-shellbar): primary title respects text spacing styles

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -42,6 +42,9 @@
 	white-space: initial;
 	overflow: initial;
 	text-overflow: initial;
+	line-height: inherit;
+	letter-spacing: inherit;
+	word-spacing: inherit;
 }
 
 ::slotted([ui5-button][slot="startButton"]) {


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/6212