### PR TITLE
fix(ui5-datetime-picker/ui5-time-picker): fix top and bottom overflows of input

### DIFF
--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -10,7 +10,7 @@
 	flex-direction: column;
 }
 
-:host([layout="Vertical"]) .ui5-tli-indicator {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator {
 	position: relative;
 	width: 2rem;
 }
@@ -22,7 +22,7 @@
 	align-items: center;
 }
 
-:host([layout="Vertical"]) .ui5-tli-indicator::before {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator::before {
 	content: "";
 	display: inline-block;
 	background-color: var(--sapContent_ForegroundBorderColor);
@@ -43,7 +43,7 @@
 	left: 2.0625rem;
 	right: var(--_ui5_timeline_tli_indicator_before_right);
 }
-:host([layout="Vertical"]) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
+:host(:not([layout="Horizontal"])) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 }
 
@@ -52,7 +52,7 @@
 }
 
 /* Line when no Icon is provided */
-:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator::before {
+:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 	top: 1.875rem;
 }
@@ -64,7 +64,7 @@
 	left: 1.6875rem;
 }
 
-:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
+:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_bottom);
 }
 
@@ -84,13 +84,13 @@
 	height: 0.375rem;
 	position: absolute;
 	top: 0.9375rem;
-	left: 50%;
+	left: 51.75%;
 	transform: translateX(-50%);
 }
 
 /* No Icon Dot in Hotizontal */
 :host([layout="Horizontal"]:not([icon])) .ui5-tli-indicator::after {
-	top: 0.78125rem;
+	top: 0.84rem;
 	left: 0.9625rem;
 }
 

--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -10,7 +10,7 @@
 	flex-direction: column;
 }
 
-:host(:not([layout="Horizontal"])) .ui5-tli-indicator {
+:host([layout="Vertical"]) .ui5-tli-indicator {
 	position: relative;
 	width: 2rem;
 }
@@ -22,7 +22,7 @@
 	align-items: center;
 }
 
-:host(:not([layout="Horizontal"])) .ui5-tli-indicator::before {
+:host([layout="Vertical"]) .ui5-tli-indicator::before {
 	content: "";
 	display: inline-block;
 	background-color: var(--sapContent_ForegroundBorderColor);
@@ -43,7 +43,7 @@
 	left: 2.0625rem;
 	right: var(--_ui5_timeline_tli_indicator_before_right);
 }
-:host(:not([layout="Horizontal"])) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
+:host([layout="Vertical"]) .ui5-tli-indicator.ui5-tli-indicator-large-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 }
 
@@ -52,7 +52,7 @@
 }
 
 /* Line when no Icon is provided */
-:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator::before {
+:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_without_icon_bottom);
 	top: 1.875rem;
 }
@@ -64,7 +64,7 @@
 	left: 1.6875rem;
 }
 
-:host(:not([layout="Horizontal"])):not([icon]) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
+:host([layout="Vertical"]:not([icon])) .ui5-tli-indicator.ui5-tli-indicator-short-line::before {
 	bottom: var(--_ui5_timeline_tli_indicator_before_bottom);
 }
 
@@ -84,13 +84,13 @@
 	height: 0.375rem;
 	position: absolute;
 	top: 0.9375rem;
-	left: 51.75%;
+	left: 50%;
 	transform: translateX(-50%);
 }
 
 /* No Icon Dot in Hotizontal */
 :host([layout="Horizontal"]:not([icon])) .ui5-tli-indicator::after {
-	top: 0.84rem;
+	top: 0.78125rem;
 	left: 0.9625rem;
 }
 

--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -47,6 +47,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
+	margin: 0;
 }
 
 :host(:not([disabled]):not([readonly])) .ui5-date-picker-input[focused] {

--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -15,6 +15,7 @@
 	color: var(--sapField_TextColor);
 	background-color: var(--sapField_Background);
 	border-radius: var(--_ui5-datepicker_border_radius);
+	margin: var(--_ui5_input_margin_top_bottom) 0;
 }
 
 :host([value-state="Error"]:not([readonly]):not([disabled])) {
@@ -47,7 +48,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
-	margin: 0;
+	margin: inherit;
 }
 
 :host(:not([disabled]):not([readonly])) .ui5-date-picker-input[focused] {

--- a/packages/main/src/themes/TimePicker.css
+++ b/packages/main/src/themes/TimePicker.css
@@ -37,6 +37,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
+	margin: 0;
 }
 
 .ui5-time-picker-input-icon-button {

--- a/packages/main/src/themes/TimePicker.css
+++ b/packages/main/src/themes/TimePicker.css
@@ -14,6 +14,7 @@
 	color: var(--sapField_TextColor);
 	background-color: var(--sapField_Background);
 	border-radius: var(--_ui5-time_picker_border_radius);
+	margin: var(--_ui5_input_margin_top_bottom) 0;
 }
 
 :host([value-state="Error"]) {
@@ -37,7 +38,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
-	margin: 0;
+	margin: inherit;
 }
 
 .ui5-time-picker-input-icon-button {

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -15,14 +15,22 @@
 
 	</head>
 	<body class="timepicker1auto">
-		<ui5-time-picker id="timepicker" format-pattern="HH:mm:ss"></ui5-time-picker>
-		<ui5-time-picker></ui5-time-picker>
-		<ui5-time-picker id="timepicker2" format-pattern="hh:mm:ss" value=""></ui5-time-picker>
-		<ui5-time-picker id="timepicker3" format-pattern="hh:mm:ss a"></ui5-time-picker>
-		<ui5-time-picker id="timepicker4" format-pattern="HH:mm" value="12:05"></ui5-time-picker>
-		<ui5-time-picker id="timepicker5" format-pattern="hh:mm:ss" value="12:00:01"></ui5-time-picker>
-		<br>
-		<ui5-time-picker class="timepicker2auto"></ui5-time-picker>
+
+		<div class="samples">
+			<div class="sample-box-1">
+				<ui5-time-picker id="timepicker" format-pattern="HH:mm:ss"></ui5-time-picker>
+				<ui5-time-picker></ui5-time-picker>
+				<ui5-time-picker id="timepicker2" format-pattern="hh:mm:ss" value=""></ui5-time-picker>
+				<ui5-time-picker id="timepicker3" format-pattern="hh:mm:ss a"></ui5-time-picker>
+				<ui5-time-picker id="timepicker4" format-pattern="HH:mm" value="12:05"></ui5-time-picker>
+				<ui5-time-picker id="timepicker5" format-pattern="hh:mm:ss" value="12:00:01"></ui5-time-picker>
+				<br>
+			</div>
+
+			<div class="sample-box-2">
+				<ui5-time-picker class="timepicker2auto"></ui5-time-picker>
+			</div>
+		</div>
 
 		<br /><br />
 		<ui5-title>Test "change" event</ui5-title>

--- a/packages/main/test/pages/styles/TimePicker.css
+++ b/packages/main/test/pages/styles/TimePicker.css
@@ -11,6 +11,7 @@ html,body {
 .sample-box-1 {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 1rem;
 }
 

--- a/packages/main/test/pages/styles/TimePicker.css
+++ b/packages/main/test/pages/styles/TimePicker.css
@@ -2,6 +2,18 @@ html,body {
     height: 100%;
 }
 
+.samples {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.sample-box-1 {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+}
+
 .timepicker1auto {
     background-color: var(--sapBackgroundColor);
 }


### PR DESCRIPTION
There was a little overflowing in the input fields of the `ui5-datetime-picker` and the `ui5-time-picker` as we can see from the example below.

### Before:
![image](https://user-images.githubusercontent.com/88034608/230614517-cbd853d6-0c87-4c83-9e74-11db101fd64e.png)

There should be margin, but it should not be visible as it was:

### After:
![image](https://user-images.githubusercontent.com/88034608/230614646-663824fa-a9cf-4a22-be98-cd3d7ab46f10.png)
![image](https://user-images.githubusercontent.com/88034608/232615575-932bfac2-04d4-47b6-89ea-c25d5919b3d7.png)



Fixes: #5912 
Fixes: #7021 
Fixes: #7104 
