### PR TITLE
fix(ui5-bar): fix top and bottom border of Buttons hidden in ui5-bar when shrinked

### DIFF
--- a/packages/fiori/src/themes/Bar.css
+++ b/packages/fiori/src/themes/Bar.css
@@ -32,6 +32,7 @@
 .ui5-bar-root.ui5-bar-root-shrinked .ui5-bar-content-container {
 	min-width: 0px;
 	overflow: hidden;
+	height: 100%;
 }
 
 .ui5-bar-root .ui5-bar-endcontent-container {


### PR DESCRIPTION
When there are a `Button/s` inside a `ui5-bar` component, which is being shrinked or is used in a small aspect, the top and bottom borders of the `Button` components are being hidden.

With this change now in every length, the `Buttons` are displayed properly.

### Before:
![image](https://user-images.githubusercontent.com/88034608/230620406-20050a38-4cdf-46e0-8dac-12fc0ead1ac8.png)

### After:
![image](https://user-images.githubusercontent.com/88034608/230620767-a14f8b2f-e145-40ab-a70a-ca7865cbbae1.png)


