### PR TITLE
fix(ui5-table): prevent Safari from crashing

### DIFF
--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -228,6 +228,10 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 		};
 	}
 
+	onEnterDOM() {
+		this._markSafari();
+	}
+
 	_onmouseup() {
 		this.deactivate();
 	}
@@ -476,6 +480,12 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 
 	static async onDefine() {
 		TableRow.i18nBundle = await getI18nBundle("@ui5/webcomponents");
+	}
+
+	_markSafari() : void {
+		if (navigator && (navigator.userAgent.indexOf("Safari") !== -1 && navigator.userAgent.indexOf("Chrome") === -1)) {
+			this.setAttribute("_onSafari", "");
+		}
 	}
 }
 

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -18,9 +18,11 @@ import {
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import { getLastTabbableElement } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
 import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
+import {
+	isSafari,
+} from "@ui5/webcomponents-base/dist/Device.js";
 import type TableCell from "./TableCell.js";
 import type { ITableRow, TableColumnInfo } from "./Table.js";
-
 import CheckBox from "./CheckBox.js";
 import TableMode from "./types/TableMode.js";
 import TableRowType from "./types/TableRowType.js";
@@ -229,7 +231,7 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 	}
 
 	onEnterDOM() {
-		this._markSafari();
+		this._markIsSafari();
 	}
 
 	_onmouseup() {
@@ -482,8 +484,8 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 		TableRow.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 
-	_markSafari() : void {
-		if (navigator && (navigator.userAgent.indexOf("Safari") !== -1 && navigator.userAgent.indexOf("Chrome") === -1)) {
+	_markIsSafari() : void {
+		if (isSafari()) {
 			this.setAttribute("_onSafari", "");
 		}
 	}

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -18,9 +18,6 @@ import {
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import { getLastTabbableElement } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
 import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
-import {
-	isSafari,
-} from "@ui5/webcomponents-base/dist/Device.js";
 import type TableCell from "./TableCell.js";
 import type { ITableRow, TableColumnInfo } from "./Table.js";
 import CheckBox from "./CheckBox.js";
@@ -228,10 +225,6 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 			handleEvent: handleToushStartEvent,
 			passive: true,
 		};
-	}
-
-	onEnterDOM() {
-		this._markIsSafari();
 	}
 
 	_onmouseup() {
@@ -482,12 +475,6 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 
 	static async onDefine() {
 		TableRow.i18nBundle = await getI18nBundle("@ui5/webcomponents");
-	}
-
-	_markIsSafari() : void {
-		if (isSafari()) {
-			this.setAttribute("_onSafari", "");
-		}
 	}
 }
 

--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -4,7 +4,6 @@
 	font-size: 0.875rem;
 	height: 100%;
 	box-sizing: border-box;
-	overflow: hidden;
 	color: var(--sapContent_LabelColor);
 	word-break: break-word;
 	vertical-align: middle;
@@ -13,7 +12,7 @@
 td {
 	display: contents;
 }
-
+ƒ
 :host([popined]) {
 	padding-left: 0;
 	padding-top: .25rem;

--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -12,7 +12,7 @@
 td {
 	display: contents;
 }
-ƒ
+
 :host([popined]) {
 	padding-left: 0;
 	padding-top: .25rem;

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -73,11 +73,6 @@
 	padding-inline-start: 1rem;
 }
 
-
-:host(:not([_onsafari])) ::slotted([ui5-table-cell]) {
-	overflow: hidden;
-}
-
 /** Hover **/
 :host([type="Active"]) .ui5-table-row-root:hover,
 :host([mode="SingleSelect"]) .ui5-table-row-root:hover:not(:active) {

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -73,6 +73,11 @@
 	padding-inline-start: 1rem;
 }
 
+
+:host(:not([_onsafari])) ::slotted([ui5-table-cell]) {
+	overflow: hidden;
+}
+
 /** Hover **/
 :host([type="Active"]) .ui5-table-row-root:hover,
 :host([mode="SingleSelect"]) .ui5-table-row-root:hover:not(:active) {


### PR DESCRIPTION
The combination of display: table-cell and overflow: hidden styles
 was causing the browser to crash upon component re-rendering

Fixes: #6570
