### PR TITLE
fix: getIconAccessibleName now handles empty strings

### DIFF
--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -147,6 +147,10 @@ const getIconData = async (name: string) => {
  * @return { Promise }
  */
 const getIconAccessibleName = async (name: string): Promise<string | undefined> => {
+	if (!name) {
+		return;
+	}
+
 	let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);
 
 	if (!iconData) {


### PR DESCRIPTION
Fixing the issue in the framework will be safer for future use cases.

closes: https://github.com/SAP/ui5-webcomponents/issues/6889