### PR TITLE
fix(ui5-menu): fix children closing unexpectedly when opener is right aligned

### DIFF
--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -105,6 +105,11 @@
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);
 }
 
+.ui5-menu-rp[sub-menu][actual-placement-type="Left"] {
+	margin-top: 0.25rem;
+	margin-inline: var(--_ui5_menu_submenu_placement_type_left_margin_offset);
+}
+
 .ui5-menu-item::part(additional-text) {
 	margin-inline-start: var(--_ui5_menu_item_additional_text_start_margin);
 	color: var(--sapContent_LabelColor);

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -18,6 +18,7 @@
 	--_ui5_progress_indicator_bar_border_radius: 0.5rem 0 0 0.5rem;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0 0.5rem 0.5rem 0;
 	--_ui5_menu_submenu_margin_offset: -0.25rem 0;
+	--_ui5_menu_submenu_placement_type_left_margin_offset: 0.25rem 0;
 	--_ui5-menu_item_icon_float: right;
 }
 
@@ -38,6 +39,7 @@
 	--_ui5_progress_indicator_bar_border_radius: 0 0.5rem 0.5rem 0;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0.5rem 0 0 0.5rem;
 
-	--_ui5_menu_submenu_margin_offset: 0 0.25rem;
+	--_ui5_menu_submenu_margin_offset: 0 -0.25rem;
+	--_ui5_menu_submenu_placement_type_left_margin_offset: 0 0.25rem;
 	--_ui5-menu_item_icon_float: left;
 }


### PR DESCRIPTION
We have an issue which occurs when using the `ui5-menu` component, where the opener of the menu is aligned to the right side of the screen. When attempting to hover over the sub-menu items, they unexpectedly close or disappear. This problem occurs more frequently when the cursor is moved slowly.

The cause of this issue seems to be a small gap between the menu and the sub-menu items, which is only noticeable when the opener is aligned to the right side of the screen. This issue can be frustrating for users who are trying to navigate the menu and its sub-menus.

With this change, the sub-menus are aligned properly ( including in **RTL**, **LTR** mode ).

### Before
![menu-before](https://user-images.githubusercontent.com/88034608/231123156-c200444d-0b29-468f-b3a4-553dd122aef6.gif)

### After
![menu-after](https://user-images.githubusercontent.com/88034608/231123204-0a533aaa-6ada-421c-8a34-0a239b04739f.gif)

Fixes: #5802

