### PR TITLE
fix(framework): correct fileName in component CSS import

### DIFF
--- a/packages/tools/lib/postcss-css-to-esm/index.js
+++ b/packages/tools/lib/postcss-css-to-esm/index.js
@@ -70,7 +70,7 @@ module.exports = function (opts) {
 			mkdirp.sync(path.dirname(targetFile));
 
 			const filePath = `${targetFile}.${tsMode ? "ts" : "js"}`;
-		
+
 			// it seems slower to read the old content, but writing the same content with no real changes
 			// (as in initial build and then watch mode) will cause an unnecessary dev server refresh
 			let oldContent = "";
@@ -80,7 +80,7 @@ module.exports = function (opts) {
 				// file not found
 			}
 
-			const content = getFileContent(tsMode, filePath, packageName, css, includeDefaultTheme);
+			const content = getFileContent(tsMode, targetFile, packageName, css, includeDefaultTheme);
 			if (content !== oldContent) {
 				fs.writeFileSync(filePath, content);
 			}


### PR DESCRIPTION
Previously fileName was stored with ts/js file extension at the end.
```ts
const styleData = {
    packageName: "@ui5/webcomponents",
    fileName: "themes/Avatar.css.ts",
    content: ".."
};
```

Storing the fileName with these extensions errors when fileName property is used. For example if we force our bundle to use links with `setUseLinks` which will trigger the framework to add link tags inside document head element will result in following errors:
![image](https://user-images.githubusercontent.com/31909318/231195351-50412873-f8e9-4dc0-9e33-eb4472f254fc.png)
![image](https://user-images.githubusercontent.com/31909318/231195410-75396140-8c6a-4273-a65d-49d809f4db5e.png)
