### PR TITLE
fix(ui5-table): correct row height in Safari

### DIFF
--- a/packages/main/src/themes/TableCell.css
+++ b/packages/main/src/themes/TableCell.css
@@ -2,7 +2,7 @@
 	display: table-cell;
 	font-family: "72override", var(--sapFontFamily);
 	font-size: 0.875rem;
-	height: 100%;
+	height: var(--ui5_table_row_height);
 	box-sizing: border-box;
 	overflow: hidden;
 	color: var(--sapContent_LabelColor);

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -11,7 +11,6 @@
 	background-color: var(--sapList_Background);
 	color: var(--sapList_TextColor);
 	border-top: 1px solid var(--sapList_BorderColor);
-	height: var(--ui5_table_row_height);
 }
 
 .ui5-table-row-root:focus {


### PR DESCRIPTION
Fixes: #6843

Safari ignores table row height. Now the `height` style property is moved from `ui5-table-row` to `ui5-table-cell`, which is more correct since the row takes the height of the cell as a min-height. 

> The height of a 'table-row' element's box is calculated once the user agent has all the cells in the row available: it is the maximum of the row's computed ['height'](https://www.w3.org/TR/CSS2/visudet.html#propdef-height), the computed ['height'](https://www.w3.org/TR/CSS2/visudet.html#propdef-height) of each cell in the row, and the minimum height (MIN) required by the cells. A ['height'](https://www.w3.org/TR/CSS2/visudet.html#propdef-height) value of 'auto' for a 'table-row' means the row height used for layout is MIN. MIN depends on cell box heights and cell box alignment (much like the calculation of a [line box](https://www.w3.org/TR/CSS2/visudet.html#line-height) height). CSS 2.1 does not define how the height of table cells and table rows is calculated when their height is specified using percentage values. CSS 2.1 does not define the meaning of ['height'](https://www.w3.org/TR/CSS2/visudet.html#propdef-height) on row groups.

Source:
https://www.w3.org/TR/CSS2/tables.html#height-layout