### PR TITLE
fix(ui5-dialog): always wait for applying of initial focus to complete

### DIFF
--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -470,16 +470,17 @@ abstract class Popup extends UI5Element {
 
 		this._show();
 
-		if (!this._disableInitialFocus && !preventInitialFocus) {
-			await this.applyInitialFocus();
-		}
-
 		this._addOpenedPopup();
 
 		this.opened = true;
 		this.open = true;
 
 		await renderFinished();
+
+		if (!this._disableInitialFocus && !preventInitialFocus) {
+			await this.applyInitialFocus();
+		}
+
 		this.fireEvent("after-open", {}, false, false);
 	}
 

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -471,7 +471,7 @@ abstract class Popup extends UI5Element {
 		this._show();
 
 		if (!this._disableInitialFocus && !preventInitialFocus) {
-			this.applyInitialFocus();
+			await this.applyInitialFocus();
 		}
 
 		this._addOpenedPopup();


### PR DESCRIPTION
Sometimes on Safari, after the dialog is opened, a focusin event will be fired on the root. This event will race with the applyInitialFocus call which results in the wrong element being focused.

This PR attempts to solve the issue.

Part of #6768
