### PR TITLE
chore: export StaticArea class

### DIFF
--- a/packages/base/src/StaticArea.ts
+++ b/packages/base/src/StaticArea.ts
@@ -1,3 +1,7 @@
+class StaticArea extends HTMLElement {}
+
 if (!customElements.get("ui5-static-area")) {
-	customElements.define("ui5-static-area", class extends HTMLElement {});
+	customElements.define("ui5-static-area", StaticArea);
 }
+
+export default StaticArea;


### PR DESCRIPTION
Since this modules has no `import`, nor `export` statements, some build tools may get confused about its module type. To avoid this, the otherwise anonymous class is now named, and exported. This will not change existing functionality.

closes: https://github.com/SAP/ui5-webcomponents/issues/6916