### PR TITLE
fix(ui5-tabcontainer): correct focus outline

### DIFF
--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -77,11 +77,15 @@
 	margin-top: 0.25rem;
 	border-radius: 0.75rem;
 	height: 1.5rem;
+	border: 0.25rem solid transparent; /* to reserve space for the outside border and prevent flickering*/
 }
 
 .ui5-tc__overflow > [ui5-button][focused] {
 	outline-offset: 0.125rem;
 	--_ui5_button_focused_border_radius: 0.75rem;
+	--_ui5_button_focused_border: none;
+	padding: 0.125rem;
+	border: 2px solid var(--sapContent_FocusColor);
 }
 
 .ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -81,6 +81,7 @@
 
 .ui5-tc__overflow > [ui5-button][focused] {
 	outline-offset: 0.125rem;
+	--_ui5_button_focused_border_radius: 0.75rem;
 }
 
 .ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -77,15 +77,12 @@
 	margin-top: 0.25rem;
 	border-radius: 0.75rem;
 	height: 1.5rem;
-	border: 0.25rem solid transparent; /* to reserve space for the outside border and prevent flickering*/
 }
 
 .ui5-tc__overflow > [ui5-button][focused] {
 	outline-offset: 0.125rem;
-	--_ui5_button_focused_border_radius: 0.75rem;
 	--_ui5_button_focused_border: none;
-	padding: 0.125rem;
-	border: 2px solid var(--sapContent_FocusColor);
+	outline: 0.125rem solid var(--sapContent_FocusColor);
 }
 
 .ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {

--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -82,7 +82,7 @@
 .ui5-tc__overflow > [ui5-button][focused] {
 	outline-offset: 0.125rem;
 	--_ui5_button_focused_border: none;
-	outline: 0.125rem solid var(--sapContent_FocusColor);
+	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 }
 
 .ui5-tc-root.ui5-tc--textOnly .ui5-tc__content {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -135,7 +135,7 @@ describe("TabContainer general interaction", () => {
 		await browser.setWindowSize(1000, 1080);
 		const tabcontainer = await browser.$("#tabContainerStartAndEndOverflow");
 		const startOverflow = await tabcontainer.shadow$(".ui5-tc__overflow--start");
-		assert.strictEqual(await startOverflow.getProperty("innerText"), "+11", "11 tabs in start overflow");
+		assert.strictEqual(await startOverflow.getProperty("innerText"), "+12", "12 tabs in start overflow");
 
 		await browser.setWindowSize(800, 1080);
 		assert.strictEqual(await startOverflow.getProperty("innerText"), "+14", "14 tabs in start overflow");

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -135,7 +135,7 @@ describe("TabContainer general interaction", () => {
 		await browser.setWindowSize(1000, 1080);
 		const tabcontainer = await browser.$("#tabContainerStartAndEndOverflow");
 		const startOverflow = await tabcontainer.shadow$(".ui5-tc__overflow--start");
-		assert.strictEqual(await startOverflow.getProperty("innerText"), "+12", "12 tabs in start overflow");
+		assert.strictEqual(await startOverflow.getProperty("innerText"), "+11", "11 tabs in start overflow");
 
 		await browser.setWindowSize(800, 1080);
 		assert.strictEqual(await startOverflow.getProperty("innerText"), "+14", "14 tabs in start overflow");


### PR DESCRIPTION
The focus outline of the overflow buttons now has correct border radius

Fixes: #6763