### PR TITLE
chore: fix globby usage in Windows

### DIFF
--- a/packages/tools/lib/esm-abs-to-rel/index.js
+++ b/packages/tools/lib/esm-abs-to-rel/index.js
@@ -49,7 +49,7 @@ const convertImports = async (srcPath) => {
 
 const generate = async () => {
 	const { globby } = await import("globby");
-	const fileNames = await globby(basePath + "**/*.js");
+	const fileNames = await globby(basePath.replace(/\\/g, "/") + "**/*.js");
 	return Promise.all(fileNames.map(convertImports).filter(x => !!x));
 };
 

--- a/packages/tools/lib/i18n/toJSON.js
+++ b/packages/tools/lib/i18n/toJSON.js
@@ -34,7 +34,7 @@ const convertToJSON = async (file) => {
 const generate = async () => {
 	const { globby } = await import("globby");
 	await fs.mkdir(messagesJSONDist, { recursive: true });
-	const files = await globby(messagesBundles);
+	const files = await globby(messagesBundles.replace(/\\/g, "/"));
 	return Promise.all(files.map(convertToJSON));
 };
 

--- a/packages/tools/lib/jsdoc/preprocess.js
+++ b/packages/tools/lib/jsdoc/preprocess.js
@@ -8,7 +8,7 @@ const sourceDir = process.argv[3];
 const preprocessTypes = async () => {
 	try {
 		const { globby } = await import("globby");
-		const fileNames = await globby(inputDir + "**/types/*.js");
+		const fileNames = await globby(inputDir.replace(/\\/g, "/") + "**/types/*.js");
 
 		return Promise.all(fileNames.map(processTypeFile));
 	} catch(e) {
@@ -63,7 +63,7 @@ const preprocessComponents = async () => {
 
 	try {
 		const { globby } = await import("globby");
-		const fileNames = await globby(sourceDir + "/*.ts");
+		const fileNames = await globby(sourceDir.replace(/\\/g, "/") + "/*.ts");
 
 		return Promise.all(fileNames.map(processComponentFile));
 	} catch(e) {

--- a/packages/tools/lib/replace-global-core/index.js
+++ b/packages/tools/lib/replace-global-core/index.js
@@ -16,7 +16,7 @@ const replaceGlobalCoreUsage = async (srcPath) => {
 
 const generate = async () => {
 	const { globby } = await import("globby");
-	const fileNames = await globby(basePath + "**/*.js");
+	const fileNames = await globby(basePath.replace(/\\/g, "/") + "**/*.js");
 	return Promise.all(fileNames.map(replaceGlobalCoreUsage).filter(x => !!x));
 };
 


### PR DESCRIPTION
`globby` is bugged on Windows and does not work if you pass it `\`, it only works with `/`

Some usages were already fixed, but some were still broken.