### PR TITLE
fix(ui5-menu): fix sub-menu closing if the first item is disabled

### DIFF
--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -110,6 +110,18 @@
 	margin-inline: var(--_ui5_menu_submenu_placement_type_left_margin_offset);
 }
 
+.ui5-menu-rp .ui5-menu-item[disabled] {
+	pointer-events: auto;
+}
+
+.ui5-menu-rp .ui5-menu-item:active[disabled] {
+	pointer-events: none;
+}
+
+.ui5-menu-rp .ui5-menu-item[disabled]:hover {
+	background-color: transparent;
+}
+
 .ui5-menu-item::part(additional-text) {
 	margin-inline-start: var(--_ui5_menu_item_additional_text_start_margin);
 	color: var(--sapContent_LabelColor);

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -20,7 +20,7 @@
 		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
-				<ui5-menu-item text="Open from C"></ui5-menu-item>
+				<ui5-menu-item text="Open from C" disabled></ui5-menu-item>
 				<ui5-menu-item text="Open from D"></ui5-menu-item>
 				<ui5-menu-item text="Open from E"></ui5-menu-item>
 			</ui5-menu-item>


### PR DESCRIPTION
When a `ui5-menu-item` is marked as **`disabled`**, and it is the first item within a `sub-menu`, the `sub-menu` is automatically closed. This is because when the mouse pointer moves over the `sub-menu`, it cannot interact with the first disabled item, which triggers the `sub-menu` to close.

### Before

![2023-04-20_12-42-07](https://user-images.githubusercontent.com/88034608/233333995-5d53709c-28a7-493d-936a-aeb3383d3d6d.gif)

### After

![2023-04-20_12-41-36](https://user-images.githubusercontent.com/88034608/233334120-1f6f9f28-3e97-4448-b823-c47589888fa3.gif)

Fixes: #6925 , #6709