### PR TITLE
fix(ui5-input): remove double border of input in dialog on phone

### DIFF
--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -23,7 +23,7 @@
 				</ui5-button>
 			</div>
 			<div class="row">
-				<div class="input-root-phone">
+				<div class="input-root-phone native-input-wrapper">
 					<ui5-input
 						class="ui5-input-inner-phone"
 						type="{{inputType}}"

--- a/packages/main/src/themes/Suggestions.css
+++ b/packages/main/src/themes/Suggestions.css
@@ -20,3 +20,15 @@
 .ui5-suggestions-popover [ui5-li-suggestion-item]::part(icon) {
 	color: var(--sapList_TextColor);
 }
+
+.input-root-phone.native-input-wrapper {
+	display: contents;
+}
+
+.input-root-phone.native-input-wrapper::before {
+	display: none;
+}
+
+.native-input-wrapper .ui5-input-inner-phone {
+	margin: 0;
+}


### PR DESCRIPTION
FIXES: #6943

The `ui5-input` is using another `ui5-input` for the content of its dialog on mobile device. Other components such as combobox share the same styles as the ui5-input, but the use native input. That leads to some issues when same styles are applied for all mobile input dialogs.
