### PR TITLE
docs(ui5-tabcontainer): rewrite JSDoc

### DIFF
--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -695,6 +695,7 @@ class Carousel extends UI5Element {
 
 	/**
 	 * The indices of the currently visible items of the component.
+	 * @public
 	 * @readonly
 	 * @since 1.0.0-rc.15
 	 * @returns {Integer[]} the indices of the visible items

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -662,22 +662,22 @@ class TabContainer extends UI5Element {
 	/**
 	 * Returns all slotted tabs and their subTabs in a flattened array.
 	 * The order of tabs is depth-first. For example, given the following slotted elements:
-	 * <code>
-	 * 	<ui5-tabcontainer>
-	 * 		<ui5-tab id="First" text="First">
+	 * <pre><code>
+	 * 	&lt;ui5-tabcontainer&gt;
+	 * 		&lt;ui5-tab id="First" text="First"&gt;
 	 * 			...
-	 * 			<ui5-tab slot="subTabs" id="Nested" text="Nested">...</ui5-tab>
-	 * 		</ui5-tab>
-	 * 		<ui5-tab id="Second" text="Second">...</ui5-tab>
-	 * 		<ui5-tab-separator id="sep"></ui5-tab-separator>
-	 * 		<ui5-tab id="Third" text="Third">...</ui5-tab>
-	 * 	</ui5-tabcontainer>
-	 * </code>
+	 * 			&lt;ui5-tab slot="subTabs" id="Nested" text="Nested"&gt;...&lt;/ui5-tab&gt;
+	 * 		&lt;/ui5-tab&gt;
+	 * 		&lt;ui5-tab id="Second" text="Second"&gt;...&lt;/ui5-tab&gt;
+	 * 		&lt;ui5-tab-separator id="sep"&gt;&lt;/ui5-tab-separator&gt;
+	 * 		&lt;ui5-tab id="Third" text="Third"&gt;...&lt;/ui5-tab&gt;
+	 * 	&lt;/ui5-tabcontainer&gt;
+	 * </code></pre>
 	 * Calling <code>allItems</code> on this TabContainer will return the instances in the following order:
 	 * <code>[ ui5-tab#First, ui5-tab#Nested, ui5-tab#Second, ui5-tab-separator#sep, ui5-tab#Third ]</code>
 	 * @public
 	 * @readonly
-     * @name sap.ui.webc.main.TabContainer.prototype.allItems
+	 * @name sap.ui.webc.main.TabContainer.prototype.allItems
 	 * @returns {sap.ui.webc.main.ITab[]}
 	 */
 	get allItems() {


### PR DESCRIPTION
Rewrote the comment to display the actual HTML code for the example.

Additionally, marked the Carousel's getter `visibleItemsIndices`
as `@public` so it shows in the playground.