### PR TITLE
fix(ui5-tabcontainer): bottom align tab strip item text with no additional text

### DIFF
--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -357,7 +357,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 		}
 
 		if (this.additionalText) {
-			classes.push("ui5-tab-strip-item--withAddionalText");
+			classes.push("ui5-tab-strip-item--withAdditionalText");
 		}
 
 		if (!this.icon && !this._mixedMode) {

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -380,6 +380,22 @@ class Tab extends UI5Element implements ITab, ITabbable {
 			classes.push(`ui5-tab-strip-item--singleClickArea`);
 		}
 
+		return {
+			itemClasses: classes.join(" "),
+			additionalTextClasses: this.additionalTextClasses,
+		};
+	}
+
+	get additionalTextClasses() {
+		const classes = [];
+		if (this.additionalText) {
+			classes.push("ui5-tab-strip-itemAdditionalText");
+		}
+
+		if (this.icon && !this.additionalText) {
+			classes.push("ui5-tab-strip-itemAdditionalText-hidden");
+		}
+
 		return classes.join(" ");
 	}
 

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -1,5 +1,5 @@
 <div id="{{this._id}}"
-	class="{{this.stripClasses}}"
+	class="{{this.stripClasses.itemClasses}}"
 	tabindex="-1"
 	role="tab"
 	aria-roledescription="{{_roleDescription}}"
@@ -62,10 +62,5 @@
 	{{/if}}
 
 {{#*inline additionalText}}
-	{{#if this.additionalText}}
-		<span class="ui5-tab-strip-itemAdditionalText" id="{{this._id}}-additionalText">{{this.additionalText}}</span>
-
-	{{else if this.icon}}
-		<span class="ui5-tab-strip-itemAdditionalText-hidden" id="{{this._id}}-additionalText-hidden"></span>
-	{{/if}}
+		<span class="{{this.stripClasses.additionalTextClasses}}" id="{{this._id}}-additionalText">{{this.additionalText}}</span>
 {{/inline}}

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -64,5 +64,8 @@
 {{#*inline additionalText}}
 	{{#if this.additionalText}}
 		<span class="ui5-tab-strip-itemAdditionalText" id="{{this._id}}-additionalText">{{this.additionalText}}</span>
+
+	{{else if this.icon}}
+		<span class="ui5-tab-strip-itemAdditionalText-hidden" id="{{this._id}}-additionalText-hidden"></span>
 	{{/if}}
 {{/inline}}

--- a/packages/main/src/themes/TabInStrip.css
+++ b/packages/main/src/themes/TabInStrip.css
@@ -230,7 +230,7 @@
 }
 
 .ui5-tab-strip-itemAdditionalText-hidden {
-	visibility: hidden ;
+	visibility: hidden;
 	margin-top: 1.25rem;
 }
 
@@ -258,7 +258,7 @@
 	padding: 0 0.188rem;
 }
 
-.ui5-tab-strip-item--textOnly.ui5-tab-strip-item--withAddionalText {
+.ui5-tab-strip-item--textOnly.ui5-tab-strip-item--withAdditionalText {
 	justify-content: flex-start;
 	height: var(--_ui5_tc_item_text_only_with_additional_text_height);
 }

--- a/packages/main/src/themes/TabInStrip.css
+++ b/packages/main/src/themes/TabInStrip.css
@@ -229,6 +229,11 @@
 	display: flex;
 }
 
+.ui5-tab-strip-itemAdditionalText-hidden {
+	visibility: hidden ;
+	margin-top: 1.25rem;
+}
+
 .ui5-tab-strip-item--inline .ui5-tab-strip-itemAdditionalText + .ui5-tab-strip-itemText {
 	display: inline;
 }

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -236,7 +236,7 @@
 			<ui5-tab stable-dom-ref="products-ref" text="Products" additional-text="125"></ui5-tab>
 			<ui5-tab-separator></ui5-tab-separator>
 			<ui5-tab icon="sap-icon://menu2" text="Laptops" design="Positive" additional-text="25"></ui5-tab>
-			<ui5-tab icon="sap-icon://menu" text="Monitors" selected design="Critical" additional-text="45"></ui5-tab>
+			<ui5-tab icon="sap-icon://menu" text="Monitors" selected design="Critical"></ui5-tab>
 			<ui5-tab icon="sap-icon://menu2" text="Keyboards" design="Negative" additional-text="15"></ui5-tab>
 			<ui5-tab icon="sap-icon://menu2" disabled text="Disabled" design="Negative" additional-text="40"></ui5-tab>
 			<ui5-tab icon="sap-icon://menu2" text="Neutral" design="Neutral" additional-text="40"></ui5-tab>


### PR DESCRIPTION
Strip tabs text is bottom aligned even when there is no additional text
Fixes: #6764