### PR TITLE
feat(ui5-calendar,date*picker): add static format (ISO) support for min/max dates

### DIFF
--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -50,7 +50,7 @@ type Month = {
 	classes: string,
 }
 
-type MothInterval = Array<Array<Month>>;
+type MonthInterval = Array<Array<Month>>;
 
 type MonthPickerChangeEventDetail = {
 	timestamp: number,
@@ -108,7 +108,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 	selectedDates!: Array<number>;
 
 	@property({ type: Object, multiple: true })
-	_months!: MothInterval;
+	_months!: MonthInterval;
 
 	@property({ type: Boolean, noAttribute: true })
 	_hidden!: boolean;
@@ -141,7 +141,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 		const localeData = getCachedLocaleDataInstance(getLocale());
 		const monthsNames = localeData.getMonthsStandAlone("wide", this._primaryCalendarType);
 
-		const months: MothInterval = [];
+		const months: MonthInterval = [];
 		const calendarDate = this._calendarDate; // store the value of the expensive getter
 		const minDate = this._minDate; // store the value of the expensive getter
 		const maxDate = this._maxDate; // store the value of the expensive getter

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -67,6 +67,11 @@
 	</section>
 
 	<section>
+		<ui5-title> Calendar with no format pattern & ISO min-max dates</ui5-title>
+		<ui5-calendar id="calendar6" min-date="2020-10-20" max-date="2023-10-20"></ui5-calendar>
+	</section>
+
+	<section>
 		<ui5-title>Calendar with primary and secondary calendar type</ui5-title>
 		<ui5-calendar id="calendar5" primary-calendar-type='Islamic' secondary-calendar-type='Gregorian'></ui5-calendar>
 	</section>

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -34,7 +34,13 @@
 	<link rel="stylesheet" type="text/css" href="./styles/DatePicker.css">
 </head>
 <body class="datepicker1auto">
-	<div style='width:500px;'>
+	<div style='width:600px;'>
+		<div>
+			<h3> DatePicker with no format pattern & min-max dates in ISO format</h3>
+			<ui5-date-picker id="dpMinMax-dates" min-date="2019-09-01" max-date="2019-11-01"></ui5-date-picker>
+		</div>
+
+		<h3>Date picker with placeholder.</h3>
 		<ui5-date-picker id='ui5-datepicker--startDate'
 			placeholder='Delivery Date...'>
 		</ui5-date-picker>

--- a/packages/main/test/pages/DatePicker_test_page.html
+++ b/packages/main/test/pages/DatePicker_test_page.html
@@ -72,6 +72,9 @@
 	<h3>DatePicker with format `yyyy` should open picker on years</h3>
 	<ui5-date-picker id="dpCalendarModeYears" format-pattern="yyyy"></ui5-date-picker>
 
+	<h3> DatePicker with no format pattern & min-max dates in ISO format</h3>
+	<ui5-date-picker id="dpISOMinMaxDates" min-date="2019-09-01" max-date="2019-11-01"></ui5-date-picker>
+
 	<section>
 		<h3>Test accessibleName and accessibleNameRef</h3>
 		<ui5-date-picker id="dpAriaLabel" accessible-name="Hello World"></ui5-date-picker>

--- a/packages/main/test/pages/DateRangePicker.html
+++ b/packages/main/test/pages/DateRangePicker.html
@@ -47,6 +47,9 @@
 		<ui5-daterange-picker id="daterange-picker6" format-pattern="yyyy-MM-dd"></ui5-daterange-picker>
 		<h3>DateRange Picker with one date selected as first & last</h3>
 		<ui5-daterange-picker id="daterange-picker7" value="Aug 20, 2020 - Aug 20, 2020"></ui5-daterange-picker>
+		<h3>DateRange Picker with no format pattern & min-max dates in ISO format</h3>
+		<ui5-daterange-picker id="daterange-picker8" min-date="2023-02-10" max-date="2023-07-22"></ui5-daterange-picker>
+
 
 	</div>
 	<script>

--- a/packages/main/test/pages/DateTimePicker.html
+++ b/packages/main/test/pages/DateTimePicker.html
@@ -85,6 +85,15 @@
 	</section>
 
 	<section>
+		<ui5-title wrapping-type="Normal">DateTimePicker with no format pattern & min-max dates in ISO format</ui5-title><br>
+		<ui5-datetime-picker
+				id="dtMinMaxDatesISO"
+				min-date="2023-05-01"
+				max-date="2023-05-31"
+		></ui5-datetime-picker>
+	</section>
+
+	<section>
 		<ui5-title wrapping-type="Normal">Test DateTimePicker change event on submit</ui5-title>
 		<br>
 

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -39,7 +39,7 @@ describe("Calendar general interaction", () => {
 		const calendar = await browser.$("#calendar1");
 		await calendar.setAttribute("timestamp", new Date(Date.UTC(2000, 10, 22, 0, 0, 0)).valueOf() / 1000);
 		const dayPicker = await calendar.shadow$("ui5-daypicker");
-		const header  = await calendar.shadow$("ui5-calendar-header");
+		const header = await calendar.shadow$("ui5-calendar-header");
 		const currentDayItem = await dayPicker.shadow$(`div[data-sap-timestamp="974851200"]`);
 		const monthButton = await header.shadow$(`[data-ui5-cal-header-btn-month]`);
 		const yearButton = await header.shadow$(`[data-ui5-cal-header-btn-year]`);
@@ -360,5 +360,57 @@ describe("Calendar general interaction", () => {
 		assert.strictEqual(await years.length, 8, "YearPicker with two types only renders 8 years")
 		assert.strictEqual(await yaerInfo[0].getText(), "1416 AH", "First text of year set in the button")
 		assert.strictEqual(await yaerInfo[1].getText(), "1995 - 1996", "Second text of year set in the button")
+	});
+
+	it("Min and max dates are set without format-pattern by using ISO (YYYY-MM-dd) format", async () => {
+		await browser.url("test/pages/Calendar.html");
+
+		const calendar = await browser.$("#calendar6");
+		await calendar.setAttribute("max-date", new Date(Date.UTC(2024, 9, 4, 0, 0, 0)).toISOString().split("T")[0]); // sets the max date to 2024-10-04
+		
+		const yearButton = await calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`);
+		await yearButton.click();
+
+		const year2025 = await calendar.shadow$("ui5-yearpicker").shadow$$(`div[role="gridcell"] span`).find(async span => {
+			const text = await span.getText();
+			return text === "2025";
+		}).parentElement();
+
+		assert.strictEqual(await year2025.hasClass("ui5-yp-item--disabled"), true, "Year 2025 is disabled");
+	});
+
+	it("Min and max dates are NOT set without format-pattern, because are not in ISO format (YYYY-MM-dd)", async () => {
+		await browser.url("test/pages/Calendar.html");
+
+		const calendar = await browser.$("#calendar1");
+		const nextButton = await calendar.shadow$("ui5-calendar-header").shadow$("[data-ui5-cal-header-btn-next]");
+		const prevButton = await calendar.shadow$("ui5-calendar-header").shadow$("[data-ui5-cal-header-btn-prev]");
+		const yearButton = await calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`);
+		// setting the min and max dates both to a valid format date, but not in the valid ISO format.
+		await calendar.setAttribute("max-date", new Date(Date.UTC(2024, 9, 4, 0, 0, 0)).valueOf() / 1000);
+		await calendar.setAttribute("min-date", "25.10.2018");
+
+		await yearButton.click();
+		await prevButton.click();
+		await prevButton.click();
+		const year1973 = await calendar.shadow$("ui5-yearpicker").shadow$$(`div[role="gridcell"] span`).find(async span => {
+			const text = await span.getText();
+			return text === "1973";
+		}).parentElement();
+
+		assert.strictEqual(await year1973.hasClass("ui5-yp-item--disabled"), false, "Year 1973 is not disabled");
+		
+		await nextButton.click();
+		await nextButton.click();
+		await nextButton.click();
+		await nextButton.click();
+		await nextButton.click();
+
+		const year2073 = await calendar.shadow$("ui5-yearpicker").shadow$$(`div[role="gridcell"] span`).find(async span => {
+			const text = await span.getText();
+			return text === "2073";
+		}).parentElement();
+
+		assert.strictEqual(await year2073.hasClass("ui5-yp-item--disabled"), false, "Year 2073 is not disabled");
 	});
 });

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1289,4 +1289,48 @@ describe("Date Picker Tests", () => {
 		assert.isFalse(await datepicker.isPickerOpen(), "picker is closed after year selection");
 	});
 
+	it("Min and max dates are set, with no format pattern provided, using valid ISO format", async () => {
+		datepicker.id = "#dpISOMinMaxDates";
+
+		const Input = await datepicker.getInput();
+		await Input.click();
+		await browser.keys("Nov 1, 2020");
+		await browser.keys("Enter");
+		assert.equal(await Input.getProperty("valueState"), "Error", "Correct value state");
+
+		await datepicker.openPicker();
+		const btnYear = await datepicker.getBtnYear();
+		await btnYear.click();
+		let displayedYear = await datepicker.getDisplayedYear(3);
+
+		assert.ok(await displayedYear.hasClass("ui5-yp-item--disabled"), "Year 2021 is disabled");
+		// close the pickers and revert the datePicker state to initial
+		await browser.keys("Enter");
+		await browser.keys("Enter");
+		await Input.setAttribute("value", "");
+	});
+
+	it("Min and max dates are NOT set because no format pattern is provided & format used is not ISO", async () => {
+		datepicker.id = "#dpISOMinMaxDates";
+		const root = await datepicker.getRoot();
+		// set min-date and max-date to valid dates, but not in ISO format
+		await root.setAttribute("min-date", "22.10.2020");
+		await root.setAttribute("max-date", "22.10.2021");
+
+		const Input = await datepicker.getInput();
+		await Input.click();
+		await browser.keys("Apr 12, 2120");
+		await browser.keys("Enter");
+		assert.equal(await Input.getProperty("valueState"), "None", "Correct value state");
+
+		await datepicker.openPicker();
+		const btnYear = await datepicker.getBtnYear();
+		const nextBtn = await datepicker.getBtnNext();
+		await btnYear.click();
+		await nextBtn.click();
+		await nextBtn.click();
+
+		let displayedYear = await datepicker.getDisplayedYear(13);
+		assert.notOk(await displayedYear.hasClass("ui5-yp-item--disabled"), "Year 2163 is not disabled");
+	});
 });

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -251,4 +251,17 @@ describe("DateRangePicker general interaction", () => {
 		assert.equal(res.endDateValue, null, "Second date is correct");
 		assert.equal(res.drpValue, await (await browser.$("#labelDate")).getHTML(false), "Event value is correct");
 	});
+
+	it("Min and max dates are set without format-pattern by using ISO (YYYY-MM-dd) format", async () => {
+		await browser.url(`test/pages/DateRangePicker.html?sap-ui-language=bg`);
+		
+		const daterangepicker = await browser.$("#daterange-picker8");
+		const dateRangePickerInput = await daterangepicker.shadow$("ui5-input");
+
+		await daterangepicker.click();
+		await daterangepicker.keys("10.02.2023 г. - 25.07.2023 г.");
+		await daterangepicker.keys("Enter");
+
+		assert.strictEqual(await dateRangePickerInput.getProperty("valueState"), "Error", "Min and max dates are set correctly");
+	});
 });

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -293,4 +293,16 @@ describe("DateTimePicker general interaction", () => {
 		// assert
 		assert.strictEqual(await pickerInput.getProperty("value"), "", "Value should not be set");
 	});
+
+	it("Min and max dates are set, with no format pattern provided, using valid ISO format", async () => {
+		const picker = await getPicker("dtMinMaxDatesISO");
+
+		// get header navigation buttons
+		const prevButton = await picker.$("ui5-calendar").shadow$("ui5-calendar-header").shadow$("div[data-ui5-cal-header-btn-prev]");
+		const nextButton = await picker.$("ui5-calendar").shadow$("ui5-calendar-header").shadow$("div[data-ui5-cal-header-btn-next]");
+
+		// assert
+		assert.strictEqual(await prevButton.hasClass("ui5-calheader-arrowbtn-disabled"), true, "The previous button is disabled.");
+		assert.strictEqual(await nextButton.hasClass("ui5-calheader-arrowbtn-disabled"), true, "The next button is disabled.");
+	});
 });


### PR DESCRIPTION
We currently receive the min and max dates in the format of the value. Either local or formatPattern set as an attribute.
The idea of the new behaviour comes from the need of a stable format API.

To address this issue, we have implemented a new behavior that adds a static format for the min and max dates. This means that if a format pattern is not provided, developers can use the date part of a Date in ISO format (YYYY-MM-dd). This new behavior will help ensure that the API is more stable and easier to use.

Additionally, we have included new samples and tests to ensure compliance with this change.

Closes: #6885 