### PR TITLE
fix(ui5-calendar): prevent focus loss during arrow navigation with mouse/touch

### DIFF
--- a/packages/localization/src/dates/modifyDateBy.ts
+++ b/packages/localization/src/dates/modifyDateBy.ts
@@ -39,4 +39,51 @@ const modifyDateBy = (date: CalendarDate, amount: number, unit: string, minDate?
 	return newDate;
 };
 
+/**
+ * Adds or subtracts a given amount of days/months/years from a date.
+ * If minDate or maxDate are given, the result will be enforced within these limits
+ *
+ * <b>Note:</b> Used in the case when user is navigating with the mouse through the arrows of the Calendar header.
+ *
+ * @param date CalendarDate instance
+ * @param amount how many days/months/years to add (can be a negative number)
+ * @param unit what to modify: "day", "month" or "year"
+ * @param minDate minimum date to enforce
+ * @param maxDate maximum date to enforce
+ */
+const modifyDateByClick = (date: CalendarDate, amount: number, unit: string, minDate?: CalendarDate, maxDate?: CalendarDate) => {
+	const newDate = new CalendarDate(date);
+
+	switch (unit) {
+	case "day":
+		newDate.setDate(date.getDate() + amount);
+		break;
+	case "month":
+		if (amount === 1) {
+			newDate.setMonth(newDate.getMonth() + amount);
+			newDate.setDate(1);
+		}
+		if (amount === -1) {
+			newDate.setDate(0);
+		}
+		break;
+	case "year":
+		newDate.setYear(date.getYear() + amount);
+		break;
+	default:
+		break;
+	}
+
+	if (minDate && newDate.valueOf() < minDate.valueOf()) {
+		return new CalendarDate(minDate);
+	}
+
+	if (maxDate && newDate.valueOf() > maxDate.valueOf()) {
+		return new CalendarDate(maxDate);
+	}
+
+	return newDate;
+};
+
 export default modifyDateBy;
+export { modifyDateByClick };

--- a/packages/main/src/CalendarHeader.ts
+++ b/packages/main/src/CalendarHeader.ts
@@ -127,10 +127,12 @@ class CalendarHeader extends UI5Element {
 
 	onPrevButtonClick(e: MouseEvent) {
 		this.fireEvent("previous-press", e);
+		e.preventDefault();
 	}
 
 	onNextButtonClick(e: MouseEvent) {
 		this.fireEvent("next-press", e);
+		e.preventDefault();
 	}
 
 	onMonthButtonClick(e: MouseEvent) {

--- a/packages/main/src/CalendarPart.ts
+++ b/packages/main/src/CalendarPart.ts
@@ -1,7 +1,7 @@
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
-import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
+import modifyDateBy, { modifyDateByClick } from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
 import getTodayUTCTimestamp from "@ui5/webcomponents-localization/dist/dates/getTodayUTCTimestamp.js";
 import DateComponentBase from "./DateComponentBase.js";
 
@@ -92,6 +92,19 @@ class CalendarPart extends DateComponentBase {
 	 */
 	_safelyModifyTimestampBy(amount: number, unit: string) {
 		const newDate = modifyDateBy(this._calendarDate, amount, unit);
+		this._safelySetTimestamp(newDate.valueOf() / 1000);
+	}
+
+	/**
+	 * Modify a timestamp by a certain amount of days/months/years and enforce limits. <br>
+	 * <b>Note:</b> Used in the case when user is navigating with the mouse through the arrows of the Calendar header.
+	 *
+	 * @param amount
+	 * @param unit
+	 * @protected
+	 */
+	_safelyModifyTimestampByClick(amount: number, unit: string) {
+		const newDate = modifyDateByClick(this._calendarDate, amount, unit);
 		this._safelySetTimestamp(newDate.valueOf() / 1000);
 	}
 

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -374,6 +374,12 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 		if (this._autoFocus && !this._hidden) {
 			this.focus();
 		}
+
+		const focusedDay = this.shadowRoot!.querySelector<HTMLElement>("[data-sap-focus-ref]");
+
+		if (focusedDay && document.activeElement !== focusedDay) {
+			focusedDay.focus();
+		}
 	}
 
 	_onfocusin() {
@@ -664,20 +670,18 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 
 	/**
 	 * Called by the Calendar component.
-	 * <b>Note:</b> same as for "PageUp"
 	 * @protected
 	 */
 	_showPreviousPage() {
-		this._modifyTimestampBy(-1, "month");
+		this._modifyTimestampByClick(-1, "month");
 	}
 
 	/**
 	 * Called by the Calendar component.
-	 * <b>Note:</b> same as for "PageDown"
 	 * @protected
 	 */
 	_showNextPage() {
-		this._modifyTimestampBy(1, "month");
+		this._modifyTimestampByClick(1, "month");
 	}
 
 	/**
@@ -689,6 +693,21 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 	_modifyTimestampBy(amount: number, unit: string) {
 		// Modify the current timestamp
 		this._safelyModifyTimestampBy(amount, unit);
+		this._updateSecondTimestamp();
+
+		// Notify the calendar to update its timestamp
+		this.fireEvent<DayPickerNavigateEventDetail>("navigate", { timestamp: this.timestamp! });
+	}
+
+	/**
+	 * <b>Note:</b> Used in the case when user is navigating with the mouse through the arrows of the Calendar header.
+	 * @param { number } amount
+	 * @param { string } unit
+	 * @private
+	 */
+	_modifyTimestampByClick(amount: number, unit: string) {
+		// Modify the current timestamp
+		this._safelyModifyTimestampByClick(amount, unit);
 		this._updateSecondTimestamp();
 
 		// Notify the calendar to update its timestamp


### PR DESCRIPTION
Currently when clicking/ tapping the arrows that navigate to the next/previous month, the focus is lost. It should be on the first day of the newly displayed month if "Next" button is clicked, and on the last day of the displayed month if the "Prev" button is clicked.

With this change we apply the focus correctly, when user is navigating through the Calendar's header using mouse or touch through the arrow buttons ( incl. DatePicker, DateRangePicker, DateTimePicker controls that utilize it ).

Fixes: #6780