### PR TITLE
fix(ui5-segmented-button): support custom width configuration

### DIFF
--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -312,10 +312,10 @@ class SegmentedButton extends UI5Element {
 			}
 
 			const widthValue = parseInt(resultWidth.replace("px", ""));
+			const minWidthAllowed = numItems * itemMinWidthPx;
 
-			if (widthValue < numItems * itemMinWidthPx) {
-				// If the width is less than minimum allowed width, sets the width to the minimum allowed width
-				resultWidth = `${numItems * itemMinWidthPx}px`;
+			if (widthValue < minWidthAllowed) {
+				resultWidth = `${minWidthAllowed}px`;
 			}
 
 			return resultWidth;

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -101,7 +101,6 @@ class SegmentedButton extends UI5Element {
 
 	hasPreviouslyFocusedItem: boolean;
 
-	widths?: Array<number>;
 	_selectedItem?: SegmentedButtonItem;
 
 	static async onDefine() {
@@ -127,7 +126,7 @@ class SegmentedButton extends UI5Element {
 
 		this.normalizeSelection();
 
-		this.style.setProperty("--colNum", `${items.length}`);
+		this.style.setProperty("--_ui5_segmented_btn_items_count", `${items.length}`);
 	}
 
 	normalizeSelection() {

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -283,7 +283,7 @@ class SegmentedButton extends UI5Element {
 		const parentWidth = this.parentNode ? (this.parentNode as HTMLElement).offsetWidth : 0;
 
 		/**
-		 * Calculates the default width for the SegmentedButton component based on the items' widths, if there is no custom width set.
+		 * Calculated default width of the SegmentedButton component based on the items' widths, if there is no custom width set.
 		 */
 		const defaultComponentWidth = `${Math.max(...this.widths!) * this.items.length}px`;
 		const inlineWidth = this.style.width; // Inline style width
@@ -330,17 +330,14 @@ class SegmentedButton extends UI5Element {
 			item.style.width = "100%";
 		});
 
-		if (parentWidth <= this.offsetWidth && this.absoluteWidthSet) {
+		if ((parentWidth <= parseInt(this.originalWidth) || parentWidth <= this.offsetWidth) && this.absoluteWidthSet) {
 			this.style.width = "100%";
 			this.percentageWidthSet = true;
-		} else if (parentWidth <= parseInt(this.originalWidth) && this.absoluteWidthSet) {
-			this.style.width = "100%";
-			this.percentageWidthSet = true;
-		}
-
-		if (parentWidth > parseInt(this.originalWidth)) {
+			this.absoluteWidthSet = false;
+		} else if (parentWidth > parseInt(this.originalWidth)) {
 			this.style.width = this.originalWidth;
 			this.absoluteWidthSet = true;
+			this.percentageWidthSet = false;
 		}
 	}
 

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -263,64 +263,54 @@ class SegmentedButton extends UI5Element {
 		}
 	}
 
+	/**
+	 * Performs the layout for the SegmentedButton component.
+	 *
+	 * Calculates and sets the appropriate width for the component based on the inline style and/or CSS class.
+	 * Adjusts the responsiveness of the component based on the parent width.
+	 *
+	 * @returns {Promise<void>} A Promise that resolves once the layout is completed.
+	 * @private
+	 */
 	async _doLayout(): Promise<void> {
-		const itemsHaveWidth = this.widths && this.widths.some(itemWidth => itemWidth > 2); // 2 pixels added for rounding
+		const itemsHaveWidth = this.widths && this.widths.some(itemWidth => itemWidth > 2);
 		if (!itemsHaveWidth) {
 			await this.measureItemsWidth();
 		}
 
 		const parentWidth = this.parentNode ? (this.parentNode as HTMLElement).offsetWidth : 0;
+
+		/**
+		 * Calculates the default width for the SegmentedButton component based on the items' widths, if there is no custom width set.
+		 */
 		const defaultComponentWidth = `${Math.max(...this.widths!) * this.items.length}px`;
+		const inlineWidth = this.style.width; // Inline style width
+		const classWidth = this.getAttribute("class") ? getComputedStyle(this).width : ""; // Width defined by CSS class
 
-		const customWidth = getComputedStyle(this).width; // set by class or style attribute or calculated by the browser
-		const hasClass = this.hasAttribute("class"); // flag to check if class attribute is set
-		const settedWidth = this.style.width; // set by style attribute/getComputedStyle
+		/**
+		 * Calculates the width to be set for the SegmentedButton component based on the inline style and/or CSS class.
+		 *
+		 * @returns {string} The calculated width for the SegmentedButton component.
+		 * @private
+		 */
+		const calculateWidth = (): string => {
+			if (inlineWidth && classWidth) {
+				return inlineWidth;
+			} if (inlineWidth) {
+				return inlineWidth;
+			} if (classWidth) {
+				return classWidth;
+			}
+			return defaultComponentWidth;
+		};
 
-		if (((!this.style.width && this.style.width === defaultComponentWidth) || this.percentageWidthSet) || (customWidth === settedWidth && !hasClass)) {
-			this.style.width = customWidth;
-			this.absoluteWidthSet = true;
-			if (!this.initialState) {
-				this.originalWidth = this.style.width;
-				this.initialState = true;
-			}
-		} else if ((!this.style.width || this.percentageWidthSet) || (customWidth === settedWidth && !hasClass)) {
-			this.style.width = defaultComponentWidth;
-			this.absoluteWidthSet = true;
-			if ((!this.style.width || this.percentageWidthSet) || customWidth === settedWidth) {
-				this.style.width = customWidth;
-				this.absoluteWidthSet = true;
-				if (!this.initialState) {
-					this.originalWidth = this.style.width;
-					this.initialState = true;
-				}
-			}
-		} else {
-			this.style.width = defaultComponentWidth;
-			this.absoluteWidthSet = true;
-			if (!this.initialState) {
-				this.originalWidth = this.style.width;
-				this.initialState = true;
-			}
-		}
+		const width = calculateWidth();
 
-		if (!this.originalWidth) {
-			this.originalWidth = defaultComponentWidth;
-		}
-
-		if (customWidth !== defaultComponentWidth && (hasClass)) {
-			this.style.width = customWidth;
-			this.absoluteWidthSet = true;
-			if (!this.initialState) {
-				this.originalWidth = customWidth;
-				this.initialState = true;
-			}
-		} else if (customWidth !== defaultComponentWidth && (!hasClass) && !this.style.width) {
-			this.style.width = defaultComponentWidth;
-			this.absoluteWidthSet = true;
-			if (!this.initialState) {
-				this.originalWidth = defaultComponentWidth;
-				this.initialState = true;
-			}
+		this.style.width = width;
+		this.absoluteWidthSet = true;
+		if (!this.initialState) {
+			this.originalWidth = width;
+			this.initialState = true;
 		}
 
 		this.items.forEach(item => {

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -105,7 +105,7 @@ class SegmentedButton extends UI5Element {
 	absoluteWidthSet: boolean // set to true whenever we set absolute width to the component
 	percentageWidthSet: boolean; // set to true whenever we set 100% width to the component
 	originalWidth!: string; // used to store the width of the component's parent before the resize
-	initialState!: boolean; // helper which indicates whether the stored width in the originalWidth is the initial one, since on change they change a few times and we want only the first one
+	initialState!: boolean; // indicates whether the stored width in the originalWidth is the initial one, since on change they change a few times and we want only the first one
 	hasPreviouslyFocusedItem: boolean;
 
 	_handleResizeBound: ResizeObserverCallback;
@@ -273,9 +273,7 @@ class SegmentedButton extends UI5Element {
 	 * @private
 	 */
 	async _doLayout(): Promise<void> {
-		const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize); // Gets the root font size in pixels in order to convert rem to pixels correctly
-		const itemMinWidth = 2.5; // Item minimum width in rem
-		const itemMinWidthPx = itemMinWidth * rootFontSize; // Converts rem to pixels
+		const itemMinWidthPx = parseInt(getComputedStyle(this.items[0]).minWidth); // gets the min-width of the items in px
 
 		const itemsHaveWidth = this.widths && this.widths.some(itemWidth => itemWidth > 2);
 		if (!itemsHaveWidth) {
@@ -301,9 +299,7 @@ class SegmentedButton extends UI5Element {
 			const numItems = this.items.length;
 			let resultWidth = "";
 
-			if (inlineWidth && classWidth) {
-				resultWidth = inlineWidth;
-			} else if (inlineWidth) {
+			if (inlineWidth) {
 				resultWidth = inlineWidth;
 			} else if (classWidth) {
 				resultWidth = classWidth;
@@ -311,7 +307,7 @@ class SegmentedButton extends UI5Element {
 				resultWidth = defaultComponentWidth;
 			}
 
-			const widthValue = parseInt(resultWidth.replace("px", ""));
+			const widthValue = parseInt(resultWidth);
 			const minWidthAllowed = numItems * itemMinWidthPx;
 
 			if (widthValue < minWidthAllowed) {
@@ -337,12 +333,12 @@ class SegmentedButton extends UI5Element {
 		if (parentWidth <= this.offsetWidth && this.absoluteWidthSet) {
 			this.style.width = "100%";
 			this.percentageWidthSet = true;
-		} else if (parentWidth <= parseInt(this.originalWidth.replace("px", "")) && this.absoluteWidthSet) {
+		} else if (parentWidth <= parseInt(this.originalWidth) && this.absoluteWidthSet) {
 			this.style.width = "100%";
 			this.percentageWidthSet = true;
 		}
 
-		if (parentWidth > parseInt(this.originalWidth.replace("px", ""))) {
+		if (parentWidth > parseInt(this.originalWidth)) {
 			this.style.width = this.originalWidth;
 			this.absoluteWidthSet = true;
 		}

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -276,9 +276,13 @@ class SegmentedButton extends UI5Element {
 		const hasClass = this.hasAttribute("class"); // flag to check if class attribute is set
 		const settedWidth = this.style.width; // set by style attribute/getComputedStyle
 
-		if ((!this.style.width || this.percentageWidthSet) || (customWidth === settedWidth && !hasClass)) {
-			this.style.width = defaultComponentWidth;
+		if (((!this.style.width && this.style.width === defaultComponentWidth) || this.percentageWidthSet) || (customWidth === settedWidth && !hasClass)) {
+			this.style.width = customWidth;
 			this.absoluteWidthSet = true;
+			if (!this.initialState) {
+				this.originalWidth = this.style.width;
+				this.initialState = true;
+			}
 		} else if ((!this.style.width || this.percentageWidthSet) || (customWidth === settedWidth && !hasClass)) {
 			this.style.width = defaultComponentWidth;
 			this.absoluteWidthSet = true;

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -273,6 +273,10 @@ class SegmentedButton extends UI5Element {
 	 * @private
 	 */
 	async _doLayout(): Promise<void> {
+		const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize); // Gets the root font size in pixels in order to convert rem to pixels correctly
+		const itemMinWidth = 2.5; // Item minimum width in rem
+		const itemMinWidthPx = itemMinWidth * rootFontSize; // Converts rem to pixels
+
 		const itemsHaveWidth = this.widths && this.widths.some(itemWidth => itemWidth > 2);
 		if (!itemsHaveWidth) {
 			await this.measureItemsWidth();
@@ -294,14 +298,27 @@ class SegmentedButton extends UI5Element {
 		 * @private
 		 */
 		const calculateWidth = (): string => {
+			const numItems = this.items.length;
+			let resultWidth = "";
+
 			if (inlineWidth && classWidth) {
-				return inlineWidth;
-			} if (inlineWidth) {
-				return inlineWidth;
-			} if (classWidth) {
-				return classWidth;
+				resultWidth = inlineWidth;
+			} else if (inlineWidth) {
+				resultWidth = inlineWidth;
+			} else if (classWidth) {
+				resultWidth = classWidth;
+			} else {
+				resultWidth = defaultComponentWidth;
 			}
-			return defaultComponentWidth;
+
+			const widthValue = parseInt(resultWidth.replace("px", ""));
+
+			if (widthValue < numItems * itemMinWidthPx) {
+				// If the width is less than minimum allowed width, sets the width to the minimum allowed width
+				resultWidth = `${numItems * itemMinWidthPx}px`;
+			}
+
+			return resultWidth;
 		};
 
 		const width = calculateWidth();

--- a/packages/main/src/themes/SegmentedButton.css
+++ b/packages/main/src/themes/SegmentedButton.css
@@ -3,13 +3,13 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
-	min-width: calc(var(--colNum) * 2.5rem);
+	min-width: calc(var(--_ui5_segmented_btn_items_count) * 2.5rem);
 }
 
 .ui5-segmented-button-root {
 	width: inherit;
 	display: grid;
-	grid-template-columns: repeat(var(--colNum), minmax(2.5rem, 1fr));
+	grid-template-columns: repeat(var(--_ui5_segmented_btn_items_count), minmax(2.5rem, 1fr));
 	margin: 0;
 	padding: 0;
 	background-color: var(--sapButton_Background);

--- a/packages/main/src/themes/SegmentedButton.css
+++ b/packages/main/src/themes/SegmentedButton.css
@@ -3,11 +3,13 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
-	width: inherit;
+	min-width: calc(var(--colNum) * 2.5rem);
 }
 
 .ui5-segmented-button-root {
-	display: flex;
+	width: inherit;
+	display: grid;
+	grid-template-columns: repeat(var(--colNum), minmax(2.5rem, 1fr));
 	margin: 0;
 	padding: 0;
 	background-color: var(--sapButton_Background);

--- a/packages/main/src/themes/SegmentedButton.css
+++ b/packages/main/src/themes/SegmentedButton.css
@@ -3,6 +3,7 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
+	width: inherit;
 }
 
 .ui5-segmented-button-root {

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -61,9 +61,9 @@
 				</section>
 
 				<section>
-					<h1>Example with Icons</h1>
+					<h1>Example with Icons and custom width</h1>
 
-					<ui5-segmented-button>
+					<ui5-segmented-button class="segmentedbutton1auto">
 						<ui5-segmented-button-item icon="employee"></ui5-segmented-button-item>
 						<ui5-segmented-button-item icon="menu" pressed></ui5-segmented-button-item>
 						<ui5-segmented-button-item icon="factory"></ui5-segmented-button-item>

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -61,12 +61,23 @@
 				</section>
 
 				<section>
-					<h1>Example with Icons and custom width</h1>
+					<h1>Example with Icons</h1>
 
-					<ui5-segmented-button class="segmentedbutton1auto">
+					<ui5-segmented-button>
 						<ui5-segmented-button-item icon="employee"></ui5-segmented-button-item>
 						<ui5-segmented-button-item icon="menu" pressed></ui5-segmented-button-item>
 						<ui5-segmented-button-item icon="factory"></ui5-segmented-button-item>
+					</ui5-segmented-button>
+				</section>
+
+				<section>
+					<h1> Example with custom width property set</h1>
+
+					<ui5-segmented-button custom-width="1000px">
+						<ui5-segmented-button-item>Item</ui5-segmented-button-item>
+						<ui5-segmented-button-item>Item</ui5-segmented-button-item>
+						<ui5-segmented-button-item>Click</ui5-segmented-button-item>
+						<ui5-segmented-button-item>Pressed SegmentedButtonItem</ui5-segmented-button-item>
 					</ui5-segmented-button>
 				</section>
 

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -71,17 +71,6 @@
 				</section>
 
 				<section>
-					<h1> Example with custom width property set</h1>
-
-					<ui5-segmented-button custom-width="1000px">
-						<ui5-segmented-button-item>Item</ui5-segmented-button-item>
-						<ui5-segmented-button-item>Item</ui5-segmented-button-item>
-						<ui5-segmented-button-item>Click</ui5-segmented-button-item>
-						<ui5-segmented-button-item>Pressed SegmentedButtonItem</ui5-segmented-button-item>
-					</ui5-segmented-button>
-				</section>
-
-				<section>
 					<h1>SegmentedButton with 100% width</h1>
 
 					<ui5-segmented-button class="segmentedbutton2auto">


### PR DESCRIPTION
With this PR we enhance the UI5 `SegmentedButton` component to provide support for setting up custom widths. With this enhancement, you can now specify the width of the SegmentedButton using inline styles or CSS classes, ensuring that the component remains responsive in various scenarios.

Fixes: #6897