### PR TITLE
docs(ui5-card): remove outdated CSS Shadow Parts text

### DIFF
--- a/packages/main/src/Card.ts
+++ b/packages/main/src/Card.ts
@@ -28,10 +28,6 @@ import cardCss from "./generated/themes/Card.css.js";
  *
  * Note: We recommend the usage of <code>ui5-card-header</code> for the header slot, so advantage can be taken for keyboard handling, styling and accessibility.
  *
- * <h3>CSS Shadow Parts</h3>
- *
- * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
- *
  * <h3>ES6 Module Import</h3>
  *
  * <code>import "@ui5/webcomponents/dist/Card";</code>


### PR DESCRIPTION
This is a leftover from a refactoring. The relevant text with the information about CSS Shadow Parts remains in the CardHeader component.

Part of #6381