### PR TITLE
fix(create-package): revert  `moduleResolution` setting to `node`

### DIFF
--- a/packages/create-package/template/tsconfig.json
+++ b/packages/create-package/template/tsconfig.json
@@ -9,8 +9,7 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
-      "module": "node16",
-      "moduleResolution": "node16",
+      "moduleResolution": "node",
       "experimentalDecorators": true,
     },
 }


### PR DESCRIPTION
We found issues with 3rd party generated packages with the `create-package` tools, caused by the recently updated (with the latest 1.13.0) `tsconfig` setting for moduleResolution -`node16` . The package is not ready for `node16`, it requires more efforts to make it work, thus reverting back to `node` to have at least a stable state and the running properly as before.