### PR TITLE
feat(framework): add `ignoreCustomElements` public API

### DIFF
--- a/docs/2-advanced/09-scrollbars-customization.md
+++ b/docs/2-advanced/09-scrollbars-customization.md
@@ -15,3 +15,4 @@ Example 1:
 </body>
 ```
 
+Next: [Ignore Custom HTML elements](./10-ignore-custom-elements.md)

--- a/docs/2-advanced/10-ignore-custom-elements.md
+++ b/docs/2-advanced/10-ignore-custom-elements.md
@@ -1,6 +1,6 @@
 # Ignore Custom HTML elements
 
-The `ignoreCustomElements` feature lets you describe all custom elements to be ignored in order to improve the rendering performance of the UI5 Web Components, by setting a given tag preffix.
+The `ignoreCustomElements` feature lets you describe all custom elements to be ignored and improve the rendering performance of the UI5 Web Components, by setting a given tag prefix.
 
 ```js
 import { ignoreCustomElements } from "@ui5/webcomponents-base/dist/IgnoreElements.js";
@@ -9,7 +9,7 @@ ignoreCustomElements("app-");
 
 ## When do I need to use the `ignoreCustomElements` feature?
 
-The feature is useful, when UI5 Web Components and used together wiht custom HTML elements with custom tags to make application's markup more semantic.
+The feature is useful, when UI5 Web Components and used together with custom HTML elements with custom tags to make the application's markup more semantic.
 
 For example:
 
@@ -19,10 +19,10 @@ For example:
 </ui5-card>
 ```
 
-The `ui5-card` is a UI5 Web Component, while the `app-trip-calendar` is an app defined custom HTML element with no JavaScript attached, with just semantic purpose. And, it is slotted in the content of the `ui5-card`.
+The `ui5-card` is a UI5 Web Component, while the `app-trip-calendar` is an app-defined custom HTML element with no JavaScript attached, with just semantic purpose. And, it is slotted in the content of the `ui5-card`.
 
-When a web component of ours is about to be defined and registered in the global CustomElements registry, the framework checks if some of the slotted children are custom elements by checking the presence of hyphen ("-") in their tag names. And, if this is true, the framework waits for the children to be defined and registered first, because the state or visual appearance of the parent may rely on the slotted elements/children.
+When a web component of ours is about to be defined and registered in the global CustomElements registry, the framework checks if some of the slotted children are custom elements by checking the presence of a hyphen ("-") in their tag names. And, if this is true, the framework waits for the children to be defined and registered first, because the state or visual appearance of the parent may rely on the slotted elements/children.
 
-While this is required in many cases, for custom HTML elements with pure semantic puropose and no JavaScript class attached (f.e. `app-trip-calendar`) - it's not.
+While this is required in many cases, for custom HTML elements with pure semantic purpose and no JavaScript class attached (f.e. `app-trip-calendar`) - it's not.
 Moreover, it leads to increasing the `time to render` parameter of the given web component (f.e.`ui5-card`).
 In cases like this, we recommend using `ignoreCustomElements` to let the UI5 Web Components framework treats such custom HTML elements as if they are standard HTML elements, such as: `div`, `span`, etc.

--- a/docs/2-advanced/10-ignore-custom-elements.md
+++ b/docs/2-advanced/10-ignore-custom-elements.md
@@ -1,0 +1,28 @@
+# Ignore Custom HTML elements
+
+The `ignoreCustomElements` feature lets you describe all custom elements to be ignored in order to improve the rendering performance of the UI5 Web Components, by setting a given tag preffix.
+
+```js
+import { ignoreCustomElements } from "@ui5/webcomponents-base/dist/IgnoreElements.js";
+ignoreCustomElements("app-");
+```
+
+## When do I need to use the `ignoreCustomElements` feature?
+
+The feature is useful, when UI5 Web Components and used together wiht custom HTML elements with custom tags to make application's markup more semantic.
+
+For example:
+
+```html
+<ui5-card>
+    <app-trip-calendar></app-trip-calendar>
+</ui5-card>
+```
+
+The `ui5-card` is a UI5 Web Component, while the `app-trip-calendar` is an app defined custom HTML element with no JavaScript attached, with just semantic purpose. And, it is slotted in the content of the `ui5-card`.
+
+When a web component of ours is about to be defined and registered in the global CustomElements registry, the framework checks if some of the slotted children are custom elements by checking the presence of hyphen ("-") in their tag names. And, if this is true, the framework waits for the children to be defined and registered first, because the state or visual appearance of the parent may rely on the slotted elements/children.
+
+While this is required in many cases, for custom HTML elements with pure semantic puropose and no JavaScript class attached (f.e. `app-trip-calendar`) - it's not.
+Moreover, it leads to increasing the `time to render` parameter of the given web component (f.e.`ui5-card`).
+In cases like this, we recommend using `ignoreCustomElements` to let the UI5 Web Components framework treats such custom HTML elements as if they are standard HTML elements, such as: `div`, `span`, etc.

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -37,6 +37,10 @@ Contains the base files for all Web Components, most notably `@ui5/webcomponents
  - `setCustomElementsScopingRules`
  - `getCustomElementsScopingRules`
 
+### `IgnoreCustomElements.js`
+
+ - `ignoreCustomElements`
+
 ###  `CSP.js`
  - `setPackageCSSRoot` 
  - `setUseLinks`

--- a/packages/base/src/IgnoreCustomElements.ts
+++ b/packages/base/src/IgnoreCustomElements.ts
@@ -1,0 +1,45 @@
+/**
+ * The tag preffixes to be ignored.
+ */
+const tagPrefixes: Array<string> = [];
+
+/**
+ * Ignores all custom HTML elements with a given tag preffix to improve the rendering performance of the UI5 Web Components.
+ * <br>
+ *
+ * <b>When used:</b> the UI5 Web Components framework treats all custom HTML elements,
+ * starting with the given preffix as if they are standard HTML elements, such as: `div`, `span`, etc, without additional processing.
+ * <br>
+ *
+ * <b>When not used:</b> the framework waits for the slotted children to be defined and registered first,
+ * because the state or visual appearance of the parent may rely on the slotted elements/children.
+ *
+ * <b>Note:</b> We recommend using `ignoreCustomElements` when slotting custom HTML elements (with only semantic purpose) inside UI5 Web Components,
+ * to improve the time to render.
+ *
+ * @public
+ * @since 1.14.0
+ * @param { string } tagPreffix
+ */
+const ignoreCustomElements = (tagPreffix: string) => {
+	if (typeof tagPreffix !== "string" || !tagPreffix.length) {
+		throw new Error("Only string characters for a tag preffix.");
+	}
+
+	tagPrefixes.push(tagPreffix);
+};
+
+/**
+ * Determines whether custom elements with the given tag should be ignored.
+ *
+ * @private
+ * @param { string } tag
+ */
+const shouldIgnoreCustomElement = (tag: string): boolean => {
+	return tagPrefixes.some(preff => tag.startsWith(preff));
+};
+
+export {
+	ignoreCustomElements,
+	shouldIgnoreCustomElement,
+};

--- a/packages/base/src/IgnoreCustomElements.ts
+++ b/packages/base/src/IgnoreCustomElements.ts
@@ -1,21 +1,21 @@
 /**
- * The tag preffixes to be ignored.
+ * The tag prefixes to be ignored.
  */
 const tagPrefixes: Array<string> = [];
 
 /**
- * Ignores all custom HTML elements with a given tag preffix to improve the rendering performance of the UI5 Web Components.
+ * Ignores all custom HTML elements with a given tag prefix to improve the rendering performance of the UI5 Web Components.
  * <br>
  *
  * <b>When used:</b> the UI5 Web Components framework treats all custom HTML elements,
- * starting with the given preffix as if they are standard HTML elements, such as: `div`, `span`, etc, without additional processing.
+ * starting with the given prefix as if they are standard HTML elements, such as: `div`, `span`, etc, without additional processing.
  * <br>
  *
  * <b>When not used:</b> the framework waits for the slotted children to be defined and registered first,
  * because the state or visual appearance of the parent may rely on the slotted elements/children.
  *
- * <b>Note:</b> We recommend using `ignoreCustomElements` when slotting custom HTML elements (with only semantic purpose) inside UI5 Web Components,
- * to improve the time to render.
+ * <b>Note:</b> We recommend using `ignoreCustomElements` when slotting custom HTML elements (with only semantic purpose)
+ * inside UI5 Web Components, to improve the time to render.
  *
  * @public
  * @since 1.14.0
@@ -23,7 +23,7 @@ const tagPrefixes: Array<string> = [];
  */
 const ignoreCustomElements = (tagPrefix: string) => {
 	if (typeof tagPrefix !== "string" || !tagPrefix.length) {
-		throw new Error("Only string characters for a tag preffix.");
+		throw new Error("Only string characters for a tag prefix.");
 	}
 
 	tagPrefixes.push(tagPrefix);
@@ -36,7 +36,7 @@ const ignoreCustomElements = (tagPrefix: string) => {
  * @param { string } tag
  */
 const shouldIgnoreCustomElement = (tag: string): boolean => {
-	return tagPrefixes.some(preff => tag.startsWith(preff));
+	return tagPrefixes.some(pref => tag.startsWith(pref));
 };
 
 export {

--- a/packages/base/src/IgnoreCustomElements.ts
+++ b/packages/base/src/IgnoreCustomElements.ts
@@ -19,14 +19,14 @@ const tagPrefixes: Array<string> = [];
  *
  * @public
  * @since 1.14.0
- * @param { string } tagPreffix
+ * @param { string } tagPrefix
  */
-const ignoreCustomElements = (tagPreffix: string) => {
-	if (typeof tagPreffix !== "string" || !tagPreffix.length) {
+const ignoreCustomElements = (tagPrefix: string) => {
+	if (typeof tagPrefix !== "string" || !tagPrefix.length) {
 		throw new Error("Only string characters for a tag preffix.");
 	}
 
-	tagPrefixes.push(tagPreffix);
+	tagPrefixes.push(tagPrefix);
 };
 
 /**

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -11,6 +11,7 @@ import EventProvider from "./EventProvider.js";
 import getSingletonElementInstance from "./util/getSingletonElementInstance.js";
 import StaticAreaItem from "./StaticAreaItem.js";
 import updateShadowRoot from "./updateShadowRoot.js";
+import { shouldIgnoreCustomElement } from "./IgnoreCustomElements.js";
 import { renderDeferred, renderImmediately, cancelRender } from "./Render.js";
 import { registerTag, isTagRegistered, recordTagRegistrationFailure } from "./CustomElementsRegistry.js";
 import { observeDOMNode, unobserveDOMNode } from "./DOMObserver.js";
@@ -333,8 +334,9 @@ abstract class UI5Element extends HTMLElement {
 			// Await for not-yet-defined custom elements
 			if (child instanceof HTMLElement) {
 				const localName = child.localName;
-				const isCustomElement = localName.includes("-");
-				if (isCustomElement) {
+				const shouldWaitForCustomElement = localName.includes("-") && !shouldIgnoreCustomElement(localName);
+
+				if (shouldWaitForCustomElement) {
 					const isDefined = window.customElements.get(localName);
 					if (!isDefined) {
 						const whenDefinedPromise = window.customElements.whenDefined(localName); // Class registered, but instances not upgraded yet

--- a/packages/main/bundle.common.js
+++ b/packages/main/bundle.common.js
@@ -118,6 +118,9 @@ import { attachDirectionChange } from "@ui5/webcomponents-base/dist/locale/direc
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import * as defaultTexts from "./dist/generated/i18n/i18n-defaults.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
+import { ignoreCustomElements, shouldIgnoreCustomElement } from "@ui5/webcomponents-base/dist/IgnoreCustomElements.js";
+ignoreCustomElements("app-");
+ignoreCustomElements("my-");
 
 // SAP Icons
 import accept from "@ui5/webcomponents-icons/dist/accept.js";
@@ -165,6 +168,8 @@ const testAssets = {
 	defaultTexts,
 	getExportedIconsValues: () => icons,
 	getEffectiveIconCollection,
+	ignoreCustomElements,
+	shouldIgnoreCustomElement,
 };
 
 // The SAP Icons V4 icon collection is set by default in sap_fiori_3,

--- a/packages/main/test/pages/base/IgnoreCustomElements.html
+++ b/packages/main/test/pages/base/IgnoreCustomElements.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<title>Ignore Custom Elements</title>
+
+    <script src="../../../bundle.esm.js" type="module"></script>
+    <link rel="stylesheet" type="text/css" href="./styles/IgnoreCustomElements.css">
+</head>
+
+<body clas="bg">
+    <ui5-card>
+		<ui5-card-header
+			slot="header"
+			status="4 of 10"
+			title-text="Product"></ui5-card-header>
+
+		<app-trip-calendar class="myCard-trip-calendar"></app-trip-calendar>
+		<my-trip-calendar class="myCard-trip-calendar"></app-trip-calendar>
+	</ui5-card>
+</body>
+</html>

--- a/packages/main/test/pages/base/styles/IgnoreCustomElements.css
+++ b/packages/main/test/pages/base/styles/IgnoreCustomElements.css
@@ -1,0 +1,10 @@
+.bg {
+	background-color: var(--sapBackgroundColor);
+}
+
+.myCard-trip-calendar {
+    display: block;
+    height: 100px;
+    background-color: yellow;
+    margin: 1rem 0;
+}

--- a/packages/main/test/specs/base/IgnoreCustomElements.spec.js
+++ b/packages/main/test/specs/base/IgnoreCustomElements.spec.js
@@ -1,0 +1,23 @@
+import { assert } from "chai";
+
+describe("Ignore Custom Elements", () => {
+	before(async () => {
+		await browser.url("test/pages/base/IgnoreCustomElements.html");
+	});
+
+	it("Tests ignore custom elements", async () => {
+		const result = await browser.executeAsync(done => {
+			const bundle = window['sap-ui-webcomponents-bundle'];
+
+			const res = {};
+			res.ignoreApp = bundle.shouldIgnoreCustomElement("app-trip-calendar"); // true - see ignoreCustomElements("app-"); in bundle.js
+			res.ignoreMy = bundle.shouldIgnoreCustomElement("my-trip-calendar "); // true - see ignoreCustomElements("my-"); in bundle.js
+			res.ignoreUI5 = bundle.shouldIgnoreCustomElement("ui5-card-header"); // false
+			done(res);
+		});
+
+		assert.ok(result.ignoreApp, "The app-trip-calendar tag is ignored");
+		assert.ok(result.ignoreMy, "The my-trip-calendar  tag is ignored");
+		assert.notOk(result.ignoreUI5, "The ui5-card-header tag is not ignored");
+	});
+});


### PR DESCRIPTION
## Background
The framework always waits for the definition of slotted children inside UI5 Web Components' if they have hyphen ("-") in their name (e.g another custom element), which is required in many cases, but unnecessary when the slotted custom HTML element has no JavaScript attached and has pure semantic purpose.

## Solution
Provide new API to allow users define such tags that later the framework can ignore, improving the time to render factor for our components.

## Usage
```js
import { ignoreCustomElements } from "@ui5/webcomponents-base/dist/IgnoreElements.js";
ignoreCustomElements("app-");
```

## When do I need to use the `ignoreCustomElements` feature?

The feature is useful, when UI5 Web Components and used together with custom HTML elements with custom tags to make application's markup more semantic.

For example:

```html
<ui5-card>
    <app-trip-calendar></app-trip-calendar>
</ui5-card>
```

The `ui5-card` is a UI5 Web Component, while the `app-trip-calendar` is an app defined custom HTML element with no JavaScript attached, with just semantic purpose. And, it is slotted in the content of the `ui5-card`.

When a web component of ours is about to be defined and registered in the global CustomElements registry, the framework checks if some of the slotted children are custom elements by checking the presence of hyphen ("-") in their tag names. And, if this is true, the framework waits for the children to be defined and registered first, because the state or visual appearance of the parent may rely on the slotted elements/children.

While this is required in many cases, for custom HTML elements with pure semantic purpose and no JavaScript class attached (f.e. `app-trip-calendar`) - it's not.
Moreover, it leads to increasing the `time to render` parameter of the given web component (f.e.`ui5-card`).
In cases like this, we recommend using `ignoreCustomElements` to let the UI5 Web Components framework treats such custom HTML elements as if they are standard HTML elements, such as: `div`, `span`, etc.


Fixes: https://github.com/SAP/ui5-webcomponents/issues/6909