### PR TITLE
chore: revert ts moduleResoluition node16  to node

### DIFF
--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -9,7 +9,6 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
-      "module": "node16",
-      "moduleResolution": "node16",
+      "moduleResolution": "node",
     },
 }

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -9,8 +9,7 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
-      "module": "node16",
-      "moduleResolution": "node16",
+      "moduleResolution": "node",
       "experimentalDecorators": true,
     },
 }

--- a/packages/icons-business-suite/tsconfig.json
+++ b/packages/icons-business-suite/tsconfig.json
@@ -9,8 +9,9 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"strict": true,
-		"module": "node16",
-      	"moduleResolution": "node16",
+		"module": "es2022",
+      	"moduleResolution": "node",
 		"resolveJsonModule": true,
+		"allowSyntheticDefaultImports": true,
 	},
 }

--- a/packages/icons-tnt/tsconfig.json
+++ b/packages/icons-tnt/tsconfig.json
@@ -9,8 +9,9 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"strict": true,
-		"module": "node16",
-      	"moduleResolution": "node16",
+		"module": "es2022",
+      	"moduleResolution": "node",
 		"resolveJsonModule": true,
+		"allowSyntheticDefaultImports": true,
 	},
 }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -9,8 +9,9 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"strict": true,
-		"module": "node16",
-      	"moduleResolution": "node16",
+		"module": "es2022",
+      	"moduleResolution": "node",
 		"resolveJsonModule": true,
+		"allowSyntheticDefaultImports": true,
 	},
 }

--- a/packages/localization/tsconfig.json
+++ b/packages/localization/tsconfig.json
@@ -9,7 +9,6 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"strict": true,
-		"module": "node16",
-		"moduleResolution": "node16",
+		"moduleResolution": "node",
 	},
 }

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -9,8 +9,7 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
-      "module": "node16",
-      "moduleResolution": "node16",
+      "moduleResolution": "node",
       "experimentalDecorators": true,
     },
 }

--- a/packages/theming/tsconfig.json
+++ b/packages/theming/tsconfig.json
@@ -9,8 +9,7 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
-      "module": "node16",
-      "moduleResolution": "node16",
+      "moduleResolution": "node",
       "experimentalDecorators": true,
     },
 }


### PR DESCRIPTION
Recently we changed our tsconfig to use [ Module Resolution "node 16"], instead of "node"(https://www.typescriptlang.org/tsconfig#moduleResolution) to get better ECMAScript Module Support:
- 'node' for Node.js’ CommonJS implementation
- 'node16' or 'nodenext' for Node.js’ ECMAScript Module Support [from TypeScript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs)

However, we faced issues on the application side. The TS compiler throws errors in Typescript applications that uses UI5 Web Components for files in applications' node_modules. More specifically, the problem was caused by new attribute  "'resolution-mode'" added to the auto-generated .d.ts files that requires also tsconfig change by the project installed our code.

```sh
Error: node_modules/@ui5/webcomponents/dist/DateComponentBase.d.ts:1:23 - error TS1452: 
'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.
/// <reference types="openui5" resolution-mode="require"/>
```
Although these errors can be handled with `skipLibCheck` flag set to "true", it's a bad experience to require a particular flag to just make an app working and we decided to revert this as it's seems the setting is not stable enough and can cause unexpected problems for consumers.

