### PR TITLE
feat: users can provide a JSDoc namespeace when creating a package

### DIFF
--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -194,7 +194,7 @@ const createWebcomponentsPackage = async () => {
 	}
 
 	if (argv.namespace && !isNamespaceValid(argv.namespace)) {
-		throw new Error("The JSDoc namespace can only contain small-case letters, numbers, dots and dashes.");
+		throw new Error("The JSDoc namespace must start with a letter and can only contain small-case letters, numbers, dots and dashes.");
 	}
 
 	if (argv.tag && !isTagValid(argv.tag) ) {
@@ -257,7 +257,7 @@ const createWebcomponentsPackage = async () => {
 			name: "namespace",
 			message: "JSDoc namespace:",
 			initial: "demo.components",
-			validate: (value) => isNamespaceValid(value) ? true : "The JSDoc namespace can only contain small-case letters, numbers, dots and dashes.",
+			validate: (value) => isNamespaceValid(value) ? true : "The JSDoc namespace must start with a letter and can only contain small-case letters, numbers, dots and dashes.",
 		});
 		namespace = response.namespace;
 	}

--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -38,8 +38,10 @@ const isNPMRC = sourcePath => {
 
 // Validation of user input
 const ComponentNamePattern = /^[A-Z][A-Za-z0-9]+$/;
+const NamespacePattern = /^[a-z][a-z0-9\.\-]+$/;
 const isNameValid = name => typeof name === "string" && name.match(/^[a-zA-Z][a-zA-Z0-9\-_]+$/);
 const isComponentNameValid = name => typeof name === "string" && ComponentNamePattern.test(name);
+const isNamespaceValid = name => typeof name === "string" && NamespacePattern.test(name);
 const isTagValid = tag => typeof tag === "string" && tag.match(/^[a-z0-9]+?-[a-zA-Z0-9\-_]+?[a-z0-9]$/);
 
 /**
@@ -105,7 +107,7 @@ const copyFiles = (vars, sourcePath, destPath) => {
 	}
 };
 
-const generateFilesContent = (name, componentName, typescript, skipSubfolder) => {
+const generateFilesContent = (name, componentName, namespace, typescript, skipSubfolder) => {
 	const tagName = argv.tag || hyphaneteComponentName(componentName);
 
 	// All variables that will be replaced in the content of the resources/
@@ -113,6 +115,7 @@ const generateFilesContent = (name, componentName, typescript, skipSubfolder) =>
 		INIT_PACKAGE_VAR_NAME: name,
 		INIT_PACKAGE_VAR_TAG: tagName,
 		INIT_PACKAGE_VAR_CLASS_NAME: componentName,
+		INIT_PACKAGE_VAR_NAMESPACE: namespace,
 		INIT_PACKAGE_VAR_TYPESCRIPT: typescript,
 	};
 
@@ -190,17 +193,22 @@ const createWebcomponentsPackage = async () => {
 		throw new Error("The component name should be a string, starting with a capital letter [A-Z][a-z], for example: Button, MyButton, etc.");
 	}
 
+	if (argv.namespace && !isNamespaceValid(argv.namespace)) {
+		throw new Error("The JSDoc namespace can only contain small-case letters, numbers, dots and dashes.");
+	}
+
 	if (argv.tag && !isTagValid(argv.tag) ) {
 		throw new Error("The tag should be in kebab-case (f.e my-component) and it can't be a single word.");
 	}
 
 	let name = argv.name || "my-package";
 	let componentName = argv.componentName || "MyComponent";
+	let namespace = argv.namespace || "demo.components";
 	let typescriptSupport = !!argv.enableTypescript;
 	const skipSubfolder = !!argv.skipSubfolder;
 
 	if (argv.skip) {
-		return generateFilesContent(name, componentName, typescriptSupport, skipSubfolder);
+		return generateFilesContent(name, componentName, namespace, typescriptSupport, skipSubfolder);
 	}
 
 	if (!argv.name) {
@@ -243,7 +251,18 @@ const createWebcomponentsPackage = async () => {
 		componentName = response.componentName;
 	}
 
-	return generateFilesContent(name, componentName, typescriptSupport, skipSubfolder);
+	if (!argv.namespace) {
+		response = await prompts({
+			type: "text",
+			name: "namespace",
+			message: "JSDoc namespace:",
+			initial: "demo.components",
+			validate: (value) => isNamespaceValid(value) ? true : "The JSDoc namespace can only contain small-case letters, numbers, dots and dashes.",
+		});
+		namespace = response.namespace;
+	}
+
+	return generateFilesContent(name, componentName, namespace, typescriptSupport, skipSubfolder);
 };
 
 createWebcomponentsPackage();

--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -112,10 +112,10 @@ const generateFilesContent = (name, componentName, namespace, typescript, skipSu
 
 	// All variables that will be replaced in the content of the resources/
 	const vars = {
+		INIT_PACKAGE_VAR_NAMESPACE: namespace, // namespace must be replaced before name
 		INIT_PACKAGE_VAR_NAME: name,
 		INIT_PACKAGE_VAR_TAG: tagName,
 		INIT_PACKAGE_VAR_CLASS_NAME: componentName,
-		INIT_PACKAGE_VAR_NAMESPACE: namespace,
 		INIT_PACKAGE_VAR_TYPESCRIPT: typescript,
 	};
 

--- a/packages/create-package/template/src/MyFirstComponent.js
+++ b/packages/create-package/template/src/MyFirstComponent.js
@@ -31,7 +31,7 @@ const metadata = {
  * The <code>INIT_PACKAGE_VAR_TAG</code> component is a demo component that displays some text.
  *
  * @constructor
- * @alias demo.components.INIT_PACKAGE_VAR_CLASS_NAME
+ * @alias INIT_PACKAGE_VAR_NAMESPACE.INIT_PACKAGE_VAR_CLASS_NAME
  * @extends sap.ui.webc.base.UI5Element
  * @tagname INIT_PACKAGE_VAR_TAG
  * @public

--- a/packages/create-package/template/src/MyFirstComponent.ts
+++ b/packages/create-package/template/src/MyFirstComponent.ts
@@ -20,7 +20,7 @@ import { PLEASE_WAIT } from "./generated/i18n/i18n-defaults.js";
  * The <code>INIT_PACKAGE_VAR_TAG</code> component is a demo component that displays some text.
  *
  * @constructor
- * @alias demo.components.INIT_PACKAGE_VAR_CLASS_NAME
+ * @alias INIT_PACKAGE_VAR_NAMESPACE.INIT_PACKAGE_VAR_CLASS_NAME
  * @extends sap.ui.webc.base.UI5Element
  * @tagname INIT_PACKAGE_VAR_TAG
  * @public


### PR DESCRIPTION
Added the option to choose a namespace for the JSDoc comments when creating a package. This is relevant for the UI5 Enablement scenario.

Note: the current templating must be improved. If the `INIT_PACKAGE_VAR_NAME` var is replaced in the templates first, it will "break" usages of `INIT_PACKAGE_VAR_NAMESPACE`. Therefore, the longer name (`INIT_PACKAGE_VAR_NAMESPACE`) must be replaced first. We should consider using the `<%= VAR_NAME %>` syntax or similar.