### PR TITLE
chore: upgrade to lit 3

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "lit-html": "^2.0.1"
+    "lit-html": "3.0.0-pre.0"
   },
   "devDependencies": {
     "@buxlabs/amd-to-es6": "0.16.1",

--- a/packages/tools/lib/hbs2lit/src/litVisitor2.js
+++ b/packages/tools/lib/hbs2lit/src/litVisitor2.js
@@ -56,7 +56,7 @@ HTMLLitVisitor.prototype.Program = function(program) {
 	this.debug && this.blockByNumber.push(key);
 
 	// this.blocks[this.currentKey()] = "function " + this.currentKey() + ` (this: any, ` + this.blockParametersDefinition.join(", ") + ") { ";
-	this.blocks[this.currentKey()] = `function ${this.currentKey()} (${this.blockParametersDefinition.join(", ")}) { `;
+	this.blocks[this.currentKey()] = `function ${this.currentKey()} (${this.blockParametersDefinition.join(", ")}): TemplateResult { `;
 
 	if (this.keys.length > 1) { //it's a nested block
 		this.blocks[this.prevKey()] += this.currentKey() + ".call(" + this.blockParametersUsage.join(", ") + ")";

--- a/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
+++ b/packages/tools/lib/hbs2ui5/RenderTemplates/LitRenderer.js
@@ -8,6 +8,7 @@ const tsImports = (controlName, hasTypes) => {
 	return `import type UI5Element from "${importPrefix}UI5Element.js";
 	${importForControl(controlName, hasTypes)}
 	import type { ClassMapValue } from "${importPrefix}types.js";
+	import type { TemplateResult } from "lit-html";
 	`;
 }
 const importForControl = (controlName, hasTypes) => {
@@ -32,6 +33,7 @@ import { html, svg, repeat, classMap, styleMap, ifDefined, unsafeHTML, scopeTag 
 ${tsImports(controlName, hasTypes)}
 ${litTemplate}
 
+export { TemplateResult };
 export default block0;`;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9075,7 +9075,14 @@ lit-element@^3.3.0:
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.7.0"
 
-lit-html@^2.0.1, lit-html@^2.7.0:
+lit-html@3.0.0-pre.0:
+  version "3.0.0-pre.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.0.0-pre.0.tgz#d285021aabdaf91a6613bb020d7f51dad9387c76"
+  integrity sha512-9rpjrE/l0WaJznK2A/IeR7lV0doCeC8HABfK46iE90O/9awaNKsFYB7Rhj3WSe94nJ7WBNOYT3TBPINgUMx3lw==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit-html@^2.7.0:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.7.2.tgz#e4593da022298d8029ae3f67d10d322c18152d3d"
   integrity sha512-ZJCfKlA2XELu5tn7XuzOziGFGvf1SeQm+ngLWoJ8bXtSkRrrR3ms6SWy+gsdxeYwySLij5xAhdd2C3EX0ftxdQ==


### PR DESCRIPTION
When upgrading to `lit-html` 3, the only error is a TS build-time error saying that the export type of `block0` cannot be implicit, because it has a dependency to `lit-html`