### PR TITLE
fix(framework): store shared resources as `meta` tag within the `head`

### DIFF
--- a/packages/base/src/getSharedResource.ts
+++ b/packages/base/src/getSharedResource.ts
@@ -1,10 +1,17 @@
 import getSingletonElementInstance from "./util/getSingletonElementInstance.js";
 
-const getSharedResourcesInstance = (): Record<string, unknown> | null => {
+const getMetaDomEl = () => {
+	const el = document.createElement("meta");
+	el.setAttribute("name", "ui5-shared-resources");
+	el.setAttribute("content", ""); // attribute "content" should be present when "name" is set.
+	return el;
+};
+
+const getSharedResourcesInstance = (): Element | null => {
 	if (typeof document === "undefined") {
 		return null;
 	}
-	return getSingletonElementInstance("ui5-shared-resources") as unknown as Record<string, unknown>;
+	return getSingletonElementInstance(`meta[name="ui5-shared-resources"]`, document.head, getMetaDomEl);
 };
 
 /**

--- a/packages/base/src/util/getSingletonElementInstance.ts
+++ b/packages/base/src/util/getSingletonElementInstance.ts
@@ -1,11 +1,20 @@
-const getSingletonElementInstance = (tag: string, parentElement: HTMLElement = document.body) => {
+/**
+ * Returns a singleton HTML element, inserted in given parent element of HTML page,
+ * used mostly to store and share global resources between multiple UI5 Web Components runtimes.
+ *
+ * @param { string } tag the element tag/selector
+ * @param { HTMLElement } parentElement the parent element to insert the singleton element instance
+ * @param { Function } createEl a factory function for the element instantiation, by default document.createElement is used
+ * @returns { Element }
+ */
+const getSingletonElementInstance = (tag: string, parentElement: HTMLElement = document.body, createEl?: () => Element) => {
 	let el = document.querySelector(tag);
 
 	if (el) {
 		return el;
 	}
 
-	el = document.createElement(tag);
+	el = createEl ? createEl() : document.createElement(tag);
 
 	return parentElement.insertBefore(el, parentElement.firstChild);
 };

--- a/packages/base/test/specs/SystemDOMElements.spec.js
+++ b/packages/base/test/specs/SystemDOMElements.spec.js
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-describe("Some configuration options can be changed at runtime", () => {
+describe("Static Area :: runtime changes", () => {
 	before(async () => {
 		await browser.url("test/pages/AllTestElements.html");
 	});
@@ -74,5 +74,15 @@ describe("Some configuration options can be changed at runtime", () => {
 			done();
 		});
 		assert.notOk(await staticArea.$(`.${componentId}`).getAttribute("dir"), "dir attribute dynamically removed for static area item owner");
+	});
+});
+
+describe("Shared Resources", () => {
+	it("Tests the presense of the shared resources 'meta' element", async () => {
+		const sharedResourcesElement = await browser.executeAsync(done => {
+			return done(document.querySelector(`meta[name="ui5-shared-resources"]`));
+		});
+
+		assert.ok(sharedResourcesElement, "The 'meta' element for shared resources is created.");
 	});
 });


### PR DESCRIPTION
**Background**
Previously we used to create `ui5-shared-resources` semantic HTML element to store shared resources (as registered runtimes, tags and SVGs) that can be reused between multiple UI5 Web Components runtimes.
The element used to be appended to the `head` in the past, but this produced invalid markup when tested with HTML validators as there is specific list of allowed tags that can be inserted in the `head`. To address this, we moved the `ui5-shared-resources` to the `body`.

**Issue**
However, currently we got another issue with `the body not being ready` at the point we access it and try to append the `ui5-shared-resources`. And, this issues is subject of the current PR.

**Solution**
Use `meta` tag with the minimum required attributes and append it to head (the `meta` tag is allowed in `head`).

FIXES: https://github.com/SAP/ui5-webcomponents/issues/7025