### PR TITLE
feat(ui5-menu): dispatch ui5-before-open for the sub-menus

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -123,14 +123,11 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @public
  * @event sap.ui.webc.main.Menu#before-open
  * @param {object} item The corresponding <code>ui5-menu-item</code> to the sub-menu that will be opened.
- * @allowPreventDefault
  * @since 1.10.0
+ * @allowPreventDefault
  */
 @event("before-open", {
 	detail: {
-		/**
-		 * @since 1.14.0
-		 */
 		item: {
 			type: Object,
 		},

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -122,9 +122,9 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  *
  * @public
  * @event sap.ui.webc.main.Menu#before-open
- * @param {object} item The corresponding <code>ui5-menu-item</code> to the sub-menu that will be opened.
- * @since 1.10.0
  * @allowPreventDefault
+ * @since 1.10.0
+ * @param {object} item The corresponding <code>ui5-menu-item</code> to the sub-menu that will be opened.
  */
 @event("before-open", {
 	detail: {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -124,7 +124,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @event sap.ui.webc.main.Menu#before-open
  * @allowPreventDefault
  * @since 1.10.0
- * @param {object} item The <code>ui5-menu-item</code> that triggers the corresponding sub-menu to get opened. Note: available since 1.14.0.
+ * @param {object} item The <code>ui5-menu-item</code> that triggers opening of the sub-menu. Note: available since 1.14.0.
  */
 @event("before-open", {
 	detail: {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -124,7 +124,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @event sap.ui.webc.main.Menu#before-open
  * @allowPreventDefault
  * @since 1.10.0
- * @param {object} item The corresponding <code>ui5-menu-item</code> to the sub-menu that will be opened.
+ * @param {object} item The <code>ui5-menu-item</code> that triggers the corresponding sub-menu to get opened. Note: available since 1.14.0.
  */
 @event("before-open", {
 	detail: {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -122,10 +122,20 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  *
  * @public
  * @event sap.ui.webc.main.Menu#before-open
+ * @param {object} item The corresponding <code>ui5-menu-item</code> to the sub-menu that will be opened.
  * @allowPreventDefault
  * @since 1.10.0
  */
-@event("before-open")
+@event("before-open", {
+	detail: {
+		/**
+		 * @since 1.14.0
+		 */
+		item: {
+			type: Object,
+		},
+	},
+})
 
 /**
  * Fired after the menu is opened. <b>This event does not bubble.</b>

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -345,6 +345,7 @@ class Menu extends UI5Element {
 			const subMenu = item.item._subMenu;
 			const menuItem = item.item;
 			if (subMenu && subMenu.busy) {
+				subMenu.innerHTML = "";
 				this._cloneItems(menuItem, subMenu);
 			}
 
@@ -455,7 +456,7 @@ class Menu extends UI5Element {
 	}
 
 	_cloneItems(item: MenuItem, menu: Menu) {
-		for (let i = menu.items.length; i < item.items.length; ++i) {
+		for (let i = 0; i < item.items.length; ++i) {
 			const clonedItem = item.items[i].cloneNode(true);
 			menu.appendChild(clonedItem);
 		}

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -111,11 +111,14 @@
 			if (item && item.text === "Open") {
 				menu.removeEventListener("ui5-before-open", fetch);
 				setTimeout(function() {
+					// item.removeAttribute("busy");
+					// item.removeAttribute("busy-delay");
 					let oneNode = document.createElement("ui5-menu-item");
 					oneNode.setAttribute("text", "One");
 					let twoNode = document.createElement("ui5-menu-item");
 					twoNode.setAttribute("text", "Two");
 					item.append(oneNode, twoNode);
+					menu.addEventListener("ui5-before-open", fetch);
 				}, 0);
 			}
 		});

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -27,7 +27,7 @@
 			<ui5-menu-item text="Open from Cloud" additional-text="Ctrl+L"></ui5-menu-item>
 		</ui5-menu-item>
 		<ui5-menu-item text="Save" icon="save">
-			<ui5-menu-item id="test" text="Save Locally" icon="save">
+			<ui5-menu-item text="Save Locally" icon="save">
 				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
 				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
 				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
@@ -108,17 +108,15 @@
 
 		menu.addEventListener("ui5-before-open", function fetch(event) {
 			const item = event.detail.item;
-			if (item && item.text === "Close") {
+			if (item && item.text === "Open") {
+				menu.removeEventListener("ui5-before-open", fetch);
 				setTimeout(function() {
-					item.removeAttribute("busy");
-					item.removeAttribute("busy-delay");
 					let oneNode = document.createElement("ui5-menu-item");
 					oneNode.setAttribute("text", "One");
 					let twoNode = document.createElement("ui5-menu-item");
 					twoNode.setAttribute("text", "Two");
 					item.append(oneNode, twoNode);
-					menu.removeEventListener("ui5-before-open", fetch);
-				}, 3000);
+				}, 0);
 			}
 		});
 

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -27,7 +27,7 @@
 			<ui5-menu-item text="Open from Cloud" additional-text="Ctrl+L"></ui5-menu-item>
 		</ui5-menu-item>
 		<ui5-menu-item text="Save" icon="save">
-			<ui5-menu-item text="Save Locally" icon="save">
+			<ui5-menu-item id="test" text="Save Locally" icon="save">
 				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
 				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
 				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
@@ -104,6 +104,22 @@
 
 		btnToggleOpen.addEventListener("click", function() {
 			menu.open = btnToggleOpen.pressed;
+		});
+
+		menu.addEventListener("ui5-before-open", function fetch(event) {
+			const item = event.detail.item;
+			if (item && item.text === "Close") {
+				setTimeout(function() {
+					item.removeAttribute("busy");
+					item.removeAttribute("busy-delay");
+					let oneNode = document.createElement("ui5-menu-item");
+					oneNode.setAttribute("text", "One");
+					let twoNode = document.createElement("ui5-menu-item");
+					twoNode.setAttribute("text", "Two");
+					item.append(oneNode, twoNode);
+					menu.removeEventListener("ui5-before-open", fetch);
+				}, 3000);
+			}
 		});
 
 		menu.addEventListener("ui5-item-click", function(event) {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -106,19 +106,18 @@
 			menu.open = btnToggleOpen.pressed;
 		});
 
+		let fetched = false;
+
 		menu.addEventListener("ui5-before-open", function fetch(event) {
 			const item = event.detail.item;
-			if (item && item.text === "Open") {
-				menu.removeEventListener("ui5-before-open", fetch);
+			if (item && item.text === "Open" && !fetched) {
 				setTimeout(function() {
-					// item.removeAttribute("busy");
-					// item.removeAttribute("busy-delay");
 					let oneNode = document.createElement("ui5-menu-item");
 					oneNode.setAttribute("text", "One");
 					let twoNode = document.createElement("ui5-menu-item");
 					twoNode.setAttribute("text", "Two");
 					item.append(oneNode, twoNode);
-					menu.addEventListener("ui5-before-open", fetch);
+					fetched = true;
 				}, 0);
 			}
 		});

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -326,7 +326,7 @@
 
 	subMenuListBusy.addEventListener("ui5-before-open", function(event) {
 		const item = event.detail.item;
-		if (item && item.text === "Save") {
+		if (item && item.text === "Save" && !feched) {
 			setTimeout(function() {
 				item.removeAttribute("busy");
 				item.removeAttribute("busy-delay");

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -179,7 +179,7 @@
 					let closeNode = document.createElement("ui5-menu-item");
 					closeNode.setAttribute("text", "Close");
 					menuBusy.appendChild(closeNode);
-				}, 3000);
+				}, 2000);
 			}, { once: true });
 		</script>
 	</div>
@@ -213,7 +213,7 @@
 			let closeNode = document.createElement("ui5-menu-item");
 			closeNode.setAttribute("text", "Close");
 			menuBusy.appendChild(closeNode);
-		}, 3000);
+		}, 2000);
 	}, { once: true });
 </script>
 	</xmp></pre>
@@ -243,7 +243,7 @@
 					let closeNode = document.createElement("ui5-menu-item");
 					closeNode.setAttribute("text", "Close");
 					menuListBusy.appendChild(closeNode);
-				}, 3000);
+				}, 2000);
 			}, { once: true });
 		</script>
 	</div>
@@ -269,7 +269,7 @@
 			let closeNode = document.createElement("ui5-menu-item");
 			closeNode.setAttribute("text", "Close");
 			menuListBusy.appendChild(closeNode);
-		}, 3000);
+		}, 2000);
 	}, { once: true });
 </script>
 	</xmp></pre>
@@ -277,6 +277,29 @@
 
 <section>
 	<h3>Sub-menu with items fetching from a database</h3>
+	<p>
+		Please do refer to this specific sample when implementing data fetching for a sub-menu <code>ui5-menu-item</code>s.</br>
+		There are a lot of scenarios that needs to be taken care of in the <code>ui5-before-open</code> handler.
+	</p>
+	<ul>
+		<li>
+			A conditional would be needed to filter the correct <code>ui5-menu-item</code></br>
+			as the <code>ui5-before-open</code> event would be fired for each <code>ui5-menu-item</code>.
+		</li>
+		<li>
+			The <code>ui5-before-open</code> event listener needs to be removed prior to the data feching.</br>
+			Otherwise the same data could be fetched multiple times during an interaction with the <code>ui5-menu-item</code>.
+		</li>
+		<li>
+			After the data is fetched the <code>ui5-before-open</code> event listener has to be re-attached to the menu.</br>
+			Otherwise the handler would not be executed for any other <code>ui5-menu-item</code>'s.
+		</li>
+		<li>
+			In this sample the <code>ui5-before-open</code> handler is a named function, in order to be</br>
+			easily detached and re-attached when needed. 
+		</li>
+	</ul>
+	  
 	<div class="snippet">
 		<ui5-button id="btnSubMenuListBusy" class="samples-margin">Open Menu</ui5-button> <br/>
 		<ui5-menu id="subMenuListBusy">
@@ -303,7 +326,8 @@
 						saveCloud.setAttribute("text", "Save on Cloud");
 						saveCloud.setAttribute("iocn", "upload-to-cloud");
 						item.append(saveLocally, saveCloud);
-					}, 3000);
+						subMenuListBusy.addEventListener("ui5-before-open", fetch);
+					}, 2000);
 				}
 			});
 		</script>
@@ -334,7 +358,8 @@
 				saveCloud.setAttribute("text", "Save on Cloud");
 				saveCloud.setAttribute("iocn", "upload-to-cloud");
 				item.append(saveLocally, saveCloud);
-			}, 3000);
+				subMenuListBusy.addEventListener("ui5-before-open", fetch);
+			}, 2000);
 		}
 	});
 </script>

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -263,7 +263,6 @@
 			menuListBusy.removeAttribute("busy");
 			let openNode = document.createElement("ui5-menu-item");
 			openNode.setAttribute("text", "Open");
-			openNode.setAttribute("icon", "open-folder");
 			openNode.setAttribute("starts-section", "");
 			menuListBusy.appendChild(openNode);
 			let closeNode = document.createElement("ui5-menu-item");
@@ -299,10 +298,8 @@
 						item.removeAttribute("busy-delay");
 						let saveLocally = document.createElement("ui5-menu-item");
 						saveLocally.setAttribute("text", "Save Locally");
-						saveLocally.setAttribute("iocn", "save");
 						let saveCloud = document.createElement("ui5-menu-item");
 						saveCloud.setAttribute("text", "Save on Cloud");
-						saveCloud.setAttribute("iocn", "upload-to-cloud");
 						item.append(saveLocally, saveCloud);
 						feched = true;
 					}, 2000);
@@ -332,10 +329,8 @@
 				item.removeAttribute("busy-delay");
 				let saveLocally = document.createElement("ui5-menu-item");
 				saveLocally.setAttribute("text", "Save Locally");
-				saveLocally.setAttribute("iocn", "save");
 				let saveCloud = document.createElement("ui5-menu-item");
 				saveCloud.setAttribute("text", "Save on Cloud");
-				saveCloud.setAttribute("iocn", "upload-to-cloud");
 				item.append(saveLocally, saveCloud);
 				feched = true;
 			}, 2000);

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -248,8 +248,10 @@
 		</script>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-button id="btnMenuListBusy">Open Menu</ui5-button> <br/>
+<ui5-button id="btnMenuListBusy" class="samples-margin">Open Menu</ui5-button> <br/>
 <ui5-menu id="menuListBusy" busy-delay="100" busy>
+	<ui5-menu-item text="New File" icon="add-document" additional-text="Ctrl+N"></ui5-menu-item>
+	<ui5-menu-item text="New Folder" icon="add-folder" additional-text="Ctrl+F" disabled></ui5-menu-item>
 </ui5-menu>
 <script>
 	btnMenuListBusy.addEventListener("click", function(event) {
@@ -269,6 +271,72 @@
 			menuListBusy.appendChild(closeNode);
 		}, 3000);
 	}, { once: true });
+</script>
+	</xmp></pre>
+</section>
+
+<section>
+	<h3>Sub-menu with items fetching from a database</h3>
+	<div class="snippet">
+		<ui5-button id="btnSubMenuListBusy" class="samples-margin">Open Menu</ui5-button> <br/>
+		<ui5-menu id="subMenuListBusy">
+			<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+			<ui5-menu-item text="Open" icon="open-folder"></ui5-menu-item>
+			<ui5-menu-item text="Save" icon="save" busy-delay="100" busy></ui5-menu-item>
+		</ui5-menu>
+		<script>
+			btnSubMenuListBusy.addEventListener("click", function(event) {
+				subMenuListBusy.showAt(btnSubMenuListBusy);
+			});
+
+			subMenuListBusy.addEventListener("ui5-before-open", function(event) {
+				const item = event.detail.item;
+				if (item && item.text === "Save") {
+					subMenuListBusy.removeEventListener("ui5-before-open", fetch);
+					setTimeout(function() {
+						item.removeAttribute("busy");
+						item.removeAttribute("busy-delay");
+						let saveLocally = document.createElement("ui5-menu-item");
+						saveLocally.setAttribute("text", "Save Locally");
+						saveLocally.setAttribute("iocn", "save");
+						let saveCloud = document.createElement("ui5-menu-item");
+						saveCloud.setAttribute("text", "Save on Cloud");
+						saveCloud.setAttribute("iocn", "upload-to-cloud");
+						item.append(saveLocally, saveCloud);
+					}, 3000);
+				}
+			});
+		</script>
+	</div>
+	<pre class="prettyprint lang-html"><xmp>
+<ui5-button id="btnSubMenuListBusy" class="samples-margin">Open Menu</ui5-button> <br/>
+<ui5-menu id="subMenuListBusy">
+	<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+	<ui5-menu-item text="Open" icon="open-folder"></ui5-menu-item>
+	<ui5-menu-item text="Save" icon="save" busy-delay="100" busy></ui5-menu-item>
+</ui5-menu>
+<script>
+	btnSubMenuListBusy.addEventListener("click", function(event) {
+		subMenuListBusy.showAt(btnSubMenuListBusy);
+	});
+
+	subMenuListBusy.addEventListener("ui5-before-open", function(event) {
+		const item = event.detail.item;
+		if (item && item.text === "Save") {
+			subMenuListBusy.removeEventListener("ui5-before-open", fetch);
+			setTimeout(function() {
+				item.removeAttribute("busy");
+				item.removeAttribute("busy-delay");
+				let saveLocally = document.createElement("ui5-menu-item");
+				saveLocally.setAttribute("text", "Save Locally");
+				saveLocally.setAttribute("iocn", "save");
+				let saveCloud = document.createElement("ui5-menu-item");
+				saveCloud.setAttribute("text", "Save on Cloud");
+				saveCloud.setAttribute("iocn", "upload-to-cloud");
+				item.append(saveLocally, saveCloud);
+			}, 3000);
+		}
+	});
 </script>
 	</xmp></pre>
 </section>

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -276,30 +276,7 @@
 </section>
 
 <section>
-	<h3>Sub-menu with items fetching from a database</h3>
-	<p>
-		Please do refer to this specific sample when implementing data fetching for a sub-menu <code>ui5-menu-item</code>s.</br>
-		There are a lot of scenarios that needs to be taken care of in the <code>ui5-before-open</code> handler.
-	</p>
-	<ul>
-		<li>
-			A conditional would be needed to filter the correct <code>ui5-menu-item</code></br>
-			as the <code>ui5-before-open</code> event would be fired for each <code>ui5-menu-item</code>.
-		</li>
-		<li>
-			The <code>ui5-before-open</code> event listener needs to be removed prior to the data feching.</br>
-			Otherwise the same data could be fetched multiple times during an interaction with the <code>ui5-menu-item</code>.
-		</li>
-		<li>
-			After the data is fetched the <code>ui5-before-open</code> event listener has to be re-attached to the menu.</br>
-			Otherwise the handler would not be executed for any other <code>ui5-menu-item</code>'s.
-		</li>
-		<li>
-			In this sample the <code>ui5-before-open</code> handler is a named function, in order to be</br>
-			easily detached and re-attached when needed. 
-		</li>
-	</ul>
-	  
+	<h3>Sub-menu with items fetching from a database</h3>  
 	<div class="snippet">
 		<ui5-button id="btnSubMenuListBusy" class="samples-margin">Open Menu</ui5-button> <br/>
 		<ui5-menu id="subMenuListBusy">
@@ -312,10 +289,11 @@
 				subMenuListBusy.showAt(btnSubMenuListBusy);
 			});
 
+			let feched = false;
+
 			subMenuListBusy.addEventListener("ui5-before-open", function(event) {
 				const item = event.detail.item;
-				if (item && item.text === "Save") {
-					subMenuListBusy.removeEventListener("ui5-before-open", fetch);
+				if (item && item.text === "Save" && !feched) {
 					setTimeout(function() {
 						item.removeAttribute("busy");
 						item.removeAttribute("busy-delay");
@@ -326,7 +304,7 @@
 						saveCloud.setAttribute("text", "Save on Cloud");
 						saveCloud.setAttribute("iocn", "upload-to-cloud");
 						item.append(saveLocally, saveCloud);
-						subMenuListBusy.addEventListener("ui5-before-open", fetch);
+						feched = true;
 					}, 2000);
 				}
 			});
@@ -344,10 +322,11 @@
 		subMenuListBusy.showAt(btnSubMenuListBusy);
 	});
 
+	let feched = false;
+
 	subMenuListBusy.addEventListener("ui5-before-open", function(event) {
 		const item = event.detail.item;
 		if (item && item.text === "Save") {
-			subMenuListBusy.removeEventListener("ui5-before-open", fetch);
 			setTimeout(function() {
 				item.removeAttribute("busy");
 				item.removeAttribute("busy-delay");
@@ -358,7 +337,7 @@
 				saveCloud.setAttribute("text", "Save on Cloud");
 				saveCloud.setAttribute("iocn", "upload-to-cloud");
 				item.append(saveLocally, saveCloud);
-				subMenuListBusy.addEventListener("ui5-before-open", fetch);
+				feched = true;
 			}, 2000);
 		}
 	});

--- a/packages/main/test/samples/Menu.sample.html
+++ b/packages/main/test/samples/Menu.sample.html
@@ -263,6 +263,7 @@
 			menuListBusy.removeAttribute("busy");
 			let openNode = document.createElement("ui5-menu-item");
 			openNode.setAttribute("text", "Open");
+			openNode.setAttribute("icon", "open-folder");
 			openNode.setAttribute("starts-section", "");
 			menuListBusy.appendChild(openNode);
 			let closeNode = document.createElement("ui5-menu-item");
@@ -298,8 +299,10 @@
 						item.removeAttribute("busy-delay");
 						let saveLocally = document.createElement("ui5-menu-item");
 						saveLocally.setAttribute("text", "Save Locally");
+						saveLocally.setAttribute("icon", "save");
 						let saveCloud = document.createElement("ui5-menu-item");
 						saveCloud.setAttribute("text", "Save on Cloud");
+						saveCloud.setAttribute("icon", "upload-to-cloud");
 						item.append(saveLocally, saveCloud);
 						feched = true;
 					}, 2000);
@@ -329,8 +332,10 @@
 				item.removeAttribute("busy-delay");
 				let saveLocally = document.createElement("ui5-menu-item");
 				saveLocally.setAttribute("text", "Save Locally");
+				saveLocally.setAttribute("icon", "save");
 				let saveCloud = document.createElement("ui5-menu-item");
 				saveCloud.setAttribute("text", "Save on Cloud");
+				saveCloud.setAttribute("icon", "upload-to-cloud");
 				item.append(saveLocally, saveCloud);
 				feched = true;
 			}, 2000);

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -148,6 +148,7 @@ describe("Menu interaction", () => {
 			const openMenuList = await openSubmenuPopover.$("ui5-list");
 
 			assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
+			assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
 
 			visualCloseItem.click();
 			await browser.pause(100);


### PR DESCRIPTION
The ui5-before-open event is now getting fired for the sub-menus as well.
As a result the application developers would be able to fetch data from
a database before a sub-menu gets opened. In the meanwhile the busy
state of the sub-menu will be displayed.

Related to: #6131