### PR TITLE
fix(ui5-tree): tree list is re-rendered when the tree changes

### DIFF
--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -490,10 +490,6 @@ class Tree extends UI5Element {
 	_isInstanceOfTreeItemBase(object: any): object is TreeItemBase {
 		return "isTreeItem" in object;
 	}
-
-	_onSlotChange() {
-		this.shadowRoot!.querySelector<TreeList>("[ui5-tree-list]")!.onBeforeRendering();
-	}
 }
 
 const walkTree = (el: Tree | TreeItemBase, level: number, callback: WalkCallback) => {

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -337,6 +337,12 @@ class Tree extends UI5Element {
 		this._prepareTreeItems();
 	}
 
+	onAfterRendering() {
+		// Note: this is a workaround for the problem that the list cannot invalidate itself when its only physical child is a slot (and the list items are inside the slot)
+		// This code should be removed once a framework-level fix is implemented
+		this.shadowRoot!.querySelector<TreeList>("[ui5-tree-list]")!.onBeforeRendering();
+	}
+
 	get list() {
 		return this.getDomRef() as TreeList;
 	}
@@ -483,6 +489,10 @@ class Tree extends UI5Element {
 
 	_isInstanceOfTreeItemBase(object: any): object is TreeItemBase {
 		return "isTreeItem" in object;
+	}
+
+	_onSlotChange() {
+		this.shadowRoot!.querySelector<TreeList>("[ui5-tree-list]")!.onBeforeRendering();
 	}
 }
 

--- a/packages/main/test/pages/TreeDynamic.html
+++ b/packages/main/test/pages/TreeDynamic.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+
+	<title>ui5-tree</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<script>// delete Document.prototype.adoptedStyleSheets;</script>
+
+	<script data-ui5-config type="application/json">
+		{
+			"language": "EN"
+		}
+	</script>
+
+
+	<script src="../../bundle.esm.js" type="module"></script>
+
+
+	<link rel="stylesheet" type="text/css" href="./styles/Tree.css">
+</head>
+
+<body class="tree1auto">
+
+	<ui5-tree id="tree" mode="MultiSelect">
+		<ui5-tree-item text="Tree 2" id="item" has-children></ui5-tree-item>
+	</ui5-tree>
+
+	<script>
+		const tree = document.getElementById("tree");
+
+		const template = `<ui5-tree-item text="Tree 2.1">
+  <ui5-tree-item text="Tree 2.1.1"></ui5-tree-item>
+  <ui5-tree-item text="Tree 2.1.2">
+    <ui5-tree-item text="Tree 2.1.2.1"></ui5-tree-item>
+    <ui5-tree-item text="Tree 2.1.2.2"></ui5-tree-item>
+    <ui5-tree-item text="Tree 2.1.2.3"></ui5-tree-item>
+    <ui5-tree-item text="Tree 2.1.2.5"></ui5-tree-item>
+  </ui5-tree-item>
+</ui5-tree-item>
+<ui5-tree-item text="Tree 2.2"></ui5-tree-item>`;
+
+		tree.addEventListener("item-toggle", (e) => {
+			if (e.detail.item.getAttribute("text") === "Tree 2") {
+				e.detail.item.innerHTML = template;
+			}
+		});
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
*This is not the final solution but a workaround.*

**This issue must be addressed on framework level.**

The problem is that the `ui5-list` inside the `ui5-tree`'s shadow root has a `slot` child and the list items are inside the slot. This slot is taken into account in the tree code (`getSlottedItems` used everywhere) so the list renders correctly regardless of whether its list items are direct children of the list, or come through a slot. However, the framework's invalidation logic does not take this case into account.

closes: https://github.com/SAP/ui5-webcomponents/issues/6726