### PR TITLE
fix(ui5-shellbar): improve RTL styling of searchField

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -307,7 +307,6 @@ slot[name="profile"] {
 	justify-content: flex-end;
 	height: inherit;
 	align-items: center;
-	float: var(--_ui5_shellbar_overflow_container_float);
 }
 
 .ui5-shellbar-overflow-button {

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -13,8 +13,6 @@
 	--_ui5_popover_left_arrow_margin: 0.125rem 0 0 0.25rem;
 	--_ui5_dialog_resize_cursor: se-resize;
 
-	--_ui5_shellbar_overflow_container_float: none;
-
 	--_ui5_progress_indicator_bar_border_radius: 0.5rem 0 0 0.5rem;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0 0.5rem 0.5rem 0;
 	--_ui5_menu_submenu_margin_offset: -0.25rem 0;
@@ -33,8 +31,6 @@
 	--_ui5_popover_downward_arrow_margin: -0.4375rem .125rem 0 0;
 	--_ui5_popover_left_arrow_margin: .1875rem -.375rem 0 0;
 	--_ui5_dialog_resize_cursor:sw-resize;
-
-	--_ui5_shellbar_overflow_container_float: left;
 
 	--_ui5_progress_indicator_bar_border_radius: 0 0.5rem 0.5rem 0;
 	--_ui5_progress_indicator_remaining_bar_border_radius: 0.5rem 0 0 0.5rem;


### PR DESCRIPTION
By removing the `float` property, the searchField slot can now expand to its parent full width container in RTL mode.

Fixes: #7065 
