### PR TITLE
fix(ui5-label): colon symbol is now language-dependent

### DIFF
--- a/packages/main/src/Label.hbs
+++ b/packages/main/src/Label.hbs
@@ -5,5 +5,10 @@
 	<span class="ui5-label-text-wrapper">
 		<bdi id="{{_id}}-bdi"><slot></slot></bdi>
 	</span>
-	<span aria-hidden="true" class="ui5-label-required-colon"></span>
+	<span 
+		aria-hidden="true" 
+		class="ui5-label-required-colon"
+		data-colon="{{_colonSymbol}}"
+	>
+	</span>
 </label>

--- a/packages/main/src/Label.ts
+++ b/packages/main/src/Label.ts
@@ -2,7 +2,10 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import WrappingType from "./types/WrappingType.js";
+import { LABEL_COLON } from "./generated/i18n/i18n-defaults.js";
 
 // Template
 import LabelTemplate from "./generated/templates/LabelTemplate.lit.js";
@@ -99,6 +102,12 @@ class Label extends UI5Element {
 	@property({ type: WrappingType, defaultValue: WrappingType.None })
 	wrappingType!: `${WrappingType}`;
 
+	static i18nBundle: I18nBundle;
+
+	static async onDefine() {
+		Label.i18nBundle = await getI18nBundle("@ui5/webcomponents-fiori");
+	}
+
 	/**
 	 * Defines the text of the component.
 	 * <br><b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
@@ -118,6 +127,10 @@ class Label extends UI5Element {
 		if (elementToFocus) {
 			elementToFocus.focus();
 		}
+	}
+
+	get _colonSymbol() {
+		return Label.i18nBundle.getText(LABEL_COLON);
 	}
 }
 

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -423,3 +423,6 @@ MENU_BACK_BUTTON_ARIA_LABEL=Back
 
 #XACT: ARIA announcement for the Menu Close button aria-label attribute
 MENU_CLOSE_BUTTON_ARIA_LABEL=Decline
+
+#XFLD: A colon to separate the "label" from an input. In some languages there might be a different symbol used for such a colon
+LABEL_COLON=:

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -35,7 +35,7 @@
 }
 
 :host([show-colon]) .ui5-label-required-colon:before {
-	content: ":";
+	content: attr(data-colon);
 }
 
 :host([required]) .ui5-label-required-colon:after {
@@ -59,4 +59,5 @@ bdi {
 
 :host([show-colon]) .ui5-label-required-colon {
 	margin-inline-start: -0.05rem; /*0.8px - fix for last letter clipping issue when style is italic*/
+	white-space: pre;
 }

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -3,7 +3,6 @@
 
 <head>
 	<meta charset="utf-8">
-
 	<title>Label</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
@@ -20,6 +19,7 @@
 
 
 	<script src="./modules/LabelPageCustomElement.js" type="module" defer></script>
+	<script src="./modules/LabelPage.js" type="module" defer></script>
 	<link rel="stylesheet" type="text/css" href="./styles/Label.css">
 </head>
 
@@ -153,8 +153,36 @@
 	</section>
 	<div>
 		<ui5-label>Short labelH</ui5-label>
-<ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label>
+		<ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label>
 	</div>
+
+	<section class="group" id="differentLanguages">
+		<h2>Labels in different languages</h2>
+		<ui5-select id="languageSelect">
+			<ui5-option id="en" selected>en</ui5-option>
+			<ui5-option id="fr">fr</ui5-option>
+			<ui5-option id="zh-CN">zh-CN (Simplified Chinese)</ui5-option>
+			<ui5-option id="zh-Hans">zh-Hans (Simplified Chinese)</ui5-option>
+			<ui5-option id="zh-TW">zh-TW (Traditional Chinese)</ui5-option>
+			<ui5-option id="zh-Hant">zh-Hant (Traditional Chinese)</ui5-option>
+		</ui5-select>
+		<div>
+			<ui5-label show-colon></ui5-label>
+			<ui5-input></ui5-input>
+		</div>
+		<div>
+			<ui5-label show-colon required></ui5-label>
+			<ui5-input></ui5-input>
+		</div>
+		<div>
+			<ui5-label show-colon class="width50px"></ui5-label>
+			<ui5-input></ui5-input>
+		</div>
+		<div>
+			<ui5-label show-colon required class="width50px"></ui5-label>
+			<ui5-input></ui5-input>
+		</div>
+	</section>
 
 </body>
 

--- a/packages/main/test/pages/modules/LabelPage.js
+++ b/packages/main/test/pages/modules/LabelPage.js
@@ -1,0 +1,27 @@
+import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+
+var select = document.getElementById("languageSelect");
+
+var labelText = {
+	"en": "This is a label",
+	"fr": "c'est une étiquette",
+	"zh-CN": "这是一个标签",
+	"zh-Hans": "这是一个标签",
+	"zh-TW": "這是一個標籤",
+	"zh-Hant": "這是一個標籤"
+}
+
+function updateLabelsText(lang) {
+	document.getElementById("differentLanguages").querySelectorAll("ui5-label").forEach(function (label) {
+		label.innerText = labelText[lang];
+	})
+}
+
+select.addEventListener("ui5-change", function (e) {
+	var lang = e.detail.selectedOption.id;
+
+	setLanguage(lang);
+	updateLabelsText(lang);
+});
+
+updateLabelsText("en");

--- a/packages/main/test/pages/styles/Label.css
+++ b/packages/main/test/pages/styles/Label.css
@@ -52,3 +52,7 @@ body {
 .label8auto {
 	font-style: italic
 }
+
+.width50px {
+	width: 50px;
+}

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -49,6 +49,23 @@ describe("General API", () => {
 		assert.strictEqual((await truncatingLabel.getSize()).height, 16, "truncated label should be single line");
 	});
 
+	it("colon symbol should be taken from the i18n bundle", async () => {
+		let actualSymbol;
+		let expectedSymbol;
+
+		actualSymbol = await browser.executeAsync(done => {
+			const label = document.getElementById("showColon-true");
+			done(window.getComputedStyle(label.shadowRoot.querySelector(".ui5-label-required-colon"), "::before").content);
+		});
+
+		expectedSymbol = await browser.executeAsync(done => {
+			const label = document.getElementById("showColon-true");
+			done(label.constructor.i18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.LABEL_COLON));
+		});
+
+		assert.strictEqual(actualSymbol, `"${expectedSymbol}"`, "Colon symbol should be taken from the i18n bundle");
+	});
+
 	describe("linked element with 'for' property", async () => {
 		it("should focus ui5-input on click", async () => {
 			const label = await browser.$("#label-for-ui5-input");


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/7048

