### PR TITLE
chore: add event detail types

### DIFF
--- a/packages/fiori/src/DynamicSideContent.ts
+++ b/packages/fiori/src/DynamicSideContent.ts
@@ -27,6 +27,13 @@ const S_M_BREAKPOINT = 720,	// Breakpoint between S and M screen sizes
 	L_XL_BREAKPOINT = 1440, // Breakpoint between L and XL screen sizes
 	MINIMUM_WIDTH_BREAKPOINT = 960; // Minimum width of the control where main and side contents are side by side
 
+type DynamicSideContentLayoutChangeEventDetail = {
+	currentBreakpoint: string,
+	previousBreakpoint: string,
+	mainContentVisible: boolean,
+	sideContentVisible: boolean,
+}
+
 /**
  * @class
  *
@@ -515,7 +522,7 @@ class DynamicSideContent extends UI5Element {
 				mainContentVisible: mainSize !== this.span0,
 				sideContentVisible: sideSize !== this.span0,
 			};
-			this.fireEvent("layout-change", eventParams);
+			this.fireEvent<DynamicSideContentLayoutChangeEventDetail>("layout-change", eventParams);
 			this._currentBreakpoint = this.breakpoint;
 		}
 
@@ -535,3 +542,6 @@ class DynamicSideContent extends UI5Element {
 DynamicSideContent.define();
 
 export default DynamicSideContent;
+export type {
+	DynamicSideContentLayoutChangeEventDetail,
+};

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -53,7 +53,7 @@ enum BREAKPOINTS {
 
 type ColumnLayout = Array<string | number>;
 
-type FCLLayoutChangeEventDetail = {
+type FlexibleColumnLayoutLayoutChangeEventDetail = {
 	layout: `${FCLLayout}`,
 	columnLayout: ColumnLayout,
 	startColumnVisible: boolean,
@@ -496,7 +496,7 @@ class FlexibleColumnLayout extends UI5Element {
 	}
 
 	fireLayoutChange(arrowUsed: boolean, resize: boolean) {
-		this.fireEvent<FCLLayoutChangeEventDetail>("layout-change", {
+		this.fireEvent<FlexibleColumnLayoutLayoutChangeEventDetail>("layout-change", {
 			layout: this.layout,
 			columnLayout: this._columnLayout!,
 			startColumnVisible: this.startColumnVisible,
@@ -815,5 +815,5 @@ export default FlexibleColumnLayout;
 
 export type {
 	MEDIA,
-	FCLLayoutChangeEventDetail,
+	FlexibleColumnLayoutLayoutChangeEventDetail,
 };

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -813,4 +813,7 @@ FlexibleColumnLayout.define();
 
 export default FlexibleColumnLayout;
 
-export type { MEDIA };
+export type {
+	MEDIA,
+	FCLLayoutChangeEventDetail,
+};

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -37,6 +37,8 @@ import NotificationListGroupItemTemplate from "./generated/templates/Notificatio
 // Styles
 import NotificationListGroupItemCss from "./generated/themes/NotificationListGroupItem.css.js";
 
+import type { NotificationListItemBaseCloseEventDetail as NotificationListGroupItemCloseEventDetail } from "./NotificationListItemBase.js";
+
 type NotificationListGroupItemToggleEventDetail = {
 	item: NotificationListGroupItem,
 };
@@ -241,3 +243,7 @@ class NotificationListGroupItem extends NotificationListItemBase {
 NotificationListGroupItem.define();
 
 export default NotificationListGroupItem;
+export type {
+	NotificationListGroupItemToggleEventDetail,
+	NotificationListGroupItemCloseEventDetail,
+};

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -39,7 +39,7 @@ import NotificationListItemTemplate from "./generated/templates/NotificationList
 // Styles
 import NotificationListItemCss from "./generated/themes/NotificationListItem.css.js";
 
-import type { NotificationListItemBaseCloseEventDetail as NotificationListGroupItemCloseEventDetail } from "./NotificationListItemBase.js";
+import type { NotificationListItemBaseCloseEventDetail as NotificationListItemCloseEventDetail } from "./NotificationListItemBase.js";
 
 type NotificationListItemPressEventDetail = {
 	item: NotificationListItem,
@@ -406,5 +406,5 @@ NotificationListItem.define();
 export default NotificationListItem;
 export type {
 	NotificationListItemPressEventDetail,
-	NotificationListGroupItemCloseEventDetail,
+	NotificationListItemCloseEventDetail,
 };

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -39,6 +39,8 @@ import NotificationListItemTemplate from "./generated/templates/NotificationList
 // Styles
 import NotificationListItemCss from "./generated/themes/NotificationListItem.css.js";
 
+import type { NotificationListItemBaseCloseEventDetail as NotificationListGroupItemCloseEventDetail } from "./NotificationListItemBase.js";
+
 type NotificationListItemPressEventDetail = {
 	item: NotificationListItem,
 };
@@ -402,3 +404,7 @@ class NotificationListItem extends NotificationListItemBase {
 NotificationListItem.define();
 
 export default NotificationListItem;
+export type {
+	NotificationListItemPressEventDetail,
+	NotificationListGroupItemCloseEventDetail,
+};

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -263,3 +263,6 @@ class NotificationListItemBase extends ListItemBase {
 }
 
 export default NotificationListItemBase;
+export type {
+	NotificationListItemBaseCloseEventDetail,
+};

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -12,7 +12,7 @@ import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
-import type { SelectionChangeEventDetail } from "@ui5/webcomponents/dist/List.js";
+import type { ListSelectionChangeEventDetail } from "@ui5/webcomponents/dist/List.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
@@ -595,7 +595,7 @@ class ShellBar extends UI5Element {
 		}, delay);
 	}
 
-	_menuItemPress(e: CustomEvent<SelectionChangeEventDetail>) {
+	_menuItemPress(e: CustomEvent<ListSelectionChangeEventDetail>) {
 		this.menuPopover!.close();
 		this.fireEvent<ShellBarMenuItemClickEventDetail>("menu-item-click", {
 			item: e.detail.selectedItems[0],

--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -37,11 +37,11 @@ import UploadCollectionTemplate from "./generated/templates/UploadCollectionTemp
 // Styles
 import UploadCollectionCss from "./generated/themes/UploadCollection.css.js";
 
-type SelectionChangeEventDetail = {
+type UploadCollectionSelectionChangeEventDetail = {
 	selectedItems: Array<UploadCollectionItem>,
 };
 
-type ItemDeleteEventDetail = {
+type UploadCollectionItemDeleteEventDetail = {
 	item: UploadCollectionItem,
 };
 
@@ -303,11 +303,11 @@ class UploadCollection extends UI5Element {
 		this._dndOverlayMode = UploadCollectionDnDOverlayMode.Drag;
 	}
 
-	_onItemDelete(e: CustomEvent<ItemDeleteEventDetail>) {
+	_onItemDelete(e: CustomEvent<UploadCollectionItemDeleteEventDetail>) {
 		this.fireEvent("item-delete", { item: e.detail.item });
 	}
 
-	_onSelectionChange(e: CustomEvent<SelectionChangeEventDetail>) {
+	_onSelectionChange(e: CustomEvent<UploadCollectionSelectionChangeEventDetail>) {
 		this.fireEvent("selection-change", { selectedItems: e.detail.selectedItems });
 	}
 
@@ -369,3 +369,7 @@ class UploadCollection extends UI5Element {
 UploadCollection.define();
 
 export default UploadCollection;
+export type {
+	UploadCollectionItemDeleteEventDetail,
+	UploadCollectionSelectionChangeEventDetail,
+};

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -12,7 +12,7 @@ import Button from "@ui5/webcomponents/dist/Button.js";
 import Label from "@ui5/webcomponents/dist/Label.js";
 import GroupHeaderListItem from "@ui5/webcomponents/dist/GroupHeaderListItem.js";
 import List from "@ui5/webcomponents/dist/List.js";
-import type { ClickEventDetail } from "@ui5/webcomponents/dist/List.js";
+import type { ListItemClickEventDetail } from "@ui5/webcomponents/dist/List.js";
 import StandardListItem from "@ui5/webcomponents/dist/StandardListItem.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
 import SegmentedButton from "@ui5/webcomponents/dist/SegmentedButton.js";
@@ -55,7 +55,12 @@ type VSDSettings = {
 }
 
 // Events' detail
-type VSDEventDetail = VSDSettings & {
+type ViewSettingsDialogConfirmEventDetail = VSDSettings & {
+	sortByItem: SortItem,
+	sortDescending: boolean,
+}
+
+type ViewSettingsDialogCancelEventDetail = VSDSettings & {
 	sortByItem: SortItem,
 	sortDescending: boolean,
 }
@@ -516,7 +521,7 @@ class ViewSettingsDialog extends UI5Element {
 		this._currentMode = ViewSettingsDialogMode[mode];
 	}
 
-	_handleFilterValueItemClick(e: CustomEvent<ClickEventDetail>) {
+	_handleFilterValueItemClick(e: CustomEvent<ListItemClickEventDetail>) {
 		// Update the component state
 		this._currentSettings.filters = this._currentSettings.filters.map(filter => {
 			if (filter.selected) {
@@ -536,7 +541,7 @@ class ViewSettingsDialog extends UI5Element {
 		this._filterStepTwo = false;
 	}
 
-	_changeCurrentFilter(e: CustomEvent<ClickEventDetail>) {
+	_changeCurrentFilter(e: CustomEvent<ListItemClickEventDetail>) {
 		this._filterStepTwo = true;
 		this._currentSettings.filters = this._currentSettings.filters.map(filter => {
 			filter.selected = filter.text === e.detail.item.innerText;
@@ -572,7 +577,7 @@ class ViewSettingsDialog extends UI5Element {
 		this.close();
 		this._confirmedSettings = this._currentSettings;
 
-		this.fireEvent<VSDEventDetail>("confirm", this.eventsParams);
+		this.fireEvent<ViewSettingsDialogConfirmEventDetail>("confirm", this.eventsParams);
 	}
 
 	/**
@@ -581,7 +586,7 @@ class ViewSettingsDialog extends UI5Element {
 	_cancelSettings() {
 		this._restoreSettings(this._confirmedSettings);
 
-		this.fireEvent<VSDEventDetail>("cancel", this.eventsParams);
+		this.fireEvent<ViewSettingsDialogCancelEventDetail>("cancel", this.eventsParams);
 		this.close();
 	}
 
@@ -659,7 +664,7 @@ class ViewSettingsDialog extends UI5Element {
 	/**
 	 * Stores <code>Sort Order</code> list as recently used control and its selected item in current state.
 	 */
-	_onSortOrderChange(e: CustomEvent<ClickEventDetail>) {
+	_onSortOrderChange(e: CustomEvent<ListItemClickEventDetail>) {
 		this._recentlyFocused = this._sortOrder!;
 		this._currentSettings.sortOrder = this.initSortOrderItems.map(item => {
 			item.selected = item.text === e.detail.item.innerText;
@@ -673,7 +678,7 @@ class ViewSettingsDialog extends UI5Element {
 	/**
 	 * Stores <code>Sort By</code> list as recently used control and its selected item in current state.
 	 */
-	 _onSortByChange(e: CustomEvent<ClickEventDetail>) {
+	 _onSortByChange(e: CustomEvent<ListItemClickEventDetail>) {
 		const selectedItemIndex = Number(e.detail.item.getAttribute("data-ui5-external-action-item-index"));
 		this._recentlyFocused = this._sortBy!;
 		this._currentSettings.sortBy = this.initSortByItems.map((item, index) => {
@@ -749,5 +754,6 @@ ViewSettingsDialog.define();
 
 export default ViewSettingsDialog;
 export type {
-	VSDEventDetail,
+	ViewSettingsDialogConfirmEventDetail,
+	ViewSettingsDialogCancelEventDetail,
 };

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -32,7 +32,7 @@ import type { LinkClickEventDetail } from "./Link.js";
 import Label from "./Label.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import List from "./List.js";
-import type { SelectionChangeEventDetail } from "./List.js";
+import type { ListSelectionChangeEventDetail } from "./List.js";
 import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
@@ -407,7 +407,7 @@ class Breadcrumbs extends UI5Element {
 	_onLinkPress(e: CustomEvent<LinkClickEventDetail>) {
 		const link = e.target as Link,
 			items = this._getItems(),
-			item = items.find(x => `${x._id}-link` === link.id),
+			item = items.find(x => `${x._id}-link` === link.id)!,
 			{
 				altKey,
 				ctrlKey,
@@ -415,7 +415,7 @@ class Breadcrumbs extends UI5Element {
 				shiftKey,
 			} = e.detail;
 
-		if (!this.fireEvent("item-click", {
+		if (!this.fireEvent<BreadcrumbsItemClickEventDetail>("item-click", {
 			item,
 			altKey,
 			ctrlKey,
@@ -445,7 +445,7 @@ class Breadcrumbs extends UI5Element {
 		});
 	}
 
-	_onOverflowListItemSelect(e: CustomEvent<SelectionChangeEventDetail>) {
+	_onOverflowListItemSelect(e: CustomEvent<ListSelectionChangeEventDetail>) {
 		const listItem = e.detail.selectedItems[0],
 			items = this._getItems(),
 			item = items.find(x => `${x._id}-li` === listItem.id)!;
@@ -663,3 +663,6 @@ class Breadcrumbs extends UI5Element {
 Breadcrumbs.define();
 
 export default Breadcrumbs;
+export type {
+	BreadcrumbsItemClickEventDetail,
+};

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -45,7 +45,7 @@ interface ICalendarPicker {
 	_lastYear?: number,
 }
 
-type CalendarChangeEventDetail = {
+type CalendarSelectedDatesChangeEventDetail = {
 	values: Array<string>,
 	dates: Array<number>,
 	timestamp: number | undefined,
@@ -441,7 +441,7 @@ class Calendar extends CalendarPart {
 			return this.getFormat().format(calendarDate.toUTCJSDate(), true);
 		});
 
-		const defaultPrevented = !this.fireEvent<CalendarChangeEventDetail>("selected-dates-change", { timestamp: this.timestamp, dates: [...selectedDates], values: datesValues }, true);
+		const defaultPrevented = !this.fireEvent<CalendarSelectedDatesChangeEventDetail>("selected-dates-change", { timestamp: this.timestamp, dates: [...selectedDates], values: datesValues }, true);
 		if (!defaultPrevented) {
 			this._setSelectedDates(selectedDates);
 		}
@@ -517,5 +517,5 @@ Calendar.define();
 export default Calendar;
 export type {
 	ICalendarPicker,
-	CalendarChangeEventDetail,
+	CalendarSelectedDatesChangeEventDetail,
 };

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -68,7 +68,7 @@ import Icon from "./Icon.js";
 import Popover from "./Popover.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import List from "./List.js";
-import type { ClickEventDetail } from "./List.js";
+import type { ListItemClickEventDetail } from "./List.js";
 import BusyIndicator from "./BusyIndicator.js";
 import Button from "./Button.js";
 import StandardListItem from "./StandardListItem.js";
@@ -1013,7 +1013,7 @@ class ComboBox extends UI5Element {
 		e.preventDefault();
 	}
 
-	_selectItem(e: CustomEvent<ClickEventDetail>) {
+	_selectItem(e: CustomEvent<ListItemClickEventDetail>) {
 		const listItem = e.detail.item as ComboBoxListItem;
 
 		this._selectedItemText = listItem.mappedItem.text;

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -55,9 +55,14 @@ import datePickerPopoverCss from "./generated/themes/DatePickerPopover.css.js";
 import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverCommon.css.js";
 
 type DatePickerChangeEventDetail = {
-	dates: Array<number>;
-	values: Array<string>
-};
+	value: string,
+	valid: boolean,
+}
+
+type DatePickerInputEventDetail = {
+	value: string,
+	valid: boolean,
+}
 
 /**
  * @class
@@ -545,7 +550,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 		}
 
 		events.forEach((e: string) => {
-			if (!this.fireEvent(e, { value, valid }, true)) {
+			if (!this.fireEvent<DatePickerChangeEventDetail>(e, { value, valid }, true)) {
 				executeEvent = false;
 			}
 		});
@@ -876,5 +881,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 DatePicker.define();
 
 export default DatePicker;
-
-export type { DatePickerChangeEventDetail };
+export type {
+	DatePickerChangeEventDetail,
+	DatePickerInputEventDetail,
+};

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -39,7 +39,7 @@ import Icon from "./Icon.js";
 import Button from "./Button.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import Calendar from "./Calendar.js";
-import type { CalendarChangeEventDetail } from "./Calendar.js";
+import type { CalendarSelectedDatesChangeEventDetail } from "./Calendar.js";
 import CalendarDateComponent from "./CalendarDate.js";
 import Input from "./Input.js";
 import InputType from "./types/InputType.js";
@@ -764,7 +764,7 @@ class DatePicker extends DateComponentBase implements IFormElement {
 	 * @param event
 	 * @protected
 	 */
-	onSelectedDatesChange(e: CustomEvent<CalendarChangeEventDetail>) {
+	onSelectedDatesChange(e: CustomEvent<CalendarSelectedDatesChangeEventDetail>) {
 		e.preventDefault();
 		const newValue = e.detail.values && e.detail.values[0];
 		this._updateValueAndFireEvents(newValue, true, ["change", "value-changed"]);

--- a/packages/main/src/DateRangePicker.ts
+++ b/packages/main/src/DateRangePicker.ts
@@ -9,8 +9,13 @@ import { DATERANGE_DESCRIPTION } from "./generated/i18n/i18n-defaults.js";
 // Styles
 import DateRangePickerCss from "./generated/themes/DateRangePicker.css.js";
 import DatePicker from "./DatePicker.js";
-import type { DatePickerChangeEventDetail } from "./DatePicker.js";
 import CalendarPickersMode from "./types/CalendarPickersMode.js";
+
+import type {
+	DatePickerChangeEventDetail as DateRangePickerChangeEventDetail,
+	DatePickerInputEventDetail as DateRangePickerInputEventDetail,
+} from "./DatePicker.js";
+import type { CalendarSelectedDatesChangeEventDetail } from "./Calendar.js";
 
 /**
  * @class
@@ -233,7 +238,7 @@ class DateRangePicker extends DatePicker {
 	/**
 	 * @override
 	 */
-	onSelectedDatesChange(event: CustomEvent<DatePickerChangeEventDetail>) {
+	onSelectedDatesChange(event: CustomEvent<CalendarSelectedDatesChangeEventDetail>) {
 		event.preventDefault(); // never let the calendar update its own dates, the parent component controls them
 		const values = event.detail.values;
 
@@ -368,3 +373,7 @@ class DateRangePicker extends DatePicker {
 DateRangePicker.define();
 
 export default DateRangePicker;
+export type {
+	DateRangePickerChangeEventDetail,
+	DateRangePickerInputEventDetail,
+};

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -12,7 +12,7 @@ import type ResponsivePopover from "./ResponsivePopover.js";
 import ToggleButton from "./ToggleButton.js";
 import SegmentedButton from "./SegmentedButton.js";
 import Calendar from "./Calendar.js";
-import type { CalendarChangeEventDetail } from "./Calendar.js";
+import type { CalendarSelectedDatesChangeEventDetail } from "./Calendar.js";
 import DatePicker from "./DatePicker.js";
 import TimeSelection from "./TimeSelection.js";
 import type { TimeSelectionChangeEventDetail, TimeSelectionSliderChangeEventDetail } from "./TimeSelection.js";
@@ -308,7 +308,7 @@ class DateTimePicker extends DatePicker {
 	/**
 	 * @override
 	 */
-	onSelectedDatesChange(e: CustomEvent<CalendarChangeEventDetail>) {
+	onSelectedDatesChange(e: CustomEvent<CalendarSelectedDatesChangeEventDetail>) {
 		e.preventDefault();
 		// @ts-ignore Needed for FF
 		const dateTimePickerContent = e.path ? e.path[1] : e.composedPath()[1];

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -14,6 +14,10 @@ import SegmentedButton from "./SegmentedButton.js";
 import Calendar from "./Calendar.js";
 import type { CalendarSelectedDatesChangeEventDetail } from "./Calendar.js";
 import DatePicker from "./DatePicker.js";
+import type {
+	DatePickerChangeEventDetail as DateTimePickerChangeEventDetail,
+	DatePickerInputEventDetail as DateTimePickerInputEventDetail,
+} from "./DatePicker.js";
 import TimeSelection from "./TimeSelection.js";
 import type { TimeSelectionChangeEventDetail, TimeSelectionSliderChangeEventDetail } from "./TimeSelection.js";
 
@@ -429,3 +433,7 @@ class DateTimePicker extends DatePicker {
 DateTimePicker.define();
 
 export default DateTimePicker;
+export type {
+	DateTimePickerChangeEventDetail,
+	DateTimePickerInputEventDetail,
+};

--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -9,6 +9,7 @@ import {
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import Popup from "./Popup.js";
+import type { PopupBeforeCloseEventDetail as DialogBeforeCloseEventDetail } from "./Popup.js";
 import Icon from "./Icon.js";
 import "@ui5/webcomponents-icons/dist/resize-corner.js";
 import "@ui5/webcomponents-icons/dist/error.js";
@@ -703,3 +704,6 @@ class Dialog extends Popup {
 Dialog.define();
 
 export default Dialog;
+export type {
+	DialogBeforeCloseEventDetail,
+};

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -34,6 +34,10 @@ import ValueStateMessageCss from "./generated/themes/ValueStateMessage.css.js";
 import type FormSupport from "./features/InputElementsFormSupport.js";
 import type { IFormElement } from "./features/InputElementsFormSupport.js";
 
+type FileUploaderChangeEventDetail = {
+	files: FileList | null,
+}
+
 /**
  * @class
  *
@@ -345,7 +349,7 @@ class FileUploader extends UI5Element implements IFormElement {
 		const changedFiles = (e.target as HTMLInputElement).files;
 
 		this._updateValue(changedFiles);
-		this.fireEvent("change", {
+		this.fireEvent<FileUploaderChangeEventDetail>("change", {
 			files: changedFiles,
 		});
 	}
@@ -509,3 +513,6 @@ class FileUploader extends UI5Element implements IFormElement {
 FileUploader.define();
 
 export default FileUploader;
+export type {
+	FileUploaderChangeEventDetail,
+};

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -116,16 +116,16 @@ type InputEventDetail = {
 	inputType?: string;
 }
 
-type SuggestionItemSelectEventDetail = {
+type InputSuggestionItemSelectEventDetail = {
 	item: SuggestionItem;
 }
 
-type SuggestionItemPreviewEventDetail = {
+type InputSuggestionItemPreviewEventDetail = {
 	item: SuggestionItem;
 	targetRef: SuggestionListItem;
 }
 
-type SuggestionScrollEventDetail = {
+type InputSuggestionScrollEventDetail = {
 	scrollTop: number;
 	scrollContainer: HTMLElement;
 }
@@ -1074,7 +1074,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	}
 
 	_scroll(e: CustomEvent<PopupScrollEventDetail>) {
-		this.fireEvent<SuggestionScrollEventDetail>("suggestion-scroll", {
+		this.fireEvent<InputSuggestionScrollEventDetail>("suggestion-scroll", {
 			scrollTop: e.detail.scrollTop,
 			scrollContainer: e.detail.targetRef,
 		});
@@ -1320,7 +1320,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		this.valueBeforeItemPreview = "";
 		this.suggestionSelectionCanceled = false;
 
-		this.fireEvent<SuggestionItemSelectEventDetail>(INPUT_EVENTS.SUGGESTION_ITEM_SELECT, { item });
+		this.fireEvent<InputSuggestionItemSelectEventDetail>(INPUT_EVENTS.SUGGESTION_ITEM_SELECT, { item });
 
 		this.isTyping = false;
 		this.openOnMobile = false;
@@ -1476,7 +1476,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 
 	onItemPreviewed(item: SuggestionListItem) {
 		this.previewSuggestion(item);
-		this.fireEvent<SuggestionItemPreviewEventDetail>("suggestion-item-preview", {
+		this.fireEvent<InputSuggestionItemPreviewEventDetail>("suggestion-item-preview", {
 			item: this.getSuggestionByListItem(item),
 			targetRef: item,
 		});
@@ -1785,7 +1785,7 @@ Input.define();
 
 export default Input;
 export type {
-	SuggestionScrollEventDetail,
-	SuggestionItemSelectEventDetail,
-	SuggestionItemPreviewEventDetail,
+	InputSuggestionScrollEventDetail,
+	InputSuggestionItemSelectEventDetail,
+	InputSuggestionItemPreviewEventDetail,
 };

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1784,3 +1784,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 Input.define();
 
 export default Input;
+export type {
+	SuggestionScrollEventDetail,
+	SuggestionItemSelectEventDetail,
+	SuggestionItemPreviewEventDetail,
+};

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -56,24 +56,34 @@ const INFINITE_SCROLL_DEBOUNCE_RATE = 250; // ms
 const PAGE_UP_DOWN_SIZE = 10;
 
 // ListItemBase-based events
-type FocusEventDetail = {
+type ListItemFocusEventDetail = {
 	item: ListItemBase,
 }
-type SelectionChangeEventDetail = {
+
+type ListSelectionChangeEventDetail = {
 	selectedItems: Array<ListItemBase>;
 	previouslySelectedItems: Array<ListItemBase>;
 	selectionComponentPressed: boolean;
 	targetItem: ListItemBase;
 	key?: string;
 }
-type DeleteEventDetail = FocusEventDetail;
 
-// ListItem-based events
-type CloseEventDetail = {
+type ListItemDeleteEventDetail = {
 	item: ListItemBase,
 }
-type ToggleEventDetail = CloseEventDetail;
-type ClickEventDetail = CloseEventDetail;
+
+// ListItem-based events
+type ListItemCloseEventDetail = {
+	item: ListItemBase,
+}
+
+type ListItemToggleEventDetail = {
+	item: ListItemBase,
+}
+
+type ListItemClickEventDetail = {
+	item: ListItemBase,
+}
 
 /**
  * @class
@@ -718,7 +728,7 @@ class List extends UI5Element {
 		}
 
 		if (selectionChange) {
-			const changePrevented = !this.fireEvent<SelectionChangeEventDetail>("selection-change", {
+			const changePrevented = !this.fireEvent<ListSelectionChangeEventDetail>("selection-change", {
 				selectedItems: this.getSelectedItems(),
 				previouslySelectedItems,
 				selectionComponentPressed: e.detail.selectionComponentPressed,
@@ -760,7 +770,7 @@ class List extends UI5Element {
 	}
 
 	handleDelete(item: ListItemBase): boolean {
-		this.fireEvent<DeleteEventDetail>("item-delete", { item });
+		this.fireEvent<ListItemDeleteEventDetail>("item-delete", { item });
 
 		return true;
 	}
@@ -943,7 +953,7 @@ class List extends UI5Element {
 		e.stopPropagation();
 
 		this._itemNavigation.setCurrentItem(target);
-		this.fireEvent<FocusEventDetail>("item-focused", { item: target });
+		this.fireEvent<ListItemFocusEventDetail>("item-focused", { item: target });
 
 		if (this.mode === ListMode.SingleSelectAuto) {
 			const detail: SelectionRequestEventDetail = {
@@ -960,7 +970,7 @@ class List extends UI5Element {
 	onItemPress(e: CustomEvent<PressEventDetail>) {
 		const pressedItem = e.detail.item;
 
-		if (!this.fireEvent<ClickEventDetail>("item-click", { item: pressedItem }, true)) {
+		if (!this.fireEvent<ListItemClickEventDetail>("item-click", { item: pressedItem }, true)) {
 			return;
 		}
 
@@ -980,12 +990,12 @@ class List extends UI5Element {
 	}
 
 	// This is applicable to NotificationListItem
-	onItemClose(e: CustomEvent<CloseEventDetail>) {
-		this.fireEvent<CloseEventDetail>("item-close", { item: e.detail.item });
+	onItemClose(e: CustomEvent<ListItemCloseEventDetail>) {
+		this.fireEvent<ListItemCloseEventDetail>("item-close", { item: e.detail.item });
 	}
 
-	onItemToggle(e: CustomEvent<ToggleEventDetail>) {
-		this.fireEvent<ToggleEventDetail>("item-toggle", { item: e.detail.item });
+	onItemToggle(e: CustomEvent<ListItemToggleEventDetail>) {
+		this.fireEvent<ListItemToggleEventDetail>("item-toggle", { item: e.detail.item });
 	}
 
 	onForwardBefore(e: CustomEvent) {
@@ -1141,10 +1151,10 @@ List.define();
 
 export default List;
 export type {
-	ClickEventDetail,
-	FocusEventDetail,
-	DeleteEventDetail,
-	CloseEventDetail,
-	ToggleEventDetail,
-	SelectionChangeEventDetail,
+	ListItemClickEventDetail,
+	ListItemFocusEventDetail,
+	ListItemDeleteEventDetail,
+	ListItemCloseEventDetail,
+	ListItemToggleEventDetail,
+	ListSelectionChangeEventDetail,
 };

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -27,7 +27,7 @@ import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import BusyIndicator from "./BusyIndicator.js";
 import type MenuItem from "./MenuItem.js";
-import type { ClickEventDetail } from "./List.js";
+import type { ListItemClickEventDetail } from "./List.js";
 import staticAreaMenuTemplate from "./generated/templates/MenuTemplate.lit.js";
 import {
 	MENU_BACK_BUTTON_ARIA_LABEL,
@@ -586,7 +586,7 @@ class Menu extends UI5Element {
 		}
 	}
 
-	_itemClick(e: CustomEvent<ClickEventDetail>) {
+	_itemClick(e: CustomEvent<ListItemClickEventDetail>) {
 		const opener = e.detail.item as OpenerStandardListItem;
 		const item = opener.associatedItem;
 		const actionId = opener.getAttribute("id")!;

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -65,7 +65,7 @@ import Icon from "./Icon.js";
 import Popover from "./Popover.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import List from "./List.js";
-import type { SelectionChangeEventDetail } from "./List.js";
+import type { ListSelectionChangeEventDetail } from "./List.js";
 import StandardListItem from "./StandardListItem.js";
 import ToggleButton from "./ToggleButton.js";
 import * as Filters from "./Filters.js";
@@ -1200,7 +1200,7 @@ class MultiComboBox extends UI5Element {
 		return this.selectedValues as Array<MultiComboBoxItem>;
 	}
 
-	_listSelectionChange(e: CustomEvent<SelectionChangeEventDetail>) {
+	_listSelectionChange(e: CustomEvent<ListSelectionChangeEventDetail>) {
 		// sync list items and cb items
 		this.syncItems((e.target as List).items);
 

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -169,7 +169,7 @@ class MultiInput extends Input {
 		}
 
 		selectedTokens.forEach(token => {
-			this.fireEvent("token-delete", { token });
+			this.fireEvent<MultiInputTokenDeleteEventDetail>("token-delete", { token });
 		});
 	}
 

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -22,6 +22,11 @@ import type { TokenizerTokenDeleteEventDetail } from "./Tokenizer.js";
 import Icon from "./Icon.js";
 import "@ui5/webcomponents-icons/dist/value-help.js";
 
+import type {
+	InputSuggestionItemSelectEventDetail as MultiInputSuggestionItemSelectEventDetail,
+	InputSuggestionItemPreviewEventDetail as MultiInputSuggestionItemPreviewEventDetail,
+} from "./Input.js";
+
 type MultiInputTokenDeleteEventDetail = {
 	token: Token;
 }
@@ -376,4 +381,8 @@ class MultiInput extends Input {
 MultiInput.define();
 
 export default MultiInput;
-export { MultiInputTokenDeleteEventDetail };
+export {
+	MultiInputTokenDeleteEventDetail,
+	MultiInputSuggestionItemSelectEventDetail,
+	MultiInputSuggestionItemPreviewEventDetail,
+};

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -8,6 +8,7 @@ import DOMReference from "@ui5/webcomponents-base/dist/types/DOMReference.js";
 import { getClosedPopupParent } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import clamp from "@ui5/webcomponents-base/dist/util/clamp.js";
 import Popup from "./Popup.js";
+import type { PopupBeforeCloseEventDetail as PopoverBeforeCloseEventDetail } from "./Popup.js";
 import PopoverPlacementType from "./types/PopoverPlacementType.js";
 import PopoverVerticalAlign from "./types/PopoverVerticalAlign.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
@@ -862,3 +863,7 @@ Popover.define();
 export default Popover;
 
 export { instanceOfPopover };
+
+export type {
+	PopoverBeforeCloseEventDetail,
+};

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -357,3 +357,6 @@ class SegmentedButton extends UI5Element {
 SegmentedButton.define();
 
 export default SegmentedButton;
+export type {
+	SegmentedButtonSelectionChangeEventDetail,
+};

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -33,7 +33,7 @@ import type { Timeout } from "@ui5/webcomponents-base/dist/types.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
 import List from "./List.js";
-import type { ClickEventDetail } from "./List.js";
+import type { ListItemClickEventDetail } from "./List.js";
 import {
 	VALUE_STATE_SUCCESS,
 	VALUE_STATE_INFORMATION,
@@ -605,7 +605,7 @@ class Select extends UI5Element implements IFormElement {
 	 * The user clicked on an item from the list
 	 * @private
 	 */
-	_handleItemPress(e: CustomEvent<ClickEventDetail>) {
+	_handleItemPress(e: CustomEvent<ListItemClickEventDetail>) {
 		const item = e.detail.item;
 		const selectedItemIndex = this._getSelectedItemIndex(item);
 

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -38,7 +38,7 @@ import Button from "./Button.js";
 import Icon from "./Icon.js";
 import List from "./List.js";
 import type Tab from "./Tab.js";
-import type { ClickEventDetail } from "./List.js";
+import type { ListItemClickEventDetail } from "./List.js";
 import type CustomListItem from "./CustomListItem.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import TabContainerTabsPlacement from "./types/TabContainerTabsPlacement.js";
@@ -647,7 +647,7 @@ class TabContainer extends UI5Element {
 		}
 	}
 
-	async _onOverflowListItemClick(e: CustomEvent<ClickEventDetail>) {
+	async _onOverflowListItemClick(e: CustomEvent<ListItemClickEventDetail>) {
 		e.preventDefault(); // cancel the item selection
 
 		this._onItemSelect(e.detail.item.id.slice(0, -3)); // strip "-li" from end of id

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -92,12 +92,12 @@ type TableColumnInfo = {
 
 type TableColumnHeaderInfo = ITabbable;
 
-type TableSelectionChangeEvent = {
+type TableSelectionChangeEventDetail = {
 	selectedRows: Array<ITableRow>,
 	previouslySelectedRows: Array<ITableRow>,
 }
 
-type TablePopinChangeEvent = {
+type TablePopinChangeEventDetail = {
 	poppedColumns: Array<TableColumnInfo>;
 }
 
@@ -735,7 +735,7 @@ class Table extends UI5Element {
 
 		const selectedRows = this.selectedRows;
 
-		this.fireEvent<TableSelectionChangeEvent>("selection-change", {
+		this.fireEvent<TableSelectionChangeEventDetail>("selection-change", {
 			selectedRows,
 			previouslySelectedRows,
 		});
@@ -767,7 +767,7 @@ class Table extends UI5Element {
 
 		const selectedRows: Array<ITableRow> = this.selectedRows;
 
-		this.fireEvent<TableSelectionChangeEvent>("selection-change", {
+		this.fireEvent<TableSelectionChangeEventDetail>("selection-change", {
 			selectedRows,
 			previouslySelectedRows,
 		});
@@ -1021,7 +1021,7 @@ class Table extends UI5Element {
 				}
 			});
 			row.selected = true;
-			this.fireEvent<TableSelectionChangeEvent>("selection-change", {
+			this.fireEvent<TableSelectionChangeEventDetail>("selection-change", {
 				selectedRows: [row],
 				previouslySelectedRows,
 			});
@@ -1046,7 +1046,7 @@ class Table extends UI5Element {
 			this._allRowsSelected = false;
 		}
 
-		this.fireEvent<TableSelectionChangeEvent>("selection-change", {
+		this.fireEvent<TableSelectionChangeEventDetail>("selection-change", {
 			selectedRows,
 			previouslySelectedRows,
 		});
@@ -1075,7 +1075,7 @@ class Table extends UI5Element {
 
 		const selectedRows = bAllSelected ? this.rows : [];
 
-		this.fireEvent<TableSelectionChangeEvent>("selection-change", {
+		this.fireEvent<TableSelectionChangeEventDetail>("selection-change", {
 			selectedRows,
 			previouslySelectedRows,
 		});
@@ -1155,7 +1155,7 @@ class Table extends UI5Element {
 		if (hiddenColumnsChange) {
 			this._hiddenColumns = hiddenColumns;
 			if (hiddenColumns.length) {
-				this.fireEvent<TablePopinChangeEvent>("popin-change", {
+				this.fireEvent<TablePopinChangeEventDetail>("popin-change", {
 					poppedColumns: this._hiddenColumns,
 				});
 			}
@@ -1289,6 +1289,6 @@ export type {
 	ITableRow,
 	TableColumnInfo,
 	TableRowClickEventDetail,
-	TableSelectionChangeEvent,
-	TablePopinChangeEvent,
+	TableSelectionChangeEventDetail,
+	TablePopinChangeEventDetail,
 };

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -36,6 +36,7 @@ import isElementInView from "@ui5/webcomponents-base/dist/util/isElementInView.j
 import TableGrowingMode from "./types/TableGrowingMode.js";
 import BusyIndicator from "./BusyIndicator.js";
 import type {
+	TableRowClickEventDetail,
 	TableRowSelectionRequestedEventDetail,
 	TableRowF7PressEventDetail,
 	TableRowForwardBeforeEventDetail,
@@ -1287,4 +1288,7 @@ export default Table;
 export type {
 	ITableRow,
 	TableColumnInfo,
+	TableRowClickEventDetail,
+	TableSelectionChangeEvent,
+	TablePopinChangeEvent,
 };

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -4,6 +4,11 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import TimePickerBase from "./TimePickerBase.js";
 
+import type {
+	TimePickerBaseChangeEventDetail as TimePickerChangeEventDetail,
+	TimePickerBaseInputEventDetail as TimePickerInputEventDetail,
+} from "./TimePickerBase.js";
+
 import {
 	TIMEPICKER_INPUT_DESCRIPTION,
 } from "./generated/i18n/i18n-defaults.js";
@@ -153,3 +158,7 @@ class TimePicker extends TimePickerBase {
 TimePicker.define();
 
 export default TimePicker;
+export type {
+	TimePickerChangeEventDetail,
+	TimePickerInputEventDetail,
+};

--- a/packages/main/src/TimePickerBase.ts
+++ b/packages/main/src/TimePickerBase.ts
@@ -44,6 +44,14 @@ import TimePickerCss from "./generated/themes/TimePicker.css.js";
 import TimePickerPopoverCss from "./generated/themes/TimePickerPopover.css.js";
 import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverCommon.css.js";
 
+type TimePickerBaseChangeInputEventDetail = {
+	value: string,
+	valid: boolean,
+}
+
+type TimePickerBaseChangeEventDetail = TimePickerBaseChangeInputEventDetail;
+type TimePickerBaseInputEventDetail = TimePickerBaseChangeInputEventDetail;
+
 /**
  * @class
  *
@@ -227,7 +235,7 @@ class TimePickerBase extends UI5Element {
 	}
 
 	submitPickers() {
-		this._updateValueAndFireEvents(this.tempValue, true, ["change", "value-changed"]);
+		this._updateValueAndFireEvents(this.tempValue!, true, ["change", "value-changed"]);
 		this.closePicker();
 	}
 
@@ -247,7 +255,7 @@ class TimePickerBase extends UI5Element {
 		}
 	}
 
-	_updateValueAndFireEvents(value: string | undefined, normalizeValue: boolean, eventsNames: Array<string>) {
+	_updateValueAndFireEvents(value: string, normalizeValue: boolean, eventsNames: Array<string>) {
 		if (value === this.value) {
 			return;
 		}
@@ -264,7 +272,7 @@ class TimePickerBase extends UI5Element {
 		this.tempValue = value; // if the picker is open, sync it
 		this._updateValueState(); // Change the value state to Error/None, but only if needed
 		eventsNames.forEach(eventName => {
-			this.fireEvent(eventName, { value, valid });
+			this.fireEvent<TimePickerBaseChangeInputEventDetail>(eventName, { value, valid });
 		});
 	}
 
@@ -492,3 +500,8 @@ class TimePickerBase extends UI5Element {
 }
 
 export default TimePickerBase;
+export type {
+	TimeSelectionChangeEventDetail,
+	TimePickerBaseChangeEventDetail,
+	TimePickerBaseInputEventDetail,
+};

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -16,9 +16,9 @@ import type {
 	TreeItemBaseStepOutEventDetail,
 } from "./TreeItemBase.js";
 import type {
-	ClickEventDetail as ListItemClickEventDetail,
-	DeleteEventDetail as ListItemDeleteEventDetail,
-	SelectionChangeEventDetail as ListSelectionChangeEventDetail,
+	ListItemClickEventDetail,
+	ListItemDeleteEventDetail,
+	ListSelectionChangeEventDetail,
 } from "./List.js";
 
 // Template

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -35,7 +35,7 @@ type TreeItemMouseoverEventDetail = TreeItemEventDetail;
 type TreeItemMouseoutEventDetail = TreeItemEventDetail;
 type TreeItemClickEventDetail = TreeItemEventDetail;
 type TreeItemDeleteEventDetail = TreeItemEventDetail;
-type TreeItemSelectionChangeEventDetail = {
+type TreeSelectionChangeEventDetail = {
 	selectedItems: Array<TreeItemBase>;
 	previouslySelectedItems: Array<TreeItemBase>;
 	targetItem: TreeItemBase;
@@ -426,7 +426,7 @@ class Tree extends UI5Element {
 			item.selected = true;
 		});
 
-		this.fireEvent<TreeItemSelectionChangeEventDetail>("selection-change", {
+		this.fireEvent<TreeSelectionChangeEventDetail>("selection-change", {
 			previouslySelectedItems,
 			selectedItems,
 			targetItem,
@@ -511,5 +511,5 @@ export type {
 	TreeItemMouseoutEventDetail,
 	TreeItemClickEventDetail,
 	TreeItemDeleteEventDetail,
-	TreeItemSelectionChangeEventDetail,
+	TreeSelectionChangeEventDetail,
 };

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -7,7 +7,7 @@ import encodeXML from "@ui5/webcomponents-base/dist/sap/base/security/encodeXML.
 import generateHighlightedMarkup from "@ui5/webcomponents-base/dist/util/generateHighlightedMarkup.js";
 import type ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import List from "../List.js";
-import type { ClickEventDetail, SelectionChangeEventDetail } from "../List.js";
+import type { ListItemClickEventDetail, ListSelectionChangeEventDetail } from "../List.js";
 import ResponsivePopover from "../ResponsivePopover.js";
 import SuggestionItem from "../SuggestionItem.js";
 import SuggestionGroupItem from "../SuggestionGroupItem.js";
@@ -75,7 +75,7 @@ class Suggestions {
 	_handledPress?: boolean;
 	attachedAfterOpened?: boolean;
 	attachedAfterClose?: boolean;
-	fnOnSuggestionItemPress: (e: CustomEvent<ClickEventDetail | SelectionChangeEventDetail>) => void;
+	fnOnSuggestionItemPress: (e: CustomEvent<ListItemClickEventDetail | ListSelectionChangeEventDetail>) => void;
 	fnOnSuggestionItemMouseOver: (e: MouseEvent) => void;
 	fnOnSuggestionItemMouseOut: (e: MouseEvent) => void;
 	static i18nBundle: I18nBundle;
@@ -310,21 +310,21 @@ class Suggestions {
 
 	/* Private methods */
 	// Note: Split into two separate handlers
-	onItemPress(e: CustomEvent<ClickEventDetail | SelectionChangeEventDetail>) {
+	onItemPress(e: CustomEvent<ListItemClickEventDetail | ListSelectionChangeEventDetail>) {
 		let pressedItem: ListItemBase; // SuggestionListItem
 		const isPressEvent = e.type === "ui5-item-click";
 
 		// Only use the press e if the item is already selected, in all other cases we are listening for 'ui5-selection-change' from the list
 		// Also we have to check if the selection-change is fired by the list's 'item-click' event handling, to avoid double handling on our side
-		if ((isPressEvent && !(e.detail as ClickEventDetail).item.selected) || (this._handledPress && !isPressEvent)) {
+		if ((isPressEvent && !(e.detail as ListItemClickEventDetail).item.selected) || (this._handledPress && !isPressEvent)) {
 			return;
 		}
 
-		if (isPressEvent && (e.detail as ClickEventDetail).item.selected) {
-			pressedItem = (e.detail as ClickEventDetail).item;
+		if (isPressEvent && (e.detail as ListItemClickEventDetail).item.selected) {
+			pressedItem = (e.detail as ListItemClickEventDetail).item;
 			this._handledPress = true;
 		} else {
-			pressedItem = (e.detail as SelectionChangeEventDetail).selectedItems[0];
+			pressedItem = (e.detail as ListSelectionChangeEventDetail).selectedItems[0];
 		}
 
 		this.onItemSelected(pressedItem as SuggestionListItem, false /* keyboardUsed */);


### PR DESCRIPTION
The PR addresses inconsistencies with event detail types: missing types, wrong naming or missing exports of types:
- add missing event detail types
- rename existing  types to follow the convention: `type {ComponentName}{EventName}EventDetail = {}`
- export all event detail types
- re-export event detail types of base classes from child classes (see DateTimePicker, DateRangePicker)

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7118