### PR TITLE
docs(ui5-file-uploader): improve accessibility showcase for samples

### DIFF
--- a/packages/main/test/samples/FileUploader.sample.html
+++ b/packages/main/test/samples/FileUploader.sample.html
@@ -22,10 +22,11 @@
 <div class="control-tag">&lt;ui5-file-uploader&gt;</div>
 
 <section>
-	<h3>Upload multiple images</h3>
+	<h3>Image Uploader</h3>
 	<div class="snippet">
+		<ui5-label id="image-uploader-ref">Handles multiple image files</ui5-label>
 		<ui5-file-uploader id="fileuploader1" accept="image/*" multiple="true">
-			<ui5-button icon="upload">Upload Images</ui5-button>
+			<ui5-button icon="upload" accessible-name-ref="image-uploader-ref">Upload Images</ui5-button>
 		</ui5-file-uploader>
 		<div id="result"></div>
 		<script>
@@ -86,10 +87,11 @@
 </section>
 
 <section>
-	<h3>Upload Single File</h3>
+	<h3>Single File Uploader</h3>
 	<div class="snippet">
+		<ui5-label id="single-file-uploader-ref">Handles a single file</ui5-label>
 		<ui5-file-uploader>
-			<ui5-button>Upload Single File</ui5-button>
+			<ui5-button accessible-name-ref="single-file-uploader-ref">Upload Single File</ui5-button>
 		</ui5-file-uploader>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
@@ -100,10 +102,11 @@
 </section>
 
 <section>
-	<h3>File Uploader With No Input</h3>
+	<h3>Hidden Input Uploader</h3>
 	<div class="snippet">
+		<ui5-label id="hidden-input-uploader-ref">File uploader with button only shown</ui5-label>
 		<ui5-file-uploader hide-input>
-			<ui5-button>Upload File</ui5-button>
+			<ui5-button accessible-name-ref="hidden-input-uploader-ref">Upload File</ui5-button>
 		</ui5-file-uploader>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>


### PR DESCRIPTION
As there are ongoing discussions regarding the inclusion of the new property **`accessibleNameRef`** in our **`ui5-file-uploader`** component, we have decided to enhance the accessibility aspects of the component's samples. This improvement involves providing instructions on utilizing the accessibility features by incorporating them into the examples. However, if the decision is made to include the mentioned property, the samples might need to be updated again.

Part of: #5893