### PR TITLE
chore: fix import to "Tent" illustration

### DIFF
--- a/packages/fiori/src/UploadCollection.hbs
+++ b/packages/fiori/src/UploadCollection.hbs
@@ -16,7 +16,7 @@
 		</ui5-list>
 		{{#if _showNoData}}
 			<div class="{{classes.noFiles}}">
-				<ui5-illustrated-message name="Tent">
+				<ui5-illustrated-message name="Tent" size="Scene">
 					<ui5-title slot="title" class="title" level="H2">{{_noDataText}}</ui5-title>
 					<span slot="subtitle" class="subtitle">{{_noDataDescription}}</span>
 				</ui5-illustrated-message>

--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -12,7 +12,7 @@ import List from "@ui5/webcomponents/dist/List.js";
 import ListMode from "@ui5/webcomponents/dist/types/ListMode.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
 import IllustratedMessage from "./IllustratedMessage.js";
-import "./illustrations/sapIllus-Scene-Tent.js";
+import "./illustrations/Tent.js";
 import "@ui5/webcomponents-icons/dist/upload-to-cloud.js";
 import "@ui5/webcomponents-icons/dist/document.js";
 import {


### PR DESCRIPTION
The import to the Tent illustration was wrong. Previously the import used to include the **"sapIllus-Scene-Tent.js"** which is the illustration just for one of the sizes (the illustration changes on resize). However, we need to import the top-level module **"Tent.js"** as it's the one to register the illustration "Tent" in the illustration registry.
And to force the "Scene" size, we can set it directly in the template as the IllustratedMessage provides a property for it - "size".

In the test pages and the playground sample we have all illustrations as part of the bundle, so the problem can't be seen - it does not matter if it's written as before or even if we don't add the import at all, the illustration will be displayed.
However, in real-case apps where the app imports only the things that are used, the illustration won't be imported properly and error will be thrown:
```sh
Error: No loader registered for the Tent illustration. Probably you forgot to import the "@ui5/webcomponents-fiori/dist/illustrations/Tent.js" module. Or you can import the "@ui5/webcomponents-fiori/dist/illustrations/AllIllustrations.js" module that will make all illustrations available, but fetch only the ones used.
```