### PR TITLE
docs(playground): use copy of attributes array for API filter

### DIFF
--- a/packages/playground/.storybook/addons/html/processors/AttributeProcessor.ts
+++ b/packages/playground/.storybook/addons/html/processors/AttributeProcessor.ts
@@ -21,7 +21,7 @@ export class AttributeProcessor implements IProcessor {
     }
 
     private removeAttributes(node: HTMLElement): void {
-        const attributes = node.attributes;
+        const attributes = Array.from(node.attributes)
 
         for (let attribute of attributes) {
             if (this.test(attribute)) {

--- a/packages/playground/.storybook/addons/html/processors/AttributeProcessor.ts
+++ b/packages/playground/.storybook/addons/html/processors/AttributeProcessor.ts
@@ -21,7 +21,7 @@ export class AttributeProcessor implements IProcessor {
     }
 
     private removeAttributes(node: HTMLElement): void {
-        const attributes = Array.from(node.attributes)
+        const attributes = Array.from(node.attributes);
 
         for (let attribute of attributes) {
             if (this.test(attribute)) {


### PR DESCRIPTION
Related to: #7035

Working with a copy of the attributes array fixes an issue of wrong indexing and randomly skipping to filter the private APIs 