### PR TITLE
fix(ui5-bar): apply correct box-shadow parameter

### DIFF
--- a/packages/fiori/src/themes/Bar.css
+++ b/packages/fiori/src/themes/Bar.css
@@ -2,7 +2,7 @@
 	background-color: var(--sapPageHeader_Background);
 	height: var(--_ui5_bar_base_height);
 	width: 100%;
-	box-shadow: inset 0 -0.0625rem var(--sapPageHeader_BorderColor);
+	box-shadow: var(--sapContent_HeaderShadow);
 	display: block;
 }
 


### PR DESCRIPTION
With this change we apply the correct value to the `box-shadow` property in our `<ui5-bar>` component, according to latest specifications.

Fixes: #6150