### PR TITLE
fix(ui5-textarea, ui5-select): collision of 'popover' property with Google Chrome 

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -301,7 +301,7 @@ class Select extends UI5Element implements IFormElement {
 	_typingTimeoutID?: Timeout | number;
 	responsivePopover!: ResponsivePopover;
 	selectedItem?: string | null;
-	popover?: Popover;
+	valueStatePopover?: Popover;
 	value!: string;
 
 	/**
@@ -876,14 +876,14 @@ class Select extends UI5Element implements IFormElement {
 	}
 
 	async openValueStatePopover() {
-		this.popover = await this._getPopover() as Popover;
-		if (this.popover) {
-			this.popover.showAt(this);
+		this.valueStatePopover = await this._getPopover() as Popover;
+		if (this.valueStatePopover) {
+			this.valueStatePopover.showAt(this);
 		}
 	}
 
 	closeValueStatePopover() {
-		this.popover && this.popover.close();
+		this.valueStatePopover && this.valueStatePopover.close();
 	}
 
 	toggleValueStatePopover(open: boolean) {

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -508,13 +508,11 @@ class TextArea extends UI5Element implements IFormElement {
 	}
 
 	async openPopover() {
-		this.popover = await this._getPopover();
-		this.popover && await this.popover.showAt(this.shadowRoot!.querySelector(".ui5-textarea-root .ui5-textarea-wrapper")!);
+		(await this._getPopover())?.showAt(this.shadowRoot!.querySelector(".ui5-textarea-root .ui5-textarea-wrapper")!);
 	}
 
 	async closePopover() {
-		this.popover = await this._getPopover();
-		this.popover && this.popover.close();
+		(await this._getPopover())?.close();
 	}
 
 	async _getPopover() {

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -374,7 +374,7 @@ class TextArea extends UI5Element implements IFormElement {
 	_keyDown?: boolean;
 	FormSupport?: typeof FormSupportT;
 	previousValue: string;
-	popover?: Popover;
+	valueStatePopover?: Popover;
 
 	static i18nBundle: I18nBundle;
 
@@ -508,11 +508,13 @@ class TextArea extends UI5Element implements IFormElement {
 	}
 
 	async openPopover() {
-		(await this._getPopover())?.showAt(this.shadowRoot!.querySelector(".ui5-textarea-root .ui5-textarea-wrapper")!);
+		this.valueStatePopover = await this._getPopover();
+		this.valueStatePopover && await this.valueStatePopover.showAt(this.shadowRoot!.querySelector(".ui5-textarea-root .ui5-textarea-wrapper")!);
 	}
 
 	async closePopover() {
-		(await this._getPopover())?.close();
+		this.valueStatePopover = await this._getPopover();
+		this.valueStatePopover && this.valueStatePopover.close();
 	}
 
 	async _getPopover() {


### PR DESCRIPTION
New property popover is released with Google Chrome version 1.114. This new property collides with our current existing class members and this collision leads to errors that block the whole page.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover

FIXES: #7147 