### PR TITLE
fix(ui5-static-area-item): element additional properties

### DIFF
--- a/packages/base/src/StaticAreaItem.ts
+++ b/packages/base/src/StaticAreaItem.ts
@@ -42,11 +42,15 @@ class StaticAreaItem extends HTMLElement {
 	 */
 	update() {
 		if (this._rendered) {
-			this._updateAdditionalAttrs();
-			this._updateContentDensity();
-			this._updateDirection();
+			this.updateAdditionalProperties();
 			updateShadowRoot(this.ownerElement!, true);
 		}
+	}
+
+	updateAdditionalProperties() {
+		this._updateAdditionalAttrs();
+		this._updateContentDensity();
+		this._updateDirection();
 	}
 
 	/**
@@ -86,7 +90,7 @@ class StaticAreaItem extends HTMLElement {
 	 * Returns reference to the DOM element where the current fragment is added.
 	 */
 	async getDomRef() {
-		this._updateContentDensity();
+		this.updateAdditionalProperties();
 		if (!this._rendered) {
 			this._rendered = true;
 			updateShadowRoot(this.ownerElement!, true);


### PR DESCRIPTION
When static area item's getDomRef function is used, it updates only content density related properties. All other properties like scoping attribute or runtime index attribute are added / updated only when the owner of the static area item owner is updated. With this change we made all properties to be properly updated.