### PR TITLE
docs(ui5-split-button): provide an example for opening a menu

### DIFF
--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
 
 	<title>ui5-split-button</title>
@@ -70,6 +70,23 @@
 	<h3>Test textContent</h3>
 	<ui5-split-button id="emptySpBtn" design="Default"></ui5-split-button>
 	<ui5-split-button id="defaultSpBtn" design="Default">Default</ui5-split-button>
+	<ui5-split-button id="splitBtnWithMenuDefaultActionDefaultAction" design="Default">
+		openMenu		
+	</ui5-split-button>
+	<ui5-menu id="menu">
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
+	</ui5-menu>
+
+	<ui5-split-button id="splitBtnWithMenuWithAssociatedLastAction" design="Default">
+		openMenu
+	</ui5-split-button>
+
+	<ui5-menu id="menuInSplitBtnAssociatedLastAction">
+		<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+		<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+		<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+	</ui5-menu>
 
 </body>
 <script>
@@ -80,6 +97,20 @@
 	document.querySelectorAll("ui5-split-button").forEach(function(item) {
 		item.addEventListener("ui5-click", displayEventDetails);
 		item.addEventListener("ui5-arrow-click", displayEventDetails);
+	});
+
+	splitBtnWithMenuDefaultActionDefaultAction.addEventListener("ui5-arrow-click", function() {
+		menu.open ? menu.close() : menu.showAt(splitBtnWithMenuDefaultActionDefaultAction);
+	})
+
+	splitBtnWithMenuWithAssociatedLastAction.addEventListener("ui5-arrow-click", function() {
+		menuInSplitBtnAssociatedLastAction.open ? 
+			menuInSplitBtnAssociatedLastAction.close() :
+			menuInSplitBtnAssociatedLastAction.showAt(splitBtnWithMenuWithAssociatedLastAction)
+	})
+
+	menuInSplitBtnAssociatedLastAction.addEventListener("ui5-item-click", function(event) {
+		splitBtnWithMenuWithAssociatedLastAction.innerText = event.detail.text;
 	});
 
 	direction.addEventListener("ui5-change", function() {

--- a/packages/main/test/samples/SplitButton.sample.html
+++ b/packages/main/test/samples/SplitButton.sample.html
@@ -53,4 +53,60 @@
 	</xmp></pre>
 </section>
 
+<section>
+	<h3>SplitButton with Menu</h3>
+	<div class="snippet">
+		<ui5-split-button id="splitBtnWithMenuDefaultAction" class="samples-margin" design="Default">Open Menu</ui5-split-button>
+		<ui5-menu id="menuInSplitBtnDefaultAction">
+			<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+			<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+			<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+		</ui5-menu>
+	</div>
+	<pre class="prettyprint lang-html"><xmp>
+<ui5-split-button id="splitBtnWithMenuDefaultActionDefaultAction" design="Default">Open Menu</ui5-split-button>
+<ui5-menu id="menuInSplitBtn">
+	<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+	<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+	<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+</ui5-menu>
+
+<div class="snippet">
+	<ui5-split-button id="splitBtnWithMenuWithAssociatedLastAction" class="samples-margin" design="Default">Open Menu</ui5-split-button>
+	<ui5-menu id="menuInSplitBtnAssociatedLastAction">
+		<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+		<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+		<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+	</ui5-menu>
+</div>
+<pre class="prettyprint lang-html"><xmp>
+<ui5-split-button id="splitBtnWithMenuWithAssociatedLastAction" design="Default">Open Menu</ui5-split-button>
+<ui5-menu id="menuInSplitBtnAssociatedLastAction">
+	<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+	<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+	<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+</ui5-menu>
+
+
+
+<script>
+	const splitBtnWithMenuDefaultAction = document.getElementById("splitBtnWithMenuDefaultAction");
+	const menuInSplitBtn = document.getElementById("menuInSplitBtnDefaultAction");
+	const splitBtnLastAction = document.getElementById("splitBtnWithMenuWithAssociatedLastAction")
+	const menuInSplitBtnLastAction = document.getElementById("menuInSplitBtnAssociatedLastAction")
+
+	splitBtnWithMenuDefaultAction.addEventListener("ui5-arrow-click", function () {
+		menuInSplitBtn.open ? menuInSplitBtn.close() : menuInSplitBtn.showAt(splitBtnWithMenuDefaultAction);
+	});
+
+	splitBtnLastAction.addEventListener("ui5-arrow-click", function () {
+		menuInSplitBtnLastAction.open ? menuInSplitBtnLastAction.close() : menuInSplitBtnLastAction.showAt(splitBtnLastAction);
+	});
+
+	menuInSplitBtnLastAction.addEventListener("ui5-item-click", function(event) {
+		menuInSplitBtnLastAction.innerText = event.detail.text;
+	});
+</script>
+	</xmp></pre>
+</section>
 <!-- JSDoc marker -->

--- a/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
+++ b/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
@@ -40,6 +40,29 @@ Basic.args = {
 	default: "Default",
 };
 
+export const SplitButtonWithMenu = Template.bind(this);
+SplitButtonWithMenu.args = {
+	default: "Open Menu",
+};
+SplitButtonWithMenu.decorators = [
+	(story) => {
+		return html`
+		<ui5-menu id="menuInSplitBtnDefaultAction">
+		<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+		<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+		<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+		</ui5-menu>
+	${story()}
+	<script>
+		const splitBtnWithMenuDefaultAction = document.querySelector("ui5-split-button");
+		const menuInSplitBtn = document.getElementById("menuInSplitBtnDefaultAction");
+
+		splitBtnWithMenuDefaultAction.addEventListener("ui5-arrow-click", function () {
+			menuInSplitBtn.open ? menuInSplitBtn.close() : menuInSplitBtn.showAt(splitBtnWithMenuDefaultAction);
+		});
+	</script>`;}
+];
+
 export const Disabled = Template.bind({});
 Disabled.storyName = "Disabled SplitButton";
 Disabled.args = {


### PR DESCRIPTION
Added are examples in Playground and Storybook where a Split Button opens a Menu and Split Button opens a Menu with associated last action (that would mean that when an action is chosen from the menu, the text of the Split Button changes to that action)