### PR TITLE
fix(ui5-datetime-picker): fix initial time value not shown correctly in mobile

### DIFF
--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -2,7 +2,6 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
@@ -217,18 +216,6 @@ class DateTimePicker extends DatePicker {
 		await super.openPicker();
 		this._currentTimeSlider = "hours";
 		this._previewValues.timeSelectionValue = this.value || this.getFormat().format(new Date());
-
-		if (isPhone()) {
-			const currentTime = new Date();
-			const hours = currentTime.getHours().toString();
-			this.onTimeSliderChange({
-				detail: {
-					slider: hours,
-					value: hours,
-					valid: true,
-				},
-			} as unknown as CustomEvent<TimeSelectionSliderChangeEventDetail>);
-		}
 	}
 
 	/**

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -215,7 +215,15 @@ class DateTimePicker extends DatePicker {
 	async openPicker() {
 		await super.openPicker();
 		this._currentTimeSlider = "hours";
-		this._previewValues.timeSelectionValue = this.value || this.getFormat().format(new Date());
+		const currentTime = new Date();
+		const hours = currentTime.getHours().toString();
+		this.onTimeSliderChange({
+			detail: {
+				slider: hours,
+				value: hours,
+				valid: true,
+			},
+		} as unknown as CustomEvent<TimeSelectionSliderChangeEventDetail>);
 	}
 
 	/**

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -2,6 +2,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import modifyDateBy from "@ui5/webcomponents-localization/dist/dates/modifyDateBy.js";
@@ -215,15 +216,19 @@ class DateTimePicker extends DatePicker {
 	async openPicker() {
 		await super.openPicker();
 		this._currentTimeSlider = "hours";
-		const currentTime = new Date();
-		const hours = currentTime.getHours().toString();
-		this.onTimeSliderChange({
-			detail: {
-				slider: hours,
-				value: hours,
-				valid: true,
-			},
-		} as unknown as CustomEvent<TimeSelectionSliderChangeEventDetail>);
+		this._previewValues.timeSelectionValue = this.value || this.getFormat().format(new Date());
+
+		if (isPhone()) {
+			const currentTime = new Date();
+			const hours = currentTime.getHours().toString();
+			this.onTimeSliderChange({
+				detail: {
+					slider: hours,
+					value: hours,
+					valid: true,
+				},
+			} as unknown as CustomEvent<TimeSelectionSliderChangeEventDetail>);
+		}
 	}
 
 	/**

--- a/packages/main/src/WheelSlider.ts
+++ b/packages/main/src/WheelSlider.ts
@@ -278,7 +278,7 @@ class WheelSlider extends UI5Element {
 		}
 
 		if (index < itemsCount && index > -1) {
-			this._scroller.scrollTo(0, scrollBy, 5, 100); // sometimes the container isn't painted yet so retry 5 times (although it succeeds on the 1st)
+			this._scroller.scrollTo(0, scrollBy, 15, 100); // sometimes the container isn't painted yet so retry few more times (although it succeeds on the 1st)
 			this._currentElementIndex = index;
 			this.value = this._items[index - (this._getCurrentRepetition() * this._items.length)];
 			this.fireEvent<WheelSliderSelectEventDetail>("select", { value: this.value });


### PR DESCRIPTION
Currently when the DateTimePicker component is being used in smaller width environment ( mobile, tablet, or just resized browser to a small width, etc), the initial value of the time starts at 00 or 01 ( depending on the settings used ).
The desired behavior is that, when the time picker is visualized in smaller width environment, the initial value should be the current time.

With this change the problem is now fixed, and we can see that it works properly.

### Before
![2023-07-06_09-43-47](https://github.com/SAP/ui5-webcomponents/assets/88034608/48073923-008e-444e-bc71-d4e2503a84d1)

### After
![2023-07-06_09-44-22](https://github.com/SAP/ui5-webcomponents/assets/88034608/5817ff12-d4e6-4b8b-8f51-d9453d6fdd7c)

Fixes: #6992
