### PR TITLE
fix(framework): prioritize external fonts over locally installed

### DIFF
--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -2,16 +2,14 @@
     font-family: "72";
     font-style: normal;
     font-weight: 400;
-    src: local("72"),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Regular.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Regular.woff2?ui5-webcomponents) format("woff2"), local("72");
 }
 
 @font-face {
     font-family: "72full";
     font-style: normal;
     font-weight: 400;
-    src: local('72-full'),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Regular-full.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Regular-full.woff2?ui5-webcomponents) format("woff2"), local('72-full');
 
 }
 
@@ -19,48 +17,63 @@
     font-family: "72";
     font-style: normal;
     font-weight: 700;
-    src: local('72-Bold'),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2"), local('72-Bold');
 }
 
 @font-face {
     font-family: "72full";
     font-style: normal;
     font-weight: 700;
-    src: local('72-Bold-full'),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold-full.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold-full.woff2?ui5-webcomponents) format("woff2");
 }
 
 @font-face {
     font-family: '72-Bold';
     font-style: normal;
-    src: local('72-Bold'),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2"), local('72-Bold');
 }
 
 @font-face {
     font-family: '72-Boldfull';
     font-style: normal;
-    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Bold-full.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold-full.woff2?ui5-webcomponents) format("woff2");
 }
 
 @font-face {
     font-family: '72-Light';
-    font-style: normal;
-    src: local('72-Light'),
-        url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light.woff2?ui5-webcomponents) format("woff2");
+    font-style: 300;
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Light.woff2?ui5-webcomponents) format("woff2"), local('72-Light');
 }
 
 @font-face {
     font-family: '72-Lightfull';
-    font-style: normal;
-    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_fiori_3/fonts/72-Light-full.woff2?ui5-webcomponents) format("woff2");
+    font-style: 300;
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Light-full.woff2?ui5-webcomponents) format("woff2");
+}
+
+@font-face {
+	font-family: '72Mono';
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Regular.woff2?ui5-webcomponents) format('woff2'), local('72Mono');
+}
+
+@font-face {
+	font-family: '72Monofull';
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Regular-full.woff2?ui5-webcomponents) format('woff2');
+}
+
+@font-face {
+	font-family: '72Mono-Bold';
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Bold.woff2?ui5-webcomponents) format('woff2'), local('72Mono-Bold');
+}
+
+@font-face {
+	font-family: '72Mono-Boldfull';
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Bold-full.woff2?ui5-webcomponents) format('woff2');
 }
 
 @font-face {
     font-family: "72Black";
     font-style: bold;
     font-weight: 900;
-    src: local('72Black'),
-    url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black.woff2?ui5-webcomponents) format("woff2");
+    src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black.woff2?ui5-webcomponents) format("woff2"), local('72Black');
 }

--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -41,13 +41,13 @@
 
 @font-face {
     font-family: '72-Light';
-    font-style: 300;
+    font-style: normal;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Light.woff2?ui5-webcomponents) format("woff2"), local('72-Light');
 }
 
 @font-face {
     font-family: '72-Lightfull';
-    font-style: 300;
+    font-style: normal;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Light-full.woff2?ui5-webcomponents) format("woff2");
 }
 

--- a/packages/main/test/pages/Card.html
+++ b/packages/main/test/pages/Card.html
@@ -51,7 +51,8 @@
 		<ui5-card-header
 			id="cardHeader2a"
 			slot="header"
-			title-text="Quick Links"
+			class="myCardHeader--ar-he-ch"
+			title-text="مرحبًا שלום"
 			subtitle-text="Quick Links">
 			<img src="./img/John_Miller.png" alt="John Miller" slot="avatar">
 		</ui5-card-header>

--- a/packages/main/test/pages/FontFace.html
+++ b/packages/main/test/pages/FontFace.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<title>Font Face</title>
+	<script src="../../bundle.esm.js" type="module"></script>
+	<link rel="stylesheet" type="text/css" href="./styles/FontFace.css">
+</head>
+
+<body class="card1auto">
+	<ui5-label>sapFontBoldFamily</ui5-label>
+	<div class="boldFamily">Hello مرحبًا שלום 你好 Hallo Hola</div>
+	<ui5-label>sapFontBoldFamily + font-weight: 700</ui5-label>
+	<div class="boldFamily makeItBold">Hello مرحبًا שלום 你好 Hallo Hola</div>
+	<ui5-label>sapFontFamily</ui5-label>
+	<div class="normal">Hello مرحبًا שלום 你好 Hallo Hola</div>
+</body>

--- a/packages/main/test/pages/styles/Card.css
+++ b/packages/main/test/pages/styles/Card.css
@@ -21,3 +21,7 @@
 .myTextContent {
 	padding: 0 1rem 1rem 1rem;
 }
+
+.myCardHeader--ar-he-ch::part(title) {
+	font-weight: 700;
+}

--- a/packages/main/test/pages/styles/FontFace.css
+++ b/packages/main/test/pages/styles/FontFace.css
@@ -1,0 +1,11 @@
+.boldFamily {
+	font-family: var(--sapFontBoldFamily);
+}
+
+.makeItBold {
+	font-weight: 700;
+}
+
+.normal {
+	font-family: var(--sapFontFamily);
+}


### PR DESCRIPTION
Fetch the latest font file and then fallback to locally installed.

- reorder font source origin `url()` and `local()` and make `url` first (previously `local()` used to be first and then followed by `url()`), so the latest version of the woff2 file will be fetched, and if this fails it will fallback to locally installed font with the same name.
This is also the order in OpenUI5: https://github.com/SAP/openui5/blob/master/src/themelib_sap_horizon/src/sap/ui/core/themes/sap_horizon/shared.less#L259

- the path to the external source is slightly changed: sap/ui/core/themes/**sap_fiori_3** changed to sap/ui/core/themes/**sap_horizon**, although it should be the same

- added test pages

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7177

