### PR TITLE
fix(framework): missing CSS variables in compact mode / rtl mode

### DIFF
--- a/packages/tools/components-package/postcss.themes.js
+++ b/packages/tools/components-package/postcss.themes.js
@@ -30,6 +30,20 @@ module.exports = {
 					},
 				],
 			}),
+			modifySelectors({
+				enable: true,
+				modify: [
+					{
+						match: (selector) => {
+							const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"]
+							return selectors.some($ => selector.startsWith($))
+						},
+						with: (selector) => {
+							return `${selector.replace(" ", "")}, ${selector}`
+						},
+					},
+				]
+			}),
 			postcssCSStoJSON({ toReplace: 'src', packageName }),
 			postcssCSStoESM({ toReplace: 'src', packageName }),
 		]

--- a/packages/tools/components-package/postcss.themes.js
+++ b/packages/tools/components-package/postcss.themes.js
@@ -7,7 +7,7 @@ const modifySelectors = require("modify-selectors");
 const fs = require("fs");
 
 const packageName = JSON.parse(fs.readFileSync("./package.json")).name;
-const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"]
+const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"];
 
 module.exports = {
 		plugins: [
@@ -36,10 +36,10 @@ module.exports = {
 				modify: [
 					{
 						match: (selector) => {
-							return selectors.some($ => selector.startsWith($))
+							return selectors.some($ => selector.startsWith($));
 						},
 						with: (selector) => {
-							return `${selector.replace(" ", "")}, ${selector}`
+							return `${selector.replace(" ", "")}, ${selector}`;
 						},
 					},
 				]

--- a/packages/tools/components-package/postcss.themes.js
+++ b/packages/tools/components-package/postcss.themes.js
@@ -7,6 +7,7 @@ const modifySelectors = require("modify-selectors");
 const fs = require("fs");
 
 const packageName = JSON.parse(fs.readFileSync("./package.json")).name;
+const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"]
 
 module.exports = {
 		plugins: [
@@ -35,7 +36,6 @@ module.exports = {
 				modify: [
 					{
 						match: (selector) => {
-							const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"]
 							return selectors.some($ => selector.startsWith($))
 						},
 						with: (selector) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,10 +4769,10 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@114.0.1:
-  version "114.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-114.0.1.tgz#6b781922e74e2f6520cbd3e363dfabc41c4347f5"
-  integrity sha512-Srkyt7xv+RL9aSNVkmARm0tAfw84fIBKge9c1MCTiHfW0tjuNFdhKVlgD0TmPmwSKOeFJrTdd1Flf2hGWWKsUw==
+chromedriver@113.0.0:
+  version "113.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-113.0.0.tgz#d4855f156ee51cea4282e04aadd29fa154e44dbb"
+  integrity sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
     axios "^1.2.1"


### PR DESCRIPTION
Currently, to scope the CSS variables in the current runtime, we modify selectors by adding [_ui5host] attribute and the final selector for compact mode looks like: `.sapUiSizeCompact [_ui5host]`. With this selector we can set compact mode to component only if parent its parent has that `.sapUiSizeCompact` class and not by adding it directly to component `<ui5-button class="sapUiSizeCompact"></ui5-button>`.

With this change we enhance the selectors to `.sapUiSizeCompact [_ui5host], .sapUiSizeCompact[_ui5host]`. This way, we can handle both cases and now, we can explicitly set compact/rtl mode to component.