### PR TITLE
WIP: fix(ui5-illustrated-message): support map based illustration loading

### DIFF
--- a/packages/fiori/src/illustrations/IllustrationsAlternates.ts
+++ b/packages/fiori/src/illustrations/IllustrationsAlternates.ts
@@ -1,0 +1,59 @@
+import tntMappings from "./tnt/theme-mappings.json";
+import baseMappings from "./theme-mappings.json";
+
+type MappingFn = (theme: string, key: string) => string;
+
+const mappings: Map<string, MappingFn> = new Map();
+
+const registerMapping = (set: string, mappingFn: MappingFn) => {
+	mappings.set(mappingFn.name, mappingFn);
+};
+
+const getIllustrationAlternateType = (theme: string, key: string): string => {
+	const set = getSet(key);
+	const mappingFn = mappings.get(set);
+
+	if (mappingFn) {
+		return mappingFn(theme, key);
+	}
+	return key;
+};
+
+const getSet = (key: string): string => {
+	if (key.startsWith("Tnt")) {
+		return "tnt";
+	}
+	return "base";
+};
+
+const tntMappingsFn: MappingFn = (theme: string, key: string) => {
+	const type = key.substring(3);
+	const mapping = tntMappings.find(m => m.theme === theme);
+
+	if (!mapping) {
+		return key;
+	}
+
+	const alternateType = mapping.mappings[type as keyof typeof mapping.mappings];
+	return `Tnt${alternateType || type}`;
+};
+
+const baseMappingsFn: MappingFn = (theme: string, key: string) => {
+	const type = key;
+	const mapping = baseMappings.find(m => m.theme === theme);
+
+	if (!mapping) {
+		return key;
+	}
+
+	const alternateType = mapping.mappings[type as keyof typeof mapping.mappings];
+	return alternateType || type;
+};
+
+registerMapping("base", baseMappingsFn);
+registerMapping("tnt", tntMappingsFn);
+
+export {
+	registerMapping,
+	getIllustrationAlternateType,
+};

--- a/packages/fiori/src/illustrations/theme-mappings.json
+++ b/packages/fiori/src/illustrations/theme-mappings.json
@@ -1,0 +1,8 @@
+[
+	{
+		"theme": "sap_fiori_3",
+		"mappings": {
+			"UnableToUpload": "BeforeSearch"
+		}
+	}
+]

--- a/packages/fiori/src/illustrations/tnt/theme-mappings.json
+++ b/packages/fiori/src/illustrations/tnt/theme-mappings.json
@@ -1,0 +1,8 @@
+[
+	{
+		"theme": "sap_fiori_3",
+		"mappings": {
+			"UnableToUpload": "BeforeSearch"
+		}
+	}
+]

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -11,5 +11,7 @@
       "strict": true,
       "moduleResolution": "node",
       "experimentalDecorators": true,
+      "resolveJsonModule": true,
+      "allowSyntheticDefaultImports": true,
     },
 }


### PR DESCRIPTION
This change provides capability to have different illustrations load in different themes. This is in order to fulfill a design requirement having variations of illustrations within the same illustration set.

Related to: #7195
