### PR TITLE
refactor(ui5-combobox): extract listItem inline

### DIFF
--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -76,17 +76,7 @@
 			{{#if isGroupItem}}
 				<ui5-li-groupheader ?focused={{this.focused}}>{{ this.text }}</ui5-li-groupheader>
 			{{else}}
-				<ui5-li
-					type="Active"
-					additional-text={{this.additionalText}}
-					group-name={{this.groupName}}
-					._tabIndex={{itemTabIndex}}
-					.mappedItem={{this}}
-					?selected={{this.selected}}
-					?focused={{this.focused}}
-				>
-					{{this.text}}
-				</ui5-li>
+				{{> listItem}}
 			{{/if}}
 
 		{{/each}}
@@ -127,4 +117,18 @@
 			{{this}}
 		{{/each}}
 	{{/if}}
+{{/inline}}
+
+{{#*inline "listItem"}}
+	<ui5-li
+			type="Active"
+			additional-text={{this.additionalText}}
+			group-name={{this.groupName}}
+			._tabIndex={{itemTabIndex}}
+			.mappedItem={{this}}
+			?selected={{this.selected}}
+			?focused={{this.focused}}
+	>
+		{{this.text}}
+	</ui5-li>
 {{/inline}}


### PR DESCRIPTION
Same implementation as `MultiComboBoxPopover.hbs` (extract `listItem` partial).

This is needed by our stakeholders who build their custom combobox, based on ours. 

