### PR TITLE
docs(framework): improve OpenUI5Support feature usage documentation

### DIFF
--- a/docs/1-getting-started/06-using-features.md
+++ b/docs/1-getting-started/06-using-features.md
@@ -16,6 +16,8 @@ Import the feature file from the respective NPM package:
 
 `import "@ui5/<PACKAGE-NAME>/dist/features/<FEATURE-NAME>.js`
 
+## Component features 
+
 Currently, only a few components offer additional features:
 
 | Package        | Affects                                           | Feature Import                                                       | Description                                                                                             |
@@ -24,10 +26,7 @@ Currently, only a few components offer additional features:
 | `main`         | `ui5-input`                                       | `@ui5/webcomponents/dist/features/InputSuggestions.js`               | Support for input suggestions while typing                                                              |
 | `main`         | Multiple (`ui5-input`, `ui5-date-picker`, etc...) | `@ui5/webcomponents/dist/features/InputElementsFormSupport.js`       | Support for using input components in forms                                                             |
 | `fiori`        | `ui5-shellbar`                                    | `@ui5/webcomponents-fiori/dist/features/CoPilotAnimation.js`         | Support for a better (but bigger in size) animation for the "co-pilot" button in the shellbar component |
-| `base`         | Framework                                         | `@ui5/webcomponents-base/dist/features/OpenUI5Support.js`            | Integration with the OpenUI5 framework, allowing synchronization and resources re-use                   |
-| `base`         | Multiple components within all libraries          | `@ui5/webcomponents-base/dist/features/F6Navigation.js`              | Support for F6 fast groups navigation                                                                   |
-| `base`         | Date related components                           | `@ui5/webcomponents-base/dist/features/LegacyDateFormats.js`         | Support for legacy date formats                                                                         |
-| `localization` | Multiple (`ui5-date-picker`, etc...)              | `@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js` | Buddhist calendar support                                                                               |
+ `localization` | Multiple (`ui5-date-picker`, etc...)              | `@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js` | Buddhist calendar support                                                                               |
 | `localization` | Multiple (`ui5-date-picker`, etc...)              | `@ui5/webcomponents-localization/dist/features/calendar/Islamic.js`  | Islamic calendar support                                                                                |
 | `localization` | Multiple (`ui5-date-picker`, etc...)              | `@ui5/webcomponents-localization/dist/features/calendar/Japanese.js` | Japanese calendar support                                                                               |
 | `localization` | Multiple (`ui5-date-picker`, etc...)              | `@ui5/webcomponents-localization/dist/features/calendar/Persian.js`  | Persian calendar support                                                                                |
@@ -36,6 +35,29 @@ For example:
 
 ```js
 import "@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js;";
+```
+
+## Framework features 
+
+| Package        | Affects                                           | Feature Import                                                       | Description                                                                                             |
+|----------------|---------------------------------------------------|----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `base`         | Framework                                         | `@ui5/webcomponents-base/dist/features/OpenUI5Support.js`            | Integration with the OpenUI5 framework, allowing synchronization and resources re-use                   |
+| `base`         | Multiple components within all libraries          | `@ui5/webcomponents-base/dist/features/F6Navigation.js`              | Support for F6 fast groups navigation                                                                   |
+| `base`         | Date related components                           | `@ui5/webcomponents-base/dist/features/LegacyDateFormats.js`         | Support for legacy date formats                                                                         |
+|
+
+Framework-level features must be imported before all components modules,
+so that the feature is enabled upon framework boot, before the components' definition.
+
+For example:
+
+```js
+import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
+
+import "@ui5/webcomponents/dist/Button.js";
+import "@ui5/webcomponents/dist/Link.js";
+import "@ui5/webcomponents/dist/Input.js";
 ```
 
 Next: [Typescript Support](./07-typescript-support)

--- a/docs/2-advanced/04-OpenUI5-integration.md
+++ b/docs/2-advanced/04-OpenUI5-integration.md
@@ -2,10 +2,20 @@
 
 *[OpenUI5](https://openui5.org/) is an open-source framework in the same product family as UI5 Web Components.*
 
-To enable OpenUI5 support:
+To enable OpenUI5 support, import the following module:
 
 ```js
 import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
+```
+
+Futhermore, the module must be imported before all components import, so that the feature is enabled upon framework boot.
+
+```js
+import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
+
+import "@ui5/webcomponents/dist/Button.js";
+import "@ui5/webcomponents/dist/Link.js";
+import "@ui5/webcomponents/dist/Input.js";
 ```
 
 If your app uses both OpenUI5 and UI5 Web Components, UI5 Web Components can benefit

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -140,6 +140,11 @@ class OpenUI5Support {
 		}
 
 		const Popup = window.sap.ui.require("sap/ui/core/Popup") as OpenUI5Popup;
+
+		if (!Popup) {
+			return;
+		}
+
 		return Popup.getNextZIndex();
 	}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -142,7 +142,7 @@ class OpenUI5Support {
 		const Popup = window.sap.ui.require("sap/ui/core/Popup") as OpenUI5Popup;
 
 		if (!Popup) {
-			return;
+			console.warn(`The OpenUI5Support feature hasn't been initialized properly. Make sure you import the "@ui5/webcomponents-base/dist/features/OpenUI5Support.js" module before all components' modules.`); // eslint-disable-line
 		}
 
 		return Popup.getNextZIndex();

--- a/packages/base/src/util/PopupUtils.ts
+++ b/packages/base/src/util/PopupUtils.ts
@@ -89,13 +89,22 @@ const getClosedPopupParent = (el: HTMLElement): HTMLElement => {
 };
 
 const getNextZIndex = () => {
-	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support && openUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
-		return openUI5Support.getNextZIndex();
+	const openUI5NextZIndex = getOpenUI5NextZIndex();
+
+	if (openUI5NextZIndex) {
+		return openUI5NextZIndex;
 	}
 
 	popupUtilsData.currentZIndex += 2;
 	return popupUtilsData.currentZIndex;
+};
+
+const getOpenUI5NextZIndex = (): number | undefined => {
+	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
+
+	if (openUI5Support && openUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
+		return openUI5Support.getNextZIndex();
+	}
 };
 
 const getCurrentZIndex = () => {

--- a/packages/base/src/util/PopupUtils.ts
+++ b/packages/base/src/util/PopupUtils.ts
@@ -89,22 +89,13 @@ const getClosedPopupParent = (el: HTMLElement): HTMLElement => {
 };
 
 const getNextZIndex = () => {
-	const openUI5NextZIndex = getOpenUI5NextZIndex();
-
-	if (openUI5NextZIndex) {
-		return openUI5NextZIndex;
+	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
+	if (openUI5Support && openUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
+		return openUI5Support.getNextZIndex();
 	}
 
 	popupUtilsData.currentZIndex += 2;
 	return popupUtilsData.currentZIndex;
-};
-
-const getOpenUI5NextZIndex = (): number | undefined => {
-	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-
-	if (openUI5Support && openUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
-		return openUI5Support.getNextZIndex();
-	}
 };
 
 const getCurrentZIndex = () => {

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -76,6 +76,27 @@
 	<ui5-button icon="download">Web Component</ui5-button>
 	<ui5-datepicker></ui5-datepicker>
 
+	<ui5-button id="btn">Open Dialog web component</ui5-button>
+	<ui5-dialog id="dg" header-text="Dialog 1">
+		<ui5-button id="btn2">Open Second Dialog web component</ui5-button>
+	</ui5-dialog>
+	<ui5-dialog id="dg2" header-text="Dialog 2"></ui5-dialog>
+	
+	<ui5-button id="btnPopup">Open Popover webc</ui5-button>
+	<ui5-popover id="popup" header-text="Popover"></ui5-popover>
+
 	<div id='content'></div>
 </body>
+
+<script>
+	btn.addEventListener("click", () => {
+		dg.show();
+	})
+	btnPopup.addEventListener("click", () => {
+		popup.showAt(btnPopup);
+	})
+	btn2.addEventListener("click", () => {
+		dg2.show();
+	})
+</script>
 </html>


### PR DESCRIPTION
In some cases the OpenUI5Support feature is enabled but `sap.ui.require("sap/ui/core/Popup")` returns `undefined` leading to exceptions when trying to read `Popup.getNextZIndex()`. 
The root cause was the import order of the modules. The OpenUI5Support feature module was included after the component's import and the features was not enabled on framework boot and not initialised properly. As a result the Popup hasn't been loaded and later when getNextZIndex is called, requiring the Popup from OpenUI5 fails and returns undefined.

Although we can add a check and prevent the exception, actually it's better to leave it fails, but add a message why the exception is thrown and how to correctly one should use the OpenUI5Support feature.
In addition, the documentation has been improved to explain this part.

For framework features is important to be enabled on boot, e.g to be imported after the components (the components definition triggers boot) so that they serve their purpose.
For example, when OpenUI5Support feature is enabled the framework reuses fonts, configuration and other assets from OpenUI5, otherwise we use ours and it does not makes sense to enable the feature later when the framework already initialized/booted and we already used or config or loaded our assets.

Related to: https://github.com/SAP/ui5-webcomponents/issues/7128

