### PR TITLE
fix(framework): support older OpenUI5 getThemeRoot API

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -19,6 +19,7 @@ type OpenUI5CoreConfiguration = {
 	getAnimationMode: () => string,
 	getLanguage: () => string,
 	getTheme: () => string,
+	getThemeRoot: () => string,
 	getRTL: () => string,
 	getTimezone: () => string,
 	getCalendarType: () => string,
@@ -80,7 +81,7 @@ class OpenUI5Support {
 			animationMode: config.getAnimationMode(),
 			language: config.getLanguage(),
 			theme: config.getTheme(),
-			themeRoot: Theming.getThemeRoot(),
+			themeRoot: config.getThemeRoot ? config.getThemeRoot() : Theming.getThemeRoot(), // Theming is the newer API, but not released yet (available on nightly snapshot). Remove "config.getThemeRoot" after Theming is released.
 			rtl: config.getRTL(),
 			timezone: config.getTimezone(),
 			calendarType: config.getCalendarType(),


### PR DESCRIPTION
Theming.getThemeRoot is recently added OpenUI5 API, but not released yet (available on nightly snapshot). To support currently released OpenUI5 versions we need to use the older API "config.getThemeRoot", that we can remove after Theming is released.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7199