### PR TITLE
fix(ui5-menu): correct focus behavior

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -542,7 +542,6 @@ class Menu extends UI5Element {
 			const item = opener.associatedItem;
 			const hoverId = opener.getAttribute("id")!;
 
-			opener.focus();
 			this._prepareSubMenuDesktopTablet(item, opener, hoverId);
 		}
 	}

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -100,10 +100,6 @@
 	color: var(--sapList_Active_TextColor);
 }
 
-.ui5-menu-item[focused]:not([active]) {
-	background-color: var(--sapList_Hover_Background);
-}
-
 .ui5-menu-rp[sub-menu] {
 	margin-top: 0.25rem;
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -17,9 +17,7 @@
 	<ui5-menu id="menu" header-text="My ui5-menu">
 
 		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
-		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
-		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
-		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
 				<ui5-menu-item text="Open from C"></ui5-menu-item>
@@ -40,6 +38,52 @@
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
+
+	<header class="header">
+		<h3 class="header-title">Clicked menu item text</h3>
+	</header>
+
+	<div class="samples-margin">
+		<ui5-input id="selectionInput"></ui5-input>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Text Direction</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-switch id="direction" text-on="RTL" text-off="LTR"></ui5-switch>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Prevent "before-open" event</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-switch id="preventBeforeOpen" text-on="Yes" text-off="No"></ui5-switch>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Prevent "before-close" event</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-switch id="preventBeforeClose" text-on="Yes" text-off="No"></ui5-switch>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">open/opener</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-button id="btnAddOpener">Add opener</ui5-button>
+		<ui5-button id="btnRemoveOpener">Remove opener</ui5-button>
+		<ui5-toggle-button id="btnToggleOpen">Toggle open</ui5-toggle-button> <br/>
+		<ui5-input id="openerInput"></ui5-input>
+	</div>
+
+	<header class="header">
+		<h3 class="header-title">Event logger</h3>
+	</header>
+	<div class="samples-margin">
+		<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
+	</div>
 
 	<script>
 		btnOpen.accessibilityAttributes = {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -17,7 +17,9 @@
 	<ui5-menu id="menu" header-text="My ui5-menu">
 
 		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
-		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
 				<ui5-menu-item text="Open from C"></ui5-menu-item>
@@ -38,52 +40,6 @@
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
-
-	<header class="header">
-		<h3 class="header-title">Clicked menu item text</h3>
-	</header>
-
-	<div class="samples-margin">
-		<ui5-input id="selectionInput"></ui5-input>
-	</div>
-
-	<header class="header">
-		<h3 class="header-title">Text Direction</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="direction" text-on="RTL" text-off="LTR"></ui5-switch>
-	</div>
-
-	<header class="header">
-		<h3 class="header-title">Prevent "before-open" event</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="preventBeforeOpen" text-on="Yes" text-off="No"></ui5-switch>
-	</div>
-
-	<header class="header">
-		<h3 class="header-title">Prevent "before-close" event</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="preventBeforeClose" text-on="Yes" text-off="No"></ui5-switch>
-	</div>
-
-	<header class="header">
-		<h3 class="header-title">open/opener</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-button id="btnAddOpener">Add opener</ui5-button>
-		<ui5-button id="btnRemoveOpener">Remove opener</ui5-button>
-		<ui5-toggle-button id="btnToggleOpen">Toggle open</ui5-toggle-button> <br/>
-		<ui5-input id="openerInput"></ui5-input>
-	</div>
-
-	<header class="header">
-		<h3 class="header-title">Event logger</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
-	</div>
 
 	<script>
 		btnOpen.accessibilityAttributes = {


### PR DESCRIPTION
Currently, in the `ui5-menu` web component, when someone hovers over an item, both the hover effect and focus are applied to that item. This behavior is not intended.

According to the design specifications, the focus should only be applied to the first focusable element. The item should maintain the focus line and regular background when it is not being hovered.

Fixes: #7097