### PR TITLE
fix(ui5-multi-combobox): delete value after OK button is pressed

### DIFF
--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1416,6 +1416,10 @@ class MultiComboBox extends UI5Element {
 			this.fireSelectionChange();
 		}
 
+		if (!this.allowCustomValues) {
+			this.value = "";
+		}
+
 		this.togglePopover();
 	}
 


### PR DESCRIPTION
On mobile device, when text is typed in the dialog's input and suggestion is selected, then the OK button is pressed, if custom value is not allowed, we have to clear the typed in value.

FIXES: #6966 