### PR TITLE
fix(ui5-combobox): prevent selection of multiple items

### DIFF
--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -992,8 +992,12 @@ class ComboBox extends UI5Element {
 		const currentlyFocusedItem = this.items.find(item => item.focused);
 		const shouldSelectionBeCleared = currentlyFocusedItem && currentlyFocusedItem.isGroupItem;
 
+		const itemToBeSelected = this._filteredItems.find(item => {
+			return !item.isGroupItem && (item.text === this.value) && !shouldSelectionBeCleared;
+		});
+
 		this._filteredItems = this._filteredItems.map(item => {
-			item.selected = !item.isGroupItem && (item.text === this.value) && !shouldSelectionBeCleared;
+			item.selected = item === itemToBeSelected;
 			return item;
 		});
 	}

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -252,6 +252,16 @@
 		</ui5-combobox>
 	</div>
 
+	<div class="demo-section">
+		<span>ComboBox - suggestions with same names </span>
+
+		<ui5-combobox class="combobox" id="same-name-suggestions-cb">
+			<ui5-cb-item text="Argentina"></ui5-cb-item>
+			<ui5-cb-item text="Germany"></ui5-cb-item>
+			<ui5-cb-item text="Argentina"></ui5-cb-item>
+		</ui5-combobox>
+	</div>
+
 	<script type="module">
 		document.getElementById("lazy").addEventListener("ui5-input", async event => {
 			const { value } = event.target;

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -989,4 +989,29 @@ describe("Keyboard navigation", async () => {
 		await input.keys("PageDown");
 		assert.strictEqual(await input.getProperty("value"), "Chile", "The +10 item should be selected on PAGEDOWN");
 	});
+
+	it ("Should select first matching item",  async () => {
+		await browser.url(`test/pages/ComboBox.html`);
+
+		const comboBox = await browser.$("#same-name-suggestions-cb");
+		const input = await comboBox.shadow$("#ui5-combobox-input");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#same-name-suggestions-cb");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		// Opened picker
+		await input.click();
+		await input.keys("A");
+
+		await browser.waitUntil(() => popover.getProperty("opened"), {
+			timeout: 200,
+			timeoutMsg: "Popover should be displayed"
+		});
+
+		assert.strictEqual(await input.getProperty("value"), "Argentina", "Value should be Argentina");
+
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
+
+		assert.ok(await listItems[0].getProperty("selected"), "List Item should be selected");
+		assert.notOk(await listItems[1].getProperty("selected"), "List Item should not be selected");
+	});
 });


### PR DESCRIPTION
Previously, all items matching the user input were selected. According to the specification, only the first matching item has to be selected.

FIXES: #6978 