### PR TITLE
chore: improve the create package component

### DIFF
--- a/packages/create-package/template/src/MyFirstComponent.js
+++ b/packages/create-package/template/src/MyFirstComponent.js
@@ -24,7 +24,7 @@ const metadata = {
 		 * @public
 		 */
 		count: {
-			validator: Integer,
+			type: Integer,
 			defaultValue: 0,
 		},
 	},

--- a/packages/create-package/template/src/themes/MyFirstComponent.css
+++ b/packages/create-package/template/src/themes/MyFirstComponent.css
@@ -1,4 +1,8 @@
 :host {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
 	padding: 0 2rem;
 	color: var(--sapAvatar_6_TextColor);
 	background-color: var(--sapAvatar_6_Background);

--- a/packages/create-package/template/src/themes/MyFirstComponent.css
+++ b/packages/create-package/template/src/themes/MyFirstComponent.css
@@ -1,5 +1,5 @@
 :host {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;

--- a/packages/create-package/template/test/pages/css/index.css
+++ b/packages/create-package/template/test/pages/css/index.css
@@ -15,7 +15,7 @@ h2 {
 	margin-bottom: 0.5rem;
 }
 
-.app, .app-first-component, .app-settings, .app-docs  {
+.app, .app-settings, .app-docs  {
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
Changes:
 - used `type` instead of `validator` for the JS version (OpenUI5 uses the 1.5 runtime where `validator` is not introduced yet) - this can be reverted once the OpenUI5 version is upgraded
 - made the styles less reliant on the test page (more CSS into the host)