### PR TITLE
docs(ui5-view-settings-dialog): fix docs page horizontally overflowing in storybook

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -691,12 +691,21 @@ class ViewSettingsDialog extends UI5Element {
 
 	/**
 	 * Sets a JavaScript object, as settings to the <code>ui5-view-settings-dialog</code>.
-	 * This method can be used after the dialog is initially open, as the dialog need to set its initial settings.
-	 * The <code>ui5-view-settings-dialog</code> throws an event called "before-open", this can be used as trigger point.
-	 * The object should have the following format:
-	 * <code>
-	 *  {sortOrder: "Ascending", sortBy: "Name", filters: [{"Filter 1": ["Some filter 1", "Some filter 2"]}, {"Filter 2": ["Some filter 4"]}]}
-	 * </code>
+	 * This method can be used after the dialog is initially open, as the dialog needs
+	 * to set its initial settings.<br>
+	 * The <code>ui5-view-settings-dialog</code> throws an event called "before-open",
+	 * which can be used as a trigger point.<br>
+	 * The object should have the following format:<br>
+	 * <pre>
+	 * {
+	 *	sortOrder: "Ascending",
+	 *	sortBy: "Name",
+	 *	filters: [
+	 *		{"Filter 1": ["Some filter 1", "Some filter 2"]},
+	 *		{"Filter 2": ["Some filter 4"]},
+	 *	]
+	 * }
+	 * </pre>
 	 * @param {Object} settings - predefined settings.
 	 * @param {string} settings.sortOrder - sort order
 	 * @param {string} settings.sortBy - sort by


### PR DESCRIPTION
The previous JSDoc description for the **`setConfirmedSettings`** method lacked proper line breaks, leading to a text overflow on the 'Docs' page of Storybook. This resulted in an unintended horizontal overflow throughout the page.

With this update, we've reformatted the JSDoc to prevent such issues, ensuring a better reading experience on the Storybook 'Docs' page.

### Before
![before vsd sample-min](https://github.com/SAP/ui5-webcomponents/assets/88034608/0147b99b-441e-461c-9e92-cf6cf7b7d7bb)

### After
![after vsd sample-min](https://github.com/SAP/ui5-webcomponents/assets/88034608/e191bc19-69af-49fe-bb34-df8faf1b9bde)
