### PR TITLE
fix(ui5-range-slider): adjust hover state visualization

### DIFF
--- a/packages/main/src/themes/RangeSlider.css
+++ b/packages/main/src/themes/RangeSlider.css
@@ -76,7 +76,8 @@
 	background: var(--_ui5_range_slider_handle_background);
 }
 
-.ui5-slider-root:hover .ui5-slider-handle:not(:focus) {
+.ui5-slider-progress-container:hover ~ .ui5-slider-handle:not(:focus),
+.ui5-slider-handle:hover  {
 	background: var(--_ui5_range_slider_root_hover_handle_bg);
 }
 

--- a/packages/main/src/themes/SliderBase.css
+++ b/packages/main/src/themes/SliderBase.css
@@ -121,7 +121,7 @@
 	height: var(--_ui5_slider_handle_icon_size);
 }
 
-.ui5-slider-root:hover .ui5-slider-handle:not(:focus),
+.ui5-slider-progress-container:hover ~ .ui5-slider-handle:not(:focus),
 .ui5-slider-handle:hover {
 	background: var(--_ui5_slider_handle_hover_background);
 	border: var(--_ui5_slider_handle_hover_border);

--- a/packages/main/src/themes/base/SliderBase-parameters.css
+++ b/packages/main/src/themes/base/SliderBase-parameters.css
@@ -10,6 +10,7 @@
 	--_ui5_slider_progress_border_radius: 0.25rem;
 	--_ui5_slider_progress_background: var(--sapActiveColor);
 	--_ui5_slider_handle_icon_display: none;
+	--_ui5_range_slider_root_hover_handle_icon_display: none;
 	--_ui5_slider_handle_height: 1.625rem;
 	--_ui5_slider_handle_width: 1.625rem;
 	--_ui5_slider_handle_border: solid 0.125rem var(--sapField_BorderColor);

--- a/packages/main/src/themes/sap_belize/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_belize/SliderBase-parameters.css
@@ -21,5 +21,4 @@
 	--_ui5_slider_tooltip_border_radius: 0;
 	--_ui5_slider_tickmark_top: -.375rem;
 	--_ui5_slider_tickmark_in_range_bg: var(--sapField_BorderColor);
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 }

--- a/packages/main/src/themes/sap_belize_hcb/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/SliderBase-parameters.css
@@ -14,6 +14,5 @@
 	--_ui5_slider_progress_background: var(--sapField_Background);
 	--_ui5_slider_tickmark_top: -0.2525rem;
 	--_ui5_slider_handle_active_border: 0.0625rem dotted var(--sapField_BorderColor);
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 	--_ui5_range_slider_handle_active_background: transparent;
 }

--- a/packages/main/src/themes/sap_belize_hcw/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/SliderBase-parameters.css
@@ -14,6 +14,5 @@
 	--_ui5_slider_progress_background: var(--sapField_Background);
 	--_ui5_slider_tickmark_top: -0.2525rem;
 	--_ui5_slider_handle_active_border: 0.0625rem dotted var(--sapField_BorderColor);
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 	--_ui5_range_slider_handle_active_background: transparent;
 }

--- a/packages/main/src/themes/sap_fiori_3/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/SliderBase-parameters.css
@@ -10,7 +10,6 @@
 	--_ui5_slider_handle_background: var(--sapButton_Background);
 	--_ui5_slider_handle_hover_background: var(--sapButton_Hover_Background);
 	--_ui5_range_slider_root_hover_handle_bg: transparent;
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 	--_ui5_range_slider_root_active_handle_icon_display: none;
 	--_ui5_slider_handle_width: 1.875rem;
 	--_ui5_slider_handle_height: 1.875rem;

--- a/packages/main/src/themes/sap_fiori_3_dark/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/SliderBase-parameters.css
@@ -2,4 +2,6 @@
 
 :root {
 	--_ui5_slider_inner_min_width: 4rem;
+	--_ui5_range_slider_handle_background: transparent;
+	--_ui5_range_slider_root_hover_handle_bg: transparent;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/SliderBase-parameters.css
@@ -4,6 +4,7 @@
 	--_ui5_slider_inner_height: 0.375rem;
 	--_ui5_slider_progress_border: solid 0.0625rem var(--sapField_BorderColor);
 	--_ui5_slider_progress_border_radius: 0.375rem;
+	--_ui5_range_slider_handle_background: transparent;
 	--_ui5_slider_handle_hover_background: var(--sapButton_Hover_Background);
 	--_ui5_slider_handle_border: solid 0.125rem var(--sapField_BorderColor);
 	--_ui5_slider_handle_height: 1.65rem;
@@ -12,5 +13,4 @@
 	--_ui5_slider_progress_background: var(--sapSelectedColor);
 	--_ui5_slider_tickmark_top: -0.2525rem;
 	--_ui5_slider_handle_margin_left: -.9375rem;
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/SliderBase-parameters.css
@@ -4,6 +4,7 @@
 	--_ui5_slider_inner_height: 0.375rem;
 	--_ui5_slider_progress_border: solid 0.0625rem var(--sapField_BorderColor);
 	--_ui5_slider_progress_border_radius: 0.375rem;
+	--_ui5_range_slider_handle_background: transparent;
 	--_ui5_slider_handle_border: solid 0.125rem var(--sapField_BorderColor);
 	--_ui5_slider_handle_height: 1.65rem;
 	--_ui5_slider_handle_width: 1.65rem;
@@ -11,5 +12,4 @@
 	--_ui5_slider_progress_background: var(--sapSelectedColor);
 	--_ui5_slider_tickmark_top: -0.2525rem;
 	--_ui5_slider_handle_margin_left: -.9375rem;
-	--_ui5_range_slider_root_hover_handle_icon_display: none;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/SliderBase-parameters.css
@@ -5,6 +5,7 @@
 	--_ui5_slider_handle_height: 1.5rem;
 	--_ui5_slider_handle_width: 2rem;
 	--_ui5_slider_handle_icon_display: inline-block;
+	--_ui5_range_slider_root_hover_handle_icon_display: inline-block;
 	--_ui5_slider_handle_border_radius: 0.5rem;
 	--_ui5_slider_handle_hover_background: var(--sapButton_Hover_Background);
 	--_ui5_slider_handle_border: 0.0625rem solid var(--sapField_BorderColor);

--- a/packages/main/src/themes/sap_horizon_hcw/SliderBase-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/SliderBase-parameters.css
@@ -5,6 +5,7 @@
 	--_ui5_slider_handle_height: 1.5rem;
 	--_ui5_slider_handle_width: 2rem;
 	--_ui5_slider_handle_icon_display: inline-block;
+	--_ui5_range_slider_root_hover_handle_icon_display: inline-block;
 	--_ui5_slider_handle_border_radius: 0.5rem;
 	--_ui5_slider_handle_hover_background: var(--sapButton_Hover_Background);
 	--_ui5_slider_handle_border: 0.0625rem solid var(--sapField_BorderColor);
@@ -15,7 +16,7 @@
 	--_ui5_slider_handle_outline: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
 	--_ui5_slider_handle_box_sizing: border-box;
 	--_ui5_range_slider_handle_background: var(--sapSlider_RangeHandleBackground);
-	--_ui5_range_slider_root_hover_handle_bg: var(--sapSlider_RangeHandleBackground);
+	--_ui5_range_slider_root_hover_handle_bg: var(--sapButton_Hover_Background);
 	--_ui5_range_slider_handle_active_background: var(--sapSlider_Active_RangeHandleBackground);
 	--_ui5_slider_handle_active_border: 0.125rem solid var(--sapField_BorderColor);
 	--_ui5_slider_inner_height: 0.25rem;


### PR DESCRIPTION
Previously, hover styles were always applied on both handles no matter that a handle is hovered or the progress bar.
According to the specification, when the progress bar is no hover, both handle should have hover styles applied and when just the handle is on hover, the other one should not receive hover visualization as well.

FIXES: #7100 