### PR TITLE
chore: support modular core

### DIFF
--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -46,7 +46,7 @@ const boot = async (): Promise<void> => {
 		registerCurrentRuntime();
 
 		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-		const isOpenUI5Loaded = openUI5Support ? openUI5Support.OpenUI5Detected() : false;
+		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isOpenUI5Detected() : false;
 		const f6Navigation = getFeature<typeof F6Navigation>("F6Navigation");
 
 		if (openUI5Support) {

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -46,7 +46,7 @@ const boot = async (): Promise<void> => {
 		registerCurrentRuntime();
 
 		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isLoaded() : false;
+		const isOpenUI5Loaded = openUI5Support ? openUI5Support.OpenUI5Detected() : false;
 		const f6Navigation = getFeature<typeof F6Navigation>("F6Navigation");
 
 		if (openUI5Support) {

--- a/packages/base/src/FontFace.ts
+++ b/packages/base/src/FontFace.ts
@@ -8,7 +8,7 @@ const insertFontFace = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
 
 	// Only set the main font if there is no OpenUI5 support, or there is, but OpenUI5 is not loaded
-	if (!openUI5Support || !openUI5Support.isLoaded()) {
+	if (!openUI5Support || !openUI5Support.OpenUI5Detected()) {
 		insertMainFontFace();
 	}
 

--- a/packages/base/src/FontFace.ts
+++ b/packages/base/src/FontFace.ts
@@ -8,7 +8,7 @@ const insertFontFace = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
 
 	// Only set the main font if there is no OpenUI5 support, or there is, but OpenUI5 is not loaded
-	if (!openUI5Support || !openUI5Support.OpenUI5Detected()) {
+	if (!openUI5Support || !openUI5Support.isOpenUI5Detected()) {
 		insertMainFontFace();
 	}
 

--- a/packages/base/src/InitialConfiguration.ts
+++ b/packages/base/src/InitialConfiguration.ts
@@ -180,7 +180,7 @@ const applyURLParam = (key: string, value: string, paramType: string) => {
 
 const applyOpenUI5Configuration = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (!openUI5Support || !openUI5Support.isLoaded()) {
+	if (!openUI5Support || !openUI5Support.OpenUI5Detected()) {
 		return;
 	}
 

--- a/packages/base/src/InitialConfiguration.ts
+++ b/packages/base/src/InitialConfiguration.ts
@@ -180,7 +180,7 @@ const applyURLParam = (key: string, value: string, paramType: string) => {
 
 const applyOpenUI5Configuration = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (!openUI5Support || !openUI5Support.OpenUI5Detected()) {
+	if (!openUI5Support || !openUI5Support.isOpenUI5Detected()) {
 		return;
 	}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -75,7 +75,7 @@ class OpenUI5Support {
 	}
 
 	static isLoaded() {
-		return typeof window.sap?.ui?.getCore === "function";
+		return typeof window.sap?.ui?.require === "function";
 	}
 
 	static init() {

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -156,15 +156,15 @@ class OpenUI5Support {
 			return;
 		}
 
+		const LocaleData = window.sap.ui.require("sap/ui/core/LocaleData") as LocaleData;
+
 		if (OpenUI5Support.isModularCore()) {
-			const LocaleData = window.sap.ui.require("sap/ui/core/LocaleData") as LocaleData;
 			const Localization = window.sap.ui.require("sap/base/i18n/Localization") as Localization;
 			return LocaleData.getInstance(Localization.getLanguageTag());
 		}
 
 		const Core = window.sap.ui.require("sap/ui/core/Core") as OpenUI5Core;
 		const config = Core.getConfiguration();
-		const LocaleData = window.sap.ui.require("sap/ui/core/LocaleData") as LocaleData;
 		return LocaleData.getInstance(config.getLocale())._get();
 	}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -74,7 +74,7 @@ class OpenUI5Support {
 	}
 
 	static isLoaded() {
-		return !!window.sap?.ui?.core;
+		return typeof window.sap?.ui?.getCore === "function";
 	}
 
 	static init() {

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -12,7 +12,7 @@ type OpenUI5Popup = {
 type OpenUI5Core = {
 	attachInit: (callback: () => void) => void,
 	ready: () => Promise<void>,
-	attachThemeChanged: (callback: () => Promise<void>) => void,
+	attachThemeChanged: (callback: () => void) => void,
 	getConfiguration: () => OpenUI5CoreConfiguration,
 };
 
@@ -48,7 +48,7 @@ type LocaleData = {
 type Theming = {
 	getThemeRoot: () => string,
 	getTheme: () => string,
-	attachApplied: (callback: () => Promise<void>) => void,
+	attachApplied: (callback: () => void) => void,
 }
 
 type Formatting = {
@@ -71,15 +71,18 @@ class OpenUI5Support {
 	static isAtLeastVersion116() {
 		const version = window.sap.ui!.version as string;
 		const parts = version.split(".");
-		return parts && parts[1] && parseInt(parts[1]) >= 116;
+		if (!parts || parts.length < 2) {
+			return false;
+		}
+		return parseInt(parts[0]) > 1 || parseInt(parts[1]) >= 116;
 	}
 
-	static OpenUI5Detected() {
+	static isOpenUI5Detected() {
 		return typeof window.sap?.ui?.require === "function";
 	}
 
 	static init() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return Promise.resolve();
 		}
 
@@ -113,7 +116,7 @@ class OpenUI5Support {
 	}
 
 	static getConfigurationSettingsObject() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 
@@ -159,7 +162,7 @@ class OpenUI5Support {
 	}
 
 	static getLocaleDataObject() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 
@@ -178,20 +181,20 @@ class OpenUI5Support {
 	static _listenForThemeChange() {
 		if (OpenUI5Support.isAtLeastVersion116()) {
 			const Theming: Theming = window.sap.ui.require("sap/ui/core/Theming");
-			Theming.attachApplied(async () => {
-				await setTheme(Theming.getTheme());
+			Theming.attachApplied(() => {
+				setTheme(Theming.getTheme());
 			});
 		} else {
 			const Core = window.sap.ui.require("sap/ui/core/Core") as OpenUI5Core;
 			const config = Core.getConfiguration();
-			Core.attachThemeChanged(async () => {
-				await setTheme(config.getTheme());
+			Core.attachThemeChanged(() => {
+				setTheme(config.getTheme());
 			});
 		}
 	}
 
 	static attachListeners() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 
@@ -199,7 +202,7 @@ class OpenUI5Support {
 	}
 
 	static cssVariablesLoaded() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 
@@ -212,7 +215,7 @@ class OpenUI5Support {
 	}
 
 	static getNextZIndex() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 
@@ -221,7 +224,7 @@ class OpenUI5Support {
 	}
 
 	static setInitialZIndex() {
-		if (!OpenUI5Support.OpenUI5Detected()) {
+		if (!OpenUI5Support.isOpenUI5Detected()) {
 			return;
 		}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -68,18 +68,18 @@ type Locale = {
 };
 
 class OpenUI5Support {
-	static isModularCore() {
+	static isAtLeastVersion116() {
 		const version = window.sap.ui!.version as string;
 		const parts = version.split(".");
 		return parts && parts[1] && parseInt(parts[1]) >= 116;
 	}
 
-	static isLoaded() {
+	static OpenUI5Detected() {
 		return typeof window.sap?.ui?.require === "function";
 	}
 
 	static init() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return Promise.resolve();
 		}
 
@@ -87,7 +87,7 @@ class OpenUI5Support {
 			window.sap.ui.require(["sap/ui/core/Core"], async (Core: OpenUI5Core) => {
 				const callback = () => {
 					let deps: Array<string> = ["sap/ui/core/Popup", "sap/ui/core/LocaleData"];
-					if (OpenUI5Support.isModularCore()) { // for versions since 1.116.0 and onward, use the modular core
+					if (OpenUI5Support.isAtLeastVersion116()) { // for versions since 1.116.0 and onward, use the modular core
 						deps = [
 							...deps,
 							"sap/base/i18n/Formatting",
@@ -102,7 +102,7 @@ class OpenUI5Support {
 						resolve();
 					});
 				};
-				if (OpenUI5Support.isModularCore()) {
+				if (OpenUI5Support.isAtLeastVersion116()) {
 					await Core.ready();
 					callback();
 				} else {
@@ -113,11 +113,11 @@ class OpenUI5Support {
 	}
 
 	static getConfigurationSettingsObject() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 
-		if (OpenUI5Support.isModularCore()) {
+		if (OpenUI5Support.isAtLeastVersion116()) {
 			const ControlBehavior = window.sap.ui.require("sap/ui/core/ControlBehavior") as ControlBehavior;
 			const Localization = window.sap.ui.require("sap/base/i18n/Localization") as Localization;
 			const Theming = window.sap.ui.require("sap/ui/core/Theming") as Theming;
@@ -159,13 +159,13 @@ class OpenUI5Support {
 	}
 
 	static getLocaleDataObject() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 
 		const LocaleData = window.sap.ui.require("sap/ui/core/LocaleData") as LocaleData;
 
-		if (OpenUI5Support.isModularCore()) {
+		if (OpenUI5Support.isAtLeastVersion116()) {
 			const Localization = window.sap.ui.require("sap/base/i18n/Localization") as Localization;
 			return LocaleData.getInstance(Localization.getLanguageTag())._get();
 		}
@@ -176,7 +176,7 @@ class OpenUI5Support {
 	}
 
 	static _listenForThemeChange() {
-		if (OpenUI5Support.isModularCore()) {
+		if (OpenUI5Support.isAtLeastVersion116()) {
 			const Theming: Theming = window.sap.ui.require("sap/ui/core/Theming");
 			Theming.attachApplied(async () => {
 				await setTheme(Theming.getTheme());
@@ -191,7 +191,7 @@ class OpenUI5Support {
 	}
 
 	static attachListeners() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 
@@ -199,7 +199,7 @@ class OpenUI5Support {
 	}
 
 	static cssVariablesLoaded() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 
@@ -212,7 +212,7 @@ class OpenUI5Support {
 	}
 
 	static getNextZIndex() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 
@@ -221,7 +221,7 @@ class OpenUI5Support {
 	}
 
 	static setInitialZIndex() {
-		if (!OpenUI5Support.isLoaded()) {
+		if (!OpenUI5Support.OpenUI5Detected()) {
 			return;
 		}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -167,7 +167,7 @@ class OpenUI5Support {
 
 		if (OpenUI5Support.isModularCore()) {
 			const Localization = window.sap.ui.require("sap/base/i18n/Localization") as Localization;
-			return LocaleData.getInstance(Localization.getLanguageTag());
+			return LocaleData.getInstance(Localization.getLanguageTag())._get();
 		}
 
 		const Core = window.sap.ui.require("sap/ui/core/Core") as OpenUI5Core;

--- a/packages/base/src/util/PopupUtils.ts
+++ b/packages/base/src/util/PopupUtils.ts
@@ -90,7 +90,7 @@ const getClosedPopupParent = (el: HTMLElement): HTMLElement => {
 
 const getNextZIndex = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support && openUI5Support.isLoaded()) { // use OpenUI5 for getting z-index values, if loaded
+	if (openUI5Support && openUI5Support.OpenUI5Detected()) { // use OpenUI5 for getting z-index values, if loaded
 		return openUI5Support.getNextZIndex();
 	}
 

--- a/packages/base/src/util/PopupUtils.ts
+++ b/packages/base/src/util/PopupUtils.ts
@@ -90,7 +90,7 @@ const getClosedPopupParent = (el: HTMLElement): HTMLElement => {
 
 const getNextZIndex = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support && openUI5Support.OpenUI5Detected()) { // use OpenUI5 for getting z-index values, if loaded
+	if (openUI5Support && openUI5Support.isOpenUI5Detected()) { // use OpenUI5 for getting z-index values, if loaded
 		return openUI5Support.getNextZIndex();
 	}
 

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -15,6 +15,7 @@
 		}
 	</script>
 
+	<!-- https://openui5nightly.hana.ondemand.com/resources/sap-ui-core.js -->
 	<script
 		src='https://sdk.openui5.org/resources/sap-ui-core.js'
 		id='sap-ui-bootstrap'


### PR DESCRIPTION
The `OpenUI5Support.ts` module must be able to work with any version of OpenUI5/SAPUI5. The latest OpenUI5 version `1.116` introduces some breaking changes (f.e. `getThemeRoot` no longer available via the central configuration class).

Additionally, the version must be resolved synchronously, therefore I reverted to the old version parsing (and removed the usage of the official version util)

WIP

Background: `OpenUI5Support.init()` is expected to be called by the framework as early as possible. Therefore, it must preload all OpenUI5 modules that might be used anywhere else in the code. 

I'm looking for feedback especially on: 
 - `isLoaded` (later renamed to `OpenUI5Detected`): is this the right check to tell if OpenUI5 is on the window or not
 - `isModularCore` (later renamed to `isAtLeastVersion116`): is there a better/simpler check to determine this than checking the version?