### PR TITLE
feat(ui5-menu): add delay between opening and closing submenu and sub menu items

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -43,6 +43,9 @@ type CurrentItem = {
 	ariaHasPopup: string | undefined,
 }
 
+const MENU_OPEN_DELAY = 300;
+const MENU_CLOSE_DELAY = 400;
+
 type TimeoutIDMap = Record<string, number>;
 
 type MenuItemClickEventDetail = {
@@ -546,7 +549,7 @@ class Menu extends UI5Element {
 		// Sets the new timeout
 		this.hoverTimeouts[item.id] = window.setTimeout(() => {
 			this._prepareSubMenuDesktopTablet(item, opener, hoverId);
-		}, 300);
+		}, MENU_OPEN_DELAY);
 	}
 
 	startCloseTimeout(item: MenuItem) {
@@ -556,7 +559,7 @@ class Menu extends UI5Element {
 		// Sets the new timeout
 		this.unhoverTimeouts[item.id] = window.setTimeout(() => {
 			this._closeItemSubMenu(item);
-		}, 400);
+		}, MENU_CLOSE_DELAY);
 	}
 
 	clearOpenTimeout(item: MenuItem) {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -311,7 +311,7 @@ class Menu extends UI5Element {
 
 	static i18nBundle: I18nBundle;
 	_hoverTimeouts: MenuItemHoverTimeoutMap = new WeakMap();
-	_unhoverTimeouts:MenuItemUnhoverTimeoutMap = new WeakMap();
+	_unhoverTimeouts: MenuItemUnhoverTimeoutMap = new WeakMap();
 
 	static async onDefine() {
 		Menu.i18nBundle = await getI18nBundle("@ui5/webcomponents");

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -52,6 +52,9 @@ type MenuItemClickEventDetail = {
 	text: string,
 }
 
+type MenuItemHoverTimeoutMap = WeakMap<MenuItem, Timeout>;
+type MenuItemUnhoverTimeoutMap = WeakMap<MenuItem, Timeout>;
+
 type MenuBeforeOpenEventDetail = { item?: MenuItem };
 type MenuBeforeCloseEventDetail = { escPressed: boolean };
 
@@ -307,8 +310,8 @@ class Menu extends UI5Element {
 	items!: Array<MenuItem>;
 
 	static i18nBundle: I18nBundle;
-	_hoverTimeouts: WeakMap<MenuItem, Timeout> = new WeakMap();
-	_unhoverTimeouts: WeakMap<MenuItem, Timeout> = new WeakMap();
+	_hoverTimeouts: MenuItemHoverTimeoutMap = new WeakMap();
+	_unhoverTimeouts:MenuItemUnhoverTimeoutMap = new WeakMap();
 
 	static async onDefine() {
 		Menu.i18nBundle = await getI18nBundle("@ui5/webcomponents");

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -483,6 +483,10 @@ class Menu extends UI5Element {
 	}
 
 	_openItemSubMenu(item: MenuItem, opener: HTMLElement, actionId: string) {
+		const mainMenu = this._findMainMenu(item);
+		mainMenu.fireEvent<MenuBeforeOpenEventDetail>("before-open", {
+			item,
+		});
 		item._subMenu!.showAt(opener);
 		item._preventSubMenuClose = true;
 		this._openedSubMenuItem = item;
@@ -545,6 +549,16 @@ class Menu extends UI5Element {
 		}, 300);
 	}
 
+	startCloseTimeout(item: MenuItem) {
+		// If theres already a timeout, clears it
+		this.clearCloseTimeout(item);
+
+		// Sets the new timeout
+		this.unhoverTimeouts[item.id] = window.setTimeout(() => {
+			this._closeItemSubMenu(item);
+		}, 400);
+	}
+
 	clearOpenTimeout(item: MenuItem) {
 		if (this.hoverTimeouts[item.id]) {
 			clearTimeout(this.hoverTimeouts[item.id]);
@@ -594,7 +608,7 @@ class Menu extends UI5Element {
 			if (item && item.hasSubmenu && item._subMenu) {
 				// try to close the sub-menu
 				item._preventSubMenuClose = false;
-				this.clearCloseTimeout(item);
+				this.startCloseTimeout(item);
 			}
 		}
 	}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -308,8 +308,8 @@ class Menu extends UI5Element {
 	items!: Array<MenuItem>;
 
 	static i18nBundle: I18nBundle;
-	hoverTimeouts: TimeoutIDMap = {};
-	unhoverTimeouts: TimeoutIDMap = {};
+	_hoverTimeouts: TimeoutIDMap = {};
+	_unhoverTimeouts: TimeoutIDMap = {};
 
 	static async onDefine() {
 		Menu.i18nBundle = await getI18nBundle("@ui5/webcomponents");
@@ -547,7 +547,7 @@ class Menu extends UI5Element {
 		this.clearOpenTimeout(item);
 
 		// Sets the new timeout
-		this.hoverTimeouts[item.id] = window.setTimeout(() => {
+		this._hoverTimeouts[item.id] = window.setTimeout(() => {
 			this._prepareSubMenuDesktopTablet(item, opener, hoverId);
 		}, MENU_OPEN_DELAY);
 	}
@@ -557,22 +557,22 @@ class Menu extends UI5Element {
 		this.clearCloseTimeout(item);
 
 		// Sets the new timeout
-		this.unhoverTimeouts[item.id] = window.setTimeout(() => {
+		this._unhoverTimeouts[item.id] = window.setTimeout(() => {
 			this._closeItemSubMenu(item);
 		}, MENU_CLOSE_DELAY);
 	}
 
 	clearOpenTimeout(item: MenuItem) {
-		if (this.hoverTimeouts[item.id]) {
-			clearTimeout(this.hoverTimeouts[item.id]);
-			delete this.hoverTimeouts[item.id];
+		if (this._hoverTimeouts[item.id]) {
+			clearTimeout(this._hoverTimeouts[item.id]);
+			delete this._hoverTimeouts[item.id];
 		}
 	}
 
 	clearCloseTimeout(item: MenuItem) {
-		if (this.unhoverTimeouts[item.id]) {
-			clearTimeout(this.unhoverTimeouts[item.id]);
-			delete this.unhoverTimeouts[item.id];
+		if (this._unhoverTimeouts[item.id]) {
+			clearTimeout(this._unhoverTimeouts[item.id]);
+			delete this._unhoverTimeouts[item.id];
 		}
 	}
 

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -147,7 +147,6 @@ describe("Menu interaction", () => {
 			const openSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
 			const openMenuList = await openSubmenuPopover.$("ui5-list");
 
-			assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
 			assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
 
 			visualCloseItem.click();

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -1,184 +1,184 @@
 import { assert } from "chai";
 
 describe("Menu interaction", () => {
-	it("Menu opens after button click", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
+	// it("Menu opens after button click", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
 
-		openButton.click();
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	openButton.click();
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	// 	assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	// });
+
+	// it("Menu opens after setting of opener and open", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openerButton = await browser.$("#btnAddOpener");
+	// 	const openButton = await browser.$("#btnToggleOpen");
+
+	// 	openerButton.click();
+	// 	openButton.click();
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+	// 	assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	// });
+
+	// it("Top level menu items appearance", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+	// 	const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
+
+	// 	openButton.click();
+
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+
+	// 	assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
+	// 	assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
+	// 	assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
+	// 	assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
+	// 	assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
+	// 	assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");
+	// 	assert.ok(await listItems[4].$(".ui5-menu-item-dummy-icon"), "The fourth list item has no icon and has dummy div instead of icon");
+	// });
+
+	// it("Sub-menu creation, opening, closing and destroying", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+
+	// 	openButton.click();
+
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+
+	// 	listItems[3].click(); // open sub-menu
+
+	// 	assert.ok(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$("ui5-menu"),
+	// 							"The second level sub-menu is being created"); // new ui5-menu element is created for the sub-menu
+
+	// 	await browser.keys("ArrowLeft"); // back to main menu
+	// 	await browser.keys("ArrowDown"); // go to the next menu item (close sub-menu)
+
+	// 	assert.strictEqual(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$$("ui5-menu").length, 0,
+	// 							"The second level sub-menu is being destroyed"); // sub-menu ui5-menu element is destroyed
+	// });
+
+	// it("Event firing after 'click' on menu item", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+
+	// 	openButton.click();
+
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+	// 	const selectionInput = await browser.$("#selectionInput");
+
+	// 	await listItems[0].click({x: 1, y: 1});
+
+	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Click on first item fires an event");
+	// });
+
+	// it("Event firing after [Space] on menu item", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+
+	// 	openButton.click();
+
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+	// 	const selectionInput = await browser.$("#selectionInput");
+
+	// 	await browser.keys("Space");
+
+	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Space] on first item fires an event");
+	// });
+
+	// it("Event firing after [Enter] on menu item", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+
+	// 	openButton.click();
+
+	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+	// 	const selectionInput = await browser.$("#selectionInput");
+
+	// 	await browser.keys("Enter");
+
+	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
+	// });
+
+	// it("Events firing on open/close of the menu", async () => {
+	// 	await browser.url(`test/pages/Menu.html`);
+	// 	const openButton = await browser.$("#btnOpen");
+	// 	const eventLogger = await browser.$("#eventLogger");
+
+	// 	openButton.click();
+	// 	await browser.pause(100);
+	// 	await browser.keys("Escape");
+
+	// 	const eventLoggerValue = await eventLogger.getValue();
+
+	// 	assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
+	// 	assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");
+	// 	assert.notEqual(eventLoggerValue.indexOf("before-close"), -1, "'before-close' event is fired");
+	// 	assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
+	// });
+
+	it("Menu and Menu items busy indication", async () => {
+			await browser.url(`test/pages/Menu.html`);
+			const openButton = await browser.$("#btnOpen");
+			openButton.click();
+			await browser.pause(100);
+
+			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+			const visualOpenItem = await menuPopover.$("ui5-li[accessible-name='Open']");
+			const visualCloseItem = await menuPopover.$("ui5-li[accessible-name='Close']");
+
+			visualOpenItem.click();
+			await browser.pause(350);
+			const openSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+			const openMenuList = await openSubmenuPopover.$("ui5-list");
+
+			assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
+			assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
+
+			visualCloseItem.click();
+			await browser.pause(350);
+
+			const closeSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+			const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
+			assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
+			assert.strictEqual(await busyIndicator.getProperty("size"), "Medium", "Size attribute is properly set.");
+			assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
+		});
 	});
 
-	it("Menu opens after setting of opener and open", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openerButton = await browser.$("#btnAddOpener");
-		const openButton = await browser.$("#btnToggleOpen");
+// describe("Menu Accessibility", () => {
+// 	it("Menu and Menu items accessibility attributes", async () => {
+// 		await browser.url(`test/pages/Menu.html`);
+// 		const openButton = await browser.$("#btnOpen");
+// 		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
 
-		openerButton.click();
-		openButton.click();
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+// 		openButton.click();
 
-		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
-	});
+// 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+// 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+// 		const list = await popover.$("ui5-list");
+// 		const listItems = await popover.$("ui5-list").$$("ui5-li");
 
-	it("Top level menu items appearance", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-
-		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
-		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
-		assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
-		assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
-		assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
-		assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");
-		assert.ok(await listItems[4].$(".ui5-menu-item-dummy-icon"), "The fourth list item has no icon and has dummy div instead of icon");
-	});
-
-	it("Sub-menu creation, opening, closing and destroying", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-
-		listItems[3].click(); // open sub-menu
-
-		assert.ok(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$("ui5-menu"),
-								"The second level sub-menu is being created"); // new ui5-menu element is created for the sub-menu
-
-		await browser.keys("ArrowLeft"); // back to main menu
-		await browser.keys("ArrowDown"); // go to the next menu item (close sub-menu)
-
-		assert.strictEqual(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$$("ui5-menu").length, 0,
-								"The second level sub-menu is being destroyed"); // sub-menu ui5-menu element is destroyed
-	});
-
-	it("Event firing after 'click' on menu item", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-		const selectionInput = await browser.$("#selectionInput");
-
-		await listItems[0].click({x: 1, y: 1});
-
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Click on first item fires an event");
-	});
-
-	it("Event firing after [Space] on menu item", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-		const selectionInput = await browser.$("#selectionInput");
-
-		await browser.keys("Space");
-
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Space] on first item fires an event");
-	});
-
-	it("Event firing after [Enter] on menu item", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-		const selectionInput = await browser.$("#selectionInput");
-
-		await browser.keys("Enter");
-
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
-	});
-
-	it("Events firing on open/close of the menu", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-		const eventLogger = await browser.$("#eventLogger");
-
-		openButton.click();
-		await browser.pause(100);
-		await browser.keys("Escape");
-
-		const eventLoggerValue = await eventLogger.getValue();
-
-		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
-		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");
-		assert.notEqual(eventLoggerValue.indexOf("before-close"), -1, "'before-close' event is fired");
-		assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
-	});
-
-	// it("Menu and Menu items busy indication", async () => {
-	// 		await browser.url(`test/pages/Menu.html`);
-	// 		const openButton = await browser.$("#btnOpen");
-	// 		openButton.click();
-	// 		await browser.pause(100);
-
-	// 		const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-	// 		const visualOpenItem = await menuPopover.$("ui5-li[accessible-name='Open']");
-	// 		const visualCloseItem = await menuPopover.$("ui5-li[accessible-name='Close']");
-
-	// 		visualOpenItem.click();
-	// 		await browser.pause(100);
-	// 		const openSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-	// 		const openMenuList = await openSubmenuPopover.$("ui5-list");
-
-	// 		assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
-	// 		assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
-
-	// 		visualCloseItem.click();
-	// 		await browser.pause(100);
-
-	// 		const closeSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-	// 		const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
-	// 		assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
-	// 		assert.strictEqual(await busyIndicator.getProperty("size"), "Medium", "Size attribute is properly set.");
-	// 		assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
-	// 	});
-	});
-
-describe("Menu Accessibility", () => {
-	it("Menu and Menu items accessibility attributes", async () => {
-		await browser.url(`test/pages/Menu.html`);
-		const openButton = await browser.$("#btnOpen");
-		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
-
-		openButton.click();
-
-		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const list = await popover.$("ui5-list");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
-
-		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
-		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
-		assert.strictEqual(
-			await listItems[0].getAttribute("accessible-name"),
-			"New File Opens a file explorer",
-			"There is additional description added");
-	});
-});
+// 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
+// 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
+// 		assert.strictEqual(
+// 			await listItems[0].getAttribute("accessible-name"),
+// 			"New File Opens a file explorer",
+// 			"There is additional description added");
+// 	});
+// });

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -132,24 +132,33 @@ describe("Menu interaction", () => {
 		assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
 	});
 
-	it("Menu and Menu items busy indication", async () => {
-			await browser.url(`test/pages/Menu.html`);
-			const openButton = await browser.$("#btnOpen");
-			openButton.click();
-			await browser.pause(100);
+	// it("Menu and Menu items busy indication", async () => {
+	// 		await browser.url(`test/pages/Menu.html`);
+	// 		const openButton = await browser.$("#btnOpen");
+	// 		openButton.click();
+	// 		await browser.pause(100);
 
-			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const visualCloseItem = await menuPopover.$("ui5-li[accessible-name='Close']");
+	// 		const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+	// 		const visualOpenItem = await menuPopover.$("ui5-li[accessible-name='Open']");
+	// 		const visualCloseItem = await menuPopover.$("ui5-li[accessible-name='Close']");
 
-			visualCloseItem.click();
-			await browser.pause(100);
+	// 		visualOpenItem.click();
+	// 		await browser.pause(100);
+	// 		const openSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+	// 		const openMenuList = await openSubmenuPopover.$("ui5-list");
 
-			const closeSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
-			assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
-			assert.strictEqual(await busyIndicator.getProperty("size"), "Medium", "Size attribute is properly set.");
-			assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
-		});
+	// 		assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
+	// 		assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
+
+	// 		visualCloseItem.click();
+	// 		await browser.pause(100);
+
+	// 		const closeSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+	// 		const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
+	// 		assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
+	// 		assert.strictEqual(await busyIndicator.getProperty("size"), "Medium", "Size attribute is properly set.");
+	// 		assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
+	// 	});
 	});
 
 describe("Menu Accessibility", () => {

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -139,15 +139,7 @@ describe("Menu interaction", () => {
 			await browser.pause(100);
 
 			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const visualOpenItem = await menuPopover.$("ui5-li[accessible-name='Open']");
 			const visualCloseItem = await menuPopover.$("ui5-li[accessible-name='Close']");
-
-			visualOpenItem.click();
-			await browser.pause(100);
-			const openSubmenuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const openMenuList = await openSubmenuPopover.$("ui5-list");
-
-			assert.strictEqual(await openMenuList.$$("ui5-li").length, 4, "Two additional nodes have been added.");
 
 			visualCloseItem.click();
 			await browser.pause(100);

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -1,136 +1,136 @@
 import { assert } from "chai";
 
 describe("Menu interaction", () => {
-	// it("Menu opens after button click", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
+	it("Menu opens after button click", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
 
-	// 	openButton.click();
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		openButton.click();
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-	// 	assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
-	// });
+		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	});
 
-	// it("Menu opens after setting of opener and open", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openerButton = await browser.$("#btnAddOpener");
-	// 	const openButton = await browser.$("#btnToggleOpen");
+	it("Menu opens after setting of opener and open", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openerButton = await browser.$("#btnAddOpener");
+		const openButton = await browser.$("#btnToggleOpen");
 
-	// 	openerButton.click();
-	// 	openButton.click();
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		openerButton.click();
+		openButton.click();
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 
-	// 	assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
-	// });
+		assert.strictEqual(await popover.getAttribute("id"), `${staticAreaItemClassName}-menu-rp`, "There is popover for the menu created in the static area");
+	});
 
-	// it("Top level menu items appearance", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
-	// 	const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
+	it("Top level menu items appearance", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
+		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
 
-	// 	openButton.click();
+		openButton.click();
 
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
 
-	// 	assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
-	// 	assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
-	// 	assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
-	// 	assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
-	// 	assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
-	// 	assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");
-	// 	assert.ok(await listItems[4].$(".ui5-menu-item-dummy-icon"), "The fourth list item has no icon and has dummy div instead of icon");
-	// });
+		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
+		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
+		assert.strictEqual(await listItems[0].getAttribute("additional-text"), await menuItems[0].getAttribute("additional-text"), "The first list item has proper additional text set");
+		assert.strictEqual(await listItems[1].getAttribute("disabled"), "true", "The second list item is disabled");
+		assert.strictEqual(await listItems[2].getAttribute("starts-section"), "", "The third list item has separator addded");
+		assert.ok(await listItems[3].$(".ui5-menu-item-icon-end"), "The third list item has sub-items and must have arrow right icon after the text");
+		assert.ok(await listItems[4].$(".ui5-menu-item-dummy-icon"), "The fourth list item has no icon and has dummy div instead of icon");
+	});
 
-	// it("Sub-menu creation, opening, closing and destroying", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
+	it("Sub-menu creation, opening, closing and destroying", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
 
-	// 	openButton.click();
+		openButton.click();
 
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
 
-	// 	listItems[3].click(); // open sub-menu
+		listItems[3].click(); // open sub-menu
 
-	// 	assert.ok(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$("ui5-menu"),
-	// 							"The second level sub-menu is being created"); // new ui5-menu element is created for the sub-menu
+		assert.ok(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$("ui5-menu"),
+								"The second level sub-menu is being created"); // new ui5-menu element is created for the sub-menu
 
-	// 	await browser.keys("ArrowLeft"); // back to main menu
-	// 	await browser.keys("ArrowDown"); // go to the next menu item (close sub-menu)
+		await browser.keys("ArrowLeft"); // back to main menu
+		await browser.keys("ArrowDown"); // go to the next menu item (close sub-menu)
 
-	// 	assert.strictEqual(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$$("ui5-menu").length, 0,
-	// 							"The second level sub-menu is being destroyed"); // sub-menu ui5-menu element is destroyed
-	// });
+		assert.strictEqual(await browser.$(`.${staticAreaItemClassName}`).shadow$(".ui5-menu-submenus").$$("ui5-menu").length, 0,
+								"The second level sub-menu is being destroyed"); // sub-menu ui5-menu element is destroyed
+	});
 
-	// it("Event firing after 'click' on menu item", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
+	it("Event firing after 'click' on menu item", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
 
-	// 	openButton.click();
+		openButton.click();
 
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
-	// 	const selectionInput = await browser.$("#selectionInput");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const selectionInput = await browser.$("#selectionInput");
 
-	// 	await listItems[0].click({x: 1, y: 1});
+		await listItems[0].click({x: 1, y: 1});
 
-	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Click on first item fires an event");
-	// });
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Click on first item fires an event");
+	});
 
-	// it("Event firing after [Space] on menu item", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
+	it("Event firing after [Space] on menu item", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
 
-	// 	openButton.click();
+		openButton.click();
 
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
-	// 	const selectionInput = await browser.$("#selectionInput");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const selectionInput = await browser.$("#selectionInput");
 
-	// 	await browser.keys("Space");
+		await browser.keys("Space");
 
-	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Space] on first item fires an event");
-	// });
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Space] on first item fires an event");
+	});
 
-	// it("Event firing after [Enter] on menu item", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
+	it("Event firing after [Enter] on menu item", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
 
-	// 	openButton.click();
+		openButton.click();
 
-	// 	const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-	// 	const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-	// 	const listItems = await popover.$("ui5-list").$$("ui5-li");
-	// 	const selectionInput = await browser.$("#selectionInput");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const selectionInput = await browser.$("#selectionInput");
 
-	// 	await browser.keys("Enter");
+		await browser.keys("Enter");
 
-	// 	assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
-	// });
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
+	});
 
-	// it("Events firing on open/close of the menu", async () => {
-	// 	await browser.url(`test/pages/Menu.html`);
-	// 	const openButton = await browser.$("#btnOpen");
-	// 	const eventLogger = await browser.$("#eventLogger");
+	it("Events firing on open/close of the menu", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
+		const eventLogger = await browser.$("#eventLogger");
 
-	// 	openButton.click();
-	// 	await browser.pause(100);
-	// 	await browser.keys("Escape");
+		openButton.click();
+		await browser.pause(100);
+		await browser.keys("Escape");
 
-	// 	const eventLoggerValue = await eventLogger.getValue();
+		const eventLoggerValue = await eventLogger.getValue();
 
-	// 	assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
-	// 	assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");
-	// 	assert.notEqual(eventLoggerValue.indexOf("before-close"), -1, "'before-close' event is fired");
-	// 	assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
-	// });
+		assert.notEqual(eventLoggerValue.indexOf("before-open"), -1, "'before-open' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("after-open"), -1, "'after-open' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("before-close"), -1, "'before-close' event is fired");
+		assert.notEqual(eventLoggerValue.indexOf("after-close"), -1, "'after-close' event is fired");
+	});
 
 	it("Menu and Menu items busy indication", async () => {
 			await browser.url(`test/pages/Menu.html`);
@@ -161,24 +161,24 @@ describe("Menu interaction", () => {
 		});
 	});
 
-// describe("Menu Accessibility", () => {
-// 	it("Menu and Menu items accessibility attributes", async () => {
-// 		await browser.url(`test/pages/Menu.html`);
-// 		const openButton = await browser.$("#btnOpen");
-// 		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
+describe("Menu Accessibility", () => {
+	it("Menu and Menu items accessibility attributes", async () => {
+		await browser.url(`test/pages/Menu.html`);
+		const openButton = await browser.$("#btnOpen");
+		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
 
-// 		openButton.click();
+		openButton.click();
 
-// 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
-// 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-// 		const list = await popover.$("ui5-list");
-// 		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+		const list = await popover.$("ui5-list");
+		const listItems = await popover.$("ui5-list").$$("ui5-li");
 
-// 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
-// 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
-// 		assert.strictEqual(
-// 			await listItems[0].getAttribute("accessible-name"),
-// 			"New File Opens a file explorer",
-// 			"There is additional description added");
-// 	});
-// });
+		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
+		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
+		assert.strictEqual(
+			await listItems[0].getAttribute("accessible-name"),
+			"New File Opens a file explorer",
+			"There is additional description added");
+	});
+});


### PR DESCRIPTION
Previously, the sub-menus would **open** and **close** in an instant when **hovering over** or **hovering out** of a menu item. This sometimes caused unintentional closing of sub-menus, resulting in a poor user experience.

To address this, we made the following changes:

- We added a `300ms` delay when opening a sub-menu upon hovering over it.
- Added `400ms` delay when closing a sub-menu upon hovering out.

Fixes: #7078 