### PR TITLE
fix(framework): fix OpenUI5Support feature usage

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -117,7 +117,7 @@ class OpenUI5Support {
 
 	static getConfigurationSettingsObject() {
 		if (!OpenUI5Support.isOpenUI5Detected()) {
-			return;
+			return {};
 		}
 
 		if (OpenUI5Support.isAtLeastVersion116()) {
@@ -208,7 +208,7 @@ class OpenUI5Support {
 
 		const link = [...document.head.children].find(el => el.id === "sap-ui-theme-sap.ui.core") as HTMLLinkElement; // more reliable than querySelector early
 		if (!link) {
-			return;
+			return false;
 		}
 
 		return !!link.href.match(/\/css(-|_)variables\.css/);

--- a/packages/base/src/theming/applyTheme.ts
+++ b/packages/base/src/theming/applyTheme.ts
@@ -56,15 +56,14 @@ const detectExternalTheme = async (theme: string) => {
 
 	// If OpenUI5Support is enabled, try to find out if it loaded variables
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support) {
-		const varsLoaded = openUI5Support.cssVariablesLoaded();
-		if (varsLoaded) {
-			return {
-				themeName: openUI5Support.getConfigurationSettingsObject()?.theme, // just themeName
-				baseThemeName: "", // baseThemeName is only relevant for custom themes
-			};
-		}
-	} else if (getThemeRoot()) {
+	if (openUI5Support && openUI5Support.cssVariablesLoaded()) {
+		return {
+			themeName: openUI5Support.getConfigurationSettingsObject()?.theme, // just themeName
+			baseThemeName: "", // baseThemeName is only relevant for custom themes
+		};
+	}
+
+	if (getThemeRoot()) {
 		await attachCustomThemeStylesToHead(theme);
 
 		return getThemeDesignerTheme();

--- a/packages/base/src/theming/applyTheme.ts
+++ b/packages/base/src/theming/applyTheme.ts
@@ -4,7 +4,7 @@ import getThemeDesignerTheme from "./getThemeDesignerTheme.js";
 import { fireThemeLoaded } from "./ThemeLoaded.js";
 import { getFeature } from "../FeaturesRegistry.js";
 import { attachCustomThemeStylesToHead, getThemeRoot } from "../config/ThemeRoot.js";
-import type OpenUI5Support from "../features/OpenUI5Support.js";
+import OpenUI5Support from "../features/OpenUI5Support.js";
 import { DEFAULT_THEME } from "../generated/AssetParameters.js";
 import { getCurrentRuntimeIndex } from "../Runtimes.js";
 
@@ -56,14 +56,15 @@ const detectExternalTheme = async (theme: string) => {
 
 	// If OpenUI5Support is enabled, try to find out if it loaded variables
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support && openUI5Support.cssVariablesLoaded()) {
-		return {
-			themeName: openUI5Support.getConfigurationSettingsObject()?.theme, // just themeName
-			baseThemeName: "", // baseThemeName is only relevant for custom themes
-		};
-	}
-
-	if (getThemeRoot()) {
+	if (openUI5Support && OpenUI5Support.isOpenUI5Detected()) {
+		const varsLoaded = openUI5Support.cssVariablesLoaded();
+		if (varsLoaded) {
+			return {
+				themeName: openUI5Support.getConfigurationSettingsObject()?.theme, // just themeName
+				baseThemeName: "", // baseThemeName is only relevant for custom themes
+			};
+		}
+	} else if (getThemeRoot()) {
 		await attachCustomThemeStylesToHead(theme);
 
 		return getThemeDesignerTheme();


### PR DESCRIPTION
**Background**

There are use-cases with multiple versions of the framework with some of them with OpenUI5Support enabled and others not. One of the consequences is that the z-indexes of popovers/dialogs on the page are not synchronised as the next z-index is calculated differently when OpenUI5Support is enabled and when isn't.

**Solution**
**To always enable the OpenUI5Support feature.** 
However, we had to ensure it's completely safe and won't have a side effect when the feature is imported, but OpenUI5 is not loaded on the page. And, this is what the PR addresses by refactoring a single usage in `applyTheme` and using `OpenUI5Support.isOpenUI5Detected` to check if OpenUI5 is available in the runtime.


Fixes: https://github.com/SAP/ui5-webcomponents/issues/7175