### PR TITLE
fix(ui5-view-settings-dialog): fix footer buttons position

### DIFF
--- a/packages/fiori/src/themes/ViewSettingsDialog.css
+++ b/packages/fiori/src/themes/ViewSettingsDialog.css
@@ -51,11 +51,12 @@
 	width: 100%;
 	display: flex;
 	justify-content: flex-end;
+	align-items: center;
 	margin: 0.1875rem 0;
 }
 
 .ui5-vsd-footer [ui5-button]:first-child {
-	margin-right: 0.5rem;
+	margin-inline-end: 0.5rem;
 	min-width: 4rem;
 }
 
@@ -71,7 +72,7 @@
 [ui5-dialog]::part(content) {
 	padding-top: 0;
 	padding-bottom: 0;
-	padding-right: 0;
+	padding-inline-end: 0;
 }
 
 :host [ui5-li]::part(native-li) {


### PR DESCRIPTION
**Issue**
In the release testing we caught an issue - the buttons in the footer were not vertically centered

1. Go to https://sap.github.io/ui5-webcomponents/nightly/playground/?path=/docs/fiori-viewsettingsdialog--docs

2. Observe the footer
<img width="382" alt="Screenshot 2023-06-29 at 12 18 44" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/35beacb8-b598-42ec-bba5-d6cc948dd1f1">

**Solution**
After setting `aling-items: center` they look better:

<img width="401" alt="Screenshot 2023-06-29 at 12 19 21" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/ef037905-fe0a-4c9a-95a1-9fc1c93d9c04">

**Additional refactoring**
In addition, `padding-*`, `margin-* ` have been replaced with equivalent CSS logical properties for out of the box RTL support.

