### PR TITLE
fix(ui5-li): remove additional text width restriction

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -146,7 +146,6 @@
 	font-size: 0.875rem;
 	min-width: 3.75rem;
 	text-align: end;
-	max-width: 40%;
 }
 
 :host([description]) .ui5-li-additional-text {


### PR DESCRIPTION
Additional text was width restricted and couldn't display its whole data, even if there was enough space for it.

After its removal the additional text is still Fiori compatible when it collides with the default text (it hyphens).

Fixes: #6937