### PR TITLE
fix(ui5-tabcontainer): fix height in compact

### DIFF
--- a/packages/main/src/AvatarGroup.ts
+++ b/packages/main/src/AvatarGroup.ts
@@ -110,8 +110,9 @@ type AvatarGroupClickEventDetail = {
  * The component provides advanced keyboard handling.
  * When focused, the user can use the following keyboard
  * shortcuts in order to perform a navigation:
+ *
  * <br>
- * - <code>type</code> Individual:
+ * <code>type</code> Individual:
  * <br>
  * <ul>
  * <li>[TAB] - Move focus to the overflow button</li>
@@ -122,7 +123,7 @@ type AvatarGroupClickEventDetail = {
  * <li>[SPACE],[ENTER],[RETURN] - Trigger <code>ui5-click</code> event</li>
  * </ul>
  * <br>
- * - <code>type</code> Group:
+ * <code>type</code> Group:
  * <br>
  * <ul>
  * <li>[TAB] - Move focus to the next interactive element after the component</li>

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -286,8 +286,8 @@
 	--_ui5_tc_item_text_line_height: 1.325rem;
 	--_ui5_tc_item_icon_size: 1rem;
 	--_ui5_tc_item_add_text_margin_top: 0.3125rem;
-	--_ui5_tc_header_height: var(--_ui5_tc_header_height_compact);
 	--_ui5_tc_item_height: 4rem;
+	--_ui5_tc_header_height: var(--_ui5_tc_item_height);
 	--_ui5_tc_item_icon_circle_size: 2rem;
 	--_ui5_tc_item_icon_size: 1rem;
 


### PR DESCRIPTION
**Issue:**
The CSS variable `--_ui5_tc_header_height_compact` is missing and TC's hight in compact is wrong.  The selection line is not visible at all.

**Solution**
Use `--_ui5_tc_item_height` instead.

Previously
<img width="948" alt="Screenshot 2023-06-30 at 15 55 45" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/bb4b2099-1580-4302-9a00-a086e1341334">

Now
<img width="964" alt="Screenshot 2023-06-30 at 15 55 03" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/ec1f3573-4e9a-4fea-9b02-939fba01ff83">



