### PR TITLE
fix(framework): fix links in starting page of new pkg

### DIFF
--- a/packages/create-package/template/test/pages/index.html
+++ b/packages/create-package/template/test/pages/index.html
@@ -21,7 +21,7 @@
 
 <body>
 	<div class="app">
-		<a href="https://sap.github.io/ui5-webcomponents/playground/getting-started" target="_blank" class="logo-link"></a>
+		<a href="https://sap.github.io/ui5-webcomponents/playground/?path=/docs/docs-getting-started-first-steps--docs" target="_blank" class="logo-link"></a>
 
 		<div class="app-first-component">
 			<h1>Hooray! It's Your First Web Component!</h1>
@@ -50,7 +50,7 @@
 
 		<div class="app-docs">
 			<h2>Documentation</h2>
-			<a class="link" href="https://sap.github.io/ui5-webcomponents/playground/development">Custom Component Development</a>
+			<a class="link" href="https://sap.github.io/ui5-webcomponents/playground/?path=/docs/docs-development-custom-ui5-web-components-packages--docs">Custom Component Development</a>
 		</div>
 	</div>
 </body>

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -45,7 +45,7 @@
             <section class="welcome-section">
                 <h1 class="title">UI5&nbsp;<span class="orange">Web Components</span></h1>
                 <div class="description">Enterprise-flavored sugar on top of native APIs!</div>
-                <p class="version">Latest Version: <a href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.14.0">1.14.0</a></p>
+                <p class="version">Latest Version: <a href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.15.0">1.15.0</a></p>
                 <a href="./playground" class="get-started-button">Get Started</a>
             </section>
         </div>

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -45,7 +45,7 @@
             <section class="welcome-section">
                 <h1 class="title">UI5&nbsp;<span class="orange">Web Components</span></h1>
                 <div class="description">Enterprise-flavored sugar on top of native APIs!</div>
-                <p class="version">Latest Version: <a href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.15.0">1.15.0</a></p>
+                <p class="version">Latest Version: <a href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.15.1">1.15.1</a></p>
                 <a href="./playground" class="get-started-button">Get Started</a>
             </section>
         </div>


### PR DESCRIPTION
links to the documentation are outdated as we now we moved. to Storybook and the URLs are different.