### PR TITLE
build(playground): optimize dev run scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ packages/playground/_stories/**/*/argTypes.ts
 packages/playground/.storybook/custom-elements.json
 packages/playground/docs/storybook/**/*
 packages/playground/docs/storybook-pages/**/*
+!packages/playground/docs/storybook-pages/.gitkeep
 
 packages/main/test/pages/fix.js
 packages/fiori/test/pages/fix.js

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,14 +47,14 @@
     "copy:assets:resources": "copy-and-watch \"../fiori/dist/resources/*\" \"./assets/js/ui5-webcomponents\"",
     "copy:assets:main": "copy-and-watch \"../main/dist/assets/**/*\" \"./assets/\"",
     "copy:assets:fiori": "copy-and-watch \"../fiori/dist/assets/**/*\" \"./assets/\"",
-    "prepare:bundle": "npm run build:bundle",
+    "prepare:build:bundle": "npm run build:bundle",
+    "prepare:build:nojekyll": "copy-and-watch \"./.nojekyll\" \"./dist\"",
+    "prepare:build:pages": "npm run clean:pages && vite-node ./build-scripts-storybook/pages-prepare.ts",
     "prepare:assets": "npm run clean:assets && npm run copy:assets",
-    "prepare:nojekyll": "copy-and-watch \"./.nojekyll\" \"./dist\"",
     "prepare:samples": "node ./build-scripts-storybook/samples-prepare.js",
     "prepare:manifest": "node ./build-scripts-storybook/parse-manifest.js",
-    "prepare:pages": "npm run clean:pages && vite-node ./build-scripts-storybook/pages-prepare.ts",
     "prepare:documentation": "vite-node ./build-scripts-storybook/documentation-prepare.ts",
     "storybook": "npm-run-all --parallel prepare:* && storybook dev -p 6006",
-    "build-storybook": "npm-run-all --parallel prepare:* && tsc && storybook build -o ./dist/playground"
+    "build-storybook": "npm-run-all --parallel prepare:build:* prepare:* && tsc && storybook build -o ./dist/playground"
   }
 }


### PR DESCRIPTION
Some npm build scripts require certain resources from the `dist` folders of the packages, but are only needed for the build of the storybook and not for local serving. 