### PR TITLE
chore: refactor I18Bundle#getText params types

### DIFF
--- a/packages/base/src/i18nBundle.ts
+++ b/packages/base/src/i18nBundle.ts
@@ -31,7 +31,7 @@ class I18nBundle {
 	 * @param params Values for the placeholders
 	 * @returns {string}
 	 */
-	getText(textObj: I18nText, ...params: Array<number | string>): string {
+	getText(textObj: I18nText | string, ...params: Array<number | string>): string {
 		if (typeof textObj === "string") {
 			textObj = { key: textObj, defaultText: textObj };
 		}


### PR DESCRIPTION
The `I18Bundle#getText` method works with both objects and strings, 
however the type is set to **I18nText** ( { key: string, defaultText: string } ) and causes TS errors when the method is called with a string as described in the referenced issue.

```ts
const msg = i18nBundle.getText("TEST");
 ```

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7300