### PR TITLE
docs(ui5-tabcontainer): remove sample of items with additional text

### DIFF
--- a/packages/playground/_stories/main/TabContainer/TabContainer.stories.ts
+++ b/packages/playground/_stories/main/TabContainer/TabContainer.stories.ts
@@ -97,16 +97,6 @@ TextOnlyEndOverflow.args = {
 <ui5-tab text="Tab 23"></ui5-tab>`,
 };
 
-export const WithAdditionalText = Template.bind({});
-WithAdditionalText.args = {
-	collapsed: true,
-	fixed: true,
-	default: `<ui5-tab text="Info" additional-text="3"></ui5-tab>
-<ui5-tab text="Attachments" additional-text="24" selected></ui5-tab>
-<ui5-tab text="Notes" additional-text="16"></ui5-tab>
-<ui5-tab text="People" additional-text="34"></ui5-tab>`,
-};
-
 export const InlineTabLayout = Template.bind({});
 InlineTabLayout.args = {
 	tabLayout: TabLayout.Inline,


### PR DESCRIPTION
"Inline" tab layout is now the recommended layout.