### PR TITLE
fix(ui5-time-picker): support relative value "now"

### DIFF
--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -115,6 +115,10 @@ class TimePicker extends TimePickerBase {
 	@property()
 	formatPattern!: string;
 
+	onBeforeRendering() {
+		this.value = this.normalizeValue(this.value!) || this.value;
+	}
+
 	get _formatPattern() {
 		const hasHours = !!this.formatPattern.match(/H/i);
 		const fallback = !this.formatPattern || !hasHours;

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -42,6 +42,9 @@
 		<ui5-time-picker id="timepickerInput"></ui5-time-picker>
 		<ui5-input id="inputResult"></ui5-input>
 
+		<br /><br />
+		<ui5-title>Test "now" value</ui5-title>
+		<ui5-time-picker id="timepickerNow" value="now"></ui5-time-picker>
 
 		<br /><br />
 		<ui5-title>Test empty value</ui5-title>

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -216,13 +216,16 @@ describe("TimePicker general interaction", () => {
 	});
 
 	it("the value 'now' returns the current time, instead of the string 'now'", async () => {
+		await browser.url(`test/pages/TimePicker.html`);
+
 		const timepicker = await browser.$("#timepicker");
 
 		// act
-		await timepicker.shadow$("ui5-input").$(".ui5-time-picker-input-icon-button").click();
+		await timepicker.click();
 		await browser.keys("now");
+		await browser.keys("Enter");
 
 		// assert that the value in the input is different than the string 'now'
-		assert.notStrictEqual(await timepicker.shadow$("ui5-input").getValue(), "now", "the value is not 'now'");
+		assert.notStrictEqual(await timepicker.shadow$("ui5-input").getProperty("value"), "now", "the value is not 'now'");
 	});
 });

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -215,4 +215,14 @@ describe("TimePicker general interaction", () => {
 		assert.notOk(await timepickerPopover.isDisplayed(), "the picker should be collapsed");
 	});
 
+	it("the value 'now' returns the current time, instead of the string 'now'", async () => {
+		const timepicker = await browser.$("#timepicker");
+
+		// act
+		await timepicker.shadow$("ui5-input").$(".ui5-time-picker-input-icon-button").click();
+		await browser.keys("now");
+
+		// assert that the value in the input is different than the string 'now'
+		assert.notStrictEqual(await timepicker.shadow$("ui5-input").getValue(), "now", "the value is not 'now'");
+	});
 });


### PR DESCRIPTION
Currently when the value of the component(s) is set to "now", text "now" is rendered instead of the current time.
With this change, we fix that issue.

### Before
![Snag_a9b37b](https://github.com/SAP/ui5-webcomponents/assets/88034608/d3b611c8-12ce-43ba-85e8-f5932459c956)

### After
![Snag_a9c761](https://github.com/SAP/ui5-webcomponents/assets/88034608/fa8c04c7-e777-440d-bd6c-ce879e0c7f0b)

Fixes: #7287
