### PR TITLE
feat(ui5-avatar): add disabled property

### DIFF
--- a/packages/main/src/Avatar.hbs
+++ b/packages/main/src/Avatar.hbs
@@ -1,6 +1,7 @@
 <div
 	class="ui5-avatar-root"
 	tabindex="{{tabindex}}"
+	?disabled="{{disabled}}"
 	data-sap-focus-ref
 	@keyup={{_onkeyup}}
 	@keydown={{_onkeydown}}

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -70,13 +70,27 @@ import "@ui5/webcomponents-icons/dist/employee.js";
 })
 /**
 * Fired on mouseup, space and enter if avatar is interactive
-*
+* <b>Note:</b> The event will not be fired if the <code>disabled</code>
+* property is set to <code>true</code>.
 * @event
 * @private
 * @since 1.0.0-rc.11
 */
 @event("click")
 class Avatar extends UI5Element implements ITabbable {
+	/**
+	 * Defines whether the component is disabled.
+	 * A disabled component can't be pressed or
+	 * focused, and it is not in the tab chain.
+	 *
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.Avatar.prototype.disabled
+	 * @defaultvalue false
+	 * @public
+	 */
+	@property({ type: Boolean })
+	disabled!: boolean;
+
 	/**
 	 * Defines if the avatar is interactive (focusable and pressable).
 	 * @type {boolean}
@@ -281,6 +295,7 @@ class Avatar extends UI5Element implements ITabbable {
 	_onclick?: (e: MouseEvent) => void;
 	static i18nBundle: I18nBundle;
 	_handleResizeBound: ResizeObserverCallback;
+	_interactive!: boolean;
 
 	constructor() {
 		super();
@@ -292,7 +307,7 @@ class Avatar extends UI5Element implements ITabbable {
 	}
 
 	get tabindex() {
-		return this._tabIndex || (this.interactive ? "0" : "-1");
+		return this._tabIndex || (this._interactive ? "0" : "-1");
 	}
 
 	/**
@@ -320,7 +335,7 @@ class Avatar extends UI5Element implements ITabbable {
 	}
 
 	get _role() {
-		return this.interactive ? "button" : undefined;
+		return this._interactive ? "button" : undefined;
 	}
 
 	get _ariaHasPopup() {
@@ -357,7 +372,8 @@ class Avatar extends UI5Element implements ITabbable {
 	 }
 
 	onBeforeRendering() {
-		this._onclick = this.interactive ? this._onClickHandler.bind(this) : undefined;
+		this._interactive = this.interactive && !this.disabled;
+		this._onclick = this._interactive ? this._onClickHandler.bind(this) : undefined;
 	}
 
 	async onAfterRendering() {
@@ -407,7 +423,7 @@ class Avatar extends UI5Element implements ITabbable {
 	}
 
 	_onkeydown(e: KeyboardEvent) {
-		if (!this.interactive) {
+		if (!this._interactive) {
 			return;
 		}
 
@@ -421,7 +437,7 @@ class Avatar extends UI5Element implements ITabbable {
 	}
 
 	_onkeyup(e: KeyboardEvent) {
-		if (this.interactive && !e.shiftKey && isSpace(e)) {
+		if (this._interactive && !e.shiftKey && isSpace(e)) {
 			this.fireEvent("click");
 		}
 	}
@@ -431,13 +447,13 @@ class Avatar extends UI5Element implements ITabbable {
 	}
 
 	_onfocusin() {
-		if (this.interactive) {
+		if (this._interactive) {
 			this.focused = true;
 		}
 	}
 
 	_getAriaHasPopup() {
-		if (!this.interactive || this.ariaHaspopup === "") {
+		if (!this._interactive || this.ariaHaspopup === "") {
 			return;
 		}
 

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -14,8 +14,12 @@
 	outline-offset: var(--_ui5_avatar_focus_offset);
 }
 
-:host([interactive]) {
+:host(:not([disabled])[interactive]) {
 	cursor: pointer;
+}
+
+:host([disabled]) {
+	opacity: var(--sapContent_DisabledOpacity);
 }
 
 :host {

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -152,6 +152,15 @@
 	</section>
 
 	<section>
+		<h3>Avatar - interactive disabled</h3>
+		<ui5-avatar id="interactive-disabled" disabled aria-haspopup="menu" interactive initials="XS" size="XS" accessible-name="Interactive avatar"></ui5-avatar>
+		<br>
+		<ui5-input id="click-event-3"></ui5-input>
+		<h3>Avatar - non-interactive disabled</h3>
+		<ui5-avatar id="non-interactive-disabled" disabled initials="S" size="S"></ui5-avatar>
+	</section>
+
+	<section>
 		<h3>Avatar - interactive</h3>
 		<ui5-avatar id="interactive-avatar" aria-haspopup="menu" interactive initials="XS" size="XS" accessible-name="Interactive avatar"></ui5-avatar>
 		<ui5-avatar id="non-interactive-avatar" initials="S" size="S"></ui5-avatar>
@@ -216,15 +225,22 @@
 
 	<script>
 		var avatar = document.getElementById("interactive-avatar"),
+			interactiveDisabled = document.getElementById("interactive-disabled"),
 			myInteractiveAvatar = document.getElementById("myInteractiveAvatar"),
 			nonInteractiveAvatar = document.getElementById("non-interactive-avatar"),
 			input = document.getElementById("click-event"),
 			input2 = document.getElementById("click-event-2"),
+			input3 = document.getElementById("click-event-3"),
 			inputValue = 0;
 			inputValue2 = 0;
+			inputValue3 = 0;
 
 		avatar.addEventListener("ui5-click", function() {
 			input.value = ++inputValue;
+		});
+
+		interactiveDisabled.addEventListener("ui5-click", function() {
+			input3.value = ++inputValue3;
 		});
 
 		nonInteractiveAvatar.addEventListener("ui5-click", function() {

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -61,6 +61,16 @@ describe("Avatar", () => {
 		assert.ok(await icon.isExisting(), "icon should be rendered, when the initials are overflowing");
 	});
 
+	it("tests clicking on interactive disabled avatar", async () => {
+
+		const avatarRoot = await browser.$("#interactive-disabled").shadow$(".ui5-avatar-root");
+		const input3 = await browser.$("#click-event");
+
+		await avatarRoot.click();
+		assert.strictEqual(await input3.getAttribute("value"), "0", "Mouse click event not thrown when avatar is interactive + disabled");
+		assert.ok(await avatarRoot.hasAttribute("disabled"), )
+	});
+
 	it("Tests noConflict 'ui5-click' event is thrown for interactive avatars", async () => {
 		const avatarRoot = await browser.$("#interactive-avatar").shadow$(".ui5-avatar-root");
 		const input = await browser.$("#click-event");

--- a/packages/playground/_stories/main/Avatar/Avatar.stories.ts
+++ b/packages/playground/_stories/main/Avatar/Avatar.stories.ts
@@ -35,6 +35,7 @@ const Template: UI5StoryArgs<Avatar, StoryArgsSlots> = (args) =>
     initials="${ifDefined(args.initials)}"
     color-scheme="${ifDefined(args.colorScheme)}"
     ?interactive="${ifDefined(args.interactive)}"
+    ?disabled="${ifDefined(args.disabled)}"
     aria-haspopup="${ifDefined(args.ariaHaspopup)}"
     accessible-name="${ifDefined(args.accessibleName)}"
   >
@@ -46,6 +47,14 @@ Basic.args = {
   initials: "FJ",
   interactive: true,
   accessibleName: "Avatar with accessible name"
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	size: AvatarSize.XL,
+	initials: "IP",
+	interactive: true,
+	disabled: true
 };
 
 export const WithImage = Template.bind({});


### PR DESCRIPTION
There is a requirement for a new `disabled` property.
The new property makes the `Avatar` non-interactive regardless of its `interactive `property.
It also adds opacity to its visual representation.
