### PR TITLE
ci: use node 18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install Dependencies


### PR DESCRIPTION
Recently our tests fail randomly with  `unknown error: unhandled inspector error: {"code":-32000,"message":"No node with given id found"}`. Issue from  https://bugs.chromium.org/p/chromedriver/issues/detail?id=4440 points out that using node 18 should fix the issue.