### PR TITLE
fix(ui5-time-picker): add explicit dep to SegmentedBtnItem

### DIFF
--- a/packages/main/src/TimeSelectionClocks.ts
+++ b/packages/main/src/TimeSelectionClocks.ts
@@ -26,6 +26,7 @@ import TimePickerInternals from "./TimePickerInternals.js";
 import TimePickerClock from "./TimePickerClock.js";
 import ToggleSpinButton from "./ToggleSpinButton.js";
 import SegmentedButton from "./SegmentedButton.js";
+import SegmentedButtonItem from "./SegmentedButtonItem.js";
 
 import type { TimePickerClockChangeEventDetail } from "./TimePickerClock.js";
 
@@ -97,6 +98,7 @@ const TYPE_COOLDOWN_DELAY = 1000; // Cooldown delay; 0 = disabled cooldown
 		TimePickerClock,
 		ToggleSpinButton,
 		SegmentedButton,
+		SegmentedButtonItem,
 	],
 })
 


### PR DESCRIPTION
The internal `TimeSelectionClocks.ts`  class has the following dependencies: `TimePickerClock`, `ToggleSpinButton` and **SegmentedButton**, and all these tags are properly scoped.

Although the SegmentedButton has dependency to SegmentedButtonItem, the `ui5-segmented-button-item` tag is used inside the TimeSelectionClocks's ShadowDom (not in the SegmentedButton's ShadowDom), and has to be explicitly added to the TimeSelectionClocks dependencies to be scoped as well.

```html
<-- TimeSelectionClocks.hbs !-->
<ui5-segmented-button
        <ui5-segmented-button-item></ui5-segmented-button-item>
</ui5-segmented-button>
```

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7343