### PR TITLE
docs(ui5-switch): remove outdated statement in the JSDocs

### DIFF
--- a/packages/main/src/Switch.ts
+++ b/packages/main/src/Switch.ts
@@ -125,7 +125,7 @@ class Switch extends UI5Element {
 	 *
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
+	 *
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOn
 	 * @defaultvalue ""
@@ -138,7 +138,7 @@ class Switch extends UI5Element {
 	 * Defines the text, displayed when the component is not checked.
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
+	 *
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOff
 	 * @defaultvalue ""


### PR DESCRIPTION
With this change, we remove outdated statement in the `ui5-switch` documentation.

Fixes: #7093
