### PR TITLE
fix(ui5-switch): align text/icon properly in switch handle

### DIFF
--- a/packages/main/src/Switch.ts
+++ b/packages/main/src/Switch.ts
@@ -125,7 +125,7 @@ class Switch extends UI5Element {
 	 *
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 *
+	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOn
 	 * @defaultvalue ""
@@ -138,7 +138,7 @@ class Switch extends UI5Element {
 	 * Defines the text, displayed when the component is not checked.
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 *
+	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOff
 	 * @defaultvalue ""

--- a/packages/main/src/Switch.ts
+++ b/packages/main/src/Switch.ts
@@ -125,7 +125,7 @@ class Switch extends UI5Element {
 	 *
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
+	 *
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOn
 	 * @defaultvalue ""
@@ -138,7 +138,7 @@ class Switch extends UI5Element {
 	 * Defines the text, displayed when the component is not checked.
 	 * <br><br>
 	 * <b>Note:</b> We recommend using short texts, up to 3 letters (larger texts would be cut off).
-	 * <b>Note:</b> This property will have no effect if the theme is set to <code>sap_horizon</code>.
+	 *
 	 * @type {string}
 	 * @name sap.ui.webc.main.Switch.prototype.textOff
 	 * @defaultvalue ""

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -158,12 +158,14 @@
 	visibility: var(--_ui5_switch_text_hidden);
 }
 
-.ui5-switch-root.ui5-switch--checked .ui5-switch-text--on {
+.ui5-switch-root.ui5-switch--checked.ui5-switch--semantic .ui5-switch-text--on, 
+.ui5-switch-root.ui5-switch--checked.ui5-switch-desktop.ui5-switch--no-label .ui5-switch-text--on {
 	left: var(--_ui5_switch_text_active_left);
 }
-.ui5-switch-root:not(.ui5-switch--checked) .ui5-switch-text--off {
+.ui5-switch-root:not(.ui5-switch--checked).ui5-switch--semantic .ui5-switch-text--off,
+.ui5-switch-root:not(.ui5-switch--checked).ui5-switch-desktop.ui5-switch--no-label .ui5-switch-text--off {
 	left: var(--_ui5_switch_text_inactive_left);
-	right: var(--_ui5_switch_text_inactive_right)
+	right: var(--_ui5_switch_text_inactive_right);
 }
 
 /* handle */


### PR DESCRIPTION
Currently there was a case where we apply **`left`**, **`right`** CSS properties, which were intended for `ui5-switch` instances, which are using icons in their handles ( f.e basic switch with no text set, switch with **`design="Graphical"`**, and so on). However these styles were applying even for switches, which had `text-on` and `text-off` properties, which caused a slight misalignment.

Please refer:
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/1c21d169-864e-4ac1-8c45-8bfb9f519fa9)

On the image above, we could see the little misalignment in the text. It was occuring for both On/Off cases.
Now the content in the `ui5-switch` handles, are properly aligned.

![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/89345236-253d-4bea-9777-90f56b40e184)

Fixes: #7094


