### PR TITLE
fix(ui5-checkbox): trigger form validation when required

### DIFF
--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -321,7 +321,8 @@ class CheckBox extends UI5Element implements IFormElement {
 		const formSupport = getFeature<typeof FormSupport>("FormSupport");
 		if (formSupport) {
 			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: HTMLInputElement) => {
-				nativeInput.disabled = element.disabled || !element.checked;
+				nativeInput.disabled = !!element.disabled;
+				nativeInput.checked = !!element.checked;
 				nativeInput.value = element.checked ? "on" : "";
 			});
 		} else if (this.name) {

--- a/packages/main/test/pages/CheckBox.html
+++ b/packages/main/test/pages/CheckBox.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 	<title>ui5-checkbox</title>
 
@@ -62,11 +62,24 @@
 	<ui5-checkbox class="defaultPreventedCb" indeterminate></ui5-checkbox>
 	<ui5-checkbox class="defaultPreventedCb" indeterminate checked></ui5-checkbox>
 
+	<br />
+	<ui5-title>Form submission</ui5-title>
+	<form id="cbForm">
+		<ui5-checkbox id="cbItem1" text="Option 1" checked></ui5-checkbox>
+		<ui5-checkbox id="cbItem2" text="Option 2" checked></ui5-checkbox>
+		<ui5-checkbox id="cbItem3" text="Option 3" required></ui5-checkbox>
+		<br><br>
+		<ui5-button id="cbSubmit" type="Submit">Submit</ui5-button>
+		<input type="hidden" id="cbFormSubmitted" value="false" />
+	</form>
+
 	<script>
 		var hcb = false;
+		var cbForm = document.querySelector("#cbForm");
 		var input = document.querySelector("#field");
 		var checkBox1 = document.querySelector("#cb1");
 		var checkBox2 = document.querySelector("#cb2");
+		var cbFormSubmitted = document.querySelector("#cbFormSubmitted");
 		var counter = 0;
 
 		[checkBox1, checkBox2].forEach(function(el) {
@@ -83,6 +96,13 @@
 				event.preventDefault();
 			});
 		});
-</script>
+
+		cbForm.addEventListener("submit", function (event) {
+			event.preventDefault();
+			cbFormSubmitted.value = true;
+			alert("Form submitted!");
+		});
+	</script>
 </body>
+
 </html>

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -88,7 +88,15 @@ describe("CheckBox general interaction", () => {
 		}
 	});
 
-	it("tests form submission when third checkbox is checked and button is clicked", async () => {
+	it("tests form submission when checkbox is required, but unchecked", async () => {
+		const submitButton = await browser.$("#cbSubmit");
+
+		await submitButton.click();
+
+		assert.strictEqual(await browser.$("#cbFormSubmitted").getValue(), "false", "Form is not submitted");
+	});
+
+	it("tests form submission when checkbox is checked and button is clicked", async () => {
 		const thirdCheckbox = await browser.$("#cbItem3");
 		const submitButton = await browser.$("#cbSubmit");
 

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -87,4 +87,14 @@ describe("CheckBox general interaction", () => {
 			assert.strictEqual(await defaultPreventedCb.getProperty("indeterminate"), state.indeterminate, "The checkbox indeterminate is not changed");
 		}
 	});
+
+	it("tests form submission when third checkbox is checked and button is clicked", async () => {
+		const thirdCheckbox = await browser.$("#cbItem3");
+		const submitButton = await browser.$("#cbSubmit");
+
+		await thirdCheckbox.click();
+		await submitButton.click();
+
+		assert.strictEqual(await browser.$("#cbFormSubmitted").getValue(), "true", "Form is submitted");
+	});
 });


### PR DESCRIPTION
The issue seems to happen because the internal `formSupport` slot has `disabled` attribute. When inputs are disabled, the client does not send their values, resulting in the browser skipping validation.

Fixes: #7319
