### PR TITLE
fix(ui5-shellbar): button focus outline adjustment

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -10,7 +10,6 @@
 	--_ui5_input_border_radius: var(--_ui5_shellbar_input_border_radius);
 	--_ui5_input_focus_border_radius: var(--_ui5_shellbar_input_focus_border_radius);
 	--_ui5_input_background_color: var(--_ui5_shellbar_input_background_color);
-	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 }
 
 .ui5-shellbar-root {
@@ -217,6 +216,10 @@ slot[name="profile"] {
 
 .ui5-shellbar-button {
 	width: 2.5rem;
+}
+
+.ui5-shellbar-button[focused]::part(button):after {
+    border: var(--_ui5_shellbar_button_focused_border);
 }
 
 .ui5-shellbar-search-button {

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -215,11 +215,8 @@ slot[name="profile"] {
 }
 
 .ui5-shellbar-button {
+	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 	width: 2.5rem;
-}
-
-.ui5-shellbar-button[focused]::part(button):after {
-    border: var(--_ui5_shellbar_button_focused_border);
 }
 
 .ui5-shellbar-search-button {

--- a/packages/fiori/src/themes/base/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/base/ShellBar-parameters.css
@@ -7,6 +7,7 @@
 	--_ui5_shellbar_button_box_shadow: none;
 	--_ui5_shellbar_button_border: none;
 	--_ui5_shellbar_button_border_radius: 0.25rem;
+	--_ui5_shellbar_button_focused_border: 0.0625rem dotted var(--sapContent_FocusColor);
 	--_ui5_shellbar_button_active_color: var(--sapShell_Active_TextColor);
 	--_ui5_shellbar_logo_outline_border_radius: 0;
 	--_ui5_shellbar_copilot_stop_color1: #C0D9F2;

--- a/packages/fiori/src/themes/sap_belize_hcb/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_belize_hcb/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_belize_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_belize_hcb/parameters-bundle.css
@@ -13,3 +13,4 @@
 @import "../base/ViewSettingsDialog-parameters.css";
 @import "../base/Wizard-parameters.css";
 @import "./WizardTab-parameters.css";
+@import "./ShellBar-parameters.css";

--- a/packages/fiori/src/themes/sap_belize_hcw/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_belize_hcw/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_belize_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_belize_hcw/parameters-bundle.css
@@ -13,3 +13,4 @@
 @import "../base/ViewSettingsDialog-parameters.css";
 @import "../base/Wizard-parameters.css";
 @import "./WizardTab-parameters.css";
+@import "./ShellBar-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -13,3 +13,4 @@
 @import "../base/ViewSettingsDialog-parameters.css";
 @import "../base/Wizard-parameters.css";
 @import "./WizardTab-parameters.css";
+@import "./ShellBar-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -13,3 +13,4 @@
 @import "../base/ViewSettingsDialog-parameters.css";
 @import "../base/Wizard-parameters.css";
 @import "./WizardTab-parameters.css";
+@import "./ShellBar-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/ShellBar-parameters.css
@@ -7,6 +7,7 @@
 
 	--_ui5_shellbar_button_border: none;
 	--_ui5_shellbar_button_border_radius: var(--sapButton_BorderCornerRadius);
+	--_ui5_shellbar_button_focused_border: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_shellbar_button_badge_border: 1px solid var(--sapContent_BadgeBackground);
 	--_ui5_shellbar_logo_border_radius: 0.5rem;
 	--_ui5_shellbar_button_box_shadow: var(--sapContent_Interaction_Shadow);

--- a/packages/fiori/src/themes/sap_horizon_dark/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/ShellBar-parameters.css
@@ -7,6 +7,7 @@
 
 	--_ui5_shellbar_button_border: none;
 	--_ui5_shellbar_button_border_radius: var(--sapButton_BorderCornerRadius);
+	--_ui5_shellbar_button_focused_border: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_shellbar_button_badge_border: 1px solid var(--sapContent_BadgeBackground);
 	--_ui5_shellbar_logo_border_radius: 0.5rem;
 	--_ui5_shellbar_button_box_shadow: var(--sapContent_Interaction_Shadow);

--- a/packages/fiori/src/themes/sap_horizon_hcb/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/ShellBar-parameters.css
@@ -3,6 +3,7 @@
 :root {
 	--_ui5_shellbar_button_border: var(--sapButton_BorderWidth) solid var(--sapButton_BorderColor);
 	--_ui5_shellbar_button_border_radius: var(--sapButton_BorderCornerRadius);
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
 	--_ui5_shellbar_button_badge_border: 1px solid var(--sapGroup_ContentBorderColor);
 	--_ui5_shellbar_outline_offset: -0.1875rem;
 	--_ui5_shellbar_search_field_height: 2.25rem;

--- a/packages/fiori/src/themes/sap_horizon_hcw/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/ShellBar-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/ShellBar-parameters.css";
+
+:root {
+	--_ui5_shellbar_button_focused_border: 0.125rem dotted var(--sapContent_FocusColor);
+}

--- a/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -13,3 +13,4 @@
 @import "../base/ViewSettingsDialog-parameters.css";
 @import "./Wizard-parameters.css";
 @import "./WizardTab-parameters.css";
+@import "./ShellBar-parameters.css";


### PR DESCRIPTION
This commit addresses an issue identified after the recent update related to runtime-based CSS variables for components.

It adjusts the focus outline of the ShellBar buttons across all themes.

Fixes #7220