### PR TITLE
fix(ui5-switch): fix text alignment in all themes

### DIFF
--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -337,11 +337,14 @@
 	color: var(--_ui5_switch_text_active_color);
 	overflow: var(--_ui5_switch_text_overflow);
 	text-overflow: ellipsis;
+	left: var(--_ui5_switch_text_active_left_alternate);
 }
 .ui5-switch-root .ui5-switch-text--off {
 	color: var(--_ui5_switch_text_inactive_color);
 	overflow: var(--_ui5_switch_text_overflow);
 	text-overflow: ellipsis;
+	left: var(--_ui5_switch_text_inactive_left_alternate);
+	right: var(--_ui5_switch_text_inactive_right_alternate);
 }
 
 .ui5-switch-root .ui5-switch-no-label-icon-on,

--- a/packages/main/src/themes/base/Switch-parameters.css
+++ b/packages/main/src/themes/base/Switch-parameters.css
@@ -116,8 +116,11 @@
 	--_ui5_switch_text_width: none;
 
 	--_ui5_switch_text_inactive_left: auto;
+	--_ui5_switch_text_inactive_left_alternate: auto;
 	--_ui5_switch_text_inactive_right: 0.125rem;
+	--_ui5_switch_text_inactive_right_alternate: 0.125rem;
 	--_ui5_switch_text_active_left: calc(-100% + 2rem);
+	--_ui5_switch_text_active_left_alternate: calc(-100% + 2rem);
 	--_ui5_switch_text_active_right: auto;
 
 	--_ui5_switch_text_active_color: var(--sapButton_Track_Selected_TextColor);

--- a/packages/main/src/themes/sap_horizon/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Switch-parameters.css
@@ -104,8 +104,11 @@
 	--_ui5_switch_text_with_label_width: 1.75rem;
 
 	--_ui5_switch_text_inactive_left: 0.1875rem;
+	--_ui5_switch_text_inactive_left_alternate: 0.0625rem;
 	--_ui5_switch_text_inactive_right: auto;
+	--_ui5_switch_text_inactive_right_alternate: 0;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 	--_ui5_switch_text_active_right: auto;
 
 	--_ui5_switch_text_active_color: var(--sapButton_Handle_Selected_TextColor);

--- a/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
@@ -103,8 +103,11 @@
 	--_ui5_switch_text_with_label_width: 1.75rem;
 
 	--_ui5_switch_text_inactive_left: 0.1875rem;
+	--_ui5_switch_text_inactive_left_alternate: 0;
 	--_ui5_switch_text_inactive_right: auto;
+	--_ui5_switch_text_inactive_right_alternate: 0;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 	--_ui5_switch_text_active_right: auto;
 
 	--_ui5_switch_text_active_color: var(--sapButton_Handle_Selected_TextColor);
@@ -145,4 +148,5 @@
 	--_ui5_switch_text_font_size: var(--sapFontSize);
 	--_ui5_switch_text_width: 1rem;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
@@ -123,8 +123,10 @@
 	--_ui5_switch_text_with_label_width: 1.75rem;
 
 	--_ui5_switch_text_inactive_left: 0.1875rem;
+	--_ui5_switch_text_inactive_left_alternate: 0.0625rem;
 	--_ui5_switch_text_inactive_right: auto;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 	--_ui5_switch_text_compact_active_left: 0.1875rem;
 	--_ui5_switch_text_active_right: auto;
 

--- a/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
@@ -104,8 +104,10 @@
 	--_ui5_switch_text_with_label_width: 1.75rem;
 
 	--_ui5_switch_text_inactive_left: 0.1875rem;
+	--_ui5_switch_text_inactive_left_alternate: 0.0625rem;
 	--_ui5_switch_text_inactive_right: auto;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 	--_ui5_switch_text_active_right: auto;
 
 	--_ui5_switch_text_active_color: var(--sapButton_Handle_Selected_TextColor);
@@ -146,4 +148,5 @@
 	--_ui5_switch_text_font_size: var(--sapFontSize);
 	--_ui5_switch_text_width: 1rem;
 	--_ui5_switch_text_active_left: 0.1875rem;
+	--_ui5_switch_text_active_left_alternate: 0.0625rem;
 }


### PR DESCRIPTION
The visual design for the Switch was broken in Fiori (Quartz) and Belize themes in the following change [link](https://github.com/SAP/ui5-webcomponents/pull/7350).
The issue appeared only after merging to the main branch for some reason.

Please refer:

![2023-08-07_14-39-47](https://github.com/SAP/ui5-webcomponents/assets/88034608/28a1b37b-81eb-4c84-abb3-310b4cd5e8d6)

In order to fix the visual design in all themes, we had to introduce an alternate CSS variable. This was added because in Horizon themes for example, for the Text and Graphical Switch, the variable `--_ui5_switch_text_inactive_left` needs to have a different value for each of the styles in order to be properly aligned.

After the fix:

![2023-08-07_15-29-00](https://github.com/SAP/ui5-webcomponents/assets/88034608/9135b5fe-9e3f-4871-b457-ae1c9beefaf5)
