### PR TITLE
chore: do not use adoptedStylesheets for Safari

### DIFF
--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -3,6 +3,7 @@ import createLinkInHead from "./util/createLinkInHead.js";
 import { shouldUseLinks, getUrl } from "./CSP.js";
 import { StyleData, StyleDataCSP } from "./types.js";
 import { getCurrentRuntimeIndex } from "./Runtimes.js";
+import { isSafari } from "./Device.js";
 
 const getStyleId = (name: string, value: string) => {
 	return value ? `${name}|${value}` : name;
@@ -20,7 +21,7 @@ const createStyle = (data: StyleData, name: string, value = "") => {
 		attributes[name] = value;
 		const href = getUrl((data as StyleDataCSP).packageName, (data as StyleDataCSP).fileName);
 		createLinkInHead(href, attributes);
-	} else if (document.adoptedStyleSheets) {
+	} else if (document.adoptedStyleSheets && !isSafari()) {
 		const stylesheet = new CSSStyleSheet();
 		stylesheet.replaceSync(content);
 		(stylesheet as Record<string, any>)._ui5StyleId = getStyleId(name, value); // set an id so that we can find the style later
@@ -42,7 +43,7 @@ const updateStyle = (data: StyleData, name: string, value = "") => {
 	if (shouldUseLinks()) {
 		const link = document.querySelector(`head>link[${name}="${value}"]`) as HTMLLinkElement;
 		link.href = getUrl((data as StyleDataCSP).packageName, (data as StyleDataCSP).fileName);
-	} else if (document.adoptedStyleSheets) {
+	} else if (document.adoptedStyleSheets && !isSafari()) {
 		const stylesheet = document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));
 		if (stylesheet) {
 			stylesheet.replaceSync(content || "");
@@ -60,7 +61,7 @@ const hasStyle = (name: string, value = "") => {
 		return !!document.querySelector(`head>link[${name}="${value}"]`);
 	}
 
-	if (document.adoptedStyleSheets) {
+	if (document.adoptedStyleSheets && !isSafari()) {
 		return !!document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));
 	}
 
@@ -71,7 +72,7 @@ const removeStyle = (name: string, value = "") => {
 	if (shouldUseLinks()) {
 		const linkElement = document.querySelector(`head>link[${name}="${value}"]`);
 		linkElement?.parentElement?.removeChild(linkElement);
-	} else if (document.adoptedStyleSheets) {
+	} else if (document.adoptedStyleSheets && !isSafari()) {
 		document.adoptedStyleSheets = document.adoptedStyleSheets.filter(sh => (sh as Record<string, any>)._ui5StyleId !== getStyleId(name, value));
 	} else {
 		const styleElement = document.querySelector(`head > style[${name}="${value}"]`);

--- a/packages/base/src/updateShadowRoot.ts
+++ b/packages/base/src/updateShadowRoot.ts
@@ -3,6 +3,7 @@ import getEffectiveStyle from "./theming/getEffectiveStyle.js";
 import getEffectiveLinksHrefs from "./theming/getEffectiveLinksHrefs.js";
 import { shouldUseLinks } from "./CSP.js";
 import type UI5Element from "./UI5Element.js";
+import { isSafari } from "./Device.js";
 
 /**
  * Updates the shadow root of a UI5Element or its static area item
@@ -27,7 +28,7 @@ const updateShadowRoot = (element: UI5Element, forStaticArea = false) => {
 
 	if (shouldUseLinks()) {
 		styleStrOrHrefsArr = getEffectiveLinksHrefs(ctor, forStaticArea);
-	} else if (document.adoptedStyleSheets) { // Chrome
+	} else if (document.adoptedStyleSheets && !isSafari()) { // Chrome
 		shadowRoot.adoptedStyleSheets = getConstructableStyle(ctor, forStaticArea);
 	} else { // FF, Safari
 		styleStrOrHrefsArr = getEffectiveStyle(ctor, forStaticArea);


### PR DESCRIPTION
Ever since Safari introduced `adoptedStylesheets` there has been a bug with the implementation. It is expected to be fixed with version `16.7`. Until then, we'll treat Safari as if didn't support adopted stylesheets at all.