### PR TITLE
docs(storybook): diisplay correct name in ArgsTable

### DIFF
--- a/packages/playground/_stories/fiori/Bar/Bar.stories.ts
+++ b/packages/playground/_stories/fiori/Bar/Bar.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-bar";
 
 export default {
 	title: "Fiori/Bar",
-	component,
+	component: "Bar",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/BarcodeScannerDialog/BarcodeScannerDialog.stories.ts
+++ b/packages/playground/_stories/fiori/BarcodeScannerDialog/BarcodeScannerDialog.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-barcode-scanner-dialog";
 
 export default {
     title: "Fiori/BarcodeScannerDialog",
-    component,
+    component: "BarcodeScannerDialog",
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
+++ b/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
@@ -18,7 +18,7 @@ const component = "ui5-dynamic-side-content";
 
 export default {
     title: "Fiori/DynamicSideContent",
-    component,
+    component: "DynamicSideContent",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/FlexibleColumnLayout/FlexibleColumnLayout.stories.ts
+++ b/packages/playground/_stories/fiori/FlexibleColumnLayout/FlexibleColumnLayout.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-flexible-column-layout";
 
 export default {
   title: "Fiori/FlexibleColumnLayout",
-  component,
+  component: "FlexibleColumnLayout",
   parameters: {
     docs: {
       page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
+++ b/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-illustrated-message";
 
 export default {
     title: "Fiori/IllustratedMessage",
-    component,
+    component: "IllustratedMessage",
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/MediaGallery/MediaGallery.stories.ts
+++ b/packages/playground/_stories/fiori/MediaGallery/MediaGallery.stories.ts
@@ -33,8 +33,8 @@ const stylesDecorator = (storyFn: PartialStoryFn) => html`
 
 export default {
     title: "Fiori/MediaGallery",
-    component,
-    subcomponents: { MediaGalleryItem: "ui5-media-gallery-item" },
+    component: "MediaGallery",
+    subcomponents: { MediaGalleryItem: "MediaGalleryItem" },
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
@@ -13,8 +13,8 @@ const component = "ui5-li-notification-group";
 
 export default {
 	title: "Fiori/Notification List Group Item",
-	component,
-	subcomponents: { 'NotificationAction': 'ui5-notification-action' },
+	component: "NotificationListGroupItem",
+	subcomponents: { 'NotificationAction': 'NotificationAction' },
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
@@ -13,8 +13,8 @@ const component = "ui5-li-notification";
 
 export default {
 	title: "Fiori/Notification List Item",
-	component,
-	subcomponents: { 'NotificationAction': 'ui5-notification-action' },
+	component: "NotificationListItem",
+	subcomponents: { 'NotificationAction': 'NotificationAction' },
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/Page/Page.stories.ts
+++ b/packages/playground/_stories/fiori/Page/Page.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-page";
 
 export default {
     title: "Fiori/Page",
-    component,
+    component: "Page",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/ProductSwitch/ProductSwitch.stories.ts
+++ b/packages/playground/_stories/fiori/ProductSwitch/ProductSwitch.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-product-switch";
 
 export default {
     title: "Fiori/ProductSwitch",
-    component,
-    subcomponents: { ProductSwitchItem: "ui5-product-switch-item" },
+    component: "ProductSwitch",
+    subcomponents: { ProductSwitchItem: "ProductSwitchItem" },
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/ShellBar/ShellBar.stories.ts
+++ b/packages/playground/_stories/fiori/ShellBar/ShellBar.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-shellbar";
 
 export default {
     title: "Fiori/ShellBar",
-    component,
-    subcomponents: { ShellBarItem: "ui5-shellbar-item" },
+    component: "ShellBar",
+    subcomponents: { ShellBarItem: "ShellbarItem" },
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/SideNavigation/SideNavigation.stories.ts
+++ b/packages/playground/_stories/fiori/SideNavigation/SideNavigation.stories.ts
@@ -14,10 +14,10 @@ const component = "ui5-side-navigation";
 
 export default {
 	title: "Fiori/Side Navigation",
-	component,
+	component: "SideNavigation",
 	subcomponents: {
-		SideNavigationItem: "ui5-side-navigation-item",
-		SideNavigationSubItem: "ui5-side-navigation-sub-item"
+		SideNavigationItem: "SideNavigationItem",
+		SideNavigationSubItem: "SideNavigationSubItem"
 	},
 	parameters: {
 		docs: {

--- a/packages/playground/_stories/fiori/Timeline/Timeline.stories.ts
+++ b/packages/playground/_stories/fiori/Timeline/Timeline.stories.ts
@@ -16,8 +16,8 @@ const component = "ui5-timeline";
 
 export default {
 	title: "Fiori/Timeline",
-	component,
-	subcomponents: {'TimelineItem' : 'ui5-timeline-item'},
+	component: "Timeline",
+	subcomponents: {'TimelineItem' : 'TimelineItem'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/UploadCollection/UploadCollection.stories.ts
+++ b/packages/playground/_stories/fiori/UploadCollection/UploadCollection.stories.ts
@@ -16,8 +16,8 @@ const component = "ui5-upload-collection";
 
 export default {
 	title: "Fiori/Upload Collection",
-	component,
-	subcomponents: {'UploadCollectionItem' : 'ui5-upload-collection-item'},
+	component: "UploadCollection",
+	subcomponents: {'UploadCollectionItem' : 'UploadCollectionItem'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/fiori/ViewSettingsDialog/ViewSettingsDialog.stories.ts
+++ b/packages/playground/_stories/fiori/ViewSettingsDialog/ViewSettingsDialog.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-view-settings-dialog";
 
 export default {
 	title: "Fiori/ViewSettingsDialog",
-	component,
-	subcomponents: {'SortItem' : 'ui5-sort-item', 'FilterItem' : 'ui5-filter-item', 'FilterItemOption' : 'ui5-filter-item-option'},
+	component: "ViewSettingsDialog",
+	subcomponents: {'SortItem' : 'SortItem', 'FilterItem' : 'FilterItem', 'FilterItemOption' : 'FilterItemOption'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/fiori/Wizard/Wizard.stories.ts
+++ b/packages/playground/_stories/fiori/Wizard/Wizard.stories.ts
@@ -12,9 +12,9 @@ const component = "ui5-wizard";
 
 export default {
 	title: "Fiori/Wizard",
-	component,
+	component: "Wizard",
 	subcomponents: {
-		WizardStep: 'ui5-wizard-step',
+		WizardStep: 'WizardStep'
 	},
 	parameters: {
 		docs: {

--- a/packages/playground/_stories/main/Avatar/Avatar.stories.ts
+++ b/packages/playground/_stories/main/Avatar/Avatar.stories.ts
@@ -17,7 +17,7 @@ const component = "ui5-avatar";
 
 export default {
   title: "Main/Avatar",
-  component,
+  component: "Avatar",
   argTypes,
   parameters: {
     docs: {

--- a/packages/playground/_stories/main/AvatarGroup/AvatarGroup.stories.ts
+++ b/packages/playground/_stories/main/AvatarGroup/AvatarGroup.stories.ts
@@ -20,7 +20,7 @@ const component = "ui5-avatar-group";
 
 export default {
   title: "Main/AvatarGroup",
-  component,
+  component: "AvatarGroup",
   argTypes,
   parameters: {
     docs: {

--- a/packages/playground/_stories/main/Badge/Badge.stories.ts
+++ b/packages/playground/_stories/main/Badge/Badge.stories.ts
@@ -12,7 +12,7 @@ const component = "ui5-badge";
 
 export default {
 	title: "Main/Badge",
-	component,
+	component: "Badge",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Breadcrumbs/Breadcrumbs.stories.ts
+++ b/packages/playground/_stories/main/Breadcrumbs/Breadcrumbs.stories.ts
@@ -16,8 +16,8 @@ const component = "ui5-breadcrumbs";
 
 export default {
     title: "Main/Breadcrumbs",
-    component,
-    subcomponents: { BreadcrumbsItem: "ui5-breadcrumbs-item" },
+    component: "Breadcrumbs",
+    subcomponents: { BreadcrumbsItem: "BreadcrumbItem" },
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/BusyIndicator/BusyIndicator.stories.ts
+++ b/packages/playground/_stories/main/BusyIndicator/BusyIndicator.stories.ts
@@ -13,7 +13,7 @@ const component = "ui5-busy-indicator";
 
 export default {
 	title: "Main/Busy Indicator",
-	component,
+	component: "BusyIndicator",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Button/Button.stories.ts
+++ b/packages/playground/_stories/main/Button/Button.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-button";
 
 export default {
 	title: "Main/Button",
-	component,
+	component: "Button",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Calendar/Calendar.stories.ts
+++ b/packages/playground/_stories/main/Calendar/Calendar.stories.ts
@@ -18,8 +18,8 @@ const component = "ui5-calendar";
 
 export default {
 	title: "Main/Calendar",
-	component,
-	subcomponents: {'CalendarDate' : 'ui5-date'},
+	component: "Calendar",
+	subcomponents: {'CalendarDate' : 'CalendarDate'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Card/Card.stories.ts
+++ b/packages/playground/_stories/main/Card/Card.stories.ts
@@ -12,8 +12,8 @@ const component = "ui5-card";
 
 export default {
 	title: "Main/Card",
-	component,
-	subcomponents: { 'CardHeader': 'ui5-card-header' },
+	component: "Card",
+	subcomponents: { 'CardHeader': 'CardHeader' },
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/Carousel/Carousel.stories.ts
+++ b/packages/playground/_stories/main/Carousel/Carousel.stories.ts
@@ -17,7 +17,7 @@ const component = "ui5-carousel";
 
 export default {
 	title: "Main/Carousel",
-	component,
+	component: "Carousel",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/CheckBox/CheckBox.stories.ts
+++ b/packages/playground/_stories/main/CheckBox/CheckBox.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-checkbox";
 
 export default {
     title: "Main/CheckBox",
-    component,
+    component: "CheckBox",
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/ColorPalette/ColorPalette.stories.ts
+++ b/packages/playground/_stories/main/ColorPalette/ColorPalette.stories.ts
@@ -14,8 +14,8 @@ const component = "ui5-color-palette";
 
 export default {
 	title: "Main/ColorPalette",
-	component,
-	subcomponents: {'ColorPaletteItem' : 'ui5-color-palette-item'},
+	component: "ColorPalette",
+	subcomponents: {'ColorPaletteItem' : 'ColorPaletteItem'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/ColorPalettePopover/ColorPalettePopover.stories.ts
+++ b/packages/playground/_stories/main/ColorPalettePopover/ColorPalettePopover.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-color-palette-popover";
 
 export default {
 	title: "Main/ColorPalettePopover",
-	component,
+	component: "ColorPalettePopover",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/ColorPicker/ColorPicker.stories.ts
+++ b/packages/playground/_stories/main/ColorPicker/ColorPicker.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-color-picker";
 
 export default {
 	title: "Main/ColorPicker",
-	component,
+	component: "ColorPicker",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/ComboBox/ComboBox.stories.ts
+++ b/packages/playground/_stories/main/ComboBox/ComboBox.stories.ts
@@ -18,10 +18,10 @@ const component = "ui5-combobox";
 
 export default {
 	title: "Main/ComboBox",
-	component,
+	component: "ComboBox",
 	subcomponents: {
-		ComboBoxItem: "ui5-cb-item",
-		ComboBoxGroupItem: "ui5-cb-group-item",
+		ComboBoxItem: "ComboBoxItem",
+		ComboBoxGroupItem: "ComboBoxGroupItem",
 	},
 	parameters: {
 		docs: {

--- a/packages/playground/_stories/main/DatePicker/DatePicker.stories.ts
+++ b/packages/playground/_stories/main/DatePicker/DatePicker.stories.ts
@@ -17,7 +17,7 @@ const component = "ui5-date-picker";
 
 export default {
 	title: "Main/DatePicker",
-	component,
+	component: "DatePicker",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/DateRangePicker/DateRangePicker.stories.ts
+++ b/packages/playground/_stories/main/DateRangePicker/DateRangePicker.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-daterange-picker";
 
 export default {
 	title: "Main/DateRangePicker",
-	component,
+	component: "DateRangePicker",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/DateTimePicker/DateTimePicker.stories.ts
+++ b/packages/playground/_stories/main/DateTimePicker/DateTimePicker.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-datetime-picker";
 
 export default {
 	title: "Main/DateTimePicker",
-	component,
+	component: "DateTimePicker",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Dialog/Dialog.stories.ts
+++ b/packages/playground/_stories/main/Dialog/Dialog.stories.ts
@@ -13,7 +13,7 @@ const component = "ui5-dialog";
 
 export default {
 	title: "Main/Dialog",
-	component,
+	component: "Dialog",
 	argTypes,
 	parameters: {
 		docs: {

--- a/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
+++ b/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-file-uploader";
 
 export default {
 	title: "Main/FileUploader",
-	component,
+	component: "FileUploader",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Icon/Icon.stories.ts
+++ b/packages/playground/_stories/main/Icon/Icon.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-icon";
 
 export default {
 	title: "Main/Icon",
-	component,
+	component: "Icon",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/Input/Input.stories.ts
+++ b/packages/playground/_stories/main/Input/Input.stories.ts
@@ -18,10 +18,10 @@ let index = 0;
 
 export default {
 	title: "Main/Input",
-	component,
+	component: "Input",
 	subcomponents: {
-		SuggestionItem: 'ui5-suggestion-item',
-		SuggestionGroupItem : 'ui5-suggestion-group-item'
+		SuggestionItem: 'SuggestionsItem',
+		SuggestionGroupItem : 'SuggestionsGroupItem'
 	},
 	parameters: {
 		docs: {

--- a/packages/playground/_stories/main/Label/Label.stories.ts
+++ b/packages/playground/_stories/main/Label/Label.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-label";
 
 export default {
 	title: "Main/Label",
-	component,
+	component: "Label",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Link/Link.stories.ts
+++ b/packages/playground/_stories/main/Link/Link.stories.ts
@@ -17,7 +17,7 @@ const component = "ui5-link";
 
 export default {
 	title: "Main/Link",
-	component,
+	component: "Link",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/List/List.stories.ts
+++ b/packages/playground/_stories/main/List/List.stories.ts
@@ -17,11 +17,11 @@ const component = "ui5-list";
 
 export default {
   title: "Main/List",
-  component,
+  component: "List",
   subcomponents: {
-    StandardListItem: "ui5-li",
-    CustomListItem: "ui5-li-custom",
-    GroupHeaderListItem: "ui5-li-groupheader",
+    StandardListItem: "StandardListItem",
+    CustomListItem: "CustomListItem",
+    GroupHeaderListItem: "GroupHeaderListItem",
   },
   parameters: {
     docs: {

--- a/packages/playground/_stories/main/Menu/Menu.stories.ts
+++ b/packages/playground/_stories/main/Menu/Menu.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-menu";
 
 export default {
 	title: "Main/Menu",
-	component,
-	subcomponents: {'MenuItem' : 'ui5-menu-item'},
+	component: "Menu",
+	subcomponents: {'MenuItem' : 'MenuItem'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/MessageStrip/MessageStrip.stories.ts
+++ b/packages/playground/_stories/main/MessageStrip/MessageStrip.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-message-strip";
 
 export default {
     title: "Main/MessageStrip",
-    component,
+    component: "MessageStrip",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/MultiComboBox/MultiComboBox.stories.ts
+++ b/packages/playground/_stories/main/MultiComboBox/MultiComboBox.stories.ts
@@ -16,8 +16,8 @@ const component = "ui5-multi-combobox";
 
 export default {
     title: "Main/MultiComboBox",
-    component,
-    subcomponents: {'MultiComboBoxItem' : 'ui5-mcb-item', 'MultiComboBoxGroupItem' : 'ui5-mcb-group-item'},
+    component: "MultiComboBox",
+    subcomponents: {'MultiComboBoxItem' : 'MultiComboBoxItem', 'MultiComboBoxGroupItem' : 'MultiComboBoxGroupItem'},
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/MultiInput/MultiInput.stories.ts
+++ b/packages/playground/_stories/main/MultiInput/MultiInput.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-multi-input";
 
 export default {
     title: "Main/MultiInput",
-    component,
-    subcomponents: {'Token' : 'ui5-token'},
+    component: "MultiInput",
+    subcomponents: {'Token' : 'Token'},
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Panel/Panel.stories.ts
+++ b/packages/playground/_stories/main/Panel/Panel.stories.ts
@@ -19,7 +19,7 @@ let index = 0;
 
 export default {
     title: "Main/Panel",
-    component,
+    component: "Panel",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Popover/Popover.stories.ts
+++ b/packages/playground/_stories/main/Popover/Popover.stories.ts
@@ -12,7 +12,7 @@ const component = "ui5-popover";
 
 export default {
 	title: "Main/Popover",
-	component,
+	component: "Popover",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/ProgressIndicator/ProgressIndicator.stories.ts
+++ b/packages/playground/_stories/main/ProgressIndicator/ProgressIndicator.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-progress-indicator";
 
 export default {
     title: "Main/ProgressIndicator",
-    component,
+    component: "ProgressIndicator",
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/RadioButton/RadioButton.stories.ts
+++ b/packages/playground/_stories/main/RadioButton/RadioButton.stories.ts
@@ -12,7 +12,7 @@ const component = "ui5-radio-button";
 
 export default {
 	title: "Main/Radio Button",
-	component,
+	component: "RadioButton",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/RangeSlider/RangeSlider.stories.ts
+++ b/packages/playground/_stories/main/RangeSlider/RangeSlider.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-range-slider";
 
 export default {
     title: "Main/RangeSlider",
-    component,
+    component: "RangeSlider",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/RatingIndicator/RatingIndicator.stories.ts
+++ b/packages/playground/_stories/main/RatingIndicator/RatingIndicator.stories.ts
@@ -15,7 +15,7 @@ let index = 0;
 
 export default {
     title: "Main/RatingIndicator",
-    component,
+    component: "RatingIndicator",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
+++ b/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
@@ -12,7 +12,7 @@ const component = "ui5-responsive-popover";
 
 export default {
 	title: "Main/Responsive Popover",
-	component,
+	component: "ResponsivePopover",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/_stories/main/SegmentedButton/SegmentedButton.stories.ts
+++ b/packages/playground/_stories/main/SegmentedButton/SegmentedButton.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-segmented-button";
 
 export default {
 	title: "Main/SegmentedButton",
-	component,
-	subcomponents: {'SegmentedButtonItem' : 'ui5-segmented-button-item'},
+	component: "SegmentedButton",
+	subcomponents: {'SegmentedButtonItem' : 'SegmentedButtonItem'},
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Select/Select.stories.ts
+++ b/packages/playground/_stories/main/Select/Select.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-select";
 
 export default {
   title: "Main/Select",
-  component,
-  subcomponents: { Option: "ui5-option" },
+  component: "Select",
+  subcomponents: { Option: "Option" },
   argTypes,
   parameters: {
     docs: {

--- a/packages/playground/_stories/main/Slider/Slider.stories.ts
+++ b/packages/playground/_stories/main/Slider/Slider.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-slider";
 
 export default {
     title: "Main/Slider",
-    component,
+    component: "Slider",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
+++ b/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-split-button";
 
 export default {
 	title: "Main/SplitButton",
-	component,
+	component: "SplitButton",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/StepInput/StepInput.stories.ts
+++ b/packages/playground/_stories/main/StepInput/StepInput.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-step-input";
 
 export default {
 	title: "Main/StepInput",
-	component,
+	component: "StepInput",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Switch/Switch.stories.ts
+++ b/packages/playground/_stories/main/Switch/Switch.stories.ts
@@ -15,7 +15,7 @@ const component = "ui5-switch";
 
 export default {
 	title: "Main/Switch",
-	component,
+	component: "Switch",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/TabContainer/TabContainer.stories.ts
+++ b/packages/playground/_stories/main/TabContainer/TabContainer.stories.ts
@@ -13,8 +13,8 @@ const component = "ui5-tabcontainer";
 
 export default {
 	title: "Main/Tab Container",
-	component,
-	subcomponents: { "Tab": "ui5-tab", "TabSeparator": "ui5-tab-separator" },
+	component: "TabContainer",
+	subcomponents: { "Tab": "Tab", "TabSeparator": "TabSeparator" },
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Table/Table.stories.ts
+++ b/packages/playground/_stories/main/Table/Table.stories.ts
@@ -19,8 +19,8 @@ let index = 0;
 
 export default {
 	title: "Main/Table",
-	component,
-	subcomponents: {'TableColumn' : 'ui5-table-column', 'TableRow' : 'ui5-table-row', 'TableGroupRow' : 'ui5-table-group-row', 'TableCell' : 'ui5-table-cell'},
+	component: "Table",
+	subcomponents: {'TableColumn' : 'TableColumn', 'TableRow' : 'TableRow', 'TableGroupRow' : 'TableGroupRow', 'TableCell' : 'TableCell'},
 	parameters: {
 		docs: {
 		  page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/TextArea/TextArea.stories.ts
+++ b/packages/playground/_stories/main/TextArea/TextArea.stories.ts
@@ -16,7 +16,7 @@ let index = 0;
 
 export default {
     title: "Main/TextArea",
-    component,
+    component: "TextArea",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/TimePicker/TimePicker.stories.ts
+++ b/packages/playground/_stories/main/TimePicker/TimePicker.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-time-picker";
 
 export default {
 	title: "Main/TimePicker",
-	component,
+	component: "TimePicker",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Title/Title.stories.ts
+++ b/packages/playground/_stories/main/Title/Title.stories.ts
@@ -14,7 +14,7 @@ const component = "ui5-title";
 
 export default {
 	title: "Main/Title",
-	component,
+	component: "Title",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Toast/Toast.stories.ts
+++ b/packages/playground/_stories/main/Toast/Toast.stories.ts
@@ -17,7 +17,7 @@ const component = "ui5-toast";
 
 export default {
     title: "Main/Toast",
-    component,
+    component: "Toast",
     parameters: {
         docs: {
           page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/ToggleButton/ToggleButton.stories.ts
+++ b/packages/playground/_stories/main/ToggleButton/ToggleButton.stories.ts
@@ -16,7 +16,7 @@ const component = "ui5-toggle-button";
 
 export default {
 	title: "Main/ToggleButton",
-	component,
+	component: "ToggleButton",
 	parameters: {
 		docs: {
 			page: DocsPage({ ...componentInfo, component })

--- a/packages/playground/_stories/main/Tree/Tree.stories.ts
+++ b/packages/playground/_stories/main/Tree/Tree.stories.ts
@@ -15,8 +15,8 @@ const component = "ui5-tree";
 
 export default {
     title: "Main/Tree",
-    component,
-    subcomponents: { TreeItem: "ui5-tree-item" },
+    component: "Tree",
+    subcomponents: { TreeItem: "TreeItem" },
     parameters: {
         docs: {
             page: DocsPage({ ...componentInfo, component }),

--- a/packages/playground/build-scripts-storybook/parse-manifest.js
+++ b/packages/playground/build-scripts-storybook/parse-manifest.js
@@ -67,6 +67,8 @@ const parseMembers = (members) => {
 
 const parseModule = (module) => {
     module.declarations = module.declarations.map((declaration) => {
+        declaration.tagName = declaration.name;
+
         // remove attributes as they are duplicated with the properties
         if (declaration.attributes) {
             delete declaration.attributes;


### PR DESCRIPTION
Related to: #7284 

### API Table wrong tab name (fixed)

Names in args (api) table  are correctly displayed when there are subcomponents shown. F.e. `UI5Select` is now just `Select`


![](https://user-images.githubusercontent.com/31909318/250114272-b2dead4c-c424-4424-908f-f01097e9c022.png)
