### PR TITLE
docs(ui5-illustrated-message): respect changes of property size in story

### DIFF
--- a/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
+++ b/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
@@ -29,6 +29,7 @@ const Template: UI5StoryArgs<IllustratedMessage, StoryArgsSlots> = (
     args
 ) => html` <ui5-illustrated-message
     name="${ifDefined(args.name)}"
+    size="${ifDefined(args.size)}"
     subtitle-text="${ifDefined(args.subtitleText)}"
     title-text="${ifDefined(args.titleText)}"
     accessible-name-ref="${ifDefined(args.accessibleNameRef)}"


### PR DESCRIPTION
Property size is now correctly passed to the illustrated message.