### PR TITLE
feat(framework): scope css variables per runtime and version

### DIFF
--- a/packages/base/src/CustomElementsScope.ts
+++ b/packages/base/src/CustomElementsScope.ts
@@ -11,6 +11,7 @@ import {
 	getCustomElementsScopingRules,
 	shouldScopeCustomElement,
 	getEffectiveScopingSuffixForTag,
+	getScopedVarName,
 } from "./CustomElementsScopeUtils.js";
 import { registerFeature } from "./FeaturesRegistry.js";
 
@@ -30,4 +31,5 @@ export {
 	getCustomElementsScopingRules,
 	shouldScopeCustomElement,
 	getEffectiveScopingSuffixForTag,
+	getScopedVarName,
 };

--- a/packages/base/src/CustomElementsScopeUtils.ts
+++ b/packages/base/src/CustomElementsScopeUtils.ts
@@ -1,3 +1,5 @@
+import VersionInfo from "./generated/VersionInfo.js";
+
 let suf: string;
 
 type Rules = {
@@ -105,6 +107,18 @@ const getEffectiveScopingSuffixForTag = (tag: string) => {
 	}
 };
 
+/**
+ * @public
+ * Used for getting a scoped name for a CSS variable using the same transformation used in the build
+ * @name the name of the css variable as written in the code
+ * @returns a variable name with the current version inserted as available at runtime
+ */
+const getScopedVarName = (name: string) => {
+	const versionStr = VersionInfo.version.replaceAll(".", "-");
+	const expr = /(--_?ui5)([^,:)\s]+)/g;
+	return name.replaceAll(expr, `$1-${versionStr}$2`);
+};
+
 export {
 	setCustomElementsScopingSuffix,
 	getCustomElementsScopingSuffix,
@@ -112,4 +126,5 @@ export {
 	getCustomElementsScopingRules,
 	shouldScopeCustomElement,
 	getEffectiveScopingSuffixForTag,
+	getScopedVarName,
 };

--- a/packages/base/src/CustomElementsScopeUtils.ts
+++ b/packages/base/src/CustomElementsScopeUtils.ts
@@ -114,7 +114,7 @@ const getEffectiveScopingSuffixForTag = (tag: string) => {
  * @returns a variable name with the current version inserted as available at runtime
  */
 const getScopedVarName = (name: string) => {
-	const versionStr = VersionInfo.version.replaceAll(".", "-");
+	const versionStr = `v${VersionInfo.version.replaceAll(".", "-")}`;
 	const expr = /(--_?ui5)([^,:)\s]+)/g;
 	return name.replaceAll(expr, `$1-${versionStr}$2`);
 };

--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -2,7 +2,6 @@ import createStyleInHead from "./util/createStyleInHead.js";
 import createLinkInHead from "./util/createLinkInHead.js";
 import { shouldUseLinks, getUrl } from "./CSP.js";
 import { StyleData, StyleDataCSP } from "./types.js";
-import { getCurrentRuntimeIndex } from "./Runtimes.js";
 import { isSafari } from "./Device.js";
 
 const getStyleId = (name: string, value: string) => {
@@ -10,11 +9,7 @@ const getStyleId = (name: string, value: string) => {
 };
 
 const createStyle = (data: StyleData, name: string, value = "") => {
-	let content = typeof data === "string" ? data : data.content;
-
-	if (content.includes("[_ui5host]")) {
-		content = content.replaceAll("[_ui5host]", `[_ui5rt${getCurrentRuntimeIndex()}]`);
-	}
+	const content = typeof data === "string" ? data : data.content;
 
 	if (shouldUseLinks()) {
 		const attributes = {} as Record<string, any>;
@@ -34,11 +29,7 @@ const createStyle = (data: StyleData, name: string, value = "") => {
 };
 
 const updateStyle = (data: StyleData, name: string, value = "") => {
-	let content = typeof data === "string" ? data : data.content;
-
-	if (content.includes("[_ui5host]")) {
-		content = content.replaceAll("[_ui5host]", `[_ui5rt${getCurrentRuntimeIndex()}]`);
-	}
+	const content = typeof data === "string" ? data : data.content;
 
 	if (shouldUseLinks()) {
 		const link = document.querySelector(`head>link[${name}="${value}"]`) as HTMLLinkElement;

--- a/packages/base/src/StaticAreaItem.ts
+++ b/packages/base/src/StaticAreaItem.ts
@@ -5,7 +5,6 @@ import getEffectiveContentDensity from "./util/getEffectiveContentDensity.js";
 import { getEffectiveScopingSuffixForTag } from "./CustomElementsScopeUtils.js";
 import getEffectiveDir from "./locale/getEffectiveDir.js";
 import type UI5Element from "./UI5Element.js";
-import { getCurrentRuntimeIndex } from "./Runtimes.js";
 
 const pureTagName = "ui5-static-area-item";
 const popupIntegrationAttr = "data-sap-ui-integration-popup-content";
@@ -79,8 +78,6 @@ class StaticAreaItem extends HTMLElement {
 	}
 
 	_updateAdditionalAttrs() {
-		this.setAttribute(`_ui5rt${getCurrentRuntimeIndex()}`, "");
-		this.setAttribute("_ui5host", "");
 		this.setAttribute(pureTagName, "");
 		this.setAttribute(popupIntegrationAttr, "");
 	}

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -25,7 +25,6 @@ import arraysAreEqual from "./util/arraysAreEqual.js";
 import { markAsRtlAware } from "./locale/RTLAwareRegistry.js";
 import preloadLinks from "./theming/preloadLinks.js";
 import executeTemplate from "./renderer/executeTemplate.js";
-import { getCurrentRuntimeIndex } from "./Runtimes.js";
 import type { TemplateFunction, TemplateFunctionResult } from "./renderer/executeTemplate.js";
 import type { PromiseResolve, ComponentStylesData, ClassMap } from "./types.js";
 
@@ -175,8 +174,6 @@ abstract class UI5Element extends HTMLElement {
 	async connectedCallback() {
 		const ctor = this.constructor as typeof UI5Element;
 
-		this.setAttribute(`_ui5rt${getCurrentRuntimeIndex()}`, "");
-		this.setAttribute("_ui5host", "");
 		this.setAttribute(ctor.getMetadata().getPureTag(), "");
 		if (ctor.getMetadata().supportsF6FastNavigation()) {
 			this.setAttribute("data-sap-ui-fastnavgroup", "true");

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -9,7 +9,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import {
 	getRGBColor,
 	HSLToRGB,

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -9,6 +9,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import Float from "@ui5/webcomponents-base/dist/types/Float.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import {
 	getRGBColor,
 	HSLToRGB,
@@ -206,7 +207,7 @@ class ColorPicker extends UI5Element {
 		const tempColor = `rgba(${this._color.r}, ${this._color.g}, ${this._color.b}, 1)`;
 		this._setHex();
 		this._setValues();
-		this.style.setProperty("--ui5_Color_Picker_Progress_Container_Color", tempColor);
+		this.style.setProperty(getScopedVarName("--ui5_Color_Picker_Progress_Container_Color"), tempColor);
 	}
 
 	_handleMouseDown(e: MouseEvent) {

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -10,6 +10,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/not-editable.js";
@@ -464,7 +465,7 @@ class ComboBox extends UI5Element {
 
 		const slottedIconsCount = this.icon.length || 0;
 		const arrowDownIconsCount = this.readonly ? 0 : 1;
-		this.style.setProperty("--_ui5-input-icons-count", `${slottedIconsCount + arrowDownIconsCount}`);
+		this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${slottedIconsCount + arrowDownIconsCount}`);
 	}
 
 	async onAfterRendering() {

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -10,7 +10,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/not-editable.js";

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -6,6 +6,7 @@ import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import {
 	isPhone,
@@ -716,7 +717,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		}
 
 		this.effectiveShowClearIcon = (this.showClearIcon && !!this.value && !this.readonly && !this.disabled);
-		this.style.setProperty("--_ui5-input-icons-count", `${this.iconsCount}`);
+		this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${this.iconsCount}`);
 
 		this.FormSupport = getFeature<typeof FormSupportT>("FormSupport");
 		const hasItems = !!this.suggestionItems.length;

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -6,7 +6,7 @@ import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import {
 	isPhone,

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -12,6 +12,7 @@ import {
 	isHome,
 	isEnd,
 } from "@ui5/webcomponents-base/dist/Keys.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import { MULTIINPUT_ROLEDESCRIPTION_TEXT } from "./generated/i18n/i18n-defaults.js";
 import Input from "./Input.js";
 import MultiInputTemplate from "./generated/templates/MultiInputTemplate.lit.js";
@@ -349,7 +350,7 @@ class MultiInput extends Input {
 	onBeforeRendering() {
 		super.onBeforeRendering();
 
-		this.style.setProperty("--_ui5-input-icons-count", `${this.iconsCount}`);
+		this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${this.iconsCount}`);
 		this.tokenizerAvailable = this.tokens && this.tokens.length > 0;
 	}
 

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -12,7 +12,7 @@ import {
 	isHome,
 	isEnd,
 } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import { MULTIINPUT_ROLEDESCRIPTION_TEXT } from "./generated/i18n/i18n-defaults.js";
 import Input from "./Input.js";
 import MultiInputTemplate from "./generated/templates/MultiInputTemplate.lit.js";

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -7,6 +7,7 @@ import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import {
 	isSpace,
 	isEnter,
@@ -151,7 +152,7 @@ class SegmentedButton extends UI5Element {
 
 		this.normalizeSelection();
 
-		this.style.setProperty("--_ui5_segmented_btn_items_count", `${items.length}`);
+		this.style.setProperty(getScopedVarName("--_ui5_segmented_btn_items_count"), `${items.length}`);
 	}
 
 	normalizeSelection() {

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -7,7 +7,7 @@ import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import {
 	isSpace,
 	isEnter,

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -32,6 +32,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 import type { Timeout } from "@ui5/webcomponents-base/dist/types.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
 import List from "./List.js";
 import type { ListItemClickEventDetail } from "./List.js";
 import {
@@ -365,7 +366,7 @@ class Select extends UI5Element implements IFormElement {
 		this._syncSelection();
 		this._enableFormSupport();
 
-		this.style.setProperty("--_ui5-input-icons-count", `${this.iconsCount}`);
+		this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${this.iconsCount}`);
 	}
 
 	onAfterRendering() {

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -32,7 +32,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 import type { Timeout } from "@ui5/webcomponents-base/dist/types.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
-import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScopeUtils.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import List from "./List.js";
 import type { ListItemClickEventDetail } from "./List.js";
 import {

--- a/packages/main/src/WheelSlider.ts
+++ b/packages/main/src/WheelSlider.ts
@@ -4,6 +4,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import {
 	isDown,
 	isUp,
@@ -212,7 +213,7 @@ class WheelSlider extends UI5Element {
 
 		if (this.shadowRoot!.querySelectorAll(".ui5-wheelslider-item").length) {
 			const itemComputedStyle = getComputedStyle(this.shadowRoot!.querySelector(".ui5-wheelslider-item")!);
-			const itemHeightValue = itemComputedStyle.getPropertyValue("--_ui5_wheelslider_item_height");
+			const itemHeightValue = itemComputedStyle.getPropertyValue(getScopedVarName("--_ui5_wheelslider_item_height"));
 			const onlyDigitsValue = itemHeightValue.replace("px", "");
 			return Number(onlyDigitsValue) || defaultSize;
 		}

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -9,7 +9,7 @@
 	width: 100%;
 	min-width: 6rem;
 	color: var(--sapField_TextColor);
-	min-height: var(--__ui5_textarea_min_height);
+	min-height: var(--_ui5_textarea_min_height);
 	font-size: var(--sapFontSize);
 	font-family: "72override", var(--sapFontFamily);
 	font-style: normal;
@@ -40,7 +40,7 @@
 .ui5-textarea-root {
 	width: 100%;
 	height: inherit;
-	min-height: var(--__ui5_textarea_min_height);
+	min-height: var(--_ui5_textarea_min_height);
 	display: inline-flex;
 	vertical-align: top;
 	outline: none;
@@ -162,7 +162,7 @@
 :host([style*="height"]) .ui5-textarea-root,
 :host([growing][style*="height"]) .ui5-textarea-wrapper {
 	height: inherit;
-	min-height: var(--__ui5_textarea_min_height);
+	min-height: var(--_ui5_textarea_min_height);
 }
 
 :host([rows]) .ui5-textarea-inner, :host([rows]) .ui5-textarea-mirror {

--- a/packages/main/src/themes/base/TextArea-parameters.css
+++ b/packages/main/src/themes/base/TextArea-parameters.css
@@ -22,7 +22,7 @@
 	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_value_state_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapContent_FocusColor);
-	--__ui5_textarea_min_height: 2.25rem;
+	--_ui5_textarea_min_height: 2.25rem;
 	--_ui5_textarea_padding_right_and_left: 0.5625rem;
 	--_ui5_textarea_padding_right_and_left_error_warning: 0.5rem;
 	--_ui5_textarea_padding_right_and_left_information: 0.5rem;
@@ -57,5 +57,5 @@
 	--_ui5_textarea_padding_bottom_information: 0.0625rem;
 	--_ui5_textarea_exceeded_text_height: 0.375rem;
 	--_ui5_textarea_margin: 0.1875rem 0;
-	--__ui5_textarea_min_height: 1.625rem;
+	--_ui5_textarea_min_height: 1.625rem;
 }

--- a/packages/main/src/themes/sap_belize/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize/TextArea-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/TextArea-parameters.css";
 
 :root {
-	--__ui5_textarea_min_height: 2.5rem;
+	--_ui5_textarea_min_height: 2.5rem;
 	--_ui5_textarea_padding_top: 0.5625rem;
 	--_ui5_textarea_padding_bottom:0.5625rem;
 	--_ui5_textarea_padding_top_readonly: 0.5625rem;
@@ -19,5 +19,5 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--__ui5_textarea_min_height: 1.625rem;
+	--_ui5_textarea_min_height: 1.625rem;
 }

--- a/packages/main/src/themes/sap_belize_hcb/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/TextArea-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/TextArea-parameters.css";
 
 :root {
-	--__ui5_textarea_min_height: 2.5rem;
+	--_ui5_textarea_min_height: 2.5rem;
 	--_ui5_textarea_error_warning_border_style: dashed;
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
 	--_ui5_textarea_information_border_width: var(--sapField_BorderWidth);

--- a/packages/main/src/themes/sap_belize_hcw/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/TextArea-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/TextArea-parameters.css";
 
 :root {
-	--__ui5_textarea_min_height: 2.5rem;
+	--_ui5_textarea_min_height: 2.5rem;
 	--_ui5_textarea_error_warning_border_style: dashed;
 	--_ui5_textarea_error_hover_background_color: var(--sapField_InvalidBackground);
 	--_ui5_textarea_information_border_width: var(--sapField_BorderWidth);

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -6,11 +6,12 @@
 
 	<title>Button</title>
 	<script>
-		// delete Document.prototype.adoptedStyleSheets
+		delete Document.prototype.adoptedStyleSheets
 	</script>
 
 
 	<script src="../../bundle.esm.js" type="module"></script>
+	<script src="https://sap.github.io/ui5-webcomponents/assets/js/ui5-webcomponents/bundle.esm.js" type="module"></script>
 
 
 	<link rel="stylesheet" type="text/css" href="./styles/Button.css">

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -6,12 +6,11 @@
 
 	<title>Button</title>
 	<script>
-		delete Document.prototype.adoptedStyleSheets
+		// delete Document.prototype.adoptedStyleSheets
 	</script>
 
 
 	<script src="../../bundle.esm.js" type="module"></script>
-	<script src="https://sap.github.io/ui5-webcomponents/assets/js/ui5-webcomponents/bundle.esm.js" type="module"></script>
 
 
 	<link rel="stylesheet" type="text/css" href="./styles/Button.css">

--- a/packages/tools/components-package/postcss.components.js
+++ b/packages/tools/components-package/postcss.components.js
@@ -1,9 +1,11 @@
 const postcssImport = require('postcss-import');
 const postcssCSStoESM = require('../lib/postcss-css-to-esm/index.js');
+const postcssScopeVars = require('../lib/postcss-scope-vars/index.js');
 const cssnano = require('cssnano');
-const fs = require("fs");
+const fs = require("fs")
 
-const packageName = JSON.parse(fs.readFileSync("./package.json")).name;
+
+const packageJSON = JSON.parse(fs.readFileSync("./package.json"))
 
 module.exports = {
 		plugins: [
@@ -16,6 +18,7 @@ module.exports = {
 					},
 				]
 			}),
-			postcssCSStoESM({ toReplace: 'src', includeDefaultTheme: true, packageName }),
+			postcssScopeVars({version: packageJSON.version}),
+			postcssCSStoESM({ toReplace: 'src', includeDefaultTheme: true, packageName: packageJSON.name }),
 		]
 }

--- a/packages/tools/components-package/postcss.themes.js
+++ b/packages/tools/components-package/postcss.themes.js
@@ -2,15 +2,17 @@ const postcssImport = require('postcss-import');
 const combineSelectors = require('../lib/postcss-combine-duplicated-selectors/index.js');
 const postcssCSStoJSON = require('../lib/postcss-css-to-json/index.js');
 const postcssCSStoESM = require('../lib/postcss-css-to-esm/index.js');
+const postcssScopeVars = require('../lib/postcss-scope-vars/index.js');
 const cssnano = require('cssnano');
-const modifySelectors = require("modify-selectors");
 const fs = require("fs");
 
-const packageName = JSON.parse(fs.readFileSync("./package.json")).name;
-const selectors = [".sapUiSizeCompact", ".ui5-content-density-compact", "[data-ui5-compact-size]", "[dir=\"rtl\"]", "[dir=\"ltr\"]"];
+
+const packageJSON = JSON.parse(fs.readFileSync("./package.json"))
+const packageName = packageJSON.name;
 
 module.exports = {
 		plugins: [
+			postcssScopeVars({version: packageJSON.version}),
 			postcssImport(),
 			combineSelectors({
 				removeDuplicatedProperties: true
@@ -22,28 +24,6 @@ module.exports = {
 					},
 				]
 			},),
-			modifySelectors({
-				enable: true,
-				suffix: [
-					{
-						match: '*',
-						with: '[_ui5host]', // Add suffix to each selector in the file (:root => :root [_ui5host])
-					},
-				],
-			}),
-			modifySelectors({
-				enable: true,
-				modify: [
-					{
-						match: (selector) => {
-							return selectors.some($ => selector.startsWith($));
-						},
-						with: (selector) => {
-							return `${selector.replace(" ", "")}, ${selector}`;
-						},
-					},
-				]
-			}),
 			postcssCSStoJSON({ toReplace: 'src', packageName }),
 			postcssCSStoESM({ toReplace: 'src', packageName }),
 		]

--- a/packages/tools/lib/postcss-css-to-esm/index.js
+++ b/packages/tools/lib/postcss-css-to-esm/index.js
@@ -60,7 +60,7 @@ module.exports = function (opts) {
 
 	return {
 		postcssPlugin: 'postcss-css-to-esm',
-		Once (root) {
+		OnceExit(root) {
 			const tsMode = process.env.UI5_TS === "true";
 
 			let css = root.toString();

--- a/packages/tools/lib/postcss-css-to-json/index.js
+++ b/packages/tools/lib/postcss-css-to-json/index.js
@@ -15,7 +15,7 @@ module.exports = function (opts) {
 
 	return {
 		postcssPlugin: 'postcss-css-to-json',
-		Once (root) {
+		OnceExit (root) {
 			let css = root.toString();
 			css = proccessCSS(css);
 

--- a/packages/tools/lib/postcss-scope-vars/index.js
+++ b/packages/tools/lib/postcss-scope-vars/index.js
@@ -1,8 +1,6 @@
 const name = "postcss-scope-vars";
 
 module.exports = (options) => {
-	console.log({options});
-	options = Object.assign({}, options);
 	const versionStr = "v" + options?.version?.replaceAll(".", "-");
 	return {
 		postcssPlugin: name,

--- a/packages/tools/lib/postcss-scope-vars/index.js
+++ b/packages/tools/lib/postcss-scope-vars/index.js
@@ -1,0 +1,26 @@
+const name = "postcss-scope-vars";
+
+module.exports = (options) => {
+	console.log({options});
+	options = Object.assign({}, options);
+	const versionStr = "v" + options?.version?.replaceAll(".", "-");
+	return {
+		postcssPlugin: name,
+		prepare() {
+			return {
+				Declaration: (declaration) => {
+					if (declaration.__ui5_replaced) {
+						return;
+					}
+					// add version after ui5
+					const expr = /(--_?ui5)([^\,\:\)\s]+)/g
+					declaration.prop = declaration.prop.replaceAll(expr, `$1-${versionStr}$2`)
+					declaration.value = declaration.value.replaceAll(expr, `$1-${versionStr}$2`)
+					declaration.__ui5_replaced = true;
+				},
+			};
+		},
+	};
+};
+
+module.exports.postcss = true;

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -51,7 +51,6 @@
     "jsdoc": "^3.6.6",
     "json-beautify": "^1.1.1",
     "mkdirp": "^1.0.4",
-    "modify-selectors": "^2.0.0",
     "nps": "^5.10.0",
     "postcss": "^8.4.5",
     "postcss-cli": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10699,11 +10699,6 @@ mocha@^10.0.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-modify-selectors@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/modify-selectors/-/modify-selectors-2.0.0.tgz#0834a1511ad291c81c58ef5f069b74640b3f5ecd"
-  integrity sha512-Hm32mqJ27AZ0AnpwyX3mXpvevAM9eAq0BsmNNVk2CSE8zqUW2bXk4ZNnA1nsjtm1z/cQJJlVmP6AGMqb/KQpKg==
-
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
# CSS variables are now scoped with the package version during build time

a css variable declaration in the <component_name>-parameters.css
```
:root {
	--_ui5_link_text_decoration: none;
```
as well as the usage in <component_name>.css
```
	text-decoration: var(--_ui5_link_text_decoration);
```

get both renamed at build time using the following convention:
```
before:
--_ui5_link_text_decoration
after:
--_ui5-v1-16-0_link_text_decoration
```

since both definition and usage get a unique name, multiple runtimes can run on the page and get their own copy of the same variable name with the correct value.

# Scoping name convention
Only variables starting with `--ui5` or `--_ui5` are renamed with the scoping prefix

# Performance optimization
One copy of all css variables per running webcomponents runtime gets inserted in the document. Compared with the current scoping approach where one set of variables is inserted in each shadow root of every web component on the page, the performance is returning back to normal, as it turned out setting a css variable somewhere in the DOM causes heavy style recalculations.

# Runtime usage of varibales
The build tooling is changing both variable definition and variable usage at build time only in CSS files. For variable access from JavaScript, a utility function is added that applies the same transformation to the variable name.

```typescript
// Input.ts
import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
...
this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${this.iconsCount}`);
```

Fixes: #7303
Fixes: #7306
