### PR TITLE
fix(ui5-split-button): add css variables for active state

### DIFF
--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -98,6 +98,21 @@
 	width: 2.25rem;
 }
 
+.ui5-split-arrow-button[active][design="Default"],
+.ui5-split-arrow-button[active][design="Emphasized"],
+.ui5-split-arrow-button[active][design="Transparent"] {
+	background-color: var(--sapButton_Selected_Background);
+}
+.ui5-split-arrow-button[active][design="Negative"] {
+	background-color: var(--sapButton_Reject_Selected_Background);
+}
+.ui5-split-arrow-button[active][design="Positive"] {
+	background-color: var(--sapButton_Accept_Selected_Background);
+}
+.ui5-split-arrow-button[active][design="Attention"] {
+	background-color: var(--sapButton_Attention_Selected_Background);
+}
+
 .ui5-split-text-button[dir="rtl"]:hover {
 	border-top-left-radius: var(--_ui5_split_button_hover_border_radius);
 	border-bottom-left-radius: var(--_ui5_split_button_hover_border_radius);


### PR DESCRIPTION
Currently in the High Contrast themes, the arrow split button didnt had the active state styling, which is wrong.
Now we apply the correct styling over the active state of the arrow button.

### Before
![2023-08-16_09-40-00](https://github.com/SAP/ui5-webcomponents/assets/88034608/9f5d8c7c-a255-45e5-a3a4-2585756d0ec0)


### After
![2023-08-16_09-41-05](https://github.com/SAP/ui5-webcomponents/assets/88034608/49b79ab5-cfed-45c7-9816-8b5416ff4c61)







Fixes: #7395 