### PR TITLE
docs: enhance storybook samples

### DIFF
--- a/packages/fiori/src/Bar.ts
+++ b/packages/fiori/src/Bar.ts
@@ -80,7 +80,7 @@ class Bar extends UI5Element {
 	design!: `${BarDesign}`
 
 	/**
-	* Defines the content at the start of the bar
+	* Defines the content at the start of the bar.
 	* @type {HTMLElement[]}
 	* @name sap.ui.webc.fiori.Bar.prototype.startContent
 	* @slot
@@ -90,7 +90,7 @@ class Bar extends UI5Element {
 	startContent!: Array<HTMLElement>;
 
 	/**
-	* Defines the content in the middle of the bar
+	* Defines the content in the middle of the bar.
 	* @type {HTMLElement[]}
 	* @name sap.ui.webc.fiori.Bar.prototype.default
 	* @slot middleContent
@@ -100,7 +100,7 @@ class Bar extends UI5Element {
 	middleContent!: Array<HTMLElement>
 
 	/**
-	* Defines the content at the end of the bar
+	* Defines the content at the end of the bar.
 	* @type {HTMLElement[]}
 	* @name sap.ui.webc.fiori.Bar.prototype.endContent
 	* @slot

--- a/packages/fiori/src/Bar.ts
+++ b/packages/fiori/src/Bar.ts
@@ -71,16 +71,6 @@ class Bar extends UI5Element {
 	/**
 	 * Defines the component's design.
 	 *
-	 * <br><br>
-	 * <b>Note:</b>
-	 * Available options are:
-	 * <ul>
-	 * <li><code>Header</code></li>
-	 * <li><code>Subheader</code></li>
-	 * <li><code>Footer</code></li>
-	 * <li><code>FloatingFooter</code></li>
-	 * </ul>
-	 *
 	 * @type {sap.ui.webc.fiori.types.BarDesign}
 	 * @name sap.ui.webc.fiori.Bar.prototype.design
 	 * @defaultvalue "Header"

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -105,18 +105,6 @@ class Button extends UI5Element implements IFormElement {
 	/**
 	 * Defines the component design.
 	 *
-	 * <br><br>
-	 * <b>The available values are:</b>
-	 *
-	 * <ul>
-	 * <li><code>Default</code></li>
-	 * <li><code>Emphasized</code></li>
-	 * <li><code>Positive</code></li>
-	 * <li><code>Negative</code></li>
-	 * <li><code>Transparent</code></li>
-	 * <li><code>Attention</code></li>
-	 * </ul>
-	 *
 	 * @type {sap.ui.webc.main.types.ButtonDesign}
 	 * @name sap.ui.webc.main.Button.prototype.design
 	 * @defaultvalue "Default"
@@ -252,15 +240,6 @@ class Button extends UI5Element implements IFormElement {
 
 	/**
 	 * Defines whether the button has special form-related functionality.
-	 *
-	 * <br><br>
-	 * <b>The available values are:</b>
-	 *
-	 * <ul>
-	 * <li><code>Button</code></li>
-	 * <li><code>Submit</code></li>
-	 * <li><code>Reset</code></li>
-	 * </ul>
 	 *
 	 * <br><br>
 	 * <b>Note:</b> For the <code>type</code> property to have effect, you must add the following import to your project:

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -226,15 +226,6 @@ class DatePicker extends DateComponentBase implements IFormElement {
 
 	/**
 	 * Defines the value state of the component.
-	 * <br><br>
-	 * Available options are:
-	 * <ul>
-	 * <li><code>None</code></li>
-	 * <li><code>Error</code></li>
-	 * <li><code>Warning</code></li>
-	 * <li><code>Success</code></li>
-	 * <li><code>Information</code></li>
-	 * </ul>
 	 *
 	 * @type {sap.ui.webc.base.types.ValueState}
 	 * @name sap.ui.webc.main.DatePicker.prototype.valueState

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -183,16 +183,6 @@ class FileUploader extends UI5Element implements IFormElement {
 
 	/**
 	 * Defines the value state of the component.
-	 * <br><br>
-	 * Available options are:
-	 * <ul>
-	 * <li><code>None</code></li>
-	 * <li><code>Error</code></li>
-	 * <li><code>Warning</code></li>
-	 * <li><code>Success</code></li>
-	 * <li><code>Information</code></li>
-	 * </ul>
-	 *
 	 * @type {sap.ui.webc.base.types.ValueState}
 	 * @name sap.ui.webc.main.FileUploader.prototype.valueState
 	 * @defaultvalue "None"

--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -135,18 +135,6 @@ class SplitButton extends UI5Element {
 	/**
 	 * Defines the component design.
 	 *
-	 * <br><br>
-	 * <b>The available values are:</b>
-	 *
-	 * <ul>
-	 * <li><code>Default</code></li>
-	 * <li><code>Emphasized</code></li>
-	 * <li><code>Positive</code></li>
-	 * <li><code>Negative</code></li>
-	 * <li><code>Transparent</code></li>
-	 * <li><code>Attention</code></li>
-	 * </ul>
-	 *
 	 * @type {sap.ui.webc.main.types.ButtonDesign}
 	 * @name sap.ui.webc.main.SplitButton.prototype.design
 	 * @defaultvalue "Default"

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -155,15 +155,6 @@ class StepInput extends UI5Element implements IFormElement {
 
 	/**
 	 * Defines the value state of the component.
-	 * <br><br>
-	 * Available options are:
-	 * <ul>
-	 * <li><code>None</code></li>
-	 * <li><code>Error</code></li>
-	 * <li><code>Warning</code></li>
-	 * <li><code>Success</code></li>
-	 * <li><code>Information</code></li>
-	 * </ul>
 	 *
 	 * @name sap.ui.webc.main.StepInput.prototype.valueState
 	 * @type {sap.ui.webc.base.types.ValueState}

--- a/packages/playground/_stories/fiori/Bar/Bar.stories.ts
+++ b/packages/playground/_stories/fiori/Bar/Bar.stories.ts
@@ -34,7 +34,7 @@ const Template: UI5StoryArgs<Bar, StoryArgsSlots> = (args) => html`<ui5-bar
 </ui5-bar>`;
 
 export const Basic = Template.bind({});
-Basic.storyName = "With Content and Design";
+Basic.storyName = "Basic";
 Basic.args = {
 	design: BarDesign.Header,
 	startContent: `<ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>`,

--- a/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
+++ b/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
@@ -62,4 +62,5 @@ Basic.args = {
 	<ui5-title level="h1">Side Content</ui5-title>
 	<p class="text">Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit. Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu porttitor dignissim. Maecenas nec fringilla tortor. Pellentesque ut elit est. Curabitur quis elit at mauris ullamcorper fringilla. Nullam diam mi, porttitor dictum orci nec, molestie luctus metus. Nunc ut ex blandit, elementum erat eget, pulvinar sapien. Donec nec lorem eu nunc eleifend tempor at non tortor. In quam velit, ornare at rutrum ac, porta ac augue. Suspendisse venenatis semper lacus at venenatis. Praesent vestibulum ligula nulla, at tempus lorem consequat suscipit. Aenean consequat dapibus dui, at bibendum mauris porta a.</p>
 </div>`,
+	sideContentVisibility: SideContentVisibility.AlwaysShow,
 };

--- a/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
+++ b/packages/playground/_stories/fiori/DynamicSideContent/DynamicSideContent.stories.ts
@@ -27,7 +27,20 @@ export default {
     argTypes,
 } as Meta<DynamicSideContent>;
 
-const Template: UI5StoryArgs<DynamicSideContent, StoryArgsSlots> = (args) => html`<ui5-dynamic-side-content
+const Template: UI5StoryArgs<DynamicSideContent, StoryArgsSlots> = (args) => html`
+<style>
+	.text {
+		display: inline-block;
+		font-size: var(--sapFontSize);
+		font-family: var(--sapFontFamily);
+		color: var(--sapTextColor);
+		line-height: normal;
+		white-space: pre-line;
+		word-wrap: break-word;
+		cursor: text;
+}
+</style>
+<ui5-dynamic-side-content
 	?equal-split="${ifDefined(args.equalSplit)}"
 	?hide-main-content="${ifDefined(args.hideMainContent)}"
 	?hide-side-content="${ifDefined(args.hideSideContent)}"
@@ -42,25 +55,11 @@ const Template: UI5StoryArgs<DynamicSideContent, StoryArgsSlots> = (args) => htm
 export const Basic = Template.bind({});
 Basic.args = {
 	default: `<div>
-	<h1>Main Content</h1>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>
+	<ui5-title level="h1">Main Content</ui5-title>
+	<p class="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>
 </div>`,
 	sideContent: `<div slot="sideContent">
-	<h1>Side Content</h1>
-	<p>Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit. Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu porttitor dignissim. Maecenas nec fringilla tortor. Pellentesque ut elit est. Curabitur quis elit at mauris ullamcorper fringilla. Nullam diam mi, porttitor dictum orci nec, molestie luctus metus. Nunc ut ex blandit, elementum erat eget, pulvinar sapien. Donec nec lorem eu nunc eleifend tempor at non tortor. In quam velit, ornare at rutrum ac, porta ac augue. Suspendisse venenatis semper lacus at venenatis. Praesent vestibulum ligula nulla, at tempus lorem consequat suscipit. Aenean consequat dapibus dui, at bibendum mauris porta a.</p>
-</div>`,
-};
-
-export const Position = Template.bind({});
-Position.storyName = "Side Content Position";
-Position.args = {
-	sideContentPosition: SideContentPosition.Start,
-	default: `<div>
-	<h1>Main Content</h1>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>
-</div>`,
-	sideContent: `<div slot="sideContent">
-	<h1>Side Content</h1>
-	<p>Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit. Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu porttitor dignissim. Maecenas nec fringilla tortor. Pellentesque ut elit est. Curabitur quis elit at mauris ullamcorper fringilla. Nullam diam mi, porttitor dictum orci nec, molestie luctus metus. Nunc ut ex blandit, elementum erat eget, pulvinar sapien. Donec nec lorem eu nunc eleifend tempor at non tortor. In quam velit, ornare at rutrum ac, porta ac augue. Suspendisse venenatis semper lacus at venenatis. Praesent vestibulum ligula nulla, at tempus lorem consequat suscipit. Aenean consequat dapibus dui, at bibendum mauris porta a.</p>
+	<ui5-title level="h1">Side Content</ui5-title>
+	<p class="text">Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit. Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu porttitor dignissim. Maecenas nec fringilla tortor. Pellentesque ut elit est. Curabitur quis elit at mauris ullamcorper fringilla. Nullam diam mi, porttitor dictum orci nec, molestie luctus metus. Nunc ut ex blandit, elementum erat eget, pulvinar sapien. Donec nec lorem eu nunc eleifend tempor at non tortor. In quam velit, ornare at rutrum ac, porta ac augue. Suspendisse venenatis semper lacus at venenatis. Praesent vestibulum ligula nulla, at tempus lorem consequat suscipit. Aenean consequat dapibus dui, at bibendum mauris porta a.</p>
 </div>`,
 };

--- a/packages/playground/_stories/main/Button/Button.stories.ts
+++ b/packages/playground/_stories/main/Button/Button.stories.ts
@@ -40,39 +40,23 @@ const Template: UI5StoryArgs<Button, StoryArgsSlots> = (args) => html`<ui5-butto
 
 export const Basic = Template.bind({});
 Basic.args = {
-	default: "Button",
+	default: "Button Text",
+	accessibleName: "Button with Accessible Name",
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-	default: "Disabled",
-	disabled: true,
-};
+export const DifferentDesigns: StoryFn = () => html`
+	<ui5-button design="${ButtonDesign.Emphasized}"> Emphasized </ui5-button>
+	<ui5-button design="${ButtonDesign.Attention}"> Attention </ui5-button>
+	<ui5-button design="${ButtonDesign.Positive}"> Positive </ui5-button>
+	<ui5-button design="${ButtonDesign.Negative}"> Negative </ui5-button>
+	<ui5-button design="${ButtonDesign.Transparent}"> Transparent </ui5-button>
+`;
 
-export const WithIconAndDesign = Template.bind({});
-WithIconAndDesign.args = {
-	default: "Warning",
-	design: ButtonDesign.Attention,
-	icon: "message-warning",
-};
-
-export const WithEndIcon = Template.bind({});
-WithEndIcon.args = {
-	default: "Download",
-	icon: "download",
-	iconEnd: true,
-};
-
-export const IconOnly = Template.bind({});
-IconOnly.storyName = "Icon-only Button";
-IconOnly.args = {
-	design: ButtonDesign.Negative,
-	icon: "cancel",
-	accessibleName: "Cancel",
-	accessibleNameRef: "lblCancel",
-	tooltip: "Cancel",
-};
-IconOnly.decorators = [
-	(story) => html`<ui5-label style="display:none;" id="lblCancel" aria-hidden="true">Cancel</ui5-label>
-	${story()}`,
-];
+export const IconOnlyButtons: StoryFn = () => html`
+	<ui5-button design="${ButtonDesign.Emphasized}" icon="business-suite/icon-target"></ui5-button>
+	<ui5-button design="${ButtonDesign.Attention}" icon="message-warning" tooltip="Warning Button"></ui5-button>
+	<ui5-button design="${ButtonDesign.Positive}" icon="business-suite/icon-completed" tooltip="Positive Button"></ui5-button>
+	<ui5-button design="${ButtonDesign.Negative}" icon="cancel" tooltip="Negative Button"></ui5-button>
+	<ui5-button design="${ButtonDesign.Transparent}" icon="account" tooltip="Transparent Button"></ui5-button>
+`;
+IconOnlyButtons.storyName = "Icon-Only Buttons";

--- a/packages/playground/_stories/main/Calendar/Calendar.stories.ts
+++ b/packages/playground/_stories/main/Calendar/Calendar.stories.ts
@@ -43,7 +43,7 @@ const Template: UI5StoryArgs<Calendar, StoryArgsSlots> = (args) => html`<ui5-cal
 export const Basic = Template.bind({});
 
 export const Bounds = Template.bind({});
-Bounds.storyName = "Min/Max Dates and Format Pattern";
+Bounds.storyName = "Formatted Date Range";
 Bounds.args = {
 	minDate: "7/10/2020", 
 	maxDate: "20/10/2020",

--- a/packages/playground/_stories/main/DatePicker/DatePicker.stories.ts
+++ b/packages/playground/_stories/main/DatePicker/DatePicker.stories.ts
@@ -55,7 +55,7 @@ State.args = {
 };
 
 export const MinMax = Template.bind({});
-MinMax.storyName = "Min/Max Dates and Format Pattern";
+MinMax.storyName = "Formatted Date Range";
 MinMax.args = {
 	minDate: "1/1/2020",
 	maxDate: "4/5/2020",

--- a/packages/playground/_stories/main/DateRangePicker/DateRangePicker.stories.ts
+++ b/packages/playground/_stories/main/DateRangePicker/DateRangePicker.stories.ts
@@ -46,7 +46,7 @@ const Template: UI5StoryArgs<DateRangePicker, StoryArgsSlots> = (args) => html`<
 export const Basic = Template.bind({});
 
 export const MinMax = Template.bind({});
-MinMax.storyName = "Min/Max Dates and Format Pattern";
+MinMax.storyName = "Formatted Date Range";
 MinMax.args = {
 	minDate: "1/1/2020",
 	maxDate: "4/5/2020",
@@ -54,7 +54,7 @@ MinMax.args = {
 };
 
 export const LongFormat = Template.bind({});
-LongFormat.storyName = "Value, Format Pattern, and Delimiter";
+LongFormat.storyName = "Formatted Value and Delimiter";
 LongFormat.args = {
 	value: "March 31, 2023 ~ April 9, 2023",
 	delimiter: "~",

--- a/packages/playground/_stories/main/DateTimePicker/DateTimePicker.stories.ts
+++ b/packages/playground/_stories/main/DateTimePicker/DateTimePicker.stories.ts
@@ -50,7 +50,7 @@ FormatPattern.args = {
 };
 
 export const MinMax = Template.bind({});
-MinMax.storyName = "Min/Max Dates and Format Pattern";
+MinMax.storyName = "Formatted Date Range";
 MinMax.args = {
 	value: "Jan 11, 2020, 11:11:11 AM",
 	minDate: "Jan 11, 2020, 00:00:00 AM",

--- a/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
+++ b/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
@@ -48,13 +48,6 @@ Basic.decorators = [
 	${story()}`,
 ];
 
-export const Custom = Template.bind({});
-Custom.storyName = "With Custom Design ";
-Custom.args = {
-	hideInput: true,
-	default: `<ui5-badge>Upload File</ui5-badge>`,
-};
-
 export const Advanced = Template.bind({});
 Advanced.storyName = "Image Uploader";
 Advanced.args = {
@@ -97,4 +90,11 @@ Advanced.parameters = {
 			inline: false,
 		},
 	}
+};
+
+export const Custom = Template.bind({});
+Custom.storyName = "With Custom Design ";
+Custom.args = {
+	hideInput: true,
+	default: `<ui5-badge>Upload File</ui5-badge>`,
 };

--- a/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
+++ b/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
@@ -91,10 +91,3 @@ Advanced.parameters = {
 		},
 	}
 };
-
-export const Custom = Template.bind({});
-Custom.storyName = "Custom Design ";
-Custom.args = {
-	hideInput: true,
-	default: `<ui5-badge>Upload File</ui5-badge>`,
-};

--- a/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
+++ b/packages/playground/_stories/main/FileUploader/FileUploader.stories.ts
@@ -62,7 +62,7 @@ Advanced.decorators = [
 	<div id="result"></div>
 	<script>
 		var fileUploader = document.querySelector("#fileuploader"),
-			resultDiv = document.querySelector("#result");
+		resultDiv = document.querySelector("#result");
 		fileUploader.addEventListener("change", function(event) {
 			var files = event.target.files;
 			if (!files.length) {
@@ -93,7 +93,7 @@ Advanced.parameters = {
 };
 
 export const Custom = Template.bind({});
-Custom.storyName = "With Custom Design ";
+Custom.storyName = "Custom Design ";
 Custom.args = {
 	hideInput: true,
 	default: `<ui5-badge>Upload File</ui5-badge>`,

--- a/packages/playground/_stories/main/Menu/Menu.stories.ts
+++ b/packages/playground/_stories/main/Menu/Menu.stories.ts
@@ -26,7 +26,7 @@ export default {
 } as Meta<Menu>;
 
 const Template: UI5StoryArgs<Menu, StoryArgsSlots> = (args) => html`<ui5-menu
-	headerText="${ifDefined(args.headerText)}"
+	header-text="${ifDefined(args.headerText)}"
 	opener="${ifDefined(args.opener)}"
 	?open="${ifDefined(args.open)}"
 	id="${ifDefined(args.id)}"
@@ -35,7 +35,7 @@ const Template: UI5StoryArgs<Menu, StoryArgsSlots> = (args) => html`<ui5-menu
 </ui5-menu>`;
 
 export const Basic = Template.bind({});
-Basic.storyName = "Basic Menu with Header Text";
+Basic.storyName = "Basic";
 Basic.args = {
 	id: "menuBasic",
 	headerText: "Basic Menu with Items",

--- a/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
+++ b/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
@@ -38,19 +38,20 @@ const Template: UI5StoryArgs<SplitButton, StoryArgsSlots> = (args) => html`<ui5-
 export const Basic = Template.bind({});
 Basic.args = {
 	default: "Default",
+	accessibleName: "Split Button with Accessible Name",
 };
 
-export const SplitButtonWithMenu = Template.bind(this);
-SplitButtonWithMenu.args = {
+export const OpeningMenu = Template.bind(this);
+OpeningMenu.args = {
 	default: "Open Menu",
 };
-SplitButtonWithMenu.decorators = [
+OpeningMenu.decorators = [
 	(story) => {
 		return html`
 		<ui5-menu id="menuInSplitBtnDefaultAction">
-		<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
-		<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
-		<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
+			<ui5-menu-item text="Edit" icon="add"></ui5-menu-item>
+			<ui5-menu-item text="Save" icon="save"></ui5-menu-item>
+			<ui5-menu-item text="Delete" icon="delete"></ui5-menu-item>
 		</ui5-menu>
 	${story()}
 	<script>
@@ -62,28 +63,10 @@ SplitButtonWithMenu.decorators = [
 	</script>`;}
 ];
 
-export const Disabled = Template.bind({});
-Disabled.storyName = "Disabled SplitButton";
-Disabled.args = {
-	default: "Disabled",
-	disabled: true,
-};
-
-export const Design = Template.bind({});
-Design.args = {
-	default: "Attention",
-	design: ButtonDesign.Attention,
-};
-
-export const WithIcon = Template.bind({});
-WithIcon.args = {
-	default: "Icon",
-	icon: "add",
-};
-
-export const WithActiveIcon = Template.bind({});
-WithActiveIcon.args = {
-	default: "Press Me",
-	icon: "add",
-	activeIcon: "accept",
-};
+export const DifferentDesigns: StoryFn = () => html`
+	<ui5-split-button design="${ButtonDesign.Emphasized}"> Emphasized </ui5-split-button>
+	<ui5-split-button design="${ButtonDesign.Attention}"> Attention </ui5-split-button>
+	<ui5-split-button design="${ButtonDesign.Positive}"> Positive </ui5-split-button>
+	<ui5-split-button design="${ButtonDesign.Negative}"> Negative </ui5-split-button>
+	<ui5-split-button design="${ButtonDesign.Transparent}"> Transparent </ui5-split-button>
+`;

--- a/packages/playground/_stories/main/StepInput/StepInput.stories.ts
+++ b/packages/playground/_stories/main/StepInput/StepInput.stories.ts
@@ -25,56 +25,47 @@ export default {
 	argTypes,
 } as Meta<StepInput>;
 
-const Template: UI5StoryArgs<StepInput, StoryArgsSlots> = (args) => html`<ui5-step-input
-	value="${ifDefined(args.value)}"
-	value-state="${ifDefined(args.valueState)}"
-	value-precision="${ifDefined(args.valuePrecision)}"
-	min="${ifDefined(args.min)}"
-	max="${ifDefined(args.max)}"
-	step="${ifDefined(args.step)}"
-	?required="${ifDefined(args.required)}"
-	?readonly="${ifDefined(args.readonly)}"
-	?disabled="${ifDefined(args.disabled)}"
-	placeholder="${ifDefined(args.placeholder)}"
-	name="${ifDefined(args.name)}"
-	accessible-name="${ifDefined(args.accessibleName)}"
-	accessible-name-ref="${ifDefined(args.accessibleNameRef)}"
-	id="${ifDefined(args.id)}"
-	style="${ifDefined(args.style)}"
->
-	${unsafeHTML(args.valueStateMessage)}
-</ui5-step-input>`;
+const Template: UI5StoryArgs<StepInput, StoryArgsSlots> = (args) => html`
+<div style="max-width: 13rem">
+	<ui5-step-input
+		value="${ifDefined(args.value)}"
+		value-state="${ifDefined(args.valueState)}"
+		value-precision="${ifDefined(args.valuePrecision)}"
+		min="${ifDefined(args.min)}"
+		max="${ifDefined(args.max)}"
+		step="${ifDefined(args.step)}"
+		?required="${ifDefined(args.required)}"
+		?readonly="${ifDefined(args.readonly)}"
+		?disabled="${ifDefined(args.disabled)}"
+		placeholder="${ifDefined(args.placeholder)}"
+		name="${ifDefined(args.name)}"
+		accessible-name="${ifDefined(args.accessibleName)}"
+		accessible-name-ref="${ifDefined(args.accessibleNameRef)}"
+		id="${ifDefined(args.id)}"
+		style="${ifDefined(args.style)}"
+	>
+		${unsafeHTML(args.valueStateMessage)}
+	</ui5-step-input>
+</div>`;
 
 export const Basic = Template.bind({});
 Basic.args = {
 	value: 5,
 };
 
-export const Readonly = Template.bind({});
-Readonly.args = {
-	value: 5,
-	readonly: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-	value: 5,
-	disabled: true,
-};
-
-export const Design = Template.bind({});
-Design.storyName = "Value State";
-Design.args = {
-	value: 5,
-	valueState: ValueState.Success,
-};
+export const DifferentValueStates: StoryFn = () => html`
+	<div style="max-width: 13rem"> <ui5-step-input value-state="Success" value="5"></ui5-step-input> </div> <br>
+	<div style="max-width: 13rem"> <ui5-step-input value-state="Warning" value="5"></ui5-step-input> </div> <br>
+	<div style="max-width: 13rem"> <ui5-step-input value-state="Error" value="5"></ui5-step-input> </div> <br>
+	<div style="max-width: 13rem"> <ui5-step-input value-state="Information" value="5"></ui5-step-input> </div> <br>
+`;
 
 export const MinMax = Template.bind({});
 MinMax.storyName = "Min/Max and Step Values";
 MinMax.args = {
 	value: 0,
-	min: -100,
-	max: 100,
+	min: -50,
+	max: 50,
 	step: 10,
 };
 
@@ -88,7 +79,7 @@ ValuePrecision.args = {
 };
 
 export const Label = Template.bind({});
-Label.storyName = "With Label and Alignment";
+Label.storyName = "With Label and Text Alignment";
 Label.args = {
 	id: "myStepInput",
 	style: "text-align: left",
@@ -96,6 +87,6 @@ Label.args = {
 	required: true,
 };
 Label.decorators = [
-	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number</ui5-label>
+	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number left alignment</ui5-label>
 	${story()}`,
 ]

--- a/packages/playground/_stories/main/StepInput/StepInput.stories.ts
+++ b/packages/playground/_stories/main/StepInput/StepInput.stories.ts
@@ -78,7 +78,7 @@ ValuePrecision.args = {
 };
 
 export const Label = Template.bind({});
-Label.storyName = "With Label and Text Alignment";
+Label.storyName = "With Text Alignment";
 Label.args = {
 	id: "myStepInput",
 	style: "text-align: left",
@@ -86,6 +86,6 @@ Label.args = {
 	required: true,
 };
 Label.decorators = [
-	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number is left aligned</ui5-label>
+	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number is left-aligned</ui5-label>
 	${story()}`,
 ]

--- a/packages/playground/_stories/main/StepInput/StepInput.stories.ts
+++ b/packages/playground/_stories/main/StepInput/StepInput.stories.ts
@@ -10,7 +10,6 @@ import type { UI5StoryArgs } from "../../../types.js";
 import { DocsPage } from "../../../.storybook/docs";
 
 import type StepInput from "@ui5/webcomponents/dist/StepInput.js";
-import ValueState from "@ui5/webcomponents-base/dist/types/ValueState";
 
 const component = "ui5-step-input";
 
@@ -87,6 +86,6 @@ Label.args = {
 	required: true,
 };
 Label.decorators = [
-	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number left alignment</ui5-label>
+	(story) => html`<ui5-label class="samples-big-margin-right" for="myStepInput">Number is left aligned</ui5-label>
 	${story()}`,
 ]

--- a/packages/playground/_stories/main/Switch/Switch.stories.ts
+++ b/packages/playground/_stories/main/Switch/Switch.stories.ts
@@ -69,13 +69,13 @@ RequiredInForm.decorators = [
 			}
 		</style>
 		<form id="myForm" class="switch-form">
-			<h3 style="margin: 0 0 1rem 0">Switch in Registration form sample</h3>
+			<h3 style="margin: 0 0 1rem 0; color: var(--sapTextColor);">Switch in Registration form sample</h3>
 			<div style="display: flex; flex-direction: column;">
 				<ui5-input required type="Email" placeholder="Email" value="your@email.com"></ui5-input>
 				<ui5-input required type="Password" placeholder="Password" value="your@email.com"></ui5-input>
 			</div>
 			<div style="display: flex; flex-direction: column; justify-content: center;">
-				<ui5-label for="mySwitch" style="margin: 1rem 0 0 0">Please accept the terms and conditions, in order to proceed</ui5-label>
+				<ui5-label for="mySwitch" style="margin: 1rem 0 0 0; color: var(--sapTextColor);">Please accept the terms and conditions, in order to proceed</ui5-label>
 				<div style="width: fit-content">
 					${story()}
 				</div>

--- a/packages/playground/_stories/main/Switch/Switch.stories.ts
+++ b/packages/playground/_stories/main/Switch/Switch.stories.ts
@@ -38,30 +38,14 @@ const Template: UI5StoryArgs<Switch, StoryArgsSlots> = (args) => html`<ui5-switc
 ></ui5-switch>`;
 
 export const Basic = Template.bind({});
-
-export const WithText = Template.bind({});
-WithText.args = {
-	textOn: "On",
-	textOff: "Off",
+Basic.args = {
+	accessibleName: "Switch with Accessible Name",
 };
 
-export const Checked = Template.bind({});
-Checked.args = {
-	textOn: "Yes",
-	textOff: "No",
-	checked: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-	disabled: true,
-	checked: true,
-};
-
-export const Design = Template.bind({});
-Design.args = {
+export const Graphical = Template.bind({});
+Graphical.args = {
 	design: SwitchDesign.Graphical,
-	accessibleName: "graphical",
+	checked: true,
 };
 
 export const RequiredInForm = Template.bind({});

--- a/packages/playground/_stories/main/Switch/Switch.stories.ts
+++ b/packages/playground/_stories/main/Switch/Switch.stories.ts
@@ -42,12 +42,6 @@ Basic.args = {
 	accessibleName: "Switch with Accessible Name",
 };
 
-export const Graphical = Template.bind({});
-Graphical.args = {
-	design: SwitchDesign.Graphical,
-	checked: true,
-};
-
 export const RequiredInForm = Template.bind({});
 RequiredInForm.args = {
 	required: true,

--- a/packages/playground/_stories/main/ToggleButton/ToggleButton.stories.ts
+++ b/packages/playground/_stories/main/ToggleButton/ToggleButton.stories.ts
@@ -39,29 +39,19 @@ Basic.args = {
 	default: "Default",
 };
 
-export const Pressed = Template.bind({});
-Pressed.args = {
-	default: "Pressed",
-	pressed: true,
-};
+export const DifferentDesigns: StoryFn = () => html`
+	<ui5-toggle-button design="${ButtonDesign.Emphasized}"> Emphasized </ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Attention}"> Attention </ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Positive}"> Positive </ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Negative}"> Negative </ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Transparent}"> Transparent </ui5-toggle-button>
+`;
 
-export const DisabledAndPressed = Template.bind({});
-DisabledAndPressed.args = {
-	default: "ToggleButton",
-	pressed: true,
-	disabled: true,
-};
-
-export const IconOnly = Template.bind({});
-IconOnly.storyName = "Icon-Only ToggleButton";
-IconOnly.args = {
-	icon: "add",
-};
-
-export const WithIconAndDesign = Template.bind({});
-WithIconAndDesign.args = {
-	default: "ToggleButton",
-	design: ButtonDesign.Positive,
-	pressed: false,
-	icon: "add",
-};
+export const IconOnlyToggleButtons: StoryFn = () => html`
+	<ui5-toggle-button design="${ButtonDesign.Emphasized}" icon="business-suite/icon-target"></ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Attention}" icon="message-warning" tooltip="Warning Button"></ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Positive}" icon="business-suite/icon-completed" tooltip="Positive Button"></ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Negative}" icon="cancel" tooltip="Negative Button"></ui5-toggle-button>
+	<ui5-toggle-button design="${ButtonDesign.Transparent}" icon="account" tooltip="Transparent Button"></ui5-toggle-button>
+`;
+IconOnlyToggleButtons.storyName = "Icon-Only Toggle Buttons";


### PR DESCRIPTION
As a part of the #7284 initiative we enhanced the Storybook samples for the following components:

#### Bar
- Cleared the JSDoc enums;
- Changed the story name to -> **_Basic_**

#### Button
- Cleared JSDoc enums;
- Remove redunant Storybook samples;

#### DatePicker
- Cleared JSDoc enums;

#### DynamicSideContent
- Added custom styling to the native HTML tags as changing the themes wasn't updating the content. For example on Dark themes like Evening Horizon, both the background and the text would appear dark, which led to poor user experience;

#### FileUploader
- Cleared JSDoc enums
- Moved the Custom FileUploader sample to lower position, because we **do not** encourage using non-focusable elements;

#### Menu
- Fixed wrong property name `headerText` -> `header-text` because it wasnt showing on Mobile Devices;
- Changed sample name -> **_Basic with Header Text_** -> **_Basic_**

#### SplitButton
- Cleared JSDoc enums;
- Remove redunant Storybook samples;

#### StepInput
- Cleared JSDoc enums;
- Wrapped the main story component in the Storybook in a **`div`** with **`max-width: 13rem`**, due to component being stretched to the whole page, causing poor user experience;
- Simplified and removed redunant Storybook samples;

#### Switch
- Remove redunant Storybook samples;
- Reduced the Textual Switch samples because we **do not** encourage using Text in our switch component;

#### ToggleButton
- Enhance samples;