### PR TITLE
fix(ui5-select): fix header on phone & update items on options change

### DIFF
--- a/packages/main/src/Option.ts
+++ b/packages/main/src/Option.ts
@@ -1,5 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import type { IOption } from "./Select.js";
 
@@ -109,6 +110,8 @@ class Option extends UI5Element implements IOption {
 	 * @slot
 	 * @public
 	 */
+	@slot({ type: Node, "default": true, invalidateOnChildChange: true })
+	text!: Array<Node>;
 
 	get stableDomRef() {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -12,7 +12,7 @@
 		style={{styles.responsivePopover}}
 	>
 		{{#if _isPhone}}
-			<div class="ui5-responsive-popover-header">
+			<div slot="header" class="ui5-responsive-popover-header">
 				<div class="row">
 					<span>{{_headerTitleText}}</span>
 					<ui5-button


### PR DESCRIPTION
The PR addresses two issues found accidentally when playing around with the component:

### 1. Header on phone
**before** - two headers are rendered 
<img width="395" alt="Screenshot 2023-08-16 at 11 57 14" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/3ca2de8e-a5d9-43d9-8d50-369667caccb1"></br>


**now** - only one header is displayed, the slot attributes was missing from the div, that meant to be a header
<img width="395" alt="Screenshot 2023-08-16 at 11 57 30" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/48bd1d4a-9202-4a82-b802-1dffc8b5e03c"></br>


### 2. Update of the Select's dropdown upon Option web component change:
 
**before**: The dropdown used to not reflect changes of the Option's text content. For example, if the content of Option is "Hello" and we change it dynamically to "World" - the change is not reflected in the dropdown immediately, but only after some interaction (that triggers re-rendering)

**now**: It does, because the Option invalidates itself upon text content changes, and this triggers Select's invalidation and the change is immediately reflected in the UI.