### PR TITLE
docs(ui5-shellbar-item): adjust `text` description & remove `native` annotation from `click` event

### DIFF
--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -53,6 +53,8 @@ class ShellBarItem extends UI5Element {
 
 	/**
 	 * Defines the item text.
+     * <br><br>
+     * <b>Note:</b> The text is only displayed inside the overflow popover list view.
 	 * @type {string}
 	 * @defaultvalue ""
 	 * @name sap.ui.webc.fiori.ShellBarItem.prototype.text

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -32,7 +32,6 @@ type ShellBarItemClickEventDetail = {
  * @allowPreventDefault
  * @param {HTMLElement} targetRef DOM ref of the clicked element
  * @public
- * @native
  */
 @event("click", {
 	detail: {


### PR DESCRIPTION
This PR adds a note to the `text` property of the ShellbarItem description, explaining that the text will only be visible when the item is inside the overflow popover. It also removes the `@native` JSDoc annotation from the `click` event as the event is a `CustomEvent`