### PR TITLE
chore: document the newly added list item shadow parts

### DIFF
--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -26,8 +26,8 @@ import customListItemCss from "./generated/themes/CustomListItem.css.js";
  * <li>content - Used to style the content area of the list item</li>
  * <li>detail-button - Used to style the button rendered when the list item is of type detail</li>
  * <li>delete-button - Used to style the button rendered when the list item is in delete mode</li>
- * <li>radio - Used to style the radio button rendered when the list item is in multiple selection mode</li>
- * <li>checkbox - Used to style the checkbox rendered when the list item is in single selection mode</li>
+ * <li>radio - Used to style the radio button rendered when the list item is in single selection mode</li>
+ * <li>checkbox - Used to style the checkbox rendered when the list item is in multiple selection mode</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -16,6 +16,20 @@ import customListItemCss from "./generated/themes/CustomListItem.css.js";
  *
  * The component accepts arbitrary HTML content to allow full customization.
  *
+ * <h3>CSS Shadow Parts</h3>
+ *
+ * <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM.
+ * <br>
+ * The <code>ui5-li-custom</code> exposes the following CSS Shadow Parts:
+ * <ul>
+ * <li>native-li - Used to style the main li tag of the list item</li>
+ * <li>content - Used to style the content area of the list item</li>
+ * <li>detail-button - Used to style the button rendered when the list item is of type detail</li>
+ * <li>delete-button - Used to style the button rendered when the list item is in delete mode</li>
+ * <li>radio - Used to style the radio button rendered when the list item is in multiple selection mode</li>
+ * <li>checkbox - Used to style the checkbox rendered when the list item is in single selection mode</li>
+ * </ul>
+ *
  * @constructor
  * @author SAP SE
  * @alias sap.ui.webc.main.CustomListItem

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -43,7 +43,7 @@
 		{{#if typeDetail}}
 			<div class="ui5-li-detailbtn">
 				<ui5-button
-					part="edit-button"
+					part="detail-button"
 					design="Transparent"
 					icon="edit"
 					@click="{{onDetailClick}}"

--- a/packages/main/src/StandardListItem.ts
+++ b/packages/main/src/StandardListItem.ts
@@ -27,6 +27,12 @@ import StandardListItemTemplate from "./generated/templates/StandardListItemTemp
  * <li>description - Used to style the description of the list item</li>
  * <li>additional-text - Used to style the additionalText of the list item</li>
  * <li>icon - Used to style the icon of the list item</li>
+ * <li>native-li - Used to style the main li tag of the list item</li>
+ * <li>content - Used to style the content area of the list item</li>
+ * <li>detail-button - Used to style the button rendered when the list item is of type detail</li>
+ * <li>delete-button - Used to style the button rendered when the list item is in delete mode</li>
+ * <li>radio - Used to style the radio button rendered when the list item is in multiple selection mode</li>
+ * <li>checkbox - Used to style the checkbox rendered when the list item is in single selection mode</li>
  * </ul>
  *
  * @constructor

--- a/packages/main/src/StandardListItem.ts
+++ b/packages/main/src/StandardListItem.ts
@@ -31,8 +31,8 @@ import StandardListItemTemplate from "./generated/templates/StandardListItemTemp
  * <li>content - Used to style the content area of the list item</li>
  * <li>detail-button - Used to style the button rendered when the list item is of type detail</li>
  * <li>delete-button - Used to style the button rendered when the list item is in delete mode</li>
- * <li>radio - Used to style the radio button rendered when the list item is in multiple selection mode</li>
- * <li>checkbox - Used to style the checkbox rendered when the list item is in single selection mode</li>
+ * <li>radio - Used to style the radio button rendered when the list item is in single selection mode</li>
+ * <li>checkbox - Used to style the checkbox rendered when the list item is in multiple selection mode</li>
  * </ul>
  *
  * @constructor


### PR DESCRIPTION
Additionally, `edit-button` was renamed to `detail-button` to be semantically correct. 