### PR TITLE
fix(framework): fix OpenUI5Support usage in applyTheme

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -38,7 +38,7 @@
     "@buxlabs/amd-to-es6": "0.16.1",
     "@openui5/sap.ui.core": "1.116.0",
     "@ui5/webcomponents-tools": "1.17.0-rc.2",
-    "chromedriver": "114.0.0",
+    "chromedriver": "116.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/base/src/theming/applyTheme.ts
+++ b/packages/base/src/theming/applyTheme.ts
@@ -4,7 +4,7 @@ import getThemeDesignerTheme from "./getThemeDesignerTheme.js";
 import { fireThemeLoaded } from "./ThemeLoaded.js";
 import { getFeature } from "../FeaturesRegistry.js";
 import { attachCustomThemeStylesToHead, getThemeRoot } from "../config/ThemeRoot.js";
-import OpenUI5Support from "../features/OpenUI5Support.js";
+import type OpenUI5Support from "../features/OpenUI5Support.js";
 import { DEFAULT_THEME } from "../generated/AssetParameters.js";
 import { getCurrentRuntimeIndex } from "../Runtimes.js";
 
@@ -56,7 +56,7 @@ const detectExternalTheme = async (theme: string) => {
 
 	// If OpenUI5Support is enabled, try to find out if it loaded variables
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-	if (openUI5Support && OpenUI5Support.isOpenUI5Detected()) {
+	if (openUI5Support && openUI5Support.isOpenUI5Detected()) {
 		const varsLoaded = openUI5Support.cssVariablesLoaded();
 		if (varsLoaded) {
 			return {

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -49,6 +49,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.17.0-rc.2",
-    "chromedriver": "114.0.0"
+    "chromedriver": "116.0.0"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.116.0",
     "@ui5/webcomponents-tools": "1.17.0-rc.2",
-    "chromedriver": "114.0.0",
+    "chromedriver": "116.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -50,6 +50,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.17.0-rc.2",
-    "chromedriver": "114.0.0"
+    "chromedriver": "116.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4603,7 +4603,7 @@ axe-core@4.2.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
   integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
 
-axios@^1.0.0, axios@^1.2.1:
+axios@^1.0.0, axios@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
@@ -5252,14 +5252,14 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@114.0.0:
-  version "114.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-114.0.0.tgz#bcead893ca0064bb3353b6a8e0c2552b0b90a354"
-  integrity sha512-Yxx5diaOuQ0lvajAXABb+ikOiemZDlw3YfpDTFP2o1fbVSFue0AY0HdpqnFPRXxGEroGD0yPWz7MSyXcVEdnkA==
+chromedriver@116.0.0:
+  version "116.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-116.0.0.tgz#3f5d07b5427953270461791651d7b68cb6afe9fe"
+  integrity sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
-    axios "^1.2.1"
-    compare-versions "^5.0.1"
+    axios "^1.4.0"
+    compare-versions "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.1"
     proxy-from-env "^1.1.0"
@@ -5500,10 +5500,10 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-compare-versions@^5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.3.tgz#a9b34fea217472650ef4a2651d905f42c28ebfd7"
-  integrity sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==
+compare-versions@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
 
 compress-commons@^4.1.0:
   version "4.1.1"


### PR DESCRIPTION
OpenUI5Support should have been imported as a type, not importing the feature itself. Importing the feature is done by the consumers, when they need better OpenUI5 integration.