### PR TITLE
fix(ui5-shellbar): align notification counter

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -316,7 +316,7 @@ slot[name="profile"] {
 	align-items: center;
 }
 
-.ui5-shellbar-overflow-container-right-child .ui5-shellbar-button[data-count]:has(+ .ui5-shellbar-overflow-button)::before  {
+.ui5-shellbar-overflow-container-right-child .ui5-shellbar-button[data-count]:has(+ .ui5-shellbar-overflow-button)::before {
 	inset-inline-end: var(--_ui5-shellbar-notification-btn-count-offset);
 }
 
@@ -387,6 +387,7 @@ slot[name="profile"] {
 
 :host([notifications-count]:not([notifications-count=""])) .ui5-shellbar-bell-button::before {
 	content: attr(data-ui5-notifications-count);
+	inset-inline-end: var(--_ui5-shellbar-notification-btn-count-offset);
 }
 
 .ui5-shellbar-button[data-count]::before {

--- a/packages/main/src/themes/base/rtl-parameters.css
+++ b/packages/main/src/themes/base/rtl-parameters.css
@@ -41,5 +41,5 @@
 	--_ui5_menu_submenu_placement_type_left_margin_offset: 0 0.25rem;
 	--_ui5-menu_item_icon_float: left;
 
-	--_ui5-shellbar-notification-btn-count-offset: unset;
+	--_ui5-shellbar-notification-btn-count-offset: auto;
 }


### PR DESCRIPTION
The notification counter badge is being trimmed when it is contained in the last element in the ShellBar.
Also adjusted the RTL support.

This change is continuation of #7208.

Fixes: #7456 
