### PR TITLE
chore: update Toolbar

### DIFF
--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -24,6 +24,7 @@ import { registerToolbarItem } from "./ToolbarRegistry.js";
  * <code>import "@ui5/webcomponents/dist/ToolbarButton";</code>
  *
  * @constructor
+ * @abstract
  * @author SAP SE
  * @alias sap.ui.webc.main.ToolbarButton
  * @extends sap.ui.webc.main.ToolbarItem
@@ -94,7 +95,7 @@ class ToolbarButton extends ToolbarItem {
 	 * @name sap.ui.webc.main.ToolbarButton.prototype.icon
 	 * @public
 	 */
-	@property({ type: String })
+	@property()
 	icon!: string;
 
 	/**
@@ -180,17 +181,21 @@ class ToolbarButton extends ToolbarItem {
 	 * @type {string}
 	 * @name sap.ui.webc.main.ToolbarButton.prototype.text
 	 */
-	@property({ type: String })
+	@property()
 	text!: string;
 
 	/**
-	 * Button width
+	 * Defines the width of the button.
+	 * <br><br>
+	 *
+	 * <b>Note:</b> all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
+	 *
 	 * @name sap.ui.webc.main.ToolbarButton.prototype.width
 	 * @defaultvalue ""
 	 * @type {string}
 	 * @public
 	 */
-	@property({ type: String })
+	@property()
 	width!: string;
 
 	static get staticAreaStyles() {

--- a/packages/main/src/ToolbarItem.ts
+++ b/packages/main/src/ToolbarItem.ts
@@ -1,7 +1,6 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import { TemplateFunction } from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
-import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 
 import ToolbarItemOverflowBehavior from "./types/ToolbarItemOverflowBehavior.js";
 
@@ -32,7 +31,6 @@ interface IToolbarItem {
  * @public
  * @since 1.17.0
  */
-@customElement("ui5-tb-item")
 class ToolbarItem extends UI5Element implements IToolbarItem {
 	/**
 	 * Property used to define the access of the item to the overflow Popover. If "NeverOverflow" option is set,
@@ -133,8 +131,6 @@ class ToolbarItem extends UI5Element implements IToolbarItem {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 }
-
-ToolbarItem.define();
 
 export type {
 	IToolbarItem,

--- a/packages/main/src/ToolbarPopover.hbs
+++ b/packages/main/src/ToolbarPopover.hbs
@@ -4,7 +4,7 @@
 	horizontal-align="Right"
 	@ui5-after-close="{{onOverflowPopoverClosed}}"
 	@ui5-after-open="{{onOverflowPopoverOpened}}"
-	no-arrow
+	hide-arrow
 >
 	<div class="ui5-overflow-list {{classes.overflow}}">
 		{{#each overflowItems}}

--- a/packages/main/src/ToolbarSelect.hbs
+++ b/packages/main/src/ToolbarSelect.hbs
@@ -1,5 +1,6 @@
 <ui5-select 
-	class="ui5-tb-item" 
+	class="ui5-tb-item"
+	style="{{this.styles}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 	value-state="{{this.valueState}}"
 	?disabled="{{this.disabled}}"

--- a/packages/main/src/ToolbarSelect.ts
+++ b/packages/main/src/ToolbarSelect.ts
@@ -74,6 +74,17 @@ type ToolbarSelectChangeEventDetail = SelectChangeEventDetail;
 @event("close")
 
 class ToolbarSelect extends ToolbarItem {
+	/**
+	 * Defines the width of the select.
+	 * <br><br>
+	 *
+	 * <b>Note:</b> all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
+	 *
+	 * @name sap.ui.webc.main.ToolbarSelect.prototype.width
+	 * @defaultvalue ""
+	 * @type {string}
+	 * @public
+	 */
 	@property()
 	width!: string;
 

--- a/packages/main/src/ToolbarSelect.ts
+++ b/packages/main/src/ToolbarSelect.ts
@@ -16,6 +16,8 @@ import Option from "./Option.js";
 import "./ToolbarSelectOption.js";
 import type { SelectChangeEventDetail } from "./Select.js";
 
+type ToolbarSelectChangeEventDetail = SelectChangeEventDetail;
+
 /**
  * @class
  *
@@ -28,6 +30,7 @@ import type { SelectChangeEventDetail } from "./Select.js";
  * <br>
  * <code>import "@ui5/webcomponents/dist/ToolbarSelectOption";</code> (comes with <code>ui5-toolbar-select</code>)
  * @constructor
+ * @abstract
  * @author SAP SE
  * @alias sap.ui.webc.main.ToolbarSelect
  * @extends sap.ui.webc.base.UI5Element
@@ -71,7 +74,7 @@ import type { SelectChangeEventDetail } from "./Select.js";
 @event("close")
 
 class ToolbarSelect extends ToolbarItem {
-	@property({ type: String })
+	@property()
 	width!: string;
 
 	/**
@@ -188,7 +191,7 @@ class ToolbarSelect extends ToolbarItem {
 	_onEventHandler(e: Event): void {
 		if (e.type === "change") {
 			// update options
-			const selectedOption = (e as CustomEvent<SelectChangeEventDetail>).detail.selectedOption;
+			const selectedOption = (e as CustomEvent<ToolbarSelectChangeEventDetail>).detail.selectedOption;
 			const selectedOptionIndex = Number(selectedOption?.getAttribute("data-ui5-external-action-item-index"));
 			this.options.forEach((option: Option, index: number) => {
 				if (index === selectedOptionIndex) {
@@ -199,6 +202,12 @@ class ToolbarSelect extends ToolbarItem {
 			});
 		}
 	}
+
+	get styles() {
+		return {
+			width: this.width,
+		};
+	}
 }
 
 registerToolbarItem(ToolbarSelect);
@@ -206,3 +215,7 @@ registerToolbarItem(ToolbarSelect);
 ToolbarSelect.define();
 
 export default ToolbarSelect;
+
+export type {
+	ToolbarSelectChangeEventDetail,
+};

--- a/packages/main/src/ToolbarSpacer.ts
+++ b/packages/main/src/ToolbarSpacer.ts
@@ -27,9 +27,15 @@ import { registerToolbarItem } from "./ToolbarRegistry.js";
 
 class ToolbarSpacer extends ToolbarItem {
 	/**
-	 * Spacer width
+	 * Defines the width of the spacer.
+	 * <br><br>
+	 *
+	 * <b>Note:</b> all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
+	 *
 	 * @public
+	 * @type {string}
 	 * @name sap.ui.webc.main.ToolbarSpacer.prototype.width
+	 * @defaultvalue ""
 	 */
 	@property({ type: String })
 	width!: string

--- a/packages/main/src/themes/ToolbarPopover.css
+++ b/packages/main/src/themes/ToolbarPopover.css
@@ -1,9 +1,12 @@
+.ui5-overflow-popover::part(content) {
+	padding: var(--_ui5_toolbar_overflow_padding);
+}
+
 .ui5-overflow-list {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	padding: 0 0.5rem;
 }
 
 .ui5-tb-popover-item {

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -148,6 +148,7 @@
 	/* Toolbar */
 	--_ui5-toolbar-separator-height: 2rem;
 	--_ui5-toolbar-height: 2.75rem;
+	--_ui5_toolbar_overflow_padding: 0.25rem 0.5rem;
 }
 
 [data-ui5-compact-size],
@@ -357,4 +358,5 @@
 	/* Toolbar */
 	--_ui5-toolbar-separator-height: 1.5rem;
 	--_ui5-toolbar-height: 2rem;
+	--_ui5_toolbar_overflow_padding: 0.1875rem 0.375rem;
 }


### PR DESCRIPTION
**Changes:**
- hide overflow popup `arrow`
- fix `padding` in the overflow
<img width="232" alt="Screenshot 2023-08-30 at 11 47 06" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/15bbddbb-b9e4-479b-94fc-85045738f6a3">
<img width="155" alt="Screenshot 2023-08-30 at 11 46 16" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/7044f8e9-781f-42e8-ab16-8f6edafb3e1f">


- add `@abstract` to all Toolbar* components
- ToolbarItem becomes a pure class, not a customElement
- ToolbarSelect now supports `width` attribute (the property was present, but the value was not propagated in the template to the ui5-select)
- The `width` property has all the JSDoc required in all components that have it ToolbarSelect, ToolbarButton and ToolbarSpacer 
- The "width" property is now public  in ToolbarSelect as well (it was public in ToolbarButton and ToolbarSpacer )

**Open for discussion:**
- The "width" property  is of type string, previously we used to have CSSSize

Example:
```js
	/**
	 * Defines the width of the select.
	 * <br><br>
	 *
	 * <b>Note:</b> all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
	 *
	 * @name sap.ui.webc.main.ToolbarSelect.prototype.width
	 * @defaultvalue ""
	 * @type {string}
	 * @public
	 */
	@property()
	width!: string;
```