### PR TITLE
chore: disable vitejs hot module reload

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,9 @@ module.exports = defineConfig(async () => {
 		build: {
 			emptyOutDir: false,
 		},
+		server: {
+			hmr: false,
+		},
 		plugins: [await virtualIndex()],
 	}
 });


### PR DESCRIPTION
Mac users who have upgraded to `Ventura 13.5` have reported the browser refreshing constantly even though no files were changed.

While a solution is found, we can disable the Hot Module Reload feature for `vitejs`.