### PR TITLE
chore: use a safe querySelector for ID

### DIFF
--- a/packages/base/src/delegate/ItemNavigation.ts
+++ b/packages/base/src/delegate/ItemNavigation.ts
@@ -381,7 +381,7 @@ class ItemNavigation {
 		}
 
 		if (currentItem.id) {
-			return currentItemDOMRef.querySelector(`#${currentItem.id}`) as HTMLElement;
+			return currentItemDOMRef.querySelector(`[id="${currentItem.id}"]`) as HTMLElement;
 		}
 	}
 }


### PR DESCRIPTION
We must not use `querySelector("#${someId}")` for IDs that can be supplied by app developers, because if these IDs have `.` or `:`, it becomes f.e. `querySelector("#something.somethingElse")`. Instead, we can use the attribute selector form.

Note: all selectors based on `this._id` are safe, because it's generated by the framework and known to be safe.