### PR TITLE
docs(ui5-toolbar): add note about allowed components in default slot

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -154,6 +154,8 @@ class Toolbar extends UI5Element {
 
 	/**
 	 * Defines the items of the component.
+     *
+     * <b>Note:</b> Currently only <code>ui5-toolbar-button</code>, <code>ui5-toolbar-select</code>, <code>ui5-toolbar-separator</code> and <code>ui5-toolbar-spacer</code> are allowed here.
 	 *
 	 * @type {sap.ui.webc.main.IToolbarItem[]}
 	 * @name sap.ui.webc.main.Toolbar.prototype.default


### PR DESCRIPTION
In the `Toolbar` of UI5WCR it was possible to pass any component as child. Since the ui5wc `Toolbar` doesn't support that feature it's confusing for users when they are migrating. (e.g. [here](https://github.com/SAP/ui5-webcomponents-react/issues/5060)) This PR adds a description of the allowed components inside the default slot to make it more clear which components can be passed there.