### PR TITLE
fix(ui5-input): improve item announcement

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -46,7 +46,7 @@ import "@ui5/webcomponents-icons/dist/alert.js";
 import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import "@ui5/webcomponents-icons/dist/information.js";
 import type SuggestionItem from "./SuggestionItem.js";
-import type { InputSuggestionText, SuggestionComponent } from "./features/InputSuggestions.js";
+import type { InputSuggestion, SuggestionComponent } from "./features/InputSuggestions.js";
 import type InputSuggestions from "./features/InputSuggestions.js";
 import type FormSupportT from "./features/InputElementsFormSupport.js";
 import type { IFormElement } from "./features/InputElementsFormSupport.js";
@@ -627,7 +627,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	typedInValue: string;
 	lastConfirmedValue: string
 	isTyping: boolean
-	suggestionsTexts: Array<InputSuggestionText>;
+	suggestionObjects: Array<InputSuggestion>;
 	_handleResizeBound: ResizeObserverCallback;
 	_keepInnerValue: boolean;
 	_shouldAutocomplete?: boolean;
@@ -677,7 +677,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		this.isTyping = false;
 
 		// Suggestions array initialization
-		this.suggestionsTexts = [];
+		this.suggestionObjects = [];
 
 		this._handleResizeBound = this._handleResize.bind(this);
 
@@ -702,7 +702,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 
 		if (this.showSuggestions) {
 			this.enableSuggestions();
-			this.suggestionsTexts = this.Suggestions!.defaultSlotProperties(this.typedInValue);
+			this.suggestionObjects = this.Suggestions!.defaultSlotProperties(this.typedInValue);
 		}
 
 		this.effectiveShowClearIcon = (this.showClearIcon && !!this.value && !this.readonly && !this.disabled);
@@ -1493,11 +1493,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	announceSelectedItem() {
 		const invisibleText = this.shadowRoot!.querySelector(`#${this._id}-selectionText`)!;
 
-		if (this.Suggestions && this.Suggestions._isItemOnTarget()) {
-			invisibleText.textContent = this.itemSelectionAnnounce;
-		} else {
-			invisibleText.textContent = "";
-		}
+		invisibleText.textContent = this.itemSelectionAnnounce;
 	}
 
 	get _readonly() {
@@ -1654,7 +1650,9 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 
 	get availableSuggestionsCount() {
 		if (this.showSuggestions && (this.value || this.Suggestions!.isOpened())) {
-			switch (this.suggestionsTexts.length) {
+			const nonGroupItems = this.suggestionObjects.filter(item => !item.groupItem);
+
+			switch (nonGroupItems.length) {
 			case 0:
 				return Input.i18nBundle.getText(INPUT_SUGGESTIONS_NO_HIT);
 
@@ -1662,7 +1660,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 				return Input.i18nBundle.getText(INPUT_SUGGESTIONS_ONE_HIT);
 
 			default:
-				return Input.i18nBundle.getText(INPUT_SUGGESTIONS_MORE_HITS, this.suggestionsTexts.length);
+				return Input.i18nBundle.getText(INPUT_SUGGESTIONS_MORE_HITS, nonGroupItems.length);
 			}
 		}
 

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -94,7 +94,7 @@
 
 {{#*inline "suggestionsList"}}
 	<ui5-list separators="{{suggestionSeparators}}" @mousedown="{{onItemMouseDown}}" mode="SingleSelect">
-		{{#each suggestionsTexts}}
+		{{#each suggestionObjects}}
 			{{#if groupItem}}
 				<ui5-li-groupheader data-ui5-key="{{key}}">{{{ this.text }}}</ui5-li-groupheader>
 			{{else}}

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -19,6 +19,7 @@ import SuggestionListItem from "../SuggestionListItem.js";
 
 import {
 	LIST_ITEM_POSITION,
+	LIST_ITEM_GROUP_HEADER,
 } from "../generated/i18n/i18n-defaults.js";
 import type ListItemType from "../types/ListItemType.js";
 import type ListItemBase from "../ListItemBase.js";
@@ -38,7 +39,7 @@ interface SuggestionComponent extends UI5Element {
 	onItemPreviewed: (item: SuggestionListItem) => void;
 }
 
-type InputSuggestionText = {
+type InputSuggestion = {
 	text: string;
 	description: string;
 	image?: string;
@@ -51,9 +52,11 @@ type InputSuggestionText = {
 }
 
 type SuggestionsAccInfo = {
+	isGroup: boolean,
 	currentPos: number;
 	listSize: number;
 	itemText: string;
+	description: string;
 }
 
 /**
@@ -110,7 +113,7 @@ class Suggestions {
 	defaultSlotProperties(hightlightValue: string) {
 		const inputSuggestionItems = this._getComponent().suggestionItems;
 		const highlight = this.highlight && !!hightlightValue;
-		const suggestions: Array<InputSuggestionText> = [];
+		const suggestions: Array<InputSuggestion> = [];
 
 		inputSuggestionItems.map((suggestion: SuggestionItem, idx: number) => {
 			const text = highlight ? this.getHighlightedText(suggestion, hightlightValue) : this.getRowText(suggestion);
@@ -283,13 +286,16 @@ class Suggestions {
 	onItemSelected(selectedItem: SuggestionListItem | null, keyboardUsed: boolean) {
 		const allItems = this._getItems();
 		const item = selectedItem || allItems[this.selectedItemIndex];
+		const nonGroupItems = this._getNonGroupItems();
 
 		this.selectedItemIndex = allItems.indexOf(item);
 
 		this.accInfo = {
-			currentPos: this.selectedItemIndex + 1,
-			listSize: allItems.length,
-			itemText: this._getRealItems()[this.selectedItemIndex].description,
+			isGroup: item.groupItem,
+			currentPos: nonGroupItems.indexOf(item) + 1,
+			listSize: nonGroupItems.length,
+			itemText: this._getRealItems()[this.selectedItemIndex].text,
+			description: this._getRealItems()[this.selectedItemIndex].description,
 		};
 
 		// If the item is "Inactive", prevent selection with SPACE or ENTER
@@ -472,6 +478,7 @@ class Suggestions {
 		const items = this._getItems();
 		const currentItem = items[nextIdx];
 		const previousItem = items[previousIdx];
+		const nonGroupItems = this._getNonGroupItems();
 
 		if (!currentItem) {
 			return;
@@ -481,9 +488,11 @@ class Suggestions {
 		this._clearValueStateFocus();
 
 		this.accInfo = {
-			currentPos: nextIdx + 1,
-			listSize: items.length,
-			itemText: this._getRealItems()[items.indexOf(currentItem)].description,
+			isGroup: currentItem.groupItem,
+			currentPos: nonGroupItems.indexOf(currentItem) + 1,
+			listSize: nonGroupItems.length,
+			itemText: this._getRealItems()[this.selectedItemIndex].text,
+			description: this._getRealItems()[items.indexOf(currentItem)].description,
 		};
 
 		if (previousItem) {
@@ -554,6 +563,10 @@ class Suggestions {
 		return this.responsivePopover ? [...this.responsivePopover.querySelector<List>("[ui5-list]")!.children] as Array<SuggestionListItem> : [];
 	}
 
+	_getNonGroupItems(): Array<SuggestionListItem> {
+		return this._getItems().filter(item => !item.groupItem);
+	}
+
 	_getComponent(): SuggestionComponent {
 		return this.component;
 	}
@@ -588,8 +601,9 @@ class Suggestions {
 		}
 
 		const itemPositionText = Suggestions.i18nBundle.getText(LIST_ITEM_POSITION, this.accInfo.currentPos, this.accInfo.listSize);
+		const groupItemText = Suggestions.i18nBundle.getText(LIST_ITEM_GROUP_HEADER);
 
-		return `${this.accInfo.itemText} ${itemPositionText}`;
+		return this.accInfo.isGroup ? `${groupItemText} ${this.accInfo.itemText}` : `${this.accInfo.description} ${itemPositionText}`;
 	}
 
 	getRowText(suggestion: SuggestionItem) {
@@ -665,5 +679,5 @@ export default Suggestions;
 
 export type {
 	SuggestionComponent,
-	InputSuggestionText,
+	InputSuggestion,
 };

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -817,7 +817,7 @@ describe("Input general interaction", () => {
 		await dynamicSuggestionsInnerInput.keys("c");
 
 		//assert
-		assert.strictEqual(await dynamicSuggestionsCount.getText(), "4 results are available", "Suggestions count is available since value is entered");
+		assert.strictEqual(await dynamicSuggestionsCount.getText(), "3 results are available", "Group items should be excluded of the count of available results.");
 		await dynamicSuggestionsInnerInput.keys("Backspace");
 
 		// Close suggestions to not intercept the click in the input below for the last test
@@ -829,6 +829,49 @@ describe("Input general interaction", () => {
 
 		//assert
 		assert.strictEqual(await suggestionsCount.getText(), "5 results are available", "Suggestions count is available since the suggestions popover is opened");
+	});
+
+	it("Suggestions announcement", async () => {
+		await browser.url(`test/pages/Input.html`);
+
+		const inputWithGroups = await $("#inputCompact");
+		const inputSuggestions = await $("#myInput2");
+		const inputWithGroupsInnerInput = await inputWithGroups.shadow$("input");
+		const inputWithGroupsAnnouncement = await inputWithGroups.shadow$(`#${await inputWithGroups.getProperty("_id")}-selectionText`);
+		const suggestionsAnnouncement = await inputSuggestions.shadow$(`#${await inputSuggestions.getProperty("_id")}-selectionText`);
+
+		//act
+		await inputWithGroups.click();
+
+		//assert
+		assert.strictEqual(await inputWithGroupsAnnouncement.getText(), "", "Suggestions announcement is not available on initially");
+
+		//act
+		await inputWithGroupsInnerInput.keys("a");
+		await inputWithGroupsInnerInput.keys("ArrowDown");
+
+		//assert
+		assert.strictEqual(await inputWithGroupsAnnouncement.getText(), "Group Header A", "Group item announcement should not contain the position and total coout.");
+
+		//act
+		await inputWithGroupsInnerInput.keys("ArrowDown");
+
+		const announcementText = await inputWithGroupsAnnouncement.getText();
+
+		//assert
+		assert.ok(announcementText.includes("List item 1 of 12"), "The total count announcement and position of items should exclude group items.");
+		await inputWithGroupsInnerInput.keys("Backspace");
+
+		// Close suggestions to not intercept the click in the input below for the last test
+		await inputWithGroupsInnerInput.keys("Escape");
+
+		//act
+		await inputSuggestions.click();
+		await (await inputSuggestions.shadow$("input")).keys("c");
+		await inputWithGroupsInnerInput.keys("ArrowDown");
+
+		//assert
+		assert.strictEqual(await suggestionsAnnouncement.getText(), "List item 1 of 5", "Item position and count is announced correctly");
 	});
 
 	it("Should close the Popover when no suggestions are available", async () => {


### PR DESCRIPTION
- Inactive and Group items should announced
- Group items should be excluded from the total count and position of items, when announced on navigation
- Group items should be excluded from the result announcement, when an user filters the list of suggestions

FIXES: #7552 
