### PR TITLE
feat(ui5-color-palette-item): add selected state

### DIFF
--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -277,8 +277,25 @@ class ColorPalette extends UI5Element {
 	}
 
 	_onclick(e: MouseEvent) {
-		const target = e.target as ColorPaletteItem;
+		this.handleSelection(e.target as ColorPaletteItem);
+	}
 
+	_onkeyup(e: KeyboardEvent) {
+		const target = e.target as ColorPaletteItem;
+		if (isSpace(e) && target.hasAttribute("ui5-color-palette-item")) {
+			e.preventDefault();
+			this.handleSelection(target);
+		}
+	}
+
+	_onkeydown(e: KeyboardEvent) {
+		const target = e.target as ColorPaletteItem;
+		if (isEnter(e) && target.hasAttribute("ui5-color-palette-item")) {
+			this.handleSelection(target);
+		}
+	}
+
+	handleSelection(target: ColorPaletteItem) {
 		if (!target.hasAttribute("ui5-color-palette-item")) {
 			return;
 		}
@@ -294,21 +311,6 @@ class ColorPalette extends UI5Element {
 		target.selected = true;
 
 		this._previouslySelected = target;
-	}
-
-	_onkeyup(e: KeyboardEvent) {
-		const target = e.target as ColorPaletteItem;
-		if (isSpace(e) && target.hasAttribute("ui5-color-palette-item")) {
-			e.preventDefault();
-			this.selectColor(target);
-		}
-	}
-
-	_onkeydown(e: KeyboardEvent) {
-		const target = e.target as ColorPaletteItem;
-		if (isEnter(e) && target.hasAttribute("ui5-color-palette-item")) {
-			this.selectColor(target);
-		}
 	}
 
 	_onDefaultColorKeyDown(e: KeyboardEvent) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -231,8 +231,13 @@ class ColorPalette extends UI5Element {
 
 	_setColor(color: string) {
 		this._selectedColor = color;
-		if (this._recentColors[0] !== this._selectedColor && !this._recentColors.includes(this._selectedColor)) {
-			this._recentColors.unshift(this._selectedColor);
+
+		if (this._recentColors[0] !== this._selectedColor) {
+			if (this._recentColors.includes(this._selectedColor)) {
+				this._recentColors.unshift(this._recentColors.splice(this._recentColors.indexOf(this._selectedColor), 1)[0]);
+			} else {
+				this._recentColors.unshift(this._selectedColor);
+			}
 		}
 
 		this.fireEvent<ColorPaletteItemClickEventDetail>("item-click", {
@@ -243,7 +248,6 @@ class ColorPalette extends UI5Element {
 	/**
 	 * Ensures that only one item is selected or only the last selected item remains active if more than one are explicitly set as 'selected'.
 	 *
-	 * @param {boolean} deselectAll - If true, will deselect all items. Otherwise, ensures only the last selected item remains active.
 	 * @private
 	 * @returns {void}
 	 */
@@ -282,13 +286,19 @@ class ColorPalette extends UI5Element {
 			return;
 		}
 
-		[...this.colors, ...this.recentColorsElements].forEach(item => {
-			item.selected = item === target;
-		});
-
 		this.selectColor(target);
 
-		this._currentlySelected = target;
+		// Handle selection for items within the 'recentColorsElements'
+		if (this.recentColorsElements.includes(target)) {
+			this.recentColorsElements[0].selected = true;
+			this.recentColorsElements[0].focus();
+			this._currentlySelected = this.recentColorsElements[0];
+		} else {
+			[...this.colors, ...this.recentColorsElements].forEach(item => {
+				item.selected = item === target;
+			});
+			this._currentlySelected = target;
+		}
 	}
 
 	_onDefaultColorKeyDown(e: KeyboardEvent) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -168,6 +168,7 @@ class ColorPalette extends UI5Element {
 	_itemNavigationRecentColors: ItemNavigation;
 	_recentColors: Array<string>;
 	moreColorsFeature?: ColorPaletteMoreColors;
+	_previouslySelected?: ColorPaletteItem;
 
 	static i18nBundle: I18nBundle;
 
@@ -198,6 +199,8 @@ class ColorPalette extends UI5Element {
 	}
 
 	onBeforeRendering() {
+		this._filterSelectedItems();
+
 		this.displayedColors.forEach((item, index) => {
 			item.index = index + 1;
 		});
@@ -241,11 +244,56 @@ class ColorPalette extends UI5Element {
 		});
 	}
 
+	/**
+	 * In case multiple 'ui5-color-palette-item' elements are explicitly set to be selected,
+	 * this function ensures that only the last one remains active, preventing multiple selections.
+	 *
+	 * @private
+	 * @returns {void}
+	 */
+	_filterSelectedItems() {
+		const allColorPaletteItems = this.colors;
+
+		const selectedItems = allColorPaletteItems.filter(item => item.selected);
+		if (selectedItems.length > 1) {
+			for (let i = 0; i < selectedItems.length - 1; i++) {
+				(selectedItems[i]).selected = !(selectedItems[i]).selected;
+			}
+		}
+	}
+
+	/**
+	 * Deselects all items in the color palette.
+	 *
+	 * @private
+	 * @returns {void}
+	 */
+	_deselectAllItems(items: ColorPaletteItem[]) {
+		items.forEach(item => {
+			if (item.selected) {
+				item.selected = !item.selected;
+			}
+		});
+	}
+
 	_onclick(e: MouseEvent) {
 		const target = e.target as ColorPaletteItem;
-		if (target.hasAttribute("ui5-color-palette-item")) {
-			this.selectColor(target);
+
+		if (!target.hasAttribute("ui5-color-palette-item")) {
+			return;
 		}
+
+		if (this._previouslySelected === target) {
+			target.selected = !target.selected;
+			return;
+		}
+
+		this._deselectAllItems([...this.colors, ...this.recentColorsElements]);
+
+		this.selectColor(target);
+		target.selected = true;
+
+		this._previouslySelected = target;
 	}
 
 	_onkeyup(e: KeyboardEvent) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -168,7 +168,7 @@ class ColorPalette extends UI5Element {
 	_itemNavigationRecentColors: ItemNavigation;
 	_recentColors: Array<string>;
 	moreColorsFeature?: ColorPaletteMoreColors;
-	_previouslySelected?: ColorPaletteItem;
+	_currentlySelected?: ColorPaletteItem;
 
 	static i18nBundle: I18nBundle;
 
@@ -281,23 +281,32 @@ class ColorPalette extends UI5Element {
 			return;
 		}
 
-		if (this._previouslySelected === target) {
+		if (this._currentlySelected === target) {
 			target.selected = !target.selected;
+			if (!target.selected) {
+				this._currentlySelected = undefined;
+				this._selectedColor = "";
+			}
 			return;
 		}
 
-		this._ensureSingleSelectionOrDeselectAll(true);
+		if (this._currentlySelected) {
+			this._currentlySelected.selected = false;
+			this._selectedColor = "";
+		}
 
 		if (this.recentColorsElements.includes(target)) {
 			target.selected = true;
 			this._selectedColor = target.value;
+			this._currentlySelected = target;
 			return;
 		}
 
+		this._ensureSingleSelectionOrDeselectAll(true);
 		this.selectColor(target);
 		target.selected = true;
 
-		this._previouslySelected = target;
+		this._currentlySelected = target;
 	}
 
 	_onDefaultColorKeyDown(e: KeyboardEvent) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -288,7 +288,7 @@ class ColorPalette extends UI5Element {
 	}
 
 	handleSelection(target: ColorPaletteItem) {
-		if (!target.hasAttribute("ui5-color-palette-item")) {
+		if (!target.hasAttribute("ui5-color-palette-item") || !target.value) {
 			return;
 		}
 
@@ -307,6 +307,11 @@ class ColorPalette extends UI5Element {
 
 	_onDefaultColorKeyDown(e: KeyboardEvent) {
 		if (isTabNext(e) && this.popupMode) {
+			e.preventDefault();
+			this._onDefaultColorClick();
+		}
+
+		if (isSpace(e) || isEnter(e)) {
 			e.preventDefault();
 			this._onDefaultColorClick();
 		}

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -231,12 +231,8 @@ class ColorPalette extends UI5Element {
 
 	_setColor(color: string) {
 		this._selectedColor = color;
-		if (this._recentColors[0] !== this._selectedColor) {
-			if (this._recentColors.includes(this._selectedColor)) {
-				this._recentColors.unshift(this._recentColors.splice(this._recentColors.indexOf(this._selectedColor), 1)[0]);
-			} else {
-				this._recentColors.unshift(this._selectedColor);
-			}
+		if (this._recentColors[0] !== this._selectedColor && !this._recentColors.includes(this._selectedColor)) {
+			this._recentColors.unshift(this._selectedColor);
 		}
 
 		this.fireEvent<ColorPaletteItemClickEventDetail>("item-click", {
@@ -251,9 +247,9 @@ class ColorPalette extends UI5Element {
 	 * @private
 	 * @returns {void}
 	 */
-	_ensureSingleSelectionOrDeselectAll(deselectAll = false) {
+	_ensureSingleSelectionOrDeselectAll() {
 		const selectedItems = [...this.colors, ...this.recentColorsElements].filter(item => item.selected);
-		!deselectAll && selectedItems.pop();
+		selectedItems.pop();
 		selectedItems.forEach(item => { item.selected = false; });
 	}
 
@@ -283,26 +279,19 @@ class ColorPalette extends UI5Element {
 
 		if (this._currentlySelected === target) {
 			target.selected = !target.selected;
-			if (!target.selected) {
-				this._currentlySelected = undefined;
-				this._selectedColor = "";
-			}
 			return;
 		}
 
-		if (this._currentlySelected) {
-			this._currentlySelected.selected = false;
-			this._selectedColor = "";
-		}
+		[...this.colors, ...this.recentColorsElements].forEach(item => {
+			item.selected = item === target;
+		});
 
-		if (this.recentColorsElements.includes(target)) {
-			target.selected = true;
-			this._selectedColor = target.value;
-			this._currentlySelected = target;
-			return;
-		}
+		this._selectedColor = target.value;
+		this.selectColor(target);
 
-		this._ensureSingleSelectionOrDeselectAll(true);
+		this._currentlySelected = target;
+
+		this._ensureSingleSelectionOrDeselectAll();
 		this.selectColor(target);
 		target.selected = true;
 

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -286,14 +286,7 @@ class ColorPalette extends UI5Element {
 			item.selected = item === target;
 		});
 
-		this._selectedColor = target.value;
 		this.selectColor(target);
-
-		this._currentlySelected = target;
-
-		this._ensureSingleSelectionOrDeselectAll();
-		this.selectColor(target);
-		target.selected = true;
 
 		this._currentlySelected = target;
 	}

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -252,20 +252,9 @@ class ColorPalette extends UI5Element {
 	 * @returns {void}
 	 */
 	_ensureSingleSelectionOrDeselectAll(deselectAll = false) {
-		const allColorPaletteItems = [...this.colors, ...this.recentColorsElements];
-
-		if (deselectAll) {
-			allColorPaletteItems.forEach(item => {
-				item.selected = false;
-			});
-		} else {
-			const selectedItems = allColorPaletteItems.filter(item => item.selected);
-			if (selectedItems.length > 1) {
-				for (let i = 0; i < selectedItems.length - 1; i++) {
-					selectedItems[i].selected = false;
-				}
-			}
-		}
+		const selectedItems = [...this.colors, ...this.recentColorsElements].filter(item => item.selected);
+		!deselectAll && selectedItems.pop();
+		selectedItems.forEach(item => { item.selected = false; });
 	}
 
 	_onclick(e: MouseEvent) {
@@ -298,6 +287,12 @@ class ColorPalette extends UI5Element {
 		}
 
 		this._ensureSingleSelectionOrDeselectAll(true);
+
+		if (this.recentColorsElements.includes(target)) {
+			target.selected = true;
+			this._selectedColor = target.value;
+			return;
+		}
 
 		this.selectColor(target);
 		target.selected = true;

--- a/packages/main/src/ColorPaletteItem.hbs
+++ b/packages/main/src/ColorPaletteItem.hbs
@@ -1,5 +1,5 @@
 <div
-	class="ui5-cp-item"
+	class="{{classes.root}}"
 	style="{{styles.root}}"
 	value="{{value}}"
 	tabindex="{{_tabIndex}}"

--- a/packages/main/src/ColorPaletteItem.ts
+++ b/packages/main/src/ColorPaletteItem.ts
@@ -53,6 +53,19 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 	value!: string;
 
 	/**
+	 * Defines if the component is selected.
+	 * <br><br>
+	 * Only one item can be selected per <code>ui5-color-palette</code>.
+	 *
+	 * @public
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.ColorPaletteItem.prototype.selected
+	 * @defaultvalue false
+	 */
+	@property({ type: Boolean })
+	selected!: boolean;
+
+	/**
 	 * Defines the tab-index of the element, helper information for the ItemNavigation.
 	 * @private
 	 */
@@ -106,6 +119,15 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 		return {
 			root: {
 				"background-color": this.value,
+			},
+		};
+	}
+
+	get classes() {
+		return {
+			root: {
+				"ui5-cp-item": true,
+				"selected": this.selected,
 			},
 		};
 	}

--- a/packages/main/src/ColorPaletteItem.ts
+++ b/packages/main/src/ColorPaletteItem.ts
@@ -55,7 +55,7 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 	/**
 	 * Defines if the component is selected.
 	 * <br><br>
-	 * Only one item can be selected per <code>ui5-color-palette</code>.
+	 * <b>Note:</b> Only one item must be selected per <code>ui5-color-palette</code>.
 	 *
 	 * @public
 	 * @type {boolean}

--- a/packages/main/src/ColorPaletteItem.ts
+++ b/packages/main/src/ColorPaletteItem.ts
@@ -56,11 +56,13 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 	 * Defines if the component is selected.
 	 * <br><br>
 	 * <b>Note:</b> Only one item must be selected per <code>ui5-color-palette</code>.
+	 * If more than one item is defined as selected, the last one would be considered as the selected one.
 	 *
 	 * @public
 	 * @type {boolean}
 	 * @name sap.ui.webc.main.ColorPaletteItem.prototype.selected
 	 * @defaultvalue false
+	 * @since 1.19.0
 	 */
 	@property({ type: Boolean })
 	selected!: boolean;
@@ -127,7 +129,7 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 		return {
 			root: {
 				"ui5-cp-item": true,
-				"selected": this.selected,
+				"ui5-cp-selected": this.selected,
 			},
 		};
 	}

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -48,8 +48,16 @@
 	box-sizing: border-box;
 }
 
-:host(:not([_disabled]):not([phone])) .ui5-cp-item:focus{
+.ui5-cp-item.selected:focus,
+:host(:not([_disabled]):not([phone])) .ui5-cp-item:focus,
+:host(:not([_disabled])[phone]) .ui5-cp-item:focus {
 	outline: none;
+}
+
+:host(:not([_disabled])[phone]) .ui5-cp-item:focus {
+	scale: 1.277778; /* (2.875rem / 2.25rem) ~ 1.277778 */
+	box-shadow: 0 0 0 1px #FFF, 0 0 0 2px var(--sapContent_ForegroundBorderColor);
+	border: var(--_ui5_color-palette-item-phone-selected-focus);
 }
 
 :host(:not([_disabled]):not([phone]):focus) .ui5-cp-item {
@@ -106,4 +114,63 @@
 	border: var(--_ui5_color-palette-item-after-focus-color);
 	border-radius: var(--_ui5_color-palette-item-after-focus-border-radius);
 	pointer-events: none;
+}
+
+
+/* Specific styling for the selected state */
+
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:not(:hover)::after,
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:hover::after {
+	border: var(--_ui5_color-palette-item-selected-focused-border-after);
+}
+
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:not(:hover)::before,
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:hover::before {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	left: var(--_ui5_color-palette-item-selected-focused-border-before);
+	top: var(--_ui5_color-palette-item-selected-focused-border-before);
+	right: var(--_ui5_color-palette-item-selected-focused-border-before);
+	bottom: var(--_ui5_color-palette-item-selected-focused-border-before);
+	border: var(--_ui5_color-palette-item-before-focus-color);
+	border-radius: var(--_ui5_color-palette-item-before-focus-border-radius);
+	pointer-events: none;
+}
+
+/* Phone specific styles for the selected state */
+
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:not(:hover)::after,
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:hover::after {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	left: var(--_ui5_color-palette-item-after-focus-offset);
+	top: var(--_ui5_color-palette-item-after-focus-offset);
+	right: var(--_ui5_color-palette-item-after-focus-offset);
+	bottom: var(--_ui5_color-palette-item-after-focus-offset);
+	border: var(--_ui5_color-palette-item-after-focus-color-phone);
+	border-radius: var(--_ui5_color-palette-item-after-focus-border-radius);
+	pointer-events: none;
+}
+
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:not(:hover)::before,
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:hover::before {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	left: var(--_ui5_color-palette-item-selected-focused-border-before);
+	top: var(--_ui5_color-palette-item-selected-focused-border-before);
+	right: var(--_ui5_color-palette-item-selected-focused-border-before);
+	bottom: var(--_ui5_color-palette-item-selected-focused-border-before);
+	border: var(--_ui5_color-palette-item-before-focus-color);
+	border-radius: .1875rem;
+	pointer-events: none;
+}
+
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus),
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus):not(:hover) {
+	scale: 1.277778; /* (2.875rem / 2.25rem) ~ 1.277778 */
+	border: 0.0625rem solid var(--sapGroup_ContentBackground);
+	box-shadow: 0 0 0 0.0625rem var(--sapContent_ForegroundBorderColor); /* gap */
 }

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -42,13 +42,13 @@
 }
 
 .ui5-cp-item:hover:not(:focus),
-.ui5-cp-item.selected {
+.ui5-cp-item.ui5-cp-selected {
 	border: 0.0625rem solid var(--sapGroup_ContentBackground);
 	border-radius: var(--_ui5_color-palette-item-hover-inner-border-radius);
 	box-sizing: border-box;
 }
 
-.ui5-cp-item.selected:focus,
+.ui5-cp-item.ui5-cp-selected:focus,
 :host(:not([_disabled]):not([phone])) .ui5-cp-item:focus,
 :host(:not([_disabled])[phone]) .ui5-cp-item:focus {
 	outline: none;
@@ -122,13 +122,13 @@
 
 /* Specific styling for the selected state */
 
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:not(:hover)::after,
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:hover::after {
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::after,
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:hover::after {
 	border: var(--_ui5_color-palette-item-selected-focused-border-after);
 }
 
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:not(:hover)::before,
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.selected:focus:hover::before {
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::before,
+:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:hover::before {
 	content: "";
 	box-sizing: border-box;
 	position: absolute;
@@ -143,8 +143,8 @@
 
 /* Phone specific styles for the selected state */
 
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:not(:hover)::after,
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:hover::after {
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::after,
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:hover::after {
 	content: "";
 	box-sizing: border-box;
 	position: absolute;
@@ -157,8 +157,8 @@
 	pointer-events: none;
 }
 
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:not(:hover)::before,
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:focus:hover::before {
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::before,
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:hover::before {
 	content: "";
 	box-sizing: border-box;
 	position: absolute;
@@ -171,8 +171,8 @@
 	pointer-events: none;
 }
 
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus),
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus):not(:hover) {
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:not(:focus),
+:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:not(:focus):not(:hover) {
 	width: 2.875rem; 
 	height: 2.875rem;
 	right: 0.125rem;

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -55,7 +55,10 @@
 }
 
 :host(:not([_disabled])[phone]) .ui5-cp-item:focus {
-	scale: 1.277778; /* (2.875rem / 2.25rem) ~ 1.277778 */
+	width: 2.875rem; 
+	height: 2.875rem;
+	right: 0.125rem;
+	bottom: 0.125rem;
 	box-shadow: 0 0 0 0.0625rem #FFF, 0 0 0 0.125rem var(--sapContent_ForegroundBorderColor);
 	border: var(--_ui5_color-palette-item-phone-selected-focus);
 }
@@ -170,7 +173,10 @@
 
 :host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus),
 :host([selected]:not([_disabled])[phone]) .ui5-cp-item.selected:not(:focus):not(:hover) {
-	scale: 1.277778; /* (2.875rem / 2.25rem) ~ 1.277778 */
+	width: 2.875rem; 
+	height: 2.875rem;
+	right: 0.125rem;
+	bottom: 0.125rem;
 	border: 0.0625rem solid var(--sapGroup_ContentBackground);
 	box-shadow: 0 0 0 0.0625rem var(--sapContent_ForegroundBorderColor); /* gap */
 }

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -43,7 +43,7 @@
 
 .ui5-cp-item:hover:not(:focus),
 .ui5-cp-item.selected {
-	border: 1px solid var(--sapGroup_ContentBackground);
+	border: 0.0625rem solid var(--sapGroup_ContentBackground);
 	border-radius: var(--_ui5_color-palette-item-hover-inner-border-radius);
 	box-sizing: border-box;
 }
@@ -56,7 +56,7 @@
 
 :host(:not([_disabled])[phone]) .ui5-cp-item:focus {
 	scale: 1.277778; /* (2.875rem / 2.25rem) ~ 1.277778 */
-	box-shadow: 0 0 0 1px #FFF, 0 0 0 2px var(--sapContent_ForegroundBorderColor);
+	box-shadow: 0 0 0 0.0625rem #FFF, 0 0 0 0.125rem var(--sapContent_ForegroundBorderColor);
 	border: var(--_ui5_color-palette-item-phone-selected-focus);
 }
 

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -8,7 +8,8 @@
 	box-sizing: border-box;
 }
 
-:host(:not([_disabled]):hover) {
+:host(:not([_disabled]):hover),
+:host([selected]) {
 	height: var(--_ui5_color-palette-item-hover-height);
 	width: var(--_ui5_color-palette-item-hover-height);
 	margin: var(--_ui5_color-palette-item-hover-margin);
@@ -40,7 +41,8 @@
 	border-radius: 0.1875rem;
 }
 
-.ui5-cp-item:hover:not(:focus) {
+.ui5-cp-item:hover:not(:focus),
+.ui5-cp-item.selected {
 	border: 1px solid var(--sapGroup_ContentBackground);
 	border-radius: var(--_ui5_color-palette-item-hover-inner-border-radius);
 	box-sizing: border-box;

--- a/packages/main/src/themes/base/ColorPalette-parameters.css
+++ b/packages/main/src/themes/base/ColorPalette-parameters.css
@@ -10,6 +10,7 @@
 	--_ui5_color-palette-item-before-focus-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem dotted black;
+	--_ui5_color-palette-item-selected-focused-border-after: var(--_ui5_color-palette-item-after-focus-color);
 	--_ui5_color-palette-item-after-focus-offset: 0.0625rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0;
@@ -18,4 +19,7 @@
 	--_ui5_color-palette-item-inner-border-radius: 0.1875rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.25rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.1875rem;
+	--_ui5_color-palette-item-selected-focused-border-before: var(--_ui5_color-palette-item-before-focus-hover-offset);
+	--_ui5_color-palette-item-after-focus-color-phone: var(--_ui5_color-palette-item-after-focus-color);
+	--_ui5_color-palette-item-phone-selected-focus: none;
 }

--- a/packages/main/src/themes/sap_horizon/ColorPalette-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ColorPalette-parameters.css
@@ -12,10 +12,14 @@
 	--_ui5_color-palette-item-before-focus-offset: -0.3125rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: -0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem solid var(--sapContent_ContrastFocusColor);
+	--_ui5_color-palette-item-selected-focused-border-after: none;
 	--_ui5_color-palette-item-after-focus-offset: -0.1875rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-after-focus-border-radius: 0.3125rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.375rem;
+	--_ui5_color-palette-item-selected-focused-border-before: -0.1875rem;
+	--_ui5_color-palette-item-after-focus-color-phone: none;
+	--_ui5_color-palette-item-phone-selected-focus: 1px solid var(--sapGroup_ContentBackground);
 }

--- a/packages/main/src/themes/sap_horizon_dark/ColorPalette-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/ColorPalette-parameters.css
@@ -12,10 +12,14 @@
 	--_ui5_color-palette-item-before-focus-offset: -0.3125rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: -0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem solid var(--sapContent_ContrastFocusColor);
+	--_ui5_color-palette-item-selected-focused-border-after: none;
 	--_ui5_color-palette-item-after-focus-offset: -0.1875rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-after-focus-border-radius: 0.3125rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.375rem;
+	--_ui5_color-palette-item-selected-focused-border-before: -0.1875rem;
+	--_ui5_color-palette-item-after-focus-color-phone: none;
+	--_ui5_color-palette-item-phone-selected-focus: 1px solid var(--sapGroup_ContentBackground);
 }

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -21,11 +21,11 @@
 <body class="colorpalette1auto">
 	<ui5-color-palette id="cp1">
 		<ui5-color-palette-item selected value="darkblue"></ui5-color-palette-item>
-		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
-		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
-		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
-		<ui5-color-palette-item value="green"></ui5-color-palette-item>
-		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="darkred"></ui5-color-palette-item>
 		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
 		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -19,8 +19,6 @@
 </head>
 
 <body class="colorpalette1auto">
-
-</body>
 	<ui5-color-palette id="cp1">
 		<ui5-color-palette-item selected value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
@@ -107,6 +105,7 @@
 		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette>
+</body>
 
 	<script>
 		cp1.addEventListener("ui5-item-click", function(event) {

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -22,7 +22,7 @@
 
 </body>
 	<ui5-color-palette id="cp1">
-		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item selected value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
 		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -120,4 +120,19 @@ describe("ColorPalette interactions", () => {
 		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[3].getProperty("value"), "darkblue");
 		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[4].getProperty("value"), "pink");
 	});
+
+	it("Tests if selected state is properly set", async () => {
+		const colorPalette = await browser.$("#cp1");
+		const colorPaletteEntries = await colorPalette.$$("[ui5-color-palette-item]");
+
+		await colorPaletteEntries[0].click();
+		await colorPaletteEntries[1].click();
+		await colorPaletteEntries[2].click();
+
+		assert.strictEqual(await colorPaletteEntries[2].getProperty("selected"), true, "Check if selected state is set");
+
+		await colorPaletteEntries[2].click();
+
+		assert.strictEqual(await colorPaletteEntries[2].getProperty("selected"), false, "Check if selected state is removed, after clicking on the same item again");
+	});
 });

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -40,8 +40,6 @@ describe("ColorPalette interactions", () => {
 		await item.keys("ArrowLeft");
 		await item.keys("Space");
 
-		await colorPalette.keys("Space");
-
 		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "#ff6699", "Check if selected value is #ff6699");
 	});
 

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -135,4 +135,16 @@ describe("ColorPalette interactions", () => {
 
 		assert.strictEqual(await colorPaletteEntries[2].getProperty("selected"), false, "Check if selected state is removed, after clicking on the same item again");
 	});
+
+	it("Clicking on an empty color-palette-item in the Recent Colors wrapper, should not get selected", async () => {
+		await browser.url(`test/pages/ColorPalette.html`);
+
+		const colorPalette = await browser.$("#cp4");
+		const colorPaletteRecentColorsWrapper = await colorPalette.shadow$(".ui5-cp-recent-colors-wrapper");
+		const colorPaletteRecentColorsWrapperEntries = await colorPaletteRecentColorsWrapper.$$("[ui5-color-palette-item]");
+
+		await colorPaletteRecentColorsWrapperEntries[0].click();
+
+		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[0].getProperty("selected"), false, "Check if selected state is set");
+	})
 });


### PR DESCRIPTION
We are introducing a **selected** property to the `ui5-color-palette-item`. 
This enhancement allows users to explicitly set a **selected state** to **any** `ui5-color-palette-item`.

For example, previously the first item was always on focus when opening the `ui5-color-palette-popover`.

Additionally, when one item is selected, any previously selected item will be deselected, ensuring that only one item can be selected within a `ui5-color-palette` at any given time.

The **`selected`** state could be set either by:

-  Setting it explicitly by using the `selected` property;
- By right-clicking on a `<ui5-color-palette-item>` with the mouse;
- By pressing `Enter` or `Space` upon focused `<ui5-color-palette-item>`; 