### PR TITLE
chore: fix JSDoc

### DIFF
--- a/packages/main/src/SelectMenuOption.ts
+++ b/packages/main/src/SelectMenuOption.ts
@@ -112,6 +112,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * <b>Note:</b> The slot is inherited and not supported. If set, it won't take any effect.
 	 *
 	 * @name sap.ui.webc.main.SelectMenuOption.prototype.deleteButton
+     * @type {Node[]}
 	 * @slot
 	 * @public
 	 * @deprecated

--- a/packages/main/src/SelectMenuOption.ts
+++ b/packages/main/src/SelectMenuOption.ts
@@ -108,15 +108,6 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @public
 	 */
 
-	/**
-	 * <b>Note:</b> The slot is inherited and not supported. If set, it won't take any effect.
-	 *
-	 * @name sap.ui.webc.main.SelectMenuOption.prototype.deleteButton
-	 * @slot
-	 * @public
-	 * @deprecated
-	 */
-
 	get _accInfo() {
 		const accInfoSettings = {
 			ariaSelected: this.selected,

--- a/packages/main/src/SelectMenuOption.ts
+++ b/packages/main/src/SelectMenuOption.ts
@@ -108,6 +108,15 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @public
 	 */
 
+	/**
+	 * <b>Note:</b> The slot is inherited and not supported. If set, it won't take any effect.
+	 *
+	 * @name sap.ui.webc.main.SelectMenuOption.prototype.deleteButton
+	 * @slot
+	 * @public
+	 * @deprecated
+	 */
+
 	get _accInfo() {
 		const accInfoSettings = {
 			ariaSelected: this.selected,

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -31,6 +31,7 @@ import { registerToolbarItem } from "./ToolbarRegistry.js";
  * @extends sap.ui.webc.main.ToolbarItem
  * @tagname ui5-toolbar-button
  * @public
+ * @implements sap.ui.webc.main.IToolbarItem
  * @since 1.17.0
  */
 @customElement({

--- a/packages/main/src/ToolbarSelect.ts
+++ b/packages/main/src/ToolbarSelect.ts
@@ -38,6 +38,7 @@ type ToolbarSelectChangeEventDetail = SelectChangeEventDetail;
  * @tagname ui5-toolbar-select
  * @appenddocs sap.ui.webc.main.ToolbarSelectOption
  * @public
+ * @implements sap.ui.webc.main.IToolbarItem
  * @since 1.17.0
  */
 @customElement({

--- a/packages/main/src/ToolbarSeparator.ts
+++ b/packages/main/src/ToolbarSeparator.ts
@@ -20,7 +20,7 @@ import ToolbarItem from "./ToolbarItem.js";
  * @extends sap.ui.webc.main.ToolbarItem
  * @tagname ui5-toolbar-separator
  * @since 1.17.0
- * @abstract
+ * @implements sap.ui.webc.main.IToolbarItem
  * @public
  */
 @customElement({

--- a/packages/main/src/ToolbarSpacer.ts
+++ b/packages/main/src/ToolbarSpacer.ts
@@ -20,6 +20,7 @@ import { registerToolbarItem } from "./ToolbarRegistry.js";
  * @tagname ui5-toolbar-spacer
  * @abstract
  * @since 1.17.0
+ * @implements sap.ui.webc.main.IToolbarItem
  * @public
  */
 @customElement({

--- a/packages/theming/css-vars-usage.json
+++ b/packages/theming/css-vars-usage.json
@@ -118,7 +118,6 @@
   "--sapButton_Lite_Hover_BorderColor",
   "--sapButton_Lite_Hover_TextColor",
   "--sapButton_Lite_TextColor",
-  "--sapButton_Negative_BorderColor",
   "--sapButton_Neutral_Background",
   "--sapButton_Reject_Active_Background",
   "--sapButton_Reject_Active_BorderColor",


### PR DESCRIPTION
These are fixes, needed for the UI5 Web Components enablement to run correctly:
 - all components that go in `ui5-toolbar` must implement its interface
 - `ui5-toolbar-separator` is not abstract
