### PR TITLE
fix(ui5-message-strip): remove button's custom width

### DIFF
--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -83,10 +83,8 @@
 
 /** Close button - always in compact mode **/
 .ui5-message-strip-close-button {
-	width: 2rem;
-	min-width: 2rem;
-	height: 1.65rem;
-	min-height: 1.65rem;
+	height: 1.625rem;
+	min-height: 1.625rem;
 	position: absolute;
 	top: var(--_ui5_message_strip_close_button_top);
 	inset-inline-end: var(--_ui5_message_strip_close_button_right);


### PR DESCRIPTION
- Close button's width is overriden to 2rem both in cosy and compact density, which is not correct. 