### PR TITLE
fix(ui5-multi-combobox): correct usage of css var

### DIFF
--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -55,6 +55,7 @@ import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import "@ui5/webcomponents-icons/dist/information.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
+import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
 import MultiComboBoxItem from "./MultiComboBoxItem.js";
 import MultiComboBoxGroupItem from "./MultiComboBoxGroupItem.js";
 import GroupHeaderListItem from "./GroupHeaderListItem.js";
@@ -1438,7 +1439,7 @@ class MultiComboBox extends UI5Element {
 		});
 
 		this.tokenizerAvailable = this._getSelectedItems().length > 0;
-		this.style.setProperty("--_ui5-input-icons-count", `${this.iconsCount}`);
+		this.style.setProperty(getScopedVarName("--_ui5-input-icons-count"), `${this.iconsCount}`);
 
 		if (!input || !value) {
 			return;


### PR DESCRIPTION
With current solution of CSS scoping a prefix with current version information is added to every css variables starting with --ui5 / --_ui5. To manipulate this kind of variables the `getScopedVarName` function should be used in order to set the correct prefix of the variable.