### PR TITLE
docs(ui5-toolbar-separator): mark component as abstract

### DIFF
--- a/packages/main/src/ToolbarSeparator.ts
+++ b/packages/main/src/ToolbarSeparator.ts
@@ -20,6 +20,7 @@ import ToolbarItem from "./ToolbarItem.js";
  * @extends sap.ui.webc.main.ToolbarItem
  * @tagname ui5-toolbar-separator
  * @since 1.17.0
+ * @abstract
  * @implements sap.ui.webc.main.IToolbarItem
  * @public
  */


### PR DESCRIPTION
I think all slots of the `ui5-toolbar` should be abstract? Maybe this was removed by accident?