### PR TITLE
docs(landing-page): dynamically fetch latest ui5wc version

### DIFF
--- a/packages/playground/assets/js/landing-page.js
+++ b/packages/playground/assets/js/landing-page.js
@@ -42,3 +42,14 @@ function rotateRight() {
         slides[selectedIndex + 1].classList.add("active");
     }
 }
+
+
+fetch('https://unpkg.com/@ui5/webcomponents@latest/package.json').then(async (response) => {
+    const ui5wcPackageJSON = await response.json();
+    const versionAnchor = document.getElementById('dynamicVersion');
+    if (ui5wcPackageJSON?.version) {
+        const { version } = ui5wcPackageJSON;
+        versionAnchor.textContent = version;
+        versionAnchor.setAttribute('href', `https://github.com/SAP/ui5-webcomponents/releases/tag/v${version}`);
+    }
+});

--- a/packages/playground/assets/js/landing-page.js
+++ b/packages/playground/assets/js/landing-page.js
@@ -44,10 +44,10 @@ function rotateRight() {
 }
 
 fetch('https://registry.npmjs.org/@ui5/webcomponents').then(async (response) => {
-    const ui5wcPackageMetadata= await response.json();
+    const ui5wcPackageMetadata = await response.json();
     const versionAnchor = document.getElementById('dynamicVersion');
-    if (ui5wcPackageMetadata?.["dist-tags"].latest) {
-        const version = ui5wcPackageMetadata["dist-tags"].latest;
+    if (ui5wcPackageMetadata?.['dist-tags'].latest) {
+        const version = ui5wcPackageMetadata['dist-tags'].latest;
         versionAnchor.textContent = version;
         versionAnchor.setAttribute('href', `https://github.com/SAP/ui5-webcomponents/releases/tag/v${version}`);
     }

--- a/packages/playground/assets/js/landing-page.js
+++ b/packages/playground/assets/js/landing-page.js
@@ -43,12 +43,11 @@ function rotateRight() {
     }
 }
 
-
-fetch('https://unpkg.com/@ui5/webcomponents@latest/package.json').then(async (response) => {
-    const ui5wcPackageJSON = await response.json();
+fetch('https://registry.npmjs.org/@ui5/webcomponents').then(async (response) => {
+    const ui5wcPackageMetadata= await response.json();
     const versionAnchor = document.getElementById('dynamicVersion');
-    if (ui5wcPackageJSON?.version) {
-        const { version } = ui5wcPackageJSON;
+    if (ui5wcPackageMetadata?.["dist-tags"].latest) {
+        const version = ui5wcPackageMetadata["dist-tags"].latest;
         versionAnchor.textContent = version;
         versionAnchor.setAttribute('href', `https://github.com/SAP/ui5-webcomponents/releases/tag/v${version}`);
     }

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -45,7 +45,9 @@
             <section class="welcome-section">
                 <h1 class="title">UI5&nbsp;<span class="orange">Web Components</span></h1>
                 <div class="description">Enterprise-flavored sugar on top of native APIs!</div>
-                <p class="version">Latest Version: <a href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.17.0">1.17.0</a></p>
+                <p class="version">Latest Version: <a id="dynamicVersion"
+                                                      href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.18.0">1.18.0</a>
+                </p>
                 <a href="./playground" class="get-started-button">Get Started</a>
             </section>
         </div>


### PR DESCRIPTION
The version of the landing page was often outdated. With this PR the latest version is now fetched from the npm registry and only if for some reason the registry is not available, the static version is displayed. I also set the static text and `href` to v1.18 already.