### PR TITLE
chore: dynamic version for nightly

### DIFF
--- a/packages/playground/assets/js/landing-page.js
+++ b/packages/playground/assets/js/landing-page.js
@@ -47,7 +47,7 @@ fetch('https://registry.npmjs.org/@ui5/webcomponents').then(async (response) => 
     const ui5wcPackageMetadata = await response.json();
     const versionAnchor = document.getElementById('dynamicVersion');
     if (ui5wcPackageMetadata?.['dist-tags'].latest) {
-        const version = ui5wcPackageMetadata['dist-tags'].latest;
+        const version = window?.location?.pathname?.endsWith("/nightly/") ? ui5wcPackageMetadata['dist-tags'].next : ui5wcPackageMetadata['dist-tags'].latest;
         versionAnchor.textContent = version;
         versionAnchor.setAttribute('href', `https://github.com/SAP/ui5-webcomponents/releases/tag/v${version}`);
     }

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -45,8 +45,7 @@
             <section class="welcome-section">
                 <h1 class="title">UI5&nbsp;<span class="orange">Web Components</span></h1>
                 <div class="description">Enterprise-flavored sugar on top of native APIs!</div>
-                <p class="version">Latest Version: <a id="dynamicVersion"
-                                                      href="https://github.com/SAP/ui5-webcomponents/releases/tag/v1.18.0">1.18.0</a>
+                <p class="version">Latest Version: <a id="dynamicVersion"></a>
                 </p>
                 <a href="./playground" class="get-started-button">Get Started</a>
             </section>


### PR DESCRIPTION
With #7643 version displayed on the playground's landing page is set dynamically, but it was setting wrong version on nightly plaground's page. 