### PR TITLE
fix(ui5-illustrated-message): enable vertical responsiveness

### DIFF
--- a/packages/fiori/src/themes/IllustratedMessage.css
+++ b/packages/fiori/src/themes/IllustratedMessage.css
@@ -5,6 +5,7 @@
 :host {
     box-sizing: border-box;
     width: 100%;
+    height:100%;
     padding: 1rem;
 }
 
@@ -13,10 +14,22 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    height:inherit;
 }
 
 .ui5-illustrated-message-illustration {
     margin-bottom: 2rem;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+.ui5-illustrated-message-illustration svg {
+    max-height: 100%;
+}
+
+.ui5-illustrated-message-illustration-svg-hidden {
+    display: none;
 }
 
 .ui5-illustrated-message-title {

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -154,6 +154,30 @@
         ></ui5-illustrated-message>
     </ui5-panel>
 
+	<h2>Vertical responsiveness</h2>
+	Container height:
+	<ui5-select id="containerHeightSelect">
+		<ui5-option selected>auto</ui5-option>
+		<ui5-option>200px</ui5-option>
+		<ui5-option>300px</ui5-option>
+		<ui5-option>500px</ui5-option>
+		<ui5-option>700px</ui5-option>
+	</ui5-select>
+	Container width:
+	<ui5-select id="containerWidthSelect">
+		<ui5-option selected>auto</ui5-option>
+		<ui5-option>100%</ui5-option>
+		<ui5-option>200px</ui5-option>
+		<ui5-option>300px</ui5-option>
+		<ui5-option>500px</ui5-option>
+		<ui5-option>700px</ui5-option>
+	</ui5-select>
+	<div id="container" class="border">
+		<ui5-illustrated-message id="illustratedMsg5" class="border contentBox">
+			<ui5-button>Action 1</ui5-button>
+		</ui5-illustrated-message>
+	</div>
+
 	<script>
 		const illustrationSelect = document.getElementById("illustrationSelect");
 		const sizeSelect = document.getElementById("sizeSelect");
@@ -161,6 +185,9 @@
 		const dialogOpener = document.getElementById("openDialogButton");
 		const dialog = document.getElementById("hello-dialog");
 		const dialogCloser = document.getElementById("closeDialogButton");
+		const containerHeightSelect = document.getElementById("containerHeightSelect");
+		const containerWidthSelect = document.getElementById("containerWidthSelect");
+		const illustratedMessageContainer = document.getElementById("container");
 		const sizes = {
 			base: 250,
 			spot: 300,
@@ -184,6 +211,14 @@
 
 		dialogCloser.addEventListener("click", () => {
 			dialog.close();
+		});
+
+		containerHeightSelect.addEventListener("ui5-change", (event) => {
+			illustratedMessageContainer.style.height = event.detail.selectedOption.textContent;
+		});
+
+		containerWidthSelect.addEventListener("ui5-change", (event) => {
+			illustratedMessageContainer.style.width = event.detail.selectedOption.textContent;
 		});
 	</script>
 </body>

--- a/packages/fiori/test/specs/IllustratedMessage.spec.js
+++ b/packages/fiori/test/specs/IllustratedMessage.spec.js
@@ -81,3 +81,96 @@ describe("Accessibility", () => {
 	});
 
 });
+
+describe("Vertical responsiveness", () => {
+	before(async () => {
+		await browser.url(`test/pages/IllustratedMessage.html`);
+	});
+
+	it("content with auto size shrinks to fit the parent container", async () => {
+
+		const newContainerHeight = 300,
+			expectedMedia = "dialog",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("content with auto size expands to fit the parent container", async () => {
+
+		const newContainerHeight = 500,
+			expectedMedia = "scene",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("content with fixed size fits the parent container", async () => {
+
+		const newContainerHeight = 200,
+			expectedMedia = "dialog",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// set fixed size
+		illustratedMsg.setProperty("size", "Dialog");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("shows image with unconstrained height when container has auto height", async () => {
+
+		const newContainerHeight = "auto",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, newContainerHeight);
+
+		// Check
+		const illustration = await illustratedMsg.shadow$(".ui5-illustrated-message-illustration svg");
+		const cssHeight = (await illustration.getCSSProperty("height")).value;
+
+		assert.strictEqual(cssHeight, "160px", "svg has expected height");
+	});
+});


### PR DESCRIPTION
The component now has 100% height to allow it fit the parent container, if that container is sized (i.e. if the parent container is given a restricted size). If the parent container is not sized, then the size of the component will be the total size of its children as before.

Fixes: #6492
