### PR TITLE
fix(framework): stop bubbling of camel case events

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -817,7 +817,7 @@ abstract class UI5Element extends HTMLElement {
 		const camelCaseEventName = kebabToCamelCase(name);
 
 		if (camelCaseEventName !== name) {
-			return eventResult && this._fireEvent(camelCaseEventName, data, cancelable);
+			return eventResult && this._fireEvent(camelCaseEventName, data, cancelable, bubbles);
 		}
 
 		return eventResult;


### PR DESCRIPTION
Previously camelCase events were not able to be stopped from bubbling.

As part of: #7637