### PR TITLE
fix(framework): string props fallback to correct value

### DIFF
--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -352,7 +352,15 @@ const validateSingleProperty = (value: PropertyValue, propData: Property) => {
 	}
 
 	if (!propertyType || propertyType === String) {
-		return (typeof value === "string" || typeof value === "undefined" || value === null) ? value : value.toString();
+		if (typeof value === "string") {
+			return value;
+		}
+
+		if (typeof value === "undefined" || value === null) {
+			return propData.defaultValue || "";
+		}
+
+		return value.toString();
 	}
 
 	if (propertyType === Boolean) {


### PR DESCRIPTION
Previously, string property without specified default value was accepting null or undefined as a valid values.

In my understanding passing a null or undefined to property defined with decorator, where the default value is not specified explicitly to be undefined, should fallback to an empty string.

Now, we are validating value in following order:
1. Check if the new value has type string and use it
2. Check if the new value has type undefined or it's null and return the defined default value or empty string
3. Any other value is converted to string

To reproduce the real issue open following snippet and inspect the value property of the input: https://codesandbox.io/s/ui5-webcomponents-forked-m777sy?file=/src/index.js

Fixes: https://github.com/SAP/ui5-webcomponents/issues/2616