### PR TITLE
feat(ui5-illustrated-message): enable vertical responsiveness

### DIFF
--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -336,6 +336,7 @@ class IllustratedMessage extends UI5Element {
 
 	static i18nBundle: I18nBundle;
 	_lastKnownOffsetWidthForMedia: Record<string, number>;
+	_lastKnownOffsetHeightForMedia: Record<string, number>;
 	_lastKnownMedia: string;
 	_handleResize: ResizeObserverCallback;
 
@@ -345,6 +346,7 @@ class IllustratedMessage extends UI5Element {
 		this._handleResize = this.handleResize.bind(this);
 		// this will store the last known offsetWidth of the IllustratedMessage DOM node for a given media (e.g. "Spot")
 		this._lastKnownOffsetWidthForMedia = {};
+		this._lastKnownOffsetHeightForMedia = {};
 		// this will store the last known media, in order to detect if IllustratedMessage has been hidden by expand/collapse container
 		this._lastKnownMedia = "base";
 	}
@@ -358,6 +360,14 @@ class IllustratedMessage extends UI5Element {
 			DIALOG: 679,
 			SPOT: 319,
 			BASE: 259,
+		};
+	}
+
+	static get BREAKPOINTS_HEIGHT() {
+		return {
+			DIALOG: 451,
+			SPOT: 296,
+			BASE: 87,
 		};
 	}
 
@@ -407,31 +417,43 @@ class IllustratedMessage extends UI5Element {
 
 	handleResize() {
 		if (this.size !== IllustrationMessageSize.Auto) {
+			this._adjustHeightToFitContainer();
 			return;
 		}
 
 		this._applyMedia();
+		window.requestAnimationFrame(this._adjustHeightToFitContainer.bind(this));
 	}
 
-	_applyMedia() {
-		const currOffsetWidth = this.offsetWidth;
+	_applyMedia(heightChange?: boolean) {
+		const currOffsetWidth = this.offsetWidth,
+			currOffsetHeight = this.offsetHeight;
+
+		const size = heightChange ? currOffsetHeight : currOffsetWidth,
+			oBreakpounts = heightChange ? IllustratedMessage.BREAKPOINTS_HEIGHT : IllustratedMessage.BREAKPOINTS;
 		let newMedia = "";
 
-		if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.BASE) {
+		if (size <= oBreakpounts.BASE) {
 			newMedia = IllustratedMessage.MEDIA.BASE;
-		} else if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.SPOT) {
+		} else if (size <= oBreakpounts.SPOT) {
 			newMedia = IllustratedMessage.MEDIA.SPOT;
-		} else if (this.offsetWidth <= IllustratedMessage.BREAKPOINTS.DIALOG) {
+		} else if (size <= oBreakpounts.DIALOG) {
 			newMedia = IllustratedMessage.MEDIA.DIALOG;
 		} else {
 			newMedia = IllustratedMessage.MEDIA.SCENE;
 		}
-		const lastKnownOffsetWidth = this._lastKnownOffsetWidthForMedia[newMedia];
+		const lastKnownOffsetWidth = this._lastKnownOffsetWidthForMedia[newMedia],
+			lastKnownOffsetHeight = this._lastKnownOffsetHeightForMedia[newMedia];
 		 // prevents infinite resizing, when same width is detected for the same media,
 		 // excluding the case in which, the control is placed inside expand/collapse container
-		if (!(lastKnownOffsetWidth && currOffsetWidth === lastKnownOffsetWidth) || this._lastKnownOffsetWidthForMedia[this._lastKnownMedia] === 0) {
+		if (!(lastKnownOffsetWidth && currOffsetWidth === lastKnownOffsetWidth
+			&& lastKnownOffsetHeight && currOffsetHeight === lastKnownOffsetHeight)
+			|| this._lastKnownOffsetWidthForMedia[this._lastKnownMedia] === 0
+			|| this._lastKnownOffsetHeightForMedia[this._lastKnownMedia] === 0
+			|| this._lastKnownMedia !== newMedia) {
 			this.media = newMedia;
 			this._lastKnownOffsetWidthForMedia[newMedia] = currOffsetWidth;
+			this._lastKnownOffsetHeightForMedia[newMedia] = currOffsetHeight;
 			this._lastKnownMedia = newMedia;
 		}
 	}
@@ -443,6 +465,19 @@ class IllustratedMessage extends UI5Element {
 				svg.setAttribute("aria-label", this.ariaLabelText);
 			} else {
 				svg.removeAttribute("aria-label");
+			}
+		}
+	}
+
+	_adjustHeightToFitContainer() {
+		const illustrationWrapper = <HTMLElement> this.shadowRoot!.querySelector(".ui5-illustrated-message-illustration"),
+			illustration = illustrationWrapper.querySelector("svg");
+
+		if (illustration) {
+			illustrationWrapper.classList.toggle("ui5-illustrated-message-illustration-fit-content", false);
+			if (this.getDomRef()!.scrollHeight > this.getDomRef()!.offsetHeight) {
+				illustrationWrapper.classList.toggle("ui5-illustrated-message-illustration-fit-content", true);
+				this._applyMedia(true /* height change */);
 			}
 		}
 	}

--- a/packages/fiori/src/themes/IllustratedMessage.css
+++ b/packages/fiori/src/themes/IllustratedMessage.css
@@ -5,6 +5,7 @@
 :host {
     box-sizing: border-box;
     width: 100%;
+    height:100%;
     padding: 1rem;
 }
 
@@ -13,10 +14,33 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    height:inherit;
 }
 
 .ui5-illustrated-message-illustration {
     margin-bottom: 2rem;
+}
+
+.ui5-illustrated-message-illustration svg {
+    max-height: 100%;
+}
+
+.ui5-illustrated-message-illustration.ui5-illustrated-message-illustration-fit-content {
+    position: relative;
+    width: 0;
+    padding: 0;
+    padding-left: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+.ui5-illustrated-message-illustration.ui5-illustrated-message-illustration-fit-content svg {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    left: 0;
+    top: 0;
 }
 
 .ui5-illustrated-message-title {

--- a/packages/fiori/test/pages/IllustratedMessage.html
+++ b/packages/fiori/test/pages/IllustratedMessage.html
@@ -154,6 +154,30 @@
         ></ui5-illustrated-message>
     </ui5-panel>
 
+	<h2>Vertical responsiveness</h2>
+	Container height:
+	<ui5-select id="containerHeightSelect">
+		<ui5-option selected>auto</ui5-option>
+		<ui5-option>200px</ui5-option>
+		<ui5-option>300px</ui5-option>
+		<ui5-option>500px</ui5-option>
+		<ui5-option>700px</ui5-option>
+	</ui5-select>
+	Container width:
+	<ui5-select id="containerWidthSelect">
+		<ui5-option selected>auto</ui5-option>
+		<ui5-option>100%</ui5-option>
+		<ui5-option>200px</ui5-option>
+		<ui5-option>300px</ui5-option>
+		<ui5-option>500px</ui5-option>
+		<ui5-option>700px</ui5-option>
+	</ui5-select>
+	<div id="container" class="border">
+		<ui5-illustrated-message id="illustratedMsg5" class="border contentBox">
+			<ui5-button>Action 1</ui5-button>
+		</ui5-illustrated-message>
+	</div>
+
 	<script>
 		const illustrationSelect = document.getElementById("illustrationSelect");
 		const sizeSelect = document.getElementById("sizeSelect");
@@ -161,6 +185,9 @@
 		const dialogOpener = document.getElementById("openDialogButton");
 		const dialog = document.getElementById("hello-dialog");
 		const dialogCloser = document.getElementById("closeDialogButton");
+		const containerHeightSelect = document.getElementById("containerHeightSelect");
+		const containerWidthSelect = document.getElementById("containerWidthSelect");
+		const illustratedMessageContainer = document.getElementById("container");
 		const sizes = {
 			base: 250,
 			spot: 300,
@@ -184,6 +211,14 @@
 
 		dialogCloser.addEventListener("click", () => {
 			dialog.close();
+		});
+
+		containerHeightSelect.addEventListener("ui5-change", (event) => {
+			illustratedMessageContainer.style.height = event.detail.selectedOption.textContent;
+		});
+
+		containerWidthSelect.addEventListener("ui5-change", (event) => {
+			illustratedMessageContainer.style.width = event.detail.selectedOption.textContent;
 		});
 	</script>
 </body>

--- a/packages/fiori/test/specs/IllustratedMessage.spec.js
+++ b/packages/fiori/test/specs/IllustratedMessage.spec.js
@@ -81,3 +81,96 @@ describe("Accessibility", () => {
 	});
 
 });
+
+describe("Vertical responsiveness", () => {
+	before(async () => {
+		await browser.url(`test/pages/IllustratedMessage.html`);
+	});
+
+	it("content with auto size shrinks to fit the parent container", async () => {
+
+		const newContainerHeight = 300,
+			expectedMedia = "dialog",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("content with auto size expands to fit the parent container", async () => {
+
+		const newContainerHeight = 500,
+			expectedMedia = "scene",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("content with fixed size fits the parent container", async () => {
+
+		const newContainerHeight = 200,
+			expectedMedia = "dialog",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// set fixed size
+		illustratedMsg.setProperty("size", "Dialog");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, `${newContainerHeight}px`);
+
+		// Check
+		const contents = await illustratedMsg.shadow$(".ui5-illustrated-message-root"),
+			scrollHeight = await contents.getProperty("scrollHeight"),
+			offsetHeight = await contents.getProperty("offsetHeight"),
+			illustratedMsgMedia = await illustratedMsg.getProperty("media");
+		assert.ok(scrollHeight < newContainerHeight, "root dom fits container");
+		assert.strictEqual(scrollHeight, offsetHeight, "no overflow of content");
+		assert.strictEqual(illustratedMsgMedia, expectedMedia, "correct media");
+	});
+
+	it("shows image with unconstrained height when container has auto height", async () => {
+
+		const newContainerHeight = "auto",
+			illustratedMsg = await browser.$("#illustratedMsg5");
+
+		// Act: apply new height
+		await browser.executeAsync(async (newContainerHeight, done) => {
+			document.getElementById("container").style.height = newContainerHeight;
+			done();
+		}, newContainerHeight);
+
+		// Check
+		const illustration = await illustratedMsg.shadow$(".ui5-illustrated-message-illustration svg");
+		const cssHeight = (await illustration.getCSSProperty("height")).value;
+
+		assert.strictEqual(cssHeight, "160px", "svg has expected height");
+	});
+});


### PR DESCRIPTION
The component now has 100% height to allow it fit the parent container, if that container is sized (i.e. if the parent container is given a restricted size). If the parent container is not sized, then the size of the component will be the total size of its children as before.

Fixes: #6492

