### PR TITLE
fix(localization): missing calendarWeekNumbering

### DIFF
--- a/packages/localization/src/sap/ui/core/Configuration.ts
+++ b/packages/localization/src/sap/ui/core/Configuration.ts
@@ -18,6 +18,8 @@ const Configuration = {
 	getOriginInfo: emptyFn,
 	getFormatSettings: () => FormatSettings,
 	getTimezone: () => getConfigTimezone() || TimezoneUtil.getLocalTimezone() as string,
+	// Calculate calendar week numbering by active format locale
+	getCalendarWeekNumbering: () => "Default",
 };
 
 export default Configuration;


### PR DESCRIPTION
Implemented the function to use the default value in order to calculate calendar week numbering by active format locale.

Fixes: #7670 