### PR TITLE
fix: escape special characters when scoping CSS vars

### DIFF
--- a/packages/tools/lib/postcss-scope-vars/index.js
+++ b/packages/tools/lib/postcss-scope-vars/index.js
@@ -1,7 +1,7 @@
 const name = "postcss-scope-vars";
 
 module.exports = (options) => {
-	const versionStr = "v" + options?.version?.replaceAll(".", "-");
+	const versionStr = "v" + options?.version?.replaceAll(/[^0-9A-Za-z\-_]/g, "-");
 	return {
 		postcssPlugin: name,
 		prepare() {


### PR DESCRIPTION
In certain scenarios the NPM version of a package may contain special characters.

The valid characters for a CSS variable name are:
 - alphanumeric characters
 - `-`
 - `_`

This change replaces each character that is not valid for a CSS variable name with a dash.