### PR TITLE
docs(playground): html addon now shows decorated styles

### DIFF
--- a/packages/playground/.storybook/addons/html/HTMLTransformation.ts
+++ b/packages/playground/.storybook/addons/html/HTMLTransformation.ts
@@ -1,4 +1,4 @@
-import { AttributeProcessor, IProcessor } from "./processors";
+import { AttributeProcessor, StylesProcessor, IProcessor } from "./processors";
 
 export interface IHTMLTransformation {
     transform(html: string): string;
@@ -9,20 +9,31 @@ export interface IHTMLTransformation {
  * Used by the HTML addon.
  */
 export class HTMLTransformation implements IHTMLTransformation {
-    constructor(private processors: IProcessor[]) {
-        this.processors = processors;
+    constructor(private headProcessors: IProcessor[], private bodyProcessors: IProcessor[]) {
+        this.headProcessors = headProcessors;
+        this.bodyProcessors = bodyProcessors;
     }
 
     transform(html: string): string {
-        const dom = this.convertToDOM(html);
+        var transformed = "";
+        const dom = this.convertToDOM(html),
+            head = dom.head,
+            body = dom.body;
 
-        this.walk(dom, (node) => {
-            this.processors.forEach((processor) => {
+        this.headProcessors.forEach((processor) => {
+            processor.process(head);
+        });
+
+        this.walk(body, (node) => {
+            this.bodyProcessors.forEach((processor) => {
                 processor.process(node);
             });
         });
 
-        const transformed = this.convertToString(dom);
+        if (head.innerHTML) {
+            transformed += this.convertToString(head);
+        }
+        transformed += this.convertToString(body);
         return transformed;
     }
 
@@ -40,13 +51,15 @@ export class HTMLTransformation implements IHTMLTransformation {
         return serializer.serializeToString(dom);
     }
 
-    private convertToDOM(html: string): HTMLElement {
+    private convertToDOM(html: string): Document {
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, "text/html");
-        return doc.body;
+        return doc;
     }
+
 }
 
-const processors = [new AttributeProcessor()];
+const headProcessors = [new StylesProcessor()];
+const bodyProcessors = [new AttributeProcessor()];
 
-export const htmlTransformation = new HTMLTransformation(processors);
+export const htmlTransformation = new HTMLTransformation(headProcessors, bodyProcessors);

--- a/packages/playground/.storybook/addons/html/HTMLTransformation.ts
+++ b/packages/playground/.storybook/addons/html/HTMLTransformation.ts
@@ -15,7 +15,7 @@ export class HTMLTransformation implements IHTMLTransformation {
     }
 
     transform(html: string): string {
-        var transformed = "";
+        let transformed = "";
         const dom = this.convertToDOM(html),
             head = dom.head,
             body = dom.body;

--- a/packages/playground/.storybook/addons/html/processors/StylesProcessor.ts
+++ b/packages/playground/.storybook/addons/html/processors/StylesProcessor.ts
@@ -1,0 +1,43 @@
+import { IProcessor } from "./IProcessor";
+
+/**
+ * This class is responsible for formatting the style elements of the story:
+ * merge multiple style elements and unify their indentation.
+ */
+export class StylesProcessor implements IProcessor {
+    process(node: HTMLElement): void {
+        this.mergeStyles(node);
+    }
+
+    private mergeStyles(dom: HTMLElement) {
+        const styleElements = Array.from(dom.getElementsByTagName('style'));
+        if (styleElements.length > 1) { // merge needed
+            let mergedStyles = "";
+            for (let i = 0; i < styleElements.length; i++) {
+                mergedStyles += this.removeIndentation(styleElements[i].innerHTML);
+                styleElements[i].remove();
+            }
+            const mergedStyleElement = styleElements[0];
+            mergedStyleElement.innerHTML = mergedStyles;
+            dom.prepend(mergedStyleElement);
+        }
+    }
+
+    private removeIndentation(str: string) {
+        const lines = str.split('\n');
+        let shortestIndent = Infinity;
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].trim().length === 0) {
+                continue;
+            }
+            let indent = lines[i].search(/\S/);
+            if (indent < shortestIndent && indent !== -1) {
+                shortestIndent = indent;
+            }
+        }
+        for (let i = 0; i < lines.length; i++) {
+            lines[i] = lines[i].substring(shortestIndent);
+        }
+        return lines.join('\n');
+    }
+}

--- a/packages/playground/.storybook/addons/html/processors/index.ts
+++ b/packages/playground/.storybook/addons/html/processors/index.ts
@@ -1,2 +1,3 @@
 export * from "./AttributeProcessor";
+export * from "./StylesProcessor";
 export * from "./IProcessor";


### PR DESCRIPTION
Related: #7284 

Problem: If the story decorator includes CSS styles, the style elements were not visualized by the HTML addon. The style elements were not visualized because they were skipped in the html transformation. 
Solution: Included style nodes in the html transformation and isolated the style-related processing into a dedicated processor for style nodes.