### PR TITLE
chore: upgrade to chromedriver 117

### DIFF
--- a/.github/workflows/deploy-latest-docs.yaml
+++ b/.github/workflows/deploy-latest-docs.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/deploy_latest.yaml
+++ b/.github/workflows/deploy_latest.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/release-auto-weekly.yaml
+++ b/.github/workflows/release-auto-weekly.yaml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/release-custom-tag.yaml
+++ b/.github/workflows/release-custom-tag.yaml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/test-issue-comments.yaml
+++ b/.github/workflows/test-issue-comments.yaml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/test-storybook.yaml
+++ b/.github/workflows/test-storybook.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install Dependencies

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -38,7 +38,7 @@
     "@buxlabs/amd-to-es6": "0.16.1",
     "@openui5/sap.ui.core": "1.116.0",
     "@ui5/webcomponents-tools": "1.19.0-rc.0",
-    "chromedriver": "116.0.0",
+    "chromedriver": "117.0.3",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -49,6 +49,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.19.0-rc.0",
-    "chromedriver": "116.0.0"
+    "chromedriver": "117.0.3"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.116.0",
     "@ui5/webcomponents-tools": "1.19.0-rc.0",
-    "chromedriver": "116.0.0",
+    "chromedriver": "117.0.3",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -50,6 +50,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.19.0-rc.0",
-    "chromedriver": "116.0.0"
+    "chromedriver": "117.0.3"
   }
 }

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -1,3 +1,5 @@
+const dns = require("node:dns");
+
 exports.config = {
 	//
 	// ====================
@@ -160,6 +162,9 @@ exports.config = {
 	 */
 	// beforeSession: function (config, capabilities, specs) {
 	// },
+	beforeSession: () => {
+        dns.setDefaultResultOrder('ipv4first');
+    },
 	/**
 	 * Gets executed before test execution begins. At this point you can access to all global
 	 * variables like `browser`. It is the perfect place to define custom commands.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,10 +5242,10 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@116.0.0:
-  version "116.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-116.0.0.tgz#3f5d07b5427953270461791651d7b68cb6afe9fe"
-  integrity sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==
+chromedriver@117.0.3:
+  version "117.0.3"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-117.0.3.tgz#4a14cc992d572367b99b53c772adcc4c19078e1e"
+  integrity sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
     axios "^1.4.0"


### PR DESCRIPTION
Chromedriver 117 needs Node.js version 18, but when we upgrade to Node.js 18, a connection error occurs, and @wdio/devtools-services cannot be loaded correctly. Mobile tests are failing because Node.js version 17 has changed the default value of dns.setDefaultResultOrder(order) to which 3rd party plugin of @wdio/cli depends. We can find a solution to the connection issue in this GitHub issue: https://github.com/webdriverio/webdriverio/issues/8279.

The issue is fixed in WebdriverIO version 8, but fixing it may require some bigger code changes.