### PR TITLE
fix(ui5-color-palette-popover): align selected state behavior with ui5-color-palette

### DIFF
--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -187,10 +187,25 @@ class ColorPalettePopover extends UI5Element {
 
 		this.responsivePopover!.showAt(opener, true);
 
+		const colorPalette = this._colorPalette();
+		const selectedItem = this.colors.find(item => item.selected)
+						  || colorPalette.recentColorsElements.find(item => item.selected);
+
+		if (selectedItem) {
+			colorPalette.focusColorElement(colorPalette.colorPaletteNavigationElements[0], colorPalette._itemNavigation);
+		}
+		this._defaultFocus(colorPalette);
+	}
+
+	/**
+	 * Sets the focus on the first item of the Palette or on the `selected` one if such exists.
+	 * @param {ColorPalette} colorPalette the color palette
+	 */
+	_defaultFocus(colorPalette: ColorPalette) {
 		if (this.showDefaultColor) {
-			this._colorPalette().colorPaletteNavigationElements[0].focus();
+			colorPalette.colorPaletteNavigationElements[0].focus();
 		} else {
-			this._colorPalette().focusColorElement(this._colorPalette().colorPaletteNavigationElements[0], this._colorPalette()._itemNavigation);
+			colorPalette.focusColorElement(colorPalette.colorPaletteNavigationElements[0], colorPalette._itemNavigation);
 		}
 	}
 

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -69,7 +69,7 @@ describe("ColorPalette interactions", () => {
 		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
-		const moreColorsButton = await colorPalette.shadow$(".ui5-cp-more-colors");
+		const lightGreen = await colorPalettePopover.$(`[value="rgb(0,200,0)"]`);
 		const firstRecentColorsElement = await colorPalette.shadow$(".ui5-cp-recent-colors-container [ui5-color-palette-item]");
 
 		await defaultButton.keys("Space");
@@ -79,7 +79,9 @@ describe("ColorPalette interactions", () => {
 		await defaultButton.keys("ArrowUp");
 		await firstRecentColorsElement.keys("ArrowUp");
 
-		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
+		const isLightGreenFocused = await lightGreen.isFocused();
+
+		assert.ok(isLightGreenFocused, "Check if light green color cell is focused");
 	});
 
 	it("Test attribute propagation propagation", async () => {


### PR DESCRIPTION
While playing around in the playground we noticed that the `selected` state behavior in `ColorPalettePopover` is quite different than the one in the `ColorPalette`.
The main reason behind this, is because while in the context of the `ColorPalette`, the main predefined colors' array `this.colors` is an array of `ui5-color-palette-item`s, while when in `ColorPalettePopover` the `ColorPalette` recieves it as array of `slot` elements, which disrupts the logic in the `handleSelection()` method and not only.

With this change we align the behaviors in the both of our components.