### PR TITLE
fix(ui5-list): shift+tab navigation in List

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -5,6 +5,7 @@
 	@ui5-_press={{onItemPress}}
 	@ui5-close={{onItemClose}}
 	@ui5-toggle={{onItemToggle}}
+	@ui5-_request-tabindex-change={{onItemTabIndexChange}}
 	@ui5-_focused={{onItemFocused}}
 	@ui5-_forward-after={{onForwardAfter}}
 	@ui5-_forward-before={{onForwardBefore}}

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -925,6 +925,11 @@ class List extends UI5Element {
 		return afterElement && afterElement.id === elementId;
 	}
 
+	onItemTabIndexChange(e: CustomEvent) {
+		const target = e.target as ListItemBase;
+		this._itemNavigation.setCurrentItem(target);
+	}
+
 	onItemFocused(e: CustomEvent) {
 		const target = e.target as ListItemBase;
 

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -27,6 +27,7 @@ import styles from "./generated/themes/ListItemBase.css.js";
 	renderer: litRender,
 	styles,
 })
+@event("_request-tabindex-change")
 @event("_focused")
 @event("_forward-after")
 @event("_forward-before")
@@ -72,6 +73,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 	focused!: boolean;
 
 	_onfocusin(e: FocusEvent) {
+		this.fireEvent("_request-tabindex-change", e);
 		if (e.target !== this.getFocusDomRef()) {
 			return;
 		}

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -424,5 +424,16 @@
 			ariaPosinset: 3,
 		};
 	</script>
+
+	<ui5-list id="effectiveTabindexChange">
+		<ui5-li-custom>
+			<button>Inner Element</button>
+		</ui5-li-custom>
+		<ui5-li-custom id="country11">
+			<button>Inner Element</button>
+		</ui5-li-custom>
+		<!-- Other list items here -->
+	</ui5-list>
+	<div id="tabIndexChangeResult"></div>
 </body>
 </html>

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -574,4 +574,17 @@ describe("List Tests", () => {
 
 		assert.strictEqual(await itemCloseResult.getProperty("value"), "0", "item-close event is not fired when the button is pressed.");
 	});
+
+	it("List item fires _request-tabindex-change event and updates tabindex when inner element receives focus", async () => {
+		const innerElement = await browser.$("#effectiveTabindexChange #country11 button");
+		const listItem = await browser.$("#effectiveTabindexChange #country11");
+		const rootItemElement = await listItem.shadow$(".ui5-li-root");
+	
+		// Focus on the target list item
+		await innerElement.click();
+	
+		const newTabIndex = await rootItemElement.getAttribute("tabindex");
+	
+		assert.equal(newTabIndex , "0", "The tabIndex of the list item root should be '0' when inner element receives focus.");
+	});
 });


### PR DESCRIPTION
Fixes: #6086

Resolved an issue where Shift+Tab incorrectly focused on a ListItem's inner element. The solution utilizes a new _effective-tabindex-change event to update the ListItem's tabIndex, ensuring correct ItemNavigation focus after toggling from another component.