### PR TITLE
fix(ui5-tree-item-custom): text wrapper allows proper alignment of flex content

### DIFF
--- a/packages/main/src/themes/TreeItem.css
+++ b/packages/main/src/themes/TreeItem.css
@@ -33,6 +33,10 @@
 	bottom: 0.125rem;
 }
 
+.ui5-li-tree-text-wrapper {
+	flex: auto;
+}
+
 :host([_minimal]) .ui5-li-text-wrapper {
 	display: none;
 }


### PR DESCRIPTION
Fixes: #7483
