### PR TITLE
fix(ui5-calendar): focus date set in slot

### DIFF
--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -514,10 +514,6 @@ class Calendar extends CalendarPart {
 		}
 	}
 
-	// get _timestamp(): number {
-	// 	return this._selectedDatesTimestamps ? this._selectedDatesTimestamps[0] : this._timestamp;
-	// }
-
 	/**
 	 * Returns an array of UTC timestamps, representing the selected dates.
 	 * @protected

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -1,4 +1,5 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import type { ChangeInfo } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
@@ -257,6 +258,8 @@ class Calendar extends CalendarPart {
 	@property({ type: CalendarPickersMode, defaultValue: CalendarPickersMode.DAY_MONTH_YEAR, noAttribute: true })
 	_pickersMode!: CalendarPickersMode;
 
+	_valueIsProcessed!: boolean
+
 	/**
 	 * Defines the selected date or dates (depending on the <code>selectionMode</code> property)
 	 * for this calendar as instances of <code>ui5-date</code>.
@@ -280,6 +283,11 @@ class Calendar extends CalendarPart {
 		}).filter((date): date is number => !!date);
 	}
 
+	constructor() {
+		super();
+
+		this._valueIsProcessed = false;
+	}
 	/**
 	 * @private
 	 */
@@ -315,6 +323,14 @@ class Calendar extends CalendarPart {
 
 	onBeforeRendering() {
 		this._normalizeCurrentPicker();
+
+		if (!this._valueIsProcessed) {
+			if (this._selectedDatesTimestamps) {
+				this.timestamp = this._selectedDatesTimestamps[0];
+			}
+
+			this._valueIsProcessed = true;
+		}
 	}
 
 	async onAfterRendering() {
@@ -338,6 +354,12 @@ class Calendar extends CalendarPart {
 		}
 
 		this._secondaryCalendarType && this._setSecondaryCalendarTypeButtonText();
+	}
+
+	onInvalidation(changeInfo: ChangeInfo) {
+		if (changeInfo.reason === "childchange") {
+			this._valueIsProcessed = false;
+		}
 	}
 
 	/**
@@ -491,6 +513,10 @@ class Calendar extends CalendarPart {
 			this._currentPicker = "year";
 		}
 	}
+
+	// get _timestamp(): number {
+	// 	return this._selectedDatesTimestamps ? this._selectedDatesTimestamps[0] : this._timestamp;
+	// }
 
 	/**
 	 * Returns an array of UTC timestamps, representing the selected dates.

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -63,7 +63,9 @@
 
 	<section>
 		<ui5-title>Calendar with Minimum and Maximum Date & Format Pattern</ui5-title>
-		<ui5-calendar id="calendar4" data-ui5-compact-size min-date="7/7/2020" max-date="20/10/2020" timestamp="1594080000" format-pattern="dd/MM/yyyy"></ui5-calendar>
+		<ui5-calendar id="calendar4" data-ui5-compact-size min-date="7/7/2020" max-date="20/10/2020" timestamp="1594166400" format-pattern="dd/MM/yyyy">
+			<ui5-date value="08/07/2020"></ui5-date>
+		</ui5-calendar>
 	</section>
 
 	<section>

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -422,7 +422,7 @@ describe("Calendar general interaction", () => {
 		assert.strictEqual(await dayPickerRoot.hasClass("ui5-dp-twocalendartypes"), false, "Secondary Calendar class is applied correctly");
 	});
 
-	it("Focus goes into the current day item of the day picker", async () => {
+	it("Focus goes into the selected day item of the day picker", async () => {
 		await browser.url(`test/pages/Calendar.html`);
 
 		const calendar = await browser.$("#calendar4");

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -362,7 +362,7 @@ describe("Calendar general interaction", () => {
 	});
 
 	it("Min and max dates are set without format-pattern by using ISO (YYYY-MM-dd) format", async () => {
-		await browser.url("test/pages/Calendar.html");
+		await browser.url(`test/pages/Calendar.html`);
 
 		const calendar = await browser.$("#calendar6");
 		await calendar.setAttribute("max-date", new Date(Date.UTC(2024, 9, 4, 0, 0, 0)).toISOString().split("T")[0]); // sets the max date to 2024-10-04
@@ -382,8 +382,6 @@ describe("Calendar general interaction", () => {
 		await browser.url("test/pages/Calendar.html");
 
 		const calendar = await browser.$("#calendar1");
-		const nextButton = await calendar.shadow$("ui5-calendar-header").shadow$("[data-ui5-cal-header-btn-next]");
-		const prevButton = await calendar.shadow$("ui5-calendar-header").shadow$("[data-ui5-cal-header-btn-prev]");
 		const yearButton = await calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`);
 		// setting the min and max dates both to a valid format date, but not in the valid ISO format.
 		await calendar.setAttribute("max-date", `${new Date(Date.UTC(2024, 9, 4, 0, 0, 0))}`);
@@ -422,5 +420,15 @@ describe("Calendar general interaction", () => {
 		const dayPickerRoot = await calendar.shadow$("ui5-daypicker").shadow$(".ui5-dp-root");
 
 		assert.strictEqual(await dayPickerRoot.hasClass("ui5-dp-twocalendartypes"), false, "Secondary Calendar class is applied correctly");
+	});
+
+	it("Focus goes into the current day item of the day picker", async () => {
+		await browser.url(`test/pages/Calendar.html`);
+
+		const calendar = await browser.$("#calendar4");
+		const dayPicker = await calendar.shadow$("ui5-daypicker");
+		const currentDayItem = await dayPicker.shadow$(`div[data-sap-timestamp="1594166400"]`);
+
+		assert.ok(await currentDayItem.isFocusedDeep(), "Current calendar day item is focused");
 	});
 });


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-webcomponents/issues/7693

We are now considering the ui5-date, set trough nested element, for the focus. Previously we only focused the date passes as timestamp, and that timestamp changed based on current day, navigation and etc. We now check if we have a value set to the control and our initial focus goes to it, if the value is set after init state, we set the focus to the newly set date.