### PR TITLE
fix(ui5-input): update clear icon accessible name

### DIFF
--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -41,7 +41,7 @@
 
 		{{#if effectiveShowClearIcon}}
 			<div @click={{_clear}} @mousedown={{_iconMouseDown}} class="ui5-input-clear-icon-wrapper" input-icon tabindex="-1">
-				<ui5-icon tabindex="-1" class="ui5-input-clear-icon" name="decline"></ui5-icon>
+				<ui5-icon tabindex="-1" class="ui5-input-clear-icon" name="decline" accessible-name="{{clearIconAccessibleName}}"></ui5-icon>
 			</div>
 		{{/if}}
 

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -74,6 +74,7 @@ import {
 	INPUT_SUGGESTIONS_ONE_HIT,
 	INPUT_SUGGESTIONS_MORE_HITS,
 	INPUT_SUGGESTIONS_NO_HIT,
+	INPUT_CLEAR_ICON_ACC_NAME,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -1502,6 +1503,10 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 
 	get _headerTitleText() {
 		return Input.i18nBundle.getText(INPUT_SUGGESTIONS_TITLE);
+	}
+
+	get clearIconAccessibleName() {
+		return Input.i18nBundle.getText(INPUT_CLEAR_ICON_ACC_NAME);
 	}
 
 	get inputType() {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -154,6 +154,9 @@ INPUT_SUGGESTIONS_MORE_HITS={0} results are available
 #XACT: ARIA announcement for the Input suggestion result if no hit
 INPUT_SUGGESTIONS_NO_HIT=No results
 
+#XACT: ARIA label for the Input clear icon
+INPUT_CLEAR_ICON_ACC_NAME=Clear
+
 #XFLD: Subtle link description label
 LINK_SUBTLE=Subtle
 


### PR DESCRIPTION
- Update clear icon accessible name to "Clear"
- Icon role remain 'img' until we think of a way to manipulate icon inner acc

FIXES: #7600 