### PR TITLE
fix(ui5-tabcontainer): add margins for the Overflow buttons (start and end)

### DIFF
--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -67,6 +67,11 @@
 
 .ui5-tc__overflow.ui5-tc__overflow--end {
 	padding-inline-start: 0.188rem;
+	margin-inline-end: 1rem;
+}
+
+.ui5-tc__overflow.ui5-tc__overflow--start {
+	margin-inline-start: 1rem;
 }
 
 .ui5-tc__overflow[hidden] {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -121,7 +121,7 @@ describe("TabContainer general interaction", () => {
 		await browser.setWindowSize(1000, 1080);
 		const tabcontainer = await browser.$("#tabContainerStartAndEndOverflow");
 		const startOverflow = await tabcontainer.shadow$(".ui5-tc__overflow--start");
-		assert.strictEqual(await startOverflow.getProperty("innerText"), "+11", "11 tabs in start overflow");
+		assert.strictEqual(await startOverflow.getProperty("innerText"), "+12", "12 tabs in start overflow");
 
 		await browser.setWindowSize(800, 1080);
 		assert.strictEqual(await startOverflow.getProperty("innerText"), "+14", "14 tabs in start overflow");


### PR DESCRIPTION

Fixes: #7291

