### PR TITLE
fix(ui5-popup): add check for initial focused element id

### DIFF
--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -431,9 +431,9 @@ abstract class Popup extends UI5Element {
 		if (this.initialFocus) {
 			element = (this.getRootNode() as Document).getElementById(this.initialFocus)
 			|| document.getElementById(this.initialFocus);
-		} else {
-			element = await getFirstFocusableElement(this) || this._root; // in case of no focusable content focus the root
 		}
+
+		element = element || await getFirstFocusableElement(this) || this._root; // in case of no focusable content focus the root
 
 		if (element) {
 			if (element === this._root) {

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -426,10 +426,14 @@ abstract class Popup extends UI5Element {
 			return;
 		}
 
-		const element = (this.getRootNode() as Document).getElementById(this.initialFocus)
-			|| document.getElementById(this.initialFocus)
-			|| await getFirstFocusableElement(this)
-			|| this._root; // in case of no focusable content focus the root
+		let element;
+
+		if (this.initialFocus) {
+			element = (this.getRootNode() as Document).getElementById(this.initialFocus)
+			|| document.getElementById(this.initialFocus);
+		} else {
+			element = await getFirstFocusableElement(this) || this._root; // in case of no focusable content focus the root
+		}
 
 		if (element) {
 			if (element === this._root) {


### PR DESCRIPTION
Problem: If there in no focused element when the Popup opens there is "Empty string passed to getElementById()." warning in Firefox.

Fixes: #7711
