### PR TITLE
docs: update TypeScript Support statement

### DIFF
--- a/docs/1-getting-started/07-typescript-support.md
+++ b/docs/1-getting-started/07-typescript-support.md
@@ -1,7 +1,10 @@
 # TypeScript Support
 
-TypeScript Support is enabled for both component development and component consumption.
-Starting from version `1.11.0` we are providing `TypeScript definitions` in the form of `.d.ts` files for all framework's and components' APIs, making them accessible to applications written in TypeScript. Previously, without definitions, our types have been inferred by the TS compiler as `any`. Now, when you access a public API, you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
+**TypeScript Support is enabled for both component development and component consumption.**
+
+Since version `1.11.0`, we have been providing TypeScript definitions under an experimental flag, and starting from version `1.18.0`, all TypeScript definitions are considered `stable`.
+With TypeScript definitions, when you access a public API, you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
+
 
 **Note:** In exceptional cases, some of the available TypeScript types may change. In such instances, we will document all changes in a prominent manner within our release change log.
 

--- a/docs/1-getting-started/07-typescript-support.md
+++ b/docs/1-getting-started/07-typescript-support.md
@@ -3,7 +3,7 @@
 **TypeScript Support is enabled for both component development and component consumption.**
 
 Since version `1.11.0`, we have been providing TypeScript definitions under an experimental flag, and starting from version `1.18.0`, all TypeScript definitions are considered `stable`.
-With TypeScript definitions, when you access a public API, you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
+With TypeScript definitions you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
 
 
 **Note:** In exceptional cases, some of the available TypeScript types may change. In such instances, we will document all changes in a prominent manner within our release change log.

--- a/docs/1-getting-started/07-typescript-support.md
+++ b/docs/1-getting-started/07-typescript-support.md
@@ -2,7 +2,7 @@
 
 **TypeScript Support is enabled for both component development and component consumption.**
 
-Since version `1.11.0`, we have been providing TypeScript definitions under an experimental flag, and starting from version `1.18.0`, all TypeScript definitions are considered `stable`.
+Since version `1.11.0`, we have been providing TypeScript definitions under an experimental flag, and starting from version `1.19.0`, all TypeScript definitions are considered `stable`.
 With TypeScript definitions you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
 
 

--- a/docs/1-getting-started/07-typescript-support.md
+++ b/docs/1-getting-started/07-typescript-support.md
@@ -1,9 +1,10 @@
 # TypeScript Support
 
-**Note: TypeScript support is experimental and subject to change**. If you consume the web components via TypeScript, you might have to adjust your code before the TypeScript definitions become final and officially supported.
+TypeScript Support is enabled for both component development and component consumption.
+Starting from version `1.11.0` we are providing `TypeScript definitions` in the form of `.d.ts` files for all framework's and components' APIs, making them accessible to applications written in TypeScript. Previously, without definitions, our types have been inferred by the TS compiler as `any`. Now, when you access a public API, you will benefit from static code checks, autocompletion, and other expected features as expected in a TypeScript application.
 
-Since `1.11.0` we are providing `TypeScript definitions` (as `.d.ts` files) for all framework's and components' APIs, available to applications, written in TypeScript. Previously, without definitions, the usage of UI5 Web Components in TypeScript application was not optimal as the types have been missing and inferred by the TS compiler as `any`.
-Now, when accessing a public API, you will benefit from static code checks, autocompletion, etc. as expected in a TypeScript app.
+**Note:** In exceptional cases, some of the available TypeScript types may change. In such instances, we will document all changes in a prominent manner within our release change log.
+
 
 **Example:** usage of `setLanguage` from `@ui5/webcomponents-base`
 


### PR DESCRIPTION
We now remove the "experimental" notion for our TypeScript support from the documentation.