### PR TITLE
feat(framework): switch default theme from Quartz Light to Morning Ho…

### DIFF
--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -22,11 +22,11 @@ There are several configuration settings that affect all UI5 Web Components glob
 <a name="theme"></a>
 
 The `theme` setting values above are the technical names of the supported themes:
-- The `sap_horizon` is known as `Morning Horizon` and it's the latest theme currently available as a preview version.
+- The `sap_horizon` is known as `Morning Horizon` and it's the latest theme and default theme.
 - The `sap_horizon_dark` is known as `Evening Horizon`.
 - The `sap_horizon_hcb` is known as `High Contrast Black`.
 - The `sap_horizon_hcw` is known as `High Contrast White`.
-- The `sap_fiori_3` is known as `Quartz Light` and it`s the default theme.
+- The `sap_fiori_3` is known as `Quartz Light`.
 - The `sap_fiori_3_dark` is known as `Quartz Dark`.
 - The `sap_fiori_3_hcb` is known as `Quartz High Contrast Black`.
 - The `sap_fiori_3_hcw` is known as `Quartz High Contrast White`.

--- a/packages/base/test/assets/Themes.js
+++ b/packages/base/test/assets/Themes.js
@@ -1,5 +1,12 @@
 import { registerThemePropertiesLoader } from "../../dist/asset-registries/Themes.js";
 
+const defaultTheme = {
+	content: `:root{ --var1: grey; }`,
+	packageName: "",
+	fileName: "",
+};
+
+
 const fiori3 = {
 	content: `:root{ --var1: red; }`,
 	packageName: "",
@@ -42,6 +49,7 @@ const fiori3Hcw = {
 	fileName: "",
 };
 
+registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_horizon", () => defaultTheme);
 registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_fiori_3", () => fiori3);
 registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_fiori_3_dark", () => fiori3Dark);
 registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_belize", () => belize);

--- a/packages/base/test/assets/bundle.light.js
+++ b/packages/base/test/assets/bundle.light.js
@@ -13,7 +13,7 @@ boot();
 const testAssets = {
     // registerThemePropertiesLoader after boot (and after attachBoot ), will call applyTheme
     registerThemeProps: async () => {
-        registerThemePropertiesLoader("@ui5/webcomponents-theming", "sap_fiori_3", () => {
+        registerThemePropertiesLoader("@ui5/webcomponents-theming", "sap_horizon", () => {
             return {
                 content: `:root{ --customCol: #fff; --customBg: #000; }`,
                 packageName: "",

--- a/packages/base/test/specs/Theming.spec.js
+++ b/packages/base/test/specs/Theming.spec.js
@@ -42,7 +42,7 @@ describe("Theming works", () => {
 			const bundle = window['sap-ui-webcomponents-bundle'];
 			const dataPropAttr = `data-ui5-component-properties-${bundle.getCurrentRuntimeIndex()}`;
 			const style = document.adoptedStyleSheets.find(sh => sh._ui5StyleId === `${dataPropAttr}|@ui5/webcomponents-base-test`).cssRules[0].cssText
-			const varsFound = style && style.includes("--var1: red"); // "red" for fiori3 - see test/assets/Themes.js
+			const varsFound = style && style.includes("--var1: grey"); // "grey" for horizon - see test/assets/Themes.js
 			done(varsFound);
 		});
 

--- a/packages/base/test/specs/Theming.spec.js
+++ b/packages/base/test/specs/Theming.spec.js
@@ -11,7 +11,7 @@ describe("Theming works", () => {
 			const bundle = window['sap-ui-webcomponents-bundle'];
 			const dataPropAttr = `data-ui5-component-properties-${bundle.getCurrentRuntimeIndex()}`;
 			const style = document.adoptedStyleSheets.find(sh => sh._ui5StyleId === `${dataPropAttr}|@ui5/webcomponents-base-test`).cssRules[0].cssText
-			done(style && style.includes("--var1: red")); // see test/assets/Themes.js
+			done(style && style.includes("--var1: grey")); // see test/assets/Themes.js
 		});
 
 		assert.strictEqual(res, true, "The fiori3 vars are found");

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -125,7 +125,7 @@
 			<ui5-breadcrumbs-item href="#">Link4</ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="#">Link5</ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item href="#">Link6</ui5-breadcrumbs-item>
-			<ui5-breadcrumbs-item id="item7" href="#">aaaaa</ui5-breadcrumbs-item>
+			<ui5-breadcrumbs-item id="item7" href="#">aa</ui5-breadcrumbs-item>
 			<ui5-breadcrumbs-item>Location</ui5-breadcrumbs-item>
 		</ui5-breadcrumbs>
 	</div>

--- a/packages/main/test/pages/CoreControls.html
+++ b/packages/main/test/pages/CoreControls.html
@@ -12,13 +12,6 @@
 
 	<script>// delete Document.prototype.adoptedStyleSheets;</script>
 
-	<script data-ui5-config type="application/json">
-		{
-			"theme": "sap_horizon",
-			"language": "EN"
-		}
-	</script>
-
 	<link rel="stylesheet" type="text/css" href="./styles/CoreControls.css">
 </head>
 

--- a/packages/main/test/pages/Icon_and_theming.html
+++ b/packages/main/test/pages/Icon_and_theming.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="icon1auto">
-	<ui5-toggle-button id="themeToggle">Horizon</ui5-toggle-button>
+	<ui5-toggle-button id="themeToggle">Quartz</ui5-toggle-button>
 
 	<div>SAPIcons auto ("home")</div>
 	<ui5-icon name="home"></ui5-icon>
@@ -72,7 +72,7 @@
 		themeToggle.addEventListener("click", event => {
 			const pressed = event.target.pressed;
 
-			window["sap-ui-webcomponents-bundle"].configuration.setTheme(pressed ? "sap_horizon" : "sap_fiori_3");
+			window["sap-ui-webcomponents-bundle"].configuration.setTheme(pressed ? "sap_fiori_3" : "sap_horizon");
 			event.target.innerHTML = pressed ? "Quartz" : "Horizon"
 		});
 	</script>

--- a/packages/main/test/pages/OpenUI5-second.html
+++ b/packages/main/test/pages/OpenUI5-second.html
@@ -11,7 +11,6 @@
 	<script data-ui5-config type="application/json">
 		{
 			"language": "de",
-			"theme": "sap_horizon"
 		}
 	</script>
 

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -66,19 +66,19 @@ describe("Icon general interaction", () => {
 		// assert - initial SVG path
 		const iconPath = await browser.$("#myIcon").shadow$(".ui5-icon-root path");
 		const pathValue = await iconPath.getAttribute("d");
-		assert.ok(pathValue.startsWith(V4_PATH_START), "Icon's path in sap_fiori_3");
+		assert.ok(pathValue.startsWith(V5_PATH_START), "Icon's path in sap_horizon.");
 
 		// act - switch theme
 		await browser.executeAsync( async (newTheme, done) => {
 			const config = window['sap-ui-webcomponents-bundle'].configuration;
 			await config.setTheme(newTheme);
 			done();
-		}, "sap_horizon");
+		}, "sap_fiori_3");
 
 		// assert - SVG path changed
 		const iconPathAfter = await browser.$("#myIcon").shadow$(".ui5-icon-root path");
 		const iconPathValueAfter = await iconPathAfter.getAttribute("d");
-		assert.ok(iconPathValueAfter.startsWith(V5_PATH_START), "Icon's path changed in sap_horizon.");
+		assert.ok(iconPathValueAfter.startsWith(V4_PATH_START), "Icon's path changed in sap_fiori_3.");
 	});
 
 	it("Tests icon modules' exported values", async () => {

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -45,9 +45,10 @@ describe("General API", () => {
 	it("should wrap the text of the link", async () => {
 		const wrappingLabel = await browser.$("#wrapping-link");
 		const truncatingLabel = await browser.$("#non-wrapping-link");
+		const LINK_HEIGHT = 20; // It's 20px in sap_horizon, previously 18px in sap_fiori_3
 
 		assert.isAbove((await wrappingLabel.getSize()).height, (await truncatingLabel.getSize()).height);
-		assert.strictEqual((await truncatingLabel.getSize()).height, 18, "The truncated label should be single line.");
+		assert.strictEqual((await truncatingLabel.getSize()).height, LINK_HEIGHT, "The truncated label should be single line.");
 	});
 
 	it("should prevent clicking on disabled link", async () => {

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -10,7 +10,6 @@
 
     <script data-ui5-config type="application/json">
         {
-          "theme": "sap_horizon",
           "language": "EN"
         }
     </script>

--- a/packages/tools/assets-meta.js
+++ b/packages/tools/assets-meta.js
@@ -1,6 +1,6 @@
 const assetsMeta = {
   "themes": {
-    "default": "sap_fiori_3",
+    "default": "sap_horizon",
     "all": [
       "sap_fiori_3",
       "sap_fiori_3_dark",


### PR DESCRIPTION
Until now, Quartz Light ("sap_fiori_3") used to be the default theme for our framework.
However, as `Morning Horizon` has been around for almost two years and most of the consumers migrated to Horizon, we are now switching our default theme from Quartz Light to Morning Horizon ("sap_horizon").