### PR TITLE
fix(FormSupport): submit linebreaks in ui5-textarea

### DIFF
--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -24,7 +24,7 @@ import {
 // Styles
 import checkboxCss from "./generated/themes/CheckBox.css.js";
 import type FormSupport from "./features/InputElementsFormSupport.js";
-import type { IFormElement } from "./features/InputElementsFormSupport.js";
+import type { IFormElement, NativeFormElement } from "./features/InputElementsFormSupport.js";
 
 // Template
 import CheckBoxTemplate from "./generated/templates/CheckBoxTemplate.lit.js";
@@ -304,9 +304,9 @@ class CheckBox extends UI5Element implements IFormElement {
 	_enableFormSupport() {
 		const formSupport = getFeature<typeof FormSupport>("FormSupport");
 		if (formSupport) {
-			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: HTMLInputElement) => {
+			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: NativeFormElement) => {
 				nativeInput.disabled = !!element.disabled;
-				nativeInput.checked = !!element.checked;
+				(nativeInput as HTMLInputElement).checked = !!element.checked;
 				nativeInput.value = element.checked ? "on" : "";
 			});
 		} else if (this.name) {

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -32,7 +32,7 @@ import FileUploaderCss from "./generated/themes/FileUploader.css.js";
 import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverCommon.css.js";
 import ValueStateMessageCss from "./generated/themes/ValueStateMessage.css.js";
 import type FormSupport from "./features/InputElementsFormSupport.js";
-import type { IFormElement } from "./features/InputElementsFormSupport.js";
+import type { IFormElement, NativeFormElement } from "./features/InputElementsFormSupport.js";
 
 type FileUploaderChangeEventDetail = {
 	files: FileList | null,
@@ -327,7 +327,7 @@ class FileUploader extends UI5Element implements IFormElement {
 				this._setFormValue();
 			} else {
 				formSupport.syncNativeFileInput(this,
-					(element: IFormElement, nativeInput: HTMLInputElement) => {
+					(element: IFormElement, nativeInput: NativeFormElement) => {
 						nativeInput.disabled = !!element.disabled;
 					},
 					this._onChange.bind(this));

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -68,7 +68,7 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
 import ValueStateMessageCss from "./generated/themes/ValueStateMessage.css.js";
 import SelectPopoverCss from "./generated/themes/SelectPopover.css.js";
 import type FormSupport from "./features/InputElementsFormSupport.js";
-import type { IFormElement } from "./features/InputElementsFormSupport.js";
+import type { IFormElement, NativeFormElement } from "./features/InputElementsFormSupport.js";
 import type ListItemBase from "./ListItemBase.js";
 import type SelectMenu from "./SelectMenu.js";
 import type { SelectMenuOptionClick, SelectMenuChange } from "./SelectMenu.js";
@@ -671,7 +671,7 @@ class Select extends UI5Element implements IFormElement {
 	_enableFormSupport() {
 		const formSupport = getFeature<typeof FormSupport>("FormSupport");
 		if (formSupport) {
-			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: HTMLInputElement) => {
+			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: NativeFormElement) => {
 				const selectElement = (element as Select);
 				nativeInput.disabled = !!element.disabled;
 				nativeInput.value = selectElement._currentlySelectedOption ? selectElement._currentlySelectedOption.value : "";

--- a/packages/main/src/Switch.ts
+++ b/packages/main/src/Switch.ts
@@ -16,7 +16,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 import "@ui5/webcomponents-icons/dist/less.js";
 import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import type FormSupport from "./features/InputElementsFormSupport.js";
-import type { IFormElement } from "./features/InputElementsFormSupport.js";
+import type { IFormElement, NativeFormElement } from "./features/InputElementsFormSupport.js";
 import Icon from "./Icon.js";
 import SwitchDesign from "./types/SwitchDesign.js";
 
@@ -245,9 +245,9 @@ class Switch extends UI5Element implements IFormElement {
 	_enableFormSupport() {
 		const formSupport = getFeature<typeof FormSupport>("FormSupport");
 		if (formSupport) {
-			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: HTMLInputElement) => {
+			formSupport.syncNativeHiddenInput(this, (element: IFormElement, nativeInput: NativeFormElement) => {
 				const switchComponent = (element as Switch);
-				nativeInput.checked = !!switchComponent.checked;
+				(nativeInput as HTMLInputElement).checked = !!switchComponent.checked;
 				nativeInput.disabled = !!switchComponent.disabled;
 				nativeInput.value = switchComponent.checked ? "on" : "";
 			});

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -405,7 +405,7 @@ class TextArea extends UI5Element implements IFormElement {
 
 		const FormSupport = getFeature<typeof FormSupportT>("FormSupport");
 		if (FormSupport) {
-			FormSupport.syncNativeHiddenInput(this);
+			FormSupport.syncNativeHiddenTextArea(this);
 		} else if (this.name) {
 			console.warn(`In order for the "name" property to have effect, you should also: import "@ui5/webcomponents/dist/features/InputElementsFormSupport.js";`); // eslint-disable-line
 		}

--- a/packages/main/src/features/InputElementsFormSupport.ts
+++ b/packages/main/src/features/InputElementsFormSupport.ts
@@ -10,7 +10,7 @@ interface IFormElement extends UI5Element {
 	checked?: boolean,
 }
 
-type NativeFormElement = HTMLInputElement & HTMLTextAreaElement;
+type NativeFormElement = HTMLInputElement | HTMLTextAreaElement;
 type NativeInputUpdateCallback = (element: IFormElement, nativeInput: NativeFormElement) => void;
 type NativeInputChangeCallback = (e: Event) => void;
 
@@ -96,10 +96,10 @@ class FormSupport {
 	 */
 	static syncNativeFileInput(element: IFormElement, nativeInputUpdateCallback: NativeInputUpdateCallback, nativeInputChangeCallback: NativeInputChangeCallback) {
 		const needsNativeInput = !!element.name;
-		let nativeInput = element.querySelector(`input[type="file"][data-ui5-form-support]`) as NativeFormElement;
+		let nativeInput = element.querySelector(`input[type="file"][data-ui5-form-support]`) as HTMLInputElement;
 
 		if (needsNativeInput && !nativeInput) {
-			nativeInput = document.createElement("input") as NativeFormElement;
+			nativeInput = document.createElement("input");
 			nativeInput.type = "file";
 			nativeInput.setAttribute("data-ui5-form-support", "");
 			nativeInput.slot = "formSupport"; // Needed to visualize the input in the light dom
@@ -172,6 +172,7 @@ export default FormSupport;
 
 export {
 	IFormElement,
+	NativeFormElement,
 	NativeInputChangeCallback,
 	NativeInputUpdateCallback,
 };

--- a/packages/main/src/features/InputElementsFormSupport.ts
+++ b/packages/main/src/features/InputElementsFormSupport.ts
@@ -10,7 +10,7 @@ interface IFormElement extends UI5Element {
 	checked?: boolean,
 }
 
-type NativeFormElement = HTMLInputElement | HTMLTextAreaElement;
+type NativeFormElement = HTMLInputElement & HTMLTextAreaElement;
 type NativeInputUpdateCallback = (element: IFormElement, nativeInput: NativeFormElement) => void;
 type NativeInputChangeCallback = (e: Event) => void;
 
@@ -34,7 +34,7 @@ class FormSupport {
 	 */
 	static syncNativeHiddenInput(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
 		const needsNativeInput = !!element.name || element.required;
-		const nativeInput = element.querySelector("input[data-ui5-form-support]") as HTMLInputElement;
+		const nativeInput = element.querySelector("input[data-ui5-form-support]") as NativeFormElement;
 
 		if (needsNativeInput) {
 			this.syncNativeElement(element, nativeInput, nativeInputUpdateCallback);
@@ -51,7 +51,7 @@ class FormSupport {
 	 */
 	static syncNativeHiddenTextArea(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
 		const needsNativeTextArea = !!element.name || element.required;
-		const nativeTextarea = element.querySelector("textarea[data-ui5-form-support]") as HTMLTextAreaElement;
+		const nativeTextarea = element.querySelector("textarea[data-ui5-form-support]") as NativeFormElement;
 
 		if (needsNativeTextArea) {
 			this.syncNativeElement(element, nativeTextarea, nativeInputUpdateCallback, "textarea");
@@ -96,10 +96,10 @@ class FormSupport {
 	 */
 	static syncNativeFileInput(element: IFormElement, nativeInputUpdateCallback: NativeInputUpdateCallback, nativeInputChangeCallback: NativeInputChangeCallback) {
 		const needsNativeInput = !!element.name;
-		let nativeInput = element.querySelector(`input[type="file"][data-ui5-form-support]`) as HTMLInputElement;
+		let nativeInput = element.querySelector(`input[type="file"][data-ui5-form-support]`) as NativeFormElement;
 
 		if (needsNativeInput && !nativeInput) {
-			nativeInput = document.createElement("input");
+			nativeInput = document.createElement("input") as NativeFormElement;
 			nativeInput.type = "file";
 			nativeInput.setAttribute("data-ui5-form-support", "");
 			nativeInput.slot = "formSupport"; // Needed to visualize the input in the light dom
@@ -160,7 +160,7 @@ class FormSupport {
 	}
 }
 
-const copyDefaultProperties = (element: IFormElement, nativeInput: HTMLInputElement | HTMLTextAreaElement) => {
+const copyDefaultProperties = (element: IFormElement, nativeInput: NativeFormElement) => {
 	nativeInput.disabled = element.disabled!;
 	nativeInput.value = element.value as string; // We do not explicitly convert to string to retain the current browser behavior
 };

--- a/packages/main/src/features/InputElementsFormSupport.ts
+++ b/packages/main/src/features/InputElementsFormSupport.ts
@@ -10,7 +10,8 @@ interface IFormElement extends UI5Element {
 	checked?: boolean,
 }
 
-type NativeInputUpdateCallback = (element: IFormElement, nativeInput: HTMLInputElement) => void;
+type NativeFormElement = HTMLInputElement | HTMLTextAreaElement;
+type NativeInputUpdateCallback = (element: IFormElement, nativeInput: NativeFormElement) => void;
 type NativeInputChangeCallback = (e: Event) => void;
 
 const findNearestFormElement = (element: IFormElement) => {
@@ -33,36 +34,57 @@ class FormSupport {
 	 */
 	static syncNativeHiddenInput(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
 		const needsNativeInput = !!element.name || element.required;
-		let nativeInput = element.querySelector("input[data-ui5-form-support]") as HTMLInputElement;
-		if (needsNativeInput && !nativeInput) {
-			nativeInput = document.createElement("input");
-
-			nativeInput.style.clip = "rect(0 0 0 0)";
-			nativeInput.style.clipPath = "inset(50%)";
-			nativeInput.style.height = "1px";
-			nativeInput.style.overflow = "hidden";
-			nativeInput.style.position = "absolute";
-			nativeInput.style.whiteSpace = "nowrap";
-			nativeInput.style.width = "1px";
-			nativeInput.style.bottom = "0";
-			nativeInput.setAttribute("tabindex", "-1");
-			nativeInput.required = element.required!;
-			nativeInput.setAttribute("data-ui5-form-support", "");
-			nativeInput.setAttribute("aria-hidden", "true");
-
-			nativeInput.addEventListener("focusin", () => element.getFocusDomRef()?.focus());
-
-			nativeInput.slot = "formSupport"; // Needed for IE - otherwise input elements are not part of the real DOM tree and are not detected by forms
-			element.appendChild(nativeInput);
-		}
-		if (!needsNativeInput && nativeInput) {
-			element.removeChild(nativeInput);
-		}
+		const nativeInput = element.querySelector("input[data-ui5-form-support]") as HTMLInputElement;
 
 		if (needsNativeInput) {
-			nativeInput.name = element.name!;
-			(nativeInputUpdateCallback || copyDefaultProperties)(element, nativeInput);
+			this.syncNativeElement(element, nativeInput, nativeInputUpdateCallback);
+		} else if (nativeInput) {
+			element.removeChild(nativeInput);
 		}
+	}
+
+	/**
+	 * Syncs the native textarea element, rendered into the component's light DOM,
+	 * with the component's state.
+	 * @param { IFormElement} element - the component with form support
+	 * @param { NativeInputUpdateCallback } nativeInputUpdateCallback - callback to calculate the native input's "disabled" and "value" properties
+	 */
+	static syncNativeHiddenTextArea(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
+		const needsNativeTextArea = !!element.name || element.required;
+		const nativeTextarea = element.querySelector("textarea[data-ui5-form-support]") as HTMLTextAreaElement;
+
+		if (needsNativeTextArea) {
+			this.syncNativeElement(element, nativeTextarea, nativeInputUpdateCallback, "textarea");
+		} else if (nativeTextarea) {
+			element.removeChild(nativeTextarea);
+		}
+	}
+
+	static syncNativeElement(element: IFormElement, nativeElement: NativeFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback, nativeElementTagName = "input") {
+		if (!nativeElement) {
+			nativeElement = document.createElement(nativeElementTagName) as NativeFormElement;
+
+			nativeElement.style.clip = "rect(0 0 0 0)";
+			nativeElement.style.clipPath = "inset(50%)";
+			nativeElement.style.height = "1px";
+			nativeElement.style.overflow = "hidden";
+			nativeElement.style.position = "absolute";
+			nativeElement.style.whiteSpace = "nowrap";
+			nativeElement.style.width = "1px";
+			nativeElement.style.bottom = "0";
+			nativeElement.setAttribute("tabindex", "-1");
+			nativeElement.required = element.required!;
+			nativeElement.setAttribute("data-ui5-form-support", "");
+			nativeElement.setAttribute("aria-hidden", "true");
+
+			nativeElement.addEventListener("focusin", () => element.getFocusDomRef()?.focus());
+
+			nativeElement.slot = "formSupport"; // Needed for IE - otherwise input elements are not part of the real DOM tree and are not detected by forms
+			element.appendChild(nativeElement);
+		}
+
+		nativeElement.name = element.name!;
+		(nativeInputUpdateCallback || copyDefaultProperties)(element, nativeElement);
 	}
 
 	/**
@@ -138,7 +160,7 @@ class FormSupport {
 	}
 }
 
-const copyDefaultProperties = (element: IFormElement, nativeInput: HTMLInputElement) => {
+const copyDefaultProperties = (element: IFormElement, nativeInput: HTMLInputElement | HTMLTextAreaElement) => {
 	nativeInput.disabled = element.disabled!;
 	nativeInput.value = element.value as string; // We do not explicitly convert to string to retain the current browser behavior
 };

--- a/packages/main/src/features/InputElementsFormSupport.ts
+++ b/packages/main/src/features/InputElementsFormSupport.ts
@@ -34,7 +34,7 @@ class FormSupport {
 	 */
 	static syncNativeHiddenInput(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
 		const needsNativeInput = !!element.name || element.required;
-		const nativeInput = element.querySelector("input[data-ui5-form-support]") as NativeFormElement;
+		const nativeInput = element.querySelector<NativeFormElement>("input[data-ui5-form-support]");
 
 		if (needsNativeInput) {
 			this.syncNativeElement(element, nativeInput, nativeInputUpdateCallback);
@@ -51,7 +51,7 @@ class FormSupport {
 	 */
 	static syncNativeHiddenTextArea(element: IFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback) {
 		const needsNativeTextArea = !!element.name || element.required;
-		const nativeTextarea = element.querySelector("textarea[data-ui5-form-support]") as NativeFormElement;
+		const nativeTextarea = element.querySelector<NativeFormElement>("textarea[data-ui5-form-support]");
 
 		if (needsNativeTextArea) {
 			this.syncNativeElement(element, nativeTextarea, nativeInputUpdateCallback, "textarea");
@@ -60,7 +60,7 @@ class FormSupport {
 		}
 	}
 
-	static syncNativeElement(element: IFormElement, nativeElement: NativeFormElement, nativeInputUpdateCallback?: NativeInputUpdateCallback, nativeElementTagName = "input") {
+	static syncNativeElement(element: IFormElement, nativeElement: NativeFormElement | null, nativeInputUpdateCallback?: NativeInputUpdateCallback, nativeElementTagName = "input") {
 		if (!nativeElement) {
 			nativeElement = document.createElement(nativeElementTagName) as NativeFormElement;
 
@@ -96,7 +96,7 @@ class FormSupport {
 	 */
 	static syncNativeFileInput(element: IFormElement, nativeInputUpdateCallback: NativeInputUpdateCallback, nativeInputChangeCallback: NativeInputChangeCallback) {
 		const needsNativeInput = !!element.name;
-		let nativeInput = element.querySelector(`input[type="file"][data-ui5-form-support]`) as HTMLInputElement;
+		let nativeInput = element.querySelector<HTMLInputElement>(`input[type="file"][data-ui5-form-support]`);
 
 		if (needsNativeInput && !nativeInput) {
 			nativeInput = document.createElement("input");
@@ -124,8 +124,8 @@ class FormSupport {
 		}
 
 		if (needsNativeInput) {
-			nativeInput.name = element.name!;
-			(nativeInputUpdateCallback || copyDefaultProperties)(element, nativeInput);
+			nativeInput!.name = element.name!;
+			(nativeInputUpdateCallback || copyDefaultProperties)(element, nativeInput!);
 		}
 	}
 

--- a/packages/main/test/pages/FormSupport.html
+++ b/packages/main/test/pages/FormSupport.html
@@ -18,7 +18,7 @@
     <ui5-input name="input" value="ok"></ui5-input>
     <ui5-input name="input_disabled" disabled value="ok"></ui5-input>
     <br><br>
-    <ui5-textarea name="ta" value="ok"></ui5-textarea>
+    <ui5-textarea id="ta" name="ta" value="ok"></ui5-textarea>
     <ui5-textarea name="ta_disabled" disabled value="ok"></ui5-textarea>
     <br><br>
     <ui5-date-picker name="dp" value="Apr 10, 2019"></ui5-date-picker>

--- a/packages/main/test/specs/FormSupport.spec.js
+++ b/packages/main/test/specs/FormSupport.spec.js
@@ -17,11 +17,18 @@ describe("Form support", () => {
 	it("Submit button does submit forms", async () => {
 		await browser.url(`test/pages/FormSupport.html`);
 
+		// Enter multiline text in TextArea
+		const textarea = await browser.$("#ta");
+		await textarea.click()
+		await browser.keys("Enter");
+		await browser.keys("o");
+		await browser.keys("k");
+
 		const submitButton = await browser.$("#b2");
 		await submitButton.click();
 
 		const formWasSubmitted = await browser.executeAsync(done => {
-			const expectedFormData = "?input=ok&ta=ok&dp=Apr+10%2C+2019&cb=on&radio=b&si=5";
+			const expectedFormData = "?input=ok&ta=ok%0D%0Aok&dp=Apr+10%2C+2019&cb=on&radio=b&si=5";
 			done(location.href.endsWith(expectedFormData));
 		});
 		assert.ok(formWasSubmitted, "For was submitted and URL changed");


### PR DESCRIPTION
Previously we used to always render an input native element in the light DOM of our input-type web components for the purposes of the FormSupport. This includes the TextArea web component. However, when linebreaks are used in the TextArea web components, they got lost (native input supports one-line text) and eventually not part of the form submission. Now we use native textarea element and the line breaks are properly submitted.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7467