### PR TITLE
fix(ui5-toolbar): remove unnecessary styles

### DIFF
--- a/packages/main/src/themes/Toolbar.css
+++ b/packages/main/src/themes/Toolbar.css
@@ -6,7 +6,6 @@
 	justify-content: flex-end;
 	padding: 0 var(--_ui5-toolbar-padding-left) 0 var(--_ui5-toolbar-padding-right);
 	box-sizing: border-box;
-	color: var(--sapButton_TextColor);
 	border-bottom: 0.0625rem solid var(--sapGroup_ContentBorderColor);
 }
 

--- a/packages/main/src/themes/Toolbar.css
+++ b/packages/main/src/themes/Toolbar.css
@@ -6,21 +6,8 @@
 	justify-content: flex-end;
 	padding: 0 var(--_ui5-toolbar-padding-left) 0 var(--_ui5-toolbar-padding-right);
 	box-sizing: border-box;
-	background: var(--ui5-toolbar-Background);
 	color: var(--sapButton_TextColor);
 	border-bottom: 0.0625rem solid var(--sapGroup_ContentBorderColor);
-}
-
-:host([design="Solid"]) {
-	background: var(--sapBaseColor);
-}
-
-:host([design="Transparent"]) {
-	background: var(--sapToolbar_Background);
-}
-
-:host([styling="Clear"]) {
-	border-bottom: 0;
 }
 
 :host([align-content="Start"]) {
@@ -37,10 +24,6 @@
 
 .ui5-tb-items-full-width {
     width: 100%;
-}
-
-.ui5-tb-item[design="Transparent"] {
-	color: inherit;
 }
 
 .ui5-tb-item {


### PR DESCRIPTION
This change removes unnecessary styles of the Toolbar.css file, related to the background of the Toolbar.
As we decided not to implement `desing` and `styling` property, some styles were not removed with the initial commit of the toolbar component.

Additionally, a risky override is removed of the color of the toolbar items.