### PR TITLE
WIP: fix(ui5-multi-combobox): change property open

### DIFF
--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -354,19 +354,6 @@ class MultiComboBox extends UI5Element {
 	filter!: `${ComboBoxFilter}`;
 
 	/**
-	 * Indicates whether the dropdown is open. True if the dropdown is open, false otherwise.
-	 *
-	 * @type {boolean}
-	 * @name sap.ui.webc.main.MultiComboBox.prototype.open
-	 * @defaultvalue false
-	 * @readonly
-	 * @since 1.0.0-rc.5
-	 * @public
-	 */
-	@property({ type: Boolean })
-	open!: boolean;
-
-	/**
 	 * Defines the accessible ARIA name of the component.
 	 *
 	 * @type {string}
@@ -389,6 +376,16 @@ class MultiComboBox extends UI5Element {
 	 */
 	@property()
 	accessibleNameRef!: string;
+
+	/**
+	 * Indicates whether the dropdown is open. True if the dropdown is open, false otherwise.
+	 *
+	 * @type {boolean}
+	 * @defaultvalue false
+	 * @private
+	 */
+	@property({ type: Boolean })
+	_open!: boolean;
 
 	@property({ type: Object, noAttribute: true, multiple: true })
 	_filteredItems!: Array<IMultiComboBoxItem>;
@@ -543,6 +540,20 @@ class MultiComboBox extends UI5Element {
 		this.filterSelected = (e.target as ToggleButton).pressed;
 		const selectedItems = this._filteredItems.filter(item => item.selected);
 		this.selectedItems = this.items.filter((item, idx, allItems) => MultiComboBox._groupItemFilter(item, ++idx, allItems, selectedItems) || selectedItems.indexOf(item) !== -1);
+	}
+
+	/**
+	 * Indicates whether the dropdown is open. True if the dropdown is open, false otherwise.
+	 *
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.MultiComboBox.prototype.open
+	 * @defaultvalue false
+	 * @readonly
+	 * @since 1.0.0-rc.5
+	 * @public
+	 */
+	get open() {
+		return this._open;
 	}
 
 	get _showAllItemsButtonPressed(): boolean {
@@ -1251,7 +1262,7 @@ class MultiComboBox extends UI5Element {
 	}
 
 	_toggle() {
-		this.open = !this.open;
+		this._open = !this._open;
 		this.fireEvent("open-change");
 	}
 
@@ -1422,6 +1433,7 @@ class MultiComboBox extends UI5Element {
 	}
 
 	onBeforeRendering() {
+		// this.toggleAttribute("open", this.open);
 		const input = this._innerInput;
 		const autoCompletedChars = input && (input.selectionEnd || 0) - (input.selectionStart || 0);
 		const value = input && input.value;


### PR DESCRIPTION
Change MultiComboBox property "open" to be private and expose a getter. 

Currently the property is documented as @readonly but  it still can be modified. So a new private property "_open" is created and a getter named "open" returns its value.
