### PR TITLE
revert(ui5-color-palette-item): revert selected state feature

### DIFF
--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -162,13 +162,13 @@ class ColorPalette extends UI5Element {
 		invalidateOnChildChange: true,
 		individualSlots: true,
 	})
+
 	colors!: Array<ColorPaletteItem>;
 
 	_itemNavigation: ItemNavigation;
 	_itemNavigationRecentColors: ItemNavigation;
 	_recentColors: Array<string>;
 	moreColorsFeature?: ColorPaletteMoreColors;
-	_currentlySelected?: ColorPaletteItem;
 
 	static i18nBundle: I18nBundle;
 
@@ -199,8 +199,6 @@ class ColorPalette extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		this._ensureSingleSelectionOrDeselectAll();
-
 		this.displayedColors.forEach((item, index) => {
 			item.index = index + 1;
 		});
@@ -245,69 +243,30 @@ class ColorPalette extends UI5Element {
 		});
 	}
 
-	/**
-	 * Ensures that only one item is selected or only the last selected item remains active if more than one are explicitly set as 'selected'.
-	 *
-	 * @private
-	 * @returns {void}
-	 */
-	_ensureSingleSelectionOrDeselectAll() {
-		const selectedItems = [...this.colors, ...this.recentColorsElements].filter(item => item.selected);
-		selectedItems.pop();
-		selectedItems.forEach(item => { item.selected = false; });
-	}
-
 	_onclick(e: MouseEvent) {
-		this.handleSelection(e.target as ColorPaletteItem);
+		const target = e.target as ColorPaletteItem;
+		if (target.hasAttribute("ui5-color-palette-item")) {
+			this.selectColor(target);
+		}
 	}
 
 	_onkeyup(e: KeyboardEvent) {
 		const target = e.target as ColorPaletteItem;
-		if (isSpace(e)) {
+		if (isSpace(e) && target.hasAttribute("ui5-color-palette-item")) {
 			e.preventDefault();
-			this.handleSelection(target);
+			this.selectColor(target);
 		}
 	}
 
 	_onkeydown(e: KeyboardEvent) {
 		const target = e.target as ColorPaletteItem;
-		if (isEnter(e)) {
-			this.handleSelection(target);
-		}
-	}
-
-	handleSelection(target: ColorPaletteItem) {
-		if (!target.hasAttribute("ui5-color-palette-item") || !target.value) {
-			return;
-		}
-
-		if (this._currentlySelected === target) {
-			target.selected = !target.selected;
-			return;
-		}
-
-		this.selectColor(target);
-
-		// Handle selection for items within the 'recentColorsElements'
-		if (this.recentColorsElements.includes(target)) {
-			this.recentColorsElements[0].selected = true;
-			this.recentColorsElements[0].focus();
-			this._currentlySelected = this.recentColorsElements[0];
-		} else {
-			[...this.colors, ...this.recentColorsElements].forEach(item => {
-				item.selected = item === target;
-			});
-			this._currentlySelected = target;
+		if (isEnter(e) && target.hasAttribute("ui5-color-palette-item")) {
+			this.selectColor(target);
 		}
 	}
 
 	_onDefaultColorKeyDown(e: KeyboardEvent) {
 		if (isTabNext(e) && this.popupMode) {
-			e.preventDefault();
-			this._onDefaultColorClick();
-		}
-
-		if (isSpace(e) || isEnter(e)) {
 			e.preventDefault();
 			this._onDefaultColorClick();
 		}

--- a/packages/main/src/ColorPaletteItem.hbs
+++ b/packages/main/src/ColorPaletteItem.hbs
@@ -1,5 +1,5 @@
 <div
-	class="{{classes.root}}"
+	class="ui5-cp-item"
 	style="{{styles.root}}"
 	value="{{value}}"
 	tabindex="{{_tabIndex}}"

--- a/packages/main/src/ColorPaletteItem.ts
+++ b/packages/main/src/ColorPaletteItem.ts
@@ -53,21 +53,6 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 	value!: string;
 
 	/**
-	 * Defines if the component is selected.
-	 * <br><br>
-	 * <b>Note:</b> Only one item must be selected per <code>ui5-color-palette</code>.
-	 * If more than one item is defined as selected, the last one would be considered as the selected one.
-	 *
-	 * @public
-	 * @type {boolean}
-	 * @name sap.ui.webc.main.ColorPaletteItem.prototype.selected
-	 * @defaultvalue false
-	 * @since 1.19.0
-	 */
-	@property({ type: Boolean })
-	selected!: boolean;
-
-	/**
 	 * Defines the tab-index of the element, helper information for the ItemNavigation.
 	 * @private
 	 */
@@ -121,15 +106,6 @@ class ColorPaletteItem extends UI5Element implements ITabbable {
 		return {
 			root: {
 				"background-color": this.value,
-			},
-		};
-	}
-
-	get classes() {
-		return {
-			root: {
-				"ui5-cp-item": true,
-				"ui5-cp-selected": this.selected,
 			},
 		};
 	}

--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -8,8 +8,7 @@
 	box-sizing: border-box;
 }
 
-:host(:not([_disabled]):hover),
-:host([selected]) {
+:host(:not([_disabled]):hover) {
 	height: var(--_ui5_color-palette-item-hover-height);
 	width: var(--_ui5_color-palette-item-hover-height);
 	margin: var(--_ui5_color-palette-item-hover-margin);
@@ -41,26 +40,14 @@
 	border-radius: 0.1875rem;
 }
 
-.ui5-cp-item:hover:not(:focus),
-.ui5-cp-item.ui5-cp-selected {
-	border: 0.0625rem solid var(--sapGroup_ContentBackground);
+.ui5-cp-item:hover:not(:focus) {
+	border: 1px solid var(--sapGroup_ContentBackground);
 	border-radius: var(--_ui5_color-palette-item-hover-inner-border-radius);
 	box-sizing: border-box;
 }
 
-.ui5-cp-item.ui5-cp-selected:focus,
-:host(:not([_disabled]):not([phone])) .ui5-cp-item:focus,
-:host(:not([_disabled])[phone]) .ui5-cp-item:focus {
+:host(:not([_disabled]):not([phone])) .ui5-cp-item:focus{
 	outline: none;
-}
-
-:host(:not([_disabled])[phone]) .ui5-cp-item:focus {
-	width: 2.875rem; 
-	height: 2.875rem;
-	right: 0.125rem;
-	bottom: 0.125rem;
-	box-shadow: 0 0 0 0.0625rem #FFF, 0 0 0 0.125rem var(--sapContent_ForegroundBorderColor);
-	border: var(--_ui5_color-palette-item-phone-selected-focus);
 }
 
 :host(:not([_disabled]):not([phone]):focus) .ui5-cp-item {
@@ -117,66 +104,4 @@
 	border: var(--_ui5_color-palette-item-after-focus-color);
 	border-radius: var(--_ui5_color-palette-item-after-focus-border-radius);
 	pointer-events: none;
-}
-
-
-/* Specific styling for the selected state */
-
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::after,
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:hover::after {
-	border: var(--_ui5_color-palette-item-selected-focused-border-after);
-}
-
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::before,
-:host([selected]:not([_disabled]):not([phone])) .ui5-cp-item.ui5-cp-selected:focus:hover::before {
-	content: "";
-	box-sizing: border-box;
-	position: absolute;
-	left: var(--_ui5_color-palette-item-selected-focused-border-before);
-	top: var(--_ui5_color-palette-item-selected-focused-border-before);
-	right: var(--_ui5_color-palette-item-selected-focused-border-before);
-	bottom: var(--_ui5_color-palette-item-selected-focused-border-before);
-	border: var(--_ui5_color-palette-item-before-focus-color);
-	border-radius: var(--_ui5_color-palette-item-before-focus-border-radius);
-	pointer-events: none;
-}
-
-/* Phone specific styles for the selected state */
-
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::after,
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:hover::after {
-	content: "";
-	box-sizing: border-box;
-	position: absolute;
-	left: var(--_ui5_color-palette-item-after-focus-offset);
-	top: var(--_ui5_color-palette-item-after-focus-offset);
-	right: var(--_ui5_color-palette-item-after-focus-offset);
-	bottom: var(--_ui5_color-palette-item-after-focus-offset);
-	border: var(--_ui5_color-palette-item-after-focus-color-phone);
-	border-radius: var(--_ui5_color-palette-item-after-focus-border-radius);
-	pointer-events: none;
-}
-
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:not(:hover)::before,
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:focus:hover::before {
-	content: "";
-	box-sizing: border-box;
-	position: absolute;
-	left: var(--_ui5_color-palette-item-selected-focused-border-before);
-	top: var(--_ui5_color-palette-item-selected-focused-border-before);
-	right: var(--_ui5_color-palette-item-selected-focused-border-before);
-	bottom: var(--_ui5_color-palette-item-selected-focused-border-before);
-	border: var(--_ui5_color-palette-item-before-focus-color);
-	border-radius: .1875rem;
-	pointer-events: none;
-}
-
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:not(:focus),
-:host([selected]:not([_disabled])[phone]) .ui5-cp-item.ui5-cp-selected:not(:focus):not(:hover) {
-	width: 2.875rem; 
-	height: 2.875rem;
-	right: 0.125rem;
-	bottom: 0.125rem;
-	border: 0.0625rem solid var(--sapGroup_ContentBackground);
-	box-shadow: 0 0 0 0.0625rem var(--sapContent_ForegroundBorderColor); /* gap */
 }

--- a/packages/main/src/themes/base/ColorPalette-parameters.css
+++ b/packages/main/src/themes/base/ColorPalette-parameters.css
@@ -10,7 +10,6 @@
 	--_ui5_color-palette-item-before-focus-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem dotted black;
-	--_ui5_color-palette-item-selected-focused-border-after: var(--_ui5_color-palette-item-after-focus-color);
 	--_ui5_color-palette-item-after-focus-offset: 0.0625rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0;
@@ -19,7 +18,4 @@
 	--_ui5_color-palette-item-inner-border-radius: 0.1875rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.25rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.1875rem;
-	--_ui5_color-palette-item-selected-focused-border-before: var(--_ui5_color-palette-item-before-focus-hover-offset);
-	--_ui5_color-palette-item-after-focus-color-phone: var(--_ui5_color-palette-item-after-focus-color);
-	--_ui5_color-palette-item-phone-selected-focus: none;
 }

--- a/packages/main/src/themes/sap_horizon/ColorPalette-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ColorPalette-parameters.css
@@ -12,14 +12,10 @@
 	--_ui5_color-palette-item-before-focus-offset: -0.3125rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: -0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem solid var(--sapContent_ContrastFocusColor);
-	--_ui5_color-palette-item-selected-focused-border-after: none;
 	--_ui5_color-palette-item-after-focus-offset: -0.1875rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-after-focus-border-radius: 0.3125rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.375rem;
-	--_ui5_color-palette-item-selected-focused-border-before: -0.1875rem;
-	--_ui5_color-palette-item-after-focus-color-phone: none;
-	--_ui5_color-palette-item-phone-selected-focus: 1px solid var(--sapGroup_ContentBackground);
 }

--- a/packages/main/src/themes/sap_horizon_dark/ColorPalette-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/ColorPalette-parameters.css
@@ -12,14 +12,10 @@
 	--_ui5_color-palette-item-before-focus-offset: -0.3125rem;
 	--_ui5_color-palette-item-before-focus-hover-offset: -0.0625rem;
 	--_ui5_color-palette-item-after-focus-color: 0.0625rem solid var(--sapContent_ContrastFocusColor);
-	--_ui5_color-palette-item-selected-focused-border-after: none;
 	--_ui5_color-palette-item-after-focus-offset: -0.1875rem;
 	--_ui5_color-palette-item-after-focus-hover-offset: 0.0625rem;
 	--_ui5_color-palette-item-before-focus-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-after-focus-border-radius: 0.3125rem;
 	--_ui5_color-palette-item-hover-outer-border-radius: 0.4375rem;
 	--_ui5_color-palette-item-hover-inner-border-radius: 0.375rem;
-	--_ui5_color-palette-item-selected-focused-border-before: -0.1875rem;
-	--_ui5_color-palette-item-after-focus-color-phone: none;
-	--_ui5_color-palette-item-phone-selected-focus: 1px solid var(--sapGroup_ContentBackground);
 }

--- a/packages/main/test/pages/ColorPalette.html
+++ b/packages/main/test/pages/ColorPalette.html
@@ -20,12 +20,12 @@
 
 <body class="colorpalette1auto">
 	<ui5-color-palette id="cp1">
-		<ui5-color-palette-item selected value="darkblue"></ui5-color-palette-item>
-		<ui5-color-palette-item selected value="pink"></ui5-color-palette-item>
-		<ui5-color-palette-item selected value="#444444"></ui5-color-palette-item>
-		<ui5-color-palette-item selected value="rgb(0,200,0)"></ui5-color-palette-item>
-		<ui5-color-palette-item selected value="green"></ui5-color-palette-item>
-		<ui5-color-palette-item selected value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
 		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
 		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -40,6 +40,8 @@ describe("ColorPalette interactions", () => {
 		await item.keys("ArrowLeft");
 		await item.keys("Space");
 
+		await colorPalette.keys("Space");
+
 		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "#ff6699", "Check if selected value is #ff6699");
 	});
 
@@ -118,31 +120,4 @@ describe("ColorPalette interactions", () => {
 		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[3].getProperty("value"), "darkblue");
 		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[4].getProperty("value"), "pink");
 	});
-
-	it("Tests if selected state is properly set", async () => {
-		const colorPalette = await browser.$("#cp1");
-		const colorPaletteEntries = await colorPalette.$$("[ui5-color-palette-item]");
-
-		await colorPaletteEntries[0].click();
-		await colorPaletteEntries[1].click();
-		await colorPaletteEntries[2].click();
-
-		assert.strictEqual(await colorPaletteEntries[2].getProperty("selected"), true, "Check if selected state is set");
-
-		await colorPaletteEntries[2].click();
-
-		assert.strictEqual(await colorPaletteEntries[2].getProperty("selected"), false, "Check if selected state is removed, after clicking on the same item again");
-	});
-
-	it("Clicking on an empty color-palette-item in the Recent Colors wrapper, should not get selected", async () => {
-		await browser.url(`test/pages/ColorPalette.html`);
-
-		const colorPalette = await browser.$("#cp4");
-		const colorPaletteRecentColorsWrapper = await colorPalette.shadow$(".ui5-cp-recent-colors-wrapper");
-		const colorPaletteRecentColorsWrapperEntries = await colorPaletteRecentColorsWrapper.$$("[ui5-color-palette-item]");
-
-		await colorPaletteRecentColorsWrapperEntries[0].click();
-
-		assert.strictEqual(await colorPaletteRecentColorsWrapperEntries[0].getProperty("selected"), false, "Check if selected state is set");
-	})
 });


### PR DESCRIPTION
Due to lack of clear guidelines around the interaction, we currently decided to not move forward with the `selected` state feature in our ColorPalette's components, and revert the current implementation, until a finalized guidelines are provided in order avoid unwanted and inconsistent interaction behaviour.

Revert of: #7598 

Closes: #7731