### PR TITLE
fix(ui5-menu): verify type of `getElementById`

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -386,7 +386,9 @@ class Menu extends UI5Element {
 		}
 		if (this.open) {
 			const rootNode = this.getRootNode() as Document;
-			const opener = this.opener instanceof HTMLElement ? this.opener : rootNode && rootNode.getElementById(this.opener);
+			const opener = this.opener instanceof HTMLElement
+				? this.opener
+				: (rootNode && typeof rootNode.getElementById === "function") && rootNode.getElementById(this.opener);
 
 			if (opener) {
 				this.showAt(opener);


### PR DESCRIPTION
In React Cypress component tests, `rootNode.getElementById` is sometimes undefined. Verifying that `rootNode.getElementById` is a function prevents exception throw in these tests.

**Thank you for your contribution!** 👏


### PR checklist
- [x] Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [x] Add proper description about the background of the change and the change itself

- [x] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [x] Read the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
