### PR TITLE
fix(ui5-popover): correct arrow position

### DIFF
--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -668,6 +668,11 @@ class Popover extends Popup {
 			safeRangeForArrowX,
 		);
 
+		if (isVertical) {
+			// if the target is with small width - only icon button for example
+			const arrowTranslateXMinimum = -(popoverSize.width / 2 - (targetRect.width / 2 + targetRect.left) + ARROW_SIZE);
+			arrowTranslateX = (arrowTranslateX < arrowTranslateXMinimum) ? arrowTranslateX : arrowTranslateXMinimum;
+		}
 		return {
 			x: Math.round(arrowTranslateX),
 			y: Math.round(arrowTranslateY),

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -673,6 +673,7 @@ class Popover extends Popup {
 			const arrowTranslateXMinimum = -(popoverSize.width / 2 - (targetRect.width / 2 + targetRect.left) + ARROW_SIZE);
 			arrowTranslateX = (arrowTranslateX < arrowTranslateXMinimum) ? arrowTranslateX : arrowTranslateXMinimum;
 		}
+
 		return {
 			x: Math.round(arrowTranslateX),
 			y: Math.round(arrowTranslateY),

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -20,7 +20,7 @@
 :host([actual-placement-type="Bottom"]) .ui5-popover-arrow {
 	left: calc(50% - 0.5625rem);
 	top: -0.5rem;
-	height: 0.5625rem;
+	height: 0.5rem;
 }
 
 :host([actual-placement-type="Bottom"]) .ui5-popover-arrow:after {
@@ -74,7 +74,7 @@
 .ui5-popover-arrow {
 	pointer-events: none;
 	display: block;
-	width: 1rem;
+	width: calc(1rem + 2px);
 	height: 1rem;
 	position: absolute;
 	overflow: hidden;

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -343,6 +343,10 @@
 	<br>
 	<br>
 
+	<div class="popover12auto-left">
+		<ui5-button id="btnOpenDynamicLeft" icon="overflow"></ui5-button>
+	</div>
+
 	<div class="popover12auto">
 		<ui5-button id="btnOpenDynamic" icon="overflow"></ui5-button>
 	</div>
@@ -556,6 +560,20 @@
 		secondBtn.addEventListener("click", function (event) {
 			popNoFocusableContent.innerHTML = "Second button is clicked";
 			popNoFocusableContent.showAt(event.target);
+		});
+
+		btnOpenDynamicLeft.addEventListener("click", function () {
+			var popoverLeft = document.createElement("ui5-popover"),
+				buttonLeft = document.createElement("ui5-button");
+
+			buttonLeft.textContent = "Focusable element";
+			popoverLeft.appendChild(buttonLeft);
+			popoverLeft.setAttribute("id", "dynamic-popover-left");
+			popoverLeft.setAttribute("placement-type", "Bottom");
+
+			document.body.appendChild(popoverLeft);
+
+			popoverLeft.showAt(btnOpenDynamicLeft);
 		});
 
 		btnOpenDynamic.addEventListener("click", function () {

--- a/packages/main/test/pages/styles/PopoverArrowBounds.css
+++ b/packages/main/test/pages/styles/PopoverArrowBounds.css
@@ -5,31 +5,37 @@
 #myBtn1 {
 	top: 0;
 	left: 0;
+	margin: 10px;
 }
 
 #myBtn2 {
 	top: 40px;
 	right: 0;
+	margin:10px;
 }
 
 #myBtn3 {
 	top: 50%;
 	left: 0;
+	margin:10px;
 }
 
 #myBtn4 {
 	top: 50%;
 	right: 0;
+	margin:10px;
 }
 
 #myBtn5 {
 	bottom: 0;
 	left: 0;
+	margin:10px;
 }
 
 #myBtn6 {
 	bottom: 0;
 	right: 0;
+	margin:10px;
 }
 
 #customSizeBtn {


### PR DESCRIPTION
In case when the target is button with small width the arrow should be centered to the button.

Fixes #7152