### PR TITLE
chore: Update commit conventions to include commits with samples

### DIFF
--- a/docs/6-contributing/02-conventions-and-guidelines.md
+++ b/docs/6-contributing/02-conventions-and-guidelines.md
@@ -24,7 +24,7 @@ The commit header is the first line of the commit message. It consists of three 
 - It must be one of the following:
     + `fix` - a bug fix (note: this will indicate a release). If possible, include a test in your change.
     + `feat` - a new feature (note: this will indicate a release)
-    + `docs` - documentation only changes
+    + `docs` - changes to the documentation or samples
     + `style` - changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
     + `refactor` - a code change that neither fixes a bug nor adds a feature
     + `perf` - a code change that improves performance


### PR DESCRIPTION
Added text to specify when a commit changes only a sample, that is should be prefixed with 'docs'.
This is already the case in practice: https://github.com/search?q=repo%3ASAP%2Fui5-webcomponents+%22docs%3A%22&type=commits
