### PR TITLE
fix: declare webpackChunkName in generated dynamic imports for readable runtime bundle names

### DIFF
--- a/packages/localization/lib/generate-json-imports/cldr.js
+++ b/packages/localization/lib/generate-json-imports/cldr.js
@@ -4,7 +4,7 @@ import assets from "@ui5/webcomponents-tools/assets-meta.js";
 const allLocales = assets.locales.all;
 
 const imports = allLocales.map(locale => `import ${locale} from "../assets/cldr/${locale}.json";`).join("\n");
-const caseImports = allLocales.map(locale => `\t\tcase "${locale}": return (await import("../assets/cldr/${locale}.json")).default;`).join("\n");
+const caseImports = allLocales.map(locale => `\t\tcase "${locale}": return (await import(/* webpackChunkName: "ui5-webcomponents-cldr-${locale}" */ "../assets/cldr/${locale}.json")).default;`).join("\n");
 const localesKeys = allLocales.join(",");
 const localesKeysStrArray = allLocales.map(_ => `"${_}"`).join(",");
 

--- a/packages/tools/lib/generate-json-imports/i18n.js
+++ b/packages/tools/lib/generate-json-imports/i18n.js
@@ -56,7 +56,7 @@ localeIds.forEach(localeId => {
 `;
 
 		// Actual imports for json assets
-		const dynamicImportsString = languages.map(key => `		case "${key}": return (await import("../assets/i18n/messagebundle_${key}.json")).default;`).join("\n");
+		const dynamicImportsString = languages.map(key => `		case "${key}": return (await import(/* webpackChunkName: "${packageName.replace("@", "").replace("/", "-")}-messagebundle-${key}" */ "../assets/i18n/messagebundle_${key}.json")).default;`).join("\n");
 
 		// Resulting file content
 		contentDynamic = `import { registerI18nLoader } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";

--- a/packages/tools/lib/generate-json-imports/themes.js
+++ b/packages/tools/lib/generate-json-imports/themes.js
@@ -22,7 +22,7 @@ const generate = async () => {
 	const importLines = themesOnFileSystem.map(theme => `import ${theme} from "../assets/themes/${theme}/parameters-bundle.css.json";`).join("\n");
 	const themeUrlsByName = "{\n" + themesOnFileSystem.join(",\n") + "\n}";
 	const availableThemesArray = `[${themesOnFileSystem.map(theme => `"${theme}"`).join(", ")}]`;
-	const dynamicImportLines = themesOnFileSystem.map(theme => `\t\tcase "${theme}": return (await import("../assets/themes/${theme}/parameters-bundle.css.json")).default;`).join("\n");
+	const dynamicImportLines = themesOnFileSystem.map(theme => `\t\tcase "${theme}": return (await import(/* webpackChunkName: "${packageName.replace("@", "").replace("/", "-")}-${theme.replace("_", "-")}-parameters-bundle" */"../assets/themes/${theme}/parameters-bundle.css.json")).default;`).join("\n");
 
 
 // static imports file content


### PR DESCRIPTION
This change will not affect any logic, but will make it so that build systems, such as Webpack, that use the `webpackChunkName` magic comment as a directive to assign a runtime bundle name, will now have more readable names for generated resources that are loaded via dynamic import (e.g. localized strings, localization data, themes).

For example, here is the network trace from SAC built with webpack:

<img width="1179" alt="image" src="https://github.com/SAP/ui5-webcomponents/assets/984276/8af7eca1-9d58-41c5-8176-da9495ce1c7b">

&nbsp;
And here are a sample of the bundles (from each package) as they appear on disk in my build:

<img width="942" alt="image" src="https://github.com/SAP/ui5-webcomponents/assets/984276/3b83d0e1-0759-4ed1-b60d-bd9f52227433">

Fixes #7716
