### PR TITLE
feat(ui5-dynamic-page): add breadcrumbs responsiveness

### DIFF
--- a/packages/fiori/src/DynamicPageTitle.hbs
+++ b/packages/fiori/src/DynamicPageTitle.hbs
@@ -1,7 +1,7 @@
 <div class="{{classes.root}}">
-  <div class="{{classes.breadcrumbs}}">
+  <div class="{{classes.topArea}}">
     {{#if hasBreadcrumb}}
-      <div>
+      <div class="{{classes.breadcrumbs}}">
         <slot name="breadcrumbs"></slot>
       </div>
     {{/if}}
@@ -16,9 +16,11 @@
       <slot name="{{headingSlotName}}"></slot>
     </div>
 
-    <div class="{{classes.content}}">
+   {{#if hasContent}}
+    <div class="{{classes.content}}"
       <slot></slot>
     </div>
+    {{/if}}
 
     <div class="{{classes.actions}}">
       <slot name="actions"></slot>

--- a/packages/fiori/src/DynamicPageTitle.ts
+++ b/packages/fiori/src/DynamicPageTitle.ts
@@ -85,6 +85,10 @@ class DynamicPageTitle extends UI5Element {
 		return !!this.breadcrumbs.length;
 	}
 
+	get hasContent() {
+		return !!this.content.length;
+	}
+
 	get hasHeading() {
 		return !!this.heading.length;
 	}
@@ -107,6 +111,9 @@ class DynamicPageTitle extends UI5Element {
 		return {
 			root: {
 				"ui5-dynamic-page-title-root": true,
+			},
+			topArea: {
+				"ui5-dynamic-page-title--top-area": true,
 			},
 			breadcrumbs: {
 				"ui5-dynamic-page-title--breadcrumbs": true,

--- a/packages/fiori/src/themes/DynamicPageTitle.css
+++ b/packages/fiori/src/themes/DynamicPageTitle.css
@@ -111,8 +111,12 @@
     flex: 0 1;
 }
 
-.ui5-dynamic-page-title--breadcrumbs {
+.ui5-dynamic-page-title--top-area {
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+.ui5-dynamic-page-title--breadcrumbs {
+    width: 100%;
 }

--- a/packages/fiori/test/pages/DynamicPage.html
+++ b/packages/fiori/test/pages/DynamicPage.html
@@ -69,8 +69,8 @@
                 </ui5-toolbar>
 
                 <ui5-toolbar slot="navigationActions">
-                    <ui5-toolbar-button icon="edit"></ui5-toolbar-button>
-                    <ui5-toolbar-button icon="delete"></ui5-toolbar-button>
+                    <ui5-toolbar-button icon="full-screen"></ui5-toolbar-button>
+                    <ui5-toolbar-button icon="decline"></ui5-toolbar-button>
                 </ui5-toolbar>
             </ui5-dynamic-page-title>
             <ui5-dynamic-page-header slot="headerArea">

--- a/packages/fiori/test/pages/styles/DynamicPage.css
+++ b/packages/fiori/test/pages/styles/DynamicPage.css
@@ -1,3 +1,4 @@
 html, body {
     height: 100%;
+    margin: 0;
 }

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -7,6 +7,7 @@ import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import {
 	isEnter,
 	isSpace,
@@ -252,7 +253,9 @@ class Breadcrumbs extends UI5Element {
 		this._preprocessItems();
 	}
 
-	onAfterRendering() {
+	async onAfterRendering() {
+		await renderFinished();
+
 		this._cacheWidths();
 		this._updateOverflow();
 	}


### PR DESCRIPTION

Two changes in the ui5-dynamic-page-title:
--The breadcrumbs now take the horizontal space that remains after positioning the navigation actions
--The content area no longer takes space if no content provided from app-side