### PR TITLE
docs: mark form properties in TextArea, StepInput

### DIFF
--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -116,6 +116,8 @@ class StepInput extends UI5Element implements IFormElement {
 	 *
 	 * @name sap.ui.webc.main.StepInput.prototype.value
 	 * @type {sap.ui.webc.base.types.Float}
+	 * @formEvents change
+	 * @formProperty
 	 * @defaultvalue 0
 	 * @public
 	 */

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -124,7 +124,7 @@ class TextArea extends UI5Element implements IFormElement {
 	 * @formProperty
 	 * @defaultvalue ""
 	 * @public
-	*/
+	 */
 	@property()
 	value!: string;
 	/**

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -120,9 +120,11 @@ class TextArea extends UI5Element implements IFormElement {
 	 *
 	 * @type {string}
 	 * @name sap.ui.webc.main.TextArea.prototype.value
+	 * @formEvents change input
+	 * @formProperty
 	 * @defaultvalue ""
 	 * @public
-		 */
+	*/
 	@property()
 	value!: string;
 	/**


### PR DESCRIPTION
Adding these tags to the form related "value" property, used by the ui5-webc-ngx wrappers to properly generate the required value accessors so the ui5-webc-ngx wrappers work in Angular reactive forms.