### PR TITLE
fix(framework): redundant fonts loading

### DIFF
--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -105,16 +105,18 @@ const updateStyle = (data: StyleData, name: string, value = "", theme?: string) 
 	}
 };
 
-const hasStyle = (name: string, value = "") => {
+const hasStyle = (name: string, value = ""): boolean => {
 	if (shouldUseLinks()) {
 		return !!document.querySelector(`head>link[${name}="${value}"]`);
 	}
 
+	const styleElement = document.querySelector(`head>style[${name}="${value}"]`);
+
 	if (document.adoptedStyleSheets && !isSafari()) {
-		return !!document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));
+		return !!styleElement || !!document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));
 	}
 
-	return !!document.querySelector(`head>style[${name}="${value}"]`);
+	return !!styleElement;
 };
 
 const removeStyle = (name: string, value = "") => {


### PR DESCRIPTION
Font-families are loaded event when the `<style data-ui5-font-face></style>` element exists because `hasStyle` is returning wrong value if adoptedStyleSheets exist.  With current PR the return value is corrected. 

Fixes: #7867 