### PR TITLE
fix: openui5 support crashes with 1.121-snapshot

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -54,6 +54,7 @@ type Theming = {
 type Formatting = {
 	getCalendarType: () => string,
 	getLegacyDateCalendarCustomizing: () => LegacyDateCalendarCustomizing,
+	getCustomIslamicCalendarData?: () => LegacyDateCalendarCustomizing,
 }
 
 type CalendarUtils = {
@@ -137,7 +138,8 @@ class OpenUI5Support {
 				calendarType: Formatting.getCalendarType(),
 				formatSettings: {
 					firstDayOfWeek: CalendarUtils.getWeekConfigurationValues().firstDayOfWeek,
-					legacyDateCalendarCustomizing: Formatting.getLegacyDateCalendarCustomizing(),
+					legacyDateCalendarCustomizing: Formatting.getCustomIslamicCalendarData?.()
+												?? Formatting.getLegacyDateCalendarCustomizing?.(),
 				},
 			};
 		}


### PR DESCRIPTION
add check for renamed openui5 formatting method

FIXES: #7871 