### PR TITLE
feat(ui5-dynamic-page): action containers respect content width

### DIFF
--- a/packages/fiori/src/DynamicPageTitle.hbs
+++ b/packages/fiori/src/DynamicPageTitle.hbs
@@ -11,21 +11,18 @@
     {{/if}}
   </div>
 
-  <div class="{{classes.wrapper}}"
-  @ui5-_min-content-width-change={{onMinContentWidthChange}}>
+  <div class="{{classes.wrapper}}">
     <div class="{{classes.heading}}">
       <slot name="{{headingSlotName}}"></slot>
     </div>
 
     {{#if hasContent}}
-      <div class="{{classes.content}}"
-        style="{{styles.content}}">
+      <div class="{{classes.content}}">
         <slot></slot>
       </div>
     {{/if}}
 
-    <div class="{{classes.actions}}"
-      style="{{styles.actions}}">
+    <div class="{{classes.actions}}">
       <slot name="actions"></slot>
       {{#unless mobileNavigationActions}}
         <div class="{{classes.actionsSeparator}}"></div>

--- a/packages/fiori/src/DynamicPageTitle.ts
+++ b/packages/fiori/src/DynamicPageTitle.ts
@@ -8,7 +8,6 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type Toolbar from "@ui5/webcomponents/dist/Toolbar.js";
-import type { ToolbarMinWidthChangeEventDetail } from "@ui5/webcomponents/dist/Toolbar.js";
 
 // Template
 import DynamicPageTitleTemplate from "./generated/templates/DynamicPageTitleTemplate.lit.js";
@@ -76,8 +75,6 @@ class DynamicPageTitle extends UI5Element {
 	mobileNavigationActions!: boolean;
 
 	_handleResize: ResizeObserverCallback;
-	minContentWidth?: number;
-	minActionsWidth?: number;
 
 	constructor() {
 		super();
@@ -139,17 +136,6 @@ class DynamicPageTitle extends UI5Element {
 		};
 	}
 
-	get styles() {
-		return {
-			content: {
-				"min-width": `${this.minContentWidth || 0}px`,
-			},
-			actions: {
-				"min-width": `${this.minActionsWidth || 0}px`,
-			},
-		};
-	}
-
 	onEnterDOM() {
 		ResizeHandler.register(this, this._handleResize);
 	}
@@ -175,15 +161,6 @@ class DynamicPageTitle extends UI5Element {
 
 	handleResize() {
 		this.mobileNavigationActions = this.offsetWidth < 1280;
-	}
-
-	onMinContentWidthChange(event: CustomEvent<ToolbarMinWidthChangeEventDetail>) {
-		const slotName = (<HTMLElement>event.target)?.assignedSlot?.name;
-		if (!slotName || slotName === "content") {
-			this.minContentWidth = event.detail.minWidth;
-		} else if (slotName === "actions") {
-			this.minActionsWidth = event.detail.minWidth;
-		}
 	}
 }
 

--- a/packages/fiori/src/themes/DynamicPageTitle.css
+++ b/packages/fiori/src/themes/DynamicPageTitle.css
@@ -76,13 +76,13 @@
 
 .ui5-dynamic-page-title--content {
     flex-shrink: 1.6;
-    min-width: 3rem;
+    min-width: fit-content;
     flex-grow: 1;
 }
 
 .ui5-dynamic-page-title--actions {
     flex-shrink: 1.6;
-    min-width: 3rem;
+    min-width: fit-content;
     flex-grow: 1;
     display: flex;
 }

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -429,12 +429,8 @@ class Toolbar extends UI5Element {
 			minWidth += this.overflowButtonSize;
 		}
 
-		if (minWidth !== this.minContentWidth) {
-			const spaceAroundContent = this.offsetWidth - this.getDomRef()!.offsetWidth;
-			this.fireEvent<ToolbarMinWidthChangeEventDetail>("_min-content-width-change", {
-				minWidth: minWidth + spaceAroundContent,
-			});
-		}
+		const spaceAroundContent = this.offsetWidth - this.getDomRef()!.offsetWidth;
+		this.style.minWidth = `${minWidth + spaceAroundContent}px`;
 
 		this.itemsWidth = totalWidth;
 		this.minContentWidth = minWidth;


### PR DESCRIPTION
- Containers of the actions and the content of the dynamic page title now respect their content's width and don't shirnk below that.
- The toolbar also sets itself a minWidth equal to the combined width of all items that will never overflow. 