### PR TITLE
feat(ui5-dynamic-page): footer no longer takes space when hidden

### DIFF
--- a/packages/fiori/src/DynamicPage.hbs
+++ b/packages/fiori/src/DynamicPage.hbs
@@ -1,5 +1,6 @@
 <div class="{{classes.root}}">
-  <div class="{{classes.scrollContainer}}">
+  <div class="{{classes.scrollContainer}}"
+    @scroll="{{snapOnScroll}}">
     <div class="{{classes.headerWrapper}}">
       <slot name="titleArea"></slot>
       {{#if headerInTitle}}

--- a/packages/fiori/src/DynamicPage.hbs
+++ b/packages/fiori/src/DynamicPage.hbs
@@ -1,36 +1,38 @@
 <div class="{{classes.root}}">
-  <div class="{{classes.headerWrapper}}">
-    <slot name="titleArea"></slot>
-    {{#if headerInTitle}}
-      <slot name="headerArea"></slot>
-    {{/if}}
+  <div class="{{classes.scrollContainer}}">
+    <div class="{{classes.headerWrapper}}">
+      <slot name="titleArea"></slot>
+      {{#if headerInTitle}}
+        <slot name="headerArea"></slot>
+      {{/if}}
 
-    {{#if actionsInTitle}}
-    <ui5-dynamic-page-header-actions
-      ?snapped="{{headerSnapped}}"
-      ?pinned="{{headerPinned}}"
-      @ui5-expand-button-click={{onExpandClick}}
-      @ui5-pin-button-click={{onPinClick}}
-    ></ui5-dynamic-page-header-actions>
-    {{/if}}
-
-  </div>
-
-  <div class="{{classes.content}}">
-    {{#if headerInContent}}
-      <slot name="headerArea"></slot>
-    {{/if}}
-
-    {{#unless actionsInTitle}}
+      {{#if actionsInTitle}}
       <ui5-dynamic-page-header-actions
-          ?snapped="{{headerSnapped}}"
-          ?pinned="{{headerPinned}}"
-          @ui5-expand-button-click={{onExpandClick}}
-          @ui5-pin-button-click={{onPinClick}}
-        ></ui5-dynamic-page-header-actions>
-    {{/unless}}
+        ?snapped="{{headerSnapped}}"
+        ?pinned="{{headerPinned}}"
+        @ui5-expand-button-click={{onExpandClick}}
+        @ui5-pin-button-click={{onPinClick}}
+      ></ui5-dynamic-page-header-actions>
+      {{/if}}
 
-    <slot></slot>
+    </div>
+
+    <div class="{{classes.content}}">
+      {{#if headerInContent}}
+        <slot name="headerArea"></slot>
+      {{/if}}
+
+      {{#unless actionsInTitle}}
+        <ui5-dynamic-page-header-actions
+            ?snapped="{{headerSnapped}}"
+            ?pinned="{{headerPinned}}"
+            @ui5-expand-button-click={{onExpandClick}}
+            @ui5-pin-button-click={{onPinClick}}
+          ></ui5-dynamic-page-header-actions>
+      {{/unless}}
+
+      <slot></slot>
+    </div>
   </div>
 
     <div class="{{classes.footer}}">

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -72,10 +72,6 @@ class DynamicPage extends UI5Element {
 	_debounceInterval?: Timeout | null;
 	showHeaderInStickArea = false;
 
-	onAfterRendering() {
-		this.addEventListener("scroll", this.snapOnScroll.bind(this));
-	}
-
 	get classes() {
 		return {
 			root: {
@@ -104,6 +100,10 @@ class DynamicPage extends UI5Element {
 		return this.querySelector<DynamicPageHeader>("[ui5-dynamic-page-header]");
 	}
 
+	get scrollContainer(): HTMLElement | null | undefined {
+		return this.getDomRef()?.querySelector(".ui5-dynamic-page-scroll-container");
+	}
+
 	get actionsInTitle(): boolean {
 		return this.headerSnapped || this.showHeaderInStickArea || this.headerPinned;
 	}
@@ -120,18 +120,20 @@ class DynamicPage extends UI5Element {
 				return;
 			}
 
-			if (this.iPreviousScrollAmount === this.scrollTop || this.headerPinned) {
+			const scrollTop = this.scrollContainer!.scrollTop;
+
+			if (this.iPreviousScrollAmount === scrollTop || this.headerPinned) {
 				return;
 			}
 
-			this.iPreviousScrollAmount = this.scrollTop;
+			this.iPreviousScrollAmount = scrollTop;
 
 			if (this.isExpanding) {
 				this.isExpanding = false;
 				return;
 			}
 
-			if (this.scrollTop > this.dynamicPageHeader.getBoundingClientRect().height) {
+			if (scrollTop > this.dynamicPageHeader.getBoundingClientRect().height) {
 				this.headerSnapped = true;
 				this.showHeaderInStickArea = false;
 			} else {

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -81,6 +81,9 @@ class DynamicPage extends UI5Element {
 			root: {
 				"ui5-dynamic-page-root": true,
 			},
+			scrollContainer: {
+				"ui5-dynamic-page-scroll-container": true,
+			},
 			headerWrapper: {
 				"ui5-dynamic-page-title-header-wrapper": true,
 			},

--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -10,6 +10,15 @@
 
 :host {
     display: block;
+    height: 100%;
+}
+
+.ui5-dynamic-page-root {
+    height: inherit;
+    overflow-y: hidden;
+}
+
+.ui5-dynamic-page-scroll-container {
     overflow-y: scroll;
     height: 100%;
 }
@@ -24,18 +33,16 @@
     padding: 0 1rem;
 }
 
+:host([show-footer]) .ui5-dynamic-page-content {
+    padding-bottom: 4rem;
+}
+
 :host([show-footer]) .ui5-dynamic-page-footer {
     animation: bounceShow 0.35s forwards ease-in-out;
 }
 
 :host(:not([show-footer])) .ui5-dynamic-page-footer {
     animation: bounceHide 0.35s forwards ease-in-out;
-}
-
-:host {
-    display: block;
-    overflow-y: scroll;
-    height: 100%;
 }
 
 ::slotted([slot="footer"]) {


### PR DESCRIPTION
When the footer is not shown, it is still in the DOM and takes space in order to allow the bouncing animation upon show/hide.

Problem: The above, however, causes scroll overflow of the container where the footer is positioned (when the footer is hidden). 
Solution: Place the footer element outside the scroll container and into a container that has "overflow-y: hidden"

Also isolated a simplified demo (html & CSS only):
with issue: https://jsbin.com/webayekoje/edit?html,output
with fix: https://jsbin.com/mavebagome/edit?html,output