### PR TITLE
fix(framework): enable `72Blackfull` font-family

### DIFF
--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -76,6 +76,12 @@
     font-style: bold;
     font-weight: 900;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black.woff2?ui5-webcomponents) format("woff2"), local('72Black');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122, U+0144;
+}
+
+@font-face {
+	font-family: '72Blackfull';
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black-full.woff2) format('woff2');
 }
 
 @font-face {

--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -80,7 +80,7 @@
 
 @font-face {
 	font-family: '72Blackfull';
-	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black-full.woff2) format('woff2');
+	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black-full.woff2?ui5-webcomponents) format('woff2');
 }
 
 @font-face {

--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -76,7 +76,6 @@
     font-style: bold;
     font-weight: 900;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black.woff2?ui5-webcomponents) format("woff2"), local('72Black');
-    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122, U+0144;
 }
 
 @font-face {

--- a/packages/main/test/pages/FontFace.html
+++ b/packages/main/test/pages/FontFace.html
@@ -16,4 +16,7 @@
 	<div class="boldFamily makeItBold">Hello مرحبًا שלום 你好 Hallo Hola</div>
 	<ui5-label>sapFontFamily</ui5-label>
 	<div class="normal">Hello مرحبًا שלום 你好 Hallo Hola</div>
+
+	<span style="font-family: var(--sapFontBlackFamily);">sapFontBlackFamily </span>
+	<span style="font-family: var(--sapFontBlackFamily);">Dzień </span>
 </body>


### PR DESCRIPTION
Font `72Blackfull` was missing from our font styles and now added. This caused unexpected font issues when `--sapFontBlackFamily` variable is used.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7800

Before - ń is thinner than the rest:
<img width="379" alt="Screenshot 2023-11-24 at 23 07 12" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/d925d892-6a54-4b79-8763-0b1b1a0ddb74">

After (patching it in place) - ń is as thick as the rest:
<img width="375" alt="Screenshot 2023-11-24 at 23 05 54" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/a60f5855-1bb0-4f31-b3e0-4ab145f0d05e">


