### PR TITLE
chore(ui5-badge): enable `font-size` customisation on tag level

### DIFF
--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -15,6 +15,7 @@
 	box-sizing: border-box;
 	font-family: var(--_ui5-badge-font);
 	font-weight: var(--_ui5-badge-font-weight);
+	font-size: var(--_ui5-badge-font-size);
 	text-align: center;
 	letter-spacing: var(--_ui5-badge-letter-spacing);
 }
@@ -36,7 +37,7 @@
 	text-overflow: ellipsis;
 	text-transform: var(--_ui5-badge-text-transform);
 	letter-spacing: inherit;
-	font-size: var(--_ui5-badge-font-size);
+	font-size: inherit;
 }
 
 :host([_icon-only]) {


### PR DESCRIPTION
A lot of css props can be customized on the Badge tag, but the font-size is not one of them. 
With this change we implement the default font-size by SAP Design and enable others to change it easier with css on the tag.

The change is in respond to recent requirements by a stakeholder that has its own Design System (based on SAP Design, but with deviations) to have different sizing of the Badge, including the text font size.