### PR TITLE
feat(ui5-main): table row disable specific rows in multi select mode

### DIFF
--- a/packages/main/src/TableRow.hbs
+++ b/packages/main/src/TableRow.hbs
@@ -28,6 +28,7 @@
 				aria-label="{{ariaLabelRowSelection}}"
 				@ui5-change="{{_handleSelection}}"
 				tabindex="-1"
+				?disabled="{{disabled}}"
 			>
 			</ui5-checkbox>
 		</td>

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -146,6 +146,17 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 	selected!: boolean;
 
 	/**
+	 * Defines whether or not the row is selectable.
+	 *
+	 * @type {boolean}
+	 * @name sap.ui.webc.main.TableRow.prototype.disabled
+	 * @defaultvalue false
+	 * @public
+	 */
+	 @property({ type: Boolean })
+	 disabled!: boolean;
+
+	/**
 	 * Indicates if the table row is navigated.
 	 *
 	 * @type {boolean}


### PR DESCRIPTION
**Thank you for your contribution!** 👏


### PR checklist
- Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- Add proper description about the background of the change and the change itself

**The change adds the "disabled" (naming might have to change) property to the TableRow component, this property is used only in the multiSelect mode, where it will disable the ability to select a row. This allows the client to render a multi select table with items that can be selected and items which cannot be selected, in a way that is intuitive and simple. Note that this property is not in any way related to the type property which is set to either active or inactive, which effects whether or not the item will respond to click events.**

- Link to an existing issue (if available)

**Fixes: {#7932}**

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- Read the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)


