### PR TITLE
chore: support mk_MK, cnr_ME & sr_Cyrl_RS

### DIFF
--- a/packages/tools/assets-meta.js
+++ b/packages/tools/assets-meta.js
@@ -83,7 +83,7 @@ const assetsMeta = {
       "ar_SA",
       "bg",
       "ca",
-      "cnr_ME", // cldr for not available yet - will fallback to browser locale
+      // "cnr_ME" - cldr for not available yet
       "cs",
       "da",
       "de",
@@ -131,7 +131,7 @@ const assetsMeta = {
       "lt",
       "lv",
       "ms",
-      "mk_MK", // cldr for not available - will fallback to browser locale
+      // "mk_MK" cldr not available yet
       "nb",
       "nl",
       "nl_BE",

--- a/packages/tools/assets-meta.js
+++ b/packages/tools/assets-meta.js
@@ -25,6 +25,7 @@ const assetsMeta = {
       "ar",
       "bg",
       "ca",
+      "cnr",
       "cs",
       "cy",
       "da",
@@ -52,6 +53,7 @@ const assetsMeta = {
       "ko",
       "lt",
       "lv",
+      "mk",
       "ms",
       "nl",
       "no",
@@ -63,6 +65,7 @@ const assetsMeta = {
       "sh",
       "sk",
       "sl",
+      "sr",
       "sv",
       "th",
       "tr",
@@ -80,6 +83,7 @@ const assetsMeta = {
       "ar_SA",
       "bg",
       "ca",
+      "cnr_ME", // cldr for not available yet - will fallback to browser locale
       "cs",
       "da",
       "de",
@@ -127,6 +131,7 @@ const assetsMeta = {
       "lt",
       "lv",
       "ms",
+      "mk_MK", // cldr for not available - will fallback to browser locale
       "nb",
       "nl",
       "nl_BE",
@@ -139,6 +144,7 @@ const assetsMeta = {
       "sk",
       "sl",
       "sr",
+      "sr_Cyrl_RS", // cldr not available - will fallback to "sr"
       "sr_Latn",
       "sv",
       "th",

--- a/packages/tools/assets-meta.js
+++ b/packages/tools/assets-meta.js
@@ -144,7 +144,7 @@ const assetsMeta = {
       "sk",
       "sl",
       "sr",
-      "sr_Cyrl_RS", // cldr not available - will fallback to "sr"
+      // "sr_Cyrl_RS" - cldr not available yet
       "sr_Latn",
       "sv",
       "th",


### PR DESCRIPTION
Locales have to be described in assets-meta.js so that the respective loaders are created.
- message bundle props files exist, but they consist of the english translation, the translations are to be provided by the translation service
- CLDRs for the locales don't exist (even in the latest openui5/core version) and only commented entries are added