### PR TITLE
fix(framework): fix font72 for special characters

### DIFF
--- a/packages/base/src/css/FontFace.css
+++ b/packages/base/src/css/FontFace.css
@@ -3,6 +3,7 @@
     font-style: normal;
     font-weight: 400;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Regular.woff2?ui5-webcomponents) format("woff2"), local("72");
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -10,7 +11,6 @@
     font-style: normal;
     font-weight: 400;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Regular-full.woff2?ui5-webcomponents) format("woff2"), local('72-full');
-
 }
 
 @font-face {
@@ -18,6 +18,7 @@
     font-style: normal;
     font-weight: 700;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2"), local('72-Bold');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -31,6 +32,7 @@
     font-family: '72-Bold';
     font-style: normal;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Bold.woff2?ui5-webcomponents) format("woff2"), local('72-Bold');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -43,6 +45,7 @@
     font-family: '72-Light';
     font-style: normal;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Light.woff2?ui5-webcomponents) format("woff2"), local('72-Light');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -54,6 +57,7 @@
 @font-face {
 	font-family: '72Mono';
 	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Regular.woff2?ui5-webcomponents) format('woff2'), local('72Mono');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -64,6 +68,7 @@
 @font-face {
 	font-family: '72Mono-Bold';
 	src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72Mono-Bold.woff2?ui5-webcomponents) format('woff2'), local('72Mono-Bold');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -76,6 +81,7 @@
     font-style: bold;
     font-weight: 900;
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-Black.woff2?ui5-webcomponents) format("woff2"), local('72Black');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }
 
 @font-face {
@@ -86,4 +92,5 @@
 @font-face {
     font-family: "72-SemiboldDuplex";
     src: url(https://sdk.openui5.org/resources/sap/ui/core/themes/sap_horizon/fonts/72-SemiboldDuplex.woff2?ui5-webcomponents) format("woff2"), local('72-SemiboldDuplex');
+    unicode-range: U+00, U+0D, U+20-7E, U+A0-FF, U+131, U+152-153, U+161, U+178, U+17D-17E, U+192, U+237, U+2C6, U+2DC, U+3BC, U+1E9E, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+20AC, U+2122;
 }

--- a/packages/main/test/pages/FontFace.html
+++ b/packages/main/test/pages/FontFace.html
@@ -19,4 +19,6 @@
 
 	<span style="font-family: var(--sapFontBlackFamily);">sapFontBlackFamily </span>
 	<span style="font-family: var(--sapFontBlackFamily);">Dzień </span>
+	<span style="font-family: var(--sapFontBlackFamily);">Čeněk Pěč  Martina Tarageĺ </span>
+	<ui5-input value="Čeněk Pěč  Martina Tarageĺ"></ui5-input>
 </body>


### PR DESCRIPTION
**Fixes the appearance of special characters** by adding unicode-range to extend the range of characters of our font family.
The PR follows the used unicode-ranges in SAPUI5 see the following [change](https://github.com/SAP/openui5/commit/17b3ae4c3b87a7d257538f4ac853d6ceb92f7c78) from Jun 2023

**Fixes**: https://github.com/SAP/ui5-webcomponents/issues/7948

**Before** (see the first and the last characters)
<img width="576" alt="Screenshot 2023-12-02 at 19 22 44" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/f2f8188b-3e30-4372-abe9-6c1e2e8166a3">

**After**
<img width="590" alt="Screenshot 2023-12-02 at 19 21 53" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/c43e8691-5bfb-490b-ab1e-f4167ba02408">




