### PR TITLE
fix(ui5-table-row): fix runtime exception in test env execution

### DIFF
--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -331,8 +331,8 @@ class TableRow extends UI5Element implements ITableRow, ITabbable {
 		this.fireEvent<TableRowSelectionRequestedEventDetail>("selection-requested", { row: this });
 	}
 
-	_activeElementHasAttribute(attr: string) {
-		return (this.getRootNode() as Document).activeElement!.hasAttribute(attr);
+	_activeElementHasAttribute(attr: string): boolean {
+		return !!((this.getRootNode() as Document).activeElement?.hasAttribute(attr));
 	}
 
 	get _ariaCurrent() {


### PR DESCRIPTION
Assuming that the activeElement is guaranteed to be non-null object is **not** entirely valid although in real case usages, nobody had a problem.
However, in a test execution environment, the authors of the linked issue got an execution thrown by `activeElement!.hasAttribute` and I think it's best to ensure this can't happen as done with the change.


Fixes: https://github.com/SAP/ui5-webcomponents/issues/7787