### PR TITLE
refactor(ui5-menu): submenus defined as ui5-menu components (PoC)

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -6,7 +6,7 @@
 	vertical-align={{verticalAlign}}
 	hide-arrow
 	allow-target-overlap
-	?sub-menu={{_isSubMenu}}
+	?sub-menu={{_isSubmenu}}
 	@ui5-before-open={{_beforePopoverOpen}}
 	@ui5-after-open={{_afterPopoverOpen}}
 	@ui5-before-close={{_beforePopoverClose}}
@@ -69,7 +69,7 @@
 				._ariaHasPopup={{this.ariaHasPopup}}
 				?disabled={{this.item.disabled}}
 				?starts-section={{this.item.startsSection}}
-				?selected={{this.item.subMenuOpened}}
+				?selected={{this.item.submenuOpened}}
 				?is-phone={{../isPhone}}
 				@mouseover={{../_itemMouseOver}}
 				@mouseout={{../_itemMouseOut}}
@@ -109,8 +109,3 @@
 	{{/if}}
 	</div>
 </ui5-responsive-popover>
-
-<div
-	class="ui5-menu-submenus"
->
-</div>

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -17,7 +17,7 @@
 		slot="header"
 		class="ui5-menu-dialog-header"
 	>
-	{{#if isSubMenuOpened}}
+	{{#if isSubmenuOpened}}
 		<ui5-button
 			icon="nav-back"
 			class="ui5-menu-back-button"

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -87,11 +87,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * <code>import "@ui5/webcomponents/dist/Menu.js";</code>
  *
  * @constructor
- * @author SAP SE
- * @alias sap.ui.webc.main.Menu
- * @extends sap.ui.webc.base.UI5Element
- * @tagname ui5-menu
- * @appenddocs sap.ui.webc.main.MenuItem
+ * @extends UI5Element
  * @since 1.3.0
  * @public
  */
@@ -114,7 +110,6 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * Fired when an item is being clicked.
  * <b>Note:</b> Since 1.17.0 the event is preventable, allowing the menu to remain open after an item is pressed.
  *
- * @event sap.ui.webc.main.Menu#item-click
  * @allowPreventDefault
  * @param { HTMLElement } item The currently clicked menu item.
  * @param { string } text The text of the currently clicked menu item.
@@ -122,9 +117,15 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  */
 @event("item-click", {
 	detail: {
+		/**
+		 * @public
+		 */
 		item: {
 			type: HTMLElement,
 		},
+		/**
+		 * @public
+		 */
 		text: {
 			type: String,
 		},
@@ -136,13 +137,15 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * <b>Note:</b> Since 1.14.0 the event is also fired before a sub-menu opens.
  *
  * @public
- * @event sap.ui.webc.main.Menu#before-open
  * @allowPreventDefault
  * @since 1.10.0
  * @param { HTMLElement } item The <code>ui5-menu-item</code> that triggers opening of the sub-menu or undefined when fired upon root menu opening. <b>Note:</b> available since 1.14.0.
  */
 @event("before-open", {
 	detail: {
+		/**
+		 * @public
+		 */
 		item: {
 			type: HTMLElement,
 		},
@@ -153,7 +156,6 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * Fired after the menu is opened. <b>This event does not bubble.</b>
  *
  * @public
- * @event sap.ui.webc.main.Menu#after-open
  * @since 1.10.0
  */
 @event("after-open")
@@ -162,14 +164,18 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * Fired before the menu is closed. This event can be cancelled, which will prevent the menu from closing. <b>This event does not bubble.</b>
  *
  * @public
- * @event sap.ui.webc.main.Menu#before-close
  * @allowPreventDefault
  * @param {boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
  * @since 1.10.0
  */
 @event("before-close", {
 	detail: {
-		escPressed: { type: Boolean },
+		/**
+		 * @public
+		 */
+		escPressed: {
+			type: Boolean,
+		},
 	},
 })
 
@@ -177,7 +183,6 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * Fired after the menu is closed. <b>This event does not bubble.</b>
  *
  * @public
- * @event sap.ui.webc.main.Menu#after-close
  * @since 1.10.0
  */
 @event("after-close")
@@ -185,9 +190,7 @@ class Menu extends UI5Element {
 	/**
 	 * Defines the header text of the menu (displayed on mobile).
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.headerText
-	 * @type {string}
-	 * @defaultvalue ""
+	 * @default ""
 	 * @public
 	 */
 	@property()
@@ -196,10 +199,8 @@ class Menu extends UI5Element {
 	/**
 	 * Indicates if the menu is open
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.open
 	 * @public
-	 * @type {boolean}
-	 * @defaultvalue false
+	 * @default false
 	 * @since 1.10.0
 	 */
 	@property({ type: Boolean })
@@ -208,9 +209,7 @@ class Menu extends UI5Element {
 	/**
 	 * Defines if a loading indicator would be displayed inside the corresponding ui5-menu popover.
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.busy
-	 * @type {boolean}
-	 * @defaultvalue false
+	 * @default false
 	 * @public
 	 * @since 1.13.0
 	 */
@@ -220,9 +219,7 @@ class Menu extends UI5Element {
 	/**
 	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover..
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.busyDelay
-	 * @type {sap.ui.webc.base.types.Integer}
-	 * @defaultValue 1000
+	 * @default 1000
 	 * @public
 	 * @since 1.13.0
 	 */
@@ -232,38 +229,27 @@ class Menu extends UI5Element {
 	/**
 	 * Defines the ID or DOM Reference of the element that the menu is shown at
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.opener
+	 * @default ""
 	 * @public
-	 * @type {sap.ui.webc.base.types.DOMReference}
-	 * @defaultvalue ""
 	 * @since 1.10.0
 	 */
 	@property({ validator: DOMReference, defaultValue: "" })
 	opener!: HTMLElement | string;
 
 	/**
-	 * Defines if the menu is sub-menu (not first-level).
-	 * @type {boolean}
-	 * @defaultvalue false
-	 * @private
-	 */
-	@property({ type: Boolean, noAttribute: true })
-	_isSubMenu!: boolean;
-
-	/**
 	 * Stores id of a list item that opened sub-menu.
-	 * @type {string}
+	 *
 	 * @private
 	 */
 	@property()
-	_subMenuOpenerId!: string;
+	_submenuOpenerId!: string;
 
 	/**
 	 * Defines the currently available menu items.
 	 * (in case of non-phone devices these are the items of the menu,
 	 * but for phone devices the items of the currently opened sub-menu
 	 * will be populated here)
-	 * @type {array}
+	 *
 	 * @private
 	 */
 	@property({ type: Object, multiple: true })
@@ -271,7 +257,7 @@ class Menu extends UI5Element {
 
 	/**
 	 * Stores a list of parent menu items for each sub-menu (on phone).
-	 * @type {array}
+	 *
 	 * @private
 	 */
 	@property({ type: Object, multiple: true })
@@ -293,16 +279,19 @@ class Menu extends UI5Element {
 	 * Stores menu item that have sub-menu opened.
 	 */
 	@property({ type: Object, defaultValue: undefined })
-	_openedSubMenuItem?: MenuItem;
+	_openedSubmenuItem?: MenuItem;
+
+	/**
+	 * Stores menu item that is currently hovered.
+	 */
+	@property({ type: Object, defaultValue: undefined })
+	_hoveredSubmenuItem?: OpenerStandardListItem;
 
 	/**
 	 * Defines the items of this component.
 	 * <br><br>
 	 * <b>Note:</b> Use <code>ui5-menu-item</code> for the intended design.
 	 *
-	 * @name sap.ui.webc.main.Menu.prototype.default
-	 * @type {sap.ui.webc.main.IMenuItem[]}
-	 * @slot items
 	 * @public
 	 */
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
@@ -316,7 +305,7 @@ class Menu extends UI5Element {
 	}
 
 	get itemsWithChildren() {
-		return !!this._currentItems.filter(item => item.item.items.length).length;
+		return !!this._currentItems.filter(item => item.item.submenu && item.item.submenu.items.length).length;
 	}
 
 	get itemsWithIcon() {
@@ -329,11 +318,11 @@ class Menu extends UI5Element {
 
 	get placementType() {
 		const placement = this.isRtl ? "Left" : "Right";
-		return this._isSubMenu ? placement : "Bottom";
+		return this._isSubmenu ? placement : "Bottom";
 	}
 
 	get verticalAlign() {
-		return this._isSubMenu ? "Top" : "Bottom";
+		return this._isSubmenu ? "Top" : "Bottom";
 	}
 
 	get labelBack() {
@@ -348,7 +337,7 @@ class Menu extends UI5Element {
 		return isPhone();
 	}
 
-	get isSubMenuOpened() {
+	get isSubmenuOpened() {
 		return !!this._parentMenuItem;
 	}
 
@@ -356,28 +345,20 @@ class Menu extends UI5Element {
 		return this._parentMenuItem ? this._parentMenuItem.text : this.headerText;
 	}
 
+	get _parentItem(): HTMLElement | undefined {
+		const parent = this.parentElement;
+
+		return parent && parent.tagName.toLowerCase() === "ui5-menu-item" ? parent : undefined;
+	}
+
+	get _isSubmenu() {
+		const parent = this.parentElement;
+
+		return parent && parent.tagName.toLowerCase() === "ui5-menu-item";
+	}
+
 	onBeforeRendering() {
 		!isPhone() && this._prepareCurrentItems(this.items);
-
-		const itemsWithChildren = this.itemsWithChildren;
-		const itemsWithIcon = this.itemsWithIcon;
-
-		this._currentItems.forEach(item => {
-			item.item._siblingsWithChildren = itemsWithChildren;
-			item.item._siblingsWithIcon = itemsWithIcon;
-			const subMenu = item.item._subMenu;
-			const menuItem = item.item;
-			if (subMenu && subMenu.busy) {
-				subMenu.innerHTML = "";
-				const fragment = this._clonedItemsFragment(menuItem);
-				subMenu.appendChild(fragment);
-			}
-
-			if (subMenu) {
-				subMenu.busy = item.item.busy;
-				subMenu.busyDelay = item.item.busyDelay;
-			}
-		});
 	}
 
 	onAfterRendering() {
@@ -398,17 +379,16 @@ class Menu extends UI5Element {
 
 	/**
 	 * Shows the Menu near the opener element.
+	 *
 	 * @param {HTMLElement} opener the element that the popover is shown at
 	 * @public
-	 * @method
-	 * @name sap.ui.webc.main.Menu#showAt
 	 */
-	async showAt(opener: HTMLElement) {
+	async showAt(opener: HTMLElement): Promise<void> {
 		if (isPhone()) {
 			this._prepareCurrentItems(this.items);
 			this._parentItemsStack = [];
 		}
-		if (!this._isSubMenu) {
+		if (!this._isSubmenu) {
 			this._parentMenuItem = undefined;
 		}
 		const popover = await this._createPopover();
@@ -424,11 +404,10 @@ class Menu extends UI5Element {
 
 	/**
 	 * Closes the Menu.
+	 *
 	 * @public
-	 * @method
-	 * @name sap.ui.webc.main.Menu#close
 	 */
-	close() {
+	close(): void {
 		if (this._popover) {
 			if (isPhone()) {
 				this._parentItemsStack = [];
@@ -449,7 +428,7 @@ class Menu extends UI5Element {
 
 		this.focus();
 		if (parentMenuItem) {
-			const parentMenuItemParent = parentMenuItem.parentElement as MenuItem;
+			const parentMenuItemParent = parentMenuItem.parentElement as Menu;
 			this._prepareCurrentItems(parentMenuItemParent.items);
 			this._parentMenuItem = this._parentItemsStack.length ? this._parentItemsStack[this._parentItemsStack.length - 1] : undefined;
 		}
@@ -465,87 +444,63 @@ class Menu extends UI5Element {
 		});
 	}
 
-	_createSubMenu(item: MenuItem, openerId: string) {
-		const ctor = this.constructor as typeof Menu;
-		const subMenu = document.createElement(ctor.getMetadata().getTag()) as Menu;
-
-		subMenu._isSubMenu = true;
-		subMenu.setAttribute("id", `submenu-${openerId}`);
-		subMenu._parentMenuItem = item;
-		subMenu.busy = item.busy;
-		subMenu.busyDelay = item.busyDelay;
-		const fragment = this._clonedItemsFragment(item);
-		subMenu.appendChild(fragment);
-		this.staticAreaItem!.shadowRoot!.querySelector(".ui5-menu-submenus")!.appendChild(subMenu);
-		item._subMenu = subMenu;
-	}
-
-	_clonedItemsFragment(item: MenuItem) {
-		const fragment = document.createDocumentFragment();
-
-		for (let i = 0; i < item.items.length; ++i) {
-			const clonedItem = item.items[i].cloneNode(true);
-			fragment.appendChild(clonedItem);
-		}
-
-		return fragment;
-	}
-
-	_openItemSubMenu(item: MenuItem, opener: HTMLElement, actionId: string) {
+	_openItemSubmenu(item: MenuItem, opener: HTMLElement, actionId: string) {
 		const mainMenu = this._findMainMenu(item);
 		mainMenu.fireEvent<MenuBeforeOpenEventDetail>("before-open", {
 			item,
 		}, false, false);
-		item._subMenu!.showAt(opener);
-		item._preventSubMenuClose = true;
-		this._openedSubMenuItem = item;
-		this._subMenuOpenerId = actionId;
+		item.submenu && item.submenu.showAt(opener);
+		item._preventSubmenuClose = true;
+		this._openedSubmenuItem = item;
+		this._submenuOpenerId = actionId;
 	}
 
-	_closeItemSubMenu(item: MenuItem, forceClose = false) {
+	_closeItemSubmenu(item: MenuItem, forceClose = false) {
 		if (item) {
 			if (forceClose) {
-				item._preventSubMenuClose = false;
-				this._closeSubMenuPopover(item._subMenu!, true);
+				item._preventSubmenuClose = false;
+				item.submenu && this._closeSubmenuPopover(item.submenu, true);
 			} else {
-				setTimeout(() => this._closeSubMenuPopover(item._subMenu!), 0);
+				setTimeout(() => item.submenu && this._closeSubmenuPopover(item.submenu), 0);
 			}
 		}
 	}
 
-	_closeSubMenuPopover(subMenu: Menu, forceClose = false) {
-		if (subMenu) {
-			const parentItem = subMenu._parentMenuItem!;
+	_closeSubmenuPopover(submenu: Menu, forceClose = false) {
+		if (submenu) {
+			const parentItem = submenu._parentMenuItem!;
 
-			if (forceClose || !parentItem._preventSubMenuClose) {
-				subMenu.close();
-				subMenu.remove();
-				parentItem._subMenu = undefined;
-				this._openedSubMenuItem = undefined;
-				this._subMenuOpenerId = "";
+			if (forceClose || (parentItem && !parentItem._preventSubmenuClose)) {
+				submenu.close();
+				this._openedSubmenuItem = undefined;
+				this._submenuOpenerId = "";
+				this._hoveredSubmenuItem && this._hoveredSubmenuItem.focus();
+				this._hoveredSubmenuItem = undefined;
 			}
 		}
 	}
 
-	_prepareSubMenuDesktopTablet(item: MenuItem, opener: HTMLElement, actionId: string) {
-		if (actionId !== this._subMenuOpenerId || (item && item.hasSubmenu)) {
+	_prepareSubmenuDesktopTablet(item: MenuItem, opener: HTMLElement, actionId: string) {
+		const submenu = item.submenu;
+		if (actionId !== this._submenuOpenerId || (item && item.hasSubmenu)) {
 			// close opened sub-menu if there is any opened
-			this._closeItemSubMenu(this._openedSubMenuItem!, true);
+			this._closeItemSubmenu(this._openedSubmenuItem!, true);
 		}
-		if (item && item.hasSubmenu) {
-			// create new sub-menu
-			this._createSubMenu(item, actionId);
-			this._openItemSubMenu(item, opener, actionId);
+		if (item && submenu) {
+			submenu._parentMenuItem = item;
+			this._openItemSubmenu(item, opener, actionId);
 		}
 		if (this._parentMenuItem) {
-			this._parentMenuItem._preventSubMenuClose = true;
+			this._parentMenuItem._preventSubmenuClose = true;
 		}
 	}
 
-	_prepareSubMenuPhone(item: MenuItem) {
-		this._prepareCurrentItems(item.items);
-		this._parentMenuItem = item;
-		this._parentItemsStack.push(item);
+	_prepareSubmenuPhone(item: MenuItem) {
+		if (item.submenu) {
+			this._prepareCurrentItems(item.submenu.items);
+			this._parentMenuItem = item;
+			this._parentItemsStack.push(item);
+		}
 	}
 
 	_startOpenTimeout(item: MenuItem, opener: OpenerStandardListItem, hoverId: string) {
@@ -554,7 +509,7 @@ class Menu extends UI5Element {
 
 		// Sets the new timeout
 		this._timeout = setTimeout(() => {
-			this._prepareSubMenuDesktopTablet(item, opener, hoverId);
+			this._prepareSubmenuDesktopTablet(item, opener, hoverId);
 		}, MENU_OPEN_DELAY);
 	}
 
@@ -564,7 +519,7 @@ class Menu extends UI5Element {
 
 		// Sets the new timeout
 		this._timeout = setTimeout(() => {
-			this._closeItemSubMenu(item);
+			this._closeItemSubmenu(item);
 		}, MENU_CLOSE_DELAY);
 	}
 
@@ -580,6 +535,7 @@ class Menu extends UI5Element {
 			const opener = e.target as OpenerStandardListItem;
 			const item = opener.associatedItem;
 			const hoverId = opener.getAttribute("id")!;
+			this._hoveredSubmenuItem = opener;
 
 			opener.focus();
 
@@ -593,7 +549,7 @@ class Menu extends UI5Element {
 
 	_busyMouseOver() {
 		if (this._parentMenuItem) {
-			this._parentMenuItem._preventSubMenuClose = true;
+			this._parentMenuItem._preventSubmenuClose = true;
 		}
 	}
 
@@ -606,9 +562,9 @@ class Menu extends UI5Element {
 			this._clearTimeout();
 
 			// Close submenu with 400ms delay
-			if (item && item.hasSubmenu && item._subMenu) {
+			if (item && item.hasSubmenu && item.submenu) {
 				// try to close the sub-menu
-				item._preventSubMenuClose = false;
+				item._preventSubmenuClose = false;
 				this._startCloseTimeout(item);
 			}
 		}
@@ -626,10 +582,10 @@ class Menu extends UI5Element {
 			const item = opener.associatedItem;
 			const hoverId = opener.getAttribute("id")!;
 
-			item.hasSubmenu && this._prepareSubMenuDesktopTablet(item, opener, hoverId);
-		} else if (isMenuClose && this._isSubMenu && this._parentMenuItem) {
+			item.hasSubmenu && this._prepareSubmenuDesktopTablet(item, opener, hoverId);
+		} else if (isMenuClose && this._isSubmenu && this._parentMenuItem) {
 			const parentMenuItemParent = this._parentMenuItem.parentElement as Menu;
-			parentMenuItemParent._closeItemSubMenu(this._parentMenuItem, true);
+			parentMenuItemParent._closeItemSubmenu(this._parentMenuItem, true);
 		}
 	}
 
@@ -640,7 +596,7 @@ class Menu extends UI5Element {
 
 		if (!item.hasSubmenu) {
 			// click on an item that doesn't have sub-items fires an "item-click" event
-			if (!this._isSubMenu) {
+			if (!this._isSubmenu) {
 				if (isPhone()) {
 					this._parentMenuItem = undefined;
 				}
@@ -664,8 +620,8 @@ class Menu extends UI5Element {
 					let openerMenuItem = item;
 					let parentMenu = openerMenuItem.parentElement as Menu;
 					do {
-						openerMenuItem._preventSubMenuClose = false;
-						this._closeItemSubMenu(openerMenuItem);
+						openerMenuItem._preventSubmenuClose = false;
+						this._closeItemSubmenu(openerMenuItem);
 						parentMenu = openerMenuItem.parentElement as Menu;
 						openerMenuItem = parentMenu._parentMenuItem as MenuItem;
 					} while (parentMenu._parentMenuItem);
@@ -675,10 +631,10 @@ class Menu extends UI5Element {
 			}
 		} else if (isPhone()) {
 			// prepares and opens sub-menu on phone
-			this._prepareSubMenuPhone(item);
+			this._prepareSubmenuPhone(item);
 		} else if (isTablet()) {
 			// prepares and opens sub-menu on tablet
-			this._prepareSubMenuDesktopTablet(item, opener, actionId);
+			this._prepareSubmenuDesktopTablet(item, opener, actionId);
 		}
 	}
 
@@ -714,9 +670,9 @@ class Menu extends UI5Element {
 			return;
 		}
 
-		if (this._openedSubMenuItem) {
-			this._openedSubMenuItem._preventSubMenuClose = false;
-			this._closeItemSubMenu(this._openedSubMenuItem);
+		if (this._openedSubmenuItem) {
+			this._openedSubmenuItem._preventSubmenuClose = false;
+			this._closeItemSubmenu(this._openedSubmenuItem);
 		}
 	}
 

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -2,7 +2,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import type Menu from "./Menu.js";
 
 /**
@@ -24,12 +23,9 @@ import type Menu from "./Menu.js";
  * <code>import "@ui5/webcomponents/dist/MenuItem.js";</code>
  *
  * @constructor
- * @author SAP SE
- * @alias sap.ui.webc.main.MenuItem
- * @extends sap.ui.webc.base.UI5Element
+ * @extends UI5Element
  * @abstract
- * @tagname ui5-menu-item
- * @implements sap.ui.webc.main.IMenuItem
+ * @implements { IMenuItem }
  * @since 1.3.0
  * @public
  */
@@ -38,9 +34,7 @@ class MenuItem extends UI5Element {
 	/**
 	 * Defines the text of the tree item.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.text
-	 * @type {string}
-	 * @defaultValue ""
+	 * @default ""
 	 * @public
 	 */
 	@property()
@@ -50,8 +44,7 @@ class MenuItem extends UI5Element {
 	 * Defines the <code>additionalText</code>, displayed in the end of the menu item.
 	 * <b>Note:</b> The additional text would not be displayed if the item has a submenu.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.additionalText
-	 * @type {string}
+	 * @default ""
 	 * @public
 	 * @since 1.8.0
 	 */
@@ -65,9 +58,7 @@ class MenuItem extends UI5Element {
 	 <b>* Example:</b>
 	 * See all the available icons in the <ui5-link target="_blank" href="https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html">Icon Explorer</ui5-link>.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.icon
-	 * @type {string}
-	 * @defaultvalue ""
+	 * @default ""
 	 * @public
 	 */
 	@property()
@@ -76,9 +67,7 @@ class MenuItem extends UI5Element {
 	/**
 	 * Defines whether a visual separator should be rendered before the item.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.startsSection
-	 * @type {boolean}
-	 * @defaultvalue false
+	 * @default false
 	 * @public
 	 */
 	@property({ type: Boolean })
@@ -89,46 +78,16 @@ class MenuItem extends UI5Element {
 	 * <br><br>
 	 * <b>Note:</b> A disabled <code>ui5-menu-item</code> is noninteractive.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.disabled
-	 * @type {boolean}
-	 * @defaultvalue false
+	 * @default false
 	 * @public
 	 */
 	@property({ type: Boolean })
 	disabled!: boolean;
 
 	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover.
-	 *
-	 * Note: If set to <code>true</code> a <code>ui5-busy-indicator</code> component will be displayed into the related one to the current <code>ui5-menu-item</code> sub-menu popover.
-	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.busy
-	 * @type {boolean}
-	 * @defaultvalue false
-	 * @public
-	 * @since 1.13.0
-	 */
-	@property({ type: Boolean })
-	busy!: boolean;
-
-	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover.
-	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.busyDelay
-	 * @type {sap.ui.webc.base.types.Integer}
-	 * @defaultValue 1000
-	 * @public
-	 * @since 1.13.0
-	 */
-	@property({ validator: Integer, defaultValue: 1000 })
-	busyDelay!: number;
-
-	/**
 	 * Defines the accessible ARIA name of the component.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.accessibleName
-	 * @type {string}
-	 * @defaultvalue ""
+	 * @default ""
 	 * @public
 	 * @since 1.7.0
 	 */
@@ -151,35 +110,26 @@ class MenuItem extends UI5Element {
 	 * Defines whether the submenu closing must be prevented
 	 */
 	@property({ type: Boolean, noAttribute: true })
-	_preventSubMenuClose!: boolean;
+	_preventSubmenuClose!: boolean;
 
 	/**
-	 * Stores Menu object with submenu items
-	 */
-	@property({ type: Object, defaultValue: undefined })
-	_subMenu?: Menu;
-
-	/**
-	 * Defines the items of this component.
+	 * Defines the submenu of this component.
 	 *
-	 * @name sap.ui.webc.main.MenuItem.prototype.default
-	 * @type {sap.ui.webc.main.IMenuItem[]}
-	 * @slot items
 	 * @public
 	 */
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
-	items!: Array<MenuItem>;
+	menu?: Array<Menu>;
+
+	get submenu(): Menu | undefined {
+		return this.menu && this.menu.length ? this.menu[0] : undefined;
+	}
 
 	get hasSubmenu() {
-		return !!(this.items.length || this.busy);
+		return !!(this.menu && this.menu.length);
 	}
 
 	get hasDummyIcon() {
 		return this._siblingsWithIcon && !this.icon;
-	}
-
-	get subMenuOpened() {
-		return !!this._subMenu;
 	}
 
 	get _additionalText() {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -14,27 +14,34 @@
 
 <body class="responsivepopover2auto">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
-	<ui5-menu id="menu" header-text="My ui5-menu">
-
+	<ui5-menu id="menu-1" header-text="My ui5-menu">
 		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
 		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
-		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
-			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
-				<ui5-menu-item text="Open from C"></ui5-menu-item>
-				<ui5-menu-item text="Open from D"></ui5-menu-item>
-				<ui5-menu-item text="Open from E"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Open from SAP Cloud" additional-text="Ctrl+L"></ui5-menu-item>
+		<ui5-menu-item text="Open" icon="open-folder" starts-section>
+			<ui5-menu id="submenu-1-3" busy-delay="100" busy>
+				<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
+					<ui5-menu id="submenu-1-3-1">
+						<ui5-menu-item text="Open from C"></ui5-menu-item>
+						<ui5-menu-item text="Open from D"></ui5-menu-item>
+						<ui5-menu-item text="Open from E"></ui5-menu-item>
+					</ui5-menu>
+				</ui5-menu-item>
+				<ui5-menu-item text="Open from SAP Cloud" additional-text="Ctrl+L"></ui5-menu-item>
+			</ui5-menu>
 		</ui5-menu-item>
 		<ui5-menu-item text="Save" icon="save">
-			<ui5-menu-item text="Save Locally" icon="save">
-				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
+			<ui5-menu id="submenu-1-4">
+				<ui5-menu-item text="Save Locally" icon="save">
+					<ui5-menu id="submenu-1-4-1">
+						<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
+						<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
+						<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
+					</ui5-menu>
+				</ui5-menu-item>
+				<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
+			</ui5-menu>
 		</ui5-menu-item>
-		<ui5-menu-item text="Close" additional-text="Ctrl+W" busy-delay="100" busy></ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W"></ui5-menu-item>
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
@@ -86,6 +93,9 @@
 	</div>
 
 	<script>
+		var menu = document.getElementById("menu-1");
+		var submenu13 = document.getElementById("submenu-1-3");
+
 		btnOpen.accessibilityAttributes = {
 			hasPopup: "Menu",
 		};
@@ -108,17 +118,18 @@
 
 		let fetched = false;
 
-		menu.addEventListener("ui5-before-open", function(event) {
-			const item = event.detail.item;
-			if (item && item.text === "Open" && !fetched) {
+		submenu13.addEventListener("ui5-before-open", function(event) {
+			const menu = event.target;
+			if (!fetched) {
 				setTimeout(function() {
-					item.removeAttribute("busy");
-					item.removeAttribute("busy-delay");
 					let oneNode = document.createElement("ui5-menu-item");
 					oneNode.setAttribute("text", "Open from Amazon Cloud");
 					let twoNode = document.createElement("ui5-menu-item");
 					twoNode.setAttribute("text", "Open from Google Cloud");
-					item.append(oneNode, twoNode);
+					menu.appendChild(oneNode);
+					menu.appendChild(twoNode);
+					menu.removeAttribute("busy");
+					menu.removeAttribute("busy-delay");
 					fetched = true;
 				}, 1000);
 			}


### PR DESCRIPTION
PoC: Submenus that are defined as **<ui-menu>** components and added in parent **<ui5-menu-item>** **'menu'** slot instead of adding their **<ui5-menu-items>** in the parent **<ui5-menu-item> 'items'** slot.

Warning: this is breaking change!!!

- The **<ui5-menu-item}> 'items'** slot is replaced with **'menu'** slot
- **busy**/**busyDelay** proerties are set directly to the **<ui5-menu>** component instead of on parent **<ui5-menu-item>** component