### PR TITLE
fix(base): add local variant for language loading

### DIFF
--- a/packages/base/src/asset-registries/i18n.ts
+++ b/packages/base/src/asset-registries/i18n.ts
@@ -79,7 +79,8 @@ const useFallbackBundle = (packageName: string, localeId: string) => {
 const fetchI18nBundle = async (packageName: string) => {
 	const language = getLocale().getLanguage();
 	const region = getLocale().getRegion();
-	let localeId = language + (region ? `-${region}` : ``);
+	const variant = getLocale().getVariant();
+	let localeId = language + (region ? `-${region}` : ``) + (variant ? `-${variant}` : ``);
 
 	if (useFallbackBundle(packageName, localeId)) {
 		localeId = normalizeLocale(localeId);


### PR DESCRIPTION
Language variant was not added to locale id and the special languages like `en_US_sappsd` falled back to `en` even though they are present.

<img width="299" alt="Screenshot 2023-12-06 at 13 43 16" src="https://github.com/SAP/ui5-webcomponents/assets/11073377/ac67b1c7-e87b-4158-8d64-774e253403c1">


FIXES: #7965 