### PR TITLE
fix: base usage from test pages

### DIFF
--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -19,7 +19,7 @@
 
 
 	<script src="./modules/LabelPageCustomElement.js" type="module" defer></script>
-	<script src="./modules/LabelPage.ts" type="module" defer></script>
+	<script src="./modules/LabelPage.js" type="module" defer></script>
 	<link rel="stylesheet" type="text/css" href="./styles/Label.css">
 </head>
 

--- a/packages/main/test/pages/modules/LabelPage.js
+++ b/packages/main/test/pages/modules/LabelPage.js
@@ -1,4 +1,3 @@
-import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 
 var select = document.getElementById("languageSelect");
 
@@ -20,7 +19,7 @@ function updateLabelsText(lang) {
 select.addEventListener("ui5-change", function (e) {
 	var lang = e.detail.selectedOption.id;
 
-	setLanguage(lang);
+	window["sap-ui-webcomponents-bundle"].configuration.setLanguage(lang);
 	updateLabelsText(lang);
 });
 


### PR DESCRIPTION
Imports like `@ui5/webcomponents/base/dist/Language.js` don't exist when using `yarn start` and can be handled by vite only if they are impoted from a `.ts` file.

This fails sometimes, so instead the method exported from the test bundle is used.