### PR TITLE
feat(ui5-color-palette-popover): introduce `open` and `opener` properties

### DIFF
--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -213,6 +213,16 @@ class ColorPalette extends UI5Element {
 		}
 	}
 
+	onAfterRendering() {
+		if (this.popupMode) {
+			if (this.showDefaultColor) {
+				this.focusFirstFocusableElement();
+			} else {
+				this.focusFirstDisplayColorElement();
+			}
+		}
+	}
+
 	selectColor(item: ColorPaletteItem) {
 		if (!item.value) {
 			return;
@@ -306,7 +316,7 @@ class ColorPalette extends UI5Element {
 			if (this.hasRecentColors) {
 				this.focusColorElement(this.colorPaletteNavigationElements[index + 1], this._itemNavigationRecentColors);
 			} else if (this.showDefaultColor) {
-				this.colorPaletteNavigationElements[0].focus();
+				this.firstFocusableElement.focus();
 			} else {
 				this.focusColorElement(this.displayedColors[0], this._itemNavigation);
 			}
@@ -324,7 +334,7 @@ class ColorPalette extends UI5Element {
 		if (isUp(e) && target === this.displayedColors[0] && this.colorPaletteNavigationElements.length > 1) {
 			e.stopPropagation();
 			if (this.showDefaultColor) {
-				this.colorPaletteNavigationElements[0].focus();
+				this.firstFocusableElement.focus();
 			} else if (!this.showDefaultColor && this.hasRecentColors) {
 				this.focusColorElement(lastElementInNavigation, this._itemNavigationRecentColors);
 			} else if (!this.showDefaultColor && this.showMoreColors) {
@@ -337,7 +347,7 @@ class ColorPalette extends UI5Element {
 			if (this.showDefaultColor && this.showMoreColors) {
 				this.colorPaletteNavigationElements[2].focus();
 			} else if (this.showDefaultColor && !this.showMoreColors && (!this.showRecentColors || !this.recentColors[0])) {
-				this.colorPaletteNavigationElements[0].focus();
+				this.firstFocusableElement.focus();
 			} else if (isRecentColorsNextElement) {
 				this.focusColorElement(lastElementInNavigation, this._itemNavigationRecentColors);
 			} else if (!this.showDefaultColor && this.showMoreColors) {
@@ -359,7 +369,7 @@ class ColorPalette extends UI5Element {
 			}
 		} else if (isDown(e)) {
 			if (this.showDefaultColor) {
-				this.colorPaletteNavigationElements[0].focus();
+				this.firstFocusableElement.focus();
 			} else {
 				e.stopPropagation();
 				this.focusColorElement(this.displayedColors[0], this._itemNavigation);
@@ -370,6 +380,18 @@ class ColorPalette extends UI5Element {
 	focusColorElement(element: ColorPaletteNavigationItem, itemNavigation: ItemNavigation) {
 		itemNavigation.setCurrentItem(element);
 		itemNavigation._focusCurrentItem();
+	}
+
+	focusFirstDisplayColorElement() {
+		this.focusColorElement(this.displayedColors[0], this._itemNavigation);
+	}
+
+	focusFirstFocusableElement() {
+		this.firstFocusableElement.focus();
+	}
+
+	get firstFocusableElement() {
+		return this.colorPaletteNavigationElements[0];
 	}
 
 	async _chooseCustomColor() {

--- a/packages/main/src/ColorPalettePopover.hbs
+++ b/packages/main/src/ColorPalettePopover.hbs
@@ -3,7 +3,7 @@
 	content-only-on-desktop
 	placement-type="Bottom"
 	?open="{{_open}}"
-	.opener="{{{opener}}}"
+	.opener="{{opener}}"
 	@ui5-after-close="{{onAfterClose}}"
 >
 	<div slot="header" class="ui5-cp-header">

--- a/packages/main/src/ColorPalettePopover.hbs
+++ b/packages/main/src/ColorPalettePopover.hbs
@@ -2,6 +2,9 @@
 	hide-arrow
 	content-only-on-desktop
 	placement-type="Bottom"
+	?open="{{_open}}"
+	.opener="{{{opener}}}"
+	@ui5-after-close="{{onAfterClose}}"
 >
 	<div slot="header" class="ui5-cp-header">
 		<ui5-title

--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -85,11 +85,11 @@ type ColorPalettePopoverItemClickEventDetail = ColorPaletteItemClickEventDetail;
 })
 /**
  * Fired when the "open" state changes due to user interaction.
- * @event sap.ui.webc.main.ColorPalettePopover#open-change
+ * @event sap.ui.webc.main.ColorPalettePopover#close
  * @since 1.21.0
  * @public
  */
-@event("open-change")
+@event("close")
 class ColorPalettePopover extends UI5Element {
 	/**
 	 * Defines whether the user can see the last used colors in the bottom of the component
@@ -188,9 +188,11 @@ class ColorPalettePopover extends UI5Element {
 	 * @public
 	 * @method
 	 * @name sap.ui.webc.main.ColorPalettePopover#showAt
+	 * @deprecated The method is deprecated in favour of <code>open</code> and <code>opener</code> properties.
 	 * @since 1.1.1
 	 */
 	showAt(opener: HTMLElement) {
+		console.warn("The method 'showAt' is deprecated and will be removed in future, use 'open' and 'opener' props instead."); // eslint-disable-line
 		this.open = true;
 		this.opener = opener;
 	}
@@ -203,10 +205,10 @@ class ColorPalettePopover extends UI5Element {
 	 * @method
 	 * @name sap.ui.webc.main.ColorPalettePopover#openPopover
 	 * @since 1.0.0-rc.16
-	 * @deprecated The method is deprecated in favour of <code>showAt</code>.
+	 * @deprecated The method is deprecated in favour of <code>open</code> and <code>opener</code> properties.
 	 */
 	openPopover(opener: HTMLElement) {
-		console.warn("The method 'openPopover' is deprecated and will be removed in future, use 'showAt' instead."); // eslint-disable-line
+		console.warn("The method 'openPopover' is deprecated and will be removed in future, use 'open' and 'opener' props instead."); // eslint-disable-line
 		this.showAt(opener);
 	}
 
@@ -216,7 +218,7 @@ class ColorPalettePopover extends UI5Element {
 
 	onAfterClose() {
 		this.closePopover();
-		this.fireEvent("open-change");
+		this.fireEvent("close");
 	}
 
 	onSelectedColor(e: CustomEvent<ColorPaletteItemClickEventDetail>) {

--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -84,7 +84,7 @@ type ColorPalettePopoverItemClickEventDetail = ColorPaletteItemClickEventDetail;
 	},
 })
 /**
- * Fired when the "open" state changes due to user interaction.
+ * Fired when the <code>ui5-color-palette-popover</code> is closed due to user interaction.
  * @event sap.ui.webc.main.ColorPalettePopover#close
  * @since 1.21.0
  * @public

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -298,7 +298,7 @@ class Popover extends Popup {
 			if (this.opener instanceof HTMLElement) {
 				opener = this.opener;
 			} else if (typeof this.opener === "string") {
-				opener = (this.getRootNode() as Document).getElementById(this.opener);
+				opener = (this.getRootNode() as Document).getElementById(this.opener) || document.getElementById(this.opener);
 			}
 
 			if (!opener) {

--- a/packages/main/src/themes/ColorPalettePopover.css
+++ b/packages/main/src/themes/ColorPalettePopover.css
@@ -16,6 +16,10 @@
 	padding: 0;
 }
 
+[ui5-title], [ui5-button] {
+	margin-bottom: 1rem;
+}
+
 .ui5-cp-item-container {
 	padding: 0.3125rem 0.6875rem;
 }

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -98,6 +98,24 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
+	<ui5-title level="H5">Test case 6 - open-change</ui5-title>
+	<ui5-button id="colorPaletteBtnTest6">Open</ui5-button>
+	<ui5-input id="inpOpenChangeCounter" placeholder="open-change count"></ui5-input>
+	<ui5-button id="btnFocusOut">Press</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest6" show-recent-colors show-more-colors  show-default-color default-color="green">
+		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
+		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>
+		<ui5-color-palette-item value="orange"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
+	</ui5-color-palette-popover>
 
 	<ui5-title level="H5">Only Colors</ui5-title>
 	<ui5-button id="btnColPop1">Open</ui5-button>
@@ -150,7 +168,6 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-
 	<ui5-title level="H5">show-recent-colors, show-more-colors and show-default-color</ui5-title>
 	<ui5-button id="btnColPop4">Open</ui5-button>
 	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green">
@@ -171,41 +188,53 @@
 	<script>
 		// Usage of "open" and "opener"
 		btnColPop1.addEventListener("click", function(event) {
-			ColPop1.open = true;
+			ColPop1.open = !ColPop1.open;
 			ColPop1.opener = "btnColPop1";
 		});
 
 		btnColPop2.addEventListener("click", function(event) {
-			ColPop2.open = true;
+			ColPop2.open = !ColPop2.open;
 			ColPop2.opener = "btnColPop2";
 		});
 
 		btnColPop3.addEventListener("click", function(event) {
-			ColPop3.open = true;
+			ColPop3.open = !ColPop3.open;
 			ColPop3.opener = btnColPop3;
 		});
 
 		btnColPop4.addEventListener("click", function(event) {
-			ColPop4.open = true;
+			ColPop4.open = !ColPop4.open;
 			ColPop4.opener = btnColPop4;
 		});
-
 
 		// Tests - default color btn should be on focus after open
 		colorPaletteBtnTest.addEventListener("click", function(event) {
 			colorPalettePopoverTest.showAt(this);
 		});
+
 		colorPaletteBtnTest2.addEventListener("click", function(event) {
-			colorPalettePopoverTest2.showAt(this);
+			colorPalettePopoverTest2.showAt(this)
 		});
+
 		colorPaletteBtnTest3.addEventListener("click", function(event) {
 			colorPalettePopoverTest3.showAt(this);
 		});
+
 		colorPaletteBtnTest4.addEventListener("click", function(event) {
 			colorPalettePopoverTest4.showAt(this);
 		});
+
 		colorPaletteBtnTest5.addEventListener("click", function(event) {
 			colorPalettePopoverTest5.showAt(this);
+		});
+
+		colorPaletteBtnTest6.addEventListener("click", function(event) {
+			colorPalettePopoverTest6.showAt(this);
+		});
+
+		let openChangeCounter = 0;
+		colorPalettePopoverTest6.addEventListener("ui5-open-change", function(event) {
+			inpOpenChangeCounter.value = ++openChangeCounter;
 		});
 	</script>
 </html>

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -4,25 +4,17 @@
 	<meta charset="utf-8">
 	<title>Color Palette Popover</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-
-	<script data-ui5-config type="application/json">
-		{
-			"rtl": false
-		}
-	</script>
-
-
 	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
-
-
 	<link rel="stylesheet" type="text/css" href="./styles/ColorPalettePopover.css">
 </head>
 
 <body class="colorpalettepopover1auto">
 
 </body>
-	<ui5-button id="colorPaletteBtn" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover" show-recent-colors show-more-colors show-default-color default-color="green">
+
+	<ui5-title level="H5">Test case 1 - Default Color Button to be focused</ui5-title>
+	<ui5-button id="colorPaletteBtnTest">Open</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest" show-recent-colors show-more-colors show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -37,8 +29,9 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-button id="colorPaletteBtn1" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover1" show-more-colors show-default-color default-color="green">
+	<ui5-title level="H5">Test case 2 - Default Color works</ui5-title>
+	<ui5-button id="colorPaletteBtnTest2">Open</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest2" show-recent-colors show-more-colors show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -53,8 +46,9 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-button id="colorPaletteBtn2" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover2" show-recent-colors show-default-color default-color="green">
+	<ui5-title level="H5">Test case 3 - Arrow Down to select displayed color</ui5-title>
+	<ui5-button id="colorPaletteBtnTest3">Open</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest3" show-recent-colors show-more-colors show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -69,8 +63,10 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-button id="colorPaletteBtn3" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover3" show-recent-colors show-more-colors>
+
+	<ui5-title level="H5">Test case 4 - Arrow Up focuses MoreColors button</ui5-title>
+	<ui5-button id="colorPaletteBtnTest4">Open</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest4" show-recent-colors show-more-colors  show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -85,8 +81,9 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-button id="colorPaletteBtn4" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover4">
+	<ui5-title level="H5">Test case 5 - Tests navigation with recent colors</ui5-title>
+	<ui5-button id="colorPaletteBtnTest5">Open</ui5-button>
+	<ui5-color-palette-popover id="colorPalettePopoverTest5" show-recent-colors show-more-colors  show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -101,8 +98,10 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-button id="colorPaletteBtn5" >Open ColorPalettePopover</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopover5" show-recent-colors show-default-color default-color="green">
+
+	<ui5-title level="H5">Only Colors</ui5-title>
+	<ui5-button id="btnColPop1">Open</ui5-button>
+	<ui5-color-palette-popover id="ColPop1">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -116,24 +115,97 @@
 		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
+
+	<ui5-title level="H5">show-default-color</ui5-title>
+	<ui5-button id="btnColPop2">Open</ui5-button>
+	<ui5-color-palette-popover id="ColPop2" show-default-color default-color="green">
+		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
+		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>
+		<ui5-color-palette-item value="orange"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
+	</ui5-color-palette-popover>
+
+	<ui5-title level="H5">show-more-colors and show-default-color</ui5-title>
+	<ui5-button id="btnColPop3">Open</ui5-button>
+	<ui5-color-palette-popover id="ColPop3" show-more-colors show-default-color default-color="green">
+		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
+		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>
+		<ui5-color-palette-item value="orange"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
+	</ui5-color-palette-popover>
+
+
+	<ui5-title level="H5">show-recent-colors, show-more-colors and show-default-color</ui5-title>
+	<ui5-button id="btnColPop4">Open</ui5-button>
+	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green">
+		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
+		<ui5-color-palette-item value="rgb(0,200,0)"></ui5-color-palette-item>
+		<ui5-color-palette-item value="green"></ui5-color-palette-item>
+		<ui5-color-palette-item value="darkred"></ui5-color-palette-item>
+		<ui5-color-palette-item value="yellow"></ui5-color-palette-item>
+		<ui5-color-palette-item value="blue"></ui5-color-palette-item>
+		<ui5-color-palette-item value="cyan"></ui5-color-palette-item>
+		<ui5-color-palette-item value="orange"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#5480e7"></ui5-color-palette-item>
+		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
+	</ui5-color-palette-popover>
+
 	<script>
-		colorPaletteBtn.addEventListener("click", function(event) {
-			colorPalettePopover.showAt(this);
+		// Usage of "open" and "opener"
+		btnColPop1.addEventListener("click", function(event) {
+			ColPop1.open = true;
+			ColPop1.opener = "btnColPop1";
 		});
-		colorPaletteBtn1.addEventListener("click", function(event) {
-			colorPalettePopover1.showAt(this);
+
+		btnColPop2.addEventListener("click", function(event) {
+			ColPop2.open = true;
+			ColPop2.opener = "btnColPop2";
 		});
-		colorPaletteBtn2.addEventListener("click", function(event) {
-			colorPalettePopover2.showAt(this);
+
+		btnColPop3.addEventListener("click", function(event) {
+			ColPop3.open = true;
+			ColPop3.opener = btnColPop3;
 		});
-		colorPaletteBtn3.addEventListener("click", function(event) {
-			colorPalettePopover3.showAt(this);
+
+		btnColPop4.addEventListener("click", function(event) {
+			ColPop4.open = true;
+			ColPop4.opener = btnColPop4;
 		});
-		colorPaletteBtn4.addEventListener("click", function(event) {
-			colorPalettePopover4.showAt(this);
+
+
+		// Tests - default color btn should be on focus after open
+		colorPaletteBtnTest.addEventListener("click", function(event) {
+			colorPalettePopoverTest.showAt(this);
 		});
-		colorPaletteBtn5.addEventListener("click", function(event) {
-			colorPalettePopover5.showAt(this);
+		colorPaletteBtnTest2.addEventListener("click", function(event) {
+			colorPalettePopoverTest2.showAt(this);
+		});
+		colorPaletteBtnTest3.addEventListener("click", function(event) {
+			colorPalettePopoverTest3.showAt(this);
+		});
+		colorPaletteBtnTest4.addEventListener("click", function(event) {
+			colorPalettePopoverTest4.showAt(this);
+		});
+		colorPaletteBtnTest5.addEventListener("click", function(event) {
+			colorPalettePopoverTest5.showAt(this);
 		});
 	</script>
 </html>

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -98,9 +98,9 @@
 		<ui5-color-palette-item value="#ff6699"></ui5-color-palette-item>
 	</ui5-color-palette-popover>
 
-	<ui5-title level="H5">Test case 6 - open-change</ui5-title>
+	<ui5-title level="H5">Test case 6 - close</ui5-title>
 	<ui5-button id="colorPaletteBtnTest6">Open</ui5-button>
-	<ui5-input id="inpOpenChangeCounter" placeholder="open-change count"></ui5-input>
+	<ui5-input id="inpOpenChangeCounter" placeholder="'close' event count"></ui5-input>
 	<ui5-button id="btnFocusOut">Press</ui5-button>
 	<ui5-color-palette-popover id="colorPalettePopoverTest6" show-recent-colors show-more-colors  show-default-color default-color="green">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
@@ -119,7 +119,7 @@
 
 	<ui5-title level="H5">Only Colors</ui5-title>
 	<ui5-button id="btnColPop1">Open</ui5-button>
-	<ui5-color-palette-popover id="ColPop1">
+	<ui5-color-palette-popover id="ColPop1" opener="btnColPop1">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -136,7 +136,7 @@
 
 	<ui5-title level="H5">show-default-color</ui5-title>
 	<ui5-button id="btnColPop2">Open</ui5-button>
-	<ui5-color-palette-popover id="ColPop2" show-default-color default-color="green">
+	<ui5-color-palette-popover id="ColPop2" show-default-color default-color="green" opener="btnColPop2">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -153,7 +153,7 @@
 
 	<ui5-title level="H5">show-more-colors and show-default-color</ui5-title>
 	<ui5-button id="btnColPop3">Open</ui5-button>
-	<ui5-color-palette-popover id="ColPop3" show-more-colors show-default-color default-color="green">
+	<ui5-color-palette-popover id="ColPop3" show-more-colors show-default-color default-color="green" opener="btnColPop3">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -170,7 +170,7 @@
 
 	<ui5-title level="H5">show-recent-colors, show-more-colors and show-default-color</ui5-title>
 	<ui5-button id="btnColPop4">Open</ui5-button>
-	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green">
+	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green" openr="btnColPop4">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -189,22 +189,18 @@
 		// Usage of "open" and "opener"
 		btnColPop1.addEventListener("click", function(event) {
 			ColPop1.open = !ColPop1.open;
-			ColPop1.opener = "btnColPop1";
 		});
 
 		btnColPop2.addEventListener("click", function(event) {
 			ColPop2.open = !ColPop2.open;
-			ColPop2.opener = "btnColPop2";
 		});
 
 		btnColPop3.addEventListener("click", function(event) {
 			ColPop3.open = !ColPop3.open;
-			ColPop3.opener = btnColPop3;
 		});
 
 		btnColPop4.addEventListener("click", function(event) {
 			ColPop4.open = !ColPop4.open;
-			ColPop4.opener = btnColPop4;
 		});
 
 		// Tests - default color btn should be on focus after open
@@ -233,7 +229,7 @@
 		});
 
 		let openChangeCounter = 0;
-		colorPalettePopoverTest6.addEventListener("ui5-open-change", function(event) {
+		colorPalettePopoverTest6.addEventListener("ui5-close", function(event) {
 			inpOpenChangeCounter.value = ++openChangeCounter;
 		});
 	</script>

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -104,6 +104,35 @@ describe("ColorPalette interactions", () => {
 
 		// assert - MoreColors is focused
 		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
+
+		// act - close popover
+		await defaultButton.click();
+	});
+
+	it("Test open-change fired when popover closes", async () => {
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest6");
+		const btnFocusOut = await browser.$("#btnFocusOut");
+		const inpOpenChangeCounter = await browser.$("#inpOpenChangeCounter");
+
+		// act - open color palette popover and click outside
+		await colorPaletteButton.click();
+		await btnFocusOut.click();
+
+		// assert
+		assert.ok(await inpOpenChangeCounter.getProperty("value"), "1", "Event open-change fired when popover closes.");
+
+		// act - open color palette popover
+		await colorPaletteButton.click();
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest6");
+		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
+		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
+
+		// act - select default color
+		await defaultButton.click();
+
+		// assert
+		assert.ok(await inpOpenChangeCounter.getProperty("value"), "2", "Event open-change fired when popover closes.");
 	});
 
 	it("Test attribute propagation propagation", async () => {

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -6,92 +6,119 @@ describe("ColorPalette interactions", () => {
 	});
 
 	it("Test if focusing first element works on initial open", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest");
+
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest");
 		const responsivePopover = await colorPalettePopover.shadow$("[ui5-responsive-popover]")
 		const colorPalette = await responsivePopover.$("[ui5-color-palette]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 
-		assert.ok(await defaultButton.getProperty("focused"),  "Check if the first element is focused");
+		// assert - default btn is focused
+		assert.ok(await defaultButton.getProperty("focused"),  "The first element is focused");
+
+		// act - close popover
+		await defaultButton.click();
 	});
 
 	it("Test if default color functionality works", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
+		const DEFAULT_COLOR =  "green";
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest2");
 
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest2");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 
+		// act - activate default color
 		await defaultButton.keys("Space");
 
-		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "green", "Check if selected value is darkgreen");
+		// assert - "green" is selected as default color
+		assert.strictEqual(await colorPalette.getProperty("selectedColor"), DEFAULT_COLOR, "The selected value is green");
 	});
 
 	it("Test if keyboard navigation on elements works", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		const EXPTECTED_COLOR = "pink"
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest3");
+
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest3");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const colorPaletteEntries = await colorPalette.shadow$$("[ui5-color-palette-item]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 		const item = colorPaletteEntries[0];
 
+		// act - navigate to a color with "ArrowDown"
 		await defaultButton.keys("ArrowDown");
 		await item.keys("Space");
 
-		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "pink", "Check if selected value is pink");
+		// assert - "pink" is selected with "SPACE"
+		assert.strictEqual(await colorPalette.getProperty("selectedColor"), EXPTECTED_COLOR, "The selected value is pink");
 	});
 
 	it("Test if keyboard navigation on elements works", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest4");
+
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+	
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest4");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const moreColorsButton = await colorPalette.shadow$(".ui5-cp-more-colors");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 
 		await defaultButton.keys("ArrowUp");
 
-		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
+		// assert - MoreColors button is focused
+		assert.ok(await moreColorsButton.getProperty("focused"),  "Button 'MoreColors' is focused");
+
+		// act - close popover
+		await defaultButton.click();
 	});
 
 	it("Tests navigation with recent colors", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
-
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest5");
+	
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest5");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 		const moreColorsButton = await colorPalette.shadow$(".ui5-cp-more-colors");
 		const firstRecentColorsElement = await colorPalette.shadow$(".ui5-cp-recent-colors-container [ui5-color-palette-item]");
 
+		// act - press default color btn and re-open color palette popover
 		await defaultButton.keys("Space");
-
 		await colorPaletteButton.click();
 
+		// act - navigate to recent colors
 		await defaultButton.keys("ArrowUp");
 		await firstRecentColorsElement.keys("ArrowUp");
 
+		// assert - MoreColors is focused
 		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
 	});
 
 	it("Test attribute propagation propagation", async () => {
-		await browser.url(`test/pages/ColorPalettePopover.html`);
+		const colorPaletteButton = await browser.$("#colorPaletteBtnTest");
 
-		const colorPaletteButton = await browser.$("#colorPaletteBtn");
+		// act - open color palette popover
 		await colorPaletteButton.click();
-		const colorPalettePopover = await browser.$("[ui5-color-palette-popover]");
+
+		const colorPalettePopover = await browser.$("#colorPalettePopoverTest");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 
+		// assert
 		assert.ok(await colorPalette.getProperty("showDefaultColor"), "Check if default color is on");
 		assert.ok(await colorPalette.getProperty("showRecentColors"), "Check if recent colors is on");
 		assert.ok(await colorPalette.getProperty("showMoreColors"), "Check if more colors is on");
-	});
+	})
+	
 });

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -109,7 +109,7 @@ describe("ColorPalette interactions", () => {
 		await defaultButton.click();
 	});
 
-	it("Test open-change fired when popover closes", async () => {
+	it("Test 'close' event fired when popover closes", async () => {
 		const colorPaletteButton = await browser.$("#colorPaletteBtnTest6");
 		const btnFocusOut = await browser.$("#btnFocusOut");
 		const inpOpenChangeCounter = await browser.$("#inpOpenChangeCounter");
@@ -119,7 +119,7 @@ describe("ColorPalette interactions", () => {
 		await btnFocusOut.click();
 
 		// assert
-		assert.ok(await inpOpenChangeCounter.getProperty("value"), "1", "Event open-change fired when popover closes.");
+		assert.ok(await inpOpenChangeCounter.getProperty("value"), "1", "Event 'close' fired when popover closes.");
 
 		// act - open color palette popover
 		await colorPaletteButton.click();
@@ -132,7 +132,7 @@ describe("ColorPalette interactions", () => {
 		await defaultButton.click();
 
 		// assert
-		assert.ok(await inpOpenChangeCounter.getProperty("value"), "2", "Event open-change fired when popover closes.");
+		assert.ok(await inpOpenChangeCounter.getProperty("value"), "2", "Event 'close' fired when popover closes.");
 	});
 
 	it("Test attribute propagation propagation", async () => {


### PR DESCRIPTION
**Background**
After we introduced the declarative option to open and close popups via  the`open` and `opener` props in the Popover in the past, the idea was to gradually enable all popover-based components to support the same convenient, declarative API. And, the ColorPalettePopover is one of them.

Recently, we have been asked how the ColorPalettePopover can be opened by default upon web page loading (not opening upon button click as usual), which is difficult with the available imperative API `showAt` as the component not only must be defined, but also rendered completely as `showAt` calls methods of the internal responsive popover. 
Providing the declarative API resolves all this - the consumer just sets `open` and `opener` and the component handles everything else in its lifecycle.
As said, the ResponsivePopover already has `open` and `opener` properties, so the ColorPalettePopover only forwards its own equivalent pair of props.

Feature
- Introduces `open` and `opener` properties to declaratively open/close the popover, - and `close` event fired when the popover closes due to user interaction - clicking outside, selecting a color, pressing esc, etc.

```html
<ui5-button id="btn">Hello World</ui5-button>
<ui5-color-palette-popover open opener="btn">
</ui5-color-palette-popover>
```

Refactoring:
- Reduces the ColorPalettePopover|ColorPalette coupling - previously the popover used to focus elements internal to the palette, while now it's completely handled on palette side.
- Improves tests - previously each test used to open the test page, now it's opened only once