### PR TITLE
refactor: fix Serbian Cyrillic mapping

### DIFF
--- a/packages/base/src/asset-registries/i18n.ts
+++ b/packages/base/src/asset-registries/i18n.ts
@@ -78,9 +78,10 @@ const useFallbackBundle = (packageName: string, localeId: string) => {
  */
 const fetchI18nBundle = async (packageName: string) => {
 	const language = getLocale().getLanguage();
+	const script = getLocale().getScript();
 	const region = getLocale().getRegion();
 	const variant = getLocale().getVariant();
-	let localeId = language + (region ? `-${region}` : ``) + (variant ? `-${variant}` : ``);
+	let localeId = language + (script ? `-${script}` : ``) + (region ? `-${region}` : ``) + (variant ? `-${variant}` : ``);
 
 	if (useFallbackBundle(packageName, localeId)) {
 		localeId = normalizeLocale(localeId);

--- a/packages/base/src/locale/normalizeLocale.ts
+++ b/packages/base/src/locale/normalizeLocale.ts
@@ -33,7 +33,7 @@ const normalizeLocale = (locale: string) => {
 		language = M_ISO639_NEW_TO_OLD[language as keyof typeof M_ISO639_NEW_TO_OLD] || language;
 
 		// Serbian Latin Script "sr-Latn"
-		if (language === "sr" && script === "latn" && !region) {
+		if (language === "sr" && script === "latn") {
 			language = "sh";
 		}
 

--- a/packages/base/src/locale/normalizeLocale.ts
+++ b/packages/base/src/locale/normalizeLocale.ts
@@ -8,7 +8,6 @@ const M_ISO639_NEW_TO_OLD = {
 	"he": "iw",
 	"yi": "ji",
 	"nb": "no",
-	// "sr": "sh",
 };
 
 /**

--- a/packages/base/src/locale/normalizeLocale.ts
+++ b/packages/base/src/locale/normalizeLocale.ts
@@ -8,7 +8,7 @@ const M_ISO639_NEW_TO_OLD = {
 	"he": "iw",
 	"yi": "ji",
 	"nb": "no",
-	"sr": "sh",
+	// "sr": "sh",
 };
 
 /**
@@ -31,6 +31,11 @@ const normalizeLocale = (locale: string) => {
 		const isPrivate = m[6];
 
 		language = M_ISO639_NEW_TO_OLD[language as keyof typeof M_ISO639_NEW_TO_OLD] || language;
+
+		// Serbian Latin Script "sr-Latn"
+		if (language === "sr" && script === "latn" && !region) {
+			language = "sh";
+		}
 
 		// recognize and convert special SAP supportability locales (overwrites m[]!)
 		if ((isPrivate && (m = SAPSupportabilityLocales.exec(isPrivate))) /* eslint-disable-line */ ||


### PR DESCRIPTION
Refactor Serbian language mapping, as now Serbian Cyrillic is supported language. Previously we had only Serbian Latin and the respective messagebundle_sh.properties, but recently we have added the messagebundle_sr.properties (that supposed to be the Cyrillic translation, currently everything is in English by default until the LX Lab team provides the translations)

- Remove the old mapping sr: sh
- Use the _sr.properties for:
sap-ui-language=sr
sap-ui-language=sr-Cyrl
sap-ui-language=sr-RS
sap-ui-language=sr-Cyrl-RS
 
- Keep using _sh.properties for:
sap-ui-language=sr-Latn
sap-ui-language=sr-Latn-RS