### PR TITLE
chore(vsd): remove obsolete dependency

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -19,7 +19,6 @@ import Title from "@ui5/webcomponents/dist/Title.js";
 import SegmentedButton from "@ui5/webcomponents/dist/SegmentedButton.js";
 import SegmentedButtonItem from "@ui5/webcomponents/dist/SegmentedButtonItem.js";
 
-import Bar from "./Bar.js";
 import ViewSettingsDialogMode from "./types/ViewSettingsDialogMode.js";
 import "@ui5/webcomponents-icons/dist/sort.js";
 import "@ui5/webcomponents-icons/dist/filter.js";
@@ -114,7 +113,6 @@ type VSDInternalSettings = {
 	styles: viewSettingsDialogCSS,
 	template: ViewSettingsDialogTemplate,
 	dependencies: [
-		Bar,
 		Button,
 		Title,
 		Dialog,


### PR DESCRIPTION
The Bar does not seems to be used in the ViewSettingsDialog any more, the Bar dependency is not needed.