### PR TITLE
fix(framework): prevent endless loop when setting focusDomRef to root

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -801,7 +801,7 @@ abstract class UI5Element extends HTMLElement {
 		const focusDomRef = this.getFocusDomRef();
 
 		if (focusDomRef && typeof focusDomRef.focus === "function") {
-			focusDomRef.focus(focusOptions);
+			HTMLElement.prototype.focus.call(focusDomRef, focusOptions);
 		}
 	}
 


### PR DESCRIPTION
When having a case where we want to focus the root of the custom element e.g.

```js
getFocusDomRef() {
    return this;
}
```

we got in an endless loop in the `UI5Element.prototype.focus` method.