### PR TITLE
fix(ui5-menu): fix runtime js error on `getElementById` call

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -384,10 +384,9 @@ class Menu extends UI5Element {
 		if (!this.opener) {
 			return;
 		}
-		if (this.open) {
-			const rootNode = this.getRootNode() as Document;
-			const opener = this.opener instanceof HTMLElement ? this.opener : rootNode && rootNode.getElementById(this.opener);
 
+		if (this.open) {
+			const opener = this.getOpener();
 			if (opener) {
 				this.showAt(opener);
 			}
@@ -442,6 +441,11 @@ class Menu extends UI5Element {
 		const staticAreaItemDomRef = await this.getStaticAreaItemDomRef();
 		this._popover = staticAreaItemDomRef!.querySelector<ResponsivePopover>("[ui5-responsive-popover]")!;
 		return this._popover;
+	}
+
+	getOpener() {
+		const rootNode = this.getRootNode() as Document;
+		return this.opener instanceof HTMLElement ? this.opener : (rootNode && rootNode.getElementById && rootNode.getElementById(this.opener));
 	}
 
 	_navigateBack() {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -12,7 +12,7 @@
 	<link rel="stylesheet" type="text/css" href="./styles/Menu.css">
 </head>
 
-<body class="responsivepopover2auto">
+<body class="bg">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
 
@@ -39,51 +39,32 @@
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
 
-	<header class="header">
-		<h3 class="header-title">Clicked menu item text</h3>
-	</header>
+	<ui5-title level="H5" class="header-title">Clicked menu item text</ui5-title>
+	<ui5-input id="selectionInput"></ui5-input>
 
-	<div class="samples-margin">
-		<ui5-input id="selectionInput"></ui5-input>
-	</div>
+	<ui5-title level="H5" class="header-title">Text Direction</ui5-title>
+	<ui5-switch id="direction" text-on="RTL" text-off="LTR"></ui5-switch>
 
-	<header class="header">
-		<h3 class="header-title">Text Direction</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="direction" text-on="RTL" text-off="LTR"></ui5-switch>
-	</div>
+	<ui5-title level="H5" class="header-title">Prevent "before-open" event</ui5-title>
+	<ui5-switch id="preventBeforeOpen" text-on="Yes" text-off="No"></ui5-switch>
 
-	<header class="header">
-		<h3 class="header-title">Prevent "before-open" event</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="preventBeforeOpen" text-on="Yes" text-off="No"></ui5-switch>
-	</div>
+	<ui5-title level="H5" class="header-title">Prevent "before-close" event</ui5-title>
+	<ui5-switch id="preventBeforeClose" text-on="Yes" text-off="No"></ui5-switch>
 
-	<header class="header">
-		<h3 class="header-title">Prevent "before-close" event</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-switch id="preventBeforeClose" text-on="Yes" text-off="No"></ui5-switch>
-	</div>
+	<ui5-title level="H5" class="header-title">open/opener</ui5-title>
+	<ui5-button id="btnAddOpener">Add opener</ui5-button>
+	<ui5-button id="btnRemoveOpener">Remove opener</ui5-button>
+	<ui5-toggle-button id="btnToggleOpen">Toggle open</ui5-toggle-button> <br/>
+	<ui5-input id="openerInput"></ui5-input>
 
-	<header class="header">
-		<h3 class="header-title">open/opener</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-button id="btnAddOpener">Add opener</ui5-button>
-		<ui5-button id="btnRemoveOpener">Remove opener</ui5-button>
-		<ui5-toggle-button id="btnToggleOpen">Toggle open</ui5-toggle-button> <br/>
-		<ui5-input id="openerInput"></ui5-input>
-	</div>
+	<ui5-title level="H5" class="header-title">Event logger</ui5-title>
+	<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
 
-	<header class="header">
-		<h3 class="header-title">Event logger</h3>
-	</header>
-	<div class="samples-margin">
-		<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
-	</div>
+	<ui5-title level="H5" class="header-title">Test menu and opener removal</ui5-title>
+	<ui5-button id="buttonA">Opens menu and removes it after 100ms</ui5-button>
+	<ui5-menu id="menuWithoutOpener">
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+	</ui5-menu>
 
 	<script>
 		btnOpen.accessibilityAttributes = {

--- a/packages/main/test/pages/styles/Menu.css
+++ b/packages/main/test/pages/styles/Menu.css
@@ -1,3 +1,11 @@
 .height100percent {
     height: 100%
 }
+
+.bg {
+    background-color: var(--sapBackgroundColor);
+}
+
+.header-title {
+    margin-block-start: 0.5rem;  
+}


### PR DESCRIPTION
The PR adds a check to guarantee `getElementById` is called only if existing, e.g. the Menu is still part of the DOM tree and has not been removed in-between.
The test pages changes are not related to the change, but we have noticed that the used CSS classes "samples-margin", "header" are missing and they are not doing anything. In addition, `h` tags have been replaced by `ui5-title`, so that the texts are readable in HC themes (otherwise you get dark texts on dark background)

Fixes: https://github.com/SAP/ui5-webcomponents/issues/8017