### PR TITLE
docs: add `Stackblitz` alternative for sample creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     id: example
     attributes:
       label: Isolated Example
-      description: Please provide a link to an isolated example if possible by forking [this codesandbox](https://codesandbox.io/s/71r1x5o51q?fontsize=14&module=%2Findex.html).
+      description: Please provide a link to an isolated example if possible by forking [this codesandbox](https://codesandbox.io/s/71r1x5o51q?fontsize=14&module=%2Findex.html), or [this stackblitz](https://stackblitz.com/edit/js-vsrpnb?file=index.js,index.html).
     validations:
       required: false
   - type: textarea

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 **Q: How can I play with UI5 Web Components easily?**
 
-**A:** Use this [CodeSandBox](https://codesandbox.io/s/71r1x5o51q?fontsize=14&module=%2Findex.html).
+**A:** Use this [CodeSandBox](https://codesandbox.io/s/71r1x5o51q?fontsize=14&module=%2Findex.html) or this [Stackblitz](https://stackblitz.com/edit/js-vsrpnb?file=index.js,index.html).
 
 
 **Q: Where is the documentation?**

--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -91,7 +91,7 @@
                     <div> <ui5-date-picker id="myDatepicker1"></ui5-date-picker> </div>
                     <div> <p class="language-html">&lt;ui5-date-picker>&lt;/ui5-date-picker> </p></div>
                 </div>
-                <a href="https://codesandbox.io/s/71r1x5o51q?fontsize=14&module=%2Findex.html" class="ui5-example-button"> CodeSandBox </a>
+                <a href="https://stackblitz.com/edit/js-vsrpnb?file=index.js,index.html" class="ui5-example-button">Stackblitz</a>
             </section>
         </div>
 


### PR DESCRIPTION
Access to `Codesandbox` is sometimes constrained on SAP corporative network, so we start suggesting the usage of `Stackblitz` as alternative platform for sample creation for testing the ui5 web comps, or to create reproducible samples to show-case bugs.
