### PR TITLE
docs(storybook): use semantic headings for better seo

### DIFF
--- a/packages/playground/.storybook/addons/TitleEnhancer.ts
+++ b/packages/playground/.storybook/addons/TitleEnhancer.ts
@@ -1,0 +1,22 @@
+import { addons } from '@storybook/manager-api';
+import { STORY_RENDERED } from '@storybook/core-events';
+
+const ADDON_ID = 'title-enhancer';
+
+addons.register(ADDON_ID, (api) => {
+    const setTitle = () => {
+        const storyData = api.getCurrentStoryData();
+        const componentName = storyData.name.split('/').pop()?.toLowerCase();
+
+        const componentTag = `ui5-${componentName}`;
+
+        if (storyData) {
+            const data = storyData;
+            document.title = `${data.title} - ${componentTag} - UI5 Web Components | Documentation`;
+        }
+    };
+
+    api.on(STORY_RENDERED, () => {
+        setTitle();
+    })
+});

--- a/packages/playground/.storybook/addons/TitleEnhancer.ts
+++ b/packages/playground/.storybook/addons/TitleEnhancer.ts
@@ -1,22 +1,33 @@
 import { addons } from '@storybook/manager-api';
-import { STORY_RENDERED } from '@storybook/core-events';
+import { CURRENT_STORY_WAS_SET } from '@storybook/core-events';
 
 const ADDON_ID = 'title-enhancer';
 
 addons.register(ADDON_ID, (api) => {
     const setTitle = () => {
         const storyData = api.getCurrentStoryData();
-        const componentName = storyData.name.split('/').pop()?.toLowerCase();
-
-        const componentTag = `ui5-${componentName}`;
-
-        if (storyData) {
-            const data = storyData;
-            document.title = `${data.title} - ${componentTag} - UI5 Web Components | Documentation`;
+        const getComponentTag = (title: string) => {
+            const componentName = title.split('/').pop();
+            return `ui5-${componentName?.split(' ').join('-').toLowerCase()}`;
         }
+
+        let keywords = "";
+
+        if (storyData?.tags?.includes('autodocs')) {
+            // autodocs generated per component
+            keywords = `${storyData.title} - ${getComponentTag(storyData.title)}`;
+        } else if (storyData?.tags?.includes('story')) {
+            // stories generated per component
+            keywords = `${storyData.title} - ${getComponentTag(storyData.title)} - ${storyData.name}`;
+        } else if (storyData?.tags?.includes('docs')) {
+            // docs generated out of the md files
+            keywords = `${storyData.title}`;
+        }
+
+        document.title = `${keywords} | UI5 Web Components | Documentation`
     };
 
-    api.on(STORY_RENDERED, () => {
+    api.on(CURRENT_STORY_WAS_SET, () => {
         setTitle();
     })
 });

--- a/packages/playground/.storybook/docs.tsx
+++ b/packages/playground/.storybook/docs.tsx
@@ -31,7 +31,7 @@ export const DocsPage = (args: DocsPageArgs) => {
                 )}
             </header>
             <div className='sb-ui5-component-package'><b>{args.package}</b></div>
-            <div className='sb-ui5-control-tag'>&lt;{args.component}&gt;</div>
+            <h2 className='sb-ui5-control-tag'>&lt;{args.component}&gt;</h2>
             <Subtitle />
             <Description />
             <br />

--- a/packages/playground/.storybook/manager.tsx
+++ b/packages/playground/.storybook/manager.tsx
@@ -1,6 +1,7 @@
 import { addons } from '@storybook/manager-api';
 import wcTheme from "./sbTheme";
 import './addons/github/Github';
+import './addons/TitleEnhancer';
 
 addons.setConfig({
   theme: wcTheme,

--- a/packages/playground/assets/css/api.css
+++ b/packages/playground/assets/css/api.css
@@ -456,7 +456,7 @@ body {
     padding-bottom: 1rem;
 }
 
-.sb-ui5-control-tag {
+h2.sb-ui5-control-tag {
     margin-bottom: 2rem;
     font-size: 1.1rem;
     font-weight: 300;


### PR DESCRIPTION
Summary: 

- TitleEnhancer introduced to inlcude keywords in the document's title tag when a story page is loaded (eg. component tag)
- The component tag displayed in the docs page is now with a semantinc h2 element.