### PR TITLE
fix: declare webpackChunkName in more generated dynamic imports

### DIFF
--- a/packages/icons-business-suite/src/json-imports/Icons.ts
+++ b/packages/icons-business-suite/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
 	let iconData: CollectionData;
 
 	if (collection === "business-suite-v1") {
-		iconData = (await import("../generated/assets/v1/SAP-icons-business-suite.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-business-suite-v1" */ "../generated/assets/v1/SAP-icons-business-suite.json")).default;
 	} else {
-		iconData = (await import("../generated/assets/v2/SAP-icons-business-suite.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-business-suite-v2" */ "../generated/assets/v2/SAP-icons-business-suite.json")).default;
 	}
 
 	if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {

--- a/packages/icons-tnt/src/json-imports/Icons.ts
+++ b/packages/icons-tnt/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
 	let iconData: CollectionData;
 
 	if (collection === "tnt-v3") {
-		iconData = (await import("../generated/assets/v3/SAP-icons-TNT.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-tnt-v3" */ "../generated/assets/v3/SAP-icons-TNT.json")).default;
 	} else {
-		iconData = (await import("../generated/assets/v2/SAP-icons-TNT.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-tnt-v2" */ "../generated/assets/v2/SAP-icons-TNT.json")).default;
 	}
 
 	if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {

--- a/packages/icons/src/json-imports/Icons.ts
+++ b/packages/icons/src/json-imports/Icons.ts
@@ -4,9 +4,9 @@ const loadIconsBundle = async (collection: string): Promise<CollectionData> => {
     let iconData: CollectionData;
 
 	if (collection === "SAP-icons-v5") {
-		iconData = (await import("../generated/assets/v5/SAP-icons.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-v5" */ "../generated/assets/v5/SAP-icons.json")).default;
 	} else {
-		iconData = (await import("../generated/assets/v4/SAP-icons.json")).default;
+		iconData = (await import(/* webpackChunkName: "ui5-webcomponents-sap-icons-v4" */ "../generated/assets/v4/SAP-icons.json")).default;
 	}
 
     if (typeof iconData === "string" && (iconData as string).endsWith(".json")) {


### PR DESCRIPTION
This change is a continuation of https://github.com/SAP/ui5-webcomponents/pull/7835.  I found a few more places where dynamic imports are used, so this is to add well-defined names to those as well.

Specifically I found 2 new cases:

1. Loading of icons
2. Loading of illustration SVGs in the fiori package.

This change tries to follow a similar naming convention as was used before.  Here's an example of some of the new chunks from my SAC build:

<img width="400" alt="image" src="https://github.com/SAP/ui5-webcomponents/assets/984276/fd66286e-fcc4-4345-9bd2-fa76d9372bc0">
