### PR TITLE
feat(ui5-checkbox): add css shadow part to the label

### DIFF
--- a/packages/main/src/CheckBox.hbs
+++ b/packages/main/src/CheckBox.hbs
@@ -35,7 +35,7 @@
 		</div>
 
 		{{#if text}}
-			<ui5-label id="{{_id}}-label" class="ui5-checkbox-label" wrapping-type="{{wrappingType}}">{{text}}</ui5-label>
+			<ui5-label part="label" id="{{_id}}-label" class="ui5-checkbox-label" wrapping-type="{{wrappingType}}">{{text}}</ui5-label>
 		{{/if}}
 
 		{{#if hasValueState}}

--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -66,6 +66,7 @@ let activeCb: CheckBox;
  * The <code>ui5-checkbox</code> exposes the following CSS Shadow Parts:
  * <ul>
  * <li>root - Used to style the outermost wrapper of the <code>ui5-checkbox</code></li>
+ * <li>label - Used to style the label of the <code>ui5-checkbox</code></li>
  * </ul>
  *
  * <br><br>


### PR DESCRIPTION
Enable overstyling of the checkbox's label.