### PR TITLE
fix(ui5-tree): correct item indentation

### DIFF
--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -254,7 +254,14 @@ class TreeItemBase extends ListItem {
 	 * @slot items
 	 * @public
 	 */
-	@slot({ type: HTMLElement, "default": true })
+	@slot({
+		type: HTMLElement,
+		invalidateOnChildChange: {
+			properties: false,
+			slots: ["default"],
+		},
+		"default": true,
+	})
 	items!: Array<TreeItemBase>;
 
 	onBeforeRendering() {

--- a/packages/main/test/pages/Tree.html
+++ b/packages/main/test/pages/Tree.html
@@ -79,6 +79,20 @@
 		</ui5-tree-item>
 
 	</ui5-tree>
+
+	<ui5-button id="btn">Add</ui5-button>
+	<ui5-tree>
+		<div slot="header">
+			<ui5-title>Add item on deeper level</ui5-title>
+		</div>
+		<ui5-tree-item text="1-0-0" expanded>
+			<ui5-tree-item id="treeItem" text="1-1-0" expanded>
+				<ui5-tree-item text="1-1-1"></ui5-tree-item>
+			</ui5-tree-item>
+			<ui5-tree-item text="1-2-0"></ui5-tree-item>
+			<ui5-tree-item text="1-3-0"></ui5-tree-item>
+		</ui5-tree-item>
+	</ui5-tree>
 	Mouseover counter
 	<ui5-input id="mouseover-counter" value="0"></ui5-input>
 	Mouseout counter
@@ -191,7 +205,6 @@
 			<ui5-tree-item text="Should have checkbox"></ui5-tree-item>
 		</ui5-tree-item>
 	</ui5-tree>
-	
 	<script>
 		const mouseOverInput = document.getElementById("mouseover-counter");
 		const mouseOutInput = document.getElementById("mouseout-counter");
@@ -298,6 +311,16 @@
 		indetereminateTree.addEventListener("ui5-selection-change", function(event) {
 			selectionChangeTargetItemResult.value = event.detail.targetItem.id;
 		});
+
+		const btn = document.getElementById("btn");
+		const treeItem = document.getElementById("treeItem");
+
+		btn.addEventListener("click", () => {
+			const newTreeItem = document.createElement("ui5-tree-item");
+			newTreeItem.text = `1-1-${treeItem.querySelectorAll("[ui5-tree-item]").length + 1}`
+
+			treeItem.appendChild(newTreeItem);
+		})
 
 	</script>
 </body>

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -188,3 +188,27 @@ describe("Tree has screen reader support", () => {
 	});
 
 });
+
+
+describe("Tree slots", () => {
+	before(async () => {
+		await browser.url(`test/pages/Tree.html`);
+	});
+
+	it.only("items slot", async () => {
+		const treeItem = await browser.$("#treeItem");
+		const btn = await browser.$("#btn");
+
+		let items = await treeItem.getProperty("items");
+		assert.strictEqual(items.length, 1, "Correct items count");
+
+		await btn.click();
+
+		items = await treeItem.getProperty("items");
+		const newlyAddedItem = await treeItem.$('#treeItem [ui5-tree-item]:last-child');
+
+		assert.strictEqual(items.length, 2, "Dynamic item is added correctly");
+		assert.strictEqual(await newlyAddedItem.getProperty("text"), "1-1-2", "Dynamic item is added correctly");
+		assert.strictEqual(await newlyAddedItem.getProperty("level"), 3, "Dynamic item is displayed correctly");
+	});
+});


### PR DESCRIPTION
Tree listens for child invalidation only on first level tree items. Adding item on a deeper level doesn't trigger invalidation and the items are displayed with wrong indentation. With this change we are triggering invalidation when default slot of nested child is changed.

Fixes: #8050
Fixes: #8048