### PR TITLE
refactor: update "value" setter

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -467,6 +467,8 @@ class Select extends UI5Element implements IFormElement {
 		this._onMenuChange = this.onMenuChange.bind(this);
 		this._attachMenuListeners = this.attachMenuListeners.bind(this);
 		this._detachMenuListeners = this.detachMenuListeners.bind(this);
+
+		this._upgradeProperty("value");
 	}
 
 	onBeforeRendering() {
@@ -540,8 +542,11 @@ class Select extends UI5Element implements IFormElement {
 	 * @formEvents change liveChange
 	 */
 	set value(newValue: string) {
-		this.selectOptions.forEach(option => {
-			option.selected = !!((option.value || option.textContent) === newValue);
+		const menu = this._getSelectMenu();
+		const selectOptions = Array.from(menu ? menu.children : this.children).filter(option => !option.getAttribute("disabled")) as Array<IOption>;
+
+		selectOptions.forEach(option => {
+			option.selected = !!((option.getAttribute("value") || option.textContent) === newValue);
 		});
 	}
 
@@ -1150,7 +1155,7 @@ class Select extends UI5Element implements IFormElement {
 	}
 
 	get _filteredItems() {
-		return this.options.filter(option => !option.disabled);
+		return this.options.filter(option => !option.getAttribute("disabled"));
 	}
 
 	itemSelectionAnnounce() {

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -1155,7 +1155,7 @@ class Select extends UI5Element implements IFormElement {
 	}
 
 	get _filteredItems() {
-		return this.options.filter(option => !option.getAttribute("disabled"));
+		return this.options.filter(option => !option.disabled);
 	}
 
 	itemSelectionAnnounce() {


### PR DESCRIPTION
There are use-cases when the "value" setter is called early on, before the component definition and that call simply does not   occur and the state is lost.
- make "value" setter "upgraded" (as it's done for the `@property` decorated properties), so that the setter is available
- the setter no longer rely on the component framework-created accessors  (`this.options` or `option.disabled`) because web components might not be defined yet. Instead, rely on the Light DOM - children and attributes.