### PR TITLE
chore: update tsconfig target and lib

### DIFF
--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
     "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,
       "outDir": "dist",

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,

--- a/packages/create-package/template/tsconfig.json
+++ b/packages/create-package/template/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,

--- a/packages/create-package/template/tsconfig.json
+++ b/packages/create-package/template/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,
       "outDir": "dist",

--- a/packages/fiori/src/UploadCollectionItem.ts
+++ b/packages/fiori/src/UploadCollectionItem.ts
@@ -153,7 +153,7 @@ class UploadCollectionItem extends ListItem implements IUploadCollectionItem {
 	 * @public
 	 */
 	@property({ type: Boolean, noAttribute: false })
-	disableDeleteButton!: boolean;
+	declare disableDeleteButton: boolean;
 
 	/**
 	 * By default, the delete button will always be shown, regardless of the <code>ui5-upload-collection</code>'s property <code>mode</code>.

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,
       "outDir": "dist",

--- a/packages/icons-business-suite/tsconfig.json
+++ b/packages/icons-business-suite/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2021",
 		"lib": ["DOM", "DOM.Iterable", "ES2023"],
 		  // Generate d.ts files
 		"declaration": true,

--- a/packages/icons-business-suite/tsconfig.json
+++ b/packages/icons-business-suite/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "es2022",
-		// Generate d.ts files
+		"target": "ES2022",
+		"lib": ["DOM", "DOM.Iterable", "ES2023"],
+		  // Generate d.ts files
 		"declaration": true,
 		"outDir": "dist",
 		"skipLibCheck": true,

--- a/packages/icons-tnt/tsconfig.json
+++ b/packages/icons-tnt/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2021",
 		"lib": ["DOM", "DOM.Iterable", "ES2023"],
 		  // Generate d.ts files
 		"declaration": true,

--- a/packages/icons-tnt/tsconfig.json
+++ b/packages/icons-tnt/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "es2022",
-		// Generate d.ts files
+		"target": "ES2022",
+		"lib": ["DOM", "DOM.Iterable", "ES2023"],
+		  // Generate d.ts files
 		"declaration": true,
 		"outDir": "dist",
 		"skipLibCheck": true,

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2021",
 		"lib": ["DOM", "DOM.Iterable", "ES2023"],
 		  // Generate d.ts files
 		"declaration": true,

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"include": ["src/**/*", "src/generated/**/*.json"],
 	"compilerOptions": {
-		"target": "es2022",
-		// Generate d.ts files
+		"target": "ES2022",
+		"lib": ["DOM", "DOM.Iterable", "ES2023"],
+		  // Generate d.ts files
 		"declaration": true,
 		"outDir": "dist",
 		"skipLibCheck": true,

--- a/packages/localization/tsconfig.json
+++ b/packages/localization/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"include": ["src/**/*"],
 	"compilerOptions": {
-		"target": "ES2021",
-		// Generate d.ts files
+		"target": "ES2022",
+		"lib": ["DOM", "DOM.Iterable", "ES2023"],
+		  // Generate d.ts files
 		"declaration": true,
 		"outDir": "dist",
 		"skipLibCheck": true,

--- a/packages/localization/tsconfig.json
+++ b/packages/localization/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": ["src/**/*"],
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2021",
 		"lib": ["DOM", "DOM.Iterable", "ES2023"],
 		  // Generate d.ts files
 		"declaration": true,

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -44,7 +44,7 @@ class CustomListItem extends ListItem {
 	 * @since 1.0.0-rc.15
 	 */
 	@property()
-	accessibleName!: string;
+	declare accessibleName: string;
 
 	_onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -217,30 +217,25 @@ abstract class ListItem extends ListItemBase {
 	_level?: number;
 
 	/**
-	 * Used in UploadCollectionItem
-	 * @private
-	 */
-	@property({ type: Boolean, noAttribute: true })
-	disableDeleteButton!: boolean;
-
-	/**
 	 * Defines the delete button, displayed in "Delete" mode.
 	 * <b>Note:</b> While the slot allows custom buttons, to match
 	 * design guidelines, please use the <code>ui5-button</code> component.
 	 * <b>Note:</b> When the slot is not present, a built-in delete button will be displayed.
 	 * @since 1.9.0
 	 * @public
-	 */
+	*/
 	@slot()
 	deleteButton!: Array<IButton>;
 
 	deactivateByKey: (e: KeyboardEvent) => void;
 	deactivate: () => void;
 	_ontouchstart: PassiveEventListenerObject;
-	// used in template, implemented in TreeItemBase
+	// used in template, implemented in TreeItemBase, StandardListItem
 	accessibleName?: string;
 	// used in ListItem template but implemented in TreeItemBase
 	indeterminate?: boolean;
+	// Used in UploadCollectionItem
+	disableDeleteButton?: boolean;
 
 	static i18nBundle: I18nBundle;
 

--- a/packages/main/src/MultiComboBoxItem.ts
+++ b/packages/main/src/MultiComboBoxItem.ts
@@ -22,7 +22,7 @@ class MultiComboBoxItem extends ComboBoxItem implements IMultiComboBoxItem {
 	 * @public
 	 */
 	@property({ type: Boolean })
-	selected!: boolean;
+	declare selected: boolean;
 
 	get stableDomRef() {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -65,7 +65,7 @@ class NavigationMenu extends Menu {
 	 * @public
 	 */
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
-	items!: Array<NavigationMenuItem>;
+	declare items: Array<NavigationMenuItem>;
 
 	_itemMouseOver(e: MouseEvent) {
 		if (isDesktop()) {

--- a/packages/main/src/SegmentedButtonItem.ts
+++ b/packages/main/src/SegmentedButtonItem.ts
@@ -46,7 +46,7 @@ class SegmentedButtonItem extends ToggleButton implements ISegmentedButtonItem {
 	 * @public
 	 */
 	@property({ type: ButtonDesign, defaultValue: ButtonDesign.Default })
-	design!: `${ButtonDesign}`;
+	declare design: `${ButtonDesign}`;
 
 	/**
 	 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
@@ -55,7 +55,7 @@ class SegmentedButtonItem extends ToggleButton implements ISegmentedButtonItem {
 	 * @public
 	 */
 	@property({ type: Boolean })
-	iconEnd!: boolean;
+	declare iconEnd: boolean;
 
 	/**
 	 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
@@ -64,7 +64,7 @@ class SegmentedButtonItem extends ToggleButton implements ISegmentedButtonItem {
 	 * @public
 	 */
 	@property({ type: Boolean })
-	submits!: boolean;
+	declare submits: boolean;
 
 	/**
 	 * Defines the index of the item inside of the SegmentedButton.

--- a/packages/main/src/SelectMenuOption.ts
+++ b/packages/main/src/SelectMenuOption.ts
@@ -58,7 +58,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @public
 	 */
 	@property({ type: Boolean })
-	disabled!: boolean;
+	declare disabled: boolean;
 
 	/**
 	 * Defines the value of the <code>ui5-select</code> inside an HTML Form element when this component is selected.
@@ -78,7 +78,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @deprecated
 	 */
 	@property({ type: ListItemType, defaultValue: ListItemType.Active })
-	type!: `${ListItemType}`;
+	declare type: `${ListItemType}`;
 
 	/**
 	 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
@@ -88,7 +88,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @deprecated
 	 */
 	@property({ type: Object })
-	accessibilityAttributes!: AccessibilityAttributes;
+	declare accessibilityAttributes: AccessibilityAttributes;
 
 	/**
 	 * <b>Note:</b> The property is inherited and not supported. If set, it won't take any effect.
@@ -98,7 +98,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @deprecated
 	 */
 	@property({ type: Boolean })
-	navigated!: boolean;
+	declare navigated: boolean;
 
 	/**
 	 * <b>Note:</b> The slot is inherited and not supported. If set, it won't take any effect.
@@ -107,7 +107,7 @@ class SelectMenuOption extends CustomListItem implements IOption {
 	 * @deprecated
 	 */
 	@slot()
-	deleteButton!: Array<IButton>;
+	declare deleteButton: Array<IButton>;
 
 	get stableDomRef() {
 		return "";

--- a/packages/main/src/StandardListItem.ts
+++ b/packages/main/src/StandardListItem.ts
@@ -119,7 +119,7 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 	 * @since 1.0.0-rc.15
 	 */
 	@property()
-	accessibleName!: string;
+	declare accessibleName: string;
 
 	/**
 	 * Defines if the text of the component should wrap, they truncate by default.

--- a/packages/main/src/TreeItem.ts
+++ b/packages/main/src/TreeItem.ts
@@ -1,6 +1,5 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
-import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import TreeItemBase from "./TreeItemBase.js";
 // Template
 import TreeItemTemplate from "./generated/templates/TreeItemTemplate.lit.js";
@@ -51,17 +50,6 @@ class TreeItem extends TreeItemBase {
 	 */
 	@property()
 	additionalText!: string;
-
-	/**
-	 * Defines the state of the <code>additionalText</code>.
-	 * <br>
-	 * Available options are: <code>"None"</code> (by default), <code>"Success"</code>, <code>"Warning"</code>, <code>"Information"</code> and <code>"Error"</code>.
-	 * @default "None"
-	 * @public
-	 * @since 1.0.0-rc.15
-	 */
-	@property({ type: ValueState, defaultValue: ValueState.None })
-	additionalTextState!: `${ValueState}`;
 
 	get _showTitle() {
 		return this.text.length;

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -24,8 +24,6 @@ import TreeItemBaseTemplate from "./generated/templates/TreeItemBaseTemplate.lit
 // Styles
 import treeItemCss from "./generated/themes/TreeItem.css.js";
 
-import HasPopup from "./types/HasPopup.js";
-
 type TreeItemBaseEventDetail = {
 	item: TreeItemBase,
 }
@@ -143,7 +141,7 @@ class TreeItemBase extends ListItem {
 	* @since 1.1.0
 	*/
 	@property({ type: Boolean })
-	indeterminate!: boolean;
+	declare indeterminate: boolean;
 
 	/**
 	 * Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
@@ -177,7 +175,7 @@ class TreeItemBase extends ListItem {
 	 * @since 1.8.0
 	 */
 	@property()
-	accessibleName!: string;
+	declare accessibleName: string;
 
 	/**
 	 * @private
@@ -194,15 +192,6 @@ class TreeItemBase extends ListItem {
 	_posinset!: number;
 
 	/**
-	 * Defines the description for the accessible role of the component.
-	 * @protected
-	 * @default undefined
-	 * @since 1.10.0
-	 */
-	@property({ type: String, defaultValue: undefined, noAttribute: true })
-	accessibleRoleDescription?: string;
-
-	/**
 	 * Defines if the item should be collapsible or not.
 	 * @private
 	 * @default false
@@ -210,14 +199,6 @@ class TreeItemBase extends ListItem {
 	 */
 	@property({ type: Boolean })
 	_fixed!: boolean;
-
-	/**
-	 * Defines the availability and type of interactive popup element that can be triggered by the component on which the property is set.
-	 * @since 1.10.0
-	 * @private
-	 */
-	@property({ type: HasPopup, noAttribute: true })
-	ariaHaspopup?: `${HasPopup}`;
 
 	/**
 	 * Defines the items of the component.

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "include": ["src/**/*", "global.d.ts"],
     "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,
       "outDir": "dist",

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,17 +1,18 @@
 {
     "include": ["_stories/**/*", ".storybook/**/*", "global.d.ts", "build-scripts-storybook/**/*"],
     "compilerOptions": {
-        "target": "ES2021",
-        // Generate d.ts files
-        "declaration": true,
-        "outDir": "dist",
-        "skipLibCheck": true,
-        "sourceMap": true,
-        "inlineSources": true,
-        "strict": true,
-        "moduleResolution": "node",
-    		"resolveJsonModule": true,
-        "esModuleInterop": true,
-        "jsx": "react-jsx",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
+      // Generate d.ts files
+      "declaration": true,
+      "outDir": "dist",
+      "skipLibCheck": true,
+      "sourceMap": true,
+      "inlineSources": true,
+      "strict": true,
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "esModuleInterop": true,
+      "jsx": "react-jsx",
     }
 }

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["_stories/**/*", ".storybook/**/*", "global.d.ts", "build-scripts-storybook/**/*"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,

--- a/packages/theming/tsconfig.json
+++ b/packages/theming/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "include": ["src/**/*"],
     "compilerOptions": {
-      "target": "ES2021",
+      "target": "ES2022",
+      "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,
       "outDir": "dist",

--- a/packages/theming/tsconfig.json
+++ b/packages/theming/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*"],
     "compilerOptions": {
-      "target": "ES2022",
+      "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files
       "declaration": true,


### PR DESCRIPTION
`Array.toSorted` is supported in all browsers, but appears in `lib: es2023` and TypeScript complains.

Checking how functionality is added in the standard es2023 - it has to be stage 4 which means the spec is final and two browsers implement it.

So for this project it seems safe to add the latest `lib: es2023`, as additions are not made there too early.