### PR TITLE
docs(ui5-navigation-menu): use new JSDoc syntax

### DIFF
--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -1,4 +1,5 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import {
 	isDesktop,
@@ -9,6 +10,7 @@ import type { ListItemClickEventDetail } from "./List.js";
 import Menu from "./Menu.js";
 import StandardListItem from "./StandardListItem.js";
 import MenuItem from "./MenuItem.js";
+import type NavigationMenuItem from "./NavigationMenuItem.js";
 import staticAreaMenuTemplate from "./generated/templates/NavigationMenuTemplate.lit.js";
 
 // Styles
@@ -43,12 +45,8 @@ type MenuItemClickEventDetail = {
  * <code>import "@ui5/webcomponents/dist/NavigationMenu.js";</code>
  *
  * @constructor
- * @author SAP SE
- * @alias sap.ui.webc.main.NavigationMenu
- * @extends sap.ui.webc.main.Menu
- * @tagname ui5-menu
- * @appenddocs sap.ui.webc.main.NavigationMenuItem
- * @since 1.3.0
+ * @extends Menu
+ * @since 1.22.0
  * @public
  */
 @customElement({
@@ -56,12 +54,19 @@ type MenuItemClickEventDetail = {
 	renderer: litRender,
 	staticAreaStyles: [staticAreaMenuCss, staticAreaNavigationMenuCss],
 	staticAreaTemplate: staticAreaMenuTemplate,
-	dependencies: [
-		Menu,
-	],
 })
 
 class NavigationMenu extends Menu {
+	/**
+	 * Defines the items of this component.
+	 * <br><br>
+	 * <b>Note:</b> Use <code>ui5-navigation-menu-item</code> for the intended design.
+	 *
+	 * @public
+	 */
+	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
+	items!: Array<NavigationMenuItem>;
+
 	_itemMouseOver(e: MouseEvent) {
 		if (isDesktop()) {
 			// respect mouseover only on desktop

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -47,7 +47,7 @@ type MenuItemClickEventDetail = {
  * @constructor
  * @extends Menu
  * @since 1.22.0
- * @public
+ * @private
  */
 @customElement({
 	tag: "ui5-navigation-menu",

--- a/packages/main/src/NavigationMenuItem.ts
+++ b/packages/main/src/NavigationMenuItem.ts
@@ -24,7 +24,7 @@ import MenuItem from "./MenuItem.js";
  * @extends MenuItem
  * @abstract
  * @since 1.22.0
- * @public
+ * @private
  */
 @customElement("ui5-navigation-menu-item")
 class NavigationMenuItem extends MenuItem {

--- a/packages/main/src/NavigationMenuItem.ts
+++ b/packages/main/src/NavigationMenuItem.ts
@@ -21,12 +21,8 @@ import MenuItem from "./MenuItem.js";
  * <code>import "@ui5/webcomponents/dist/NavigationMenuItem.js";</code>
  *
  * @constructor
- * @author SAP SE
- * @alias sap.ui.webc.main.NavigationMenuItem
- * @extends sap.ui.webc.main.MenuItem
+ * @extends MenuItem
  * @abstract
- * @tagname ui5-navigation-menu-item
- * @implements sap.ui.webc.main.INavigationMenuItem
  * @since 1.22.0
  * @public
  */
@@ -39,9 +35,7 @@ class NavigationMenuItem extends MenuItem {
 	 * for the <code>click</code> event should be registered.
 	 *
 	 * @public
-	 * @type {string}
-	 * @defaultvalue ""
-	 * @name sap.ui.webc.main.NavigationMenuItem.prototype.href
+	 * @default ""
 	 * @since 1.22.0
 	 */
 	@property()
@@ -63,9 +57,7 @@ class NavigationMenuItem extends MenuItem {
 	 * <b>This property must only be used when the <code>href</code> property is set.</b>
 	 *
 	 * @public
-	 * @type {string}
-	 * @defaultvalue ""
-	 * @name sap.ui.webc.main.NavigationMenuItem.prototype.target
+	 * @default ""
 	 * @since 1.22.0
 	 */
 	@property()


### PR DESCRIPTION
Changes:
 - updated the `JSDoc` to use the new format (no `@name`, no `@alias`, `@defaultvalue` -> `@default`, no namespaces)
 - updated the `@since` from `1.3` to `1.22`
 - removed `Menu` from `dependencies` as it's not used in the template (there are no extra components used in the `NavitgationMenu.hbs` compared to `Menu.hbs`, therefore `dependencies` should not be changed)
 - removed the non-existent interface `sap.ui.webc.main.INavigationMenuItem` and overrid the `@slot` to correctly aggregate the new item