### PR TITLE
fix(ui5-list): removed _level property

### DIFF
--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -213,9 +213,6 @@ abstract class ListItem extends ListItemBase {
 	@property({ type: HasPopup, noAttribute: true })
 	ariaHaspopup?: `${HasPopup}`;
 
-	@property({ type: Integer })
-	_level?: number;
-
 	/**
 	 * Used in UploadCollectionItem
 	 * @private
@@ -489,7 +486,7 @@ abstract class ListItem extends ListItemBase {
 		return {
 			role: this.accessibleRole || this.role,
 			ariaExpanded: undefined,
-			ariaLevel: this._level || undefined,
+			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
 			ariaLabelRadioButton: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_RADIO_BUTTON),
 			ariaSelectedText: this.ariaSelectedText,

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -1,5 +1,4 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { isSpace, isEnter, isDelete } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";


### PR DESCRIPTION
Fixes: #8047

_level property is removed from ui5-li, since it is no longer used.
Also, import of 'Integer' is removed, since it is not used as well.