### PR TITLE
docs: publish "sap_belize-*" deprecation statement

### DIFF
--- a/docs/1-getting-started/08-wrapping-up.md
+++ b/docs/1-getting-started/08-wrapping-up.md
@@ -60,9 +60,9 @@ npm install @ui5/webcomponents-icons
 
  5) Test the assets.
 
-  Try running the test page with the following URL parameters: `sap-ui-theme=sap_belize_hcb&sap-ui-language=de`
+  Try running the test page with the following URL parameters: `sap-ui-theme=sap_horizon_hcb&sap-ui-language=de`
 
-  [http://localhost:3000/?sap-ui-theme=sap_belize_hcb&sap-ui-language=de](http://localhost:3000/?sap-ui-theme=sap_belize_hcb&sap-ui-language=de)
+  [http://localhost:3000/?sap-ui-theme=sap_horizon_hcb&sap-ui-language=de](http://localhost:3000/?sap-ui-theme=sap_horizon_hcb&sap-ui-language=de)
   
   You should be able to see the page with an accessibility theme, and in German language.
   

--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -8,7 +8,7 @@ There are several configuration settings that affect all UI5 Web Components glob
 
 | Setting                                       | Values                                                                                                                                                                                                                                                                                         | Default Value | Description                                                            | Applies To                                                     |
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |---------------| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [theme](#theme)                               | `sap_fiori_3`, `sap_fiori_3_dark`, `sap_fiori_3_hcb`, `sap_fiori_3_hcw`, `sap_horizon`, `sap_horizon_dark`, `sap_horizon_hcb`, `sap_horizon_hcw`                                                                                             | `sap_horizon` | Visual theme to be applied                                             | All components                                                 |
+| [theme](#theme)                               | `sap_fiori_3`, `sap_fiori_3_dark`, `sap_fiori_3_hcb`, `sap_fiori_3_hcw`, `sap_horizon`, `sap_horizon_dark`, `sap_horizon_hcb`, `sap_horizon_hcw`                                                                      | `sap_horizon` | Visual theme to be applied                                             | All components                                                 |
 | [language](#language)                         | `ar`, `bg`, `ca`, `cs`, `cy`, `da`, `de`, `el`, `en`, `en_GB`, `es`, `es_MX`, `et`, `fi`, `fr`, `fr_CA`, `hi`, `hr`, `hu`, `in`, `it`, `iw`, `ja`, `kk`, `ko`, `lt`, `lv`, `ms`, `nl`, `no`, `pl`, `pt_PT`, `pt`, `ro`, `ru`, `sh`, `sk`, `sl`, `sv`, `th`, `tr`, `uk`, `vi`, `zh_CN`, `zh_TW` | N/A (`null`)  | Language to be used for translatable texts                             | Components and icons with translatable texts                   |
 | [animationMode](#animationMode)               | `full`, `basic`, `minimal`, `none`                                                                                                                                                                                                                                                             | `full`        | Amount/intensity of animations to be played for some components        | Components with animations (`ui5-panel`, `ui5-carousel`, etc.) |
 | [calendarType](#calendarType)                 | `Gregorian`, `Islamic`, `Buddhist`, `Japanese`, `Persian`                                                                                                                                                                                                                                      | `Gregorian`   | Default calendar type to be used for date-related components           | Date/time components (`ui5-date-picker`, etc.)                 |
@@ -60,12 +60,11 @@ setTheme(getDefaultTheme());
 
 **Note: Deprecated themes**
 
-The following themes are deprecated and no longer maintained.
-The themes will work until the next major version (2.0) and will be removed afterwards.
-- The `sap_belize` is known as `Belize`.
-- The `sap_belize_hcb` is known as `High Contrast Black`.
-- The `sap_belize_hcw` is known as `High Contrast White`.
-
+The following themes are deprecated and no longer developed. We recommend using `Quartz` (sap_fiori_3) and `Horizon` (sap_horizon) theme families.
+- The `sap_belize` is known as `Belize` [deprecated since 1.21].
+- The `sap_belize_hcb` is known as `High Contrast Black` [deprecated since 1.21].
+- The `sap_belize_hcw` is known as `High Contrast White` [deprecated since 1.21].
+* the themes will work until the next major version (2.0) and will be removed afterwards.
 
 ### language
 <a name="language"></a>

--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -60,11 +60,11 @@ setTheme(getDefaultTheme());
 
 **Note: Deprecated themes**
 
-The following themes are deprecated and no longer developed. We recommend using `Quartz` (sap_fiori_3) and `Horizon` (sap_horizon) theme families.
-- The `sap_belize` is known as `Belize` [deprecated since 1.21].
-- The `sap_belize_hcb` is known as `High Contrast Black` [deprecated since 1.21].
-- The `sap_belize_hcw` is known as `High Contrast White` [deprecated since 1.21].
-* the themes will work until the next major version (2.0) and will be removed afterwards.
+The following themes are deprecated and no longer maintained - out of maintenance and left for compatibility only. The themes will be removed in the next major version.
+We recommend using `Horizon` (sap_horizon) and `Quartz` (sap_fiori_3) theme families.
+- The `sap_belize` is known as `Belize` [deprecated since 1.22].
+- The `sap_belize_hcb` is known as `High Contrast Black` [deprecated since 1.22].
+- The `sap_belize_hcw` is known as `High Contrast White` [deprecated since 1.22].
 
 ### language
 <a name="language"></a>

--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -8,7 +8,7 @@ There are several configuration settings that affect all UI5 Web Components glob
 
 | Setting                                       | Values                                                                                                                                                                                                                                                                                         | Default Value | Description                                                            | Applies To                                                     |
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |---------------| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [theme](#theme)                               | `sap_fiori_3`, `sap_fiori_3_dark`, `sap_fiori_3_hcb`, `sap_fiori_3_hcw`, `sap_belize`, `sap_belize_hcb`, `sap_belize_hcw`, `sap_horizon`, `sap_horizon_dark`, `sap_horizon_hcb`, `sap_horizon_hcw`                                                                                             | `sap_horizon` | Visual theme to be applied                                             | All components                                                 |
+| [theme](#theme)                               | `sap_fiori_3`, `sap_fiori_3_dark`, `sap_fiori_3_hcb`, `sap_fiori_3_hcw`, `sap_horizon`, `sap_horizon_dark`, `sap_horizon_hcb`, `sap_horizon_hcw`                                                                                             | `sap_horizon` | Visual theme to be applied                                             | All components                                                 |
 | [language](#language)                         | `ar`, `bg`, `ca`, `cs`, `cy`, `da`, `de`, `el`, `en`, `en_GB`, `es`, `es_MX`, `et`, `fi`, `fr`, `fr_CA`, `hi`, `hr`, `hu`, `in`, `it`, `iw`, `ja`, `kk`, `ko`, `lt`, `lv`, `ms`, `nl`, `no`, `pl`, `pt_PT`, `pt`, `ro`, `ru`, `sh`, `sk`, `sl`, `sv`, `th`, `tr`, `uk`, `vi`, `zh_CN`, `zh_TW` | N/A (`null`)  | Language to be used for translatable texts                             | Components and icons with translatable texts                   |
 | [animationMode](#animationMode)               | `full`, `basic`, `minimal`, `none`                                                                                                                                                                                                                                                             | `full`        | Amount/intensity of animations to be played for some components        | Components with animations (`ui5-panel`, `ui5-carousel`, etc.) |
 | [calendarType](#calendarType)                 | `Gregorian`, `Islamic`, `Buddhist`, `Japanese`, `Persian`                                                                                                                                                                                                                                      | `Gregorian`   | Default calendar type to be used for date-related components           | Date/time components (`ui5-date-picker`, etc.)                 |
@@ -29,9 +29,7 @@ The `theme` setting values above are the technical names of the supported themes
 - The `sap_fiori_3_dark` is known as `Quartz Dark`.
 - The `sap_fiori_3_hcb` is known as `Quartz High Contrast Black`.
 - The `sap_fiori_3_hcw` is known as `Quartz High Contrast White`.
-- The `sap_belize` is known as `Belize`.
-- The `sap_belize_hcb` is known as `High Contrast Black`.
-- The `sap_belize_hcw` is known as `High Contrast White`.
+
 
 The default theme (`sap_horizon`) is built in all UI5 Web Components. Thus, components are always themed.
 Configuring another theme will additionally fetch and use that theme. Any theme is fetched just once.
@@ -51,7 +49,7 @@ For more about assets, see the dedicated [Assets](../1-getting-started/05-using-
 Example:
 ```js
 import { setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
-setTheme("sap_belize_hcb");
+setTheme("sap_horizon_hcb");
 ```
 
 - To reset the theme to the default one:
@@ -59,6 +57,15 @@ setTheme("sap_belize_hcb");
 import { setTheme, getDefaultTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 setTheme(getDefaultTheme());
 ```
+
+**Note: Deprecated themes**
+
+The following themes are deprecated and no longer maintained.
+The themes will work until the next major version (2.0) and will be removed afterwards.
+- The `sap_belize` is known as `Belize`.
+- The `sap_belize_hcb` is known as `High Contrast Black`.
+- The `sap_belize_hcw` is known as `High Contrast White`.
+
 
 ### language
 <a name="language"></a>

--- a/docs/5-development/01-custom-UI5-Web-Components-Packages.md
+++ b/docs/5-development/01-custom-UI5-Web-Components-Packages.md
@@ -206,9 +206,10 @@ In addition, you can define your own CSS Vars and provide different values for t
 | File                                                | Purpose                                                                                        |
 |-----------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `src/themes/MyFirstComponent.css`                   | All CSS rules for the Web Component, same for all themes; will be inserted in the shadow root. |
-| `src/themes/sap_belize/parameters-bundle.css`       | Values for the component-specific CSS Vars for the `sap_belize` theme                          |
-| `src/themes/sap_belize_hcb/parameters-bundle.css`   | Values for the component-specific CSS Vars for the `sap_belize_hcb` theme                      |
-| `src/themes/sap_belize_hcw/parameters-bundle.css`   | Values for the component-specific CSS Vars for the `sap_belize_hcw` theme                      |
+| `src/themes/sap_horizon/parameters-bundle.css`      | Values for the component-specific CSS Vars for the `sap_horizon` theme                         |
+| `src/themes/sap_horizon_dark/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_horizon_dark` theme                    |
+| `src/themes/sap_horizon_hcb/parameters-bundle.css`  | Values for the component-specific CSS Vars for the `sap_horizon_hcb` theme                     |
+| `src/themes/sap_horizon_hcw/parameters-bundle.css`  | Values for the component-specific CSS Vars for the `sap_horizon_hcw` theme                     |
 | `src/themes/sap_fiori_3/parameters-bundle.css`      | Values for the component-specific CSS Vars for the `sap_fiori_3` theme                         |
 | `src/themes/sap_fiori_3_dark/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_fiori_3_dark` theme                    |
 | `src/themes/sap_fiori_3_hcb/parameters-bundle.css`  | Values for the component-specific CSS Vars for the `sap_fiori_3_hcb` theme                     |

--- a/docs/5-development/02-custom-UI5-Web-Components.md
+++ b/docs/5-development/02-custom-UI5-Web-Components.md
@@ -238,8 +238,8 @@ Vars for each theme in the respective theme directory in `themes/`:
 
 File | Descriptions
 ------------|-------------
-`themes/sap_belize/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_belize` theme.
-`themes/sap_belize_hcb/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_belize_hcb` theme.
+`themes/sap_horizon/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_horizon` theme.
+`themes/sap_horizon_hcb/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_horizon_hcb` theme.
 `themes/sap_fiori_3/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_fiori_3` theme.
 `themes/sap_fiori_3_dark/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_fiori_3_dark` theme.
 
@@ -513,8 +513,8 @@ Let's inspect the following files (one with CSS declarations, the others with CS
 File | Purpose
 ------------|-------------
 `themes/Demo.css` | All CSS rules for the Web Component, same for all themes; will be inserted in the shadow root.
-`themes/sap_belize/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_belize` theme.
-`themes/sap_belize_hcb/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_belize_hcb` theme.
+`themes/sap_horizon/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_horizon` theme.
+`themes/sap_horizon_hcb/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_horizon_hcb` theme.
 `themes/sap_fiori_3/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_fiori_3` theme.
 `themes/sap_fiori_3_dark/parameters-bundle.css` | Values for the component-specific CSS Vars for the `sap_fiori_3_dark` theme.
 


### PR DESCRIPTION
The following themes are deprecated and no longer maintained.
The themes will work until the next major version (2.0) and will be removed afterwards.
- The `sap_belize` is known as `Belize`.
- The `sap_belize_hcb` is known as `High Contrast Black`.
- The `sap_belize_hcw` is known as `High Contrast White`.