### PR TITLE
fix(ui5-shellbar): logo aligned with visual specification

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -192,6 +192,7 @@ slot[name="profile"] {
 
 .ui5-shellbar-logo {
 	cursor: pointer;
+	padding: .25rem;
 	max-height: 2rem;
 }
 


### PR DESCRIPTION
The logo now has small gap between itself and its focus/hover outline in order to avoid overlap.

Fixes: #8058
