### PR TITLE
chore: enable errors for cem validation

### DIFF
--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -43,8 +43,8 @@ const scripts = {
 	generateTemplates: `mkdirp src/generated/templates && cross-env UI5_BASE=true UI5_TS=true node "${LIB}/hbs2ui5/index.js" -d test/elements -o src/generated/templates`,
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",
-		generateCEM: `cem analyze --config  "${LIB}/cem/custom-elements-manifest.config.mjs" --ui5package`,
-		validateCEM: `node "${LIB}/cem/validate.js" --ui5package`,
+		generateCEM: `cem analyze --config  "${LIB}/cem/custom-elements-manifest.config.mjs" --dev`,
+		validateCEM: `node "${LIB}/cem/validate.js" --dev`,
 	},
 	watch: {
 		default: 'concurrently "nps watch.src" "nps watch.styles"',

--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -43,8 +43,8 @@ const scripts = {
 	generateTemplates: `mkdirp src/generated/templates && cross-env UI5_BASE=true UI5_TS=true node "${LIB}/hbs2ui5/index.js" -d test/elements -o src/generated/templates`,
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",
-		generateCEM: `cem analyze --config  "${LIB}/cem/custom-elements-manifest.config.mjs"`,
-		validateCEM: `node "${LIB}/cem/validate.js"`,
+		generateCEM: `cem analyze --config  "${LIB}/cem/custom-elements-manifest.config.mjs" --ui5package`,
+		validateCEM: `node "${LIB}/cem/validate.js" --ui5package`,
 	},
 	watch: {
 		default: 'concurrently "nps watch.src" "nps watch.styles"',

--- a/packages/fiori/package-scripts.cjs
+++ b/packages/fiori/package-scripts.cjs
@@ -15,6 +15,7 @@ const filterOut = [
 const options = {
 	port: 8081,
 	portStep: 2,
+	ui5package: true,
 	fioriPackage: true,
 	typescript: true,
 	noWatchTS: true,

--- a/packages/fiori/package-scripts.cjs
+++ b/packages/fiori/package-scripts.cjs
@@ -15,7 +15,7 @@ const filterOut = [
 const options = {
 	port: 8081,
 	portStep: 2,
-	ui5package: true,
+	dev: true,
 	fioriPackage: true,
 	typescript: true,
 	noWatchTS: true,

--- a/packages/main/package-scripts.cjs
+++ b/packages/main/package-scripts.cjs
@@ -5,7 +5,7 @@ const options = {
 	portStep: 2,
 	typescript: true,
 	noWatchTS: true,
-	ui5package: true,
+	dev: true,
 };
 
 const scripts = getScripts(options);

--- a/packages/main/package-scripts.cjs
+++ b/packages/main/package-scripts.cjs
@@ -5,6 +5,7 @@ const options = {
 	portStep: 2,
 	typescript: true,
 	noWatchTS: true,
+	ui5package: true,
 };
 
 const scripts = getScripts(options);

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -136,8 +136,8 @@ const getScripts = (options) => {
 		},
 		generateAPI: {
 			default: `nps ${ tsOption ? "generateAPI.generateCEM generateAPI.validateCEM" : "generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup generateAPI.prepareManifest"}`,
-			generateCEM: `cem analyze --config "${LIB}/cem/custom-elements-manifest.config.mjs" ${ options.ui5package ? "--ui5package" : "" }`,
-			validateCEM: `node "${LIB}/cem/validate.js" ${ options.ui5package ? "--ui5package" : "" }`,
+			generateCEM: `cem analyze --config "${LIB}/cem/custom-elements-manifest.config.mjs" ${ options.dev ? "--ui5package" : "" }`,
+			validateCEM: `node "${LIB}/cem/validate.js" ${ options.dev ? "--ui5package" : "" }`,
 			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
 			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" dist dist`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -136,8 +136,8 @@ const getScripts = (options) => {
 		},
 		generateAPI: {
 			default: `nps ${ tsOption ? "generateAPI.generateCEM generateAPI.validateCEM" : "generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup generateAPI.prepareManifest"}`,
-			generateCEM: `cem analyze --config  "${LIB}/cem/custom-elements-manifest.config.mjs"`,
-			validateCEM: `node "${LIB}/cem/validate.js"`,
+			generateCEM: `cem analyze --config "${LIB}/cem/custom-elements-manifest.config.mjs" ${ options.ui5package ? "--ui5package" : "" }`,
+			validateCEM: `node "${LIB}/cem/validate.js" ${ options.ui5package ? "--ui5package" : "" }`,
 			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
 			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" dist dist`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -136,8 +136,8 @@ const getScripts = (options) => {
 		},
 		generateAPI: {
 			default: `nps ${ tsOption ? "generateAPI.generateCEM generateAPI.validateCEM" : "generateAPI.prepare generateAPI.preprocess generateAPI.jsdoc generateAPI.cleanup generateAPI.prepareManifest"}`,
-			generateCEM: `cem analyze --config "${LIB}/cem/custom-elements-manifest.config.mjs" ${ options.dev ? "--ui5package" : "" }`,
-			validateCEM: `node "${LIB}/cem/validate.js" ${ options.dev ? "--ui5package" : "" }`,
+			generateCEM: `cem analyze --config "${LIB}/cem/custom-elements-manifest.config.mjs" ${ options.dev ? "--dev" : "" }`,
+			validateCEM: `node "${LIB}/cem/validate.js" ${ options.dev ? "--dev" : "" }`,
 			prepare: `node "${LIB}/copy-and-watch/index.js" --silent "dist/**/*.js" jsdoc-dist/`,
 			prepareManifest: `node "${LIB}/generate-custom-elements-manifest/index.js" dist dist`,
 			preprocess: `node "${preprocessJSDocScript}" jsdoc-dist/ src`,

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -441,7 +441,7 @@ export default {
 				})
 			},
 			packageLinkPhase({ customElementsManifest, context }) {
-				if (context.ui5package) {
+				if (context.dev) {
 					const JSDocErrors = getJSDocErrors();
 					if (JSDocErrors.length > 0) {
 						console.log(JSDocErrors.join("\n"));

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -440,14 +440,15 @@ export default {
 					}
 				})
 			},
-			packageLinkPhase({ customElementsManifest }) {
-				// Uncomment and handle errors appropriately
-				// const JSDocErrors = getJSDocErrors();
-				// if (JSDocErrors.length > 0) {
-				// 	console.log(JSDocErrors.join("\n"));
-				// 	console.log(`Invalid JSDoc. ${JSDocErrors.length} were found.`);
-				// 	throw new Error(`Invalid JSDoc.`);
-				// }
+			packageLinkPhase({ customElementsManifest, context }) {
+				if (context.ui5package) {
+					const JSDocErrors = getJSDocErrors();
+					if (JSDocErrors.length > 0) {
+						console.log(JSDocErrors.join("\n"));
+						console.log(`Invalid JSDoc. ${JSDocErrors.length} were found.`);
+						throw new Error(`Invalid JSDoc.`);
+					}
+				}
 
 				customElementsManifest.modules?.forEach(m => {
 					m.path = m.path?.replace(/^src/, "dist").replace(/\.ts$/, ".js");

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -44,7 +44,7 @@ const ajv = new Ajv({ allowUnionTypes: true, allError: true })
 let validate = ajv.compile(internalSchema)
 
 // Validate the JSON data against the schema
-if (argv.ui5package) {
+if (argv.dev) {
     if (validate(inputDataInternal)) {
         console.log('Internal custom  element manifest is validated successfully');
     } else {
@@ -61,7 +61,7 @@ if (validate(inputDataExternal)) {
     fs.writeFileSync(inputFilePath, JSON.stringify(inputDataExternal, null, 2), 'utf8');
     fs.writeFileSync(inputFilePath.replace("custom-elements", "custom-elements-internal"), JSON.stringify(inputDataInternal, null, 2), 'utf8');
 } else {
-    if (argv.ui5package) {
+    if (argv.dev) {
         throw new Error(`Validation of public custom elements manifest failed: ${validate.errors}`);
     }
 }

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const Ajv = require('ajv');
 const path = require('path');
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const argv = yargs(hideBin(process.argv))
+	.argv;
 
 // Load your JSON schema
 const extenalSchema = require('./schema.json');
@@ -46,8 +50,7 @@ let validate = ajv.compile(internalSchema)
 if (validate(inputDataInternal)) {
     console.log('Validation internal custom-elements successful');
 } else {
-    console.error('Validation of internal custom-elements failed');
-    // console.error('Validation of internal custom-elements failed:', validate.errors);
+    console.error('Validation of internal custom-elements failed:', argv.ui5package ? validate.errors : "");
 }
 
 validate = ajv.compile(extenalSchema)
@@ -58,6 +61,5 @@ if (validate(inputDataExternal)) {
     fs.writeFileSync(inputFilePath, JSON.stringify(inputDataExternal, null, 2), 'utf8');
     fs.writeFileSync(inputFilePath.replace("custom-elements", "custom-elements-internal"), JSON.stringify(inputDataInternal, null, 2), 'utf8');
 } else {
-    console.error('Validation of external custom-elements failed:');
-    // console.error('Validation of external custom-elements failed:', ajv.errorsText(validate.errors));
+    console.error('Validation of external custom-elements failed:', argv.ui5package ? validate.errors : "" );
 }

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -40,34 +40,28 @@ const clearProps = (data) => {
     return data;
 }
 
-const inputDataExternal = clearProps(JSON.parse(JSON.stringify(inputDataInternal)));
-
 const ajv = new Ajv({ allowUnionTypes: true, allError: true })
-
 let validate = ajv.compile(internalSchema)
 
 // Validate the JSON data against the schema
-if (validate(inputDataInternal)) {
-    console.log('Validation internal custom-elements successful');
-} else {
-    if (argv.ui5package) {
-        throw new Error(`Validation of internal custom-elements failed: ${validate.errors}`);
+if (argv.ui5package) {
+    if (validate(inputDataInternal)) {
+        console.log('Internal custom  element manifest is validated successfully');
     } else {
-        console.error('Validation of internal custom-elements failed')
+        throw new Error(`Validation of internal custom elements manifest failed: ${validate.errors}`);
     }
 }
 
+const inputDataExternal = clearProps(JSON.parse(JSON.stringify(inputDataInternal)));
 validate = ajv.compile(extenalSchema)
 
 // Validate the JSON data against the schema
 if (validate(inputDataExternal)) {
-    console.log('Validation external custom-elements successful');
+    console.log('Custom element manifest is validated successfully');
     fs.writeFileSync(inputFilePath, JSON.stringify(inputDataExternal, null, 2), 'utf8');
     fs.writeFileSync(inputFilePath.replace("custom-elements", "custom-elements-internal"), JSON.stringify(inputDataInternal, null, 2), 'utf8');
 } else {
     if (argv.ui5package) {
-        throw new Error(`Validation of external custom-elements failed: ${validate.errors}`);
-    } else {
-        console.error('Validation of external custom-elements failed')
+        throw new Error(`Validation of public custom elements manifest failed: ${validate.errors}`);
     }
 }

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -50,7 +50,11 @@ let validate = ajv.compile(internalSchema)
 if (validate(inputDataInternal)) {
     console.log('Validation internal custom-elements successful');
 } else {
-    console.error('Validation of internal custom-elements failed:', argv.ui5package ? validate.errors : "");
+    if (argv.ui5package) {
+        throw new Error(`Validation of internal custom-elements failed: ${validate.errors}`);
+    } else {
+        console.error('Validation of internal custom-elements failed')
+    }
 }
 
 validate = ajv.compile(extenalSchema)
@@ -61,5 +65,9 @@ if (validate(inputDataExternal)) {
     fs.writeFileSync(inputFilePath, JSON.stringify(inputDataExternal, null, 2), 'utf8');
     fs.writeFileSync(inputFilePath.replace("custom-elements", "custom-elements-internal"), JSON.stringify(inputDataInternal, null, 2), 'utf8');
 } else {
-    console.error('Validation of external custom-elements failed:', argv.ui5package ? validate.errors : "" );
+    if (argv.ui5package) {
+        throw new Error(`Validation of external custom-elements failed: ${validate.errors}`);
+    } else {
+        console.error('Validation of external custom-elements failed')
+    }
 }

--- a/patches/@custom-elements-manifest+analyzer+0.8.4.patch
+++ b/patches/@custom-elements-manifest+analyzer+0.8.4.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/@custom-elements-manifest/analyzer/cli.js b/node_modules/@custom-elements-manifest/analyzer/cli.js
+index 49da928..1868c9b 100755
+--- a/node_modules/@custom-elements-manifest/analyzer/cli.js
++++ b/node_modules/@custom-elements-manifest/analyzer/cli.js
+@@ -63,7 +63,7 @@ export async function cli({ argv = process.argv, cwd = process.cwd(), noWrite }
+       let plugins = await addFrameworkPlugins(mergedOptions);
+       plugins = [...plugins, ...(userConfig?.plugins || [])];
+ 
+-      const context = { dev: mergedOptions.dev, thirdPartyCEMs };
++      const context = { dev: mergedOptions.dev, thirdPartyCEMs, ui5package: mergedOptions.ui5package };
+ 
+       /**
+        * Create the manifest
+diff --git a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
+index 30cfee9..ff27d8b 100644
+--- a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
++++ b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
+@@ -61,6 +61,7 @@ export const DEFAULTS = {
+   stencil: false,
+   fast: false,
+   catalyst: false,
++  ui5generation: false,
+   'catalyst-major-2': false,
+ }
+ 
+@@ -80,6 +81,7 @@ export function getCliConfig(argv) {
+     { name: 'fast', type: Boolean },
+     { name: 'catalyst', type: Boolean },
+     { name: 'catalyst-major-2', type: Boolean },
++    { name: 'ui5generation', type: Boolean },
+   ];
+ 
+   return commandLineArgs(optionDefinitions, { argv });

--- a/patches/@custom-elements-manifest+analyzer+0.8.4.patch
+++ b/patches/@custom-elements-manifest+analyzer+0.8.4.patch
@@ -12,14 +12,14 @@ index 49da928..1868c9b 100755
        /**
         * Create the manifest
 diff --git a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
-index 30cfee9..ff27d8b 100644
+index 30cfee9..338e5a3 100644
 --- a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
 +++ b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
 @@ -61,6 +61,7 @@ export const DEFAULTS = {
    stencil: false,
    fast: false,
    catalyst: false,
-+  ui5generation: false,
++  ui5package: false,
    'catalyst-major-2': false,
  }
  
@@ -27,7 +27,7 @@ index 30cfee9..ff27d8b 100644
      { name: 'fast', type: Boolean },
      { name: 'catalyst', type: Boolean },
      { name: 'catalyst-major-2', type: Boolean },
-+    { name: 'ui5generation', type: Boolean },
++    { name: 'ui5package', type: Boolean },
    ];
  
    return commandLineArgs(optionDefinitions, { argv });

--- a/patches/@custom-elements-manifest+analyzer+0.8.4.patch
+++ b/patches/@custom-elements-manifest+analyzer+0.8.4.patch
@@ -1,33 +1,60 @@
 diff --git a/node_modules/@custom-elements-manifest/analyzer/cli.js b/node_modules/@custom-elements-manifest/analyzer/cli.js
-index 49da928..1868c9b 100755
+index 49da928..bd1c1c3 100755
 --- a/node_modules/@custom-elements-manifest/analyzer/cli.js
 +++ b/node_modules/@custom-elements-manifest/analyzer/cli.js
-@@ -63,7 +63,7 @@ export async function cli({ argv = process.argv, cwd = process.cwd(), noWrite }
-       let plugins = await addFrameworkPlugins(mergedOptions);
-       plugins = [...plugins, ...(userConfig?.plugins || [])];
+@@ -70,10 +70,6 @@ export async function cli({ argv = process.argv, cwd = process.cwd(), noWrite }
+        */
+        const customElementsManifest = create({modules, plugins, context});
  
--      const context = { dev: mergedOptions.dev, thirdPartyCEMs };
-+      const context = { dev: mergedOptions.dev, thirdPartyCEMs, ui5package: mergedOptions.ui5package };
+-       if (mergedOptions.dev) {
+-        console.log(JSON.stringify(customElementsManifest, null, 2));
+-      }
+-
+       if(!noWrite) {
+         const outdir = path.join(cwd, mergedOptions.outdir);
+         if (!fs.existsSync(outdir)) {
+diff --git a/node_modules/@custom-elements-manifest/analyzer/src/create.js b/node_modules/@custom-elements-manifest/analyzer/src/create.js
+index 15ef0e2..9356bfb 100644
+--- a/node_modules/@custom-elements-manifest/analyzer/src/create.js
++++ b/node_modules/@custom-elements-manifest/analyzer/src/create.js
+@@ -15,8 +15,6 @@ export function create({modules, plugins = [], context = {dev:false}}) {
+     modules: [],
+   };
  
-       /**
-        * Create the manifest
-diff --git a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
-index 30cfee9..338e5a3 100644
---- a/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
-+++ b/node_modules/@custom-elements-manifest/analyzer/src/utils/cli-helpers.js
-@@ -61,6 +61,7 @@ export const DEFAULTS = {
-   stencil: false,
-   fast: false,
-   catalyst: false,
-+  ui5package: false,
-   'catalyst-major-2': false,
- }
+-  const { dev } = context;
+-
+   const mergedPlugins = [
+     ...FEATURES,
+     ...plugins,
+@@ -24,7 +22,6 @@ export function create({modules, plugins = [], context = {dev:false}}) {
  
-@@ -80,6 +81,7 @@ export function getCliConfig(argv) {
-     { name: 'fast', type: Boolean },
-     { name: 'catalyst', type: Boolean },
-     { name: 'catalyst-major-2', type: Boolean },
-+    { name: 'ui5package', type: Boolean },
-   ];
  
-   return commandLineArgs(optionDefinitions, { argv });
+   modules.forEach(currModule => {
+-    if(dev) console.log('[COLLECT PHASE]: ', currModule.fileName);
+     /**
+      * COLLECT PHASE
+      * First pass through all modules. Can be used to gather imports, exports, types, default values,
+@@ -34,7 +31,6 @@ export function create({modules, plugins = [], context = {dev:false}}) {
+   });
+ 
+   modules.forEach(currModule => {
+-    if(dev) console.log('[ANALYZE PHASE]: ', currModule.fileName);
+     const moduleDoc = {
+       kind: "javascript-module",
+       path: currModule.fileName,
+@@ -51,7 +47,6 @@ export function create({modules, plugins = [], context = {dev:false}}) {
+     analyze(currModule, moduleDoc, context, mergedPlugins);
+     customElementsManifest.modules.push(moduleDoc);
+ 
+-    if(dev) console.log('[MODULE LINK PHASE]: ', currModule.fileName);
+     /**
+      * LINK PHASE
+      * All information for a module has been gathered, now we can link information together. Like:
+@@ -65,7 +60,6 @@ export function create({modules, plugins = [], context = {dev:false}}) {
+     });
+   });
+ 
+-  if(dev) console.log('[PACKAGE LINK PHASE]');
+   /**
+    * PACKAGE LINK PHASE
+    * All modules have now been parsed, we can now link information from across modules together


### PR DESCRIPTION
Enable errors when validating custom-element-manifest for ui5 packages and stop the build if invalid syntax is used.

In this PR a patch for `@custom-elements-manifest/analyzer` package is added to enable `ui5generation` cli parameter because the package has strict check for used parameters.