### PR TITLE
chore: cem enhancements

### DIFF
--- a/packages/base/src/decorators/event.ts
+++ b/packages/base/src/decorators/event.ts
@@ -1,5 +1,3 @@
-import { EventData } from "../UI5ElementMetadata.js";
-
 /**
  * Returns an event class decorator.
  *
@@ -7,7 +5,7 @@ import { EventData } from "../UI5ElementMetadata.js";
  * @param { EventData } data the event data
  * @returns { ClassDecorator }
  */
-const event = (name: string, data: EventData = {}): ClassDecorator => {
+const event = <EventDetail>(name: string, data: { detail?: Record<keyof EventDetail, { type: any }> } = {}): ClassDecorator => {
 	return (target: any) => {
 		if (!Object.prototype.hasOwnProperty.call(target, "metadata")) {
 			target.metadata = {};

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -91,7 +91,7 @@ type BarcodeScannerDialogScanErrorEventDetail = {
  * @param {Object} rawBytes the scan result as a Uint8Array
  * @public
  */
-@event("scan-success", {
+@event<BarcodeScannerDialogScanSuccessEventDetail>("scan-success", {
 	detail: {
 		/**
 		* @public
@@ -110,7 +110,7 @@ type BarcodeScannerDialogScanErrorEventDetail = {
  * @param {string} message the error message
  * @public
  */
-@event("scan-error", {
+@event<BarcodeScannerDialogScanErrorEventDetail>("scan-error", {
 	detail: {
 		/**
 		* @public

--- a/packages/fiori/src/DynamicSideContent.ts
+++ b/packages/fiori/src/DynamicSideContent.ts
@@ -123,7 +123,7 @@ type DynamicSideContentLayoutChangeEventDetail = {
  * @param {boolean} sideContentVisible visibility of the side content.
  * @public
  */
-@event("layout-change", {
+@event<DynamicSideContentLayoutChangeEventDetail>("layout-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -151,7 +151,7 @@ type AccessibilityRoles = {
  * @param {boolean} resize Indicates if the layout is changed via resizing
  * @public
  */
-@event("layout-change", {
+@event<FlexibleColumnLayoutLayoutChangeEventDetail>("layout-change", {
 	detail: {
 		/**
 		* @public
@@ -178,9 +178,13 @@ type AccessibilityRoles = {
 		*/
 		arrowsUsed: { type: Boolean },
 		/**
-		* @public
+		 * @public
 		*/
 		resize: { type: Boolean },
+		/**
+		 * @private
+		*/
+		arrowUsed: { type: Boolean },
 	},
 })
 class FlexibleColumnLayout extends UI5Element {

--- a/packages/fiori/src/MediaGallery.ts
+++ b/packages/fiori/src/MediaGallery.ts
@@ -99,7 +99,7 @@ const COLUMNS_COUNT: Record<string, number> = {
  * @param {HTMLElement} item the selected item.
  * @public
  */
-@event("selection-change", {
+@event<MediaGallerySelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/fiori/src/NotificationAction.ts
+++ b/packages/fiori/src/NotificationAction.ts
@@ -26,7 +26,7 @@ type NotificationActionClickEventDetail = {
  * @param {HTMLElement} targetRef DOM ref of the clicked element
  * @public
  */
-@event("click", {
+@event<NotificationActionClickEventDetail>("click", {
 	detail: {
 		targetRef: { type: HTMLElement },
 	},

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -60,12 +60,14 @@ type NotificationListItemBaseCloseEventDetail = {
  * @param {HTMLElement} item the closed item.
  * @public
  */
-@event("close", {
+@event<NotificationListItemBaseCloseEventDetail>("close", {
 	 detail: {
 		/**
 		 * @public
 		 */
-		item: HTMLElement,
+		item: {
+			type: HTMLElement,
+		},
 	},
 })
 class NotificationListItemBase extends ListItemBase {

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -184,7 +184,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @param {HTMLElement} targetRef dom ref of the activated element
  * @public
  */
-@event("notifications-click", {
+@event<ShellBarNotificationsClickEventDetail>("notifications-click", {
 	detail: {
 		/**
 		 * @public
@@ -199,7 +199,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @param {HTMLElement} targetRef dom ref of the activated element
  * @public
  */
-@event("profile-click", {
+@event<ShellBarProfileClickEventDetail>("profile-click", {
 	detail: {
 		/**
 		 * @public
@@ -216,7 +216,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @param {HTMLElement} targetRef dom ref of the activated element
  * @public
  */
-@event("product-switch-click", {
+@event<ShellBarProductSwitchClickEventDetail>("product-switch-click", {
 	detail: {
 		/**
 		 * @public
@@ -232,7 +232,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @since 0.10
  * @public
  */
-@event("logo-click", {
+@event<ShellBarLogoClickEventDetail>("logo-click", {
 	detail: {
 		/**
 		 * @public
@@ -248,7 +248,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @since 0.10
  * @public
  */
-@event("co-pilot-click", {
+@event<ShellBarCoPilotClickEventDetail>("co-pilot-click", {
 	detail: {
 		/**
 		 * @public
@@ -265,7 +265,7 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  * @since 0.10
  * @public
  */
-@event("menu-item-click", {
+@event<ShellBarMenuItemClickEventDetail>("menu-item-click", {
 	detail: {
 		/**
 		 * @public

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -34,7 +34,7 @@ type ShellBarItemClickEventDetail = {
  * @param {HTMLElement} targetRef DOM ref of the clicked element
  * @public
  */
-@event("click", {
+@event<ShellBarItemClickEventDetail>("click", {
 	detail: {
 		targetRef: { type: HTMLElement },
 	},

--- a/packages/fiori/src/SideNavigation.ts
+++ b/packages/fiori/src/SideNavigation.ts
@@ -63,10 +63,8 @@ type PopupClickEventDetail = {
 
 // used for the inner side navigation used in the SideNavigationPopoverTemplate
 type NavigationMenuClickEventDetail = {
-	detail: {
-		item: {
-			associatedItem: SideNavigationItemBase
-		}
+	item: {
+		associatedItem: SideNavigationItemBase
 	}
 };
 
@@ -134,7 +132,7 @@ type NavigationMenuClickEventDetail = {
  * @allowPreventDefault
  * @public
  */
-@event("selection-change", {
+@event<NavigationMenuClickEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public
@@ -265,7 +263,7 @@ class SideNavigation extends UI5Element {
 		this.closePicker();
 	}
 
-	handleOverflowItemClick(e: NavigationMenuClickEventDetail) {
+	handleOverflowItemClick(e: CustomEvent<NavigationMenuClickEventDetail>) {
 		const associatedItem = e.detail?.item.associatedItem;
 
 		associatedItem.fireEvent("click");

--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -94,7 +94,7 @@ type UploadCollectionItemDeleteEventDetail = {
  * @param {HTMLElement} item The <code>ui5-upload-collection-item</code> which was deleted.
  * @public
  */
-@event("item-delete", {
+@event<UploadCollectionItemDeleteEventDetail>("item-delete", {
 	detail: {
 		/**
 		 * @public
@@ -110,7 +110,7 @@ type UploadCollectionItemDeleteEventDetail = {
  * @param {Array} selectedItems An array of the selected items.
  * @public
  */
-@event("selection-change", {
+@event<UploadCollectionSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -131,7 +131,7 @@ type VSDInternalSettings = {
  * @param {Array} filters The selected filters items.
  * @public
  */
-@event("confirm", {
+@event<ViewSettingsDialogConfirmEventDetail>("confirm", {
 	detail: {
 		/**
 		 * @public
@@ -166,7 +166,7 @@ type VSDInternalSettings = {
  * @param {Array} filters The selected filters items.
  * @public
  */
-@event("cancel", {
+@event<ViewSettingsDialogCancelEventDetail>("cancel", {
 	detail: {
 		/**
 		 * @public

--- a/packages/fiori/src/Wizard.ts
+++ b/packages/fiori/src/Wizard.ts
@@ -217,7 +217,7 @@ type StepInfo = {
  * @param {boolean} changeWithClick The step change occurs due to user's click or 'Enter'/'Space' key press on step within the navigation.
  * @public
  */
-@event("step-change", {
+@event<WizardStepChangeEventDetail>("step-change", {
 	detail: {
 		/**
 		* @public
@@ -230,7 +230,7 @@ type StepInfo = {
 		/**
 		* @public
 		*/
-		changeWithClick: { Boolean },
+		changeWithClick: { type: Boolean },
 	},
 })
 

--- a/packages/main/src/AvatarGroup.ts
+++ b/packages/main/src/AvatarGroup.ts
@@ -153,7 +153,7 @@ type AvatarGroupClickEventDetail = {
 * @public
 * @since 1.0.0-rc.11
 */
-@event("click", {
+@event<AvatarGroupClickEventDetail>("click", {
 	detail: {
 		/**
 		* @public

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -121,7 +121,7 @@ type FocusAdaptor = ITabbable & {
  * @param {Boolean} shiftKey Returns whether the "SHIFT" key was pressed when the event was triggered.
  * @public
  */
-@event("item-click", {
+@event<BreadcrumbsItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -184,7 +184,7 @@ type CalendarSelectedDatesChangeEventDetail = {
  * @param {Array<number>} dates The selected dates as UTC timestamps
  * @public
  */
-@event("selected-dates-change", {
+@event<CalendarSelectedDatesChangeEventDetail>("selected-dates-change", {
 	detail: {
 		/**
 		 * @public
@@ -194,6 +194,8 @@ type CalendarSelectedDatesChangeEventDetail = {
 		 * @public
 		 */
 		values: { type: Array },
+
+		timestamp: { type: Number },
 	},
 })
 

--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -123,7 +123,7 @@ type CarouselNavigateEventDetail = {
  * @public
  * @since 1.0.0-rc.7
  */
-@event("navigate", {
+@event<CarouselNavigateEventDetail>("navigate", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -82,7 +82,7 @@ type ColorPaletteItemClickEventDetail = {
  * @since 1.0.0-rc.15
  * @param {string} color the selected color
  */
-@event("item-click", {
+@event<ColorPaletteItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -73,7 +73,7 @@ type ColorPalettePopoverItemClickEventDetail = ColorPaletteItemClickEventDetail;
  * @public
  * @param {string} color the selected color
  */
-@event("item-click", {
+@event<ColorPalettePopoverItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -192,7 +192,7 @@ type ComboBoxSelectionChangeEventDetail = {
  * @param {IComboBoxItem} item item to be selected.
  * @public
  */
-@event("selection-change", {
+@event<ComboBoxSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		* @public

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -177,7 +177,7 @@ type DatePickerInputEventDetail = {
  * @param {string} value The submitted value.
  * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 */
-@event("change", {
+@event<DatePickerChangeEventDetail>("change", {
 	detail: {
 		/**
 		 * @public
@@ -201,7 +201,7 @@ type DatePickerInputEventDetail = {
  * @param {string} value The submitted value.
  * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 */
-@event("input", {
+@event<DatePickerInputEventDetail>("input", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -84,7 +84,7 @@ type FileUploaderChangeEventDetail = {
  * @param {FileList | null} files The current files.
  * @public
  */
-@event("change", {
+@event<FileUploaderChangeEventDetail>("change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -214,7 +214,7 @@ type InputSuggestionScrollEventDetail = {
  * @param {HTMLElement} item The selected item.
  * @public
  */
-@event("suggestion-item-select", {
+@event<InputSuggestionItemSelectEventDetail>("suggestion-item-select", {
 	detail: {
 		/**
 	 	* @public
@@ -232,7 +232,7 @@ type InputSuggestionScrollEventDetail = {
  * @public
  * @since 1.0.0-rc.8
  */
-@event("suggestion-item-preview", {
+@event<InputSuggestionItemPreviewEventDetail>("suggestion-item-preview", {
 	detail: {
 		/**
 	 	* @public
@@ -253,7 +253,7 @@ type InputSuggestionScrollEventDetail = {
  * @protected
  * @since 1.0.0-rc.8
  */
-@event("suggestion-scroll", {
+@event<InputSuggestionScrollEventDetail>("suggestion-scroll", {
 	detail: {
 		/**
 	 	* @public

--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -84,7 +84,7 @@ type LinkClickEventDetail = {
  * @param {boolean} metaKey Returns whether the "META" key was pressed when the event was triggered.
  * @param {boolean} shiftKey Returns whether the "SHIFT" key was pressed when the event was triggered.
  */
-@event("click", {
+@event<LinkClickEventDetail>("click", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -164,7 +164,7 @@ type ListItemClickEventDetail = {
  * @param {HTMLElement} item The clicked item.
  * @public
  */
-@event("item-click", {
+@event<ListItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public
@@ -183,7 +183,7 @@ type ListItemClickEventDetail = {
  * @public
  * @since 1.0.0-rc.8
  */
-@event("item-close", {
+@event<ListItemCloseEventDetail>("item-close", {
 	detail: {
 		/**
 		 * @public
@@ -201,7 +201,7 @@ type ListItemClickEventDetail = {
  * @public
  * @since 1.0.0-rc.8
  */
-@event("item-toggle", {
+@event<ListItemToggleEventDetail>("item-toggle", {
 	detail: {
 		/**
 		 * @public
@@ -219,7 +219,7 @@ type ListItemClickEventDetail = {
  * @param {HTMLElement} item the deleted item.
  * @public
  */
-@event("item-delete", {
+@event<ListItemDeleteEventDetail>("item-delete", {
 	detail: {
 		/**
 		 * @public
@@ -237,7 +237,7 @@ type ListItemClickEventDetail = {
  * @param {Array<ListItemBase>} previouslySelectedItems An array of the previously selected items.
  * @public
  */
-@event("selection-change", {
+@event<ListSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public
@@ -247,8 +247,20 @@ type ListItemClickEventDetail = {
 		 * @public
 		 */
 		previouslySelectedItems: { type: Array },
-		targetItem: { type: HTMLElement }, // protected, holds the event target item
-		selectionComponentPressed: { type: Boolean }, // protected, indicates if the user used the selection components to change the selection
+		/**
+		 * protected, holds the event target item
+		 * @protected
+		 */
+		targetItem: { type: HTMLElement },
+		/**
+		 * protected, indicates if the user used the selection components to change the selection
+		 * @protected
+		 */
+		selectionComponentPressed: { type: Boolean },
+		/**
+		 * @private
+		 */
+		key: { type: String },
 	},
 })
 
@@ -265,7 +277,7 @@ type ListItemClickEventDetail = {
 /**
  * @private
  */
-@event("item-focused", {
+@event<ListItemFocusEventDetail>("item-focused", {
 	detail: {
 		item: { type: HTMLElement },
 	},

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -116,7 +116,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @param { string } text The text of the currently clicked menu item.
  * @public
  */
-@event("item-click", {
+@event<MenuItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public
@@ -143,7 +143,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @since 1.10.0
  * @param { HTMLElement } item The <code>ui5-menu-item</code> that triggers opening of the sub-menu or undefined when fired upon root menu opening. <b>Note:</b> available since 1.14.0.
  */
-@event("before-open", {
+@event<MenuBeforeOpenEventDetail>("before-open", {
 	detail: {
 		/**
 		 * @public
@@ -170,7 +170,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
  * @param {boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
  * @since 1.10.0
  */
-@event("before-close", {
+@event<MenuBeforeCloseEventDetail>("before-close", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -212,7 +212,7 @@ type MultiComboboxItemWithSelection = {
  * @param {IMultiComboBoxItem[]} items an array of the selected items.
  * @public
  */
-@event("selection-change", {
+@event<MultiComboBoxSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/MultiComboBoxGroupItem.ts
+++ b/packages/main/src/MultiComboBoxGroupItem.ts
@@ -9,6 +9,7 @@ import type { IMultiComboBoxItem } from "./MultiComboBox.js";
  * that can be used to split the <code>ui5-multi-combobox</code> suggestions into groups.
  *
  * @constructor
+ * @extends {UI5Element}
  * @abstract
  * @public
  * @implements {IMultiComboBoxItem}

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -80,7 +80,7 @@ type MultiInputTokenDeleteEventDetail = {
  * @param {HTMLElement} token deleted token.
  * @public
  */
-@event("token-delete", {
+@event<MultiInputTokenDeleteEventDetail>("token-delete", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -105,7 +105,7 @@ type PopupBeforeCloseEventDetail = {
  * @allowPreventDefault
  * @param {boolean} escPressed Indicates that <code>ESC</code> key has triggered the event.
  */
-@event("before-close", {
+@event<PopupBeforeCloseEventDetail>("before-close", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -63,7 +63,7 @@ type SegmentedButtonSelectionChangeEventDetail = {
  * @param {Array<ISegmentedButtonItem>} selectedItems an array of selected items.
  * @public
  */
-@event("selection-change", {
+@event<SegmentedButtonSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -160,7 +160,7 @@ type SelectLiveChangeEventDetail = {
  * @param {IOption} selectedOption the selected option.
  * @public
  */
-@event("change", {
+@event<SelectChangeEventDetail>("change", {
 	detail: {
 		/**
 		* @public
@@ -176,7 +176,7 @@ type SelectLiveChangeEventDetail = {
  * @public
  * @since 1.17.0
  */
-@event("live-change", {
+@event<SelectLiveChangeEventDetail>("live-change", {
 	detail: {
 		/**
 		* @public

--- a/packages/main/src/SelectMenu.ts
+++ b/packages/main/src/SelectMenu.ts
@@ -74,7 +74,7 @@ type SelectMenuChange = {
 		Button,
 	],
 })
-@event("option-click", {
+@event<SelectMenuOptionClick>("option-click", {
 	detail: {
 		option: { type: HTMLElement },
 		optionIndex: { type: Integer },
@@ -83,7 +83,7 @@ type SelectMenuChange = {
 @event("before-open")
 @event("after-open")
 @event("after-close")
-@event("menu-change", {
+@event<SelectMenuChange>("menu-change", {
 	detail: {
 		text: { type: String },
 		selectedIndex: { type: Integer },

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -141,7 +141,7 @@ interface TabContainerTabInOverflow extends CustomListItem {
  * @public
  * @allowPreventDefault
  */
-@event("tab-select", {
+@event<TabContainerTabSelectEventDetail>("tab-select", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -177,7 +177,7 @@ enum TableFocusTargetElement {
 * @param {HTMLElement} row the activated row.
 * @public
 */
-@event("row-click", {
+@event<TableRowClickEventDetail>("row-click", {
 	detail: {
 		/**
 		* @public
@@ -193,7 +193,7 @@ enum TableFocusTargetElement {
 * @since 1.0.0-rc.6
 * @public
 */
-@event("popin-change", {
+@event<TablePopinChangeEventDetail>("popin-change", {
 	detail: {
 		/**
 		* @public
@@ -223,7 +223,7 @@ enum TableFocusTargetElement {
 * @public
 * @since 1.0.0-rc.15
 */
-@event("selection-change", {
+@event<TableSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/TableGroupRow.ts
+++ b/packages/main/src/TableGroupRow.ts
@@ -28,6 +28,7 @@ import tableGroupRowStyles from "./generated/themes/TableGroupRow.css.js";
  * @constructor
  * @since 1.0.0-rc.15
  * @implements {ITableRow}
+ * @extends {UI5Element}
  * @public
  * @slot {Node[]} default - Defines the text of the component. <br> <b>Note:</b> Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
  * @csspart group-row - Used to style the native <code>tr</code> element

--- a/packages/main/src/TimePickerBase.ts
+++ b/packages/main/src/TimePickerBase.ts
@@ -89,7 +89,7 @@ type TimePickerBaseInputEventDetail = TimePickerBaseChangeInputEventDetail;
  * @param {string} value The submitted value.
  * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 */
-@event("change", {
+@event<TimePickerBaseChangeEventDetail>("change", {
 	detail: {
 		/**
 		 * @public
@@ -113,7 +113,7 @@ type TimePickerBaseInputEventDetail = TimePickerBaseChangeInputEventDetail;
  * @param {string} value The current value.
  * @param {boolean} valid Indicator if the value is in correct format pattern and in valid range.
 */
-@event("input", {
+@event<TimePickerBaseInputEventDetail>("input", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -98,7 +98,7 @@ const CLOCK_MIDDOT_CLASS = "ui5-tp-clock-mid-dot";
  * @param { string } stringValue The new <code>value</code> of the clock, as string, zero-prepended when necessary.
  * @param { boolean } finalChange <code>true</code> when a value is selected and confirmed, <code>false</code> when a value is only selected but not confirmed.
  */
-@event("change", {
+@event<TimePickerClockChangeEventDetail>("change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/TimePickerInternals.ts
+++ b/packages/main/src/TimePickerInternals.ts
@@ -86,7 +86,7 @@ const TYPE_COOLDOWN_DELAY = 1000; // Cooldown delay; 0 = disabled cooldown
 /**
  * Fired when the value changes due to user interaction with the sliders.
  */
-@event("change", {
+@event<TimeSelectionChangeEventDetail>("change", {
 	detail: {
 		value: { type: String },
 		valid: { type: Boolean },

--- a/packages/main/src/TimeSelection.ts
+++ b/packages/main/src/TimeSelection.ts
@@ -68,7 +68,7 @@ type TimeSelectionSliderChangeEventDetail = {
 /**
  * Fired when the value changes due to user interaction with the sliders
  */
-@event("change", {
+@event<TimeSelectionChangeEventDetail>("change", {
 	detail: {
 		value: { type: String },
 		valid: { type: Boolean },
@@ -78,7 +78,7 @@ type TimeSelectionSliderChangeEventDetail = {
 /**
  * Fired when the expanded/collapsed slider changes (a new slider is expanded or the expanded slider is collapsed)
  */
-@event("sliderChange", {
+@event<TimeSelectionSliderChangeEventDetail>("sliderChange", {
 	detail: {
 		slider: { type: String },
 	},

--- a/packages/main/src/Token.ts
+++ b/packages/main/src/Token.ts
@@ -67,7 +67,7 @@ type TokenDeleteEventDetail = {
  * @param {Boolean} delete Indicates whether token is deleted by delete key.
  * @private
  */
-@event("delete", {
+@event<TokenDeleteEventDetail>("delete", {
 	detail: {
 		"backSpace": { type: Boolean },
 		"delete": { type: Boolean },

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -121,10 +121,7 @@ enum ClipboardDataOperation {
 	},
 })
 
-@event("before-more-popover-open", {
-	detail: {},
-})
-
+@event("before-more-popover-open")
 class Tokenizer extends UI5Element {
 	@property({ type: Boolean })
 	showMore!: boolean;

--- a/packages/main/src/ToolbarSelect.ts
+++ b/packages/main/src/ToolbarSelect.ts
@@ -48,7 +48,7 @@ type ToolbarSelectChangeEventDetail = SelectChangeEventDetail;
  * @param {HTMLElement} selectedOption the selected option.
  * @public
  */
-@event("change", {
+@event<ToolbarSelectChangeEventDetail>("change", {
 	detail: {
 		/**
 		* @public

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -112,7 +112,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @allowPreventDefault
  * @public
  */
-@event("item-toggle", {
+@event<TreeItemToggleEventDetail>("item-toggle", {
 	detail: {
 		/**
 		 * @public
@@ -126,7 +126,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @since 1.0.0-rc.16
  * @public
  */
-@event("item-mouseover", {
+@event<TreeItemMouseoverEventDetail>("item-mouseover", {
 	detail: {
 		/**
 		 * @public
@@ -140,7 +140,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @since 1.0.0-rc.16
  * @public
  */
-@event("item-mouseout", {
+@event<TreeItemMouseoutEventDetail>("item-mouseout", {
 	detail: {
 		/**
 		 * @public
@@ -155,7 +155,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @param {HTMLElement} item The clicked item.
  * @public
  */
-@event("item-click", {
+@event<TreeItemClickEventDetail>("item-click", {
 	detail: {
 		/**
 		 * @public
@@ -173,7 +173,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @param {HTMLElement} item the deleted item.
  * @public
  */
-@event("item-delete", {
+@event<TreeItemDeleteEventDetail>("item-delete", {
 	detail: {
 		/**
 		 * @public
@@ -191,7 +191,7 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
  * @param {HTMLElement} targetItem The item triggering the event.
  * @public
  */
-@event("selection-change", {
+@event<TreeSelectionChangeEventDetail>("selection-change", {
 	detail: {
 		/**
 		 * @public

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -57,7 +57,7 @@ type TreeItemBaseStepOutEventDetail = TreeItemBaseEventDetail;
  * @param {HTMLElement} item the toggled item.
  * @protected
  */
-@event("toggle", {
+@event<TreeItemBaseToggleEventDetail>("toggle", {
 	detail: {
 		item: { type: HTMLElement },
 	},
@@ -69,7 +69,7 @@ type TreeItemBaseStepOutEventDetail = TreeItemBaseEventDetail;
  * @param {HTMLElement} item the item on which right arrow was pressed.
  * @protected
  */
-@event("step-in", {
+@event<TreeItemBaseStepInEventDetail>("step-in", {
 	detail: {
 		item: { type: HTMLElement },
 	},
@@ -81,7 +81,7 @@ type TreeItemBaseStepOutEventDetail = TreeItemBaseEventDetail;
  * @param {HTMLElement} item the item on which left arrow was pressed.
  * @protected
  */
-@event("step-out", {
+@event<TreeItemBaseStepOutEventDetail>("step-out", {
 	detail: {
 		item: { type: HTMLElement },
 	},

--- a/packages/main/src/WheelSlider.ts
+++ b/packages/main/src/WheelSlider.ts
@@ -54,7 +54,7 @@ type WheelSliderSelectEventDetail = { value: string };
  * @public
  * @param {string} value The selected value.
  */
-@event("select", {
+@event<WheelSliderSelectEventDetail>("select", {
 	detail: {
 		/**
 		 * @public

--- a/packages/tools/lib/cem/event.mjs
+++ b/packages/tools/lib/cem/event.mjs
@@ -4,6 +4,7 @@ import {
 	getDeprecatedStatus,
 	getSinceStatus,
 	getType,
+	getTypeRefs,
 	validateJSDocComment,
 	hasTag,
 	findTag,
@@ -84,6 +85,16 @@ function processEvent(ts, event, classNode, moduleDoc) {
 
 	if (native) {
 		result.type = { text: "Event" };
+	} else if (event?.expression?.typeArguments) {
+		const typesText = event?.expression?.typeArguments.map(type => type.typeName?.text).filter(Boolean).join(" | ");
+		const typeRefs = (getTypeRefs(ts, event.expression)
+			?.map(e => getReference(ts, e, event, moduleDoc.path)).filter(Boolean)) || [];
+
+		result.type = { text: `CustomEvent<${typesText}>` };
+
+		if (typeRefs.length) {
+			result.type.references = typeRefs;
+		}
 	}
 
 	if (privacy) {

--- a/packages/tools/lib/cem/types-internal.d.ts
+++ b/packages/tools/lib/cem/types-internal.d.ts
@@ -1,4 +1,12 @@
-export type Privacy = "private" | "protected" | "public"
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
 
 /**
  * The top-level interface of a custom elements manifest file.
@@ -15,14 +23,10 @@ export type Privacy = "private" | "protected" | "public"
  */
 export interface Package {
   /**
-   * Whether the package is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
+   * The version of the schema used in this file.
    */
-  deprecated?: string | boolean
-  /**
-   * An array of the modules this package contains.
-   */
-  modules: JavaScriptModule[]
+  schemaVersion: string;
+
   /**
    * The Markdown to use for the main readme of this package.
    *
@@ -30,13 +34,43 @@ export interface Package {
    * file contains information irrelevant to custom element catalogs and
    * documentation viewers.
    */
-  readme?: string
+  readme?: string;
+
   /**
-   * The version of the schema used in this file.
+   * An array of the modules this package contains.
    */
-  schemaVersion: string
+  modules: Array<Module>;
+
+  /**
+   * Whether the package is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
 }
+
+// This type may expand in the future to include JSON, CSS, or HTML
+// modules.
+export type Module = JavaScriptModule;
+
 export interface JavaScriptModule {
+  kind: 'javascript-module';
+
+  /**
+   * Path to the javascript file needed to be imported. 
+   * (not the path for example to a typescript file.)
+   */
+  path: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the module.
+   */
+  description?: string;
+
   /**
    * The declarations of a module.
    *
@@ -44,98 +78,93 @@ export interface JavaScriptModule {
    * exports should be described here. Ie, functions and objects that may be
    * properties of exported objects, or passed as arguments to functions.
    */
-  declarations?: (
-    | ClassDeclaration
-    | EnumDeclaration
-    | InterfaceDeclaration
-    | FunctionDeclaration
-    | MixinDeclaration
-    | VariableDeclaration
-    | CustomElementDeclaration
-    | CustomElementMixinDeclaration
-  )[]
-  /**
-   * Whether the module is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the module.
-   */
-  description?: string
+  declarations?: Array<Declaration>;
+
   /**
    * The exports of a module. This includes JavaScript exports and
    * custom element definitions.
    */
-  exports?: (JavaScriptExport | CustomElementExport)[]
-  kind: "javascript-module"
+  exports?: Array<Export>;
+
   /**
-   * Path to the javascript file needed to be imported.
-   * (not the path for example to a typescript file.)
-   */
-  path: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-export interface ClassDeclaration {
-  _ui5package?: string
-  _ui5implements?: Reference[]
-  _ui5privacy?: Privacy
-  /**
-   * Marks when the field was
-   */
-  _ui5since?: string
-  /**
-   * Whether the class or mixin is deprecated.
+   * Whether the module is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "class"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
+  deprecated?: boolean | string;
 }
+
+export type Export = JavaScriptExport | CustomElementExport;
+
+export interface JavaScriptExport {
+  kind: 'js';
+
+  /**
+   * The name of the exported symbol.
+   *
+   * JavaScript has a number of ways to export objects which determine the
+   * correct name to use.
+   *
+   * - Default exports must use the name "default".
+   * - Named exports use the name that is exported. If the export is renamed
+   *   with the "as" clause, use the exported name.
+   * - Aggregating exports (`* from`) should use the name `*`
+   */
+  name: string;
+
+  /**
+   * A reference to the exported declaration.
+   *
+   * In the case of aggregating exports, the reference's `module` field must be
+   * defined and the `name` field must be `"*"`.
+   */
+  declaration: Reference;
+
+  /**
+   * Whether the export is deprecated. For example, the name of the export was changed.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+/**
+ * A global custom element defintion, ie the result of a
+ * `customElements.define()` call.
+ *
+ * This is represented as an export because a definition makes the element
+ * available outside of the module it's defined it.
+ */
+export interface CustomElementExport {
+  kind: 'custom-element-definition';
+
+  /**
+   * The tag name of the custom element.
+   */
+  name: string;
+
+  /**
+   * A reference to the class or other declaration that implements the
+   * custom element.
+   */
+  declaration: Reference;
+
+  /**
+   * Whether the custom-element export is deprecated.
+   * For example, a future version will not register the custom element in this file.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export type Declaration =
+  | ClassDeclaration
+  | FunctionDeclaration
+  | MixinDeclaration
+  | VariableDeclaration
+  | CustomElementDeclaration
+  | EnumDeclaration
+  | InterfaceDeclaration
+  | CustomElementMixinDeclaration;
+
 /**
  * A reference to an export of a module.
  *
@@ -150,44 +179,11 @@ export interface ClassDeclaration {
  * use a `package` name of `"global:"`.
  */
 export interface Reference {
-  module?: string
-  name: string
-  package?: string
+  name: string;
+  package?: string;
+  module?: string;
 }
-export interface ClassField {
-  _ui5validator?: string
-  _ui5formProperty?: boolean
-  _ui5formEvents?: string
-  /**
-   * Marks when the field was introduced
-   */
-  _ui5since?: string
-  default?: string
-  /**
-   * Whether the property is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  kind: "field"
-  name: string
-  privacy?: Privacy
-  /**
-   * Whether the property is read-only.
-   */
-  readonly?: boolean
-  source?: SourceReference
-  static?: boolean
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
-}
+
 /**
  * A reference to the source of a declaration or member.
  */
@@ -195,9 +191,262 @@ export interface SourceReference {
   /**
    * An absolute URL to the source (ie. a GitHub URL).
    */
-  href: string
+  href: string;
 }
+
+/**
+ * A description of a custom element class.
+ *
+ * Custom elements are JavaScript classes, so this extends from
+ * `ClassDeclaration` and adds custom-element-specific features like
+ * attributes, events, and slots.
+ *
+ * Note that `tagName` in this interface is optional. Tag names are not
+ * neccessarily part of a custom element class, but belong to the definition
+ * (often called the "registration") or the `customElements.define()` call.
+ *
+ * Because classes and tag names can only be registered once, there's a
+ * one-to-one relationship between classes and tag names. For ease of use,
+ * we allow the tag name here.
+ *
+ * Some packages define and register custom elements in separate modules. In
+ * these cases one `Module` should contain the `CustomElement` without a
+ * tagName, and another `Module` should contain the
+ * `CustomElementExport`.
+ */
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementDeclaration
+  extends ClassDeclaration,
+  CustomElement {
+  _ui5abstract?: boolean
+  /**
+   * Marks when the field was introduced
+   */
+  _ui5since?: string
+}
+
+/**
+ * The additional fields that a custom element adds to classes and mixins.
+ */
+export interface CustomElement extends ClassLike {
+  /**
+   * An optional tag name that should be specified if this is a
+   * self-registering element.
+   *
+   * Self-registering elements must also include a CustomElementExport
+   * in the module's exports.
+   */
+  tagName?: string;
+
+  /**
+   * The attributes that this element is known to understand.
+   */
+  attributes?: Attribute[];
+
+  /**
+   * The events that this element fires.
+   */
+  events?: Event[];
+
+  /**
+   * The shadow dom content slots that this element accepts.
+   */
+  slots?: Slot[];
+
+  cssParts?: CssPart[];
+
+  cssProperties?: CssCustomProperty[];
+
+  demos?: Demo[];
+
+  /**
+   * Distinguishes a regular JavaScript class from a
+   * custom element class
+   */
+  customElement: true;
+}
+
+export interface Attribute {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  inheritedFrom?: Reference;
+
+  /**
+   * The type that the attribute will be serialized/deserialized as.
+   */
+  type?: Type;
+
+  /**
+   * The default value of the attribute, if any.
+   *
+   * As attributes are always strings, this is the actual value, not a human
+   * readable description.
+   */
+  default?: string;
+
+  /**
+   * The name of the field this attribute is associated with, if any.
+   */
+  fieldName?: string;
+
+  /**
+   * Whether the attribute is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export type EnumDeclaration = ClassDeclaration;
+export type InterfaceDeclaration = ClassDeclaration;
+
+export interface Event {
+  _ui5parameters?: Parameter[]
+  _ui5privacy?: Privacy
+  /**
+   * Whether the parameter is optional. Undefined implies non-optional.
+   */
+  _ui5allowPreventDefault?: boolean
+  /**
+   * Marks when the field was introduced
+   */
+  _ui5since?: string
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * The type of the event object that's fired.
+   */
+  type: Type;
+
+  inheritedFrom?: Reference;
+
+  /**
+   * Whether the event is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface Slot {
+  _ui5propertyName?: string
+  _ui5type?: Type
+  _ui5privacy?: Privacy
+  /**
+   * Marks when the field was introduced
+   */
+  _ui5since?: string
+  /**
+   * The slot name, or the empty string for an unnamed slot.
+   */
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the slot is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+/**
+ * The description of a CSS Part
+ */
+export interface CssPart {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the CSS shadow part is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface CssCustomProperty {
+  /**
+   * The name of the property, including leading `--`.
+   */
+  name: string;
+
+  /**
+   * The expected syntax of the defined property. Defaults to "*".
+   *
+   * The syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)
+   * as defined in the CSS Properties and Values API.
+   *
+   * Examples:
+   *
+   * "<color>": accepts a color
+   * "<length> | <percentage>": accepts lengths or percentages but not calc expressions with a combination of the two
+   * "small | medium | large": accepts one of these values set as custom idents.
+   * "*": any valid token
+   */
+  syntax?: string;
+
+  default?: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the CSS custom property is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
 export interface Type {
+  /**
+   * The full string representation of the type, in whatever type syntax is
+   * used, such as JSDoc, Closure, or TypeScript.
+   */
+  text: string;
+
   /**
    * An array of references to the types in the type string.
    *
@@ -207,14 +456,11 @@ export interface Type {
    * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
    * and `BarElement` without understanding arrays, generics, or union types.
    */
-  references?: TypeReference[]
-  source?: SourceReference
-  /**
-   * The full string representation of the type, in whatever type syntax is
-   * used, such as JSDoc, Closure, or TypeScript.
-   */
-  text: string
+  references?: TypeReference[];
+
+  source?: SourceReference;
 }
+
 /**
  * A reference that is associated with a type string and optionally a range
  * within the string.
@@ -224,234 +470,177 @@ export interface Type {
  * type string is the symbol referenced and the name should match the type
  * string.
  */
-export interface TypeReference {
-  end?: number
-  module?: string
-  name: string
-  package?: string
-  start?: number
+export interface TypeReference extends Reference {
+  start?: number;
+  end?: number;
 }
-export interface ClassMethod {
-  /**
-   * Marks when the field was introduced
-   */
-  _ui5since?: string
-  /**
-   * Whether the function is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  kind: "method"
-  name: string
-  parameters?: Parameter[]
-  privacy?: Privacy
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  static?: boolean
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-export interface Parameter {
+
+/**
+ * The common interface of classes and mixins.
+ */
+export interface ClassLike {
+  _ui5package?: string
+  _ui5implements?: Reference[]
   _ui5privacy?: Privacy
   /**
    * Marks when the field was introduced
    */
   _ui5since?: string
-  default?: string
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the class.
+   */
+  description?: string;
+
+  /**
+   * The superclass of this class.
+   *
+   * If this class is defined with mixin applications, the prototype chain
+   * includes the mixin applications and the true superclass is computed
+   * from them.
+   */
+  superclass?: Reference;
+
+  /**
+   * Any class mixins applied in the extends clause of this class.
+   *
+   * If mixins are applied in the class definition, then the true superclass
+   * of this class is the result of applying mixins in order to the superclass.
+   *
+   * Mixins must be listed in order of their application to the superclass or
+   * previous mixin application. This means that the innermost mixin is listed
+   * first. This may read backwards from the common order in JavaScript, but
+   * matches the order of language used to describe mixin application, like
+   * "S with A, B".
+   *
+   * @example
+   *
+   * ```javascript
+   * class T extends B(A(S)) {}
+   * ```
+   *
+   * is described by:
+   * ```json
+   * {
+   *   "kind": "class",
+   *   "superclass": {
+   *     "name": "S"
+   *   },
+   *   "mixins": [
+   *     {
+   *       "name": "A"
+   *     },
+   *     {
+   *       "name": "B"
+   *     },
+   *   ]
+   * }
+   * ```
+   */
+  mixins?: Array<Reference>;
+  members?: Array<ClassMember>;
+
+  source?: SourceReference;
+
+  /**
+   * Whether the class or mixin is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface ClassDeclaration extends ClassLike {
+  kind: 'class';
+}
+
+export type ClassMember = ClassField | ClassMethod;
+
+/**
+ * The common interface of variables, class fields, and function
+ * parameters.
+ */
+export interface PropertyLike {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the field.
+   */
+  description?: string;
+
+  type?: Type;
+
+  default?: string;
+
   /**
    * Whether the property is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  name: string
-  /**
-   * Whether the parameter is optional. Undefined implies non-optional.
-   */
-  optional?: boolean
+  deprecated?: boolean | string;
+
   /**
    * Whether the property is read-only.
    */
-  readonly?: boolean
-  /**
-   * Whether the parameter is a rest parameter. Only the last parameter may be a rest parameter.
-   * Undefined implies single parameter.
-   */
-  rest?: boolean
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
+  readonly?: boolean;
 }
-export interface EnumDeclaration {
-  _ui5package?: string
-  _ui5privacy?: Privacy
+
+export interface ClassField extends PropertyLike {
+  _ui5validator?: string
+  _ui5formProperty?: boolean
+  _ui5formEvents?: string
   /**
    * Marks when the field was introduced
    */
   _ui5since?: string
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "enum"
-  members?: ClassField[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
+  kind: 'field';
+  static?: boolean;
+  privacy?: Privacy;
+  inheritedFrom?: Reference;
+  source?: SourceReference;
 }
-export interface InterfaceDeclaration {
-  _ui5package?: string
-  _ui5privacy?: Privacy
+
+/**
+ * Additional metadata for fields on custom elements.
+ */
+export interface CustomElementField extends ClassField {
+  /**
+   * The corresponding attribute name if there is one.
+   * 
+   * If this property is defined, the attribute must be listed in the classes'
+   * `attributes` array.
+   */
+  attribute?: string;
+
+  /**
+   * If the property reflects to an attribute.
+   *
+   * If this is true, the `attribute` property must be defined.
+   */
+  reflects?: boolean;
+}
+
+export interface ClassMethod extends FunctionLike {
   /**
    * Marks when the field was introduced
    */
   _ui5since?: string
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "interface"
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
+  kind: 'method';
+  static?: boolean;
+  privacy?: Privacy;
+  inheritedFrom?: Reference;
+  source?: SourceReference;
 }
-export interface FunctionDeclaration {
-  _ui5package?: string
-  /**
-   * Marks when the field was introduced
-   */
-  _ui5since?: string
-  /**
-   * Whether the function is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  kind: "function"
-  name: string
-  parameters?: Parameter[]
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
+
 /**
  * A description of a class mixin.
  *
@@ -475,558 +664,129 @@ export interface FunctionDeclaration {
  *
  * See [this article]{@link https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/}
  * for more information on the classmixin pattern in JavaScript.
+ *
+ * @example
+ *
+ * This JavaScript mixin declaration:
+ * ```javascript
+ * const MyMixin = (base) => class extends base {
+ *   foo() { ... }
+ * }
+ * ```
+ *
+ * Is described by this JSON:
+ * ```json
+ * {
+ *   "kind": "mixin",
+ *   "name": "MyMixin",
+ *   "parameters": [
+ *     {
+ *       "name": "base",
+ *     }
+ *   ],
+ *   "members": [
+ *     {
+ *       "kind": "method",
+ *       "name": "foo",
+ *     }
+ *   ]
+ * }
+ * ```
  */
-export interface MixinDeclaration {
-  _ui5package?: string
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "mixin"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  parameters?: Parameter[]
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
+export interface MixinDeclaration extends ClassLike, FunctionLike {
+  kind: 'mixin';
 }
-export interface VariableDeclaration {
-  _ui5package?: string
-  default?: string
-  /**
-   * Whether the property is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  kind: "variable"
-  name: string
-  /**
-   * Whether the property is read-only.
-   */
-  readonly?: boolean
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
-}
+
 /**
- * A description of a custom element class.
- *
- * Custom elements are JavaScript classes, so this extends from
- * `ClassDeclaration` and adds custom-element-specific features like
- * attributes, events, and slots.
- *
- * Note that `tagName` in this interface is optional. Tag names are not
- * neccessarily part of a custom element class, but belong to the definition
- * (often called the "registration") or the `customElements.define()` call.
- *
- * Because classes and tag names can only be registered once, there's a
- * one-to-one relationship between classes and tag names. For ease of use,
- * we allow the tag name here.
- *
- * Some packages define and register custom elements in separate modules. In
- * these cases one `Module` should contain the `CustomElement` without a
- * tagName, and another `Module` should contain the
- * `CustomElementExport`.
+ * A class mixin that also adds custom element related properties.
  */
-export interface CustomElementDeclaration {
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementMixinDeclaration
+  extends MixinDeclaration,
+  CustomElement { }
+
+export interface VariableDeclaration extends PropertyLike {
+  kind: 'variable';
+  source?: SourceReference;
+}
+
+export interface FunctionDeclaration extends FunctionLike {
   _ui5package?: string
-  _ui5implements?: Reference[]
-  _ui5abstract?: boolean
+  /**
+   * Marks when the field was introduced
+   */
+  _ui5since?: string
+  kind: 'function';
+  source?: SourceReference;
+}
+
+export interface Parameter extends PropertyLike {
   _ui5privacy?: Privacy
   /**
    * Marks when the field was introduced
    */
   _ui5since?: string
   /**
-   * The attributes that this element is known to understand.
+   * Whether the parameter is optional. Undefined implies non-optional.
    */
-  attributes?: Attribute[]
-  cssParts?: CssPart[]
-  cssProperties?: CssCustomProperty[]
+  optional?: boolean;
   /**
-   * Distinguishes a regular JavaScript class from a
-   * custom element class
+   * Whether the parameter is a rest parameter. Only the last parameter may be a rest parameter.
+   * Undefined implies single parameter.
    */
-  customElement: true
-  demos?: Demo[]
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  /**
-   * The events that this element fires.
-   */
-  events?: Event[]
-  kind: "class"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  /**
-   * The shadow dom content slots that this element accepts.
-   */
-  slots?: Slot[]
-  source?: SourceReference
+  rest?: boolean;
+}
+
+export interface FunctionLike {
+  name: string;
+
   /**
    * A markdown summary suitable for display in a listing.
    */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
-  /**
-   * An optional tag name that should be specified if this is a
-   * self-registering element.
-   *
-   * Self-registering elements must also include a CustomElementExport
-   * in the module's exports.
-   */
-  tagName?: string
-}
-export interface Attribute {
-  /**
-   * The default value of the attribute, if any.
-   *
-   * As attributes are always strings, this is the actual value, not a human
-   * readable description.
-   */
-  default?: string
-  /**
-   * Whether the attribute is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
+  summary?: string;
+
   /**
    * A markdown description.
    */
-  description?: string
+  description?: string;
+
   /**
-   * The name of the field this attribute is associated with, if any.
+   * Whether the function is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
    */
-  fieldName?: string
-  inheritedFrom?: Reference
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The type that the attribute will be serialized/deserialized as.
-   */
-  type?: {
+  deprecated?: boolean | string;
+
+  parameters?: Parameter[];
+
+  return?: {
+    type?: Type;
+
     /**
-     * An array of references to the types in the type string.
-     *
-     * These references have optional indices into the type string so that tools
-     * can understand the references in the type string independently of the type
-     * system and syntax. For example, a documentation viewer could display the
-     * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
-     * and `BarElement` without understanding arrays, generics, or union types.
+     * A markdown summary suitable for display in a listing.
      */
-    references?: TypeReference[]
-    source?: SourceReference
+    summary?: string;
+
     /**
-     * The full string representation of the type, in whatever type syntax is
-     * used, such as JSDoc, Closure, or TypeScript.
+     * A markdown description.
      */
-    text: string
-  }
+    description?: string;
+  };
 }
-/**
- * The description of a CSS Part
- */
-export interface CssPart {
-  /**
-   * Whether the CSS shadow part is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-export interface CssCustomProperty {
-  default?: string
-  /**
-   * Whether the CSS custom property is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  /**
-   * The name of the property, including leading `--`.
-   */
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The expected syntax of the defined property. Defaults to "*".
-   *
-   * The syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)
-   * as defined in the CSS Properties and Values API.
-   *
-   * Examples:
-   *
-   * "<color>": accepts a color
-   * "<length> | <percentage>": accepts lengths or percentages but not calc expressions with a combination of the two
-   * "small | medium | large": accepts one of these values set as custom idents.
-   * "*": any valid token
-   */
-  syntax?: string
-}
+
+export type Privacy = 'public' | 'private' | 'protected';
+
 export interface Demo {
   /**
    * A markdown description of the demo.
    */
-  description?: string
-  source?: SourceReference
+  description?: string;
+
   /**
    * Relative URL of the demo if it's published with the package. Absolute URL
    * if it's hosted.
    */
-  url: string
-}
-export interface Event {
-  _ui5parameters?: Parameter[]
-  _ui5privacy?: Privacy
-  /**
-   * Whether the parameter is optional. Undefined implies non-optional.
-   */
-  _ui5allowPreventDefault?: boolean
-  /**
-   * Marks when the field was introduced
-   */
-  _ui5since?: string
-  /**
-   * Whether the event is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The type of the event object that's fired.
-   */
-  type: {
-    /**
-     * An array of references to the types in the type string.
-     *
-     * These references have optional indices into the type string so that tools
-     * can understand the references in the type string independently of the type
-     * system and syntax. For example, a documentation viewer could display the
-     * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
-     * and `BarElement` without understanding arrays, generics, or union types.
-     */
-    references?: TypeReference[]
-    source?: SourceReference
-    /**
-     * The full string representation of the type, in whatever type syntax is
-     * used, such as JSDoc, Closure, or TypeScript.
-     */
-    text: string
-  }
-}
-export interface Slot {
-  _ui5propertyName?: string
-  _ui5type?: Type
-  _ui5privacy?: Privacy
-  /**
-   * Marks when the field was introduced
-   */
-  _ui5since?: string
-  /**
-   * Whether the slot is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  /**
-   * The slot name, or the empty string for an unnamed slot.
-   */
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-/**
- * A class mixin that also adds custom element related properties.
- */
-export interface CustomElementMixinDeclaration {
-  _ui5package?: string
-  /**
-   * The attributes that this element is known to understand.
-   */
-  attributes?: Attribute[]
-  cssParts?: CssPart[]
-  cssProperties?: CssCustomProperty[]
-  /**
-   * Distinguishes a regular JavaScript class from a
-   * custom element class
-   */
-  customElement: true
-  demos?: Demo[]
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  /**
-   * The events that this element fires.
-   */
-  events?: Event[]
-  kind: "mixin"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  parameters?: Parameter[]
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  /**
-   * The shadow dom content slots that this element accepts.
-   */
-  slots?: Slot[]
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-  }
-  /**
-   * An optional tag name that should be specified if this is a
-   * self-registering element.
-   *
-   * Self-registering elements must also include a CustomElementExport
-   * in the module's exports.
-   */
-  tagName?: string
-}
-export interface JavaScriptExport {
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  declaration: {
-    module?: string
-    name: string
-    package?: string
-  }
-  /**
-   * Whether the export is deprecated. For example, the name of the export was changed.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  kind: "js"
-  /**
-   * The name of the exported symbol.
-   *
-   * JavaScript has a number of ways to export objects which determine the
-   * correct name to use.
-   *
-   * - Default exports must use the name "default".
-   * - Named exports use the name that is exported. If the export is renamed
-   *   with the "as" clause, use the exported name.
-   * - Aggregating exports (`* from`) should use the name `*`
-   */
-  name: string
-}
-/**
- * A global custom element defintion, ie the result of a
- * `customElements.define()` call.
- *
- * This is represented as an export because a definition makes the element
- * available outside of the module it's defined it.
- */
-export interface CustomElementExport {
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  declaration: {
-    module?: string
-    name: string
-    package?: string
-  }
-  /**
-   * Whether the custom-element export is deprecated.
-   * For example, a future version will not register the custom element in this file.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  kind: "custom-element-definition"
-  /**
-   * The tag name of the custom element.
-   */
-  name: string
+  url: string;
+
+  source?: SourceReference;
 }

--- a/packages/tools/lib/cem/types-internal.d.ts
+++ b/packages/tools/lib/cem/types-internal.d.ts
@@ -307,10 +307,16 @@ export interface Attribute {
   deprecated?: boolean | string;
 }
 
-export type EnumDeclaration = ClassDeclaration;
-export type InterfaceDeclaration = ClassDeclaration;
+export interface EnumDeclaration extends ClassDeclaration {
+  kind: "enum"
+};
+
+export interface InterfaceDeclaration extends ClassDeclaration {
+  kind: "interface"
+}
 
 export interface Event {
+  _ui5package?: string;
   _ui5parameters?: Parameter[]
   _ui5privacy?: Privacy
   /**
@@ -556,6 +562,7 @@ export interface ClassLike {
 }
 
 export interface ClassDeclaration extends ClassLike {
+  _ui5package?: string;
   kind: 'class';
 }
 
@@ -694,6 +701,7 @@ export interface ClassMethod extends FunctionLike {
  * ```
  */
 export interface MixinDeclaration extends ClassLike, FunctionLike {
+  _ui5package?: string;
   kind: 'mixin';
 }
 
@@ -707,12 +715,13 @@ export interface CustomElementMixinDeclaration
   CustomElement { }
 
 export interface VariableDeclaration extends PropertyLike {
+  _ui5package?: string;
   kind: 'variable';
   source?: SourceReference;
 }
 
 export interface FunctionDeclaration extends FunctionLike {
-  _ui5package?: string
+  _ui5package?: string;
   /**
    * Marks when the field was introduced
    */

--- a/packages/tools/lib/cem/types.d.ts
+++ b/packages/tools/lib/cem/types.d.ts
@@ -1,4 +1,12 @@
-export type Privacy = "private" | "protected" | "public"
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
 
 /**
  * The top-level interface of a custom elements manifest file.
@@ -15,14 +23,10 @@ export type Privacy = "private" | "protected" | "public"
  */
 export interface Package {
   /**
-   * Whether the package is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
+   * The version of the schema used in this file.
    */
-  deprecated?: string | boolean
-  /**
-   * An array of the modules this package contains.
-   */
-  modules: JavaScriptModule[]
+  schemaVersion: string;
+
   /**
    * The Markdown to use for the main readme of this package.
    *
@@ -30,13 +34,43 @@ export interface Package {
    * file contains information irrelevant to custom element catalogs and
    * documentation viewers.
    */
-  readme?: string
+  readme?: string;
+
   /**
-   * The version of the schema used in this file.
+   * An array of the modules this package contains.
    */
-  schemaVersion: string
+  modules: Array<Module>;
+
+  /**
+   * Whether the package is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
 }
+
+// This type may expand in the future to include JSON, CSS, or HTML
+// modules.
+export type Module = JavaScriptModule;
+
 export interface JavaScriptModule {
+  kind: 'javascript-module';
+
+  /**
+   * Path to the javascript file needed to be imported. 
+   * (not the path for example to a typescript file.)
+   */
+  path: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the module.
+   */
+  description?: string;
+
   /**
    * The declarations of a module.
    *
@@ -44,117 +78,91 @@ export interface JavaScriptModule {
    * exports should be described here. Ie, functions and objects that may be
    * properties of exported objects, or passed as arguments to functions.
    */
-  declarations?: (
-    | ClassDeclaration
-    | FunctionDeclaration
-    | MixinDeclaration
-    | VariableDeclaration
-    | CustomElementDeclaration
-    | CustomElementMixinDeclaration
-  )[]
-  /**
-   * Whether the module is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the module.
-   */
-  description?: string
+  declarations?: Array<Declaration>;
+
   /**
    * The exports of a module. This includes JavaScript exports and
    * custom element definitions.
    */
-  exports?: (JavaScriptExport | CustomElementExport)[]
-  kind: "javascript-module"
+  exports?: Array<Export>;
+
   /**
-   * Path to the javascript file needed to be imported.
-   * (not the path for example to a typescript file.)
-   */
-  path: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-export interface ClassDeclaration {
-  /**
-   * Whether the class or mixin is deprecated.
+   * Whether the module is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "class"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
+  deprecated?: boolean | string;
 }
-export interface ClassField {
-  default?: string
+
+export type Export = JavaScriptExport | CustomElementExport;
+
+export interface JavaScriptExport {
+  kind: 'js';
+
   /**
-   * Whether the property is deprecated.
+   * The name of the exported symbol.
+   *
+   * JavaScript has a number of ways to export objects which determine the
+   * correct name to use.
+   *
+   * - Default exports must use the name "default".
+   * - Named exports use the name that is exported. If the export is renamed
+   *   with the "as" clause, use the exported name.
+   * - Aggregating exports (`* from`) should use the name `*`
+   */
+  name: string;
+
+  /**
+   * A reference to the exported declaration.
+   *
+   * In the case of aggregating exports, the reference's `module` field must be
+   * defined and the `name` field must be `"*"`.
+   */
+  declaration: Reference;
+
+  /**
+   * Whether the export is deprecated. For example, the name of the export was changed.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  kind: "field"
-  name: string
-  privacy?: Privacy
-  /**
-   * Whether the property is read-only.
-   */
-  readonly?: boolean
-  source?: SourceReference
-  static?: boolean
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
+  deprecated?: boolean | string;
 }
+
+/**
+ * A global custom element defintion, ie the result of a
+ * `customElements.define()` call.
+ *
+ * This is represented as an export because a definition makes the element
+ * available outside of the module it's defined it.
+ */
+export interface CustomElementExport {
+  kind: 'custom-element-definition';
+
+  /**
+   * The tag name of the custom element.
+   */
+  name: string;
+
+  /**
+   * A reference to the class or other declaration that implements the
+   * custom element.
+   */
+  declaration: Reference;
+
+  /**
+   * Whether the custom-element export is deprecated.
+   * For example, a future version will not register the custom element in this file.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export type Declaration =
+  | ClassDeclaration
+  | FunctionDeclaration
+  | MixinDeclaration
+  | VariableDeclaration
+  | CustomElementDeclaration
+  | CustomElementMixinDeclaration;
+
 /**
  * A reference to an export of a module.
  *
@@ -169,10 +177,11 @@ export interface ClassField {
  * use a `package` name of `"global:"`.
  */
 export interface Reference {
-  module?: string
-  name: string
-  package?: string
+  name: string;
+  package?: string;
+  module?: string;
 }
+
 /**
  * A reference to the source of a declaration or member.
  */
@@ -180,9 +189,236 @@ export interface SourceReference {
   /**
    * An absolute URL to the source (ie. a GitHub URL).
    */
-  href: string
+  href: string;
 }
+
+/**
+ * A description of a custom element class.
+ *
+ * Custom elements are JavaScript classes, so this extends from
+ * `ClassDeclaration` and adds custom-element-specific features like
+ * attributes, events, and slots.
+ *
+ * Note that `tagName` in this interface is optional. Tag names are not
+ * neccessarily part of a custom element class, but belong to the definition
+ * (often called the "registration") or the `customElements.define()` call.
+ *
+ * Because classes and tag names can only be registered once, there's a
+ * one-to-one relationship between classes and tag names. For ease of use,
+ * we allow the tag name here.
+ *
+ * Some packages define and register custom elements in separate modules. In
+ * these cases one `Module` should contain the `CustomElement` without a
+ * tagName, and another `Module` should contain the
+ * `CustomElementExport`.
+ */
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementDeclaration
+  extends ClassDeclaration,
+    CustomElement {}
+
+/**
+ * The additional fields that a custom element adds to classes and mixins.
+ */
+export interface CustomElement extends ClassLike {
+  /**
+   * An optional tag name that should be specified if this is a
+   * self-registering element.
+   *
+   * Self-registering elements must also include a CustomElementExport
+   * in the module's exports.
+   */
+  tagName?: string;
+
+  /**
+   * The attributes that this element is known to understand.
+   */
+  attributes?: Attribute[];
+
+  /**
+   * The events that this element fires.
+   */
+  events?: Event[];
+
+  /**
+   * The shadow dom content slots that this element accepts.
+   */
+  slots?: Slot[];
+
+  cssParts?: CssPart[];
+
+  cssProperties?: CssCustomProperty[];
+
+  demos?: Demo[];
+
+  /**
+   * Distinguishes a regular JavaScript class from a
+   * custom element class
+   */
+  customElement: true;
+}
+
+export interface Attribute {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  inheritedFrom?: Reference;
+
+  /**
+   * The type that the attribute will be serialized/deserialized as.
+   */
+  type?: Type;
+
+  /**
+   * The default value of the attribute, if any.
+   *
+   * As attributes are always strings, this is the actual value, not a human
+   * readable description.
+   */
+  default?: string;
+
+  /**
+   * The name of the field this attribute is associated with, if any.
+   */
+  fieldName?: string;
+
+  /**
+   * Whether the attribute is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface Event {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * The type of the event object that's fired.
+   */
+  type: Type;
+
+  inheritedFrom?: Reference;
+
+  /**
+   * Whether the event is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface Slot {
+  /**
+   * The slot name, or the empty string for an unnamed slot.
+   */
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the slot is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+/**
+ * The description of a CSS Part
+ */
+export interface CssPart {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the CSS shadow part is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
+export interface CssCustomProperty {
+  /**
+   * The name of the property, including leading `--`.
+   */
+  name: string;
+
+  /**
+   * The expected syntax of the defined property. Defaults to "*".
+   *
+   * The syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)
+   * as defined in the CSS Properties and Values API.
+   *
+   * Examples:
+   *
+   * "<color>": accepts a color
+   * "<length> | <percentage>": accepts lengths or percentages but not calc expressions with a combination of the two
+   * "small | medium | large": accepts one of these values set as custom idents.
+   * "*": any valid token
+   */
+  syntax?: string;
+
+  default?: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the CSS custom property is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
+}
+
 export interface Type {
+  /**
+   * The full string representation of the type, in whatever type syntax is
+   * used, such as JSDoc, Closure, or TypeScript.
+   */
+  text: string;
+
   /**
    * An array of references to the types in the type string.
    *
@@ -192,14 +428,11 @@ export interface Type {
    * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
    * and `BarElement` without understanding arrays, generics, or union types.
    */
-  references?: TypeReference[]
-  source?: SourceReference
-  /**
-   * The full string representation of the type, in whatever type syntax is
-   * used, such as JSDoc, Closure, or TypeScript.
-   */
-  text: string
+  references?: TypeReference[];
+
+  source?: SourceReference;
 }
+
 /**
  * A reference that is associated with a type string and optionally a range
  * within the string.
@@ -209,109 +442,159 @@ export interface Type {
  * type string is the symbol referenced and the name should match the type
  * string.
  */
-export interface TypeReference {
-  end?: number
-  module?: string
-  name: string
-  package?: string
-  start?: number
+export interface TypeReference extends Reference {
+  start?: number;
+  end?: number;
 }
-export interface ClassMethod {
-  /**
-   * Whether the function is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  kind: "method"
-  name: string
-  parameters?: Parameter[]
-  privacy?: Privacy
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  static?: boolean
+
+/**
+ * The common interface of classes and mixins.
+ */
+export interface ClassLike {
+  name: string;
+
   /**
    * A markdown summary suitable for display in a listing.
    */
-  summary?: string
+  summary?: string;
+
+  /**
+   * A markdown description of the class.
+   */
+  description?: string;
+
+  /**
+   * The superclass of this class.
+   *
+   * If this class is defined with mixin applications, the prototype chain
+   * includes the mixin applications and the true superclass is computed
+   * from them.
+   */
+  superclass?: Reference;
+
+  /**
+   * Any class mixins applied in the extends clause of this class.
+   *
+   * If mixins are applied in the class definition, then the true superclass
+   * of this class is the result of applying mixins in order to the superclass.
+   *
+   * Mixins must be listed in order of their application to the superclass or
+   * previous mixin application. This means that the innermost mixin is listed
+   * first. This may read backwards from the common order in JavaScript, but
+   * matches the order of language used to describe mixin application, like
+   * "S with A, B".
+   *
+   * @example
+   *
+   * ```javascript
+   * class T extends B(A(S)) {}
+   * ```
+   *
+   * is described by:
+   * ```json
+   * {
+   *   "kind": "class",
+   *   "superclass": {
+   *     "name": "S"
+   *   },
+   *   "mixins": [
+   *     {
+   *       "name": "A"
+   *     },
+   *     {
+   *       "name": "B"
+   *     },
+   *   ]
+   * }
+   * ```
+   */
+  mixins?: Array<Reference>;
+  members?: Array<ClassMember>;
+
+  source?: SourceReference;
+
+  /**
+   * Whether the class or mixin is deprecated.
+   * If the value is a string, it's the reason for the deprecation.
+   */
+  deprecated?: boolean | string;
 }
-export interface Parameter {
-  default?: string
+
+export interface ClassDeclaration extends ClassLike {
+  kind: 'class';
+}
+
+export type ClassMember = ClassField | ClassMethod;
+
+/**
+ * The common interface of variables, class fields, and function
+ * parameters.
+ */
+export interface PropertyLike {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description of the field.
+   */
+  description?: string;
+
+  type?: Type;
+
+  default?: string;
+
   /**
    * Whether the property is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  name: string
-  /**
-   * Whether the parameter is optional. Undefined implies non-optional.
-   */
-  optional?: boolean
+  deprecated?: boolean | string;
+
   /**
    * Whether the property is read-only.
    */
-  readonly?: boolean
-  /**
-   * Whether the parameter is a rest parameter. Only the last parameter may be a rest parameter.
-   * Undefined implies single parameter.
-   */
-  rest?: boolean
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
+  readonly?: boolean;
 }
-export interface FunctionDeclaration {
-  /**
-   * Whether the function is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  kind: "function"
-  name: string
-  parameters?: Parameter[]
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
+
+export interface ClassField extends PropertyLike {
+  kind: 'field';
+  static?: boolean;
+  privacy?: Privacy;
+  inheritedFrom?: Reference;
+  source?: SourceReference;
 }
+
+/**
+ * Additional metadata for fields on custom elements.
+ */
+export interface CustomElementField extends ClassField {
+  /**
+   * The corresponding attribute name if there is one.
+   * 
+   * If this property is defined, the attribute must be listed in the classes'
+   * `attributes` array.
+   */
+  attribute?: string;
+
+  /**
+   * If the property reflects to an attribute.
+   *
+   * If this is true, the `attribute` property must be defined.
+   */
+  reflects?: boolean;
+}
+
+export interface ClassMethod extends FunctionLike {
+  kind: 'method';
+  static?: boolean;
+  privacy?: Privacy;
+  inheritedFrom?: Reference;
+  source?: SourceReference;
+}
+
 /**
  * A description of a class mixin.
  *
@@ -335,537 +618,119 @@ export interface FunctionDeclaration {
  *
  * See [this article]{@link https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/}
  * for more information on the classmixin pattern in JavaScript.
+ *
+ * @example
+ *
+ * This JavaScript mixin declaration:
+ * ```javascript
+ * const MyMixin = (base) => class extends base {
+ *   foo() { ... }
+ * }
+ * ```
+ *
+ * Is described by this JSON:
+ * ```json
+ * {
+ *   "kind": "mixin",
+ *   "name": "MyMixin",
+ *   "parameters": [
+ *     {
+ *       "name": "base",
+ *     }
+ *   ],
+ *   "members": [
+ *     {
+ *       "kind": "method",
+ *       "name": "foo",
+ *     }
+ *   ]
+ * }
+ * ```
  */
-export interface MixinDeclaration {
+export interface MixinDeclaration extends ClassLike, FunctionLike {
+  kind: 'mixin';
+}
+
+/**
+ * A class mixin that also adds custom element related properties.
+ */
+// Note: this needs to be an interface to be included in the generated JSON
+// Schema output.
+export interface CustomElementMixinDeclaration
+  extends MixinDeclaration,
+    CustomElement {}
+
+export interface VariableDeclaration extends PropertyLike {
+  kind: 'variable';
+  source?: SourceReference;
+}
+
+export interface FunctionDeclaration extends FunctionLike {
+  kind: 'function';
+  source?: SourceReference;
+}
+
+export interface Parameter extends PropertyLike {
   /**
-   * Whether the class or mixin is deprecated.
+   * Whether the parameter is optional. Undefined implies non-optional.
+   */
+  optional?: boolean;
+  /**
+   * Whether the parameter is a rest parameter. Only the last parameter may be a rest parameter.
+   * Undefined implies single parameter.
+   */
+  rest?: boolean;
+}
+
+export interface FunctionLike {
+  name: string;
+
+  /**
+   * A markdown summary suitable for display in a listing.
+   */
+  summary?: string;
+
+  /**
+   * A markdown description.
+   */
+  description?: string;
+
+  /**
+   * Whether the function is deprecated.
    * If the value is a string, it's the reason for the deprecation.
    */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  kind: "mixin"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  parameters?: Parameter[]
+  deprecated?: boolean | string;
+
+  parameters?: Parameter[];
+
   return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
+    type?: Type;
+
     /**
      * A markdown summary suitable for display in a listing.
      */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
-}
-export interface VariableDeclaration {
-  default?: string
-  /**
-   * Whether the property is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the field.
-   */
-  description?: string
-  kind: "variable"
-  name: string
-  /**
-   * Whether the property is read-only.
-   */
-  readonly?: boolean
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  type?: Type
-}
-/**
- * A description of a custom element class.
- *
- * Custom elements are JavaScript classes, so this extends from
- * `ClassDeclaration` and adds custom-element-specific features like
- * attributes, events, and slots.
- *
- * Note that `tagName` in this interface is optional. Tag names are not
- * neccessarily part of a custom element class, but belong to the definition
- * (often called the "registration") or the `customElements.define()` call.
- *
- * Because classes and tag names can only be registered once, there's a
- * one-to-one relationship between classes and tag names. For ease of use,
- * we allow the tag name here.
- *
- * Some packages define and register custom elements in separate modules. In
- * these cases one `Module` should contain the `CustomElement` without a
- * tagName, and another `Module` should contain the
- * `CustomElementExport`.
- */
-export interface CustomElementDeclaration {
-  /**
-   * The attributes that this element is known to understand.
-   */
-  attributes?: Attribute[]
-  cssParts?: CssPart[]
-  cssProperties?: CssCustomProperty[]
-  /**
-   * Distinguishes a regular JavaScript class from a
-   * custom element class
-   */
-  customElement: true
-  demos?: Demo[]
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  /**
-   * The events that this element fires.
-   */
-  events?: Event[]
-  kind: "class"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  /**
-   * The shadow dom content slots that this element accepts.
-   */
-  slots?: Slot[]
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
-  /**
-   * An optional tag name that should be specified if this is a
-   * self-registering element.
-   *
-   * Self-registering elements must also include a CustomElementExport
-   * in the module's exports.
-   */
-  tagName?: string
-}
-export interface Attribute {
-  /**
-   * The default value of the attribute, if any.
-   *
-   * As attributes are always strings, this is the actual value, not a human
-   * readable description.
-   */
-  default?: string
-  /**
-   * Whether the attribute is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  /**
-   * The name of the field this attribute is associated with, if any.
-   */
-  fieldName?: string
-  inheritedFrom?: Reference
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The type that the attribute will be serialized/deserialized as.
-   */
-  type?: {
+    summary?: string;
+
     /**
-     * An array of references to the types in the type string.
-     *
-     * These references have optional indices into the type string so that tools
-     * can understand the references in the type string independently of the type
-     * system and syntax. For example, a documentation viewer could display the
-     * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
-     * and `BarElement` without understanding arrays, generics, or union types.
+     * A markdown description.
      */
-    references?: TypeReference[]
-    source?: SourceReference
-    /**
-     * The full string representation of the type, in whatever type syntax is
-     * used, such as JSDoc, Closure, or TypeScript.
-     */
-    text: string
-    [k: string]: unknown
-  }
+    description?: string;
+  };
 }
-/**
- * The description of a CSS Part
- */
-export interface CssPart {
-  /**
-   * Whether the CSS shadow part is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-export interface CssCustomProperty {
-  default?: string
-  /**
-   * Whether the CSS custom property is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  /**
-   * The name of the property, including leading `--`.
-   */
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The expected syntax of the defined property. Defaults to "*".
-   *
-   * The syntax must be a valid CSS [syntax string](https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax)
-   * as defined in the CSS Properties and Values API.
-   *
-   * Examples:
-   *
-   * "<color>": accepts a color
-   * "<length> | <percentage>": accepts lengths or percentages but not calc expressions with a combination of the two
-   * "small | medium | large": accepts one of these values set as custom idents.
-   * "*": any valid token
-   */
-  syntax?: string
-}
+
+export type Privacy = 'public' | 'private' | 'protected';
+
 export interface Demo {
   /**
    * A markdown description of the demo.
    */
-  description?: string
-  source?: SourceReference
+  description?: string;
+
   /**
    * Relative URL of the demo if it's published with the package. Absolute URL
    * if it's hosted.
    */
-  url: string
-}
-export interface Event {
-  /**
-   * Whether the event is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  inheritedFrom?: Reference
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * The type of the event object that's fired.
-   */
-  type: {
-    /**
-     * An array of references to the types in the type string.
-     *
-     * These references have optional indices into the type string so that tools
-     * can understand the references in the type string independently of the type
-     * system and syntax. For example, a documentation viewer could display the
-     * type `Array<FooElement | BarElement>` with cross-references to `FooElement`
-     * and `BarElement` without understanding arrays, generics, or union types.
-     */
-    references?: TypeReference[]
-    source?: SourceReference
-    /**
-     * The full string representation of the type, in whatever type syntax is
-     * used, such as JSDoc, Closure, or TypeScript.
-     */
-    text: string
-    [k: string]: unknown
-  }
-}
-export interface Slot {
-  /**
-   * Whether the slot is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description.
-   */
-  description?: string
-  /**
-   * The slot name, or the empty string for an unnamed slot.
-   */
-  name: string
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-}
-/**
- * A class mixin that also adds custom element related properties.
- */
-export interface CustomElementMixinDeclaration {
-  /**
-   * The attributes that this element is known to understand.
-   */
-  attributes?: Attribute[]
-  cssParts?: CssPart[]
-  cssProperties?: CssCustomProperty[]
-  /**
-   * Distinguishes a regular JavaScript class from a
-   * custom element class
-   */
-  customElement: true
-  demos?: Demo[]
-  /**
-   * Whether the class or mixin is deprecated.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  /**
-   * A markdown description of the class.
-   */
-  description?: string
-  /**
-   * The events that this element fires.
-   */
-  events?: Event[]
-  kind: "mixin"
-  members?: (ClassField | ClassMethod)[]
-  /**
-   * Any class mixins applied in the extends clause of this class.
-   *
-   * If mixins are applied in the class definition, then the true superclass
-   * of this class is the result of applying mixins in order to the superclass.
-   *
-   * Mixins must be listed in order of their application to the superclass or
-   * previous mixin application. This means that the innermost mixin is listed
-   * first. This may read backwards from the common order in JavaScript, but
-   * matches the order of language used to describe mixin application, like
-   * "S with A, B".
-   */
-  mixins?: Reference[]
-  name: string
-  parameters?: Parameter[]
-  return?: {
-    /**
-     * A markdown description.
-     */
-    description?: string
-    /**
-     * A markdown summary suitable for display in a listing.
-     */
-    summary?: string
-    type?: Type
-    [k: string]: unknown
-  }
-  /**
-   * The shadow dom content slots that this element accepts.
-   */
-  slots?: Slot[]
-  source?: SourceReference
-  /**
-   * A markdown summary suitable for display in a listing.
-   */
-  summary?: string
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  superclass?: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
-  /**
-   * An optional tag name that should be specified if this is a
-   * self-registering element.
-   *
-   * Self-registering elements must also include a CustomElementExport
-   * in the module's exports.
-   */
-  tagName?: string
-}
-export interface JavaScriptExport {
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  declaration: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
-  /**
-   * Whether the export is deprecated. For example, the name of the export was changed.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  kind: "js"
-  /**
-   * The name of the exported symbol.
-   *
-   * JavaScript has a number of ways to export objects which determine the
-   * correct name to use.
-   *
-   * - Default exports must use the name "default".
-   * - Named exports use the name that is exported. If the export is renamed
-   *   with the "as" clause, use the exported name.
-   * - Aggregating exports (`* from`) should use the name `*`
-   */
-  name: string
-}
-/**
- * A global custom element defintion, ie the result of a
- * `customElements.define()` call.
- *
- * This is represented as an export because a definition makes the element
- * available outside of the module it's defined it.
- */
-export interface CustomElementExport {
-  /**
-   * A reference to an export of a module.
-   *
-   * All references are required to be publically accessible, so the canonical
-   * representation of a reference is the export it's available from.
-   *
-   * `package` should generally refer to an npm package name. If `package` is
-   * undefined then the reference is local to this package. If `module` is
-   * undefined the reference is local to the containing module.
-   *
-   * References to global symbols like `Array`, `HTMLElement`, or `Event` should
-   * use a `package` name of `"global:"`.
-   */
-  declaration: {
-    module?: string
-    name: string
-    package?: string
-    [k: string]: unknown
-  }
-  /**
-   * Whether the custom-element export is deprecated.
-   * For example, a future version will not register the custom element in this file.
-   * If the value is a string, it's the reason for the deprecation.
-   */
-  deprecated?: string | boolean
-  kind: "custom-element-definition"
-  /**
-   * The tag name of the custom element.
-   */
-  name: string
+  url: string;
+
+  source?: SourceReference;
 }

--- a/packages/tools/lib/cem/utils.mjs
+++ b/packages/tools/lib/cem/utils.mjs
@@ -18,7 +18,7 @@ const normalizeDescription = (description) => {
 	return typeof description === 'string' ? description.replaceAll(/^-\s+|^(\n)+|(\n)+$/g, ""): description;
 }
 
-const getTypeRefs = (ts, classNodeMember, member) => {
+const getTypeRefs = (ts, node, member) => {
     const extractTypeRefs = (type) => {
         if (type?.kind === ts.SyntaxKind.TypeReference) {
             return type.typeArguments?.length
@@ -29,7 +29,7 @@ const getTypeRefs = (ts, classNodeMember, member) => {
                 .map((type) => extractTypeRefs(type))
                 .flat(1);
         } else if (type?.kind === ts.SyntaxKind.TemplateLiteralType) {
-            if (member.type) {
+            if (member?.type) {
                 member.type.text = member.type.text.replaceAll?.(/`|\${|}/g, "");
             }
 
@@ -39,7 +39,7 @@ const getTypeRefs = (ts, classNodeMember, member) => {
         }
     };
 
-    let typeRefs = extractTypeRefs(classNodeMember.type);
+    let typeRefs = extractTypeRefs(node.type) || node?.typeArguments?.map(n => extractTypeRefs(n)).flat(2);
 
     if (typeRefs) {
         typeRefs = typeRefs.filter((e) => !!e);
@@ -180,7 +180,7 @@ const getReference = (ts, type, classNode, modulePath) => {
         typeName,
         packageJSON,
         modulePath
-    );
+    )?.replace(`${packageName}/`, "");
 
     return packageName && {
         name: typeName,


### PR DESCRIPTION
- Module’s path of superclass to be relative to the package from which it comes
- Add missing JSDoc tags for MultiComboBoxGroupItem / TableGroupRow
- Fix type definitions for internal and external manifests
- Enhance event decorator by making it generic. Check the details object with the type provided to the generic (every key described in the type should have respective key in the detail object)