### PR TITLE
fix(ui5-split-button): use correct params

### DIFF
--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -32,7 +32,7 @@
 
 :host([active-arrow-button][design="Emphasized"]) .ui5-split-arrow-button,
 :host([design="Emphasized"]) .ui5-split-arrow-button[active] {
-	background-color: var(--sapButton_Selected_Background);
+	background-color: var(--sapButton_Emphasized_Active_Background);
 	border: 0.0625rem solid var(--sapButton_Emphasized_Active_BorderColor);
 }
 
@@ -41,7 +41,7 @@
 :host([design="Transparent"]) .ui5-split-arrow-button[active],
 :host([design="Default"]) .ui5-split-arrow-button[active],
 .ui5-split-arrow-button[active], .ui5-split-arrow-button[active]:hover {
-	background-color: var(--sapButton_Selected_Background);
+	background-color: var(--sapButton_Active_Background);
 	border: 0.0625rem solid var(--sapButton_Lite_Active_BorderColor);
 	color: var(--sapButton_Active_TextColor);
 }
@@ -317,7 +317,7 @@
 
 .ui5-split-text-button[active][design="Emphasized"] {
 	color: var(--sapButton_Emphasized_Active_TextColor);
-	background-color: var(--sapButton_Selected_Background);
+	background-color: var(--sapButton_Emphasized_Active_Background);
 }
 
 :host([design="Emphasized"][active-arrow-button]) .ui5-split-arrow-button,


### PR DESCRIPTION
After updating the theming version and adapting new values of the css parameters, we found few issues we had in the SplitButton. 

With this change we apply the correct parameters, and align the Split Button with the Visual Specifications.

Fixes: #8136