### PR TITLE
fix(ui5-badge): correct text-shadow for Quartz dark theme

### DIFF
--- a/packages/main/src/themes/sap_fiori_3_dark/Badge-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/Badge-parameters.css
@@ -1,0 +1,5 @@
+@import "../base/Badge-parameters.css";
+
+:root {
+	--ui5-badge-text-shadow: var(--sapContent_ContrastTextShadow);
+}

--- a/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -1,6 +1,6 @@
 @import "./Avatar-parameters.css";
 @import "../base/AvatarGroup-parameters.css";
-@import "../base/Badge-parameters.css";
+@import "./Badge-parameters.css";
 @import "../base/BrowserScrollbar-parameters.css";
 @import "../base/BusyIndicator-parameters.css";
 @import "./Button-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcb/Badge-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Badge-parameters.css
@@ -40,4 +40,7 @@
 	--ui5-badge-color-scheme-10-background: var(--sapGroup_ContentBackground);
 	--ui5-badge-color-scheme-10-border: var(--sapGroup_ContentBorderColor);
 	--ui5-badge-color-scheme-10-color: var(--sapTextColor);
+
+	--ui5-badge-text-shadow: none;
+	--ui5-badge-contrast-text-shadow: none;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/Badge-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Badge-parameters.css
@@ -40,4 +40,7 @@
 	--ui5-badge-color-scheme-10-background: var(--sapGroup_ContentBackground);
 	--ui5-badge-color-scheme-10-border: var(--sapGroup_ContentBorderColor);
 	--ui5-badge-color-scheme-10-color: var(--sapTextColor);
+
+	--ui5-badge-text-shadow: none;
+	--ui5-badge-contrast-text-shadow: none;
 }


### PR DESCRIPTION
Fixes #8126
