### PR TITLE
fix(ui5-color-palette): add i18n text for default color button's text

### DIFF
--- a/packages/main/src/ColorPalette.hbs
+++ b/packages/main/src/ColorPalette.hbs
@@ -10,7 +10,7 @@
 				class="ui5-cp-default-color-button"
 				design="Transparent" 
 				@click={{_onDefaultColorClick}}
-				@keydown={{_onDefaultColorKeyDown}}>Default color</ui5-button>
+				@keydown={{_onDefaultColorKeyDown}}>{{colorPaletteDefaultColorText}}</ui5-button>
 			<div class="ui5-cp-separator"></div>
 		</div>
 	{{/if}}
@@ -35,7 +35,7 @@
 				class="ui5-cp-more-colors"
 				@click="{{_openMoreColorsDialog}}"
 				@keydown={{_onMoreColorsKeyDown}}
-			>{{colorPaleteMoreColorsText}}</ui5-button>
+			>{{colorPaletteMoreColorsText}}</ui5-button>
 		</div>
 	{{/if}}
 

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -30,6 +30,7 @@ import type { IColorPaletteItem } from "./Interfaces.js";
 import {
 	COLORPALETTE_CONTAINER_LABEL,
 	COLOR_PALETTE_MORE_COLORS_TEXT,
+	COLOR_PALETTE_DEFAULT_COLOR_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -422,8 +423,12 @@ class ColorPalette extends UI5Element {
 		return ColorPalette.i18nBundle.getText(COLORPALETTE_CONTAINER_LABEL);
 	}
 
-	get colorPaleteMoreColorsText() {
+	get colorPaletteMoreColorsText() {
 		return ColorPalette.i18nBundle.getText(COLOR_PALETTE_MORE_COLORS_TEXT);
+	}
+
+	get colorPaletteDefaultColorText() {
+		return ColorPalette.i18nBundle.getText(COLOR_PALETTE_DEFAULT_COLOR_TEXT);
 	}
 
 	get _showMoreColors() {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -106,8 +106,11 @@ COLOR_PALETTE_DIALOG_OK_BUTTON=OK
 #XTIT: Color Palette dialog title of the Color Picker
 COLOR_PALETTE_DIALOG_TITLE=Change Color
 
-#XTIT: Color Palette dialog title of the Color Picker
+#XTIT: Color Palette dialog button text to open the Color Picker
 COLOR_PALETTE_MORE_COLORS_TEXT=More Colors...
+
+#XTIT: Color Palette dialog button text to set the default color
+COLOR_PALETTE_DEFAULT_COLOR_TEXT=Default Color
 
 #XACT: Aria information for the ColorPicker Alpha slider
 COLORPICKER_ALPHA_SLIDER=Alpha control


### PR DESCRIPTION
Currently in our `<ui5-color-palette>` and `<ui5-color-palette-popover>` components the **'More Colors...'** button have its text in the i18n Bundle, while in the **'Default Color'** button the text was hardcoded, which is inconsistent and leads to a non-translated text in different regions.

With this change we added the text of the **'Default Color'** button in the I18N Bundle.

Fixes: #8155 