### PR TITLE
fix(ui5-toolbar-select): options added to bundle

### DIFF
--- a/packages/main/src/bundle.esm.ts
+++ b/packages/main/src/bundle.esm.ts
@@ -167,6 +167,7 @@ import ToolbarButton from "./ToolbarButton.js";
 import ToolbarSeparator from "./ToolbarSeparator.js";
 import ToolbarSpacer from "./ToolbarSpacer.js";
 import ToolbarSelect from "./ToolbarSelect.js";
+import ToolbarSelectOption from "./ToolbarSelectOption.js";
 import Tree from "./Tree.js";
 import TreeList from "./TreeList.js";
 import TreeItem from "./TreeItem.js";


### PR DESCRIPTION
After importing ToolbarSelectOption class only as a type in ToolbarSelect, options was not rendering properly.
Adding it to the bundle fixes the reference.