### PR TITLE
chore: add noattribute information

### DIFF
--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -166,6 +166,7 @@ function processClass(ts, classNode, moduleDoc) {
 
 				if (propertyDecorator) {
 					member._ui5validator = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => ["validator", "type"].includes(property.name.text))?.initializer?.text || "String";
+					member._ui5noAttribute = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "noAttribute")?.initializer?.kind  === ts.SyntaxKind.TrueKeyword || undefined;
 				}
 
 				if (hasTag(memberParsedJsDoc, "formProperty")) {

--- a/packages/tools/lib/cem/schema-internal.json
+++ b/packages/tools/lib/cem/schema-internal.json
@@ -245,6 +245,9 @@
     "ClassField": {
       "additionalProperties": false,
       "properties": {
+        "_ui5noAttribute": {
+          "type": "boolean"
+        },
         "_ui5validator": {
           "type": "string"
         },

--- a/packages/tools/lib/cem/types-internal.d.ts
+++ b/packages/tools/lib/cem/types-internal.d.ts
@@ -602,6 +602,7 @@ export interface PropertyLike {
 }
 
 export interface ClassField extends PropertyLike {
+  _ui5noAttribute?: boolean;
   _ui5validator?: string
   _ui5formProperty?: boolean
   _ui5formEvents?: string


### PR DESCRIPTION
Provide information in the manifest for properties that are explicitly set to not have attribute.