### PR TITLE
chore: process bracket array syntax

### DIFF
--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -240,7 +240,7 @@ function processClass(ts, classNode, moduleDoc) {
 			if (member.return) {
 				const returnTag = findTag(memberParsedJsDoc, "returns");
 				member.return.description = returnTag?.description ? `${returnTag.name} ${returnTag.description}` : returnTag?.name;
-				member.return.type.text = classNodeMember?.type?.getFullText?.()?.trim();
+				member.return.type.text = formatArrays(classNodeMember?.type?.getFullText?.()?.trim());
 				const typeRefs = (getTypeRefs(ts, classNodeMember, member.return)
 					?.map(typeRef => getReference(ts, typeRef, classNodeMember, moduleDoc.path)).filter(Boolean)) || [];
 

--- a/packages/tools/lib/cem/utils.mjs
+++ b/packages/tools/lib/cem/utils.mjs
@@ -24,6 +24,8 @@ const getTypeRefs = (ts, node, member) => {
             return type.typeArguments?.length
                 ? type.typeArguments.map((typeRef) => typeRef.typeName?.text)
                 : [type.typeName?.text];
+        } else if (type?.kind === ts.SyntaxKind.ArrayType) {
+            return [type.elementType?.typeName?.text];
         } else if (type?.kind === ts.SyntaxKind.UnionType) {
             return type.types
                 .map((type) => extractTypeRefs(type))
@@ -352,7 +354,7 @@ const displayDocumentationErrors = () => {
 }
 
 const formatArrays = (typeText) => {
-	return typeText.replaceAll(/(\S+)\[\]/g, "Array<$1>")
+	return typeText?.replaceAll(/(\S+)\[\]/g, "Array<$1>")
 }
 
 export {


### PR DESCRIPTION
References from return types described as following were not correctly generated:

```ts
get hiddenItems(): IAvatar[] 
```

Now, `IAvatar[]` and `Array<IAvatar>` generate correct references and both are transpiled to `Array<IAvatar>` as basic array syntax into custom-elements.json.