### PR TITLE
chore: fix ssr-shim import resolve on dev

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "121.0.0",
+    "chromedriver": "120.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "119.0.1",
+    "chromedriver": "121.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-// import "@ui5/webcomponents-base/dist/ssr-dom.js";
+import "@ui5/webcomponents-base/dist/ssr-dom.js";
 import merge from "./thirdparty/merge.js";
 import { boot } from "./Boot.js";
 import UI5ElementMetadata, {

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -35,7 +35,7 @@
     "generate": "nps generate",
     "generateAPI": "nps generateAPI",
     "bundle": "nps build.bundle",
-    "test": "wc-dev test",
+    "test": "wc-dev test && yarn test:ssr",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "create-ui5-element": "wc-create-ui5-element",
     "prepublishOnly": "tsc"

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "121.0.0"
+    "chromedriver": "120.0.0"
   }
 }

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "119.0.1"
+    "chromedriver": "121.0.0"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -35,7 +35,7 @@
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
     "babel-plugin-amd-to-esm": "^2.0.3",
-    "chromedriver": "121.0.0",
+    "chromedriver": "120.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -35,7 +35,7 @@
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
     "babel-plugin-amd-to-esm": "^2.0.3",
-    "chromedriver": "119.0.1",
+    "chromedriver": "121.0.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"
   },

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -25,7 +25,7 @@
     "generateAPI": "nps generateAPI",
     "build": "wc-dev build",
     "bundle": "nps build.bundle",
-    "test": "wc-dev test",
+    "test": "wc-dev test && yarn test:ssr",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "test:suite-1": "wc-dev test-suite-1",
     "test:suite-2": "wc-dev test-suite-2",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "119.0.1"
+    "chromedriver": "121.0.0"
   }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.22.0-rc.2",
-    "chromedriver": "121.0.0"
+    "chromedriver": "120.0.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,9 +71,10 @@ const customResolver = (id, source, options) => {
 		
 	}
 
-	// base package
-	if (id.startsWith("@ui5/webcomponents-base/dist") && (id.endsWith("ssr-dom.js") || id.endsWith("ssr-dom-shim.js"))) {
-		return join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
+	// The `base/package.json` has exports that resolves the absolute import to "dist/ssr-dom.js".
+	// However, in development, the file is not present in `dist`. Instead, load `ssr-dom.ts` from `src`.
+	if (id === "@ui5/webcomponents-base/dist/ssr-dom.js") {
+		return join("packages/base/src/ssr-dom.ts");
 	}
 
 	

--- a/vite.config.js
+++ b/vite.config.js
@@ -68,8 +68,24 @@ const customResolver = (id, source, options) => {
 			}
 			return resolved;
 		}
+		
 	}
 
+	// base package
+	if (id.startsWith("@ui5/webcomponents-base/dist")) {
+		if (id.endsWith("ssr-dom.js")) {
+			const resolved = join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
+			console.log("HERE HERE 1", resolved)
+			return resolved;
+		}
+		if (id.endsWith("ssr-dom-shim.js")) {
+			const resolved = join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
+			console.log("HERE HERE 2", resolved)
+			return resolved;
+		}
+	}
+
+	
 	// relative imports from fiori src that are to a folder starting with `illustrations` are in dist
 	if (source.includes("fiori/src/") && id.includes("/illustrations") && !id.includes("AllIllustrations") && id.startsWith(".")) {
 		let absoluteId = resolve(dirname(source), id);

--- a/vite.config.js
+++ b/vite.config.js
@@ -72,17 +72,8 @@ const customResolver = (id, source, options) => {
 	}
 
 	// base package
-	if (id.startsWith("@ui5/webcomponents-base/dist")) {
-		if (id.endsWith("ssr-dom.js")) {
-			const resolved = join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
-			console.log("HERE HERE 1", resolved)
-			return resolved;
-		}
-		if (id.endsWith("ssr-dom-shim.js")) {
-			const resolved = join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
-			console.log("HERE HERE 2", resolved)
-			return resolved;
-		}
+	if (id.startsWith("@ui5/webcomponents-base/dist") && (id.endsWith("ssr-dom.js") || id.endsWith("ssr-dom-shim.js"))) {
+		return join("packages/base/src", id.replace("@ui5/webcomponents-base/dist/", "")).replace(".js", ".ts");
 	}
 
 	

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,7 +4829,7 @@ axios@^1.0.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.6.5:
+axios@^1.6.0:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
   integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
@@ -5454,13 +5454,13 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@121.0.0:
-  version "121.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-121.0.0.tgz#f8d11dce8e5ce4b6ad75e2b84eed17a0eecabfb9"
-  integrity sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==
+chromedriver@120.0.0:
+  version "120.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-120.0.0.tgz#34d60a6726a104a348d8dbf82106ca45a430684b"
+  integrity sha512-LGy2LhWRBiqDarFIU8gQ43EEyj+07Tc3JuUhthkESAwZ99lrifSnKZwKU0aVwansU84+k6bt71z7K3dkk65gZg==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
-    axios "^1.6.5"
+    axios "^1.6.0"
     compare-versions "^6.1.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4820,12 +4820,21 @@ axe-core@4.2.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
   integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
 
-axios@^1.0.0, axios@^1.6.0:
+axios@^1.0.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
   integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
     follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.6.5:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -5445,13 +5454,13 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@119.0.1:
-  version "119.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-119.0.1.tgz#064f3650790ccea055e9bfd95c600f5ea60295e9"
-  integrity sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==
+chromedriver@121.0.0:
+  version "121.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-121.0.0.tgz#f8d11dce8e5ce4b6ad75e2b84eed17a0eecabfb9"
+  integrity sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
-    axios "^1.6.0"
+    axios "^1.6.5"
     compare-versions "^6.1.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.1"
@@ -7405,6 +7414,11 @@ follow-redirects@^1.15.0:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
In `dev` the shim `js` files are not in `dist` and we need to add resolver so vite finds the `ts` files in `src`