### PR TITLE
feat(ui5-shellbar): new event added

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -818,7 +818,7 @@ class ShellBar extends UI5Element {
 	}
 
 	_handleSearchIconPress() {
-		const searchButtonRef = this.shadowRoot!.querySelector<Button>(".ui5-shellbar-button")!;
+		const searchButtonRef = this.shadowRoot!.querySelector<Button>(".ui5-shellbar-search-button")!;
 		const bDefaultPrevented = !this.fireEvent<ShellBarSearchButtonEventDetail>("search-button-click", {
 			targetRef: searchButtonRef,
 			isVisible: this.showSearchField,

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -102,7 +102,7 @@ type ShellBarMenuItemClickEventDetail = {
 
 type ShellBarSearchButtonEventDetail = {
 	targetRef: HTMLElement;
-	isVisible: boolean;
+	searchFieldVisible: boolean;
 };
 
 type ShellBarCoPilot = {
@@ -290,14 +290,14 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
  *
  * @allowPreventDefault
  * @param {HTMLElement} targetRef dom ref of the activated element
- * @param {Boolean} isVisible whether the search field is visible
+ * @param {Boolean} searchFieldVisible whether the search field is visible
  * @public
  */
 
 @event<ShellBarSearchButtonEventDetail>("search-button-click", {
 	detail: {
 		targetRef: { type: HTMLElement },
-		isVisible: { type: Boolean },
+		searchFieldVisible: { type: Boolean },
 	},
 })
 
@@ -819,12 +819,12 @@ class ShellBar extends UI5Element {
 
 	_handleSearchIconPress() {
 		const searchButtonRef = this.shadowRoot!.querySelector<Button>(".ui5-shellbar-search-button")!;
-		const bDefaultPrevented = !this.fireEvent<ShellBarSearchButtonEventDetail>("search-button-click", {
+		const defaultPrevented = !this.fireEvent<ShellBarSearchButtonEventDetail>("search-button-click", {
 			targetRef: searchButtonRef,
-			isVisible: this.showSearchField,
+			searchFieldVisible: this.showSearchField,
 		}, true);
 
-		if (bDefaultPrevented) {
+		if (defaultPrevented) {
 			return;
 		}
 		this.showSearchField = !this.showSearchField;

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -100,6 +100,11 @@ type ShellBarMenuItemClickEventDetail = {
 	item: HTMLElement;
 };
 
+type ShellBarSearchButtonEventDetail = {
+	targetRef: HTMLElement;
+	isVisible: boolean;
+};
+
 type ShellBarCoPilot = {
 	animated?: boolean,
 	animationValues?: string,
@@ -276,6 +281,23 @@ const HANDLE_RESIZE_DEBOUNCE_RATE = 200; // ms
 		 * @public
 		 */
 		item: { type: HTMLElement },
+	},
+})
+
+/**
+ * Fired, when the search button is activated.
+ * <b>Note:</b> You can prevent expanding/collapsing of the search field by calling <code>event.preventDefault()</code>.
+ *
+ * @allowPreventDefault
+ * @param {HTMLElement} targetRef dom ref of the activated element
+ * @param {Boolean} isVisible whether the search field is visible
+ * @public
+ */
+
+@event<ShellBarSearchButtonEventDetail>("search-button-click", {
+	detail: {
+		targetRef: { type: HTMLElement },
+		isVisible: { type: Boolean },
 	},
 })
 
@@ -796,6 +818,15 @@ class ShellBar extends UI5Element {
 	}
 
 	_handleSearchIconPress() {
+		const searchButtonRef = this.shadowRoot!.querySelector<Button>(".ui5-shellbar-button")!;
+		const bDefaultPrevented = !this.fireEvent<ShellBarSearchButtonEventDetail>("search-button-click", {
+			targetRef: searchButtonRef,
+			isVisible: this.showSearchField,
+		}, true);
+
+		if (bDefaultPrevented) {
+			return;
+		}
 		this.showSearchField = !this.showSearchField;
 
 		if (!this.showSearchField) {
@@ -1328,4 +1359,5 @@ export type {
 	ShellBarAccessibilityAttributes,
 	ShellBarAccessibilityRoles,
 	ShellBarAccessibilityTexts,
+	ShellBarSearchButtonEventDetail,
 };

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -264,10 +264,6 @@
 			window["press-input"].value = "Logo";
 		});
 
-		shellbar.addEventListener("ui5-search-button-click", function(event) {
-			window["press-input"].value = "Search Button";
-		});
-
 		shellbarWithLogoClick.addEventListener("ui5-logo-click", function(event) {
 			window["press-input2"].value = shellbarWithLogoClick.primaryTitle.replace(/\s/g, "");
 		});

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -236,6 +236,12 @@
 		<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
 	</ui5-shellbar>
 
+	<ui5-shellbar id="sbEvent">
+		<ui5-input slot="searchField">
+			<ui5-li icon="world" description="travel the world" additional-text="explore" additional-text-state="Success">1</ui5-li>
+		</ui5-input>
+	</ui5-shellbar>
+
 	<script>
 		mySearch.addEventListener("ui5-suggestion-item-select", function (event) {
 			console.log(event);
@@ -267,6 +273,10 @@
 
 		shellbar.addEventListener("ui5-co-pilot-click", function(event) {
 			window["press-input"].value = "CoPilot";
+		});
+
+		shellbar.addEventListener("ui5-search-button-click", function(event) {
+			window["press-input"].value = "Search Button";
 		});
 
 		shellbar.addEventListener("ui5-menu-item-click", function(event) {
@@ -325,6 +335,11 @@
 		sbAccRoles.accessibilityRoles = {
 			logoRole: "link"
 		};
+
+		sbEvent.addEventListener("ui5-search-button-click", function(event) {
+			event.preventDefault();
+		});
+
 	</script>
 </body>
 </html>

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -232,11 +232,8 @@
 		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
 	</ui5-shellbar>
 
-	<ui5-shellbar id="sbAccRoles">
+	<ui5-shellbar id="sb">
 		<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
-	</ui5-shellbar>
-
-	<ui5-shellbar id="sbEvent">
 		<ui5-input slot="searchField">
 			<ui5-li icon="world" description="travel the world" additional-text="explore" additional-text-state="Success">1</ui5-li>
 		</ui5-input>
@@ -265,6 +262,10 @@
 
 		shellbar.addEventListener("ui5-logo-click", function(event) {
 			window["press-input"].value = "Logo";
+		});
+
+		shellbar.addEventListener("ui5-search-button-click", function(event) {
+			window["press-input"].value = "Search Button";
 		});
 
 		shellbarWithLogoClick.addEventListener("ui5-logo-click", function(event) {
@@ -332,11 +333,11 @@
 			logoTitle: "Custom logo title",
 		};
 
-		sbAccRoles.accessibilityRoles = {
+		sb.accessibilityRoles = {
 			logoRole: "link"
 		};
 
-		sbEvent.addEventListener("ui5-search-button-click", function(event) {
+		sb.addEventListener("ui5-search-button-click", function(event) {
 			event.preventDefault();
 		});
 

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -349,6 +349,23 @@ describe("Component Behavior", () => {
 				assert.ok(await menuPopover.isDisplayedInViewport(), "Menu should be shown");
 			});
 
+			it("tests search-button-click event", async () => {
+				const searchButton = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
+				const input = await browser.$("#press-input");
+
+				await searchButton.click();
+				assert.strictEqual(await input.getValue(), "Search Button", "Input value is set by click event of Search Button");
+			});
+
+			it("tests preventDefault of search-button-click event", async () => {
+				const searchButton  = await browser.$("#sbEvent").shadow$(".ui5-shellbar-search-button");
+				const searchField  = await browser.$("#sbEvent").shadow$(".ui5-shellbar-search-field");
+				assert.strictEqual(await searchField .isDisplayed(), false, "Search is hidden by default");
+
+				await searchButton .click();
+				assert.notOk(await searchField .isDisplayed(), "Search field should not be opened");
+			});
+
 			it("tests notificationsClick event", async () => {
 				const notificationsIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 				const input = await browser.$("#press-input");

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -47,7 +47,7 @@ describe("Component Behavior", () => {
 		});
 
 		it("tests acc custom roles", async () => {
-			const sb = await browser.$("#sbAccRoles");
+			const sb = await browser.$("#sb");
 			const logoDOM = await sb.shadow$(".ui5-shellbar-logo");
 
 			// assertHANDLE_RESIZE_DEBOUNCE_RATE_WAIT
@@ -349,23 +349,6 @@ describe("Component Behavior", () => {
 				assert.ok(await menuPopover.isDisplayedInViewport(), "Menu should be shown");
 			});
 
-			it("tests search-button-click event", async () => {
-				const searchButton = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
-				const input = await browser.$("#press-input");
-
-				await searchButton.click();
-				assert.strictEqual(await input.getValue(), "Search Button", "Input value is set by click event of Search Button");
-			});
-
-			it("tests preventDefault of search-button-click event", async () => {
-				const searchButton  = await browser.$("#sbEvent").shadow$(".ui5-shellbar-search-button");
-				const searchField  = await browser.$("#sbEvent").shadow$(".ui5-shellbar-search-field");
-				assert.strictEqual(await searchField .isDisplayed(), false, "Search is hidden by default");
-
-				await searchButton .click();
-				assert.notOk(await searchField .isDisplayed(), "Search field should not be opened");
-			});
-
 			it("tests notificationsClick event", async () => {
 				const notificationsIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-bell-button");
 				const input = await browser.$("#press-input");
@@ -405,6 +388,30 @@ describe("Component Behavior", () => {
 				await coPilot.click();
 				assert.strictEqual(await input.getValue(), "CoPilot", "Input value is set by click event of CoPilot");
 			});
+
+			it("tests search-button-click event", async () => {
+				setTimeout(async () => {
+					const searchIcon = await browser.$("#shellbar").shadow$(".ui5-shellbar-search-button");
+					const input = await browser.$("#press-input");
+
+					await searchIcon.click();
+					assert.strictEqual(await input.getValue(), "Search Button", "Input value is set by click event of Search Button");
+				}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
+
+			});
+
+			it("tests search-button-click event", async () => {
+				setTimeout(async () => {
+					const searchButton  = await browser.$("#sb").shadow$(".ui5-shellbar-search-button");
+					const searchField  = await browser.$("#sb").shadow$(".ui5-shellbar-search-field");
+					assert.strictEqual(await searchField.isDisplayed(), false, "Search is hidden by default");
+
+					await searchButton .click();
+					assert.notOk(await searchField.isDisplayed(), "Search field should not be opened");
+				}, HANDLE_RESIZE_DEBOUNCE_RATE_WAIT);
+
+			});
+
 
 			it("tests menuItemClick event", async () => {
 				const primaryTitle = await browser.$("#shellbar").shadow$(".ui5-shellbar-menu-button");


### PR DESCRIPTION
New event search-button-click is added, which allows different actions to be triggered
when it is fired on the search button inside the ui5-shellbar.
If its preventDefault  method is called, the default action of the search button
(expanding/collapsing the input) won`t be triggered, but let the users trigger their own.

Related: https://github.com/SAP/ui5-webcomponents/issues/6273