### PR TITLE
chore: run test:ssr standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "test:main": "yarn workspace @ui5/webcomponents test",
     "test:main:suite-1": "yarn workspace @ui5/webcomponents test:suite-1",
     "test:main:suite-2": "yarn workspace @ui5/webcomponents test:suite-2",
+    "test:main:ssr": "yarn workspace @ui5/webcomponents test:ssr",
     "test:fiori": "yarn workspace @ui5/webcomponents-fiori test",
+    "test:fiori:ssr": "yarn workspace @ui5/webcomponents-fiori test:ssr",
     "test": "yarn wsrun --exclude-missing test",
 
     "build": "yarn ci:releasebuild",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -35,7 +35,7 @@
     "generate": "nps generate",
     "generateAPI": "nps generateAPI",
     "bundle": "nps build.bundle",
-    "test": "wc-dev test && yarn test:ssr",
+    "test": "wc-dev test",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "create-ui5-element": "wc-create-ui5-element",
     "prepublishOnly": "tsc"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -25,7 +25,7 @@
     "generateAPI": "nps generateAPI",
     "build": "wc-dev build",
     "bundle": "nps build.bundle",
-    "test": "wc-dev test && yarn test:ssr",
+    "test": "wc-dev test",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "test:suite-1": "wc-dev test-suite-1",
     "test:suite-2": "wc-dev test-suite-2",


### PR DESCRIPTION
Using `test:ssr` as part of the `test` command prevents from running individual component tests.
Solution: remove `test:ssr` from `test` and run the ssr separately.