### PR TITLE
fix(framework): property with empty object as default value

### DIFF
--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -77,7 +77,12 @@ class UI5ElementMetadata {
 					console.warn("The 'defaultValue' metadata key is ignored for all booleans properties, they would be initialized with 'false' by default"); // eslint-disable-line
 				}
 			} else if (props[propName].multiple) {
-				initialState[propName] = [];
+				Object.defineProperty(initialState, propName, {
+					enumerable: true,
+					get() {
+					  return [];
+					},
+				  });
 			} else if (propType === Object) {
 				Object.defineProperty(initialState, propName, {
 					enumerable: true,

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -79,7 +79,12 @@ class UI5ElementMetadata {
 			} else if (props[propName].multiple) {
 				initialState[propName] = [];
 			} else if (propType === Object) {
-				initialState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : {};
+				Object.defineProperty(initialState, propName, {
+					enumerable: true,
+					get() {
+					  return "defaultValue" in props[propName] ? props[propName].defaultValue : {};
+					},
+				  });
 			} else if (propType === String) {
 				initialState[propName] = "defaultValue" in props[propName] ? props[propName].defaultValue : "";
 			} else {


### PR DESCRIPTION
Properties with `type: Object` that don't have specified default value in their declaration decorator have `{}` as default value.

This `{}` is stored in the initial state of the component and its reference is shared between instanced.

Same apply for multiple properties but with `[]` instead of `{}`

In some cases where the property value is changed with an index instead of a new reference, the component starts to behave wrongly because the value of the shared reference is changed. 

```ts
this.propertyName.somethingNested = "Some new value"
```

With this change, we provide a new object reference whether the default value of the property is accessed