### PR TITLE
chore: update stock actions to latest, to run on Node 20

### DIFF
--- a/.github/workflows/ci-test-storybook.yaml
+++ b/.github/workflows/ci-test-storybook.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         suite: ['base', 'main:suite-1', 'main:suite-2', 'fiori']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/deploy-latest-playground-on-push.yaml
+++ b/.github/workflows/deploy-latest-playground-on-push.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/deploy-latest-playground-on-release.yaml
+++ b/.github/workflows/deploy-latest-playground-on-release.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/deploy-main-playground-on-push.yaml
+++ b/.github/workflows/deploy-main-playground-on-push.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/deploy-main-playground.yaml
+++ b/.github/workflows/deploy-main-playground.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/issues-handling.yaml
+++ b/.github/workflows/issues-handling.yaml
@@ -6,11 +6,11 @@ jobs:
   test-issue-comment:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/release-downport.yaml
+++ b/.github/workflows/release-downport.yaml
@@ -12,11 +12,11 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/release-experimental.yaml
+++ b/.github/workflows/release-experimental.yaml
@@ -7,8 +7,8 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/release-rc-auto.yaml
+++ b/.github/workflows/release-rc-auto.yaml
@@ -8,11 +8,11 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -7,11 +7,11 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -17,11 +17,11 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: 18
         cache: 'yarn'

--- a/.github/workflows/reset-gh-pages.yaml
+++ b/.github/workflows/reset-gh-pages.yaml
@@ -8,7 +8,7 @@ jobs:
   reset-gh-pages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
         fetch-depth: 0


### PR DESCRIPTION
As Node 16 is reaching end of support, there is deprecation process - [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). 
As users of several stock actions (`checkout`, `setup-node`) we must ensure our workflows use the latest versions of the actions that are running on Node 20. Currently, workflows containing actions running on Node 16, will display only warnings, but it's nevertheless good to follow the recommendations and update.

<img width="1097" alt="Screenshot 2024-02-01 at 9 15 12" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/eac2381c-5966-4d5b-b272-87322259711d">



