### PR TITLE
fix(ui5-shellbar): fixed secondaryTitle visual presentation

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -106,7 +106,6 @@ slot[name="profile"] {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	color: var(--sapShell_TextColor);
-	flex: auto;
 }
 
 :host(:not([primary-title])) .ui5-shellbar-menu-button {


### PR DESCRIPTION
After a recent change for the XXL breakpoint, the secondaryTitle didn't looked properly aligned. Now it's fixed by removing redundant CSS styling.

Fixes: #8189