### PR TITLE
fix: release build

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -37,7 +37,7 @@
     "generateAPI": "nps generateAPI",
     "bundle": "nps build.bundle",
     "test": "nps test",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "dependencies": {
     "@lit-labs/ssr-dom-shim": "^1.1.2",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -38,7 +38,7 @@
     "test": "wc-dev test",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "create-ui5-element": "wc-create-ui5-element",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "repository": {
     "type": "git",

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -20,7 +20,7 @@
     "clean": "wc-dev clean",
     "build": "wc-dev build",
     "generate": "nps generate",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "repository": {
     "type": "git",

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -20,7 +20,7 @@
     "clean": "wc-dev clean",
     "build": "wc-dev build",
     "generate": "nps generate",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "repository": {
     "type": "git",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,7 +20,7 @@
     "clean": "wc-dev clean",
     "generate": "nps generate",
     "build": "wc-dev build",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "repository": {
     "type": "git",

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -26,7 +26,7 @@
     "start": "nps start",
     "build": "nps build",
     "generate": "nps generate",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -30,7 +30,7 @@
     "test:suite-1": "wc-dev test-suite-1",
     "test:suite-2": "wc-dev test-suite-2",
     "create-ui5-element": "wc-create-ui5-element",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "exports": {
     "./.port": "./.port",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -22,7 +22,7 @@
     "generate": "nps generate",
     "start": "nps start",
     "verify": "node ./lib/verify-vars/index.js",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc -b"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Executing TypeScript in `prepublishOnly` command wasn't enable to check for existing build information.