### PR TITLE
chore: show interface declarations in cem

### DIFF
--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -166,7 +166,7 @@ function processClass(ts, classNode, moduleDoc) {
 
 				if (propertyDecorator) {
 					member._ui5validator = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => ["validator", "type"].includes(property.name.text))?.initializer?.text || "String";
-					member._ui5noAttribute = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "noAttribute")?.initializer?.kind  === ts.SyntaxKind.TrueKeyword || undefined;
+					member._ui5noAttribute = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "noAttribute")?.initializer?.kind === ts.SyntaxKind.TrueKeyword || undefined;
 				}
 
 				if (hasTag(memberParsedJsDoc, "formProperty")) {
@@ -468,9 +468,6 @@ export default {
 						}
 					}
 				})
-
-				moduleDoc.exports = moduleDoc.exports.
-					filter(e => moduleDoc.declarations.find(d => d.name === e.declaration.name && ["class", "function", "variable", "enum"].includes(d.kind)) || e.name === "default");
 			},
 			packageLinkPhase({ context }) {
 				if (context.dev) {

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -15,6 +15,11 @@ const inputFilePath = path.join(process.cwd(), "dist/custom-elements.json"); // 
 const customManifest = fs.readFileSync(inputFilePath, 'utf8');
 const inputDataInternal = JSON.parse(customManifest);
 
+inputDataInternal.modules.forEach(moduleDoc => {
+    moduleDoc.exports = moduleDoc.exports.
+    filter(e => moduleDoc.declarations.find(d => d.name === e.declaration.name && ["class", "function", "variable", "enum"].includes(d.kind)) || e.name === "default");
+})
+
 const clearProps = (data) => {
     if (Array.isArray(data)) {
         for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
By default `custom-elements-manifest/analyzer` removes every declaration without export from the `custom-elements.json`. Previously, we were removing exports of interfaces during the generation of the manifest and this leads to removed declarations of interfaces. Now, we remove interfaces exports during the validation phase.