### PR TITLE
refactor(ui5-tabcontainer): simplify popover logic

### DIFF
--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -138,8 +138,11 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	@property({ type: Boolean })
 	forcedSelected!: boolean;
 
-	@property({ type: Object })
+	@property({ type: Object, defaultValue: null })
 	realTabReference!: Tab;
+
+	@property({ type: Object, defaultValue: null })
+	selectedTabReference!: Tab;
 
 	@property({ type: Boolean })
 	isTopLevelTab!: boolean;
@@ -230,7 +233,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get isOnSelectedTabPath(): boolean {
-		return this.realTabReference === this || this.tabs.some(subTab => subTab.isOnSelectedTabPath);
+		return this.selectedTabReference === this || this.tabs.some(subTab => subTab.isOnSelectedTabPath);
 	}
 
 	get _effectiveSlotName() {
@@ -238,7 +241,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get _defaultSlotName() {
-		return this.realTabReference === this ? "" : "disabled-slot";
+		return this.selectedTabReference === this ? "" : "disabled-slot";
 	}
 
 	get hasOwnContent() {

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -141,9 +141,6 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	@property({ type: Object, defaultValue: null })
 	realTabReference!: Tab;
 
-	@property({ type: Object, defaultValue: null })
-	selectedTabReference!: Tab;
-
 	@property({ type: Boolean })
 	isTopLevelTab!: boolean;
 
@@ -233,7 +230,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get isOnSelectedTabPath(): boolean {
-		return this.selectedTabReference === this || this.tabs.some(subTab => subTab.isOnSelectedTabPath);
+		return this.selected || this.tabs.some(subTab => subTab.isOnSelectedTabPath);
 	}
 
 	get _effectiveSlotName() {
@@ -241,7 +238,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get _defaultSlotName() {
-		return this.selectedTabReference === this ? "" : "disabled-slot";
+		return this.selected ? "" : "disabled-slot";
 	}
 
 	get hasOwnContent() {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -617,14 +617,25 @@ class TabContainer extends UI5Element {
 		return this._getAllSubItems(this.items);
 	}
 
-	_getAllSubItems(items: Array<ITab>, result: Array<ITab> = [], level = 1) {
+	_calcIndentLevels(items: Array<ITab>, level = 1) {
 		items.forEach(item => {
 			if (item.hasAttribute("ui5-tab") || item.hasAttribute("ui5-tab-separator")) {
 				item.forcedLevel = level;
+
+				if (item.subTabs) {
+					this._calcIndentLevels(item.subTabs, level + 1);
+				}
+			}
+		});
+	}
+
+	_getAllSubItems(items: Array<ITab>, result: Array<ITab> = []) {
+		items.forEach(item => {
+			if (item.hasAttribute("ui5-tab") || item.hasAttribute("ui5-tab-separator")) {
 				result.push(item);
 
 				if (item.subTabs) {
-					this._getAllSubItems(item.subTabs, result, level + 1);
+					this._getAllSubItems(item.subTabs, result);
 				}
 			}
 		});
@@ -1123,6 +1134,7 @@ class TabContainer extends UI5Element {
 			this._popoverItemsFlat = _flattenedNewItems;
 			// eslint-disable-next-line no-warning-comments
 			this._overflowItems = items; // TODO: get rid of _popoverItems in favor or _popoverItemsFlat
+			this._calcIndentLevels(this._overflowItems);
 			this._addStyleIndent(this._overflowItems);
 		}
 	}

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -491,25 +491,32 @@ class TabContainer extends UI5Element {
 		e.stopPropagation();
 		e.preventDefault();
 
-		let button = e.target as HTMLElement;
-		let tabInstance = (button as TabContainerExpandButton).tab;
+		let tabInstance: Tab;
+
+		if (isTabInStrip(e.target as HTMLElement)) {
+			tabInstance = e.target as Tab;
+		} else {
+			tabInstance = (e.target as TabContainerExpandButton).tab;
+		}
+
+		let opener = e.target as HTMLElement;
 
 		if (tabInstance) {
 			tabInstance.focus();
 		}
 
 		if (e.type === "keydown" && !(e.target as Tab).realTabReference.isSingleClickArea) {
-			button = (e.target as Tab).querySelectorAll<HTMLElement>(".ui5-tab-expand-button")[0];
+			opener = (e.target as Tab).querySelector<TabContainerExpandButton>(".ui5-tab-expand-button [ui5-button]")!;
 			tabInstance = (e.target as Tab).realTabReference;
 		}
 
 		// if clicked between the expand button and the tab
 		if (!tabInstance) {
-			this._onHeaderItemSelect(button.parentElement as HTMLElement);
+			this._onHeaderItemSelect(opener.parentElement as HTMLElement);
 			return;
 		}
 
-		await this._togglePopover(button, true);
+		await this._togglePopover(opener, true);
 	}
 
 	_setPopoverInitialFocus() {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -84,7 +84,6 @@ interface ITab extends UI5Element {
 	forcedPosinset?: number;
 	forcedSetsize?: number;
 	realTabReference?: Tab;
-	selectedTabReference?: Tab;
 	isTopLevelTab?: boolean;
 	forcedStyle?: Record<string, any>;
 }
@@ -452,13 +451,6 @@ class TabContainer extends UI5Element {
 			tab.forcedPosinset = index + 1;
 			tab.forcedSetsize = arr.length;
 			tab.isTopLevelTab = items.some(i => i === tab);
-			tab.selectedTabReference = this._selectedTab;
-
-			if (tab.subTabs) {
-				walk(tab.subTabs, _tab => {
-					_tab.selectedTabReference = this._selectedTab;
-				});
-			}
 		});
 
 		this._setIndentLevels(items);

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -8,7 +8,7 @@
 	class="ui5-tab-container-responsive-popover"
 >
 	<ui5-list mode="SingleSelect" separators="None" @ui5-item-click="{{_onOverflowListItemClick}}">
-		{{#each _overflowItems}}
+		{{#each _popoverItemsFlat}}
 			{{overflowPresentation}}
 		{{/each}}
 	</ui5-list>

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -27,6 +27,3 @@
 		</div>
 	</div>
 </ui5-li-custom>
-{{#each subTabs}}
-	{{overflowPresentation}}
-{{/each}}

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -5,7 +5,7 @@
 	aria-disabled="{{this.effectiveDisabled}}"
 	aria-selected="{{this.effectiveSelected}}"
 	.realTabReference="{{this}}"
-	style="{{this._style}}"
+	style="{{this.forcedStyle}}"
 >
 	<div class="ui5-tab-overflow-itemContent-wrapper">
 		<div class="ui5-tab-overflow-itemContent">

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -324,6 +324,27 @@ describe("TabContainer general interaction", () => {
 
 });
 
+describe("TabContainer keyboard handling", () => {
+	before(async () => {
+		await browser.url(`test/pages/TabContainer.html`);
+	});
+
+	it("[Arrow Down] on two-click area tab", async () => {
+		const tabcontainer = await browser.$("#tabContainerNestedTabs");
+		const item = tabcontainer.shadow$$(".ui5-tab-strip-item")[3];
+
+		assert.strictEqual(await item.getProperty("innerText"), "Four", "Correct tab is found");
+
+		await item.click();
+		await item.keys("ArrowDown");
+
+		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#tabContainerNestedTabs");
+		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
+
+		assert.ok(await popover.isDisplayed(), "Popover is opened");
+	});
+});
+
 describe("TabContainer popover", () => {
 	before(async () => {
 		await browser.url(`test/pages/TabContainer.html`);

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -348,7 +348,6 @@ describe("TabContainer popover", () => {
 			done();
 		});
 
-		// await browser.pause(50000)
 		const newListItemsCount = await popover.$$("[ui5-li-custom]").length;
 
 		assert.strictEqual(newListItemsCount, listItemsCount + 1, "Overflow list displays all its items");


### PR DESCRIPTION
This PR is preparation to handle drop operations.

- Popover content is now refreshed if item is inserted or removed in it, while it is open
- Opening the popover now just requires an opener
- Popover items are now stored in flattened array
- Items `forcedLevel` is no longer set in `_getAllSubItems`. It is now extracted in dedicated method
- `_getAllSubItems` is renamed to `_flatten` and it is reused
- Avoided ambiguous code `realTabReference = this._selectedTab`, which caused unpredictable behavior. Now there is dedicated property `selectedTabReference`.
- Fixed indentation in popover
- Added tests
