### PR TITLE
chore: align internal cem types

### DIFF
--- a/packages/tools/lib/cem/types-internal.d.ts
+++ b/packages/tools/lib/cem/types-internal.d.ts
@@ -307,16 +307,15 @@ export interface Attribute {
   deprecated?: boolean | string;
 }
 
-export interface EnumDeclaration extends ClassDeclaration {
+export interface EnumDeclaration extends ClassLike {
   kind: "enum"
-};
+}
 
-export interface InterfaceDeclaration extends ClassDeclaration {
+export interface InterfaceDeclaration extends ClassLike {
   kind: "interface"
 }
 
 export interface Event {
-  _ui5package?: string;
   _ui5parameters?: Parameter[]
   _ui5privacy?: Privacy
   /**
@@ -485,7 +484,6 @@ export interface TypeReference extends Reference {
  * The common interface of classes and mixins.
  */
 export interface ClassLike {
-  _ui5package?: string
   _ui5implements?: Reference[]
   _ui5privacy?: Privacy
   /**
@@ -562,7 +560,6 @@ export interface ClassLike {
 }
 
 export interface ClassDeclaration extends ClassLike {
-  _ui5package?: string;
   kind: 'class';
 }
 
@@ -702,7 +699,6 @@ export interface ClassMethod extends FunctionLike {
  * ```
  */
 export interface MixinDeclaration extends ClassLike, FunctionLike {
-  _ui5package?: string;
   kind: 'mixin';
 }
 
@@ -716,13 +712,11 @@ export interface CustomElementMixinDeclaration
   CustomElement { }
 
 export interface VariableDeclaration extends PropertyLike {
-  _ui5package?: string;
   kind: 'variable';
   source?: SourceReference;
 }
 
 export interface FunctionDeclaration extends FunctionLike {
-  _ui5package?: string;
   /**
    * Marks when the field was introduced
    */


### PR DESCRIPTION
`_ui5package` is property specific to storybook so we're removing it from the types. In addition wrong inheritance was causing errors in Enum and Interface declarations and now it's fixed.