### PR TITLE
fix(tools): fix usage of require in mjs

### DIFF
--- a/packages/tools/lib/css-processors/scope-variables.mjs
+++ b/packages/tools/lib/css-processors/scope-variables.mjs
@@ -1,4 +1,7 @@
 import * as path from "path";
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 /**
  * Tries to detect an override for a package


### PR DESCRIPTION
We have `require` call but in `mjs` ES module.  The change uses an alternative `require` for es module 

```js
import { createRequire } from 'node:module';
const require = createRequire(import.meta.url);
```
Read more: https://nodejs.org/api/module.html#modulecreaterequirefilename