### PR TITLE
docs(landing-page): fix link to Blog post

### DIFF
--- a/packages/playground/docs/landing-page.html
+++ b/packages/playground/docs/landing-page.html
@@ -31,7 +31,7 @@
 
         <div class="navbar-right-container">
             <a href="./playground" class="item link">Documentation</a>
-            <a href="https://blogs.sap.com/tag/ui5-web-components/" class="item navbar-button">Blog</a>
+            <a href="https://community.sap.com/t5/tag/ui5%20web%20components/tg-p/board-id/technology-blog-sap" class="item navbar-button">Blog</a>
             <a href="https://github.com/SAP/ui5-webcomponents" class="item">
                 <img src="./assets/icons/github-icon.svg" alt="GithHub Repository">
             </a>


### PR DESCRIPTION
The new link points to https://community.sap.com with tag: "ui5 web components" in "Technology Blogs by SAP".

Fixes #8270

