### PR TITLE
feat(ui5-rating-indicator): introduced "remaining-bar" CSS part

### DIFF
--- a/packages/main/src/ProgressIndicator.hbs
+++ b/packages/main/src/ProgressIndicator.hbs
@@ -12,7 +12,7 @@
            {{> valueLabel}}
         {{/unless}}
     </div>
-    <div class="ui5-progress-indicator-remaining-bar">
+    <div class="ui5-progress-indicator-remaining-bar" part="remaining-bar">
         {{#if showValueInRemainingBar}}
            {{> valueLabel}}
         {{/if}}

--- a/packages/main/src/ProgressIndicator.ts
+++ b/packages/main/src/ProgressIndicator.ts
@@ -36,6 +36,8 @@ import ProgressIndicatorCss from "./generated/themes/ProgressIndicator.css.js";
  *
  * <code>import "@ui5/webcomponents/dist/ProgressIndicator.js";</code>
  *
+ * @csspart remaining-bar - Used to style the remaining bar of the <code>ui5-progress-indicator</code>
+ *
  * @constructor
  * @extends UI5Element
  * @public


### PR DESCRIPTION
The part can be used like this to alter the end points' size.
		
```
[ui5-progress-indicator]::part(remaining-bar)::before,
[ui5-progress-indicator]::part(remaining-bar)::after {
	width: 0.375rem;
	height: 0.375rem;
}
```

Related to: #8213
