### PR TITLE
fix(ui5-tree-item): fix background color on hover

### DIFF
--- a/packages/main/src/themes/TreeItem.css
+++ b/packages/main/src/themes/TreeItem.css
@@ -21,7 +21,7 @@
 }
 
 :host([_toggle-button-end]:not([selected])) .ui5-li-root-tree:hover,
-:host([_mode]:not([_mode="None"]):not([_mode="Delete"]):not([active]):not([selected])) .ui5-li-root-tree:hover {
+:host(:not([_mode="None"]):not([_mode="Delete"]):not([active]):not([selected])) .ui5-li-root-tree:hover {
 	background: var(--sapList_Hover_Background);
 	cursor: pointer;
 }
@@ -42,7 +42,7 @@
 	background: var(--sapList_SelectionBackgroundColor);
 }
 
-:host([_mode]:not([_mode="None"]):not([_mode="Delete"]):not([active]):not([selected])) .ui5-li-root-tree:hover {
+:host(:not([_mode="None"]):not([_mode="Delete"]):not([active])[selected]) .ui5-li-root-tree:hover {
 	background-color: var(--sapList_Hover_SelectionBackground);
 	cursor: pointer;
 }


### PR DESCRIPTION
Background color on hovering items is alligned with the ones for the ui5-list as they share the same spec for their state styles.

Issues solved:
 - when no mode was set, the items still can be hovered and clicked. The background color was not changed despite cursor pointer was shown.
 - when a selected item was hovered its background color was not changed. 
 
