### PR TITLE
docs(ui5-calendar-legend, ui5-calendar-legend-item): fix tabulation, add overview

### DIFF
--- a/packages/main/src/CalendarLegendItem.ts
+++ b/packages/main/src/CalendarLegendItem.ts
@@ -23,6 +23,11 @@ import CalendarLegendItemCss from "./generated/themes/CalendarLegendItem.css.js"
  *
  * <h3 class="comment-api-title">Overview</h3>
  *
+ * Each <code>ui5-calendar-legend-item</code> represents a legend item, displaying a color with a label.
+ * The color is determined by the <code>type</code> property and the label by the <code>text</code> property.
+ * If a <code>ui5-special-date</code> is used within the <code>ui5-calendar</code> and a type is set, clicking on a <code>ui5-calendar-legend-item</code>
+ * with the same type will emphasize the respective date(s) in the calendar.
+ *
  * <h3>Usage</h3>
  * The <code>ui5-calendar-legend-item</code> is intended to be used within the <code>ui5-calendar-legend</code> component.
  *

--- a/packages/playground/_stories/main/CalendarLegend/CalendarLegend.stories.ts
+++ b/packages/playground/_stories/main/CalendarLegend/CalendarLegend.stories.ts
@@ -15,34 +15,36 @@ export default {
 	argTypes,
 } as Meta<CalendarLegend>;
 
-const Template: UI5StoryArgs<CalendarLegend, StoryArgsSlots> = (args) => html`<ui5-calendar-legend
-	?hide-today="${ifDefined(args.hideToday)}"
-	?hide-selected-day="${ifDefined(args.hideSelectedDay)}"
-	?hide-non-working-day="${ifDefined(args.hideNonWorkingDay)}"
-	?hide-working-day="${ifDefined(args.hideWorkingDay)}"
-	slot="calendarLegend"
->
-	${unsafeHTML(args.default)}
-</ui5-calendar-legend>`;
+const Template: UI5StoryArgs<CalendarLegend, StoryArgsSlots> = (args) => html`
+		<ui5-calendar-legend
+			?hide-today="${ifDefined(args.hideToday)}"
+			?hide-selected-day="${ifDefined(args.hideSelectedDay)}"
+			?hide-non-working-day="${ifDefined(args.hideNonWorkingDay)}"
+			?hide-working-day="${ifDefined(args.hideWorkingDay)}"
+			slot="calendarLegend"
+		>
+			${unsafeHTML(args.default)}
+		</ui5-calendar-legend>
+`;
 
 export const Basic = Template.bind({});
 
 Basic.decorators = [
 	(story) => {
 		return html`
-			<ui5-calendar>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
-				${story()}
-			</ui5-calendar>
+<ui5-calendar>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	<ui5-special-date slot="specialDates" value="" type=""></ui5-special-date>
+	${story()}
+</ui5-calendar>
 
-	<script>
+<script>
 	// Function that maps special dates to the current month
 	function updateSpecialDates() {
 		const currentDate = new Date();
@@ -76,8 +78,8 @@ Basic.decorators = [
 
 Basic.args = {
 	default: `
-		<ui5-calendar-legend-item type="Type05" text="Holiday"></ui5-calendar-legend-item>
-		<ui5-calendar-legend-item type="Type07" text="School Vacation"></ui5-calendar-legend-item>
-		<ui5-calendar-legend-item type="Type13" text="Wedding"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type05" text="Holiday"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type07" text="School Vacation"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type13" text="Wedding"></ui5-calendar-legend-item>
 	`,
 };


### PR DESCRIPTION
Currently the tabulations in the Calendar Legend Overview story is a little bit off.

![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/10f0f521-0f60-48ff-baed-7e80bdad785b)

Also an Overview explanation about the Calendar Legend Item Component was missing.

With this change we add the Overview description of the Calendar Legend Item, and fix the tabulations in the Storybook.