### PR TITLE
fix(ui5-illustrated-message): improved story and documentation

### DIFF
--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -173,6 +173,10 @@ class IllustratedMessage extends UI5Element {
 	*
 	* <b>Note:</b> Used for accessibility purposes only.
 	*
+	* <br/>
+	*
+	* <b>Note:</b> Doesn't take effect when <code>title</code> slot is being used.
+	*
 	* @default "H2"
 	* @public
 	* @since 1.20.0

--- a/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
+++ b/packages/playground/_stories/fiori/IllustratedMessage/IllustratedMessage.stories.ts
@@ -80,3 +80,7 @@ CustomTitle.args = {
     default: `
 	<ui5-button icon="refresh">Try again</ui5-button>`,
 };
+
+CustomTitle.parameters = {
+	controls: { exclude: ['titleLevel'] },
+};


### PR DESCRIPTION
In the "Custom Title" story we had "titleLevel" story control which didn't take any effect upon being changed. This control has been removed and "titleLevel" property is now documented that it doesn't work when we are using "title" slot.