### PR TITLE
feat(ui5-li): add tooltip support to list items

### DIFF
--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -14,7 +14,7 @@
 	@click="{{_onclick}}"
 	role="{{_accInfo.role}}"
 	aria-expanded="{{_accInfo.ariaExpanded}}"
-	title="{{title}}"
+	title="{{_accInfo.tooltip}}"
 	aria-level="{{_accInfo.ariaLevel}}"
 	aria-haspopup="{{_accInfo.ariaHaspopup}}"
 	aria-posinset="{{_accInfo.posinset}}"

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -63,6 +63,7 @@ type AccInfo = {
 	ariaChecked?: boolean;
 	listItemAriaLabel?: string;
 	ariaOwns?: string;
+	tooltip?: string;
 }
 
 type AccessibilityAttributes = {
@@ -146,6 +147,16 @@ abstract class ListItem extends ListItemBase {
 	navigated!: boolean;
 
 	/**
+	 * Defines the text of the tooltip that would be displayed for the list item.
+	 *
+	 * @default ""
+	 * @public
+	 * @since 1.23.0
+	 */
+	@property({ type: String, defaultValue: "" })
+	tooltip!: string;
+
+	/**
 	 * Indicates if the list item is active, e.g pressed down with the mouse or the keyboard keys.
 	 *
 	 * @private
@@ -156,6 +167,7 @@ abstract class ListItem extends ListItemBase {
 	/**
 	 * Defines the tooltip of the component.
 	 * @default ""
+	 * @deprecated
 	 * @private
 	 * @since 1.0.0-rc.15
 	 */
@@ -487,6 +499,7 @@ abstract class ListItem extends ListItemBase {
 			ariaHaspopup: this.ariaHaspopup?.toLowerCase() as Lowercase<HasPopup> || undefined,
 			setsize: this.accessibilityAttributes.ariaSetsize,
 			posinset: this.accessibilityAttributes.ariaPosinset,
+			tooltip: this.tooltip || this.title,
 		};
 	}
 

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -237,6 +237,16 @@
 		<ui5-li >item</ui5-li>
 	</ui5-list>
 
+	<br/><br/>
+
+	<ui5-list id="myList7" header-text="API: ListItem tooltip">
+		<ui5-li tooltip="Option #1">Option 1</ui5-li>
+		<ui5-li tooltip="Option #2">Option 2</ui5-li>
+		<ui5-li tooltip="Option #3">Option 3</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
+
 	<ui5-list id="listWithEmptyItem">
 		<ui5-li id="emptyItem"></ui5-li>
 		<ui5-li>IPhone 3</ui5-li>
@@ -406,7 +416,7 @@
 		listWithCustomItems.addEventListener("ui5-item-close", function(e) {
 			customListItemSelectResult.value = ++customListItemSelectResult.value
 		});
-		
+
 	</script>
 
 	<ui5-list growing="Scroll">

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -581,12 +581,12 @@ describe("List Tests", () => {
 		const innerElement = await browser.$("#effectiveTabindexChange #country11 button");
 		const listItem = await browser.$("#effectiveTabindexChange #country11");
 		const rootItemElement = await listItem.shadow$(".ui5-li-root");
-	
+
 		// Focus on the target list item
 		await innerElement.click();
-	
+
 		const newTabIndex = await rootItemElement.getAttribute("tabindex");
-	
+
 		assert.equal(newTabIndex , "0", "The tabIndex of the list item root should be '0' when inner element receives focus.");
 	});
 
@@ -596,5 +596,23 @@ describe("List Tests", () => {
 		const display = await endMarker.getCSSProperty("display");
 
 		assert.strictEqual(display.value, 'inline-block', "The end marker is displayed");
+	});
+
+	it("Checks if tooltip property value equals the title of li element", async () => {
+		const listItem = await browser.$("#myList7 ui5-li");
+
+		let rootTooltip = await listItem.getProperty("tooltip");
+		let innerTooltip = await listItem.shadow$("li").getAttribute("title");
+
+		assert.strictEqual(rootTooltip, innerTooltip, "Tooltip of root element and title of inner li element are equal.");
+
+		const newTooltip = "Updated tooltip";
+		await listItem.setProperty("tooltip", newTooltip);
+
+		rootTooltip = await listItem.getProperty("tooltip");
+		innerTooltip = await listItem.shadow$("li").getAttribute("title");
+
+		assert.strictEqual(rootTooltip, newTooltip, "Tooltip of root element is updated correctly at runtime.");
+		assert.strictEqual(rootTooltip, innerTooltip, "Tooltip of root element and title of inner li element are equal after runtime change.");
 	});
 });

--- a/packages/playground/_stories/fiori/UploadCollection/UploadCollectionItem/UploadCollectionItem.stories.ts
+++ b/packages/playground/_stories/fiori/UploadCollection/UploadCollectionItem/UploadCollectionItem.stories.ts
@@ -29,6 +29,7 @@ const Template: UI5StoryArgs<UploadCollectionItem, StoryArgsSlots> = (args) => {
 		?hide-delete-button="${ifDefined(args.hideDeleteButton)}"
 		?hide-retry-button="${ifDefined(args.hideRetryButton)}"
 		?hide-terminate-button="${ifDefined(args.hideTerminateButton)}"
+		tooltip="${ifDefined(args.tooltip)}"
 	>
 		${unsafeHTML(args.default)}
 		${unsafeHTML(args.thumbnail)}

--- a/packages/playground/_stories/main/List/CustomListItem/CustomListItem.stories.ts
+++ b/packages/playground/_stories/main/List/CustomListItem/CustomListItem.stories.ts
@@ -23,6 +23,7 @@ const Template: UI5StoryArgs<CustomListItem, StoryArgsSlots> = (args) => {
       ?navigated="${ifDefined(args.navigated)}"
       type="${ifDefined(args.type)}"
       ?selected="${ifDefined(args.selected)}"
+	  tooltip="${ifDefined(args.tooltip)}"
     >
       ${unsafeHTML(args.default)}
       ${unsafeHTML(args.deleteButton)}

--- a/packages/playground/_stories/main/List/StandardListItem/StandardListItem.stories.ts
+++ b/packages/playground/_stories/main/List/StandardListItem/StandardListItem.stories.ts
@@ -29,6 +29,7 @@ const Template: UI5StoryArgs<StandardListItem, StoryArgsSlots> = (args) => {
     ?navigated="${ifDefined(args.navigated)}"
     type="${ifDefined(args.type)}"
     ?selected="${ifDefined(args.selected)}"
+	tooltip="${ifDefined(args.tooltip)}"
   >
     ${unsafeHTML(args.default)}
     ${unsafeHTML(args.imageContent)}

--- a/packages/playground/_stories/main/Tree/TreeItem/TreeItem.stories.ts
+++ b/packages/playground/_stories/main/Tree/TreeItem/TreeItem.stories.ts
@@ -29,6 +29,7 @@ const Template: UI5StoryArgs<TreeItem, StoryArgsSlots> = (args) => html`<ui5-tre
         navigated="${ifDefined(args.navigated)}"
         type="${ifDefined(args.type)}"
         selected="${ifDefined(args.selected)}"
+		tooltip="${ifDefined(args.tooltip)}"
     >
         ${unsafeHTML(args.default)}
         ${unsafeHTML(args.deleteButton)}

--- a/packages/playground/_stories/main/Tree/TreeItemCustom/TreeItemCustom.stories.ts
+++ b/packages/playground/_stories/main/Tree/TreeItemCustom/TreeItemCustom.stories.ts
@@ -28,6 +28,7 @@ const Template: UI5StoryArgs<TreeItemCustom, StoryArgsSlots> = (args) => html`<u
         navigated="${ifDefined(args.navigated)}"
         type="${ifDefined(args.type)}"
         selected="${ifDefined(args.selected)}"
+		tooltip="${ifDefined(args.tooltip)}"
     >
         ${unsafeHTML(args.content)}
         ${unsafeHTML(args.default)}


### PR DESCRIPTION
With this change, the `ui5-li` component now supports the `tooltip` property. This allows developers to provide a tooltip for each list item, which will be displayed when hovering over the item.

Related to: #7372  
