### PR TITLE
ci: reorder version-build-publish order

### DIFF
--- a/.github/workflows/release-rc-auto.yaml
+++ b/.github/workflows/release-rc-auto.yaml
@@ -20,6 +20,18 @@ jobs:
     - name: Install
       run: yarn --frozen-lockfile
 
+    - name: Version Bump
+      env:
+        NPM_USERNAME: ${{ secrets.NPM_USER }}
+        NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_AUTH_TOKEN }}
+        GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+      run: |
+          npm config set //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+          git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
+          git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
+          yarn lerna version --conventional-prerelease --force-publish --yes --exact --create-release github
+
     - name: Build
       run: yarn ci:releasebuild
 
@@ -29,9 +41,4 @@ jobs:
         NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_AUTH_TOKEN }}
         GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
-      run: |
-        npm config set //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
-        git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
-        git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
-        yarn lerna version --conventional-prerelease --force-publish --yes --exact --create-release github 
-        yarn lerna publish from-git --yes
+      run: yarn lerna publish from-git --yes

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -19,6 +19,18 @@ jobs:
     - name: Install
       run: yarn --frozen-lockfile
 
+    - name: Version Bump
+      env:
+        NPM_USERNAME: ${{ secrets.NPM_USER }}
+        NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_AUTH_TOKEN }}
+        GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+      run: |
+          npm config set //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+          git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
+          git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
+          yarn lerna version --conventional-prerelease --force-publish --yes --exact --create-release github
+
     - name: Build
       run: yarn ci:releasebuild
 
@@ -28,9 +40,4 @@ jobs:
         NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_AUTH_TOKEN }}
         GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
-      run: |
-        npm config set //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
-        git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
-        git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
-        yarn lerna version --conventional-prerelease --force-publish --yes --exact --create-release github
-        yarn lerna publish from-git --yes
+      run: yarn lerna publish from-git --yes


### PR DESCRIPTION
Ensure build tasks are run against the updated version (the one that will be released)
- previously: build -> release (version and publish)
- now: version -> build -> publish