### PR TITLE
feat(ui5-menu): enable navigation over disabled items

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -752,7 +752,7 @@ class List extends UI5Element {
 	}
 
 	getEnabledItems(): Array<ListItemBase> {
-		return this.getItems().filter(item => !item.disabled);
+		return this.getItems().filter(item => item._focusable);
 	}
 
 	getItems(): Array<ListItemBase> {
@@ -848,7 +848,7 @@ class List extends UI5Element {
 		}
 
 		if (lastTabbableEl === target) {
-			if (this.getFirstItem(x => x.selected && !x.disabled)) {
+			if (this.getFirstItem(x => x.selected && x._focusable)) {
 				this.focusFirstSelectedItem();
 			} else if (this.getPreviouslyFocusedItem()) {
 				this.focusPreviouslyFocusedItem();
@@ -1023,7 +1023,7 @@ class List extends UI5Element {
 	 */
 	focusFirstItem() {
 		// only enabled items are focusable
-		const firstItem = this.getFirstItem(x => !x.disabled);
+		const firstItem = this.getFirstItem(x => x._focusable);
 
 		if (firstItem) {
 			firstItem.focus();
@@ -1040,7 +1040,7 @@ class List extends UI5Element {
 
 	focusFirstSelectedItem() {
 		// only enabled items are focusable
-		const firstSelectedItem = this.getFirstItem(x => x.selected && !x.disabled);
+		const firstSelectedItem = this.getFirstItem(x => x.selected && x._focusable);
 
 		if (firstSelectedItem) {
 			firstSelectedItem.focus();

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -386,7 +386,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	fireItemPress(e: Event) {
-		if (this.isInactive) {
+		if (this.isInactive || this.disabled) {
 			return;
 		}
 		if (isEnter(e as KeyboardEvent)) {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -130,7 +130,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 		return {
 			main: {
 				"ui5-li-root": true,
-				"ui5-li--focusable": !this.disabled,
+				"ui5-li--focusable": this._focusable,
 			},
 		};
 	}
@@ -139,12 +139,16 @@ class ListItemBase extends UI5Element implements ITabbable {
 		return this.disabled ? true : undefined;
 	}
 
+	get _focusable() {
+		return !this.disabled;
+	}
+
 	get hasConfigurableMode() {
 		return false;
 	}
 
 	get _effectiveTabIndex() {
-		if (this.disabled) {
+		if (!this._focusable) {
 			return -1;
 		}
 		if (this.selected) {

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -58,7 +58,7 @@
 			@mouseover="{{_busyMouseOver}}"
 		>
 		{{#each _currentItems}}
-			<ui5-li
+			<ui5-menu-li
 				.associatedItem="{{this.item}}"
 				class="ui5-menu-item"
 				id="{{../_id}}-menu-item-{{@index}}"
@@ -66,7 +66,7 @@
 				accessible-name={{this.item.ariaLabelledByText}}
 				accessible-role="menuitem"
 				.additionalText="{{this.item._additionalText}}"
-				._ariaHasPopup={{this.ariaHasPopup}}
+				tooltip="{{this.item.tooltip}}"
 				?disabled={{this.item.disabled}}
 				?starts-section={{this.item.startsSection}}
 				?selected={{this.item.subMenuOpened}}
@@ -101,7 +101,7 @@
 					</div>
 				{{/if}}
 				</div>
-			</ui5-li>
+			</ui5-menu-li>
 		{{/each}}
 		</ui5-list>
 	{{else if busy}}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -24,6 +24,7 @@ import ResponsivePopover from "./ResponsivePopover.js";
 import type { ResponsivePopoverBeforeCloseEventDetail } from "./ResponsivePopover.js";
 import Button from "./Button.js";
 import List from "./List.js";
+import MenuListItem from "./MenuListItem.js";
 import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import BusyIndicator from "./BusyIndicator.js";
@@ -101,6 +102,7 @@ type OpenerStandardListItem = StandardListItem & { associatedItem: MenuItem };
 		Button,
 		List,
 		StandardListItem,
+		MenuListItem,
 		Icon,
 		BusyIndicator,
 	],

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -118,6 +118,16 @@ class MenuItem extends UI5Element {
 	accessibleName!: string;
 
 	/**
+	 * Defines the text of the tooltip that would be displayed for the menu item.
+	 *
+	 * @default ""
+	 * @public
+	 * @since 1.23.0
+	 */
+	@property({ type: String, defaultValue: "" })
+	tooltip!: string;
+
+	/**
 	 * Indicates whether any of the element siblings have children items.
 	 */
 	@property({ type: Boolean, noAttribute: true })

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -118,7 +118,7 @@ class MenuItem extends UI5Element {
 	accessibleName!: string;
 
 	/**
-	 * Defines the text of the tooltip that would be displayed for the menu item.
+	 * Defines the text of the tooltip for the menu item.
 	 *
 	 * @default ""
 	 * @public

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -124,7 +124,7 @@ class MenuItem extends UI5Element {
 	 * @public
 	 * @since 1.23.0
 	 */
-	@property({ type: String, defaultValue: "" })
+	@property({ type: String })
 	tooltip!: string;
 
 	/**

--- a/packages/main/src/MenuListItem.ts
+++ b/packages/main/src/MenuListItem.ts
@@ -1,0 +1,48 @@
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import StandardListItem from "./StandardListItem.js";
+import StandardListItemTemplate from "./generated/templates/StandardListItemTemplate.lit.js";
+import MenuItem from "./MenuItem.js";
+import HasPopup from "./types/HasPopup.js";
+
+// Styles
+import menuListItemCss from "./generated/themes/MenuListItem.css.js";
+
+/**
+ * @class
+ *
+ * @constructor
+ * @extends StandardListItem
+ * @since 1.23.0
+ * @private
+ */
+@customElement({
+	tag: "ui5-menu-li",
+	template: StandardListItemTemplate,
+	styles: [StandardListItem.styles, menuListItemCss],
+})
+class MenuListItem extends StandardListItem {
+	/**
+	 * Defines the associated MenuItem instance
+	 * @private
+	 */
+	@property({ type: Object, multiple: false })
+	associatedItem?: MenuItem;
+
+	get _focusable() {
+		return true;
+	}
+
+	get _accInfo() {
+		const accInfoSettings = {
+			role: "menuitem",
+			ariaHaspopup: this.associatedItem?.hasSubmenu ? HasPopup.Menu.toLowerCase() as Lowercase<HasPopup> : undefined,
+		};
+
+		return { ...super._accInfo, ...accInfoSettings };
+	}
+}
+
+MenuListItem.define();
+
+export default MenuListItem;

--- a/packages/main/src/MenuListItem.ts
+++ b/packages/main/src/MenuListItem.ts
@@ -26,7 +26,7 @@ class MenuListItem extends StandardListItem {
 	 * Defines the associated MenuItem instance
 	 * @private
 	 */
-	@property({ type: Object, multiple: false })
+	@property({ type: Object })
 	associatedItem?: MenuItem;
 
 	get _focusable() {

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -108,10 +108,6 @@
 	color: var(--sapList_Active_TextColor);
 }
 
-.ui5-menu-item[focused]:not([active]) {
-	background-color: var(--sapList_Hover_Background);
-}
-
 .ui5-menu-rp[sub-menu] {
 	margin-top: 0.25rem;
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);

--- a/packages/main/src/themes/MenuListItem.css
+++ b/packages/main/src/themes/MenuListItem.css
@@ -1,0 +1,18 @@
+:host([disabled]) {
+	pointer-events: initial;
+}
+
+/* hovered and active */
+:host([disabled][actionable]:not([active]):not([selected]):hover),
+:host([disabled][active][actionable]) {
+	background: var(--ui5-listitem-background-color);
+}
+
+/* active */
+:host([disabled][active][actionable]) .ui5-li-root .ui5-li-icon {
+	color: var(--sapContent_NonInteractiveIconColor);
+}
+
+:host([focused]:not([active]):not([disabled])) {
+	background-color: var(--sapList_Hover_Background);
+}

--- a/packages/main/src/themes/MenuListItem.css
+++ b/packages/main/src/themes/MenuListItem.css
@@ -1,5 +1,10 @@
 :host([disabled]) {
 	pointer-events: initial;
+	opacity: initial;
+}
+
+:host([disabled])::part(content) {
+    opacity: var(--_ui5-listitembase_disabled_opacity);
 }
 
 /* hovered and active */

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -16,7 +16,7 @@
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
 
-		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" icon="add-document"></ui5-menu-item>
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file" icon="add-document"></ui5-menu-item>
 		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -34,7 +34,7 @@ describe("Menu interaction", () => {
 
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const listItems = await popover.$("ui5-list").$$("ui5-menu-li");
 
 		assert.strictEqual(await menuItems.length, 7, "There are proper count of menu items in the top level menu");
 		assert.strictEqual(await listItems.length, 7, "There are proper count of list items in the top level menu popover list");
@@ -54,7 +54,7 @@ describe("Menu interaction", () => {
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const staticAreaItem = await browser.$(`.${staticAreaItemClassName}`);
 		const popover = staticAreaItem.shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const listItems = await popover.$("ui5-list").$$("ui5-menu-li");
 		const submenuList = await staticAreaItem.shadow$(".ui5-menu-submenus");
 
 		listItems[3].click(); // open sub-menu
@@ -87,7 +87,7 @@ describe("Menu interaction", () => {
 
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const listItems = await popover.$("ui5-list").$$("ui5-menu-li");
 		const selectionInput = await browser.$("#selectionInput");
 
 		await listItems[0].click({x: 1, y: 1});
@@ -103,7 +103,6 @@ describe("Menu interaction", () => {
 
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
 		const selectionInput = await browser.$("#selectionInput");
 
 		await browser.keys("Space");
@@ -119,7 +118,6 @@ describe("Menu interaction", () => {
 
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
 		const selectionInput = await browser.$("#selectionInput");
 
 		await browser.keys("Enter");
@@ -182,11 +180,26 @@ describe("Menu interaction", () => {
 			await browser.pause(100);
 
 			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const newFileItem = await menuPopover.$("ui5-li[accessible-name='New File']");
+			const newFileItem = await menuPopover.$("ui5-menu-li[accessible-name='New File']");
 			newFileItem.click();
 			await browser.pause(100);
 
 			assert.ok(await menuPopover.getProperty("open"), "Menu is still opened.");
+		});
+
+		it("Enable navigaion over disabled items", async () => {
+			await browser.url(`test/pages/Menu.html`);
+			const openButton = await browser.$("#btnOpen");
+			openButton.click();
+			await browser.pause(100);
+
+			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
+			const listItem = await menuPopover.$("ui5-menu-li[accessible-name='Preferences']");
+			listItem.click();
+			await browser.pause(100);
+
+			assert.ok(await listItem.getProperty("disabled"), "The menu item is disabled");
+			assert.ok(await listItem.getProperty("focused"), "The menu item is focused");
 		});
 	});
 
@@ -194,17 +207,18 @@ describe("Menu Accessibility", () => {
 	it("Menu and Menu items accessibility attributes", async () => {
 		await browser.url(`test/pages/Menu.html`);
 		const openButton = await browser.$("#btnOpen");
-		const menuItems = await browser.$$("ui5-menu>ui5-menu-item");
 
 		openButton.click();
 
 		const staticAreaItemClassName = await browser.getStaticAreaItemClassName("#menu");
 		const popover = await browser.$(`.${staticAreaItemClassName}`).shadow$("ui5-responsive-popover");
 		const list = await popover.$("ui5-list");
-		const listItems = await popover.$("ui5-list").$$("ui5-li");
+		const listItems = await popover.$("ui5-list").$$("ui5-menu-li");
 
 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
+		assert.strictEqual(await listItems[0].getAttribute("title"), "Select a file", "There is a tooltip");
+		assert.strictEqual(await listItems[0].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
 		assert.strictEqual(
 			await listItems[0].getAttribute("accessible-name"),
 			"New File Opens a file explorer",

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -217,7 +217,7 @@ describe("Menu Accessibility", () => {
 
 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
-		assert.strictEqual(await listItems[0].getAttribute("title"), "Select a file", "There is a tooltip");
+		assert.strictEqual(await listItems[0].getAttribute("tooltip"), "Select a file", "There is a tooltip");
 		assert.strictEqual(await listItems[0].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
 		assert.strictEqual(
 			await listItems[0].getAttribute("accessible-name"),

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -218,7 +218,7 @@ describe("Menu Accessibility", () => {
 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
 		assert.strictEqual(await listItems[0].getAttribute("tooltip"), "Select a file", "There is a tooltip");
-		assert.strictEqual(await listItems[0].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
+		assert.strictEqual(await listItems[2].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
 		assert.strictEqual(
 			await listItems[0].getAttribute("accessible-name"),
 			"New File Opens a file explorer",


### PR DESCRIPTION
- There is a new behavior implemented, which enables
the end users to navigate via mouse and keyboard to a
disabled `ui5-menu-item` element. This behavior is aimed
to improve the accessibility of the `ui5-menu` component
by providing screen reader announcements for disabled
menu items as well.

- The haspopup attribute is now applied to the` ui5-menu item`'s
with a sub-menu.

- There is a new `tooltip` property for the `ui5-menu-item`.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7096
Fixes: https://github.com/SAP/ui5-webcomponents/issues/8214