### PR TITLE
fix(ui5-li-notification-group): expand arrow visible

### DIFF
--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -13,6 +13,7 @@ import type { NotificationListItemBaseCloseEventDetail as NotificationListGroupI
 
 // Icons
 import "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";
+import "@ui5/webcomponents-icons/dist/navigation-down-arrow.js";
 import "@ui5/webcomponents-icons/dist/overflow.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 


### PR DESCRIPTION
Expand icon (navigation-down-arrow) is now imported properly.

Fixes: #8302
