### PR TITLE
fix(ui5-popup): move popup registry to shared resource

### DIFF
--- a/packages/main/src/popup-utils/OpenedPopupsRegistry.ts
+++ b/packages/main/src/popup-utils/OpenedPopupsRegistry.ts
@@ -1,16 +1,17 @@
+import getSharedResource from "@ui5/webcomponents-base/dist/getSharedResource.js";
 import { isEscape } from "@ui5/webcomponents-base/dist/Keys.js";
 import Popup from "../Popup.js";
 
-type RegisteredPopupT = {
+type RegisteredPopup = {
 	instance: Popup;
 	parentPopovers: Array<Popup>;
 }
 
-let openedRegistry: Array<RegisteredPopupT> = [];
+const OpenedPopupsRegistry = getSharedResource<{ openedRegistry: Array<RegisteredPopup> }>("OpenedPopupsRegistry", { openedRegistry: [] });
 
 const addOpenedPopup = (instance: Popup, parentPopovers: Array<Popup> = []) => {
-	if (!openedRegistry.some(popup => popup.instance === instance)) {
-		openedRegistry.push({
+	if (!OpenedPopupsRegistry.openedRegistry.some(popup => popup.instance === instance)) {
+		OpenedPopupsRegistry.openedRegistry.push({
 			instance,
 			parentPopovers,
 		});
@@ -18,34 +19,35 @@ const addOpenedPopup = (instance: Popup, parentPopovers: Array<Popup> = []) => {
 
 	_updateTopModalPopup();
 
-	if (openedRegistry.length === 1) {
+	if (OpenedPopupsRegistry.openedRegistry.length === 1) {
 		attachGlobalListener();
 	}
 };
 
 const removeOpenedPopup = (instance: Popup) => {
-	openedRegistry = openedRegistry.filter(el => {
+	OpenedPopupsRegistry.openedRegistry = OpenedPopupsRegistry.openedRegistry.filter(el => {
 		return el.instance !== instance;
 	});
 
 	_updateTopModalPopup();
 
-	if (!openedRegistry.length) {
+	if (!OpenedPopupsRegistry.openedRegistry.length) {
 		detachGlobalListener();
 	}
 };
 
 const getOpenedPopups = () => {
-	return [...openedRegistry];
+	return [...OpenedPopupsRegistry.openedRegistry];
 };
 
 const _keydownListener = (event: KeyboardEvent) => {
-	if (!openedRegistry.length) {
+	if (!OpenedPopupsRegistry.openedRegistry.length) {
 		return;
 	}
 
 	if (isEscape(event)) {
-		openedRegistry[openedRegistry.length - 1].instance.close(true);
+		event.stopPropagation();
+		OpenedPopupsRegistry.openedRegistry[OpenedPopupsRegistry.openedRegistry.length - 1].instance.close(true);
 	}
 };
 
@@ -61,8 +63,8 @@ const _updateTopModalPopup = () => {
 	let popup;
 	let hasModal = false;
 
-	for (let i = openedRegistry.length - 1; i >= 0; i--) {
-		popup = openedRegistry[i].instance;
+	for (let i = OpenedPopupsRegistry.openedRegistry.length - 1; i >= 0; i--) {
+		popup = OpenedPopupsRegistry.openedRegistry[i].instance;
 
 		if (!hasModal && popup.isModal) {
 			popup.isTopModalPopup = true;


### PR DESCRIPTION
Previously, registered opened popup exists only in the current runtime registry and pressing `escape` key was triggering close action for every registry handler that exists.

With this change we are moving the opened popup registry to shared resource and all popups are registered into the same central place where single close handler will be executed.

Fixes: #6884