### PR TITLE
fix(ui5-time-picker): remove redundant aria attributes

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -718,7 +718,6 @@ class DatePicker extends DateComponentBase implements IFormElement {
 		return {
 			"ariaRoledescription": this.dateAriaDescription,
 			"ariaHasPopup": HasPopup.Grid.toLowerCase(),
-			"ariaAutoComplete": "none",
 			"ariaRequired": this.required,
 			"ariaLabel": getEffectiveAriaLabelText(this),
 		};

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -145,8 +145,6 @@ class TimePicker extends TimePickerBase {
 		return {
 			"ariaRoledescription": this.dateAriaDescription,
 			"ariaHasPopup": "dialog",
-			"ariaAutoComplete": "none",
-			"ariaControls": `${this._id}-responsive-popover`,
 		};
 	}
 


### PR DESCRIPTION
The aria-autocomplete and aria-controls attributes are no longer considered as valid for the ui5-time-picker and ui5-date-picker input fields.

Fixes: #6931