### PR TITLE
fix(ui5-avatar): resolve initial flickering during fallback to icon

### DIFF
--- a/packages/main/src/Avatar.hbs
+++ b/packages/main/src/Avatar.hbs
@@ -20,8 +20,11 @@
 		{{/if}}
 
 		{{#if initials}}
-			<span class="ui5-avatar-initials">{{validInitials}}</span>
-			<ui5-icon class="ui5-avatar-icon ui5-avatar-icon-fallback" name="{{fallbackIcon}}"></ui5-icon>
+			<span class="ui5-avatar-initials ui5-avatar-initials-hidden">{{validInitials}}</span>
+			<ui5-icon
+				class="ui5-avatar-icon ui5-avatar-icon-fallback ui5-avatar-fallback-icon-hidden" 
+				name="{{fallbackIcon}}"
+			></ui5-icon>
 		{{/if}}
 
 	{{/if}}

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -358,7 +358,11 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 
 	get initialsContainer(): HTMLObjectElement | null {
 		return this.getDomRef()!.querySelector(".ui5-avatar-initials");
-	 }
+	}
+
+	get fallBackIconDomRef(): Icon | null {
+		return this.getDomRef()!.querySelector(".ui5-avatar-icon-fallback");
+	}
 
 	onBeforeRendering() {
 		this._onclick = this._interactive ? this._onClickHandler.bind(this) : undefined;
@@ -388,20 +392,25 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	}
 
 	_checkInitials() {
-		const avatar = this.getDomRef()!,
-			avatarInitials = avatar.querySelector(".ui5-avatar-initials");
-		// if there aren`t initalts set - the fallBack icon should be shown
-		if (!this.validInitials) {
-			avatarInitials!.classList.add("ui5-avatar-initials-hidden");
+		const avatar = this.getDomRef()!;
+		const avatarInitials = avatar.querySelector(".ui5-avatar-initials");
+		const validInitials = this.validInitials && avatarInitials && avatarInitials.scrollWidth <= avatar.scrollWidth;
+
+		if (validInitials) {
+			this.showInitials();
 			return;
 		}
-		// if initials` width is bigger than the avatar, an icon should be shown inside the avatar
-		avatarInitials && avatarInitials.classList.remove("ui5-avatar-initials-hidden");
-		if (this.initials && this.initials.length === 3) {
-			if (avatarInitials && avatarInitials.scrollWidth > avatar.scrollWidth) {
-				avatarInitials.classList.add("ui5-avatar-initials-hidden");
-			}
-		}
+		this.showFallbackIcon();
+	}
+
+	showFallbackIcon() {
+		this.initialsContainer?.classList.add("ui5-avatar-initials-hidden");
+		this.fallBackIconDomRef?.classList.remove("ui5-avatar-fallback-icon-hidden");
+	}
+
+	showInitials() {
+		this.initialsContainer?.classList.remove("ui5-avatar-initials-hidden");
+		this.fallBackIconDomRef?.classList.add("ui5-avatar-fallback-icon-hidden");
 	}
 
 	_onClickHandler(e: MouseEvent) {

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -241,7 +241,7 @@
 	display: none;
 }
 
-.ui5-avatar-initials:not(.ui5-avatar-initials-hidden) + .ui5-avatar-icon-fallback {
+.ui5-avatar-fallback-icon-hidden {
 	display: none;
 }
 


### PR DESCRIPTION
Fixes: #8345 

Now both initials and fallback icon have visibility:hidden initially. Later on when we measure the sizes in onAfterRendering we decide which one to show.