### PR TITLE
docs(ui5-dialog): add documentation for keyboard handling

### DIFF
--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -82,7 +82,7 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  *<h3>Keyboard Handling</h3>
  *
  * <h4>Basic Navigation</h4>
- * When the <code>ui5-dialog</code> is focused and has the <code>draggable</code> property set, the user can move the dialog
+ * When the <code>ui5-dialog</code> has the <code>draggable<code> property set and the header is focused, the user can move the dialog
  * with the following keyboard shortcuts:
  * <br>
  * <ul>
@@ -91,7 +91,7 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  * </ul>
  *
  * <h4>Resizing</h4>
- * When the <code>ui5-dialog</code> is focused and has the <code>resizable</code> property set, the user can change the size of the dialog
+ * When the <code>ui5-dialog</code> has the <code>resizable<code> property set and the header is focused, the user can change the size of the dialog
  * with the following keyboard shortcuts:
  * <br>
  * <ul>

--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -86,8 +86,8 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  * with the following keyboard shortcuts:
  * <br>
  * <ul>
- * <li>[UP/DOWN] arrow keys - Move the dialog to the top/bottom.</li>
- * <li>[LEFT/RIGHT] arrow keys - Move the dialog to the left/right.</li>
+ * <li>[UP/DOWN] arrow keys - Move the dialog up/down.</li>
+ * <li>[LEFT/RIGHT] arrow keys - Move the dialog left/right.</li>
  * </ul>
  *
  * <h4>Resizing</h4>

--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -82,7 +82,7 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  *<h3>Keyboard Handling</h3>
  *
  * <h4>Basic Navigation</h4>
- * When the <code>ui5-dialog</code> has the <code>draggable<code> property set and the header is focused, the user can move the dialog
+ * When the <code>ui5-dialog</code> has the <code>draggable</code> property set to <code>true</code> and the header is focused, the user can move the dialog
  * with the following keyboard shortcuts:
  * <br>
  * <ul>
@@ -91,7 +91,7 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  * </ul>
  *
  * <h4>Resizing</h4>
- * When the <code>ui5-dialog</code> has the <code>resizable<code> property set and the header is focused, the user can change the size of the dialog
+ * When the <code>ui5-dialog</code> has the <code>resizable</code> property set to <code>true</code> and the header is focused, the user can change the size of the dialog
  * with the following keyboard shortcuts:
  * <br>
  * <ul>

--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -79,6 +79,25 @@ const ICON_PER_STATE: Record<ValueStateWithIcon, string> = {
  * <br>
  * For more information see the sample "Bar in Header/Footer".
 
+ *<h3>Keyboard Handling</h3>
+ *
+ * <h4>Basic Navigation</h4>
+ * When the <code>ui5-dialog</code> is focused and has the <code>draggable</code> property set, the user can move the dialog
+ * with the following keyboard shortcuts:
+ * <br>
+ * <ul>
+ * <li>[UP/DOWN] arrow keys - Move the dialog to the top/bottom.</li>
+ * <li>[LEFT/RIGHT] arrow keys - Move the dialog to the left/right.</li>
+ * </ul>
+ *
+ * <h4>Resizing</h4>
+ * When the <code>ui5-dialog</code> is focused and has the <code>resizable</code> property set, the user can change the size of the dialog
+ * with the following keyboard shortcuts:
+ * <br>
+ * <ul>
+ * <li>[SHIFT] + [UP/DOWN] - Decrease/Increase the height of the dialog.</li>
+ * <li>[SHIFT] + [LEFT/RIGHT] - Decrease/Increase the width of the dialog.</li>
+ * </ul>
  *
  * <h3>ES6 Module Import</h3>
  *


### PR DESCRIPTION
Missing information about keyboard shortcuts for dragging/resizing the dialog is now properly documented.

Fixes #8190