### PR TITLE
refactor(ui5-menu): adjust menu and sub-menu creation

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -38,7 +38,7 @@
 			icon="decline"
 			design="Transparent"
 			aria-label="{{labelClose}}"
-			@click={{close}}
+			@click={{_closeAll}}
 		>
 		</ui5-button>
 	</div>
@@ -67,6 +67,7 @@
 				accessible-role="menuitem"
 				.additionalText="{{this.item._additionalText}}"
 				tooltip="{{this.item.tooltip}}"
+				selected="{{this.item.subMenuOpened}}"
 				?disabled={{this.item.disabled}}
 				?starts-section={{this.item.startsSection}}
 				?selected={{this.item.subMenuOpened}}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -509,7 +509,7 @@ class Menu extends UI5Element {
 		}
 	}
 
-	_prepareSubMenuDesktopTablet(item: MenuItem, opener: HTMLElement) {
+	_prepareSubMenu(item: MenuItem, opener: HTMLElement) {
 		if (opener.id !== this._subMenuOpenerId || (item && item.hasSubmenu)) {
 			// close opened sub-menu if there is any opened
 			this._closeItemSubMenu(this._openedSubMenuItem!, true);
@@ -539,7 +539,7 @@ class Menu extends UI5Element {
 
 		// Sets the new timeout
 		this._timeout = setTimeout(() => {
-			this._prepareSubMenuDesktopTablet(item, opener);
+			this._prepareSubMenu(item, opener);
 		}, MENU_OPEN_DELAY);
 	}
 
@@ -598,7 +598,7 @@ class Menu extends UI5Element {
 			const opener = e.target as OpenerStandardListItem;
 			const item = opener.associatedItem;
 
-			item.hasSubmenu && this._prepareSubMenuDesktopTablet(item, opener);
+			item.hasSubmenu && this._prepareSubMenu(item, opener);
 		} else if (shouldCloseMenu && this._isSubMenu && this._parentMenuItem) {
 			const parentMenuItemParent = this._parentMenuItem.parentElement as Menu;
 			parentMenuItemParent._closeItemSubMenu(this._parentMenuItem, true, true);
@@ -642,17 +642,17 @@ class Menu extends UI5Element {
 				}
 			}
 		} else {
-			this._prepareSubMenuDesktopTablet(item, opener);
+			this._prepareSubMenu(item, opener);
 		}
 	}
 
 	_findMainMenu(element: MenuItem | Menu) {
-		let parentMenu = this._isMenu(element) ? element as Menu : element.parentElement as Menu;
-		while (parentMenu && parentMenu._parentMenuItem) {
-			parentMenu = parentMenu._parentMenuItem.parentElement as Menu;
+		let menu = this._isMenu(element) ? element as Menu : element.parentElement as Menu;
+		while (menu && menu._parentMenuItem) {
+			menu = menu._parentMenuItem.parentElement as Menu;
 		}
 
-		return parentMenu;
+		return menu;
 	}
 
 	_isMenu(element: HTMLElement) {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -396,9 +396,10 @@ class Menu extends UI5Element {
 			this._parentMenuItem = undefined;
 			this._opener = undefined;
 		}
+		const busyWithoutItems = !this._parentMenuItem?.items.length && this._parentMenuItem?.busy;
 		const popover = await this._createPopover();
 		popover.initialFocus = `${this._id}-menu-item-0`;
-		popover.showAt(opener, this._parentMenuItem?.busy);
+		popover.showAt(opener, busyWithoutItems);
 	}
 
 	/**

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -339,7 +339,7 @@ class Menu extends UI5Element {
 	}
 
 	get isSubMenuOpened() {
-		return !!this._popover?.isOpen();
+		return this._parentMenuItem && this._popover?.isOpen();
 	}
 
 	get menuHeaderTextPhone() {
@@ -398,7 +398,7 @@ class Menu extends UI5Element {
 		}
 		const popover = await this._createPopover();
 		popover.initialFocus = `${this._id}-menu-item-0`;
-		popover.showAt(opener);
+		popover.showAt(opener, this._parentMenuItem?.busy);
 	}
 
 	/**

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -168,7 +168,7 @@ class MenuItem extends UI5Element {
 	}
 
 	get subMenuOpened() {
-		return !!this._subMenu;
+		return !!this._subMenu?._popover?.isOpen();
 	}
 
 	get _additionalText() {

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -3,8 +3,6 @@ import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import {
 	isDesktop,
-	isPhone,
-	isTablet,
 } from "@ui5/webcomponents-base/dist/Device.js";
 import type { ListItemClickEventDetail } from "./List.js";
 import Menu from "./Menu.js";
@@ -67,6 +65,10 @@ class NavigationMenu extends Menu {
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
 	declare items: Array<NavigationMenuItem>;
 
+	_isMenu(element: HTMLElement) {
+		return element.hasAttribute("ui5-navigation-menu");
+	}
+
 	_itemMouseOver(e: MouseEvent) {
 		if (isDesktop()) {
 			// respect mouseover only on desktop
@@ -124,14 +126,9 @@ class NavigationMenu extends Menu {
 			mainMenu._popover!.close();
 		}
 
-		if (isPhone()) {
-			// prepares and opens sub-menu on phone
-			this._prepareSubMenuPhone(item);
-		} else if (isTablet()) {
-			// prepares and opens sub-menu on tablet
-			this._prepareSubMenuDesktopTablet(item, opener);
-		}
+		this._prepareSubMenuDesktopTablet(item, opener);
 	}
+
 	get accSideNavigationPopoverHiddenText() {
 		return NavigationMenu.i18nBundle.getText(NAVIGATION_MENU_POPOVER_HIDDEN_TEXT);
 	}

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -126,7 +126,7 @@ class NavigationMenu extends Menu {
 			mainMenu._popover!.close();
 		}
 
-		this._prepareSubMenuDesktopTablet(item, opener);
+		this._prepareSubMenu(item, opener);
 	}
 
 	get accSideNavigationPopoverHiddenText() {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -15,7 +15,7 @@
 <body class="bg">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
-		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file" icon="add-document"></ui5-menu-item>
+		<ui5-menu-item text="New File(selection prevented)" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file - prevent default" icon="add-document"></ui5-menu-item>
 		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
@@ -119,7 +119,7 @@
 		menu.addEventListener("ui5-item-click", function(event) {
 			const item = event.detail.item;
 			selectionInput.value = item.text;
-			if (item && item.text === "New File") {
+			if (item && item.text === "New File(selection prevented)") {
 				event.preventDefault();
 			}
 		});

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -59,24 +59,22 @@ describe("Menu interaction", () => {
 
 		listItems[3].click(); // open sub-menu
 
-		await submenuList.$("ui5-menu").waitForExist({
+		await submenuList.$("ui5-menu:nth-of-type(1)").waitForExist({
 			timeout: 1000,
-			timeoutMsg: "The second level sub-menu is should be created"
+			timeoutMsg: "First sub-menu is created"
 		})
 
 		assert.ok(await submenuList.$("ui5-menu"), "The second level sub-menu is being created"); // new ui5-menu element is created for the sub-menu
 
-		await browser.keys("ArrowLeft"); // back to main menu
-		await browser.keys("ArrowDown"); // go to the next menu item (close sub-menu)
+		listItems[4].click(); // open sub-menu
 
-		await submenuList.$("ui5-menu").waitForExist({
-			reverse: true,
+		await submenuList.$("ui5-menu:nth-of-type(2)").waitForExist({
 			timeout: 1000,
-			timeoutMsg: "The second level sub-menu is should be destroyed"
+			timeoutMsg: "Second sub-menu is created"
 		})
 
-		assert.strictEqual(await submenuList.$$("ui5-menu").length, 0,
-								"The second level sub-menu is being destroyed"); // sub-menu ui5-menu element is destroyed
+		assert.strictEqual(await submenuList.$$("ui5-menu").length, 2,
+								"Two sub-menus are present");
 	});
 
 	it("Event firing after 'click' on menu item", async () => {

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -90,7 +90,7 @@ describe("Menu interaction", () => {
 
 		await listItems[0].click({x: 1, y: 1});
 
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Click on first item fires an event");
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File(selection prevented)", "Click on first item fires an event");
 	});
 
 	it("Event firing after [Space] on menu item", async () => {
@@ -105,7 +105,7 @@ describe("Menu interaction", () => {
 
 		await browser.keys("Space");
 
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Space] on first item fires an event");
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File(selection prevented)", "Pressing [Space] on first item fires an event");
 	});
 
 	it("Event firing after [Enter] on menu item", async () => {
@@ -120,7 +120,7 @@ describe("Menu interaction", () => {
 
 		await browser.keys("Enter");
 
-		assert.strictEqual(await selectionInput.getAttribute("value"), "New File", "Pressing [Enter] on first item fires an event");
+		assert.strictEqual(await selectionInput.getAttribute("value"), "New File(selection prevented)", "Pressing [Enter] on first item fires an event");
 	});
 
 	it("Events firing on open/close of the menu", async () => {
@@ -178,7 +178,7 @@ describe("Menu interaction", () => {
 			await browser.pause(100);
 
 			const menuPopover = await browser.$("ui5-static-area-item:last-of-type").shadow$("ui5-responsive-popover");
-			const newFileItem = await menuPopover.$("ui5-menu-li[accessible-name='New File']");
+			const newFileItem = await menuPopover.$("ui5-menu-li[accessible-name='New File(selection prevented)']");
 			newFileItem.click();
 			await browser.pause(100);
 
@@ -215,11 +215,11 @@ describe("Menu Accessibility", () => {
 
 		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
 		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
-		assert.strictEqual(await listItems[0].getAttribute("tooltip"), "Select a file", "There is a tooltip");
+		assert.strictEqual(await listItems[0].getAttribute("tooltip"), "Select a file - prevent default", "There is a tooltip");
 		assert.strictEqual(await listItems[2].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
 		assert.strictEqual(
 			await listItems[0].getAttribute("accessible-name"),
-			"New File Opens a file explorer",
+			"New File(selection prevented) Opens a file explorer",
 			"There is additional description added");
 	});
 });


### PR DESCRIPTION
- The ui5-menu elements used for sub-menus are created only once and are being reused afterwards. They are no longer destroyed on close. This contributes to lowering the count of the slow DOM manipulation operations.

- There is now no differentiation between mobile and desktop device in regards to the display mechanism. In both cases we rely on the template to do the job as the components used for composition like ui5-list and ui5-responsive-popover do comply with the device.

Fixes: #7767
Fixes: #7423
Fixes: #6761
