### PR TITLE
fix(ui5-breadcrumbs): fixed not working separators

### DIFF
--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -81,11 +81,11 @@
 }
 
 :host([separator-style="BackSlash"]) .ui5-breadcrumbs-separator::after {
-	content: "\\";
+	content: "\\\\";
 }
 
 :host([separator-style="DoubleBackSlash"]) .ui5-breadcrumbs-separator::after {
-	content: "\\\\";
+	content: "\\\\\\\\";
 }
 
 :host([separator-style="GreaterThan"]) .ui5-breadcrumbs-separator::after {


### PR DESCRIPTION
It seems that in the context of our project backslashes in CSS need to be escaped twice. Presenting this fix as a temporary solution.
