### PR TITLE
fix(framework): fix handling of 'null' set to str props

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -550,7 +550,11 @@ abstract class UI5Element extends HTMLElement {
 			}
 		} else if (typeof newValue !== "object") {
 			if (attrValue !== newValue) {
-				this.setAttribute(attrName, newValue as string);
+				if (attrValue === null && newValue === undefined) {
+					this.removeAttribute(attrName);
+				} else {
+					this.setAttribute(attrName, newValue as string);
+				}
 			}
 		} // else { return; } // old object handling
 	}

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -354,8 +354,11 @@ const validateSingleProperty = (value: PropertyValue, propData: Property) => {
 	}
 
 	if (!propertyType || propertyType === String) {
+		if (value === null) {
+			return "defaultValue" in propData ? propData.defaultValue : "";
+		}
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string -- if an object is passed as a value to a string property, this was an error so displaying [object Object] will indicate the issue to the developer
-		return (typeof value === "string" || typeof value === "undefined" || value === null) ? value : value.toString();
+		return (typeof value === "string" || typeof value === "undefined") ? value : value.toString();
 	}
 
 	if (propertyType === Boolean) {

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -359,6 +359,8 @@ const validateSingleProperty = (value: PropertyValue, propData: Property) => {
 		}
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string -- if an object is passed as a value to a string property, this was an error so displaying [object Object] will indicate the issue to the developer
 		return (typeof value === "string" || typeof value === "undefined") ? value : value.toString();
+		// eslint-disable-next-line @typescript-eslint/no-base-to-string -- if an object is passed as a value to a string property, this was an error so displaying [object Object] will indicate the issue to the developer
+		// return (typeof value === "string" || typeof value === "undefined" || value === null) ? value : value.toString();
 	}
 
 	if (propertyType === Boolean) {
@@ -366,7 +368,12 @@ const validateSingleProperty = (value: PropertyValue, propData: Property) => {
 	}
 
 	if (propertyType === Object) {
-		return typeof value === "object" ? value : propData.defaultValue;
+		if (value === null) {
+			return {};
+		}
+
+		return typeof value === "object" ? value : {};
+		// return typeof value === "object" ? value : propData.defaultValue;
 	}
 
 	// Check if "value" is part of the enum (propertyType) values and return the defaultValue if not found.


### PR DESCRIPTION
**Issue**
Setting "null" is set to property from type String leads to strange and incorrect state

Example:

(1) Input has value property:
```ts
@property()
value!: string
```

(2) When we set the property to null:
```js
input.value = null;
```

(3) we pass "null"  lit-html template, that wraps it with ifDefined directive, that treats null as "nothing", and as a result lit-html sets the property to undefined (via this [code](https://github.com/lit/lit/blob/1b00c07a58707f45ad066809cd79f878fc3590d2/packages/lit-html/src/lit-html.ts#L1943)).

**Current behaviour**
After the 1,2,3 steps are done, the state is:
- the native input of the Input component shows "undefined" in the input field
- the Input component'value property is null
- the Input component'value attr is not updated (shows the previously set value)

**Behaviour with this change**
With this change, we add validation and fallback to empty string in case of setting "null".
So, in the same case, the state is:
- the value in the native input will be cleared
- the Input component'value property is empty string
- the Input component'value attr is updated to empty string.
