### PR TITLE
docs: wrap long props and better tooltips for copy icon name/svg

### DIFF
--- a/packages/website/build-scripts/icons-generation/index.mjs
+++ b/packages/website/build-scripts/icons-generation/index.mjs
@@ -90,7 +90,6 @@ const _generateIconsPage = (sourceDir, config) => {
         icons += `
         <div
             tabIndex="-1"
-            title="Copy Icon"
             className="icon__wrapper"
             onClick={function(e) {
                 const target = e.target;
@@ -110,14 +109,14 @@ const _generateIconsPage = (sourceDir, config) => {
             <span className="icon__wrapper__title">{${iconNameImport}.replace("tnt/", "").replace("business-suite/", "")}</span>
 
             <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-                <button className="button button--secondary icon__button--copy"
+                <button title="Copy Icon Name" className="button button--secondary icon__button--copy"
                     onClick={function(e) {
                         navigator.clipboard.writeText(${iconNameImport});
                 }}>
                     <CopySvg className="icon__svg--copy" />
                 </button>
 
-                <button className="button button--secondary icon__button--picture"
+                <button title="Copy SVG" className="button button--secondary icon__button--picture"
                     onClick={function(e) {
                         navigator.clipboard.writeText(document.querySelector("#${svgImport}_svg")?.innerHTML);
                 }}>

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -127,7 +127,7 @@
 }
 
 code {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 


### PR DESCRIPTION
- wrap long props

<img width="756" alt="Screenshot 2024-03-07 at 9 24 35" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/ac122b72-b030-4995-acbf-c830f5e73fd9">

-  better tooltips for copy icon name/svg
<img width="170" alt="Screenshot 2024-03-07 at 9 33 35" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/8c5d9f8c-6c93-49eb-ab80-23276b6ec4c1">


