### PR TITLE
chore: add attributes to cem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,10 @@
         "./packages/localization",
         "./packages/main",
         "./packages/fiori",
-    ]
+    ],
+    "html.customData": [
+        "./packages/base/dist/vscode.html-custom-data.json",
+        "./packages/main/dist/vscode.html-custom-data.json",
+        "./packages/fiori/dist/vscode.html-custom-data.json"
+    ],
 }

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -19,8 +19,11 @@ import {
 	isClass,
 	normalizeTagType,
 	logDocumentationError,
-	displayDocumentationErrors
+	displayDocumentationErrors,
+	toKebabCase
 } from "./utils.mjs";
+import { generateCustomData } from "cem-plugin-vs-code-custom-data-generator";
+import { customElementJetBrainsPlugin } from "custom-element-jet-brains-integration";
 
 const packageJSON = JSON.parse(fs.readFileSync("./package.json"));
 
@@ -167,6 +170,23 @@ function processClass(ts, classNode, moduleDoc) {
 				if (propertyDecorator) {
 					member._ui5validator = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => ["validator", "type"].includes(property.name.text))?.initializer?.text || "String";
 					member._ui5noAttribute = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "noAttribute")?.initializer?.kind === ts.SyntaxKind.TrueKeyword || undefined;
+				}
+
+				if (currClass.customElement && member.privacy === "public" && !propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "multiple") && !["object"].includes(member._ui5validator?.toLowerCase())) {
+					const filename = classNode.getSourceFile().fileName;
+					const sourceFile = typeProgram.getSourceFile(filename);
+					const tsProgramClassNode = sourceFile.statements.find(statement => ts.isClassDeclaration(statement) && statement.name?.text === classNode.name?.text);
+					const tsProgramMember = tsProgramClassNode.members.find(m => ts.isPropertyDeclaration(m) && m.name?.text === member.name);
+					const attributeValue = typeChecker.typeToString(typeChecker.getTypeAtLocation(tsProgramMember), tsProgramMember);
+
+					currClass.attributes.push({
+						description: member.description,
+						name: toKebabCase(member.name),
+						default: member.default,
+						fieldName: member.name,
+						type: { text: attributeValue },
+						deprecated: member.deprecated
+					})
 				}
 
 				if (hasTag(memberParsedJsDoc, "formProperty")) {
@@ -334,7 +354,7 @@ const processPublicAPI = object => {
 		if ((key === "privacy" && object[key] !== "public") || (key === "_ui5privacy" && object[key] !== "public")) {
 			return true;
 		} else if (typeof object[key] === "object") {
-			if (key === "cssParts" || key === "_ui5implements") {
+			if (key === "cssParts" || key === "attributes" || key === "_ui5implements") {
 				continue;
 			}
 
@@ -475,5 +495,7 @@ export default {
 				}
 			}
 		},
+		generateCustomData({ outdir: "dist", cssFileName: null, cssPropertiesDocs: false }),
+		customElementJetBrainsPlugin({ outdir: "dist", cssFileName: null, cssPropertiesDocs: false })
 	],
 };

--- a/packages/tools/lib/cem/utils.mjs
+++ b/packages/tools/lib/cem/utils.mjs
@@ -14,6 +14,10 @@ const getDeprecatedStatus = (jsdocComment) => {
             : undefined;
 };
 
+const toKebabCase = str => {
+    return str.replaceAll(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? "-" : "") + $.toLowerCase())
+}
+
 const normalizeDescription = (description) => {
 	return typeof description === 'string' ? description.replaceAll(/^-\s+|^(\n)+|(\n)+$/g, ""): description;
 }
@@ -376,4 +380,5 @@ export {
     normalizeTagType,
     displayDocumentationErrors,
     logDocumentationError,
+    toKebabCase
 };

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@custom-elements-manifest/analyzer": "^0.8.4",
+    "cem-plugin-vs-code-custom-data-generator": "^1.4.2",
+    "custom-element-jet-brains-integration": "^1.4.4",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "@wdio/cli": "^7.19.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7466,6 +7466,13 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+cem-plugin-vs-code-custom-data-generator@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/cem-plugin-vs-code-custom-data-generator/-/cem-plugin-vs-code-custom-data-generator-1.4.2.tgz#d81d93231d31701eb45be823109ebe9bb22a3aa2"
+  integrity sha512-Hjj7U0CkX1H8uym9SDkuRj5t2SEx6Iyys4hC4m/5F2MBcCeMPkMR5BJZlTpatcKdDRZh21tVJz+S/FbKqiniNA==
+  dependencies:
+    prettier "^2.7.1"
+
 chai@^4.3.4:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
@@ -8690,6 +8697,13 @@ currently-unhandled@^0.4.1:
   integrity sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==
   dependencies:
     array-find-index "^1.0.1"
+
+custom-element-jet-brains-integration@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/custom-element-jet-brains-integration/-/custom-element-jet-brains-integration-1.4.4.tgz#7dfd406d42b69a2097d5be67226521b845a82857"
+  integrity sha512-HEiTy5jBKQa1QdC5jaFbFkXkhHmgwJ0oRLjKK/mZuxuUx0+/wCFRjHBZX51qu5KYj6Ta/gPXcr3blCzuBHXF7A==
+  dependencies:
+    prettier "^2.8.0"
 
 custom-elements-manifest@1.0.0:
   version "1.0.0"
@@ -16787,7 +16801,7 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
-prettier@^2.8.0, prettier@^2.8.1:
+prettier@^2.7.1, prettier@^2.8.0, prettier@^2.8.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==


### PR DESCRIPTION
Fill attributes array with properties that have attribute representation for custom elements. In addition provide `vscode.html-custom-data.json` and `web-types.json` for better integration with IDEs.

Usage:
- JetBrains automatically detect when `web-types.json` exist
- For VS code manual work has to be done
    - `.vscode/settings.json` is adjusted for improve development in ui5-webcomponents packages (you need to build the project for autocompletion)
    - if you are using ui5-webcomponents inside your project you have to create `.vscode/settings.json` on your own and to add:

 ```json
{
    "html.customData": [
        "./node_modules/@ui5/webcomponents/dist/vscode.html-custom-data.json",
        "./node_modules/@ui5/webcomponents-fiori/dist/vscode.html-custom-data.json"
    ]
}
```

Fixes: https://github.com/SAP/ui5-webcomponents/issues/8392