### PR TITLE
chore: fix ts dev error

### DIFF
--- a/packages/base/.eslintignore
+++ b/packages/base/.eslintignore
@@ -14,3 +14,4 @@ package-scripts.cjs
 .eslintrc.cjs
 src/renderer/directives/style-map.js
 src/util/metaUrl.js
+src/ssr-dom*

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
-    "compilerOptions": {
+    // ssr-dom is imported with bare specifier so that import contions are used, but this treats it as input and output
+    "exclude": ["src/ssr-dom*"],
+      "compilerOptions": {
       "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
-    // ssr-dom is imported with bare specifier so that import contions are used, but this treats it as input and output
+    // ssr-dom is imported with bare specifier so that conditional exports are used, but this treats it as input and output
     "exclude": ["src/ssr-dom*.d.ts"],
     "compilerOptions": {
       "target": "ES2021",

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
     // ssr-dom is imported with bare specifier so that import contions are used, but this treats it as input and output
-    "exclude": ["src/ssr-dom*"],
-      "compilerOptions": {
+    "exclude": ["src/ssr-dom*.d.ts"],
+    "compilerOptions": {
       "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],
       // Generate d.ts files


### PR DESCRIPTION
### Dev time error
`Cannot write file '.../ui5-webcomponents/packages/base/dist/ssr-dom.d.ts' because it would overwrite input file.`

### background
There is a special import in the base package inside UI5Element for a dom-shim. Even though it is in the same package, it is imported with a bare module specifier
`import "@ui5/webcomponents-base/dist/ssr-dom.js";`
so that export conditions can be checked - an empty module on the browser and a shim in a nodejs environement

This import leads to an error at dev time as the typescript compiler seems to treat the `dist` folder of this modules as both input and output and throws an error that the output will overwrite the input.

### fix
This change adds an ignore for these two special files, so their types are not treated as input and will not be overwritten in the output.