### PR TITLE
fix(ui5-button): remove bold font of emphasized button in safari and …

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -227,7 +227,7 @@ bdi {
 	border-color: var(--sapButton_Emphasized_BorderColor);
 	border-width: var(--_ui5_button_emphasized_border_width);
 	color: var(--sapButton_Emphasized_TextColor);
-	font-weight: var(--sapButton_Emphasized_FontWeight);
+	font-family: var(--sapFontBoldFamily );
 }
 
 /*The ui5_hovered class is set by FileUploader to indicate hover state of the control*/


### PR DESCRIPTION
Previously, in Safari and Chrome browsers, the text in the Emphasized `<ui5-button>` component, appeared bolder than expected.

With this change we align the boldness of the text in all browsers.

Fixes: #8361