### PR TITLE
chore: enable more concise custom element samples

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1065,9 +1065,7 @@ abstract class UI5Element extends HTMLElement {
 	 * Returns the CSS for this UI5 Web Component Class
 	 * @protected
 	 */
-	static get styles(): ComponentStylesData {
-		return "";
-	}
+	static styles: ComponentStylesData = "";
 
 	/**
 	 * Returns the Static Area CSS for this UI5 Web Component Class

--- a/packages/base/src/decorators.ts
+++ b/packages/base/src/decorators.ts
@@ -1,0 +1,11 @@
+import customElement from "./decorators/customElement.js";
+import event from "./decorators/event.js";
+import property from "./decorators/property.js";
+import slot from "./decorators/slot.js";
+
+export {
+	customElement,
+	event,
+	property,
+	slot,
+};

--- a/packages/website/src/pages/play.tsx
+++ b/packages/website/src/pages/play.tsx
@@ -23,8 +23,7 @@ const ts = `
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
-import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import { customElement, property } from "@ui5/webcomponents-base/dist/decorators.js";
 
 @customElement({
   tag: "my-element",
@@ -43,6 +42,12 @@ export class MyElement extends UI5Element {
         </button>
       </div>\`
   }
+
+  static styles = \`
+    button {
+      padding: 1rem;
+      border-radius: 1rem;
+    }\`;
 
   _onClick() {
     this.count += 2;


### PR DESCRIPTION
UI5 element has a static getter for the styles, which prevents using a static assignement and forces cubsclasses to overwrite the getter which is more verbose.

Before:
```js
static get styles() {
  return "some styles";
}
```

Now:
```js
static styles = "some styles";
```

The second change makes all decorators available from a single export, so the imports are smaller in the samples:
```js
import { customElement, property, slot } from "@ui5/webcomponents-base/dist/decorators.js";
```