### PR TITLE
fix(ui5-calendar): switch to two column layout on Islamic or Persian secondary calendar type

### DIFF
--- a/packages/main/src/MonthPicker.hbs
+++ b/packages/main/src/MonthPicker.hbs
@@ -9,28 +9,22 @@
 	@click={{_selectMonth}}
 >
 	{{#each _months}}
-		<div class="ui5-mp-quarter">
-
-			{{#each this}}
-				<div
-					data-sap-timestamp={{this.timestamp}}
-					tabindex={{this._tabIndex}}
-					?data-sap-focus-ref="{{this.focusRef}}"
-					class="{{this.classes}}"
-					role="gridcell"
-					aria-selected="{{this.ariaSelected}}"
-				>
-					<span class="ui5-dp-monthtext">
-						{{this.name}}
-					</span>
-					{{#if this.nameInSecType}}
-						<span class="ui5-dp-monthtext ui5-dp-monthsectext">
-							{{this.nameInSecType}}
-						</span>
-					{{/if}}
-				</div>
-			{{/each}}
-
+		<div
+			data-sap-timestamp={{this.timestamp}}
+			tabindex={{this._tabIndex}}
+			?data-sap-focus-ref="{{this.focusRef}}"
+			class="{{this.classes}}"
+			role="gridcell"
+			aria-selected="{{this.ariaSelected}}"
+		>
+			<span class="ui5-dp-monthtext">
+				{{this.name}}
+			</span>
+			{{#if this.nameInSecType}}
+				<span class="ui5-dp-monthtext ui5-dp-monthsectext">
+					{{this.nameInSecType}}
+				</span>
+			{{/if}}
 		</div>
 	{{/each}}
 </div>

--- a/packages/main/src/MonthPicker.hbs
+++ b/packages/main/src/MonthPicker.hbs
@@ -9,22 +9,28 @@
 	@click={{_selectMonth}}
 >
 	{{#each _months}}
-		<div
-			data-sap-timestamp={{this.timestamp}}
-			tabindex={{this._tabIndex}}
-			?data-sap-focus-ref="{{this.focusRef}}"
-			class="{{this.classes}}"
-			role="gridcell"
-			aria-selected="{{this.ariaSelected}}"
-		>
-			<span class="ui5-dp-monthtext">
-				{{this.name}}
-			</span>
-			{{#if this.nameInSecType}}
-				<span class="ui5-dp-monthtext ui5-dp-monthsectext">
-					{{this.nameInSecType}}
-				</span>
-			{{/if}}
+		<div class="ui5-mp-quarter">
+
+			{{#each this}}
+				<div
+					data-sap-timestamp={{this.timestamp}}
+					tabindex={{this._tabIndex}}
+					?data-sap-focus-ref="{{this.focusRef}}"
+					class="{{this.classes}}"
+					role="gridcell"
+					aria-selected="{{this.ariaSelected}}"
+				>
+					<span class="ui5-dp-monthtext">
+						{{this.name}}
+					</span>
+					{{#if this.nameInSecType}}
+						<span class="ui5-dp-monthtext ui5-dp-monthsectext">
+							{{this.nameInSecType}}
+						</span>
+					{{/if}}
+				</div>
+			{{/each}}
+
 		</div>
 	{{/each}}
 </div>

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -144,7 +144,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 		let timestamp;
 
 		/* eslint-disable no-loop-func */
-		for (let i = 0; i < PAGE_SIZE; i++) {
+		for (let i = 0; i < 12; i++) {
 			tempDate.setMonth(i);
 			timestamp = tempDate.valueOf() / 1000;
 
@@ -210,7 +210,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 		} else if (isHomeCtrl(e)) {
 			this._setTimestamp(parseInt(this._months[0].timestamp)); // first month of first row
 		} else if (isEndCtrl(e)) {
-			this._setTimestamp(parseInt(this._months[PAGE_SIZE - 1].timestamp)); // last month of last row
+			this._setTimestamp(parseInt(this._months[this._months.length - 1].timestamp)); // last month of last row
 		} else {
 			preventDefault = false;
 		}
@@ -221,7 +221,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 	}
 
 	_onHomeOrEnd(homePressed: boolean) {
-		this._setTimestamp(parseInt(this._months[homePressed ? 0 : PAGE_SIZE - 1].timestamp));
+		this._setTimestamp(parseInt(this._months[homePressed ? 0 : this._months.length - 1].timestamp));
 	}
 
 	/**

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -36,7 +36,7 @@ import MonthPickerTemplate from "./generated/templates/MonthPickerTemplate.lit.j
 import monthPickerStyles from "./generated/themes/MonthPicker.css.js";
 
 const PAGE_SIZE = 12; // total months on a single page
-const ROW_SIZE = 3; // months per row (4 rows of 3 months each)
+let ROW_SIZE = 3; // months per row (4 rows of 3 months each)
 
 type Month = {
 	timestamp: string,
@@ -117,6 +117,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 
 	onBeforeRendering() {
 		this._buildMonths();
+		ROW_SIZE = this.secondaryCalendarType === "Islamic" || this.secondaryCalendarType === "Persian" ? 2 : 3;
 	}
 
 	onAfterRendering() {

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -144,7 +144,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 		let timestamp;
 
 		/* eslint-disable no-loop-func */
-		for (let i = 0; i < 12; i++) {
+		for (let i = 0; i < PAGE_SIZE; i++) {
 			tempDate.setMonth(i);
 			timestamp = tempDate.valueOf() / 1000;
 
@@ -210,7 +210,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 		} else if (isHomeCtrl(e)) {
 			this._setTimestamp(parseInt(this._months[0].timestamp)); // first month of first row
 		} else if (isEndCtrl(e)) {
-			this._setTimestamp(parseInt(this._months[this._months.length - 1].timestamp)); // last month of last row
+			this._setTimestamp(parseInt(this._months[PAGE_SIZE - 1].timestamp)); // last month of last row
 		} else {
 			preventDefault = false;
 		}
@@ -221,7 +221,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 	}
 
 	_onHomeOrEnd(homePressed: boolean) {
-		this._setTimestamp(parseInt(this._months[homePressed ? 0 : this._months.length - 1].timestamp));
+		this._setTimestamp(parseInt(this._months[homePressed ? 0 : PAGE_SIZE - 1].timestamp));
 	}
 
 	/**

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -5,6 +5,7 @@ import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/ge
 import convertMonthNumbersToMonthNames from "@ui5/webcomponents-localization/dist/dates/convertMonthNumbersToMonthNames.js";
 import transformDateToSecondaryType from "@ui5/webcomponents-localization/dist/dates/transformDateToSecondaryType.js";
 import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDate.js";
+import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import {
 	isEnter,
 	isSpace,
@@ -125,7 +126,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 	}
 
 	get rowSize() {
-		return this.secondaryCalendarType === "Islamic" || this.secondaryCalendarType === "Persian" ? 2 : 3;
+		return this.secondaryCalendarType === CalendarType.Islamic || this.secondaryCalendarType === CalendarType.Persian ? 2 : 3;
 	}
 
 	_buildMonths() {

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -126,7 +126,8 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 	}
 
 	get rowSize() {
-		return this.secondaryCalendarType === CalendarType.Islamic || this.secondaryCalendarType === CalendarType.Persian ? 2 : 3;
+		return (this.secondaryCalendarType === CalendarType.Islamic && this.primaryCalendarType !== CalendarType.Islamic)
+			|| (this.secondaryCalendarType === CalendarType.Persian && this.primaryCalendarType !== CalendarType.Persian) ? 2 : 3;
 	}
 
 	_buildMonths() {

--- a/packages/main/src/themes/Calendar.css
+++ b/packages/main/src/themes/Calendar.css
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: column-reverse;
     justify-content: flex-end;
+    overflow: hidden;
 }
 
 .ui5-cal-root [ui5-calendar-header] {

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -93,7 +93,7 @@
 :host([secondary-calendar-type="Persian"]:not([primary-calendar-type="Persian"])) .ui5-mp-root,
 :host([secondary-calendar-type="Islamic"]:not([primary-calendar-type="Islamic"])) .ui5-mp-root {
 	display: grid;
-	padding: 1rem 0 1rem;
+	padding: 0.75rem 0 0.75rem;
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--_ui5_monthpicker_item_margin);
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -91,6 +91,7 @@
 :host([secondary-calendar-type="Persian"]) .ui5-mp-root,
 :host([secondary-calendar-type="Islamic"]) .ui5-mp-root {
 	display: grid;
+	padding: 1rem 0 1rem;
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--_ui5_monthpicker_item_margin);
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -90,22 +90,22 @@
 }
 
 /* Switching to a two column layout */
-:host([secondary-calendar-type="Persian"]) .ui5-mp-root,
-:host([secondary-calendar-type="Islamic"]) .ui5-mp-root {
+:host([secondary-calendar-type="Persian"]:not([primary-calendar-type="Persian"])) .ui5-mp-root,
+:host([secondary-calendar-type="Islamic"]:not([primary-calendar-type="Islamic"])) .ui5-mp-root {
 	display: grid;
 	padding: 1rem 0 1rem;
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--_ui5_monthpicker_item_margin);
 }
 
-:host([secondary-calendar-type="Persian"]) .ui5-mp-item,
-:host([secondary-calendar-type="Islamic"]) .ui5-mp-item {
+:host([secondary-calendar-type="Persian"]:not([primary-calendar-type="Persian"])) .ui5-mp-item,
+:host([secondary-calendar-type="Islamic"]:not([primary-calendar-type="Islamic"])) .ui5-mp-item {
 	margin: 0;
 	width: auto;
 }
 
-:host([secondary-calendar-type="Persian"]) .ui5-mp-quarter,
-:host([secondary-calendar-type="Islamic"]) .ui5-mp-quarter {
+:host([secondary-calendar-type="Persian"]:not([primary-calendar-type="Persian"])) .ui5-mp-quarter,
+:host([secondary-calendar-type="Islamic"]:not([primary-calendar-type="Islamic"])) .ui5-mp-quarter {
 	width: 100%;
 	display: contents;
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -93,7 +93,7 @@
 :host([secondary-calendar-type="Persian"]:not([primary-calendar-type="Persian"])) .ui5-mp-root,
 :host([secondary-calendar-type="Islamic"]:not([primary-calendar-type="Islamic"])) .ui5-mp-root {
 	display: grid;
-	padding: 0.75rem 0 0.75rem;
+	padding: 0.5625rem 0;
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--_ui5_monthpicker_item_margin);
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -11,22 +11,24 @@
 .ui5-mp-root {
 	box-sizing: border-box;
 	padding: 2rem 0 1rem 0;
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: var(--_ui5_monthpicker_item_margin);
+	display: flex;
+	flex-direction: column;
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
+	justify-content: center;
+	align-items: center;
 }
 
 .ui5-mp-item {
 	display: flex;
 	flex-direction: column;
-	box-sizing: border-box;
-	height: calc(var(--_ui5_month_picker_item_height) - var(--_ui5_monthpicker_item_margin));
+	width: calc(33.333% - 0.125rem);
+	height: var(--_ui5_month_picker_item_height);
 	color: var(--sapButton_Lite_TextColor);
 	background-color: var(--sapLegend_WorkingBackground);
 	align-items: center;
 	justify-content: center;
+	margin: var(--_ui5_monthpicker_item_margin);
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
@@ -80,9 +82,30 @@
 	border-radius: var(--_ui5_monthpicker_item_focus_after_border_radius);
 }
 
+.ui5-mp-quarter {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+}
+
 /* Switching to a two column layout */
 :host([secondary-calendar-type="Persian"]) .ui5-mp-root,
 :host([secondary-calendar-type="Islamic"]) .ui5-mp-root {
+	display: grid;
 	padding: 1rem 0 1rem;
 	grid-template-columns: repeat(2, 1fr);
+	gap: var(--_ui5_monthpicker_item_margin);
+}
+
+:host([secondary-calendar-type="Persian"]) .ui5-mp-item,
+:host([secondary-calendar-type="Islamic"]) .ui5-mp-item {
+	margin: 0;
+	width: auto;
+}
+
+:host([secondary-calendar-type="Persian"]) .ui5-mp-quarter,
+:host([secondary-calendar-type="Islamic"]) .ui5-mp-quarter {
+	width: 100%;
+	display: contents;
 }

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -86,3 +86,23 @@
 	align-items: center;
 	width: 100%;
 }
+
+/* Switching to a two column layout */
+:host([secondary-calendar-type="Persian"]) .ui5-mp-root,
+:host([secondary-calendar-type="Islamic"]) .ui5-mp-root {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: var(--_ui5_monthpicker_item_margin);
+}
+
+:host([secondary-calendar-type="Persian"]) .ui5-mp-item,
+:host([secondary-calendar-type="Islamic"]) .ui5-mp-item {
+	margin: 0;
+	width: auto;
+}
+
+:host([secondary-calendar-type="Persian"]) .ui5-mp-quarter,
+:host([secondary-calendar-type="Islamic"]) .ui5-mp-quarter {
+	width: 100%;
+	display: contents;
+}

--- a/packages/main/src/themes/MonthPicker.css
+++ b/packages/main/src/themes/MonthPicker.css
@@ -1,3 +1,4 @@
+
 :host(:not([hidden])) {
 	display: block;
 }
@@ -8,25 +9,24 @@
 }
 
 .ui5-mp-root {
+	box-sizing: border-box;
 	padding: 2rem 0 1rem 0;
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: var(--_ui5_monthpicker_item_margin);
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
-	justify-content: center;
-	align-items: center;
 }
 
 .ui5-mp-item {
 	display: flex;
 	flex-direction: column;
-	width: calc(33.333% - 0.125rem);
-	height: var(--_ui5_month_picker_item_height);
+	box-sizing: border-box;
+	height: calc(var(--_ui5_month_picker_item_height) - var(--_ui5_monthpicker_item_margin));
 	color: var(--sapButton_Lite_TextColor);
 	background-color: var(--sapLegend_WorkingBackground);
 	align-items: center;
 	justify-content: center;
-	margin: var(--_ui5_monthpicker_item_margin);
 	box-sizing: border-box;
 	-webkit-user-select: none;
 	-moz-user-select: none;
@@ -80,30 +80,9 @@
 	border-radius: var(--_ui5_monthpicker_item_focus_after_border_radius);
 }
 
-.ui5-mp-quarter {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: 100%;
-}
-
 /* Switching to a two column layout */
 :host([secondary-calendar-type="Persian"]) .ui5-mp-root,
 :host([secondary-calendar-type="Islamic"]) .ui5-mp-root {
-	display: grid;
 	padding: 1rem 0 1rem;
 	grid-template-columns: repeat(2, 1fr);
-	gap: var(--_ui5_monthpicker_item_margin);
-}
-
-:host([secondary-calendar-type="Persian"]) .ui5-mp-item,
-:host([secondary-calendar-type="Islamic"]) .ui5-mp-item {
-	margin: 0;
-	width: auto;
-}
-
-:host([secondary-calendar-type="Persian"]) .ui5-mp-quarter,
-:host([secondary-calendar-type="Islamic"]) .ui5-mp-quarter {
-	width: 100%;
-	display: contents;
 }


### PR DESCRIPTION
Previously when `secondaryCalendarType` was set to `Islamic` or `Persian`, the texts of the months' names didnt had enough space in the cell to be displayed on one row, which wasnt the desired behavior.

Now, when any of those two calendar types is set as a `secondaryCalendarType`, when the end user is in month view of the calendar, the months are displayed in two column layout, instead of three, providing enough space for the texts to be displayed in one row.

Tested in both Cozy/Compact modes in following scenarios:

------------------------------

### Primary/SecondaryCalendarType:

1. Gregorian/Buddhist
2. Gregorian/Islamic
3. Gregorian/Japanese
4. Gregorian/Persian
5. Buddhist/Gregorian
6. Buddhist/Islamic
7. Buddhist/Japanese
8. Buddhist/Persian
9. Islamic/Gregorian
10. Islamic/Buddhist
11. Islamic/Japanese
12. Islamic/Persian
13. Japanese/Gregorian
14. Japanese/Buddhist
15. Japanese/Islamic
16. Japanese/Persian
17. Persian/Gregorian
18. Persian/Buddhist
19. Persian/Islamic
20. Persian/Japanese

#### Before
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/93b53e03-941f-4a34-bcb0-d612d89fd16f)


#### After
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/ff78e32c-e86c-4b27-ba01-ae364f59ede7)


Fixes: #7712 