### PR TITLE
docs: remove unnecessary "Next:"

### DIFF
--- a/docs/1-getting-started/01-first-steps.md
+++ b/docs/1-getting-started/01-first-steps.md
@@ -108,5 +108,3 @@ dist/assets/vendor.c05c7785.js 114.92kb / brotli: 24.30kb
 The contents of the `dist` folder is ready to be deployed for productive usage. The hashes in the file names make them safe for caching and the produced bundle is optimized for production.
 
 #### 4. Enjoy UI5 Web Components.
-
-Next: [Importing UI5 Web Components](./02-importing-components.md)

--- a/docs/1-getting-started/02-importing-components.md
+++ b/docs/1-getting-started/02-importing-components.md
@@ -54,5 +54,3 @@ For example:
 
 **Note:** For most components the name of the module (f.e. `Button.js`, `Icon.js`) coincides with the name of the tag (`ui5-button`, `ui5-icon`), 
 whereas for others this is not the case (f.e. `StandardListItem.js` and `ui5-li`). Always consult the documentation when in doubt.
-
-Next: [Understanding UI5 Web Components APIs](./03-understanding-components-APIs.md)

--- a/docs/1-getting-started/03-understanding-components-APIs.md
+++ b/docs/1-getting-started/03-understanding-components-APIs.md
@@ -242,5 +242,3 @@ Consult the documentation for the available public methods for each UI5 Web Comp
 As you can see from this article, UI5 Web Components, being HTML elements in the first place,
 comply with the same rules. There are some novelties that come with the Web Components standard,
 such as `slot`, but otherwise everything else is what you already know and use from HTML.
-
-Next: [Using Icons](./04-using-icons.md)

--- a/docs/1-getting-started/04-using-icons.md
+++ b/docs/1-getting-started/04-using-icons.md
@@ -171,5 +171,3 @@ Tip: for multi-colored icons, you can specify multiple SVG elements and put a fi
     <path stroke-linecap="round" stroke-linejoin="round" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
 </g>
 ```
-
-Next: [Using Additional Assets](./05-using-assets.md)

--- a/docs/1-getting-started/05-using-assets.md
+++ b/docs/1-getting-started/05-using-assets.md
@@ -55,4 +55,3 @@ The `ui5-date-picker` component will have all translatable texts in Spanish, and
 Additional assets are `.json` files with the respective data. When you import the `dist/Assets.js` file of a given package, assets are only **registered**, but not yet fetched.
 When they are needed, they are loaded on the fly with **dymamic imports**, and then used.
 
-Next: [Using Additional Features](./06-using-features.md)

--- a/docs/1-getting-started/06-using-features.md
+++ b/docs/1-getting-started/06-using-features.md
@@ -65,5 +65,3 @@ import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Link.js";
 import "@ui5/webcomponents/dist/Input.js";
 ```
-
-Next: [Typescript Support](./07-typescript-support.md)

--- a/docs/1-getting-started/07-typescript-support.md
+++ b/docs/1-getting-started/07-typescript-support.md
@@ -39,6 +39,3 @@ You will get a TypeScript error:
 ```html
 Argument of type 'boolean' is not assignable to parameter of type 'string'.
 ```
-
-
-Next: [Wrapping Up](./08-wrapping-up.md)

--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -297,5 +297,3 @@ import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSet
 ```js
 import { getFetchDefaultLanguage, setFetchDefaultLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 ```
-
-Next: [Right-To-Left (RTL) And Compact Mode](./02-RTL-and-compact-mode.md)

--- a/docs/2-advanced/02-RTL-and-compact-mode.md
+++ b/docs/2-advanced/02-RTL-and-compact-mode.md
@@ -82,5 +82,3 @@ Example 2:
 (Compact mode will be set for Button 2 and Button 3.)
 
 Unlike RTL, compact mode does not require additional APIs when its markers are changed dynamically.
-
-Next: [Micro-Frontends and Custom Elements Scoping](./03-scoping.md)

--- a/docs/2-advanced/03-scoping.md
+++ b/docs/2-advanced/03-scoping.md
@@ -89,5 +89,3 @@ having the word `-test-` in their name are not scoped.
 
 Setting scoping rules is handy if, for example, your library uses both standard and custom UI5 Web Components and you don't want
 to scope the custom ones (as no disambiguation will be necessary for them).
-
-Next:  [OpenUI5 Integration](./04-OpenUI5-integration.md)

--- a/docs/2-advanced/04-OpenUI5-integration.md
+++ b/docs/2-advanced/04-OpenUI5-integration.md
@@ -30,5 +30,3 @@ When you import the above module:
 
 Therefore, if you intend to run both frameworks in the same browser window,
 it is highly recommended to enable OpenUI5 support and benefit from these optimizations.
-
-Next: [Using the Framework](./05-other-framework-level-APIs.md)

--- a/docs/2-advanced/05-other-framework-level-APIs.md
+++ b/docs/2-advanced/05-other-framework-level-APIs.md
@@ -21,5 +21,3 @@ attachBoot(() => {
 	console.log("Framework booted");
 });
 ```
-
-Next: [UI5 Web Components i18n for Apps](./06-using-i18n-for-apps.md)

--- a/docs/2-advanced/06-using-i18n-for-apps.md
+++ b/docs/2-advanced/06-using-i18n-for-apps.md
@@ -116,5 +116,3 @@ and return the data directly in `.json` format if you want to load a little bit 
 | `assets/messagebundle_es.json` | `{"PLEASE_WAIT": "Espere"}`       |
 | `assets/messagebundle_en.json` | `{"PLEASE_WAIT": "Please wait"}`  |
 
-
-Next: [Accessibility](./07-accessibility.md)

--- a/docs/2-advanced/07-accessibility.md
+++ b/docs/2-advanced/07-accessibility.md
@@ -341,5 +341,3 @@ In order to process the issues correctly, we would like to have the following in
 
 Have in mind that UI5 Web Components is optimized for the High Contrast mode of Windows when using Chrome and Edge. If you have enabled both the Windows High Contrast setting and the SAPUI5 High Contrast theme and you are using browser different than Chrome and Edge this may cause conflicts, and deficiencies in the theme can occur. In such cases, please switch off the Windows High Contrast setting or use different browser.
 
-
-Next: [CSP](./08-CSP.md)

--- a/docs/2-advanced/08-CSP.md
+++ b/docs/2-advanced/08-CSP.md
@@ -99,4 +99,3 @@ that support them (Chrome, Edge) out of the box. For the other browsers (Firefox
 achieve CSP-compliance, you must instruct the framework to use `<link>` instead of `<style>` tags, but
 then you must also copy the CSS resources to a directory you can serve them from.
 
-Next: [Scrollbars customization](./09-scrollbars-customization.md)

--- a/docs/2-advanced/09-scrollbars-customization.md
+++ b/docs/2-advanced/09-scrollbars-customization.md
@@ -14,5 +14,3 @@ Example 1:
     ...
 </body>
 ```
-
-Next: [Ignore Custom HTML elements](./10-ignore-custom-elements.md)

--- a/docs/3-customizing/01-styles.md
+++ b/docs/3-customizing/01-styles.md
@@ -64,5 +64,3 @@ ui5-button {
 ## Custom Theme schema
 To change the entire colour scheme, the users can create a custom theme.
 You can find here more info in the next article.
-
-Next: [Custom Theming](./02-theme.md)

--- a/docs/3-customizing/02-theme.md
+++ b/docs/3-customizing/02-theme.md
@@ -110,5 +110,3 @@ To load a custom theme via URL, you can also use the available `setThemeRoot` me
 import { setThemeRoot } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
 setThemeRoot("https://my-example-host.com/");
 ```
-
-Next: [Custom Fonts](./03-theme_part2.md)

--- a/docs/3-customizing/03-theme_part2.md
+++ b/docs/3-customizing/03-theme_part2.md
@@ -172,5 +172,3 @@ setTheme("mytheme");
 
 Everything said so far is implemented in the following demo project - [ui5-webcomponents-custom-theme](https://github.com/ilhan007/ui5-webcomponents-custom-theme/).
 The project implements the script for producing the custom CSS vars and provides a simple test page to demonstrate the custom theme usage.
-
-Next: [Custom Fonts](./04-fonts.md)

--- a/docs/5-development/01-custom-UI5-Web-Components-Packages.md
+++ b/docs/5-development/01-custom-UI5-Web-Components-Packages.md
@@ -290,5 +290,3 @@ import "my-ui5-webcomponents/dist/MyFirstComponent.js"; // for my-first-componen
 import "my-ui5-webcomponents/dist/SomeOtherComponent.js";
 import "my-ui5-webcomponents/dist/YetAnotherComponent.js";
 ```
-
-Next: [Developing Custom UI5 Web Components](./02-custom-UI5-Web-Components.md)

--- a/docs/5-development/02-custom-UI5-Web-Components.md
+++ b/docs/5-development/02-custom-UI5-Web-Components.md
@@ -542,4 +542,3 @@ Respectively, the definitions file for, let's say `sap_fiori_3`, contains:
 What's important to understand here is that you author all the `.css` files listed in the table above, but the build script
 generates from them a single `.js` file for you, and this is namely the file you pass to the Web Component class: `generated/themes/Demo.css.js`.
 
-Next: [Understanding UI5 Web Components Metadata](./03-understanding-components-metadata.md)

--- a/docs/5-development/03-understanding-components-metadata.md
+++ b/docs/5-development/03-understanding-components-metadata.md
@@ -278,4 +278,3 @@ However, there are some very rare cases where a component must behave differentl
 For example, the `ui5-icon` component must show different versions of the icons based on the theme. Use the `themeAware` setting
 in these exceptional cases to guarantee that your component will be re-rendered on theme change.
 
-Next: [Understanding the Handlebars (`.hbs`) templates](./04-understanding-hbs-templates.md)

--- a/docs/5-development/04-understanding-hbs-templates.md
+++ b/docs/5-development/04-understanding-hbs-templates.md
@@ -900,4 +900,3 @@ The resulting DOM from the loop above will look like this:
 
 This allows you to have arbitrary DOM around each child and implement complex UX design, otherwise impossible if all children were just normally rendered next to each other in a single slot.
 
-Next: [Testing UI5 Web Components](./05-testing-UI5-Web-Components.md)

--- a/docs/5-development/05-testing-UI5-Web-Components.md
+++ b/docs/5-development/05-testing-UI5-Web-Components.md
@@ -247,4 +247,3 @@ You have 2 options:
 
  Just installing the package (with no extra configuration) is enough to let WebdriverIO run the *synchronous* tests.
 
-Next: [Deep dive and best practices](./06-deep-dive-and-best-practices.md)

--- a/docs/5-development/06-deep-dive-and-best-practices.md
+++ b/docs/5-development/06-deep-dive-and-best-practices.md
@@ -1397,5 +1397,3 @@ by using the attribute selector (`[ui5-popover]`), as is the best practice. See 
 
 Also, note that no matter how many times you call `getStaticAreaItemDomRef`, the static area item will be created only the first time.
 
-
-Next: [Typescript In UI5 Web Components](./07-typescript-in-UI5-Web-Components.md)


### PR DESCRIPTION
Remove unnecessary "Next:", as Docusaurus already puts next and previous.

**Thank you for your contribution!** 👏


### PR checklist
- [ ] Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [ ] Add proper description about the background of the change and the change itself

- [ ] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [ ] Read the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
