### PR TITLE
docs: show default values

### DIFF
--- a/packages/website/build-scripts/api-reference-generation/component-file.mjs
+++ b/packages/website/build-scripts/api-reference-generation/component-file.mjs
@@ -40,14 +40,15 @@ No properties available for this component.`
 |             |   |
 |-------------|---|
 | Description | ${processDescription(property.description)} |
-| Type        | ${processType(property.type)} |`
+| Type        | ${processType(property.type)}               |
+| Default     | ${property.default}                         |`
 
         if (property._ui5since) {
             propertyResult += `\n| Since | ${property._ui5since} |`
         }
 
         if (property.deprecated) {
-            propertyResult += `\n| Deprecated | ${processDescription(typeof property.deprecated === "boolean" ? "true" : property.deprecated)} |`
+            propertyResult += `\n| **Deprecated** | ${processDescription(typeof property.deprecated === "boolean" ? "true" : property.deprecated)} |`
         }
 
         return propertyResult


### PR DESCRIPTION
We have missed to show the default values in the the API references table

<img width="785" alt="Screenshot 2024-03-16 at 12 38 08" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/998ac193-2a3d-4ea1-a6ea-937a5101e2c7">


<img width="760" alt="Screenshot 2024-03-16 at 12 38 04" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/8e4e7277-c1b7-477c-8702-989bf2f3863a">
