### PR TITLE
fix(ui5-timeline-item): fix subtitle text overflows when long text provided

### DIFF
--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -231,7 +231,6 @@
 	font-weight: 400;
 	font-size: var(--sapFontSmallSize);
 	padding-top: var(--_ui5_TimelineItem_bubble_content_subtitle_padding_top);
-	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }

--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -231,8 +231,6 @@
 	font-weight: 400;
 	font-size: var(--sapFontSmallSize);
 	padding-top: var(--_ui5_TimelineItem_bubble_content_subtitle_padding_top);
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 .ui5-tli-desc {


### PR DESCRIPTION
When having a long `subTitle` text in a `<ui5-timeline-item>`, the text is getting truncated without an ellipsis and the item is getting cut from the side.

With this change we fix the unwanted border and text cut from the side.

### Before
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/d77b4d5d-82a5-4e2a-917d-fc26552af326)

### After
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/75392eab-ba8d-4258-8698-0797f79f62f2)

Fixes: #8438