### PR TITLE
docs: add `Privacy` page

### DIFF
--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -15,17 +15,18 @@ const DEVELOPMENT_ENVIRONMENT =  process.env.NODE_ENV === "development";
 const getBaseURL = () => {
   // localhost
   if (DEVELOPMENT_ENVIRONMENT) {
-    return "";
+    return "/";
   }
 
-  // latest deployment
-  if (LATEST_DEPLOYMENT) {
-    return LATEST_URL_PARTH;
-  }
-
-  // nightly deployment
-  return NIGHTLY_URL_PARTH;
+  // latest deployment or nightly deployment
+  return LATEST_DEPLOYMENT ? LATEST_URL_PARTH : NIGHTLY_URL_PARTH;
 };
+
+const BASE_URL = getBaseURL();
+
+const getFullURL = () => {
+  return DEVELOPMENT_ENVIRONMENT ? `${BASE_URL}` : `https://sap.github.io${BASE_URL}`
+}
 
 
 const config: Config = {
@@ -37,7 +38,7 @@ const config: Config = {
   url: 'https://sap.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: getBaseURL(),
+  baseUrl: BASE_URL,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -198,7 +199,7 @@ const config: Config = {
           items: [
             {
               label: 'Privacy',
-              href: `${DEVELOPMENT_ENVIRONMENT ? "/Privacy" : `https://sap.github.io${LATEST_DEPLOYMENT ? LATEST_URL_PARTH : NIGHTLY_URL_PARTH}Privacy`}`,
+              href: `${getFullURL()}Privacy`,
             },
             {
               label: 'Legal Disclosure',

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -6,20 +6,25 @@ import packageJson from "./package.json";
 
 console.log(process.env.DEPLOYMENT_TYPE); // eslint-disable-line
 
+const LATEST_URL_PARTH = "/ui5-webcomponents/";
+const NIGHTLY_URL_PARTH = "/ui5-webcomponents/nightly/";
+
+const LATEST_DEPLOYMENT = process.env.DEPLOYMENT_TYPE === "latest";
+const DEVELOPMENT_ENVIRONMENT =  process.env.NODE_ENV === "development";
 
 const getBaseURL = () => {
   // localhost
-  if (process.env.NODE_ENV === "development") {
+  if (DEVELOPMENT_ENVIRONMENT) {
     return "";
   }
 
   // latest deployment
-  if (process.env.DEPLOYMENT_TYPE === "latest") {
-    return "/ui5-webcomponents/";
+  if (LATEST_DEPLOYMENT) {
+    return LATEST_URL_PARTH;
   }
 
   // nightly deployment
-  return "/ui5-webcomponents/nightly/";
+  return NIGHTLY_URL_PARTH;
 };
 
 
@@ -193,7 +198,7 @@ const config: Config = {
           items: [
             {
               label: 'Privacy',
-              href: 'https://www.sap.com/about/legal/privacy.html',
+              href: `${DEVELOPMENT_ENVIRONMENT ? "/Privacy" : `https://sap.github.io${LATEST_DEPLOYMENT ? LATEST_URL_PARTH : NIGHTLY_URL_PARTH}Privacy`}`,
             },
             {
               label: 'Legal Disclosure',

--- a/packages/website/src/pages/Privacy.md
+++ b/packages/website/src/pages/Privacy.md
@@ -1,0 +1,7 @@
+---
+title: Privacy
+---
+
+# Privacy
+
+This site is hosted by [GitHub Pages](https://pages.github.com/). Please see the [GitHub Privacy Statement](https://docs.github.com/en/github/site-policy/github-privacy-statement) for any information how GitHub processes your personal data.


### PR DESCRIPTION
As hosted on Github Pages, we need to reference different kind of privacy information:

<img width="1134" alt="Screenshot 2024-03-18 at 16 05 26" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/d7eb9869-ddd3-464c-9f64-8e08e30ab53f">
