### PR TITLE
chore: fix components API hierarchy

### DIFF
--- a/packages/website/build-scripts/api-reference-generation/components.mjs
+++ b/packages/website/build-scripts/api-reference-generation/components.mjs
@@ -1,89 +1,10 @@
 import fs from "fs"
 import path from "path"
 import { parseComponentDeclaration } from "./component-file.mjs"
-import { generateTypes } from "./types.mjs";
 import { removeFileExtension } from "./utils.mjs";
-
-await generateTypes();
+import { findDeclaration, realPackagesName } from "./manifest.mjs";
 
 const packages = ["main", "fiori"];
-const manifests = {};
-
-const findDeclaration = (manifest, declarationName) => {
-    let declaration;
-
-    for (let _module of manifest.modules) {
-        for (let _declaration of _module.declarations) {
-            if (_declaration.name === declarationName) {
-                declaration = _declaration;
-                break;
-            }
-        }
-    }
-
-    return declaration;
-}
-
-[...packages, "base"].map(packageName => {
-    return manifests[packageName] = JSON.parse(fs.readFileSync(path.resolve(`./../${packageName}/dist/custom-elements-internal.json`), { encoding: "utf-8" }))
-});
-
-const parseTypeAsString = (typeObj) => {
-    if (!typeObj || !typeObj.references) {
-        return typeObj;
-    }
-
-    typeObj.references.forEach(reference => {
-        let packageName;
-
-        if (reference.package === "@ui5/webcomponents") {
-            packageName = "main"
-        } else if (reference.package === "@ui5/webcomponents-fiori") {
-            packageName = "fiori"
-        } else if (reference.package === "@ui5/webcomponents-base") {
-            packageName = "base"
-        }
-
-        const foundReference = findDeclaration(manifests[packageName], reference.name);
-
-        if (foundReference && foundReference.kind === "enum") {
-            const enumFields = foundReference.members
-                .filter(member => member.kind === "field" && member.static)
-                .map(member => `"${member.name}"`)
-                .join(" | ");
-
-            const regexp = new RegExp(`\\b${foundReference.name}\\b`, "g");
-            typeObj.text = typeObj.text.replaceAll(regexp, enumFields);
-        }
-    })
-}
-
-const resolveTypes = declaration => {
-    declaration.members
-        ?.filter(member => member.kind === "field")
-        .forEach(field => {
-            parseTypeAsString(field.type);
-        })
-
-    declaration.members
-        ?.filter(member => member.kind === "method")
-        .forEach(method => {
-            if (method.return) parseTypeAsString(method.type);
-            if (method.parameters) method.parameters.forEach(param => parseTypeAsString(param.type))
-        })
-
-    declaration.events
-        ?.forEach(event => {
-            parseTypeAsString(event.type)
-            if (event._ui5parameters) event._ui5parameters.forEach(param => parseTypeAsString(param.type))
-        })
-
-    declaration.slots
-        ?.forEach(slot => {
-            parseTypeAsString(slot._ui5type)
-        })
-
-}
 
 const generateComponents = (source = "./docs/_components_pages", level = 1) => {
     const sourcePath = path.resolve(source);
@@ -100,8 +21,6 @@ const generateComponents = (source = "./docs/_components_pages", level = 1) => {
         const fileName = removeFileExtension(file);
 
         if (isDirectory) {
-            console.log(`${"-".repeat(level)} ${file} (folder)`)
-
             if (!packages.includes(file)) {
                 fs.mkdirSync(path.join(targetPath, file), { recursive: true });
                 fs.writeFileSync(path.join(targetPath, file, "_category_.json"), `{
@@ -122,12 +41,9 @@ const generateComponents = (source = "./docs/_components_pages", level = 1) => {
 
             if (packageName) {
                 const fileContent = fs.readFileSync(path.join(sourcePath, file), { encoding: "utf-8" });
-                const declaration = findDeclaration(manifests[packageName], fileName)
-
-                resolveTypes(declaration);
+                const declaration = findDeclaration({ package: realPackagesName(packageName), name: fileName })
 
                 fs.writeFileSync(path.join(targetPath, `${fileName}.mdx`), parseComponentDeclaration(declaration, fileContent))
-                console.log(`${"-".repeat(level)} ${file}`)
             }
         }
     }

--- a/packages/website/build-scripts/api-reference-generation/index.mjs
+++ b/packages/website/build-scripts/api-reference-generation/index.mjs
@@ -1,6 +1,9 @@
 import { generateTypes } from "./types.mjs";
 import { generateComponents } from "./components.mjs";
+import { loadManifests } from "./manifest.mjs";
 
-await generateTypes();
+loadManifests();
 
-await generateComponents();
+generateTypes();
+
+generateComponents();

--- a/packages/website/build-scripts/api-reference-generation/manifest.mjs
+++ b/packages/website/build-scripts/api-reference-generation/manifest.mjs
@@ -1,0 +1,221 @@
+import fs from "fs"
+import path from "path"
+
+const _manifest = {
+    modules: []
+}
+const processedDeclarations = new Map();
+
+const findDeclaration = ({ package: packageName, name }) => {
+    let declaration;
+
+    for (let _module of _manifest.modules) {
+        for (let _declaration of _module.declarations) {
+            if (_declaration.name === name && _declaration._ui5package === packageName) {
+                declaration = _declaration;
+                break;
+            }
+        }
+    }
+
+    return declaration;
+}
+
+const findAllImplementations = (interfaceReference) => {
+    let declarationNames = [];
+
+    for (let _module of _manifest.modules) {
+        for (let _declaration of _module.declarations) {
+            if (_declaration?._ui5implements?.some(reference => reference.name === interfaceReference.name && reference.package === interfaceReference._ui5package)) {
+                declarationNames.push(`${_declaration._ui5package}/${_declaration.name}`)
+            }
+        }
+    }
+
+    return declarationNames;
+}
+
+const flattenAPIsHierarchicalStructure = module => {
+    if (!module) {
+        return;
+    }
+
+    const declarations = module.declarations;
+
+    declarations.forEach(declaration => {
+        let superclassDeclaration = processedDeclarations.get(`${declaration.superclass?.package}/${declaration.superclass?.name}`);
+
+        if (!superclassDeclaration) {
+            const superclassModule = _manifest.modules.find(_m => _m.declarations.find(_d => _d.name === declaration.superclass?.name && _d._ui5package === declaration.superclass?.package));
+
+            if (superclassModule) {
+                flattenAPIsHierarchicalStructure(superclassModule);
+            }
+
+            superclassDeclaration = processedDeclarations.get(`${declaration.superclass?.package}/${declaration.superclass?.name}`);
+        }
+
+        if (superclassDeclaration && superclassDeclaration.name !== "UI5Element" && superclassDeclaration._ui5package !== realPackagesName("base")) {
+            processedDeclarations.set(`${declaration._ui5package}/${declaration.name}`, mergeClassMembers(declaration, processedDeclarations.get(`${declaration.superclass?.package}/${declaration.superclass?.name}`)));
+        } else {
+            processedDeclarations.set(`${declaration._ui5package}/${declaration.name}`, declaration);
+        }
+    })
+}
+
+const mergeClassMembers = (declaration, superclassDeclaration) => {
+    const props = ["members", "slots", "events", "cssParts"];
+
+    props.forEach(prop => {
+        if (declaration[prop]?.length) {
+            declaration[prop] = (superclassDeclaration[prop] || []).reduce(mergeArraysWithoutDuplicates, declaration[prop])
+        } else if (superclassDeclaration[prop]?.length) {
+            declaration[prop] = superclassDeclaration[prop];
+        }
+    });
+
+    if (declaration._ui5implements?.length) {
+        declaration._ui5implements = [...new Set([...(superclassDeclaration._ui5implements || []), ...declaration._ui5implements])]
+    } else if (superclassDeclaration._ui5implements?.length) {
+        declaration._ui5implements = superclassDeclaration._ui5implements;
+    }
+
+    return declaration;
+}
+
+const mergeArraysWithoutDuplicates = (currentValues, newValue) => {
+    const hasDuplicate = currentValues.find(currentValue => {
+        return currentValue.name === newValue.name
+    });
+
+    if (!hasDuplicate) {
+        currentValues.push(newValue);
+    }
+
+    return currentValues;
+}
+
+const parseTypeAsString = (typeObj) => {
+    if (!typeObj || !typeObj.references) {
+        return typeObj;
+    }
+
+    typeObj.references.forEach(reference => {
+        const foundReference = findDeclaration(reference);
+
+        if (foundReference && foundReference.kind === "enum") {
+            const enumFields = foundReference.members
+                .filter(member => member.kind === "field" && member.static)
+                .map(member => `"${member.name}"`)
+                .join(" | ");
+
+            const regexp = new RegExp(`\\b${foundReference.name}\\b`, "g");
+            typeObj.text = typeObj.text.replaceAll(regexp, enumFields);
+        }
+    })
+}
+
+const resolveTypes = declaration => {
+    declaration.members
+        ?.filter(member => member.kind === "field")
+        .forEach(field => {
+            parseTypeAsString(field.type);
+        })
+
+    declaration.members
+        ?.filter(member => member.kind === "method")
+        .forEach(method => {
+            if (method.return) parseTypeAsString(method.type);
+            if (method.parameters) method.parameters.forEach(param => parseTypeAsString(param.type))
+        })
+
+    declaration.events
+        ?.forEach(event => {
+            parseTypeAsString(event.type)
+            if (event._ui5parameters) event._ui5parameters.forEach(param => parseTypeAsString(param.type))
+        })
+
+    declaration.slots
+        ?.forEach(slot => {
+            parseTypeAsString(slot._ui5type)
+        })
+
+}
+
+// Load manifests for each package, merge child + parent classes to fulfill missing properties and transform enumaration values to strings.
+const loadManifests = () => {
+    getPackages().forEach(packageName => {
+        const currentLoadedManifest = JSON.parse(fs.readFileSync(path.resolve(`./../${packageName}/dist/custom-elements-internal.json`), { encoding: "utf-8" }))
+
+        _manifest.modules = [
+            ..._manifest.modules,
+            ...currentLoadedManifest.modules.map(_module => {
+                return {
+                    ..._module,
+                    declarations: [..._module.declarations.map(_declaration => {
+                        _declaration._ui5package = realPackagesName(packageName)
+                        return _declaration
+                    })
+                    ]
+                }
+            }).filter(_module => _module.declarations.length)
+        ]
+    })
+
+    _manifest.modules?.forEach(_module => {
+        flattenAPIsHierarchicalStructure(_module);
+        _module.declarations?.forEach(resolveTypes);
+    });
+}
+
+const getPackages = () => {
+    return ["main", "fiori", "base"];
+}
+
+const realPackagesName = (key) => {
+    const map = {
+        "base": "@ui5/webcomponents-base",
+        "main": "@ui5/webcomponents",
+        "fiori": "@ui5/webcomponents-fiori"
+    };
+
+    return map[key];
+}
+
+const getEnums = packageName => {
+    const enums = [];
+
+    _manifest.modules.forEach(_module => {
+        _module.declarations.forEach(_declaration => {
+            if (_declaration.kind === "enum" && _declaration._ui5package === packageName) {
+                enums.push(_declaration);
+            }
+        })
+    })
+
+    return enums
+}
+
+const getInterfaces = packageName => {
+    const interfaces = [];
+
+    _manifest.modules.forEach(_module => {
+        _module.declarations.forEach(_declaration => {
+            if (_declaration.kind === "interface" && _declaration._ui5package === packageName) {
+                interfaces.push(_declaration);
+            }
+        })
+    })
+
+    return interfaces
+}
+
+export {
+    loadManifests,
+    findDeclaration,
+    getPackages,
+    findAllImplementations,
+    realPackagesName,
+    getEnums,
+    getInterfaces
+}

--- a/packages/website/build-scripts/api-reference-generation/types.mjs
+++ b/packages/website/build-scripts/api-reference-generation/types.mjs
@@ -1,37 +1,11 @@
 import fs from "fs/promises"
 import path from "path"
 import { parseDeclaration } from "./component-file.mjs"
+import { findAllImplementations, getInterfaces, getEnums, realPackagesName } from "./manifest.mjs"
 
 const packages = ["main", "fiori"];
-const manifests = {};
 
-await Promise.all(packages.map(async packageName => {
-    manifests[packageName] = JSON.parse(await fs.readFile(path.resolve(`./../${packageName}/dist/custom-elements-internal.json`), { encoding: "utf-8" }))
-}));
-
-
-const findAllImplementations = (interfaceName) => {
-    let declarationNames = [];
-
-    for (let packageName of packages) {
-        for (let _module of manifests[packageName].modules) {
-            for (let _declaration of _module.declarations) {
-                if (_declaration?._ui5implements?.some(reference => reference.name === interfaceName)) {
-                    let fullPackageName = packageName === "main" ? "@ui5/webcomponents" : "@ui5/webcomponents-fiori";
-                    declarationNames.push(`${fullPackageName}/${_declaration.name}`)
-                }
-            }
-        }
-    }
-
-    return declarationNames;
-}
-
-const generateTypes = async () => {
-    await Promise.all(packages.map(async packageName => {
-        manifests[packageName] = JSON.parse(await fs.readFile(path.resolve(`./../${packageName}/dist/custom-elements-internal.json`), { encoding: "utf-8" }))
-    }));
-
+const generateTypes = () => {
     packages.forEach(async (packageName) => {
         await fs.mkdir(`./docs/components/${packageName}/enums`, { recursive: true })
         await fs.mkdir(`./docs/components/${packageName}/interfaces`, { recursive: true })
@@ -46,19 +20,21 @@ import DocCardList from '@theme/DocCardList';
 <DocCardList />`)
         }))
 
-        manifests[packageName].modules.forEach(_module => {
-            _module.declarations.forEach(async (declaration) => {
-                if (declaration.kind === "enum") {
-                    await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
-                    await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
-                } else if (declaration.kind === "interface") {
-                    declaration._implementations = findAllImplementations(declaration.name);
+        const intefaces = getInterfaces(realPackagesName(packageName));
+        const enums = getEnums(realPackagesName(packageName));
 
-                    await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
-                    await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
-                }
-            });
-        });
+
+        intefaces.forEach(async (declaration) => {
+            declaration._implementations = findAllImplementations(declaration);
+
+            await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
+            await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
+        })
+
+        enums.forEach(async (declaration) => {
+            await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
+            await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
+        })
     })
 }
 


### PR DESCRIPTION
Previously, if there was a multi package hierarchy (e.g. NotificationListItem) some properties were missing. With this change all properties are displayed.

In addition, implemented interfaces are added to each child component and now list with components that implement a specific interface is extended (IButton)