### PR TITLE
chore: force Avatar size, used as ShellBar profile

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -87,6 +87,7 @@ slot[name="profile"] {
 	min-width: 0;
 	width: 2rem;
 	height: 2rem;
+	min-height: 2rem;
 	padding: .25rem;
 	pointer-events: none;
 }


### PR DESCRIPTION
Fix sizing issue with the Avatar, when used as a profile within the ShellBar. The default styles for the Avatar  are applied when the `size` attribute is not present (which is the recommended way of using the Avatar in the SHellBar). The default size is `S`, so `S` size styles are applied. And, this is how exactly the Avatar is supposed to be working.
However, this was not always the case. Recently, we have fixed this in the Avatar with this change: https://github.com/SAP/ui5-webcomponents/pull/8415

Previously, prior to this change, the Avatar did not handle the case when no `size` attribute was passed, e.g
this was missing and we added this selector to cover it:
```css
:host(:not([size]))
```

Otherwise, without the change, an Avatar without size and an Avatar with Size="S" looked differently, while they should look the same.

Finally, we come to the ShellBar. It turns out that the ShellBar relied on the wrong behaviour, that's why the
 issue is recent. So, now the ShellBar's overwriting css need to be updated as well.


The issue can be seen here: 
https://sap.github.io/ui5-webcomponents/nightly/components/fiori/ShellBar/#profile-area

and here:
https://sap.github.io/ui5-webcomponents/storybook/playground/fiori/pages/ShellBar/?sap-ui-theme=sap_horizon

<img width="148" alt="Screenshot 2024-03-19 at 16 41 36" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/7587fcaf-ded6-4f96-816c-2fe503ef5af1">


Alternatively, we can ask from users to set size="XS" to the Avatar, this will also fix the problem, but somehow it's more convenient to work out of the box as it was.
