### PR TITLE
docs: fix typo in MessageStrip sample

### DIFF
--- a/packages/website/docs/_components_pages/main/MessageStrip.mdx
+++ b/packages/website/docs/_components_pages/main/MessageStrip.mdx
@@ -20,7 +20,7 @@ import HideIconAndButton from "../../_samples/main/MessageStrip/HideIconAndButto
 <Design />
 
 ### Hide Icon and Close Button 
-Use <b>hideIcon</b> and <b>hideCloseButton</b> properties to hide some partos of the MessageStrip.
+Use <b>hideIcon</b> and <b>hideCloseButton</b> properties to hide some parts of the MessageStrip.
 
 <HideIconAndButton />
 


### PR DESCRIPTION
Fix typo 'partos' --> 'parts'
