### PR TITLE
refactor(framework): remove internet explorer related checks

### DIFF
--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -75,7 +75,6 @@ import {
 // Device.ts
 import {
 	supportsTouch,
-	isIE,
 	isSafari,
 	isChrome,
 	isFirefox,
@@ -187,7 +186,6 @@ export {
 
 	// Device.ts
 	supportsTouch,
-	isIE,
 	isSafari,
 	isChrome,
 	isFirefox,

--- a/packages/base/src/Device.ts
+++ b/packages/base/src/Device.ts
@@ -13,17 +13,12 @@ const internals = {
 		}
 		return "ontouchstart" in window || navigator.maxTouchPoints > 0;
 	},
-	get ie() {
-		if (isSSR) {
-			return false;
-		}
-		return /(msie|trident)/i.test(internals.userAgent);
-	},
+
 	get chrome() {
 		if (isSSR) {
 			return false;
 		}
-		return !internals.ie && /(Chrome|CriOS)/.test(internals.userAgent);
+		return /(Chrome|CriOS)/.test(internals.userAgent);
 	},
 	get firefox() {
 		if (isSSR) {
@@ -35,13 +30,13 @@ const internals = {
 		if (isSSR) {
 			return false;
 		}
-		return !internals.ie && !internals.chrome && /(Version|PhantomJS)\/(\d+\.\d+).*Safari/.test(internals.userAgent);
+		return !internals.chrome && /(Version|PhantomJS)\/(\d+\.\d+).*Safari/.test(internals.userAgent);
 	},
 	get webkit() {
 		if (isSSR) {
 			return false;
 		}
-		return !internals.ie && /webkit/.test(internals.userAgent);
+		return /webkit/.test(internals.userAgent);
 	},
 	get windows() {
 		if (isSSR) {
@@ -156,11 +151,10 @@ const detectTablet = () => {
 		return;
 	}
 
-	tablet = (internals.ie && internals.userAgent.indexOf("Touch") !== -1) || (internals.android && !internals.androidPhone);
+	tablet = internals.userAgent.indexOf("Touch") !== -1 || (internals.android && !internals.androidPhone);
 };
 
 const supportsTouch = (): boolean => internals.touch;
-const isIE = (): boolean => internals.ie;
 const isSafari = (): boolean => internals.safari;
 const isChrome = (): boolean => internals.chrome;
 const isFirefox = (): boolean => internals.firefox;
@@ -200,7 +194,6 @@ const isAndroid = (): boolean => {
 
 export {
 	supportsTouch,
-	isIE,
 	isSafari,
 	isChrome,
 	isFirefox,

--- a/packages/base/test/ssr/Device.js
+++ b/packages/base/test/ssr/Device.js
@@ -5,7 +5,6 @@ describe('SSR / Device', () => {
 
     it('all detections should return false', () => {
         assert.strictEqual(Device.supportsTouch(), false, `'supportsTouch' should be false`);
-        assert.strictEqual(Device.isIE(), false, `'isIE' should be false`);
         assert.strictEqual(Device.isSafari(), false, `'isSafari' should be false`);
         assert.strictEqual(Device.isChrome(), false, `'isChrome' should be false`);
         assert.strictEqual(Device.isFirefox(), false, `'isFirefox' should be false`);


### PR DESCRIPTION
We're discontinuing support for Internet Explorer as it is no longer supported. With this change, we're removing all Internet Explorer-related checks from the framework.

BREAKING CHANGE: "isIE" method is removed

Related to https://github.com/SAP/ui5-webcomponents/issues/8461