### PR TITLE
refactor(ui5-tabcontainer): replace some ITab properties

### DIFF
--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -182,17 +182,17 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	_forcedSetsize?: number;
 	_isTopLevelTab?: boolean;
 	_forcedStyleInOverflow?: Record<string, any>;
-	getElementInStrip?: () => ITab | null;
+	_getElementInStrip?: () => HTMLElement | undefined;
 	_individualSlot!: string;
 
 	static i18nBundle: I18nBundle;
 
 	set forcedTabIndex(val: string) {
-		this.getTabInStripDomRef()!.setAttribute("tabindex", val);
+		this.getDomRefInStrip()!.setAttribute("tabindex", val);
 	}
 
 	get forcedTabIndex() {
-		return this.getTabInStripDomRef()!.getAttribute("tabindex")!;
+		return this.getDomRefInStrip()!.getAttribute("tabindex")!;
 	}
 
 	get displayText() {
@@ -255,6 +255,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 		this._forcedSetsize = info.setsize;
 		this._isInline = info.isInline;
 		this._isTopLevelTab = info.isTopLevelTab;
+		this._getElementInStrip = info.getElementInStrip;
 	}
 
 	receiveOverflowPresentationInfo(info: ITabPresentationInOverflowInfo) {
@@ -264,28 +265,18 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	/**
 	 * Returns the DOM reference of the tab that is placed in the header.
 	 *
-	 * **Note:** Tabs, placed in the `subTabs` slot of other tabs are not shown in the header. Calling this method on such tabs will return `null`.
+	 * **Note:** Tabs, placed in the `subTabs` slot of other tabs are not shown in the header. Calling this method on such tabs will return `undefined`.
 	 *
 	 * **Note:** If you need a DOM ref to the tab content please use the `getDomRef` method.
 	 * @public
-	 * @since 1.0.0-rc.16
+	 * @since 2.0.0
 	 */
-	getTabInStripDomRef(): ITab | null {
-		if (this.getElementInStrip) {
-			return this.getElementInStrip();
-		}
-
-		return null;
+	getDomRefInStrip(): HTMLElement | undefined {
+		return this._getElementInStrip?.();
 	}
 
 	getFocusDomRef() {
-		let focusedDomRef = super.getFocusDomRef();
-
-		if (this.getElementInStrip && this.getElementInStrip()) {
-			focusedDomRef = this.getElementInStrip()!;
-		}
-
-		return focusedDomRef;
+		return this.getDomRefInStrip();
 	}
 
 	async focus(focusOptions?: FocusOptions): Promise<void> {

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -24,7 +24,7 @@ import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import SemanticColor from "./types/SemanticColor.js";
 import ListItemType from "./types/ListItemType.js";
 import TabContainer from "./TabContainer.js";
-import type { ITab, ITabPresentationInStripInfo } from "./TabContainer.js";
+import type { ITab, ITabPresentationInOverflowInfo, ITabPresentationInStripInfo } from "./TabContainer.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
 import CustomListItem from "./CustomListItem.js";
@@ -181,6 +181,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	_forcedPosinset?: number;
 	_forcedSetsize?: number;
 	_isTopLevelTab?: boolean;
+	_forcedStyleInOverflow?: Record<string, any>;
 	getElementInStrip?: () => ITab | null;
 	_individualSlot!: string;
 
@@ -254,6 +255,10 @@ class Tab extends UI5Element implements ITab, ITabbable {
 		this._forcedSetsize = info.setsize;
 		this._isInline = info.isInline;
 		this._isTopLevelTab = info.isTopLevelTab;
+	}
+
+	receiveOverflowPresentationInfo(info: ITabPresentationInOverflowInfo) {
+		this._forcedStyleInOverflow = info.style;
 	}
 
 	/**

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -24,7 +24,7 @@ import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import SemanticColor from "./types/SemanticColor.js";
 import ListItemType from "./types/ListItemType.js";
 import TabContainer from "./TabContainer.js";
-import type { ITab } from "./TabContainer.js";
+import type { ITab, ITabPresentationInStripInfo } from "./TabContainer.js";
 import Icon from "./Icon.js";
 import Button from "./Button.js";
 import CustomListItem from "./CustomListItem.js";
@@ -146,9 +146,6 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	@property({ type: Object, defaultValue: null })
 	realTabReference!: Tab;
 
-	@property({ type: Boolean })
-	isTopLevelTab!: boolean;
-
 	/**
 	 * Holds the content associated with this tab.
 	 * @public
@@ -179,8 +176,11 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	})
 	subTabs!: Array<ITab>
 
-	isInline?: boolean;
-	forcedMixedMode?: boolean;
+	_isInline?: boolean;
+	_forcedMixedMode?: boolean;
+	_forcedPosinset?: number;
+	_forcedSetsize?: number;
+	_isTopLevelTab?: boolean;
 	getElementInStrip?: () => ITab | null;
 	_individualSlot!: string;
 
@@ -197,7 +197,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	get displayText() {
 		let text = this.text;
 
-		if (this.isInline && this.additionalText) {
+		if (this._isInline && this.additionalText) {
 			text += ` (${this.additionalText})`;
 		}
 
@@ -221,15 +221,15 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get requiresExpandButton() {
-		return this.subTabs.length > 0 && this.isTopLevelTab && this.hasOwnContent;
+		return this.subTabs.length > 0 && this._isTopLevelTab && this.hasOwnContent;
 	}
 
 	get isSingleClickArea() {
-		return this.subTabs.length > 0 && this.isTopLevelTab && !this.hasOwnContent;
+		return this.subTabs.length > 0 && this._isTopLevelTab && !this.hasOwnContent;
 	}
 
 	get isTwoClickArea() {
-		return this.subTabs.length > 0 && this.isTopLevelTab && this.hasOwnContent;
+		return this.subTabs.length > 0 && this._isTopLevelTab && this.hasOwnContent;
 	}
 
 	get isOnSelectedTabPath(): boolean {
@@ -246,6 +246,14 @@ class Tab extends UI5Element implements ITab, ITabbable {
 
 	get hasOwnContent() {
 		return willShowContent(this.content);
+	}
+
+	receiveStripPresentationInfo(info: ITabPresentationInStripInfo) {
+		this._forcedMixedMode = info.mixedMode;
+		this._forcedPosinset = info.posinset;
+		this._forcedSetsize = info.setsize;
+		this._isInline = info.isInline;
+		this._isTopLevelTab = info.isTopLevelTab;
 	}
 
 	/**
@@ -281,11 +289,11 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	}
 
 	get isMixedModeTab() {
-		return !this.icon && this.forcedMixedMode;
+		return !this.icon && this._forcedMixedMode;
 	}
 
 	get isTextOnlyTab() {
-		return !this.icon && !this.forcedMixedMode;
+		return !this.icon && !this._forcedMixedMode;
 	}
 
 	get isIconTab() {
@@ -342,7 +350,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 			classes.push("ui5-tab-strip-item--disabled");
 		}
 
-		if (this.isInline) {
+		if (this._isInline) {
 			classes.push("ui5-tab-strip-item--inline");
 		}
 
@@ -350,7 +358,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 			classes.push("ui5-tab-strip-item--withAdditionalText");
 		}
 
-		if (!this.icon && !this.forcedMixedMode) {
+		if (!this.icon && !this._forcedMixedMode) {
 			classes.push("ui5-tab-strip-item--textOnly");
 		}
 
@@ -358,7 +366,7 @@ class Tab extends UI5Element implements ITab, ITabbable {
 			classes.push("ui5-tab-strip-item--withIcon");
 		}
 
-		if (!this.icon && this.forcedMixedMode) {
+		if (!this.icon && this._forcedMixedMode) {
 			classes.push("ui5-tab-strip-item--mixedMode");
 		}
 

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -143,9 +143,6 @@ class Tab extends UI5Element implements ITab, ITabbable {
 	@property({ type: Boolean })
 	forcedSelected!: boolean;
 
-	@property({ type: Object, defaultValue: null })
-	realTabReference!: Tab;
-
 	/**
 	 * Holds the content associated with this tab.
 	 * @public

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -69,10 +69,22 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
  * Interface for components that may be slotted inside `ui5-tabcontainer` as items
  * @public
  */
+
+type ITabPresentationInStripInfo = {
+	isInline: boolean;
+	mixedMode: boolean;
+	posinset: number;
+	setsize: number;
+	isTopLevelTab: boolean;
+}
+
 interface ITab extends UI5Element {
+	get stripPresentation(): object;
+	get overflowPresentation(): object;
+	receiveStripPresentationInfo?: (attributes: ITabPresentationInStripInfo) => void;
 	isSeparator: boolean;
-	getTabInStripDomRef: () => ITab | null;
 	additionalText?: string;
+	getTabInStripDomRef: () => ITab | null;
 	design?: `${SemanticColor}`;
 	disabled?: boolean;
 	icon?: string;
@@ -86,12 +98,7 @@ interface ITab extends UI5Element {
 	forcedLevel?: number;
 	forcedSelected?: boolean;
 	getElementInStrip?: () => ITab | null;
-	isInline?: boolean;
-	forcedMixedMode?: boolean;
-	forcedPosinset?: number;
-	forcedSetsize?: number;
 	realTabReference: ITab;
-	isTopLevelTab?: boolean;
 	forcedStyle?: Record<string, any>;
 }
 
@@ -472,11 +479,13 @@ class TabContainer extends UI5Element {
 		});
 
 		allTabs.forEach((tab, index, arr) => {
-			tab.isInline = this.tabLayout === TabLayout.Inline;
-			tab.forcedMixedMode = this.mixedMode;
-			tab.forcedPosinset = index + 1;
-			tab.forcedSetsize = arr.length;
-			tab.isTopLevelTab = items.some(i => i === tab);
+			tab.receiveStripPresentationInfo?.({
+				isInline: this.tabLayout === TabLayout.Inline,
+				mixedMode: this.mixedMode,
+				posinset: index + 1,
+				setsize: arr.length,
+				isTopLevelTab: items.some(i => i === tab),
+			});
 		});
 
 		this._setIndentLevels(items);
@@ -1498,6 +1507,7 @@ TabContainer.define();
 export default TabContainer;
 export type {
 	ITab,
+	ITabPresentationInStripInfo,
 	TabContainerTabSelectEventDetail,
 	TabContainerMoveEventDetail,
 };

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -85,8 +85,8 @@ type ITabPresentationInOverflowInfo = {
 interface ITab extends UI5Element {
 	get stripPresentation(): object;
 	get overflowPresentation(): object;
-	receiveStripPresentationInfo?: (info: ITabPresentationInStripInfo) => void;
-	receiveOverflowPresentationInfo?: (info: ITabPresentationInOverflowInfo) => void;
+	receiveStripPresentationInfo: (info: ITabPresentationInStripInfo) => void;
+	receiveOverflowPresentationInfo: (info: ITabPresentationInOverflowInfo) => void;
 	isSeparator: boolean;
 	additionalText?: string;
 	design?: `${SemanticColor}`;

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -102,21 +102,17 @@ interface ITab extends UI5Element {
 	forcedSelected?: boolean;
 }
 
-type TabContainerPopoverOwner = "start-overflow" | "end-overflow" | ITabPresentation | ITab;
+type TabContainerPopoverOwner = "start-overflow" | "end-overflow" | ITabPresentation;
 
 const tabStyles: Array<StyleData> = [];
 const staticAreaTabStyles: Array<StyleData> = [];
 const PAGE_UP_DOWN_SIZE = 5;
 
-interface TabContainerExpandButton extends Button {
-	tab: ITab;
-}
-
 interface ITabPresentation extends HTMLElement {
 	realTabReference: ITab;
 }
 
-interface TabContainerTabInOverflow extends CustomListItem {
+interface ITabPresentationInOverflow extends CustomListItem {
 	realTabReference: ITab;
 }
 
@@ -689,18 +685,17 @@ class TabContainer extends UI5Element {
 		if (isTabInStrip(e.target as HTMLElement)) {
 			tabInstance = e.target as ITabPresentation;
 		} else {
-			tabInstance = (e.target as TabContainerExpandButton).tab;
+			tabInstance = getTabInStrip(e.target as HTMLElement) as ITabPresentation;
 		}
-
-		let opener = e.target as HTMLElement;
 
 		if (tabInstance) {
 			tabInstance.focus();
 		}
 
+		let opener = e.target as HTMLElement;
+
 		if (e.type === "keydown" && !(e.target as ITabPresentation).realTabReference.isSingleClickArea) {
-			opener = opener.querySelector<TabContainerExpandButton>(".ui5-tab-expand-button [ui5-button]")!;
-			tabInstance = (e.target as ITabPresentation).realTabReference;
+			opener = opener.querySelector(".ui5-tab-expand-button [ui5-button]")!;
 		}
 
 		// if clicked between the expand button and the tab
@@ -720,13 +715,13 @@ class TabContainer extends UI5Element {
 	}
 
 	_getSelectedTabInOverflow() {
-		return <TabContainerTabInOverflow>(<List> this.responsivePopover!.content[0]).items.find(item => {
-			return (<TabContainerTabInOverflow>item).realTabReference && (<TabContainerTabInOverflow>item).realTabReference.selected;
+		return <ITabPresentationInOverflow>(<List> this.responsivePopover!.content[0]).items.find(item => {
+			return (<ITabPresentationInOverflow>item).realTabReference && (<ITabPresentationInOverflow>item).realTabReference.selected;
 		});
 	}
 
 	_getFirstFocusableItemInOverflow() {
-		return <TabContainerTabInOverflow>(<List> this.responsivePopover!.content[0]).items.find(item => item.classList.contains("ui5-tab-overflow-item"));
+		return <ITabPresentationInOverflow>(<List> this.responsivePopover!.content[0]).items.find(item => item.classList.contains("ui5-tab-overflow-item"));
 	}
 
 	_onTabStripKeyDown(e: KeyboardEvent) {
@@ -1280,11 +1275,7 @@ class TabContainer extends UI5Element {
 			return "end-overflow";
 		}
 
-		if (opener instanceof Button) {
-			return (opener as TabContainerExpandButton).tab;
-		}
-
-		return (opener as ITabPresentation);
+		return getTabInStrip(opener) as ITabPresentation;
 	}
 
 	_getPopoverItemsFor(targetOwner: TabContainerPopoverOwner) {
@@ -1304,11 +1295,7 @@ class TabContainer extends UI5Element {
 			});
 		}
 
-		if (isTabInStrip(targetOwner)) {
-			return (targetOwner as ITabPresentation).realTabReference.subTabs!;
-		}
-
-		return (targetOwner as ITab).subTabs!;
+		return targetOwner.realTabReference.subTabs!;
 	}
 
 	_setPopoverItems(items: Array<ITab>) {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -103,7 +103,6 @@ interface ITab extends UI5Element {
 	forcedSelected?: boolean;
 	// >>>>
 	realTabReference: ITab;
-	tabs?: Array<ITab>
 }
 
 type TabContainerPopoverOwner = "start-overflow" | "end-overflow" | Tab;
@@ -669,7 +668,9 @@ class TabContainer extends UI5Element {
 			return;
 		}
 
-		if (!tab.realTabReference.hasOwnContent && tab.realTabReference.tabs.length) {
+		const tabHasSubTabs = tab.realTabReference.subTabs.some(item => !item.isSeparator);
+
+		if (!tab.realTabReference.hasOwnContent && tabHasSubTabs) {
 			await this._togglePopover(tab);
 
 			return;

--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -1,7 +1,7 @@
 <ui5-li-custom
 	id="{{this._id}}-li"
 	class="{{this.overflowClasses}}"
-	style="{{this.forcedStyle}}"
+	style="{{this._forcedStyleInOverflow}}"
 	type="{{this.overflowState}}"
 	aria-disabled="{{this.effectiveDisabled}}"
 	aria-selected="{{this.effectiveSelected}}"

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -4,8 +4,8 @@
 	role="tab"
 	aria-roledescription="{{_roleDescription}}"
 	aria-haspopup="{{_ariaHasPopup}}"
-	aria-posinset="{{this.forcedPosinset}}"
-	aria-setsize="{{this.forcedSetsize}}"
+	aria-posinset="{{this._forcedPosinset}}"
+	aria-setsize="{{this._forcedSetsize}}"
 	aria-controls="ui5-tc-content"
 	aria-selected="{{this.effectiveSelected}}"
 	aria-disabled="{{this.effectiveDisabled}}"
@@ -29,7 +29,7 @@
 	{{/if}}
 
 	<div class="ui5-tab-strip-itemContent">
-		{{#unless this.isInline}}
+		{{#unless this._isInline}}
 			{{> additionalText}}
 		{{/unless}}
 

--- a/packages/main/src/TabInStrip.hbs
+++ b/packages/main/src/TabInStrip.hbs
@@ -53,7 +53,6 @@
 		<div class="ui5-tab-expand-button-separator"></div>
 		<div class="ui5-tab-expand-button" @click="{{_onTabExpandButtonClick}}">
 			<ui5-button
-				.tab={{this}}
 				icon="slim-arrow-down"
 				design="Transparent"
 				tabindex="-1"

--- a/packages/main/src/TabSeparator.ts
+++ b/packages/main/src/TabSeparator.ts
@@ -4,7 +4,7 @@ import executeTemplate from "@ui5/webcomponents-base/dist/renderer/executeTempla
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import TabContainer from "./TabContainer.js";
-import type { ITab } from "./TabContainer.js";
+import type { ITab, ITabPresentationInOverflowInfo } from "./TabContainer.js";
 
 // Templates
 import TabSeparatorInStripTemplate from "./generated/templates/TabSeparatorInStripTemplate.lit.js";
@@ -30,6 +30,8 @@ import overflowCss from "./generated/themes/TabSeparatorInOverflow.css.js";
 class TabSeparator extends UI5Element implements ITab {
 	@property({ type: Object, defaultValue: null })
 	realTabReference!: TabSeparator;
+
+	_forcedStyleInOverflow?: Record<string, any>;
 
 	getElementInStrip?: () => ITab | null;
 
@@ -77,6 +79,12 @@ class TabSeparator extends UI5Element implements ITab {
 
 	get overflowPresentation() {
 		return executeTemplate(TabSeparator.overflowTemplate, this);
+	}
+
+	receiveStripPresentationInfo() {}
+
+	receiveOverflowPresentationInfo(info: ITabPresentationInOverflowInfo) {
+		this._forcedStyleInOverflow = info.style;
 	}
 }
 

--- a/packages/main/src/TabSeparator.ts
+++ b/packages/main/src/TabSeparator.ts
@@ -2,7 +2,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import executeTemplate from "@ui5/webcomponents-base/dist/renderer/executeTemplate.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import TabContainer from "./TabContainer.js";
 import type { ITab, ITabPresentationInOverflowInfo, ITabPresentationInStripInfo } from "./TabContainer.js";
 
@@ -28,9 +27,6 @@ import overflowCss from "./generated/themes/TabSeparatorInOverflow.css.js";
 	renderer: litRender,
 })
 class TabSeparator extends UI5Element implements ITab {
-	@property({ type: Object, defaultValue: null })
-	realTabReference!: TabSeparator;
-
 	_forcedStyleInOverflow?: Record<string, any>;
 	_getElementInStrip?: () => HTMLElement | undefined;
 

--- a/packages/main/src/TabSeparator.ts
+++ b/packages/main/src/TabSeparator.ts
@@ -4,7 +4,7 @@ import executeTemplate from "@ui5/webcomponents-base/dist/renderer/executeTempla
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import TabContainer from "./TabContainer.js";
-import type { ITab, ITabPresentationInOverflowInfo } from "./TabContainer.js";
+import type { ITab, ITabPresentationInOverflowInfo, ITabPresentationInStripInfo } from "./TabContainer.js";
 
 // Templates
 import TabSeparatorInStripTemplate from "./generated/templates/TabSeparatorInStripTemplate.lit.js";
@@ -32,8 +32,7 @@ class TabSeparator extends UI5Element implements ITab {
 	realTabReference!: TabSeparator;
 
 	_forcedStyleInOverflow?: Record<string, any>;
-
-	getElementInStrip?: () => ITab | null;
+	_getElementInStrip?: () => HTMLElement | undefined;
 
 	static get stripTemplate() {
 		return TabSeparatorInStripTemplate;
@@ -55,20 +54,6 @@ class TabSeparator extends UI5Element implements ITab {
 		return true;
 	}
 
-	/**
-	 * Returns the DOM reference of the separator that is placed in the header.
-	 *
-	 * **Note:** Tabs and separators, placed in the `subTabs` slot of other tabs are not shown in the header. Calling this method on such tabs or separators will return `null`.
-	 * @public
-	 */
-	getTabInStripDomRef(): ITab | null {
-		if (this.getElementInStrip) {
-			return this.getElementInStrip();
-		}
-
-		return null;
-	}
-
 	get stableDomRef() {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
@@ -81,10 +66,23 @@ class TabSeparator extends UI5Element implements ITab {
 		return executeTemplate(TabSeparator.overflowTemplate, this);
 	}
 
-	receiveStripPresentationInfo() {}
+	receiveStripPresentationInfo(info: ITabPresentationInStripInfo) {
+		this._getElementInStrip = info.getElementInStrip;
+	}
 
 	receiveOverflowPresentationInfo(info: ITabPresentationInOverflowInfo) {
 		this._forcedStyleInOverflow = info.style;
+	}
+
+	/**
+	 * Returns the DOM reference of the separator that is placed in the header.
+	 *
+	 * **Note:** Tabs and separators, placed in the `subTabs` slot of other tabs are not shown in the header. Calling this method on such tabs or separators will return `undefined`.
+	 * @public
+	 * @since 2.0.0
+	 */
+	getDomRefInStrip(): HTMLElement | undefined {
+		return this._getElementInStrip?.();
 	}
 }
 

--- a/packages/main/src/TabSeparatorInOverflow.hbs
+++ b/packages/main/src/TabSeparatorInOverflow.hbs
@@ -3,7 +3,7 @@
 	role="separator"
 	class="{{classes.root}}"
 	disabled
-	style="{{this._style}}"
+	style="{{this._forcedStyleInOverflow}}"
 	.realTabReference="{{this}}"
 >
 </ui5-li-custom>

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -259,20 +259,20 @@ describe("TabContainer general interaction", () => {
 
 	it("selecting a tab programatically will update the tab strip", async () => {
 		// Setup
-		const getTabInStripDomRef = tab => tab.getTabInStripDomRef();
+		const getTabDomRefInStrip = tab => tab.getDomRefInStrip();
 		const getElementInBrowser = el => document.querySelector(el);
 
 		const tabContainer = await browser.$("#tcSmall");
 		await tabContainer.scrollIntoView();
 
 		const firstTab = await browser.execute(getElementInBrowser, "#firstTab");
-		const firstTabInStrip = await browser.$(await browser.execute(getTabInStripDomRef, firstTab));
+		const firstTabInStrip = await browser.$(await browser.execute(getTabDomRefInStrip, firstTab));
 
 		const lastTab = await browser.execute(getElementInBrowser, "#lastTab");
-		const lastTabInStrip = await browser.$(await browser.execute(getTabInStripDomRef, lastTab));
+		const lastTabInStrip = await browser.$(await browser.execute(getTabDomRefInStrip, lastTab));
 
 		const nestedTabParentTab = await browser.execute(getElementInBrowser, "#nestedTabParent");
-		const nestedTabParentInTabStrip = await browser.$(await browser.execute(getTabInStripDomRef, nestedTabParentTab));
+		const nestedTabParentInTabStrip = await browser.$(await browser.execute(getTabDomRefInStrip, nestedTabParentTab));
 
 		// Assert
 		assert.notOk(await lastTabInStrip.isDisplayed(), "last tab in strip is not visible");
@@ -330,7 +330,7 @@ describe("TabContainer general interaction", () => {
 		// Assert
 		assert.ok(productsTabDomRef.isEqual(productsTabStableDomRef) , "Stable dom ref of the tab is the same as its dom ref");
 
-		const productsTabDomRefInStrip = await browser.$(() => document.querySelector("[stable-dom-ref='products-ref']").getTabInStripDomRef());
+		const productsTabDomRefInStrip = await browser.$(() => document.querySelector("[stable-dom-ref='products-ref']").getDomRefInStrip());
 		const productsTabDomRefInStripExpected = await browser.$(() => document.getElementById("tabContainer1").getDomRef().querySelector(".ui5-tab-strip-item:first-child"));
 
 		// Assert
@@ -349,7 +349,7 @@ describe("TabContainer general interaction", () => {
 	it("test that tab can be focused right after is inserted in the tab container", async () => {
 		await browser.$("#insertAndFocusNewTab").click();
 		const isNewTabFocused = await browser.executeAsync((done) => {
-			const tabInStripDomRef = document.getElementById("newlyInsertedFocusedTab").getTabInStripDomRef();
+			const tabInStripDomRef = document.getElementById("newlyInsertedFocusedTab").getDomRefInStrip();
 			const activeElement = document.activeElement.shadowRoot.activeElement;
 
 			done(tabInStripDomRef === activeElement);


### PR DESCRIPTION
- Replaces `isInline`, `forcedMixedMode`, `forcedPosinset`, `forcedSetsize`, `isTopLevelTab`, `getElementInStrip` with 2 new methods: `receiveStripPresentationInfo(info)` and `receiveOverflowPresentationInfo(info)`. This way it is clear that those properties are not expected to be set by the ITab implementer, but provided by the TabContainer to the ITab implementer
- Adds `stripPresentation()` and `overflowPresentation()` getters, to make it clear that ITab implementer has to provide these templates
- Renames `getTabInStripDomRef` to `getDomRefInStrip` and makes its return type match `UI5Element#getDomRef`
- Removes `realTabReference` to avoid confusion that tab presentations and tabs are the same thing. Only tab presentations have `realTabReference`
- Removes `forcedStyle` and `forcedLevel`. They were set and used only by the TabContainer.

BREAKING CHANGE: If your class implements the `ITab` interface, it must also provide `receiveOverflowPresentationInfo`, `receiveStripPresentationInfo`, `getDomRefInStrip`, `stripPresentation` and `overflowPresentation`. The rest of the properties are obsolete and can be deleted.
```ts
import type { ITab } from "@ui5/webcomponents-base/dist/TabContainer.js";
class MyTab implements ITab {
    getDomRefInStrip(): HTMLElement | undefined {
        return ...
    }
    receiveOverflowPresentationInfo(info) {
       // provides info for your overflow presentation
    }
    receiveStripPresentationInfo(info) {
        // provides info for your strip presentation
    }
    stripPresentation() {
       // this method was required prior this change, but it is not made clear
       // return strip presentation template
    }
    overflowPresentation() {
       // this method was required prior this change, but it is not made clear
       // return overflow presentation template
    }
}
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461 
