### PR TITLE
refactor(ui5-card): remove ICardHeader interface

### DIFF
--- a/packages/main/src/Card.ts
+++ b/packages/main/src/Card.ts
@@ -12,20 +12,10 @@ import {
 	ARIA_ROLEDESCRIPTION_CARD,
 	ARIA_LABEL_CARD_CONTENT,
 } from "./generated/i18n/i18n-defaults.js";
+import type CardHeader from "./CardHeader.js";
 
 // Styles
 import cardCss from "./generated/themes/Card.css.js";
-
-/**
- * Interface for components that may be slotted inside `ui5-card` as header
- * @public
- */
-interface ICardHeader extends HTMLElement {
-	subtitleText: string,
-	titleText: string,
-	status: string,
-	interactive: boolean,
-}
 
 /**
  * @class
@@ -40,7 +30,7 @@ interface ICardHeader extends HTMLElement {
  *
  * ### ES6 Module Import
  *
- * `import "@ui5/webcomponents/dist/Card";`
+ * `import "@ui5/webcomponents/dist/Card.js";`
  *
  * `import "@ui5/webcomponents/dist/CardHeader.js";` (for `ui5-card-header`)
  * @constructor
@@ -93,7 +83,7 @@ class Card extends UI5Element {
 	 * @public
 	*/
 	@slot({ type: HTMLElement, invalidateOnChildChange: true })
-	header!: Array<ICardHeader>;
+	header!: Array<CardHeader>;
 
 	static i18nBundle: I18nBundle;
 
@@ -129,7 +119,3 @@ class Card extends UI5Element {
 Card.define();
 
 export default Card;
-
-export type {
-	ICardHeader,
-};

--- a/packages/main/src/CardHeader.ts
+++ b/packages/main/src/CardHeader.ts
@@ -9,7 +9,6 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isFirefox } from "@ui5/webcomponents-base/dist/Device.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
-import type { ICardHeader } from "./Card.js";
 import CardHeaderTemplate from "./generated/templates/CardHeaderTemplate.lit.js";
 
 import {
@@ -36,7 +35,6 @@ import cardHeaderCss from "./generated/themes/CardHeader.css.js";
  *
  * `import "@ui5/webcomponents/dist/CardHeader";`
  * @constructor
- * @implements {ICardHeader}
  * @extends UI5Element
  * @public
  * @since 1.0.0-rc.15
@@ -59,7 +57,7 @@ import cardHeaderCss from "./generated/themes/CardHeader.css.js";
  * @public
  */
 @event("click")
-class CardHeader extends UI5Element implements ICardHeader {
+class CardHeader extends UI5Element {
 	/**
 	 * Defines the title text.
 	 * @default ""
@@ -238,6 +236,3 @@ class CardHeader extends UI5Element implements ICardHeader {
 CardHeader.define();
 
 export default CardHeader;
-export type {
-	ICardHeader,
-};


### PR DESCRIPTION
Removes the `ICardHeader` interface as no other header types are currently supported or requested.

BREAKING CHANGE: Removed the `ICardHeader` interface. If you previously used the interface
```ts
import type { ICardHeader } from "@ui5/webcomponents-base/dist/Card.js"
```
Use the CardHeader type instead:
```ts
import type CardHeader from "@ui5/webcomponents-base/dist/CardHeader.js"
```

Related to [#8461](https://github.com/SAP/ui5-webcomponents/issues/8461)