### PR TITLE
refactor(ui5-popover): rename enum values

### DIFF
--- a/packages/fiori/src/NotificationOverflowActionsPopover.hbs
+++ b/packages/fiori/src/NotificationOverflowActionsPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-popover
 	class="ui5-notification-overflow-popover"
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	hide-arrow
 >
 	<div class="ui5-notification-overflow-list">

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -28,6 +28,7 @@ import "@ui5/webcomponents-icons/dist/overflow.js";
 import "@ui5/webcomponents-icons/dist/grid.js";
 import type { Timeout, ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import type ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
+import PopoverHorizontalAlign from "@ui5/webcomponents/dist/types/PopoverHorizontalAlign.js";
 import type ShellBarItem from "./ShellBarItem.js";
 
 // Templates
@@ -1208,8 +1209,8 @@ class ShellBar extends UI5Element {
 		return this.primaryTitle || this.showLogoInMenuButton;
 	}
 
-	get popoverHorizontalAlign() {
-		return this.effectiveDir === "rtl" ? "Left" : "Right";
+	get popoverHorizontalAlign(): `${PopoverHorizontalAlign}` {
+		return this.effectiveDir === "rtl" ? "Start" : "End";
 	}
 
 	get hasSearchField() {

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -178,7 +178,7 @@
 
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
-	<ui5-popover id="notificationsPopover" class="notificationlistgroupitem2auto" placement-type="Bottom" horizontal-align="Right">
+	<ui5-popover id="notificationsPopover" class="notificationlistgroupitem2auto" placement-type="Bottom" horizontal-align="End">
 		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'">
 			<ui5-li-notification-group
 				show-close

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -146,7 +146,7 @@
 
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
-	<ui5-popover id="notificationsPopover" class="notificationlistitem2auto" placement-type="Bottom" horizontal-align="Right">
+	<ui5-popover id="notificationsPopover" class="notificationlistitem2auto" placement-type="Bottom" horizontal-align="End">
 		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'">
 			<ui5-li-notification
 				show-close

--- a/packages/fiori/test/samples/NotificationListGroupItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListGroupItem.sample.html
@@ -186,7 +186,7 @@
 		>
 		</ui5-shellbar>
 
-		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="Right">
+		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="End">
 			<ui5-list id="notificationListTop" header-text="Notifications grouped">
 				<ui5-li-notification-group
 					show-close
@@ -329,7 +329,7 @@
 	id="notificationsPopover"
 	style="max-width: 400px"
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 >
 	<ui5-list header-text="Notifications">
 		<ui5-li-notification-group

--- a/packages/fiori/test/samples/NotificationListItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListItem.sample.html
@@ -190,7 +190,7 @@
 		>
 		</ui5-shellbar>
 
-		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="Right">
+		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="End">
 			<ui5-list id="notificationListTop" header-text="Notifications">
 				<ui5-li-notification
 					show-close

--- a/packages/main/src/BreadcrumbsPopover.hbs
+++ b/packages/main/src/BreadcrumbsPopover.hbs
@@ -3,7 +3,7 @@
 	hide-arrow
 	content-only-on-desktop
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	_hide-header
 	@keydown="{{_onkeydown}}">
 	<ui5-list mode="SingleSelect"

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -1195,7 +1195,7 @@ class ComboBox extends UI5Element {
 	}
 
 	get _valueStatePopoverHorizontalAlign(): `${PopoverHorizontalAlign}` {
-		return this.effectiveDir !== "rtl" ? PopoverHorizontalAlign.Left : PopoverHorizontalAlign.Right;
+		return this.effectiveDir !== "rtl" ? PopoverHorizontalAlign.Start : PopoverHorizontalAlign.End;
 	}
 
 	/**

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -2,7 +2,7 @@
 	class="{{classes.popover}}"
 	hide-arrow
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	style="{{styles.suggestionsPopover}}"
 	@ui5-after-open={{_afterOpenPopover}}
 	@ui5-after-close={{_afterClosePopover}}

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -2,7 +2,7 @@
 	id="{{_id}}-responsive-popover"
 	allow-target-overlap
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	hide-arrow
 	?_hide-header={{_shouldHideHeader}}
 	@keydown="{{_onkeydown}}"

--- a/packages/main/src/FileUploaderPopover.hbs
+++ b/packages/main/src/FileUploaderPopover.hbs
@@ -5,7 +5,7 @@
 	hide-arrow
 	class="ui5-valuestatemessage-popover"
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 >
 	<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">
 		{{#if _valueStateMessageInputIcon}}

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -57,6 +57,7 @@ import Popover from "./Popover.js";
 import Icon from "./Icon.js";
 import type { IIcon } from "./Icon.js";
 import type ListItemType from "./types/ListItemType.js";
+import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 // Templates
 import InputTemplate from "./generated/templates/InputTemplate.lit.js";
 import InputPopoverTemplate from "./generated/templates/InputPopoverTemplate.lit.js";
@@ -1677,8 +1678,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		return "";
 	}
 
-	get _valueStatePopoverHorizontalAlign() {
-		return this.effectiveDir !== "rtl" ? "Left" : "Right";
+	get _valueStatePopoverHorizontalAlign(): `${PopoverHorizontalAlign}` {
+		return this.effectiveDir !== "rtl" ? "Start" : "End";
 	}
 
 	/**

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -4,7 +4,7 @@
 		hide-arrow
 		_disable-initial-focus
 		placement-type="Bottom"
-		horizontal-align="Left"
+		horizontal-align="Start"
 		style="{{styles.suggestionsPopover}}"
 		@ui5-after-open="{{_afterOpenPopover}}"
 		@ui5-after-close="{{_afterClosePopover}}"

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	id="{{_id}}-menu-rp"
 	class="ui5-menu-rp"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	placement-type={{placementType}}
 	vertical-align={{verticalAlign}}
 	hide-arrow

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -29,6 +29,7 @@ import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import BusyIndicator from "./BusyIndicator.js";
 import type MenuItem from "./MenuItem.js";
+import PopoverPlacementType from "./types/PopoverPlacementType.js";
 import type { ListItemClickEventDetail } from "./List.js";
 import staticAreaMenuTemplate from "./generated/templates/MenuTemplate.lit.js";
 import {
@@ -344,8 +345,8 @@ class Menu extends UI5Element {
 		return this.effectiveDir === "rtl";
 	}
 
-	get placementType() {
-		const placement = this.isRtl ? "Left" : "Right";
+	get placementType(): `${PopoverPlacementType}` {
+		const placement = this.isRtl ? "Start" : "End";
 		return this._isSubMenu ? placement : "Bottom";
 	}
 

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -106,6 +106,7 @@ import type FormSupportT from "./features/InputElementsFormSupport.js";
 import type ListItemBase from "./ListItemBase.js";
 import CheckBox from "./CheckBox.js";
 import Input, { InputEventDetail } from "./Input.js";
+import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 
 /**
  * Interface for components that may be slotted inside a `ui5-multi-combobox` as items
@@ -1881,8 +1882,8 @@ class MultiComboBox extends UI5Element {
 		return shouldBeExpanded;
 	}
 
-	get _valueStatePopoverHorizontalAlign() {
-		return this.effectiveDir !== "rtl" ? "Left" : "Right";
+	get _valueStatePopoverHorizontalAlign(): `${PopoverHorizontalAlign}` {
+		return this.effectiveDir !== "rtl" ? "Start" : "End";
 	}
 
 	get iconsCount() {

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-responsive-popover
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	class="{{classes.popover}}"
 	hide-arrow
 	_disable-initial-focus

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -105,10 +105,10 @@ class Popover extends Popup {
 
 	/**
 	 * Determines on which side the component is placed at.
-	 * @default "Right"
+	 * @default "End"
 	 * @public
 	 */
-	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.Right })
+	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.End })
 	placementType!: `${PopoverPlacementType}`;
 
 	/**
@@ -199,7 +199,7 @@ class Popover extends Popup {
 	 * Returns the calculated placement depending on the free space
 	 * @private
 	 */
-	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.Right })
+	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.End })
 	actualPlacementType!: `${PopoverPlacementType}`;
 
 	@property({ validator: Integer, noAttribute: true })
@@ -313,8 +313,8 @@ class Popover extends Popup {
 	shouldCloseDueToOverflow(placement: `${PopoverPlacementType}`, openerRect: DOMRect): boolean {
 		const threshold = 32;
 		const limits = {
-			"Right": openerRect.right,
-			"Left": openerRect.left,
+			"Start": openerRect.right,
+			"End": openerRect.left,
 			"Top": openerRect.top,
 			"Bottom": openerRect.bottom,
 		};
@@ -400,7 +400,7 @@ class Popover extends Popup {
 			document.documentElement.clientWidth - popoverSize.width - Popover.VIEWPORT_MARGIN,
 		);
 
-		if (this.actualPlacementType === PopoverPlacementType.Right) {
+		if (this.actualPlacementType === PopoverPlacementType.End) {
 			left = Math.max(left, this._left!);
 		}
 
@@ -533,7 +533,7 @@ class Popover extends Popup {
 				maxHeight = clientHeight - targetRect.bottom - arrowOffset;
 			}
 			break;
-		case PopoverPlacementType.Left:
+		case PopoverPlacementType.Start:
 			left = Math.max(targetRect.left - popoverSize.width - arrowOffset, 0);
 			top = this.getHorizontalTop(targetRect, popoverSize);
 
@@ -541,7 +541,7 @@ class Popover extends Popup {
 				maxWidth = targetRect.left - arrowOffset;
 			}
 			break;
-		case PopoverPlacementType.Right:
+		case PopoverPlacementType.End:
 			left = targetRect.left + targetRect.width + arrowOffset;
 			top = this.getHorizontalTop(targetRect, popoverSize);
 
@@ -605,11 +605,11 @@ class Popover extends Popup {
 		const horizontalAlign = this._actualHorizontalAlign;
 		let arrowXCentered = horizontalAlign === PopoverHorizontalAlign.Center || horizontalAlign === PopoverHorizontalAlign.Stretch;
 
-		if (horizontalAlign === PopoverHorizontalAlign.Right && left <= targetRect.left) {
+		if (horizontalAlign === PopoverHorizontalAlign.End && left <= targetRect.left) {
 			arrowXCentered = true;
 		}
 
-		if (horizontalAlign === PopoverHorizontalAlign.Left && left + popoverSize.width >= targetRect.left + targetRect.width) {
+		if (horizontalAlign === PopoverHorizontalAlign.Start && left + popoverSize.width >= targetRect.left + targetRect.width) {
 			arrowXCentered = true;
 		}
 
@@ -651,11 +651,11 @@ class Popover extends Popup {
 	 */
 	fallbackPlacement(clientWidth: number, clientHeight: number, targetRect: DOMRect, popoverSize: PopoverSize): PopoverPlacementType | undefined {
 		if (targetRect.left > popoverSize.width) {
-			return PopoverPlacementType.Left;
+			return PopoverPlacementType.Start;
 		}
 
 		if (clientWidth - targetRect.right > targetRect.left) {
-			return PopoverPlacementType.Right;
+			return PopoverPlacementType.End;
 		}
 
 		if (clientHeight - targetRect.bottom > popoverSize.height) {
@@ -687,12 +687,12 @@ class Popover extends Popup {
 				actualPlacementType = PopoverPlacementType.Top;
 			}
 			break;
-		case PopoverPlacementType.Left:
+		case PopoverPlacementType.Start:
 			if (targetRect.left < popoverSize.width) {
 				actualPlacementType = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placementType;
 			}
 			break;
-		case PopoverPlacementType.Right:
+		case PopoverPlacementType.End:
 			if (clientWidth - targetRect.right < popoverSize.width) {
 				actualPlacementType = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placementType;
 			}
@@ -711,10 +711,10 @@ class Popover extends Popup {
 		case PopoverHorizontalAlign.Stretch:
 			left = targetRect.left - (popoverSize.width - targetRect.width) / 2;
 			break;
-		case PopoverHorizontalAlign.Left:
+		case PopoverHorizontalAlign.Start:
 			left = targetRect.left;
 			break;
-		case PopoverHorizontalAlign.Right:
+		case PopoverHorizontalAlign.End:
 			left = targetRect.right - popoverSize.width;
 			break;
 		}
@@ -793,12 +793,12 @@ class Popover extends Popup {
 
 	get _actualHorizontalAlign() {
 		if (this.effectiveDir === "rtl") {
-			if (this.horizontalAlign === PopoverHorizontalAlign.Left) {
-				return PopoverHorizontalAlign.Right;
+			if (this.horizontalAlign === PopoverHorizontalAlign.Start) {
+				return PopoverHorizontalAlign.End;
 			}
 
-			if (this.horizontalAlign === PopoverHorizontalAlign.Right) {
-				return PopoverHorizontalAlign.Left;
+			if (this.horizontalAlign === PopoverHorizontalAlign.End) {
+				return PopoverHorizontalAlign.Start;
 			}
 		}
 

--- a/packages/main/src/SelectMenu.hbs
+++ b/packages/main/src/SelectMenu.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	class="ui5-select-menu"
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	@ui5-after-open="{{_onAfterOpen}}"
 	@ui5-after-close="{{_onAfterClose}}"
 	@ui5-before-open="{{_onBeforeOpen}}"

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -4,7 +4,7 @@
 		_disable-initial-focus
 		placement-type="Bottom"
 		class="ui5-select-popover {{classes.popover}}"
-		horizontal-align="Left"
+		horizontal-align="Start"
 		@ui5-after-open="{{_afterOpen}}"
 		@ui5-before-open="{{_beforeOpen}}"
 		@ui5-after-close="{{_afterClose}}"
@@ -71,7 +71,7 @@
 		hide-arrow
 		class="ui5-valuestatemessage-popover"
 		placement-type="Bottom"
-		horizontal-align="Left"
+		horizontal-align="Start"
 	>
 		<div class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">
 			<ui5-icon class="ui5-input-value-state-message-icon" name="{{_valueStateMessageInputIcon}}"></ui5-icon>

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-responsive-popover
 	id="{{_id}}-overflowMenu"
-	horizontal-align="Right"
+	horizontal-align="End"
 	placement-type="Bottom"
 	content-only-on-desktop
 	hide-arrow

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -16,6 +16,7 @@ import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { isEscape } from "@ui5/webcomponents-base/dist/Keys.js";
 import Popover from "./Popover.js";
 import Icon from "./Icon.js";
+import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 import "@ui5/webcomponents-icons/dist/error.js";
 import "@ui5/webcomponents-icons/dist/alert.js";
 import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
@@ -617,8 +618,8 @@ class TextArea extends UI5Element implements IFormElement {
 		return this.valueStateMessage.map(x => x.cloneNode(true));
 	}
 
-	get _valueStatePopoverHorizontalAlign() {
-		return this.effectiveDir !== "rtl" ? "Left" : "Right";
+	get _valueStatePopoverHorizontalAlign(): `${PopoverHorizontalAlign}` {
+		return this.effectiveDir !== "rtl" ? "Start" : "End";
 	}
 
 	/**

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -2,7 +2,7 @@
 	id="{{_id}}-responsive-popover"
 	class="ui5-time-picker-popover"
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	allow-target-overlap
 	_hide-header
 	hide-arrow
@@ -31,7 +31,7 @@
 	id="{{_id}}-popover"
 	class="ui5-time-picker-inputs-popover"
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	allow-target-overlap
 	_hide-header
 	hide-arrow

--- a/packages/main/src/TokenizerPopover.hbs
+++ b/packages/main/src/TokenizerPopover.hbs
@@ -5,7 +5,7 @@
 	?content-only-on-desktop="{{noValueStatePopover}}"
 	hide-arrow
 	placement-type="Bottom"
-	horizontal-align="Left"
+	horizontal-align="Start"
 	@before-close={{handleBeforeClose}}
 	@before-open="{{handleBeforeOpen}}"
 >

--- a/packages/main/src/ToolbarPopover.hbs
+++ b/packages/main/src/ToolbarPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-popover
 	class="ui5-overflow-popover"
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	@ui5-after-close="{{onOverflowPopoverClosed}}"
 	@ui5-after-open="{{onOverflowPopoverOpened}}"
 	hide-arrow

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -113,7 +113,7 @@
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);
 }
 
-.ui5-menu-rp[sub-menu][actual-placement-type="Left"] {
+.ui5-menu-rp[sub-menu][actual-placement-type="Start"] {
 	margin-top: 0.25rem;
 	margin-inline: var(--_ui5_menu_submenu_placement_type_left_margin_offset);
 }

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -28,13 +28,13 @@
 }
 
 /* pointing right arrow */
-:host([actual-placement-type="Left"]) .ui5-popover-arrow {
+:host([actual-placement-type="Start"]) .ui5-popover-arrow {
 	top: calc(50% - 0.5625rem);
 	right: -0.5625rem;
 	width: 0.5625rem;
 }
 
-:host([actual-placement-type="Left"]) .ui5-popover-arrow:after {
+:host([actual-placement-type="Start"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_right_arrow_margin);
 }
 
@@ -51,7 +51,7 @@
 
 /* pointing left arrow */
 :host(:not([actual-placement-type])) .ui5-popover-arrow,
-:host([actual-placement-type="Right"]) .ui5-popover-arrow {
+:host([actual-placement-type="End"]) .ui5-popover-arrow {
 	left: -0.5625rem;
 	top: calc(50% - 0.5625rem);
 	width: 0.5625rem;
@@ -59,7 +59,7 @@
 }
 
 :host(:not([actual-placement-type])) .ui5-popover-arrow:after,
-:host([actual-placement-type="Right"]) .ui5-popover-arrow:after {
+:host([actual-placement-type="End"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_left_arrow_margin);
 }
 

--- a/packages/main/src/types/PopoverHorizontalAlign.ts
+++ b/packages/main/src/types/PopoverHorizontalAlign.ts
@@ -10,16 +10,16 @@ enum PopoverHorizontalAlign {
 	Center = "Center",
 
 	/**
-	 * Popover is aligned with the left side of the target. When direction is RTL, it is right aligned.
+	 * Popover is aligned with the start of the target.
 	 * @public
 	 */
-	Left = "Left",
+	Start = "Start",
 
 	/**
-	 * Popover is aligned with the right side of the target. When direction is RTL, it is left aligned.
+	 * Popover is aligned with the end of the target.
 	 * @public
 	 */
-	Right = "Right",
+	End = "End",
 
 	/**
 	 * Popover is stretched.

--- a/packages/main/src/types/PopoverPlacementType.ts
+++ b/packages/main/src/types/PopoverPlacementType.ts
@@ -4,16 +4,16 @@
  */
 enum PopoverPlacementType {
 	/**
-	 * Popover will be placed at the left side of the reference element.
+	 * Popover will be placed at the start of the reference element.
 	 * @public
 	 */
-	Left = "Left",
+	Start = "Start",
 
 	/**
-	 * Popover will be placed at the right side of the reference element.
+	 * Popover will be placed at the end of the reference element.
 	 * @public
 	 */
-	Right = "Right",
+	End = "End",
 
 	/**
 	 * Popover will be placed at the top of the reference element.

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -78,7 +78,7 @@
 	<div class="input_quickview6auto">Test mouseover on item</div>
 	<ui5-input id="mouseoverResult" class="input_quickview7auto"></ui5-input>
 
-	<ui5-popover id="quickViewCard2" hide-arrow placement-type="Right" height="500px">
+	<ui5-popover id="quickViewCard2" hide-arrow placement-type="End" height="500px">
 		<ui5-input id="searchInput2" class="input_quickview4auto">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -322,12 +322,12 @@
 		</section>
 
 		<section class="kitchen6auto">
-			<ui5-date-picker class="kitchen7auto" id="myDatepicker" value="Jun 06, 2018" popover-horizontal-align="Left"></ui5-date-picker>
+			<ui5-date-picker class="kitchen7auto" id="myDatepicker" value="Jun 06, 2018"></ui5-date-picker>
 			<ui5-date-picker class="kitchen7auto" id="myDatepicker1"></ui5-date-picker>
 		</section>
 
 		<section class="kitchen6auto">
-			<ui5-datetime-picker class="kitchen7auto" id="myDateTimepicker" value="Jun 06, 2018" popover-horizontal-align="Left"></ui5-datetime-picker>
+			<ui5-datetime-picker class="kitchen7auto" id="myDateTimepicker" value="Jun 06, 2018"></ui5-datetime-picker>
 			<ui5-datetime-picker class="kitchen7auto" id="myDateTimepicker1"></ui5-datetime-picker>
 		</section>
 

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -309,7 +309,7 @@
 		<section class="kitchen_openui59auto">
 			<div id="sapMDatePicker"></div>
 
-			<ui5-date-picker class="kitchen_openui510auto" id="myDatepicker" value="Jun 06, 2018" popover-horizontal-align="Left"></ui5-date-picker>
+			<ui5-date-picker class="kitchen_openui510auto" id="myDatepicker" value="Jun 06, 2018"></ui5-date-picker>
 			<ui5-date-picker class="kitchen_openui510auto" id="myDatepicker"></ui5-date-picker>
 		</section>
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -210,21 +210,21 @@ z-index: 1;
 	<ui5-button id="btnMoveFocus">focusable element</ui5-button>
 	<br>
 	<br>
-	<ui5-title>placement-type="Right" (default)</ui5-title>
-	<p>No space on the Right, try Left, Bottom, Top</p>
+	<ui5-title>placement-type="End" (default)</ui5-title>
+	<p>No space on the End, try Start, Bottom, Top</p>
 	<ui5-button id="btnFullWidth" class="fullWidth">Click me !</ui5-button>
 	<ui5-button id="btnNormalWidth">Click me !</ui5-button>
 	<br>
 	<br>
-	<ui5-title>placement-type="Right" (default) and allow-target-overlap=true </ui5-title>
-	<p>No space on the right, try Left, Bottom, Top and if nothing works, the target will be overlapped</p>
+	<ui5-title>placement-type="End" (default) and allow-target-overlap=true </ui5-title>
+	<p>No space on the End, try Start, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthTargetOverlap" class="fullWidth">Click me !</ui5-button>
 	<ui5-button id="btnNormalWidthTargetOverlap">Click me !</ui5-button>
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Left"</ui5-title>
-	<p>No space on the Left, try Right, Bottom, Top</p>
+	<ui5-title>placement-type="Start"</ui5-title>
+	<p>No space on the Start, try End, Bottom, Top</p>
 	<ui5-button id="btnFullWidthLeft" class="fullWidth">Click me !</ui5-button>
 	<div class="popover13auto">
 		<ui5-button id="btnNormalWidthLeft">Click me !</ui5-button>
@@ -232,8 +232,8 @@ z-index: 1;
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Left" and allow-target-overlap=true</ui5-title>
-	<p>No space on the right, try Right, Bottom, Top and if nothing works, the target will be overlapped</p>
+	<ui5-title>placement-type="Start" and allow-target-overlap=true</ui5-title>
+	<p>No space on the Start, try End, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthLeftTargetOverlap" class="fullWidth">Click me !</ui5-button>
 	<div class="popover13auto">
 		<ui5-button id="btnNormalWidthLeftTargetOverlap">Click me !</ui5-button>
@@ -282,7 +282,7 @@ z-index: 1;
 	</ui5-popover>
 
 
-	<ui5-popover header-text="My Heading" id="popFullWidthLeft" class="popover6auto" placement-type="Left">
+	<ui5-popover header-text="My Heading" id="popFullWidthLeft" class="popover6auto" placement-type="Start">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -294,7 +294,7 @@ z-index: 1;
 		</ui5-list>
 	</ui5-popover>
 
-	<ui5-popover header-text="My Heading" id="popFullWidthLeftTargetOverlap" class="popover6auto" placement-type="Left" allow-target-overlap>
+	<ui5-popover header-text="My Heading" id="popFullWidthLeftTargetOverlap" class="popover6auto" placement-type="Start" allow-target-overlap>
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -332,7 +332,7 @@ z-index: 1;
 	</ui5-popover>
 
 
-	<ui5-popover id="quickViewCard" placement-type="Right" height="500px">
+	<ui5-popover id="quickViewCard" placement-type="End" height="500px">
 		<ui5-input id="searchInput" class="popover6auto">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>
@@ -350,11 +350,11 @@ z-index: 1;
 
 
 	<div class="popover11auto">
-		<p>Right-aligned Popover, wider than button, arrow should be centered on the button</p>
+		<p>End-aligned Popover, wider than button, arrow should be centered on the button</p>
 		<ui5-button id="btnOpenXRightWide">Open</ui5-button>
 	</div>
 
-	<ui5-popover id="popXRightWide" placement-type="Bottom" horizontal-align="Right">
+	<ui5-popover id="popXRightWide" placement-type="Bottom" horizontal-align="End">
 		Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni architecto tenetur quia nam reprehenderit quas eveniet possimus similique quisquam culpa distinctio ex doloremque molestiae maxime sed harum, in exercitationem! Incidunt?
 	</ui5-popover>
 
@@ -434,8 +434,8 @@ z-index: 1;
 	<div>
 		<ui5-radio-button name="horizontalAlign" checked text="Center"></ui5-radio-button>
 		<ui5-radio-button name="horizontalAlign" text="Stretch"></ui5-radio-button>
-		<ui5-radio-button name="horizontalAlign" text="Left"></ui5-radio-button>
-		<ui5-radio-button name="horizontalAlign" text="Right"></ui5-radio-button>
+		<ui5-radio-button name="horizontalAlign" text="Start"></ui5-radio-button>
+		<ui5-radio-button name="horizontalAlign" text="End"></ui5-radio-button>
 	</div>
 	<div>
 		<ui5-checkbox id="rtlCb" text="rtl"></ui5-checkbox>

--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -18,12 +18,12 @@
 </head>
 
 <body class="sapUiSizeCompact">
-	<ui5-button id="myBtn1" data-placement-type="Left" class="myBtn">1</ui5-button>
-	<ui5-button id="myBtn2" data-placement-type="Left" data-vertical-align="Top" class="myBtn">2</ui5-button>
+	<ui5-button id="myBtn1" data-placement-type="Start" class="myBtn">1</ui5-button>
+	<ui5-button id="myBtn2" data-placement-type="Start" data-vertical-align="Top" class="myBtn">2</ui5-button>
 	<ui5-button id="myBtn3" data-placement-type="Bottom" class="myBtn">3</ui5-button>
 	<ui5-button id="myBtn4" data-placement-type="Top" class="myBtn">4</ui5-button>
-	<ui5-button id="myBtn5" data-placement-type="Left" class="myBtn">5</ui5-button>
-	<ui5-button id="myBtn6" data-placement-type="Left" class="myBtn">6</ui5-button>
+	<ui5-button id="myBtn5" data-placement-type="Start" class="myBtn">5</ui5-button>
+	<ui5-button id="myBtn6" data-placement-type="Start" class="myBtn">6</ui5-button>
 
 	<ui5-toggle-button id="customSizeBtn">Bigger Popover</ui5-toggle-button>
 

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -81,7 +81,7 @@
 				<ui5-button class="wcBtnOpenNewDialog">Open New Dialog</ui5-button>
 				<ui5-button class="wcBtnCloseDialog">Close Dialog</ui5-button>
 
-				<ui5-popover placement-type="Right" class="wcNewDialogPopover" header-text="Second Popover">
+				<ui5-popover placement-type="End" class="wcNewDialogPopover" header-text="Second Popover">
 					<ui5-button class="wcBtnOpenNewPopoverDialog1">Open New Popover </ui5-button>
 					<ui5-button class="wcBtnClosePopoverDialog1">Popover Button</ui5-button>
 				</ui5-popover>
@@ -111,7 +111,7 @@
 				<ui5-button>Accept</ui5-button>
 			</div>
 			<ui5-date-picker></ui5-date-picker>
-			<ui5-popover placement-type="Right" class="wcNewPopover" header-text="Second Popover">
+			<ui5-popover placement-type="End" class="wcNewPopover" header-text="Second Popover">
 				<ui5-button class="wcBtnOpenNewPopover1">Open New Popover </ui5-button>
 				<ui5-button class="wcBtnClosePopover1">Popover Button</ui5-button>
 			</ui5-popover>

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -481,8 +481,8 @@ describe("Alignment", () => {
 			assert.ok(await isHorizontallyCentered(popover, opener), `Popover should be centered`);
 		});
 
-		it("Left", async () => {
-			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Left']").click();
+		it("Start", async () => {
+			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Start']").click();
 			await browser.$("#horizontalAlignBtn").click();
 			const popover = await browser.$("#popoverHorizontalAlign");
 			const opener = await browser.$("#targetOpener");
@@ -490,8 +490,8 @@ describe("Alignment", () => {
 			assert.ok(await isHorizontallyLeftAligned(popover, opener), `Popover should be left aligned`);
 		});
 
-		it("Right", async () => {
-			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Right']").click();
+		it("End", async () => {
+			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='End']").click();
 			await browser.$("#horizontalAlignBtn").click();
 			const popover = await browser.$("#popoverHorizontalAlign");
 			const opener = await browser.$("#targetOpener");
@@ -509,8 +509,8 @@ describe("Alignment", () => {
 			assert.ok(await isHorizontallyCentered(popover, opener), `Popover should be centered`);
 		});
 
-		it("Left, in RTL", async () => {
-			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Left']").click();
+		it("Start, in RTL", async () => {
+			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Start']").click();
 			await browser.$("#horizontalAlignBtn").click();
 			const popover = await browser.$("#popoverHorizontalAlign");
 			const opener = await browser.$("#targetOpener");
@@ -518,8 +518,8 @@ describe("Alignment", () => {
 			assert.ok(isHorizontallyRightAligned(popover, opener), `Popover should be right aligned, flipped by RTL direction`);
 		});
 
-		it("Right, in RTL", async () => {
-			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='Right']").click();
+		it("End, in RTL", async () => {
+			await browser.$("[ui5-radio-button][name='horizontalAlign'][text='End']").click();
 			await browser.$("#horizontalAlignBtn").click();
 			const popover = await browser.$("#popoverHorizontalAlign");
 			const opener = await browser.$("#targetOpener");

--- a/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
@@ -215,7 +215,7 @@ InShellBar.decorators = [
 ></ui5-shellbar>
 <ui5-popover
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	id="popover-with-notifications"
 >
 	${wrapInList(story)}

--- a/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
@@ -195,7 +195,7 @@ InShellBar.decorators = [
 ></ui5-shellbar>
 <ui5-popover
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	id="popover-with-notifications"
 >
 	${wrapInList(story)}

--- a/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
@@ -20,7 +20,7 @@
 ></ui5-shellbar>
 <ui5-popover
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	id="popover-with-notifications"
 >
 <ui5-list header-text="Notifications Grouped">

--- a/packages/website/docs/_samples/fiori/NotificationListItem/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationListItem/InShellBar/sample.html
@@ -21,7 +21,7 @@
 </ui5-shellbar>
 <ui5-popover
 	placement-type="Bottom"
-	horizontal-align="Right"
+	horizontal-align="End"
 	id="popover-with-notifications"
 >
     <ui5-list header-text="Notifications">

--- a/packages/website/docs/_samples/main/Popover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/Popover/Placement/sample.html
@@ -57,7 +57,7 @@
         </div>
     </ui5-popover>
 
-    <ui5-popover id="popover2" opener="btn2" header-text="Newsletter subscription" placement-type="Left">
+    <ui5-popover id="popover2" opener="btn2" header-text="Newsletter subscription" placement-type="Start">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>

--- a/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
@@ -57,7 +57,7 @@
         </div>
     </ui5-responsive-popover>
 
-    <ui5-responsive-popover id="respPopover2" opener="btn2" header-text="Newsletter subscription" placement-type="Left">
+    <ui5-responsive-popover id="respPopover2" opener="btn2" header-text="Newsletter subscription" placement-type="Start">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>


### PR DESCRIPTION
Renames the `Left` and `Right` values of `PopoverHorizontalAlign` and `PopoverPlacementType` to `Start` and `End`.

BREAKING CHANGE: The `Left` and `Right` options option have been removed. If you previously used them to set the placement or alignment of the popover:
```html
<ui5-popover horizontal-align="Left" placement-type="Left"></ui5-popover>
```
Now use `Start` or `End` instead:
```html
<ui5-popover horizontal-align="Start" placement-type="Start"></ui5-popover>
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461