### PR TITLE
refactor(ui5-upload-collection): remove IUploadCollectionItem interface

### DIFF
--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -14,6 +14,7 @@ import ListMode from "@ui5/webcomponents/dist/types/ListMode.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
 import IllustratedMessage from "./IllustratedMessage.js";
 import "./illustrations/Tent.js";
+import type UploadCollectionItem from "./UploadCollectionItem.js";
 import "@ui5/webcomponents-icons/dist/upload-to-cloud.js";
 import "@ui5/webcomponents-icons/dist/document.js";
 import {
@@ -37,18 +38,12 @@ import UploadCollectionTemplate from "./generated/templates/UploadCollectionTemp
 // Styles
 import UploadCollectionCss from "./generated/themes/UploadCollection.css.js";
 
-/**
- * Interface for components that may be slotted inside `ui5-upload-collection` as items
- * @public
- */
-interface IUploadCollectionItem extends HTMLElement { }
-
 type UploadCollectionSelectionChangeEventDetail = {
-	selectedItems: Array<IUploadCollectionItem>,
+	selectedItems: Array<UploadCollectionItem>,
 };
 
 type UploadCollectionItemDeleteEventDetail = {
-	item: IUploadCollectionItem,
+	item: UploadCollectionItem,
 };
 
 /**
@@ -183,7 +178,7 @@ class UploadCollection extends UI5Element {
 	 * @public
 	 */
 	@slot({ type: HTMLElement, "default": true })
-	items!: Array<IUploadCollectionItem>;
+	items!: Array<UploadCollectionItem>;
 
 	/**
 	 * Defines the `ui5-upload-collection` header.
@@ -272,11 +267,11 @@ class UploadCollection extends UI5Element {
 	}
 
 	_onItemDelete(e: CustomEvent) {
-		this.fireEvent<UploadCollectionItemDeleteEventDetail>("item-delete", { item: e.target as IUploadCollectionItem });
+		this.fireEvent<UploadCollectionItemDeleteEventDetail>("item-delete", { item: e.target as UploadCollectionItem });
 	}
 
 	_onSelectionChange(e: CustomEvent<ListSelectionChangeEventDetail>) {
-		this.fireEvent<UploadCollectionSelectionChangeEventDetail>("selection-change", { selectedItems: e.detail.selectedItems as IUploadCollectionItem[] });
+		this.fireEvent<UploadCollectionSelectionChangeEventDetail>("selection-change", { selectedItems: e.detail.selectedItems as UploadCollectionItem[] });
 	}
 
 	get classes() {
@@ -338,7 +333,6 @@ UploadCollection.define();
 
 export default UploadCollection;
 export type {
-	IUploadCollectionItem,
 	UploadCollectionItemDeleteEventDetail,
 	UploadCollectionSelectionChangeEventDetail,
 };

--- a/packages/fiori/src/UploadCollectionItem.ts
+++ b/packages/fiori/src/UploadCollectionItem.ts
@@ -30,7 +30,6 @@ import {
 	UPLOADCOLLECTIONITEM_TERMINATE_BUTTON_TEXT,
 	UPLOADCOLLECTIONITEM_EDIT_BUTTON_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
-import type { IUploadCollectionItem } from "./UploadCollection.js";
 
 // Template
 import UploadCollectionItemTemplate from "./generated/templates/UploadCollectionItemTemplate.lit.js";
@@ -50,7 +49,6 @@ import UploadCollectionItemCss from "./generated/themes/UploadCollectionItem.css
  * @constructor
  * @extends ListItem
  * @public
- * @implements {IUploadCollectionItem}
  * @slot {Node[]} default - Hold the description of the `ui5-upload-collection-item`. Will be shown below the file name.
  * @since 1.0.0-rc.7
  */
@@ -112,7 +110,7 @@ import UploadCollectionItemCss from "./generated/themes/UploadCollectionItem.css
  * @private
  */
 @event("_uci-delete")
-class UploadCollectionItem extends ListItem implements IUploadCollectionItem {
+class UploadCollectionItem extends ListItem {
 	/**
 	 * Holds an instance of `File` associated with this item.
 	 * @default null


### PR DESCRIPTION
Removes the `IUploadCollectionItem` interface as no other item types are currently supported or requested.

BREAKING CHANGE: Removed the `IUploadCollectionItem` interface. If you previously used the interface

```js
import type { IUploadCollectionItem} from "@ui5/webcomponents-fiori/dist/UploadCollection.js"
```
Use the `UploadCollectionItem` type instead:

```js
import type UploadCollectionItem from "@ui5/webcomponents-fiori/dist/UploadCollectionItem.js"
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461