### PR TITLE
chore: don't cache iframe in case of early access

### DIFF
--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -197,9 +197,9 @@ ${fixAssetPaths(js)}`,
     }
     window.addEventListener("message", messageHandler);
 
-    previewRef.current.project = projectRef.current;
     tabBarRef.current.project = projectRef.current;
     fileEditorRef.current.project = projectRef.current;
+    previewRef.current.project = projectRef.current;
 
     tabBarRef.current.editor = fileEditorRef.current;
 

--- a/patches/playground-elements+0.18.1.patch
+++ b/patches/playground-elements+0.18.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/playground-elements/playground-preview.js b/node_modules/playground-elements/playground-preview.js
-index 1c2996f..cebf666 100644
+index 1c2996f..4259730 100644
 --- a/node_modules/playground-elements/playground-preview.js
 +++ b/node_modules/playground-elements/playground-preview.js
 @@ -151,6 +151,7 @@ let PlaygroundPreview = class PlaygroundPreview extends PlaygroundConnectedEleme
@@ -10,3 +10,12 @@ index 1c2996f..cebf666 100644
            @load=${this._onIframeLoad}
            ?hidden=${!this._loadedAtLeastOnce}
          ></iframe>
+@@ -298,7 +299,7 @@ __decorate([
+     property()
+ ], PlaygroundPreview.prototype, "location", void 0);
+ __decorate([
+-    query('iframe', true)
++    query('iframe')
+ ], PlaygroundPreview.prototype, "iframe", void 0);
+ __decorate([
+     query('slot')


### PR DESCRIPTION
The `playground-preview` element has an `iframe` property that is cached and used internally. But we also use it to send configuration, and when accessed too early from outside, the shadow root is not ready and the `iframe` gets initialized with null. Because it is cached, it never initializes leading to an empty preview.

This patch makes it not cached, as the alternative to access it after the element is defined is a bit more complicated.