### PR TITLE
refactor(ui5-busy-indicator): rename BusyIndicatorSize values to S, M and L

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.hbs
+++ b/packages/fiori/src/BarcodeScannerDialog.hbs
@@ -10,7 +10,7 @@
 	</div>
 	<ui5-busy-indicator
 		?active={{loading}}
-		size="Large"
+		size="L"
 		text="{{_busyIndicatorText}}"
 		class="ui5-barcode-scanner-dialog-busy">
 	</ui5-busy-indicator>

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -83,7 +83,6 @@
 		<ui5-busy-indicator
 				delay="{{busyDelay}}"
 				active
-				size="Medium"
 				class="ui5-nli-busy"
 		></ui5-busy-indicator>
 	{{/if}}

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -97,7 +97,6 @@
 		<ui5-busy-indicator
 				delay="{{busyDelay}}"
 				active
-				size="Medium"
 				class="ui5-nli-busy"
 				data-sap-focus-ref
 		></ui5-busy-indicator>

--- a/packages/main/src/BusyIndicator.ts
+++ b/packages/main/src/BusyIndicator.ts
@@ -77,10 +77,10 @@ class BusyIndicator extends UI5Element {
 
 	/**
 	 * Defines the size of the component.
-	 * @default "Medium"
+	 * @default "M"
 	 * @public
 	 */
-	@property({ type: BusyIndicatorSize, defaultValue: BusyIndicatorSize.Medium })
+	@property({ type: BusyIndicatorSize, defaultValue: BusyIndicatorSize.M })
 	size!: `${BusyIndicatorSize}`;
 
 	/**

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -9,7 +9,6 @@
 >
 	<ui5-busy-indicator
 		?active={{loading}}
-		size="Medium"
 		class="ui5-combobox-busy"
 	>
 	</ui5-busy-indicator>

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -73,7 +73,6 @@
 			<ui5-busy-indicator
 				delay="{{busyDelay}}"
 				active
-				size="Medium"
 				class="ui5-list-busy-ind"
 				style="{{styles.busyInd}}"
 				data-sap-focus-ref

--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -115,7 +115,6 @@
 			class="ui5-table-busy-ind"
 			style="{{styles.busy}}"
 			active
-			size="Medium"
 			data-sap-focus-ref
 		></ui5-busy-indicator>
 	</div>

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -6,62 +6,62 @@
 	color: var(--_ui5_busy_indicator_color);
 }
 
-:host([size="Small"]) .ui5-busy-indicator-root {
+:host([size="S"]) .ui5-busy-indicator-root {
 	min-width: 1.625rem; /*width of the dots plus the gap between them*/
 	min-height: .5rem;
 }
 
-:host([size="Small"][text]:not([text=""])) .ui5-busy-indicator-root {
+:host([size="S"][text]:not([text=""])) .ui5-busy-indicator-root {
 	min-height: 1.75rem;
 }
 
-:host([size="Small"]) .ui5-busy-indicator-circle {
+:host([size="S"]) .ui5-busy-indicator-circle {
 	width: .5rem;
 	height: .5rem;
 }
 
-:host([size="Small"]) .ui5-busy-indicator-circle:first-child,
-:host([size="Small"]) .ui5-busy-indicator-circle:nth-child(2) {
+:host([size="S"]) .ui5-busy-indicator-circle:first-child,
+:host([size="S"]) .ui5-busy-indicator-circle:nth-child(2) {
 	margin-inline-end: 0.0625rem;
 }
 
 :host(:not([size])) .ui5-busy-indicator-root,
-:host([size="Medium"]) .ui5-busy-indicator-root {
+:host([size="M"]) .ui5-busy-indicator-root {
 	min-width: 3.375rem; /*width of the dots plus the gap between them*/
 	min-height: 1rem;
 }
 
-:host([size="Medium"]) .ui5-busy-indicator-circle:first-child,
-:host([size="Medium"]) .ui5-busy-indicator-circle:nth-child(2) {
+:host([size="M"]) .ui5-busy-indicator-circle:first-child,
+:host([size="M"]) .ui5-busy-indicator-circle:nth-child(2) {
 	margin-inline-end: 0.1875rem;
 }
 
 :host(:not([size])[text]:not([text=""])) .ui5-busy-indicator-root,
-:host([size="Medium"][text]:not([text=""])) .ui5-busy-indicator-root {
+:host([size="M"][text]:not([text=""])) .ui5-busy-indicator-root {
 	min-height: 2.25rem;
 }
 
 :host(:not([size])) .ui5-busy-indicator-circle,
-:host([size="Medium"])  .ui5-busy-indicator-circle {
+:host([size="M"])  .ui5-busy-indicator-circle {
 	width: 1rem;
 	height: 1rem;
 }
 
-:host([size="Large"]) .ui5-busy-indicator-root {
+:host([size="L"]) .ui5-busy-indicator-root {
 	min-width: 6.5rem; /*width of the dots plus the gap between them*/
 	min-height: 2rem;
 }
 
-:host([size="Large"]) .ui5-busy-indicator-circle:first-child,
-:host([size="Large"]) .ui5-busy-indicator-circle:nth-child(2) {
+:host([size="L"]) .ui5-busy-indicator-circle:first-child,
+:host([size="L"]) .ui5-busy-indicator-circle:nth-child(2) {
 	margin-inline-end: 0.25rem;
 }
 
-:host([size="Large"][text]:not([text=""])) .ui5-busy-indicator-root {
+:host([size="L"][text]:not([text=""])) .ui5-busy-indicator-root {
 	min-height: 3.25rem;
 }
 
-:host([size="Large"]) .ui5-busy-indicator-circle {
+:host([size="L"]) .ui5-busy-indicator-circle {
 	width: 2rem;
 	height: 2rem;
 }

--- a/packages/main/src/types/BusyIndicatorSize.ts
+++ b/packages/main/src/types/BusyIndicatorSize.ts
@@ -7,19 +7,19 @@ enum BusyIndicatorSize {
 	 * small size
 	 * @public
 	 */
-	Small = "Small",
+	S = "S",
 
 	/**
 	 * medium size
 	 * @public
 	 */
-	Medium = "Medium",
+	M = "M",
 
 	/**
 	 * large size
 	 * @public
 	 */
-	Large = "Large",
+	L = "L",
 }
 
 export default BusyIndicatorSize;

--- a/packages/main/test/pages/BusyIndicator.html
+++ b/packages/main/test/pages/BusyIndicator.html
@@ -26,16 +26,16 @@
 
 <body class="busyindicator1auto">
 	<ui5-title>Large ui5-busy-indicator</ui5-title>
-	<ui5-busy-indicator active size="Large"></ui5-busy-indicator>
+	<ui5-busy-indicator active size="L"></ui5-busy-indicator>
 	<br/>
 	<br/>
 
 	<ui5-title>Default Medium ui5-busy-indicator</ui5-title>
-	<ui5-busy-indicator size="Medium" active id="indicator1"></ui5-busy-indicator>
+	<ui5-busy-indicator size="M" active id="indicator1"></ui5-busy-indicator>
 
 	<br />
 	<br />
-	<ui5-busy-indicator size="Medium" active id="indicator2"></ui5-busy-indicator>
+	<ui5-busy-indicator size="M" active id="indicator2"></ui5-busy-indicator>
 
 	<ui5-title>ui5-busy-indicator with text</ui5-title>
 
@@ -48,7 +48,7 @@
 
 	<div>
 		<ui5-button id="beforeIndicatorWithBtn">focus stop before</ui5-button>
-		<ui5-busy-indicator id="indicatorWithBtn" size="Medium" active>
+		<ui5-busy-indicator id="indicatorWithBtn" size="M" active>
 			<ui5-button>Hello World</ui5-button>
 		</ui5-busy-indicator>
 		<ui5-button id="afterIndicatorWithBtn" >focus stop after</ui5-button>
@@ -56,7 +56,7 @@
 
 	<br />
 	<br />
-	<ui5-busy-indicator size="Medium" active text="Loading">
+	<ui5-busy-indicator size="M" active text="Loading">
 		<ui5-checkbox text="Hello World"></ui5-checkbox>
 	</ui5-busy-indicator>
 
@@ -66,7 +66,7 @@
 	<ui5-button id="fetch-btn" class="busyindicator3auto">Fetch List Data</ui5-button>
 	<br>
 	<br>
-	<ui5-busy-indicator id="busy-container" class="busyindicator4auto" size="Medium" text="Loading">
+	<ui5-busy-indicator id="busy-container" class="busyindicator4auto" size="M" text="Loading">
 		<ui5-list id="fetch-list" no-data-text="No Data" header-text="Available Items" class="busyindicator5auto"></ui5-list>
 	</ui5-busy-indicator>
 
@@ -76,7 +76,7 @@
 	<br>
 	<br>
 
-	<ui5-busy-indicator size="Medium" active class="busyindicator6auto">
+	<ui5-busy-indicator size="M" active class="busyindicator6auto">
 		<ui5-list class="busyindicator7auto">
 			<ui5-li>Item 1</ui5-li>
 			<ui5-li>Item 2</ui5-li>
@@ -84,7 +84,7 @@
 		</ui5-list>
 	</ui5-busy-indicator>
 
-	<ui5-busy-indicator size="Medium" active class="busyindicator6auto" text="Custom loading text">
+	<ui5-busy-indicator size="M" active class="busyindicator6auto" text="Custom loading text">
 		<ui5-list class="busyindicator7auto">
 			<ui5-li>Item 1</ui5-li>
 			<ui5-li>Item 2</ui5-li>
@@ -107,21 +107,21 @@
 
 	<br>
 	<br>
-	<ui5-busy-indicator size="Small" active></ui5-busy-indicator>
+	<ui5-busy-indicator size="S" active></ui5-busy-indicator>
 	<br>
 	<br>
 	<span>Medium </span>
 
 	<br>
 	<br>
-	<ui5-busy-indicator size="Medium" active></ui5-busy-indicator>
+	<ui5-busy-indicator size="M" active></ui5-busy-indicator>
 	<br>
 	<br>
 	<span>Large </span>
 
 	<br>
 	<br>
-	<ui5-busy-indicator size="Large" active></ui5-busy-indicator>
+	<ui5-busy-indicator size="L" active></ui5-busy-indicator>
 	<br>
 	<br>
 

--- a/packages/main/test/samples/BusyIndicator.sample.html
+++ b/packages/main/test/samples/BusyIndicator.sample.html
@@ -32,14 +32,14 @@
 <section>
 		<h3>Busy Indicator with different size</h3>
 		<div class="snippet flex center">
-			<ui5-busy-indicator active size="Small"></ui5-busy-indicator>
-			<ui5-busy-indicator active size="Medium"></ui5-busy-indicator>
-			<ui5-busy-indicator active size="Large"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="S"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="M"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="L"></ui5-busy-indicator>
 		</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-busy-indicator active size="Small"></ui5-busy-indicator>
-<ui5-busy-indicator active size="Medium"></ui5-busy-indicator>
-<ui5-busy-indicator active size="Large"></ui5-busy-indicator>
+<ui5-busy-indicator active size="S"></ui5-busy-indicator>
+<ui5-busy-indicator active size="M"></ui5-busy-indicator>
+<ui5-busy-indicator active size="L"></ui5-busy-indicator>
 	</xmp></pre>
 </section>
 
@@ -49,7 +49,7 @@
 	<div class="snippet flex">
 		<ui5-button id="fetch-btn" style="width: 120px;">Fetch List Data</ui5-button>
 
-		<ui5-busy-indicator id="busy-container" size="Medium">
+		<ui5-busy-indicator id="busy-container" size="M">
 			<ui5-list id="fetch-list" no-data-text="No Data" header-text="Available Items"></ui5-list>
 		</ui5-busy-indicator>
 
@@ -57,7 +57,7 @@
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="fetch-btn" style="width: 120px;">Fetch List Data</ui5-button>
 
-<ui5-busy-indicator id="busy-container" size="Medium">
+<ui5-busy-indicator id="busy-container" size="M">
 	<ui5-list id="fetch-list" no-data-text="No Data" header-text="Available Items"></ui5-list>
 </ui5-busy-indicator>
 

--- a/packages/playground/_stories/main/BusyIndicator/BusyIndicator.stories.ts
+++ b/packages/playground/_stories/main/BusyIndicator/BusyIndicator.stories.ts
@@ -28,12 +28,12 @@ const Template: UI5StoryArgs<BusyIndicator, StoryArgsSlots> = (args) => {
 export const Basic = Template.bind({});
 Basic.args = {
 	active: true,
-	size: BusyIndicatorSize.Medium,
+	size: BusyIndicatorSize.M,
 };
 
 export const UsageWithComponents = Template.bind({});
 UsageWithComponents.args = {
-	size: BusyIndicatorSize.Medium,
+	size: BusyIndicatorSize.M,
 	default: `<ui5-list
 	no-data-text="No Data"
 	header-text="Available Items"

--- a/packages/website/docs/_components_pages/main/BusyIndicator.mdx
+++ b/packages/website/docs/_components_pages/main/BusyIndicator.mdx
@@ -18,7 +18,7 @@ import TextPlacement from "../../_samples/main/BusyIndicator/TextPlacement/TextP
 ## More Samples 
 
 ### Sizes
-The BusyIndicator comes in several sizes - Small, Medium and Large.
+The BusyIndicator comes in several sizes - S, M and L.
 
 <Sizes />
 

--- a/packages/website/docs/_samples/main/BusyIndicator/Basic/sample.html
+++ b/packages/website/docs/_samples/main/BusyIndicator/Basic/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-busy-indicator size="Medium" active></ui5-busy-indicator>
+    <ui5-busy-indicator active></ui5-busy-indicator>
 
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/BusyIndicator/Sizes/sample.html
+++ b/packages/website/docs/_samples/main/BusyIndicator/Sizes/sample.html
@@ -11,9 +11,9 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-busy-indicator size="Small" active></ui5-busy-indicator>
-    <ui5-busy-indicator size="Medium" active></ui5-busy-indicator>
-    <ui5-busy-indicator size="Large" active></ui5-busy-indicator>
+    <ui5-busy-indicator size="S" active></ui5-busy-indicator>
+    <ui5-busy-indicator size="M" active></ui5-busy-indicator>
+    <ui5-busy-indicator size="L" active></ui5-busy-indicator>
 
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/BusyIndicator/WithComponent/sample.html
+++ b/packages/website/docs/_samples/main/BusyIndicator/WithComponent/sample.html
@@ -14,7 +14,7 @@
 
     <div class="sample">
         <ui5-button>Fetch List Data</ui5-button>
-        <ui5-busy-indicator size="Medium">
+        <ui5-busy-indicator>
             <ui5-list no-data-text="No Data" header-text="Available Items">
             </ui5-list>
         </ui5-busy-indicator>


### PR DESCRIPTION
Renames the values of BusyIndicatorSize from "Small", "Medium" and "Large" to "S", "M" and "L".

BREAKING CHANGE: The `size` property now accepts different values. If you previously used it like:
```html
<ui5-busy-indicator size="Small"></ui5-busy-indicator>
```
Now use the new values instead:
```html
<ui5-busy-indicator size="S"></ui5-busy-indicator>
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461
