### PR TITLE
chore: restore configuration tests

### DIFF
--- a/packages/base/test/specs/ConfigurationChange.spec.js
+++ b/packages/base/test/specs/ConfigurationChange.spec.js
@@ -6,13 +6,23 @@ describe("Some configuration options can be changed at runtime", () => {
 	});
 
 	it("Tests that theme can be changed", async () => {
-		const newTheme = 'sap_belize_hcb';
+		const newTheme = 'sap_horizon_hcb';
 
-		assert.strictEqual(newTheme, newTheme, "Theme changed to HCB");
+		const res = await browser.executeAsync(async (newTheme, done) => {
+			const config = window['sap-ui-webcomponents-bundle'].configuration;
+			await config.setTheme(newTheme);
+			done(config.getTheme());
+		}, newTheme);
+		assert.strictEqual(res, newTheme, "Theme changed to HCB");
 	});
 
 	it("Tests that noConflict can be changed", async () => {
-		assert.include("selection-change", "selection-change", "selection-change was successfully registered as a no conflict event");
+		const res = await browser.executeAsync(done => {
+			const config = window['sap-ui-webcomponents-bundle'].configuration;
+			config.setNoConflict({ events: ["selection-change"] });
+			done(config.getNoConflict());
+		});
+		assert.include(res.events, "selection-change", "selection-change was successfully registered as a no conflict event");
 	});
 
 	it("Tests that theme is applied", async () => {


### PR DESCRIPTION
Restoring configuration tests that were removed with #6617 by mistake