### PR TITLE
docs: add reset button in playground

### DIFF
--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -10,6 +10,7 @@ import { encodeToBase64, decodeFromBase64 } from "./share.js";
 import clsx from "clsx";
 import ShareIcon from "../../../local-cdn/local-cdn/icons/dist/v5/share-2.svg";
 import { Splitter } from 'react-splitter-light';
+import ResetIcon from "../../../local-cdn/local-cdn/icons/dist/v5/reset.svg";
 import DownloadIcon from "../../../local-cdn/local-cdn/icons/dist/v5/download-from-cloud.svg";
 import EditIcon from "../../../local-cdn/local-cdn/icons/dist/v5/edit.svg";
 import ActionIcon from "../../../local-cdn/local-cdn/icons/dist/v5/action.svg";
@@ -123,6 +124,12 @@ export default function Editor({html, js, css, mainFile = "main.js", canShare = 
     delete files["playground-support.js"];
 
     return files;
+  }
+
+  const reset = () => {
+    localStorage.clear("project");
+    location.hash = "";
+    location.reload();
   }
 
   const download = () => {
@@ -332,6 +339,14 @@ ${fixAssetPaths(js)}`,
         ?
           <>
             <div className={`${styles.editor__toolbar}`}>
+              <button
+                className={`button button--secondary ${styles.previewResult__download}`}
+                onClick={ reset }
+              >
+               <ResetIcon className={`${styles.btn__icon}`}/>
+                Reset exapmle
+              </button>
+
               <button
                 className={`button button--secondary ${styles.previewResult__download}`}
                 onClick={ download }


### PR DESCRIPTION
When opening a sample from the components, it overwrites the initial playground example and there is now UI to get it back.

Add a reset button that just deletes what is in local storage and refreshes the page which brings back the default example.