### PR TITLE
chore: update chromedriver

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
-    "chromedriver": "^121.0.2",
+    "chromedriver": "^122.0.6",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
-    "chromedriver": "^121.0.2"
+    "chromedriver": "^122.0.6"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -35,7 +35,7 @@
     "@openui5/sap.ui.core": "1.120.3",
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
     "babel-plugin-amd-to-esm": "^2.0.3",
-    "chromedriver": "^121.0.2",
+    "chromedriver": "^122.0.6",
     "estree-walk": "^2.2.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
-    "chromedriver": "^121.0.2"
+    "chromedriver": "^122.0.6"
   }
 }


### PR DESCRIPTION
development machines already get chrome 123 and 121 breaks, but the GH actions image has 122 so this is the update