### PR TITLE
feat(framework): support sr, mk, cnr locales

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,7 +44,7 @@
     "lit-html": "^2.0.1"
   },
   "devDependencies": {
-    "@openui5/sap.ui.core": "1.120.3",
+    "@openui5/sap.ui.core": "1.120.5",
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
     "chromedriver": "^121.0.2",
     "clean-css": "^5.2.2",

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.23.7",
     "@babel/generator": "^7.23.6",
     "@babel/parser": "^7.23.6",
-    "@openui5/sap.ui.core": "1.120.3",
+    "@openui5/sap.ui.core": "1.120.5",
     "@ui5/webcomponents-tools": "1.24.0-rc.2",
     "babel-plugin-amd-to-esm": "^2.0.3",
     "chromedriver": "^121.0.2",

--- a/packages/tools/assets-meta.js
+++ b/packages/tools/assets-meta.js
@@ -83,7 +83,7 @@ const assetsMeta = {
       "ar_SA",
       "bg",
       "ca",
-      // "cnr_ME" - cldr for not available yet
+      "cnr",
       "cs",
       "da",
       "de",
@@ -131,7 +131,7 @@ const assetsMeta = {
       "lt",
       "lv",
       "ms",
-      // "mk_MK" cldr not available yet
+      "mk",
       "nb",
       "nl",
       "nl_BE",
@@ -144,7 +144,6 @@ const assetsMeta = {
       "sk",
       "sl",
       "sr",
-      // "sr_Cyrl_RS" - cldr not available yet
       "sr_Latn",
       "sv",
       "th",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3845,10 +3845,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@openui5/sap.ui.core@1.120.3":
-  version "1.120.3"
-  resolved "https://registry.yarnpkg.com/@openui5/sap.ui.core/-/sap.ui.core-1.120.3.tgz#5ccddddc254f23c346ba5d1bd919d547ad84b0f1"
-  integrity sha512-KTV80IiK2pGwnyRh3VGROoK5DYJ8jhNImhVu7wH760BcFv8NskPvhek8+N0b52oKG9jwr6ijdzzfUJtK/znMjg==
+"@openui5/sap.ui.core@1.120.5":
+  version "1.120.5"
+  resolved "https://registry.yarnpkg.com/@openui5/sap.ui.core/-/sap.ui.core-1.120.5.tgz#845d961628285500534969beb26622bb58b12b6c"
+  integrity sha512-NsEaubmKHuLgMnzoRr/RFDr2ZauGQx6LDVA+9dnSsdAb069+w2SO5G8IUj5iWZ9o3FhUf8eNr/hSl6QWN1fI/Q==
 
 "@parcel/watcher@2.0.4":
   version "2.0.4"


### PR DESCRIPTION
The following languages `mk_MK`, `cnr_ME` and `sr_Cyrl_RS` locales and languages are now availabe and supported by the relevant components.