### PR TITLE
docs: update LocaleData.ts

### DIFF
--- a/packages/base/src/asset-registries/LocaleData.ts
+++ b/packages/base/src/asset-registries/LocaleData.ts
@@ -150,7 +150,7 @@ const registerLocaleDataLoader = (localeId: string, loader: LocaleDataLoader) =>
 
 // register default loader for "en" from ui5 CDN (dev workflow without assets)
 registerLocaleDataLoader("en", async () => {
-	const cldrContent = await fetch(`https://sdk.openui5.org/1.103.0/resources/sap/ui/core/cldr/en.json`);
+	const cldrContent = await fetch(`https://sdk.openui5.org/1.120.5/resources/sap/ui/core/cldr/en.json`);
 	return cldrContent.json() as Promise<CLDRData>;
 });
 


### PR DESCRIPTION
UI5 version 1.103.0 is out of support and not available on CDN any more. Update to latest long-term maintenance version 1.120.5.

Related to: #8535 
