### PR TITLE
refactor(ui5-color-picker): rename `color` to `value`

### DIFF
--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -405,7 +405,7 @@ class ColorPalette extends UI5Element {
 
 	async _chooseCustomColor() {
 		const colorPicker = await this.getColorPicker();
-		this._setColor(colorPicker.color);
+		this._setColor(colorPicker.value);
 		this._closeDialog();
 	}
 

--- a/packages/main/src/ColorPicker.hbs
+++ b/packages/main/src/ColorPicker.hbs
@@ -66,7 +66,7 @@
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
                 accessible-name="{{redInputLabel}}"
-                value="{{_color.r}}"
+                value="{{_value.r}}"
             ></ui5-input>
             <ui5-label>R</ui5-label>
         </div>
@@ -76,7 +76,7 @@
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
                 accessible-name="{{greenInputLabel}}"
-                value="{{_color.g}}"
+                value="{{_value.g}}"
             ></ui5-input>
             <ui5-label>G</ui5-label>
         </div>
@@ -86,7 +86,7 @@
                 class="ui5-color-picker-rgb-input"
                 disabled="{{inputsDisabled}}"
                 accessible-name="{{blueInputLabel}}"
-                value="{{_color.b}}"
+                value="{{_value.b}}"
             ></ui5-input>
             <ui5-label>B</ui5-label>
         </div>

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -96,7 +96,7 @@ class ColorPicker extends UI5Element {
 	 * @public
 	 */
 	@property({ validator: CSSColor, defaultValue: "rgba(255, 255, 255, 1)" })
-	color!: string;
+	value!: string;
 
 	/**
 	 * Defines the HEX code of the currently selected color
@@ -112,14 +112,14 @@ class ColorPicker extends UI5Element {
 	 * @private
 	 */
 	@property({ type: Object })
-	_mainColor!: ColorRGB;
+	_mainValue!: ColorRGB;
 
 	/**
 	 * Defines the currenty selected color from the main color section.
 	 * @private
 	 */
 	@property({ type: Object })
-	_color!: ColorRGB;
+	_value!: ColorRGB;
 
 	/**
 	 * @private
@@ -179,7 +179,7 @@ class ColorPicker extends UI5Element {
 		};
 
 		// Default main color is red
-		this._mainColor = {
+		this._mainValue = {
 			r: 255,
 			g: 0,
 			b: 0,
@@ -192,9 +192,9 @@ class ColorPicker extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		// we have the color & _mainColor properties here
-		this._color = getRGBColor(this.color);
-		const tempColor = `rgba(${this._color.r}, ${this._color.g}, ${this._color.b}, 1)`;
+		// we have the color & ._mainValue properties here
+		this._value = getRGBColor(this.value);
+		const tempColor = `rgba(${this._value.r}, ${this._value.g}, ${this._value.b}, 1)`;
 		this._setHex();
 		this._setValues();
 		this.style.setProperty(getScopedVarName("--ui5_Color_Picker_Progress_Container_Color"), tempColor);
@@ -260,7 +260,7 @@ class ColorPicker extends UI5Element {
 	_handleAlphaInput(e: CustomEvent) {
 		const aphaInputValue: string = (e.target as Input).value;
 		this._alpha = parseFloat(aphaInputValue);
-		this._setColor(this._color);
+		this._setColor(this._value);
 	}
 
 	_handleHueInput(e: CustomEvent) {
@@ -316,18 +316,18 @@ class ColorPicker extends UI5Element {
 		let tempColor;
 		switch (target.id) {
 		case "red":
-			tempColor = { ...this._color, r: targetValue };
+			tempColor = { ...this._value, r: targetValue };
 			break;
 
 		case "green":
-			tempColor = { ...this._color, g: targetValue };
+			tempColor = { ...this._value, g: targetValue };
 			break;
 
 		case "blue":
-			tempColor = { ...this._color, b: targetValue };
+			tempColor = { ...this._value, b: targetValue };
 			break;
 		default:
-			tempColor = { ...this._color };
+			tempColor = { ...this._value };
 		}
 
 		this._setColor(tempColor);
@@ -335,37 +335,37 @@ class ColorPicker extends UI5Element {
 
 	_setMainColor(hueValue: number) {
 		if (hueValue <= 255) {
-			this._mainColor = {
+			this._mainValue = {
 				r: 255,
 				g: hueValue,
 				b: 0,
 			};
 		} else if (hueValue <= 510) {
-			this._mainColor = {
+			this._mainValue = {
 				r: 255 - (hueValue - 255),
 				g: 255,
 				b: 0,
 			};
 		} else if (hueValue <= 765) {
-			this._mainColor = {
+			this._mainValue = {
 				r: 0,
 				g: 255,
 				b: hueValue - 510,
 			};
 		} else if (hueValue <= 1020) {
-			this._mainColor = {
+			this._mainValue = {
 				r: 0,
 				g: 765 - (hueValue - 255),
 				b: 255,
 			};
 		} else if (hueValue <= 1275) {
-			this._mainColor = {
+			this._mainValue = {
 				r: hueValue - 1020,
 				g: 0,
 				b: 255,
 			};
 		} else {
-			this._mainColor = {
+			this._mainValue = {
 				r: 255,
 				g: 0,
 				b: 1275 - (hueValue - 255),
@@ -425,7 +425,7 @@ class ColorPicker extends UI5Element {
 	}
 
 	_setColor(color: ColorRGB = { r: 0, g: 0, b: 0 }) {
-		this.color = `rgba(${color.r}, ${color.g}, ${color.b}, ${this._alpha})`;
+		this.value = `rgba(${color.r}, ${color.g}, ${color.b}, ${this._alpha})`;
 		this._wrongHEX = !this.isValidRGBColor(color);
 		this.fireEvent("change");
 	}
@@ -435,9 +435,9 @@ class ColorPicker extends UI5Element {
 	}
 
 	_setHex() {
-		let red = this._color.r.toString(16),
-			green = this._color.g.toString(16),
-			blue = this._color.b.toString(16);
+		let red = this._value.r.toString(16),
+			green = this._value.g.toString(16),
+			blue = this._value.b.toString(16);
 
 		if (red.length === 1) {
 			red = `0${red}`;
@@ -453,7 +453,7 @@ class ColorPicker extends UI5Element {
 	}
 
 	_setValues() {
-		const hslColours: ColorHSL = RGBToHSL(this._color);
+		const hslColours: ColorHSL = RGBToHSL(this._value);
 		this._selectedCoordinates = {
 			x: ((Math.round(hslColours.l * 100) * 2.56)) - PICKER_POINTER_WIDTH, // Center the coordinates, because of the width of the circle
 			y: (256 - (Math.round(hslColours.s * 100) * 2.56)) - PICKER_POINTER_WIDTH, // Center the coordinates, because of the height of the circle
@@ -510,14 +510,14 @@ class ColorPicker extends UI5Element {
 	get styles() {
 		return {
 			mainColor: {
-				"background-color": `rgb(${this._mainColor.r}, ${this._mainColor.g}, ${this._mainColor.b})`,
+				"background-color": `rgb(${this._mainValue.r}, ${this._mainValue.g}, ${this._mainValue.b})`,
 			},
 			circle: {
 				left: `${this._selectedCoordinates.x}px`,
 				top: `${this._selectedCoordinates.y}px`,
 			},
 			colorSpan: {
-				"background-color": `rgba(${this._color.r}, ${this._color.g}, ${this._color.b}, ${this._alpha})`,
+				"background-color": `rgba(${this._value.r}, ${this._value.g}, ${this._value.b}, ${this._alpha})`,
 			},
 		};
 	}

--- a/packages/main/test/pages/ColorPicker.html
+++ b/packages/main/test/pages/ColorPicker.html
@@ -51,7 +51,8 @@
 			colorPicker1 = document.getElementById("cp1"),
 			stepInput = document.getElementById("changeEventCounter");
 
-		colorPicker.addEventListener("ui5-change", function(event) {
+		colorPicker.addEventListener("ui5-change", () => {
+			debugger
 			colorLabel.value = event.target.value;
 		});
 

--- a/packages/main/test/pages/ColorPicker.html
+++ b/packages/main/test/pages/ColorPicker.html
@@ -52,7 +52,6 @@
 			stepInput = document.getElementById("changeEventCounter");
 
 		colorPicker.addEventListener("ui5-change", () => {
-			debugger
 			colorLabel.value = event.target.value;
 		});
 

--- a/packages/main/test/pages/ColorPicker.html
+++ b/packages/main/test/pages/ColorPicker.html
@@ -52,7 +52,7 @@
 			stepInput = document.getElementById("changeEventCounter");
 
 		colorPicker.addEventListener("ui5-change", function(event) {
-			colorLabel.value = event.target.color;
+			colorLabel.value = event.target.value;
 		});
 
 		colorPicker1.addEventListener("ui5-change", function(event) {

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -84,7 +84,7 @@ describe("ColorPalette interactions", () => {
 
 		assert.ok(colorPicker, "Color picker is rendered");
 
-		await colorPicker.setProperty("color", "#fafafa");
+		await colorPicker.setProperty("value", "#fafafa");
 
 		// The initial focus is on the HEX input
 		await browser.keys("Tab"); // Slider 1

--- a/packages/main/test/specs/ColorPicker.spec.js
+++ b/packages/main/test/specs/ColorPicker.spec.js
@@ -41,7 +41,7 @@ describe("Color Picker general interaction", () => {
 		const colorPicker = await browser.$("#cp1");
 		const alphaInput = await colorPicker.shadow$("#alpha");
 
-		await colorPicker.setAttribute("color", "rgba(100, 100, 100, 1)");
+		await colorPicker.setAttribute("value", "rgba(100, 100, 100, 1)");
 
 		await alphaInput.click();
 		await browser.keys('Delete');
@@ -49,7 +49,7 @@ describe("Color Picker general interaction", () => {
 		await browser.keys("0");
 		await browser.keys("Tab");
 
-		assert.strictEqual(await colorPicker.getAttribute("color"), "rgba(100, 100, 100, 0)", "Alpha value propely changed");
+		assert.strictEqual(await colorPicker.getAttribute("value"), "rgba(100, 100, 100, 0)", "Alpha value propely changed");
 	});
 
 	it("Alpha value change via the slider", async () => {
@@ -59,11 +59,11 @@ describe("Color Picker general interaction", () => {
 
 		await stepInput.setAttribute("value", 0);
 		await colorPicker.scrollIntoView();
-		await colorPicker.setAttribute("color", "rgba(183, 61, 61, 1)");
+		await colorPicker.setAttribute("value", "rgba(183, 61, 61, 1)");
 
 		await alphaSliderHandle.dragAndDrop({ x: 200, y: 0 });
 
-		assert.strictEqual(await colorPicker.getAttribute("color"), "rgba(183, 61, 61, 0.83)", "Alpha value propely changed");
+		assert.strictEqual(await colorPicker.getAttribute("value"), "rgba(183, 61, 61, 0.83)", "Alpha value propely changed");
 		assert.strictEqual(await stepInput.getAttribute("value"), "1", "Change event gets fired on alpha slider change");
 	});
 
@@ -73,11 +73,11 @@ describe("Color Picker general interaction", () => {
 		const stepInput = await browser.$("#changeEventCounter");
 
 		await colorPicker.scrollIntoView();
-		await colorPicker.setAttribute("color", "rgba(183, 61, 61, 0.83)");
+		await colorPicker.setAttribute("value", "rgba(183, 61, 61, 0.83)");
 
 		await hueSliderHandle.dragAndDrop({ x: 200, y: 0 });
 
-		assert.strictEqual(await colorPicker.getAttribute("color"), "rgba(182, 61, 184, 0.83)", "Color properly changed");
+		assert.strictEqual(await colorPicker.getAttribute("value"), "rgba(182, 61, 184, 0.83)", "Color properly changed");
 		assert.strictEqual(await stepInput.getAttribute("value"), "2", "Change event gets fired on hue slider change");
 	});
 
@@ -85,19 +85,19 @@ describe("Color Picker general interaction", () => {
 		const colorPicker = await browser.$("#cp3");
 		const hexInput = await colorPicker.shadow$(".ui5-color-picker-hex-input");
 
-		await colorPicker.setProperty("color", "rgb(0, 255, 0)");
+		await colorPicker.setProperty("value", "rgb(0, 255, 0)");
 		assert.strictEqual(await hexInput.getProperty("value"), "00ff00", "RGB value is parsed correctly");
 
-		await colorPicker.setProperty("color", "rgba(255, 0, 255, 1)");
+		await colorPicker.setProperty("value", "rgba(255, 0, 255, 1)");
 		assert.strictEqual(await hexInput.getProperty("value"), "ff00ff", "RGBA value is parsed correctly");
 
-		await colorPicker.setProperty("color", "#fafafa");
+		await colorPicker.setProperty("value", "#fafafa");
 		assert.strictEqual(await hexInput.getProperty("value"), "fafafa", "HEX value is parsed correctly");
 
-		await colorPicker.setProperty("color", "#123");
+		await colorPicker.setProperty("value", "#123");
 		assert.strictEqual(await hexInput.getProperty("value"), "112233", "HEX shorthand value is parsed correctly");
 
-		await colorPicker.setProperty("color", "grey");
+		await colorPicker.setProperty("value", "grey");
 		assert.strictEqual(await hexInput.getProperty("value"), "808080", "CSS values are parsed correctly");
 	});
 
@@ -110,7 +110,7 @@ describe("Color Picker general interaction", () => {
 		await browser.keys("0854a0");
 		await browser.keys("Enter");
 
-		const color = await colorPicker.getAttribute("color");
+		const value = await colorPicker.getAttribute("value");
 
 		await hueSliderHandle.dragAndDrop({ x: 200, y: 0 });
 
@@ -118,7 +118,7 @@ describe("Color Picker general interaction", () => {
 		await browser.keys("0854a0");
 		await browser.keys("Enter");
 
-		assert.strictEqual(await colorPicker.getAttribute("color"), color, "Color is changed to the old color");
+		assert.strictEqual(await colorPicker.getAttribute("value"), value, "Color is changed to the old color");
 	});
 
 	it("Hue value remains unchanged when user presses over the main color section", async () => {

--- a/packages/playground/_stories/main/ColorPicker/ColorPicker.stories.ts
+++ b/packages/playground/_stories/main/ColorPicker/ColorPicker.stories.ts
@@ -14,10 +14,10 @@ export default {
 } as Meta<ColorPicker>;
 
 const Template: UI5StoryArgs<ColorPicker, StoryArgsSlots> = (args) => html`<ui5-color-picker
-	color="${ifDefined(args.color)}"
+	color="${ifDefined(args.value)}"
 >Picker</ui5-color-picker>`;
 
 export const Basic = Template.bind({});
 Basic.args = {
-	color: "rgba(220, 208, 255, 1)",
+	value: "rgba(220, 208, 255, 1)",
 };

--- a/packages/website/docs/_samples/main/ColorPicker/Basic/sample.html
+++ b/packages/website/docs/_samples/main/ColorPicker/Basic/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-color-picker color="rgba(220, 208, 255, 1)">Picker</ui5-color-picker>
+    <ui5-color-picker value="rgba(220, 208, 255, 1)">Picker</ui5-color-picker>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
Renames the `color` property name of the ColorPicker to `value` and the names of two private properties.

BREAKING CHANGE: The property `color`  is renamed to `value`. If you previously used the change event of the ColorPicker as follows:
```html
<ui5-color-picker color="red"></ui5-color-picker>
```
Now you have to use it like this:
```html
<ui5-color-picker value="red"></ui5-color-picker>
```

Related to: https://github.com/SAP/ui5-webcomponents/issues/8461