### PR TITLE
refactor(ui5-color-palette): remove deprecated APIs

### DIFF
--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -166,31 +166,6 @@ class ColorPalettePopover extends UI5Element {
 		return this.shadowRoot!.querySelector<ResponsivePopover>("[ui5-responsive-popover]")!;
 	}
 
-	/**
-	 * Shows the ColorPalettePopover.
-	 * @param opener the element that the popover is shown at
-	 * @public
-	 * @deprecated The method is deprecated in favour of `open` and `opener` properties.
-	 * @since 1.1.1
-	 */
-	showAt(opener: HTMLElement): void {
-		console.warn("The method 'showAt' is deprecated and will be removed in future, use 'open' and 'opener' props instead."); // eslint-disable-line
-		this.open = true;
-		this.opener = opener;
-	}
-
-	/**
-	 * Shows the ColorPalettePopover.
-	 * @param opener the element that the popover is shown at
-	 * @public
-	 * @since 1.0.0-rc.16
-	 * @deprecated The method is deprecated in favour of `open` and `opener` properties.
-	 */
-	openPopover(opener: HTMLElement): void {
-		console.warn("The method 'openPopover' is deprecated and will be removed in future, use 'open' and 'opener' props instead."); // eslint-disable-line
-		this.showAt(opener);
-	}
-
 	closePopover() {
 		this.open = false;
 	}

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -14,7 +14,7 @@
 
 	<ui5-title level="H5">Test case 1 - Default Color Button to be focused</ui5-title>
 	<ui5-button id="colorPaletteBtnTest">Open</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest" show-recent-colors show-more-colors show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest" show-recent-colors show-more-colors show-default-color default-color="green" opener="colorPaletteBtnTest">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -31,7 +31,7 @@
 
 	<ui5-title level="H5">Test case 2 - Default Color works</ui5-title>
 	<ui5-button id="colorPaletteBtnTest2">Open</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest2" show-recent-colors show-more-colors show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest2" show-recent-colors show-more-colors show-default-color default-color="green" opener="colorPaletteBtnTest2">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -48,7 +48,7 @@
 
 	<ui5-title level="H5">Test case 3 - Arrow Down to select displayed color</ui5-title>
 	<ui5-button id="colorPaletteBtnTest3">Open</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest3" show-recent-colors show-more-colors show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest3" show-recent-colors show-more-colors show-default-color default-color="green" opener="colorPaletteBtnTest3">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -66,7 +66,7 @@
 
 	<ui5-title level="H5">Test case 4 - Arrow Up focuses MoreColors button</ui5-title>
 	<ui5-button id="colorPaletteBtnTest4">Open</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest4" show-recent-colors show-more-colors  show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest4" show-recent-colors show-more-colors  show-default-color default-color="green" opener="colorPaletteBtnTest4">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -83,7 +83,7 @@
 
 	<ui5-title level="H5">Test case 5 - Tests navigation with recent colors</ui5-title>
 	<ui5-button id="colorPaletteBtnTest5">Open</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest5" show-recent-colors show-more-colors  show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest5" show-recent-colors show-more-colors  show-default-color default-color="green" opener="colorPaletteBtnTest5">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -102,7 +102,7 @@
 	<ui5-button id="colorPaletteBtnTest6">Open</ui5-button>
 	<ui5-input id="inpOpenChangeCounter" placeholder="'close' event count"></ui5-input>
 	<ui5-button id="btnFocusOut">Press</ui5-button>
-	<ui5-color-palette-popover id="colorPalettePopoverTest6" show-recent-colors show-more-colors  show-default-color default-color="green">
+	<ui5-color-palette-popover id="colorPalettePopoverTest6" show-recent-colors show-more-colors  show-default-color default-color="green" opener="colorPaletteBtnTest6">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -205,27 +205,27 @@
 
 		// Tests - default color btn should be on focus after open
 		colorPaletteBtnTest.addEventListener("click", function(event) {
-			colorPalettePopoverTest.showAt(this);
+			colorPalettePopoverTest.open = !colorPalettePopoverTest.open;
 		});
 
 		colorPaletteBtnTest2.addEventListener("click", function(event) {
-			colorPalettePopoverTest2.showAt(this)
+			colorPalettePopoverTest2.open = !colorPalettePopoverTest2.open;
 		});
 
 		colorPaletteBtnTest3.addEventListener("click", function(event) {
-			colorPalettePopoverTest3.showAt(this);
+			colorPalettePopoverTest3.open = !colorPalettePopoverTest3.open;
 		});
 
 		colorPaletteBtnTest4.addEventListener("click", function(event) {
-			colorPalettePopoverTest4.showAt(this);
+			colorPalettePopoverTest4.open = !colorPalettePopoverTest4.open;
 		});
 
 		colorPaletteBtnTest5.addEventListener("click", function(event) {
-			colorPalettePopoverTest5.showAt(this);
+			colorPalettePopoverTest5.open = !colorPalettePopoverTest5.open;
 		});
 
 		colorPaletteBtnTest6.addEventListener("click", function(event) {
-			colorPalettePopoverTest6.showAt(this);
+			colorPalettePopoverTest6.open = !colorPalettePopoverTest6.open;
 		});
 
 		let openChangeCounter = 0;

--- a/packages/main/test/pages/ColorPalettePopover.html
+++ b/packages/main/test/pages/ColorPalettePopover.html
@@ -170,7 +170,7 @@
 
 	<ui5-title level="H5">show-recent-colors, show-more-colors and show-default-color</ui5-title>
 	<ui5-button id="btnColPop4">Open</ui5-button>
-	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green" openr="btnColPop4">
+	<ui5-color-palette-popover id="ColPop4" show-recent-colors show-more-colors show-default-color default-color="green" opener="btnColPop4">
 		<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 		<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 		<ui5-color-palette-item value="#444444"></ui5-color-palette-item>

--- a/packages/main/test/samples/ColorPalettePopover.sample.html
+++ b/packages/main/test/samples/ColorPalettePopover.sample.html
@@ -10,7 +10,7 @@
 	<h3>Color Palette Popover with recent colors, default color and more colors features</h3>
 	<div class="snippet">
 		<ui5-button id="colorPaletteBtn" >Open ColorPalettePopover</ui5-button>
-		<ui5-color-palette-popover id="colorPalettePopover" show-recent-colors show-more-colors show-default-color default-color="green">
+		<ui5-color-palette-popover id="colorPalettePopover" show-recent-colors show-more-colors show-default-color default-color="green" opener="colorPaletteBtn">
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -26,13 +26,13 @@
 		</ui5-color-palette-popover>
 	</div>
 	<script>
-		colorPaletteBtn.addEventListener("click", function(event) {
-			colorPalettePopover.showAt(this);
+		colorPaletteBtn.addEventListener("click", (event) => {
+			colorPalettePopover.open = !colorPalettePopover.open;
 		});
 	</script>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="colorPaletteBtn" >Open ColorPalettePopover</ui5-button>
-<ui5-color-palette-popover id="colorPalettePopover" show-recent-colors show-more-colors show-default-color default-color="green">
+<ui5-color-palette-popover id="colorPalettePopover" show-recent-colors show-more-colors show-default-color default-color="green" opener="colorPaletteBtn">
 	<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 	<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 	<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -48,7 +48,7 @@
 </ui5-color-palette-popover>
 <script>
 	colorPaletteBtn.addEventListener("click", (event) => {
-		colorPalettePopover.showAt(this);
+		colorPalettePopover.open = !colorPalettePopover.open;
 	});
 </script>
 </xmp></pre>
@@ -58,7 +58,7 @@
 	<h3>Color Palette Popover without any additional features</h3>
 	<div class="snippet">
 		<ui5-button id="colorPaletteBtn1" >Open ColorPalettePopover</ui5-button>
-		<ui5-color-palette-popover id="colorPalettePopover1">
+		<ui5-color-palette-popover id="colorPalettePopover1" opener="colorPaletteBtn1">
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -74,13 +74,13 @@
 		</ui5-color-palette-popover>
 	</div>
 	<script>
-		colorPaletteBtn1.addEventListener("click", function (event) {
-			colorPalettePopover1.showAt(this);
+		colorPaletteBtn1.addEventListener("click", (event) => {
+			colorPalettePopover1.open = !colorPalettePopover1.open;
 		});
 	</script>
 	<pre class="prettyprint lang-html"><xmp>
 <ui5-button id="colorPaletteBtn1" >Open ColorPalettePopover</ui5-button>
-<ui5-color-palette-popover id="colorPalettePopover1">
+<ui5-color-palette-popover id="colorPalettePopover1" opener="colorPaletteBtn1">
 	<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 	<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 	<ui5-color-palette-item value="#444444"></ui5-color-palette-item>
@@ -96,7 +96,7 @@
 </ui5-color-palette-popover>
 <script>
 	colorPaletteBtn1.addEventListener("click", (event) => {
-		colorPalettePopover1.showAt(this);
+		colorPalettePopover1.open = !colorPalettePopover1.open;
 	});
 </script>
 </xmp></pre>

--- a/packages/playground/_stories/main/ColorPalettePopover/ColorPalettePopover.stories.ts
+++ b/packages/playground/_stories/main/ColorPalettePopover/ColorPalettePopover.stories.ts
@@ -16,6 +16,7 @@ export default {
 
 const Template: UI5StoryArgs<ColorPalettePopover, StoryArgsSlots> = (args) => html`<ui5-color-palette-popover
 	id="${ifDefined(args.id)}"
+	opener="${ifDefined(args.opener)}"
 	?show-recent-colors="${ifDefined(args.showRecentColors)}"
 	?show-more-colors="${ifDefined(args.showMoreColors)}"
 	?show-default-color="${ifDefined(args.showDefaultColor)}"
@@ -27,6 +28,7 @@ const Template: UI5StoryArgs<ColorPalettePopover, StoryArgsSlots> = (args) => ht
 export const Basic = Template.bind({});
 Basic.args = {
 	id: "colorPalettePopover",
+	opener: "colorPaletteBtn",
 	default: `<ui5-color-palette-item value="lightsalmon"></ui5-color-palette-item>
 <ui5-color-palette-item value="lightpink"></ui5-color-palette-item>
 <ui5-color-palette-item value="rgb(216,124,172)"></ui5-color-palette-item>
@@ -42,8 +44,8 @@ Basic.decorators = [
 	(story) => html`<ui5-button id="colorPaletteBtn">Open ColorPalettePopover</ui5-button>
 	${story()}
 	<script>
-		colorPaletteBtn.addEventListener("click", function(event) {
-			colorPalettePopover.showAt(this);
+		colorPaletteBtn.addEventListener("click", (event) => {
+			colorPalettePopover.open = !colorPalettePopover.open;
 		});
 	</script>`,
 ];
@@ -60,6 +62,7 @@ export const DefaultColor = Template.bind({});
 DefaultColor.storyName = "Default, Recent, and More Colors";
 DefaultColor.args = {
 	id: "colorPalettePopover",
+	opener: "colorPaletteBtn",
 	defaultColor: "orange",
 	showDefaultColor: true,
 	showRecentColors: true,
@@ -84,8 +87,8 @@ DefaultColor.decorators = [
 	(story) => html`<ui5-button id="colorPaletteBtn">Open ColorPalettePopover</ui5-button>
 	${story()}
 	<script>
-		colorPaletteBtn.addEventListener("click", function(event) {
-			colorPalettePopover.showAt(this);
+		colorPaletteBtn.addEventListener("click", (event) => {
+			colorPalettePopover.open = !colorPalettePopover.open;
 		});
 	</script>`,
 ];

--- a/packages/website/docs/_samples/main/ColorPalettePopover/Basic/main.js
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/Basic/main.js
@@ -2,6 +2,6 @@ import "@ui5/webcomponents/dist/ColorPalettePopover.js";
 import "@ui5/webcomponents/dist/ColorPaletteItem.js";
 import "@ui5/webcomponents/dist/Button.js";
 
-colorPaletteBtn.addEventListener("click", function () {
-    colorPalettePopover.showAt(this);
+colorPaletteBtn.addEventListener("click", () => {
+	colorPalettePopover.open = !colorPalettePopover.open;
 });

--- a/packages/website/docs/_samples/main/ColorPalettePopover/Basic/sample.html
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/Basic/sample.html
@@ -13,7 +13,7 @@
 
 
     <ui5-button id="colorPaletteBtn">Open ColorPalettePopover</ui5-button>
-    <ui5-color-palette-popover id="colorPalettePopover">
+    <ui5-color-palette-popover id="colorPalettePopover" opener="colorPaletteBtn">
         <ui5-color-palette-item value="lightsalmon"></ui5-color-palette-item>
         <ui5-color-palette-item value="lightpink"></ui5-color-palette-item>
         <ui5-color-palette-item value="rgb(216,124,172)"></ui5-color-palette-item>

--- a/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/main.js
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/main.js
@@ -4,6 +4,6 @@ import "@ui5/webcomponents/dist/Button.js";
 
 import "@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js"
 
-colorPaletteBtn.addEventListener("click", function () {
-    colorPalettePopover.showAt(this);
+colorPaletteBtn.addEventListener("click", () => {
+	colorPalettePopover.open = !colorPalettePopover.open;
 });

--- a/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/sample.html
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/sample.html
@@ -14,6 +14,7 @@
     <ui5-button id="colorPaletteBtn">Open ColorPalettePopover</ui5-button>
     <ui5-color-palette-popover
         id="colorPalettePopover"
+        opener="colorPaletteBtn"
         show-default-color
         default-color="orange"
     >

--- a/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/main.js
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/main.js
@@ -5,6 +5,6 @@ import "@ui5/webcomponents/dist/Button.js";
 
 import "@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js"
 
-colorPaletteBtn.addEventListener("click", function () {
-    colorPalettePopover.showAt(this);
+colorPaletteBtn.addEventListener("click", () => {
+	colorPalettePopover.open = !colorPalettePopover.open;
 });

--- a/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/sample.html
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/sample.html
@@ -14,6 +14,7 @@
     <ui5-button id="colorPaletteBtn">Open ColorPalettePopover</ui5-button>
 
     <ui5-color-palette-popover id="colorPalettePopover"
+        opener="colorPaletteBtn"
         show-recent-colors
         show-more-colors
         show-default-color


### PR DESCRIPTION
Removes the `openPopover` and `showAt` methods from the `ui5-color-palette-popover`.

BREAKING CHANGE:
The `openPopover` and `showAt` methods are removed in favor of `open`  and `opener` properties. If you previously used the imperative API:
```js
button.addEventListener("click", function(event) {
	colorPalettePopover.showAt(this);
});
```
Now the declarative API should be used instead:
```html
<ui5-button id="opener">Open</ui5-button>
<ui5-color-palette-popover opener="opener">
```
```js
button.addEventListener("click", function(event) {
	colorPalettePopover.open = !colorPalettePopover.open;
});
```

Related to: #8461