### PR TITLE
fix(ui5-carousel): Fixed paging indicator numbers in right-to-left (RTL) mode

### DIFF
--- a/packages/main/src/Carousel.hbs
+++ b/packages/main/src/Carousel.hbs
@@ -49,7 +49,7 @@
 							></div>
 						{{/each}}
 					{{else}}
-						<div class="ui5-carousel-navigation-text">{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pagesCount}}</div>
+						<div dir="auto" class="ui5-carousel-navigation-text">{{selectedIndexToShow}}&nbsp;{{ofText}}&nbsp;{{pagesCount}}</div>
 					{{/if}}
 				{{/unless}}
 			</div>

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -53,6 +53,7 @@ describe("Carousel general interaction", () => {
 		const navigation = await carousel.shadow$(".ui5-carousel-navigation > .ui5-carousel-navigation-text");
 
 		assert.ok(await navigation.isExisting(), "Navigation is rendered");
+		assert.ok(await navigation.getAttribute("dir"), "auto", "text direction is auto");
 	});
 
 	it("Buttons are rendered in the content only when hovering (arrows-placement)", async () => {


### PR DESCRIPTION
Fixes #8473 