### PR TITLE
chore: set tab in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 [*.{css,html,java,js,json,less,txt,ts}]
 trim_trailing_whitespace = true
 end_of_line = lf
+indent_style = tab
 tab_width = 4
 
 [pom.xml]


### PR DESCRIPTION
The `.editorconfig` does not explicitly set `indent_style` which causes some IDEs to assume `space` is the default.