### PR TITLE
fix(ui5-bar): fix import in samples

### DIFF
--- a/packages/website/docs/_samples/fiori/IllustratedMessage/WithDialog/main.js
+++ b/packages/website/docs/_samples/fiori/IllustratedMessage/WithDialog/main.js
@@ -1,7 +1,7 @@
 import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Dialog.js";
 
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents-fiori/dist/IllustratedMessage.js";
 import "@ui5/webcomponents-fiori/dist/illustrations/UnableToLoad.js";
 

--- a/packages/website/docs/_samples/fiori/MediaGallery/Interactive/main.js
+++ b/packages/website/docs/_samples/fiori/MediaGallery/Interactive/main.js
@@ -3,7 +3,7 @@ import "@ui5/webcomponents/dist/Dialog.js";
 import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Title.js";
 
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents-fiori/dist/MediaGallery.js";
 import "@ui5/webcomponents-fiori/dist/MediaGalleryItem.js";
 

--- a/packages/website/docs/_samples/fiori/Page/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/Page/Basic/main.js
@@ -1,7 +1,7 @@
 import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Label.js";
 
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents-fiori/dist/Page.js";
 
 import "@ui5/webcomponents-icons/dist/home.js";

--- a/packages/website/docs/_samples/fiori/Page/FloatingFooter/main.js
+++ b/packages/website/docs/_samples/fiori/Page/FloatingFooter/main.js
@@ -1,7 +1,7 @@
 import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Label.js";
 
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents-fiori/dist/Page.js";
 
 import "@ui5/webcomponents-icons/dist/home.js";

--- a/packages/website/docs/_samples/fiori/Wizard/PageMode/main.js
+++ b/packages/website/docs/_samples/fiori/Wizard/PageMode/main.js
@@ -11,7 +11,7 @@ import "@ui5/webcomponents/dist/Dialog.js";
 
 import "@ui5/webcomponents-fiori/dist/Wizard.js";
 import "@ui5/webcomponents-fiori/dist/WizardStep.js";
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 
 import "@ui5/webcomponents-icons/dist/product.js";
 import "@ui5/webcomponents-icons/dist/hint.js";

--- a/packages/website/docs/_samples/main/Dialog/BarInDialog/main.js
+++ b/packages/website/docs/_samples/main/Dialog/BarInDialog/main.js
@@ -2,7 +2,7 @@ import "@ui5/webcomponents/dist/Dialog.js";
 import "@ui5/webcomponents/dist/Title.js";
 import "@ui5/webcomponents/dist/Button.js";
 
-import "@ui5/webcomponents-fiori/dist/Bar.js";
+import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents-icons/dist/decline.js";
 
 var dialogOpener = document.getElementById("dialogOpener");


### PR DESCRIPTION
Correct imports are now used after we moved the ui5-bar control to main library.
