### PR TITLE
docs: prevent 404 request on each keystroke

### DIFF
--- a/packages/base/src/renderer/directives/style-map.ts
+++ b/packages/base/src/renderer/directives/style-map.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+/* eslint-disable */
 /**
  * @license
  * Copyright 2018 Google LLC


### PR DESCRIPTION
Typing in the playground editor for a TS project sends a request on each keystroke for a `style-map.d.ts` which results in a 404. Typing even for a short time triggers the github pages rate limit for too many requests.

This change provides the .d.ts file so it is cached and there are no requests on each keystroke.