### PR TITLE
fix(ui5-illustrated-message): vertical alignment

### DIFF
--- a/packages/fiori/src/themes/IllustratedMessage.css
+++ b/packages/fiori/src/themes/IllustratedMessage.css
@@ -17,6 +17,7 @@
     align-items: center;
     justify-content: center;
     height:inherit;
+    flex-basis: content;
 }
 
 .ui5-illustrated-message-illustration {


### PR DESCRIPTION
Recent DOT feature led to improper vertical alignment of Illustrated Message's SVG when the IM is inside tall container. Now we make sure both the text and the SVG container are vertically centered in case of tall container.
Fixes: #8490

