### PR TITLE
fix(ui5-day-picker): improve  day name length check

### DIFF
--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -377,7 +377,7 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 	 * @private
 	 */
 	namesTooLong(dayNames: Array<string>): boolean {
-		return dayNames.some(dayName => dayName.length > 3);
+		return dayNames.some(dayName => dayName.length > 4);
 	}
 
 	onAfterRendering() {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -431,15 +431,4 @@ describe("Calendar general interaction", () => {
 
 		assert.ok(await currentDayItem.isFocusedDeep(), "Current calendar day item is focused");
 	});
-
-	it("Focus goes into the selected day item of the day picker", async () => {
-		await browser.url(`test/pages/Calendar.html?sap-ui-language=MK_mk`);
-
-		const calendar = await browser.$("#calendar4");
-		const dayPicker = await calendar.shadow$("ui5-daypicker");
-		const dayHeader = await dayPicker.shadow$(".ui5-dp-firstday");
-		const dayHeaderText = await dayHeader.getText();
-
-		assert.strictEqual(dayHeaderText, "пон.", "week name is with the correct length");
-	});
 });

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -431,4 +431,15 @@ describe("Calendar general interaction", () => {
 
 		assert.ok(await currentDayItem.isFocusedDeep(), "Current calendar day item is focused");
 	});
+
+	it("Focus goes into the selected day item of the day picker", async () => {
+		await browser.url(`test/pages/Calendar.html?sap-ui-language=MK_mk`);
+
+		const calendar = await browser.$("#calendar4");
+		const dayPicker = await calendar.shadow$("ui5-daypicker");
+		const dayHeader = await dayPicker.shadow$(".ui5-dp-firstday");
+		const dayHeaderText = await dayHeader.getText();
+
+		assert.strictEqual(dayHeaderText, "пон.", "week name is with the correct length");
+	});
 });


### PR DESCRIPTION
With support of new cldr, we add one more symbol allowance in the check for the day names length.