### PR TITLE
feat: enable property decorator for property accessors

### DIFF
--- a/packages/base/bundle.esm.js
+++ b/packages/base/bundle.esm.js
@@ -5,6 +5,7 @@ import EventProvider from "./dist/EventProvider.js";
 import "./dist/features/OpenUI5Support.js";
 
 // Test components
+import "./test/elements/Accessor.js";
 import "./test/elements/Generic.js";
 import "./test/elements/NoShadowDOM.js";
 import "./test/elements/Parent.js";

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -976,8 +976,26 @@ abstract class UI5Element extends HTMLElement {
 				throw new Error(`Cannot set a default value for property "${prop}". All multiple properties are empty arrays by default.`);
 			}
 
+			const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+			// if the decorator is on a setter, proxy the new setter to it
+			let origSet: (v: any) => void;
+			if (descriptor?.set) {
+				// eslint-disable-next-line @typescript-eslint/unbound-method
+				origSet = descriptor.set;
+			}
+			// if the decorator is on a setter, there will be a corresponding getter - proxy the new getter to it
+			let origGet: () => PropertyValue;
+			if (descriptor?.get) {
+				// eslint-disable-next-line @typescript-eslint/unbound-method
+				origGet = descriptor.get;
+			}
+
 			Object.defineProperty(proto, prop, {
 				get(this: UI5Element) {
+					// proxy the getter to the original accessor if there was one
+					if (origGet) {
+						return origGet.call(this);
+					}
 					if (this._state[prop] !== undefined) {
 						return this._state[prop];
 					}
@@ -1003,7 +1021,7 @@ abstract class UI5Element extends HTMLElement {
 					value = metadataCtor.validatePropertyValue(value, propData);
 					const propertyType = propData.type;
 					let propertyValidator = propData.validator as typeof DataType;
-					const oldState = this._state[prop];
+					const oldState = origGet ? origGet.call(this) : this._state[prop];
 
 					if (propertyType && (propertyType as typeof DataType).isDataTypeClass) {
 						propertyValidator = propertyType as typeof DataType;
@@ -1018,7 +1036,12 @@ abstract class UI5Element extends HTMLElement {
 					}
 
 					if (isDifferent) {
-						this._state[prop] = value;
+						// if the decorator is on a setter, use it for storage
+						if (origSet) {
+							origSet.call(this, value);
+						} else {
+							this._state[prop] = value;
+						}
 						_invalidate.call(this, {
 							type: "property",
 							name: prop,

--- a/packages/base/test/elements/Accessor.js
+++ b/packages/base/test/elements/Accessor.js
@@ -1,0 +1,68 @@
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+import UI5Element from "../../dist/UI5Element.js";
+import customElement from "../../dist/decorators/customElement.js";
+import property from "../../dist/decorators/property.js";
+import litRender, { html } from "../../dist/renderer/LitRenderer.js";
+let Accessor = class Accessor extends UI5Element {
+    constructor() {
+        super(...arguments);
+        this.storage = false;
+    }
+    set myProp(value) {
+        this.storage = value;
+    }
+    get myProp() {
+        return this.storage;
+    }
+    render() {
+        return html `<div>${this.myProp}</div>`;
+    }
+};
+__decorate([
+    property({type: Boolean})
+], Accessor.prototype, "myProp", null);
+Accessor = __decorate([
+    customElement({
+        tag: "ui5-test-accessor",
+        renderer: litRender,
+    })
+], Accessor);
+Accessor.define();
+export default Accessor;
+
+/*
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+
+@customElement({
+	tag: "ui5-test-accessor",
+	renderer: litRender,
+})
+class Accessor extends UI5Element {
+	storage: boolean = false;
+
+	@property()
+	set myProp(value: boolean) {
+		this.storage = value;
+	}
+
+	get myProp() {
+		return this.storage;
+	}
+
+	render() {
+		return html`<div>${this.myProp}</div>`;
+	}
+}
+
+Accessor.define();
+
+export default Accessor;
+*/

--- a/packages/base/test/pages/Accessor.html
+++ b/packages/base/test/pages/Accessor.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+
+    <title>Base package default test page</title>
+
+	<script src="../../bundle.esm.js" type="module"></script>
+</head>
+
+<body>
+    <ui5-test-accessor id="accessor"></ui5-test-accessor>
+</body>
+</html>

--- a/packages/base/test/specs/Accessor.spec.js
+++ b/packages/base/test/specs/Accessor.spec.js
@@ -1,0 +1,60 @@
+import { assert } from "chai";
+
+describe("Framework boot", async () => {
+	before(async () => {
+		await browser.url("test/pages/Accessor.html");
+	});
+
+	it("Setting property updates attribute, state and DOM", async () => {
+		// set to true
+		const res = await browser.executeAsync( async (done) => {
+			const el = document.getElementById("accessor");
+			el.myProp = true;
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+			done([el.getAttribute("my-prop"), el.shadowRoot.querySelector("div").innerText, el.storage]);
+		});
+
+		assert.strictEqual(res[0], "", "attribute is set");
+		assert.strictEqual(res[1], "true", "content is rendered in shadowDOM");
+		assert.strictEqual(res[2], true, "internal storage is updated");
+
+		// set to false
+		const res2 = await browser.executeAsync( async (done) => {
+			const el = document.getElementById("accessor");
+			el.myProp = false;
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+			done([el.getAttribute("my-prop"), el.shadowRoot.querySelector("div").innerText, el.storage]);
+		});
+
+		assert.strictEqual(res2[0], null, "attribute is removed");
+		assert.strictEqual(res2[1], "false", "content is rendered in shadowDOM");
+		assert.strictEqual(res2[2], false, "internal storage is updated");
+	});
+
+	it("Setting attribute updates property, state and DOM", async () => {
+		// set to true
+		const res = await browser.executeAsync( async (done) => {
+			const el = document.getElementById("accessor");
+			el.setAttribute("my-prop", "");
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+			done([el.myProp, el.shadowRoot.querySelector("div").innerText, el.storage]);
+		});
+
+		assert.strictEqual(res[0], true, "property is updated");
+		assert.strictEqual(res[1], "true", "content is rendered in shadowDOM");
+		assert.strictEqual(res[2], true, "internal storage is updated");
+
+		// set to false
+		const res2 = await browser.executeAsync( async (done) => {
+			const el = document.getElementById("accessor");
+			el.removeAttribute("my-prop")
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+			done([el.myProp, el.shadowRoot.querySelector("div").innerText, el.storage]);
+		});
+
+		assert.strictEqual(res2[0], false, "property is updated");
+		assert.strictEqual(res2[1], "false", "content is rendered in shadowDOM");
+		assert.strictEqual(res2[2], false, "internal storage is updated");
+	});
+
+});


### PR DESCRIPTION
It is now possible to use the `@property` decorator on a property accessor like this:

```ts
class Accessor extends UI5Element {
  storage: boolean = false;

  @property()
  set myProp(value: boolean) {
    this.storage = value;
    // do sync work here
  }

  get myProp() {
    return this.storage;
  }

  render() {
    return html`<div>${this.myProp}</html>`;
  }
}
```

The main use case for this is to to synchronously make a DOM operation (like adding a class to show the dialog when a property is set), as the normal setting of a property triggers an async rendering cycle. A real use case is setting the focus to the first element of the dialog will show the iOS keyboard only if it is in the same tick as the click handler that triggered the operation (#8583)

### Implementation
Previously, the `@property` decorator was overwriting such accessors and using the internal UI5Element `_state` for storage. With this change, if an accessor pair exists, it will be used for storage, this triggering the custom logic.

Additionally, setting the property will still trigger invalidation, as well as update the attribute in the DOM.