### PR TITLE
refactor(ui5-popover): rename property placementType to placement

### DIFF
--- a/packages/fiori/src/NotificationOverflowActionsPopover.hbs
+++ b/packages/fiori/src/NotificationOverflowActionsPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-popover
 	class="ui5-notification-overflow-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	hide-arrow
 >

--- a/packages/fiori/src/ShellBarPopover.hbs
+++ b/packages/fiori/src/ShellBarPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-popover class="ui5-shellbar-menu-popover"
 	hide-arrow
-	placement-type="Bottom"
+	placement="Bottom"
 	@ui5-before-open={{_menuPopoverBeforeOpen}}
 	@ui5-after-close={{_menuPopoverAfterClose}}
 >
@@ -12,7 +12,7 @@
 </ui5-popover>
 
 <ui5-popover class="ui5-shellbar-overflow-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="{{popoverHorizontalAlign}}"
 	hide-arrow
 	@ui5-before-open={{_overflowPopoverBeforeOpen}}

--- a/packages/fiori/src/WizardPopover.hbs
+++ b/packages/fiori/src/WizardPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-responsive-popover
 	horizontal-align="Center"
-	placement-type="Bottom"
+	placement="Bottom"
 	aria-label="{{actionSheetStepsText}}"
 	class="{{classes.popover}}"
 	@ui5-after-close={{_afterClosePopover}}

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -178,7 +178,7 @@
 
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
-	<ui5-popover id="notificationsPopover" class="notificationlistgroupitem2auto" placement-type="Bottom" horizontal-align="End">
+	<ui5-popover id="notificationsPopover" class="notificationlistgroupitem2auto" placement="Bottom" horizontal-align="End">
 		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'">
 			<ui5-li-notification-group
 				show-close

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -146,7 +146,7 @@
 
 	<ui5-toast id="wcToastBS" duration="2000"></ui5-toast>
 
-	<ui5-popover id="notificationsPopover" class="notificationlistitem2auto" placement-type="Bottom" horizontal-align="End">
+	<ui5-popover id="notificationsPopover" class="notificationlistitem2auto" placement="Bottom" horizontal-align="End">
 		<ui5-list id="notificationListTop" header-text="Notifications titleText and content 'truncates'">
 			<ui5-li-notification
 				show-close

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -148,7 +148,7 @@
 		</div>
 	</section>
 
-	<ui5-popover id="popover" placement-type="Bottom">
+	<ui5-popover id="popover" placement="Bottom">
 		<div class="popover-header">
 			<ui5-title class="shellbar2auto">John Doe</ui5-title>
 		</div>
@@ -164,7 +164,7 @@
 		</div>
 	</ui5-popover>
 
-	<ui5-popover id="app-list-popover" placement-type="Bottom">
+	<ui5-popover id="app-list-popover" placement="Bottom">
 		<ui5-list separators="None">
 			<ui5-li>Application 1</ui5-li>
 			<ui5-li>Application 2</ui5-li>
@@ -174,7 +174,7 @@
 		</ui5-list>
 	</ui5-popover>
 
-	<ui5-popover id="custom-item-popover" placement-type="Bottom">
+	<ui5-popover id="custom-item-popover" placement="Bottom">
 		<ui5-list separators="None">
 			<ui5-li id="custom-item-1" type="Active">Custom Popover Item 1</ui5-li>
 			<ui5-li type="Active">Custom Popover Item 2</ui5-li>

--- a/packages/fiori/test/samples/NotificationListGroupItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListGroupItem.sample.html
@@ -186,7 +186,7 @@
 		>
 		</ui5-shellbar>
 
-		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="End">
+		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement="Bottom" horizontal-align="End">
 			<ui5-list id="notificationListTop" header-text="Notifications grouped">
 				<ui5-li-notification-group
 					show-close
@@ -328,7 +328,7 @@
 <ui5-popover
 	id="notificationsPopover"
 	style="max-width: 400px"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 >
 	<ui5-list header-text="Notifications">

--- a/packages/fiori/test/samples/NotificationListItem.sample.html
+++ b/packages/fiori/test/samples/NotificationListItem.sample.html
@@ -190,7 +190,7 @@
 		>
 		</ui5-shellbar>
 
-		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement-type="Bottom" horizontal-align="End">
+		<ui5-popover id="notificationsPopover" style="max-width: 400px" placement="Bottom" horizontal-align="End">
 			<ui5-list id="notificationListTop" header-text="Notifications">
 				<ui5-li-notification
 					show-close
@@ -264,7 +264,7 @@
 <ui5-popover
 	id="notificationsPopover"
 	style="max-width: 400px"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Right"
 >
 	<ui5-list header-text="Notifications">

--- a/packages/fiori/test/samples/ProductSwitch.sample.html
+++ b/packages/fiori/test/samples/ProductSwitch.sample.html
@@ -40,7 +40,7 @@
 			show-product-switch
 			show-co-pilot>
 		</ui5-shellbar>
-		<ui5-popover id="productswitch-popover" placement-type="Bottom">
+		<ui5-popover id="productswitch-popover" placement="Bottom">
 			<ui5-product-switch>
 				<ui5-product-switch-item title-text="Home" subtitle-text="Central Home" icon="home"></ui5-product-switch-item>
 				<ui5-product-switch-item title-text="Analytics Cloud" subtitle-text="Analytics Cloud" icon="business-objects-experience"></ui5-product-switch-item>
@@ -82,7 +82,7 @@
 	show-product-switch
 	show-co-pilot>
 </ui5-shellbar>
-<ui5-popover id="productswitch-popover" placement-type="Bottom">
+<ui5-popover id="productswitch-popover" placement="Bottom">
 	<ui5-product-switch>
 		<ui5-product-switch-item title-text="Home" subtitle-text="Central Home" icon="home"></ui5-product-switch-item>
 		<ui5-product-switch-item title-text="Analytics Cloud" subtitle-text="Analytics Cloud" icon="business-objects-experience"></ui5-product-switch-item>

--- a/packages/fiori/test/samples/ShellBar.sample.html
+++ b/packages/fiori/test/samples/ShellBar.sample.html
@@ -48,7 +48,7 @@
 		<ui5-li slot="menuItems">Application 5</ui5-li>
 	</ui5-shellbar>
 
-	<ui5-popover id="action-popover" placement-type="Bottom">
+	<ui5-popover id="action-popover" placement="Bottom">
 		<div class="action-popover-header">
 			<ui5-title style="padding: 0.25rem 1rem 0rem 1rem">An Kimura</ui5-title>
 		</div>
@@ -101,7 +101,7 @@
 
 </ui5-shellbar>
 
-<ui5-popover id="popover" placement-type="Bottom">
+<ui5-popover id="popover" placement="Bottom">
 	<div class="popover-header">
 		<ui5-title style="padding: 0.25rem 1rem 0rem 1rem">An Kimura</ui5-title>
 	</div>

--- a/packages/main/src/BreadcrumbsPopover.hbs
+++ b/packages/main/src/BreadcrumbsPopover.hbs
@@ -2,7 +2,7 @@
 	class="ui5-breadcrumbs-popover"
 	hide-arrow
 	content-only-on-desktop
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	_hide-header
 	@keydown="{{_onkeydown}}">

--- a/packages/main/src/ColorPalettePopover.hbs
+++ b/packages/main/src/ColorPalettePopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	hide-arrow
 	content-only-on-desktop
-	placement-type="Bottom"
+	placement="Bottom"
 	?open="{{_open}}"
 	.opener="{{opener}}"
 	@ui5-after-close="{{onAfterClose}}"

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	class="{{classes.popover}}"
 	hide-arrow
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	style="{{styles.suggestionsPopover}}"
 	@ui5-after-open={{_afterOpenPopover}}
@@ -96,7 +96,7 @@
 		hide-arrow
 		class="ui5-valuestatemessage-popover"
 		horizontal-align="{{_valueStatePopoverHorizontalAlign}}"
-		placement-type="Bottom"
+		placement="Bottom"
 	>
 		<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">
 			<ui5-icon class="ui5-input-value-state-message-icon" name="{{_valueStateMessageIcon}}"></ui5-icon>

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	id="{{_id}}-responsive-popover"
 	allow-target-overlap
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	hide-arrow
 	?_hide-header={{_shouldHideHeader}}

--- a/packages/main/src/FileUploaderPopover.hbs
+++ b/packages/main/src/FileUploaderPopover.hbs
@@ -4,7 +4,7 @@
 	prevent-focus-restore
 	hide-arrow
 	class="ui5-valuestatemessage-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 >
 	<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -3,7 +3,7 @@
 		class="{{classes.popover}}"
 		hide-arrow
 		_disable-initial-focus
-		placement-type="Bottom"
+		placement="Bottom"
 		horizontal-align="Start"
 		style="{{styles.suggestionsPopover}}"
 		@ui5-after-open="{{_afterOpenPopover}}"
@@ -72,7 +72,7 @@
 			prevent-focus-restore
 			hide-arrow
 			class="ui5-valuestatemessage-popover"
-			placement-type="Bottom"
+			placement="Bottom"
 			horizontal-align="{{_valueStatePopoverHorizontalAlign}}"
 		>
 			<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -2,7 +2,7 @@
 	id="{{_id}}-menu-rp"
 	class="ui5-menu-rp"
 	horizontal-align="Start"
-	placement-type={{placementType}}
+	placement={{placement}}
 	vertical-align={{verticalAlign}}
 	hide-arrow
 	allow-target-overlap

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -28,7 +28,7 @@ import StandardListItem from "./StandardListItem.js";
 import Icon from "./Icon.js";
 import BusyIndicator from "./BusyIndicator.js";
 import type MenuItem from "./MenuItem.js";
-import PopoverPlacementType from "./types/PopoverPlacementType.js";
+import PopoverPlacement from "./types/PopoverPlacement.js";
 import type { ListItemClickEventDetail } from "./List.js";
 import staticAreaMenuTemplate from "./generated/templates/MenuTemplate.lit.js";
 import {
@@ -337,7 +337,7 @@ class Menu extends UI5Element {
 		return this.effectiveDir === "rtl";
 	}
 
-	get placementType(): `${PopoverPlacementType}` {
+	get placement(): `${PopoverPlacement}` {
 		const placement = this.isRtl ? "Start" : "End";
 		return this._isSubMenu ? placement : "Bottom";
 	}

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -1,5 +1,5 @@
 <ui5-responsive-popover
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	class="{{classes.popover}}"
 	hide-arrow
@@ -106,7 +106,7 @@
 		prevent-focus-restore
 		hide-arrow
 		class="ui5-valuestatemessage-popover"
-		placement-type="Bottom"
+		placement="Bottom"
 		horizontal-align="{{_valueStatePopoverHorizontalAlign}}"
 	>
 		<div slot="header" class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -11,7 +11,7 @@ import isElementContainingBlock from "@ui5/webcomponents-base/dist/util/isElemen
 import getParentElement from "@ui5/webcomponents-base/dist/util/getParentElement.js";
 import Popup from "./Popup.js";
 import type { PopupBeforeCloseEventDetail as PopoverBeforeCloseEventDetail } from "./Popup.js";
-import PopoverPlacementType from "./types/PopoverPlacementType.js";
+import PopoverPlacement from "./types/PopoverPlacement.js";
 import PopoverVerticalAlign from "./types/PopoverVerticalAlign.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 import { addOpenedPopover, removeOpenedPopover } from "./popup-utils/PopoverRegistry.js";
@@ -39,7 +39,7 @@ type CalculatedPlacement = {
 	arrow: ArrowPosition,
 	top: number,
 	left: number,
-	placementType: `${PopoverPlacementType}`,
+	placement: `${PopoverPlacement}`,
 }
 
 /**
@@ -108,8 +108,8 @@ class Popover extends Popup {
 	 * @default "End"
 	 * @public
 	 */
-	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.End })
-	placementType!: `${PopoverPlacementType}`;
+	@property({ type: PopoverPlacement, defaultValue: PopoverPlacement.End })
+	placement!: `${PopoverPlacement}`;
 
 	/**
 	 * Determines the horizontal alignment of the component.
@@ -199,8 +199,8 @@ class Popover extends Popup {
 	 * Returns the calculated placement depending on the free space
 	 * @private
 	 */
-	@property({ type: PopoverPlacementType, defaultValue: PopoverPlacementType.End })
-	actualPlacementType!: `${PopoverPlacementType}`;
+	@property({ type: PopoverPlacement, defaultValue: PopoverPlacement.End })
+	actualPlacement!: `${PopoverPlacement}`;
 
 	@property({ validator: Integer, noAttribute: true })
 	_maxHeight?: number;
@@ -310,7 +310,7 @@ class Popover extends Popup {
 		removeOpenedPopover(this);
 	}
 
-	shouldCloseDueToOverflow(placement: `${PopoverPlacementType}`, openerRect: DOMRect): boolean {
+	shouldCloseDueToOverflow(placement: `${PopoverPlacement}`, openerRect: DOMRect): boolean {
 		const threshold = 32;
 		const limits = {
 			"Start": openerRect.right,
@@ -392,7 +392,7 @@ class Popover extends Popup {
 		}
 
 		this._oldPlacement = placement;
-		this.actualPlacementType = placement.placementType;
+		this.actualPlacement = placement.placement;
 
 		let left = clamp(
 			this._left!,
@@ -400,7 +400,7 @@ class Popover extends Popup {
 			document.documentElement.clientWidth - popoverSize.width - Popover.VIEWPORT_MARGIN,
 		);
 
-		if (this.actualPlacementType === PopoverPlacementType.End) {
+		if (this.actualPlacement === PopoverPlacement.End) {
 			left = Math.max(left, this._left!);
 		}
 
@@ -410,7 +410,7 @@ class Popover extends Popup {
 			document.documentElement.clientHeight - popoverSize.height - Popover.VIEWPORT_MARGIN,
 		);
 
-		if (this.actualPlacementType === PopoverPlacementType.Bottom) {
+		if (this.actualPlacement === PopoverPlacement.Bottom) {
 			top = Math.max(top, this._top!);
 		}
 
@@ -497,12 +497,12 @@ class Popover extends Popup {
 		let maxHeight = clientHeight;
 		let maxWidth = clientWidth;
 
-		const placementType = this.getActualPlacementType(targetRect, popoverSize);
+		const placement = this.getActualPlacement(targetRect, popoverSize);
 
-		this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placementType, targetRect);
+		this._preventRepositionAndClose = this.shouldCloseDueToNoOpener(targetRect) || this.shouldCloseDueToOverflow(placement, targetRect);
 
-		const isVertical = placementType === PopoverPlacementType.Top
-			|| placementType === PopoverPlacementType.Bottom;
+		const isVertical = placement === PopoverPlacement.Top
+			|| placement === PopoverPlacement.Bottom;
 
 		if (this.horizontalAlign === PopoverHorizontalAlign.Stretch && isVertical) {
 			popoverSize.width = targetRect.width;
@@ -514,8 +514,8 @@ class Popover extends Popup {
 		const arrowOffset = this.hideArrow ? 0 : ARROW_SIZE;
 
 		// calc popover positions
-		switch (placementType) {
-		case PopoverPlacementType.Top:
+		switch (placement) {
+		case PopoverPlacement.Top:
 			left = this.getVerticalLeft(targetRect, popoverSize);
 			top = Math.max(targetRect.top - popoverSize.height - arrowOffset, 0);
 
@@ -523,7 +523,7 @@ class Popover extends Popup {
 				maxHeight = targetRect.top - arrowOffset;
 			}
 			break;
-		case PopoverPlacementType.Bottom:
+		case PopoverPlacement.Bottom:
 			left = this.getVerticalLeft(targetRect, popoverSize);
 			top = targetRect.bottom + arrowOffset;
 
@@ -533,7 +533,7 @@ class Popover extends Popup {
 				maxHeight = clientHeight - targetRect.bottom - arrowOffset;
 			}
 			break;
-		case PopoverPlacementType.Start:
+		case PopoverPlacement.Start:
 			left = Math.max(targetRect.left - popoverSize.width - arrowOffset, 0);
 			top = this.getHorizontalTop(targetRect, popoverSize);
 
@@ -541,7 +541,7 @@ class Popover extends Popup {
 				maxWidth = targetRect.left - arrowOffset;
 			}
 			break;
-		case PopoverPlacementType.End:
+		case PopoverPlacement.End:
 			left = targetRect.left + targetRect.width + arrowOffset;
 			top = this.getHorizontalTop(targetRect, popoverSize);
 
@@ -586,7 +586,7 @@ class Popover extends Popup {
 			arrow: arrowPos,
 			top: this._top,
 			left: this._left,
-			placementType,
+			placement,
 		};
 	}
 
@@ -649,57 +649,57 @@ class Popover extends Popup {
 	 * Fallbacks to new placement, prioritizing `Left` and `Right` placements.
 	 * @private
 	 */
-	fallbackPlacement(clientWidth: number, clientHeight: number, targetRect: DOMRect, popoverSize: PopoverSize): PopoverPlacementType | undefined {
+	fallbackPlacement(clientWidth: number, clientHeight: number, targetRect: DOMRect, popoverSize: PopoverSize): PopoverPlacement | undefined {
 		if (targetRect.left > popoverSize.width) {
-			return PopoverPlacementType.Start;
+			return PopoverPlacement.Start;
 		}
 
 		if (clientWidth - targetRect.right > targetRect.left) {
-			return PopoverPlacementType.End;
+			return PopoverPlacement.End;
 		}
 
 		if (clientHeight - targetRect.bottom > popoverSize.height) {
-			return PopoverPlacementType.Bottom;
+			return PopoverPlacement.Bottom;
 		}
 
 		if (clientHeight - targetRect.bottom < targetRect.top) {
-			return PopoverPlacementType.Top;
+			return PopoverPlacement.Top;
 		}
 	}
 
-	getActualPlacementType(targetRect: DOMRect, popoverSize: PopoverSize): `${PopoverPlacementType}` {
-		const placementType = this.placementType;
-		let actualPlacementType = placementType;
+	getActualPlacement(targetRect: DOMRect, popoverSize: PopoverSize): `${PopoverPlacement}` {
+		const placement = this.placement;
+		let actualPlacement = placement;
 
 		const clientWidth = document.documentElement.clientWidth;
 		const clientHeight = document.documentElement.clientHeight;
 
-		switch (placementType) {
-		case PopoverPlacementType.Top:
+		switch (placement) {
+		case PopoverPlacement.Top:
 			if (targetRect.top < popoverSize.height
 				&& targetRect.top < clientHeight - targetRect.bottom) {
-				actualPlacementType = PopoverPlacementType.Bottom;
+				actualPlacement = PopoverPlacement.Bottom;
 			}
 			break;
-		case PopoverPlacementType.Bottom:
+		case PopoverPlacement.Bottom:
 			if (clientHeight - targetRect.bottom < popoverSize.height
 				&& clientHeight - targetRect.bottom < targetRect.top) {
-				actualPlacementType = PopoverPlacementType.Top;
+				actualPlacement = PopoverPlacement.Top;
 			}
 			break;
-		case PopoverPlacementType.Start:
+		case PopoverPlacement.Start:
 			if (targetRect.left < popoverSize.width) {
-				actualPlacementType = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placementType;
+				actualPlacement = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placement;
 			}
 			break;
-		case PopoverPlacementType.End:
+		case PopoverPlacement.End:
 			if (clientWidth - targetRect.right < popoverSize.width) {
-				actualPlacementType = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placementType;
+				actualPlacement = this.fallbackPlacement(clientWidth, clientHeight, targetRect, popoverSize) || placement;
 			}
 			break;
 		}
 
-		return actualPlacementType;
+		return actualPlacement;
 	}
 
 	getVerticalLeft(targetRect: DOMRect, popoverSize: PopoverSize): number {

--- a/packages/main/src/SelectMenu.hbs
+++ b/packages/main/src/SelectMenu.hbs
@@ -1,6 +1,6 @@
 <ui5-responsive-popover
 	class="ui5-select-menu"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	@ui5-after-open="{{_onAfterOpen}}"
 	@ui5-after-close="{{_onAfterClose}}"

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -2,7 +2,7 @@
 	<ui5-responsive-popover
 		hide-arrow
 		_disable-initial-focus
-		placement-type="Bottom"
+		placement="Bottom"
 		class="ui5-select-popover {{classes.popover}}"
 		horizontal-align="Start"
 		@ui5-after-open="{{_afterOpen}}"
@@ -70,7 +70,7 @@
 		prevent-focus-restore
 		hide-arrow
 		class="ui5-valuestatemessage-popover"
-		placement-type="Bottom"
+		placement="Bottom"
 		horizontal-align="Start"
 	>
 		<div class="{{classes.popoverValueState}}" style="{{styles.popoverHeader}}">

--- a/packages/main/src/TabContainerPopover.hbs
+++ b/packages/main/src/TabContainerPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	id="{{_id}}-overflowMenu"
 	horizontal-align="End"
-	placement-type="Bottom"
+	placement="Bottom"
 	content-only-on-desktop
 	hide-arrow
 	_hide-header

--- a/packages/main/src/TextAreaPopover.hbs
+++ b/packages/main/src/TextAreaPopover.hbs
@@ -6,7 +6,7 @@
 		_disable-initial-focus
 		class="ui5-valuestatemessage-popover"
 		style="{{styles.valueStateMsgPopover}}"
-		placement-type="Bottom"
+		placement="Bottom"
 		horizontal-align="{{_valueStatePopoverHorizontalAlign}}"
 	>
 		<div slot="header" class="ui5-valuestatemessage-root {{classes.valueStateMsg}}">

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -1,7 +1,7 @@
 <ui5-responsive-popover
 	id="{{_id}}-responsive-popover"
 	class="ui5-time-picker-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	allow-target-overlap
 	_hide-header
@@ -30,7 +30,7 @@
 <ui5-popover
 	id="{{_id}}-popover"
 	class="ui5-time-picker-inputs-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	allow-target-overlap
 	_hide-header

--- a/packages/main/src/TokenizerPopover.hbs
+++ b/packages/main/src/TokenizerPopover.hbs
@@ -4,7 +4,7 @@
 	class={{classes.popover}}
 	?content-only-on-desktop="{{noValueStatePopover}}"
 	hide-arrow
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="Start"
 	@before-close={{handleBeforeClose}}
 	@before-open="{{handleBeforeOpen}}"

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -340,7 +340,7 @@ class Toolbar extends UI5Element {
 	async openOverflow(): Promise<void> {
 		const overflowPopover = await this.getOverflowPopover();
 		overflowPopover!.showAt(this.overflowButtonDOM!);
-		this.reverseOverflow = overflowPopover!.actualPlacementType === "Top";
+		this.reverseOverflow = overflowPopover!.actualPlacement === "Top";
 	}
 
 	async closeOverflow() {

--- a/packages/main/src/ToolbarPopover.hbs
+++ b/packages/main/src/ToolbarPopover.hbs
@@ -1,6 +1,6 @@
 <ui5-popover
 	class="ui5-overflow-popover"
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	@ui5-after-close="{{onOverflowPopoverClosed}}"
 	@ui5-after-open="{{onOverflowPopoverOpened}}"

--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -50,7 +50,7 @@
 	margin-inline: var(--_ui5_menu_submenu_margin_offset);
 }
 
-.ui5-menu-rp[sub-menu][actual-placement-type="Start"] {
+.ui5-menu-rp[sub-menu][actual-placement="Start"] {
 	margin-top: 0.25rem;
 	margin-inline: var(--_ui5_menu_submenu_placement_type_left_margin_offset);
 }

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -8,58 +8,58 @@
 	box-shadow: var(--_ui5_popover_no_arrow_box_shadow);
 }
 
-:host([opened][actual-placement-type="Top"]) {
+:host([opened][actual-placement="Top"]) {
 	margin-top: var(--_ui5-popover-margin-bottom);
 }
 
-:host([opened][actual-placement-type="Bottom"]) {
+:host([opened][actual-placement="Bottom"]) {
 	margin-top: var(--_ui5-popover-margin-top);
 }
 
 /* pointing upward arrow */
-:host([actual-placement-type="Bottom"]) .ui5-popover-arrow {
+:host([actual-placement="Bottom"]) .ui5-popover-arrow {
 	left: calc(50% - 0.5625rem);
 	top: -0.5rem;
 	height: 0.5625rem;
 }
 
-:host([actual-placement-type="Bottom"]) .ui5-popover-arrow:after {
+:host([actual-placement="Bottom"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_upward_arrow_margin);
 }
 
 /* pointing right arrow */
-:host([actual-placement-type="Start"]) .ui5-popover-arrow {
+:host([actual-placement="Start"]) .ui5-popover-arrow {
 	top: calc(50% - 0.5625rem);
 	right: -0.5625rem;
 	width: 0.5625rem;
 }
 
-:host([actual-placement-type="Start"]) .ui5-popover-arrow:after {
+:host([actual-placement="Start"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_right_arrow_margin);
 }
 
 /* pointing downward arrow */
-:host([actual-placement-type="Top"]) .ui5-popover-arrow {
+:host([actual-placement="Top"]) .ui5-popover-arrow {
 	left: calc(50% - 0.5625rem);
 	height: 0.5625rem;
 	top: 100%;
 }
 
-:host([actual-placement-type="Top"]) .ui5-popover-arrow:after {
+:host([actual-placement="Top"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_downward_arrow_margin);
 }
 
 /* pointing left arrow */
-:host(:not([actual-placement-type])) .ui5-popover-arrow,
-:host([actual-placement-type="End"]) .ui5-popover-arrow {
+:host(:not([actual-placement])) .ui5-popover-arrow,
+:host([actual-placement="End"]) .ui5-popover-arrow {
 	left: -0.5625rem;
 	top: calc(50% - 0.5625rem);
 	width: 0.5625rem;
 	height: 1rem;
 }
 
-:host(:not([actual-placement-type])) .ui5-popover-arrow:after,
-:host([actual-placement-type="End"]) .ui5-popover-arrow:after {
+:host(:not([actual-placement])) .ui5-popover-arrow:after,
+:host([actual-placement="End"]) .ui5-popover-arrow:after {
 	margin: var(--_ui5_popover_left_arrow_margin);
 }
 

--- a/packages/main/src/types/PopoverPlacement.ts
+++ b/packages/main/src/types/PopoverPlacement.ts
@@ -1,8 +1,8 @@
 /**
- * Popover placement types.
+ * Popover placements.
  * @public
  */
-enum PopoverPlacementType {
+enum PopoverPlacement {
 	/**
 	 * Popover will be placed at the start of the reference element.
 	 * @public
@@ -28,4 +28,4 @@ enum PopoverPlacementType {
 	Bottom = "Bottom",
 }
 
-export default PopoverPlacementType;
+export default PopoverPlacement;

--- a/packages/main/test/pages/AvatarGroup.html
+++ b/packages/main/test/pages/AvatarGroup.html
@@ -51,7 +51,7 @@
 
 	<div id="avatar-group-wrapper">
 
-		<ui5-popover header-text="My Heading" id="group-pop" class="avatargroup1auto" placement-type="Bottom" accessible-name="This popover is important">
+		<ui5-popover header-text="My Heading" id="group-pop" class="avatargroup1auto" placement="Bottom" accessible-name="This popover is important">
 			<div slot="header">
 				<h5>Business card</h5>
 			</div>
@@ -65,7 +65,7 @@
 			</div>
 		</ui5-popover>
 
-		<ui5-popover header-text="My Heading" id="individual-pop" class="avatargroup3auto" placement-type="Bottom" accessible-name="This popover is important" prevent-focus-restore>
+		<ui5-popover header-text="My Heading" id="individual-pop" class="avatargroup3auto" placement="Bottom" accessible-name="This popover is important" prevent-focus-restore>
 			<div slot="header">
 				<h5>Business card</h5>
 			</div>

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -388,7 +388,7 @@
 		</div>
 	</ui5-dialog>
 
-	<ui5-popover header-text="My Heading" id="pop" class="dialog8auto" placement-type="Top">
+	<ui5-popover header-text="My Heading" id="pop" class="dialog8auto" placement="Top">
 		<!-- <div slot="header">
 			Hello World
 		</div> -->
@@ -424,7 +424,7 @@
 		</div>
 	</ui5-popover>
 
-	<ui5-dialog placement-type="Bottom" id='danger'>
+	<ui5-dialog placement="Bottom" id='danger'>
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>World</ui5-li>

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -33,7 +33,7 @@
 		<ui5-suggestion-item class="suggestionItem" text="IPad Air"></ui5-suggestion-item>
 	</ui5-input>
 
-	<ui5-popover id="quickViewCard" hide-arrow placement-type="Right" height="500px" prevent-focus-restore>
+	<ui5-popover id="quickViewCard" hide-arrow placement="Right" height="500px" prevent-focus-restore>
 		<button>hello</button>
 		<ui5-input id="searchInput" class="input_quickview4auto">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
@@ -78,7 +78,7 @@
 	<div class="input_quickview6auto">Test mouseover on item</div>
 	<ui5-input id="mouseoverResult" class="input_quickview7auto"></ui5-input>
 
-	<ui5-popover id="quickViewCard2" hide-arrow placement-type="End" height="500px">
+	<ui5-popover id="quickViewCard2" hide-arrow placement="End" height="500px">
 		<ui5-input id="searchInput2" class="input_quickview4auto">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -287,7 +287,7 @@
 	<br />
 	<br />
 	<ui5-button id="btnOpenPopup">Open popup with List</ui5-button>
-	<ui5-responsive-popover id="popup" placement-type="Bottom" class="list_test_page5auto">
+	<ui5-responsive-popover id="popup" placement="Bottom" class="list_test_page5auto">
 		<ui5-list>
 			<div slot="header">
 				<ui5-button id="btnInHeader" icon="refresh"></ui5-button>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -28,7 +28,7 @@
 	<iframe id="clickThisIframe" src="//localhost:8080"></iframe>
 	<ui5-button id="btn">Click me !</ui5-button>
 
-	<ui5-popover id="pop" class="popover6auto" placement-type="Top" accessible-name="This popover is important">
+	<ui5-popover id="pop" class="popover6auto" placement="Top" accessible-name="This popover is important">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -44,7 +44,7 @@
 
 		<ui5-button id="popbtn">Open Popover</ui5-button>
 
-		<ui5-popover placement-type="Bottom" hide-arrow id="danger">
+		<ui5-popover placement="Bottom" hide-arrow id="danger">
 
 			<ui5-list>
 				<ui5-li>Hello</ui5-li>
@@ -129,7 +129,7 @@ z-index: 1;
 			</pre>
 		</div>
 		<ui5-button id="openPopoverInsideContainingBlockButton">Open Popover Inside a Containing Block</ui5-button>
-		<ui5-popover id="popoverInsideContainingBlock" placement-type="Bottom">
+		<ui5-popover id="popoverInsideContainingBlock" placement="Bottom">
 			Popover<br>Inside<br>Containing<br>Block
 		</ui5-popover>
 	</div>
@@ -141,7 +141,7 @@ z-index: 1;
 		Open Big Popover
 	</ui5-button>
 
-	<ui5-popover placement-type="Bottom" id="big-popover" header-text="hello world">
+	<ui5-popover placement="Bottom" id="big-popover" header-text="hello world">
 		<ui5-list id="bigList"></ui5-list>
 	</ui5-popover>
 
@@ -153,11 +153,11 @@ z-index: 1;
 		Open Popover ACC role - None
 	</ui5-button>
 
-	<ui5-popover placement-type="Bottom" id="acc-role-popover" header-text="Test ACC world" accessible-role="AlertDialog">
+	<ui5-popover placement="Bottom" id="acc-role-popover" header-text="Test ACC world" accessible-role="AlertDialog">
 		<ui5-list id="bigList2"></ui5-list>
 	</ui5-popover>
 
-	<ui5-popover placement-type="Bottom" id="acc-role-popover2" header-text="Test ACC world" accessible-role="None">
+	<ui5-popover placement="Bottom" id="acc-role-popover2" header-text="Test ACC world" accessible-role="None">
 		<ui5-list id="bigList3"></ui5-list>
 	</ui5-popover>
 
@@ -210,20 +210,20 @@ z-index: 1;
 	<ui5-button id="btnMoveFocus">focusable element</ui5-button>
 	<br>
 	<br>
-	<ui5-title>placement-type="End" (default)</ui5-title>
+	<ui5-title>placement="End" (default)</ui5-title>
 	<p>No space on the End, try Start, Bottom, Top</p>
 	<ui5-button id="btnFullWidth" class="fullWidth">Click me !</ui5-button>
 	<ui5-button id="btnNormalWidth">Click me !</ui5-button>
 	<br>
 	<br>
-	<ui5-title>placement-type="End" (default) and allow-target-overlap=true </ui5-title>
+	<ui5-title>placement="End" (default) and allow-target-overlap=true </ui5-title>
 	<p>No space on the End, try Start, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthTargetOverlap" class="fullWidth">Click me !</ui5-button>
 	<ui5-button id="btnNormalWidthTargetOverlap">Click me !</ui5-button>
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Start"</ui5-title>
+	<ui5-title>placement="Start"</ui5-title>
 	<p>No space on the Start, try End, Bottom, Top</p>
 	<ui5-button id="btnFullWidthLeft" class="fullWidth">Click me !</ui5-button>
 	<div class="popover13auto">
@@ -232,7 +232,7 @@ z-index: 1;
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Start" and allow-target-overlap=true</ui5-title>
+	<ui5-title>placement="Start" and allow-target-overlap=true</ui5-title>
 	<p>No space on the Start, try End, Bottom, Top and if nothing works, the target will be overlapped</p>
 	<ui5-button id="btnFullWidthLeftTargetOverlap" class="fullWidth">Click me !</ui5-button>
 	<div class="popover13auto">
@@ -241,7 +241,7 @@ z-index: 1;
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Top"</ui5-title>
+	<ui5-title>placement="Top"</ui5-title>
 	<ui5-button id="btnFullWidthTop" class="fullWidth">Click me !</ui5-button>
 	<div class="flexContainerSpaceBetween">
 		<ui5-button id="btnLeftEdgeTop">...</ui5-button>
@@ -250,7 +250,7 @@ z-index: 1;
 
 	<br>
 	<br>
-	<ui5-title>placement-type="Bottom"</ui5-title>
+	<ui5-title>placement="Bottom"</ui5-title>
 	<ui5-button id="btnFullWidthBottom" class="fullWidth">Click me !</ui5-button>
 	<div class="flexContainerSpaceBetween">
 		<ui5-button id="btnLeftEdgeBottom">...</ui5-button>
@@ -282,7 +282,7 @@ z-index: 1;
 	</ui5-popover>
 
 
-	<ui5-popover header-text="My Heading" id="popFullWidthLeft" class="popover6auto" placement-type="Start">
+	<ui5-popover header-text="My Heading" id="popFullWidthLeft" class="popover6auto" placement="Start">
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -294,32 +294,7 @@ z-index: 1;
 		</ui5-list>
 	</ui5-popover>
 
-	<ui5-popover header-text="My Heading" id="popFullWidthLeftTargetOverlap" class="popover6auto" placement-type="Start" allow-target-overlap>
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-
-		<ui5-list>
-			<ui5-li>Hello</ui5-li>
-			<ui5-li>World</ui5-li>
-			<ui5-li>Again</ui5-li>
-		</ui5-list>
-	</ui5-popover>
-
-
-	<ui5-popover header-text="My Heading" id="popFullWidthTop" class="popover6auto" placement-type="Top">
-		<div slot="header">
-			<ui5-button id="first-focusable">I am in the header</ui5-button>
-		</div>
-
-		<ui5-list>
-			<ui5-li>Hello</ui5-li>
-			<ui5-li>World</ui5-li>
-			<ui5-li>Again</ui5-li>
-		</ui5-list>
-	</ui5-popover>
-
-	<ui5-popover header-text="My Heading" id="popFullWidthBottom" class="popover6auto" placement-type="Bottom">
+	<ui5-popover header-text="My Heading" id="popFullWidthLeftTargetOverlap" class="popover6auto" placement="Start" allow-target-overlap>
 		<div slot="header">
 			<ui5-button id="first-focusable">I am in the header</ui5-button>
 		</div>
@@ -332,7 +307,32 @@ z-index: 1;
 	</ui5-popover>
 
 
-	<ui5-popover id="quickViewCard" placement-type="End" height="500px">
+	<ui5-popover header-text="My Heading" id="popFullWidthTop" class="popover6auto" placement="Top">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+
+		<ui5-list>
+			<ui5-li>Hello</ui5-li>
+			<ui5-li>World</ui5-li>
+			<ui5-li>Again</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
+	<ui5-popover header-text="My Heading" id="popFullWidthBottom" class="popover6auto" placement="Bottom">
+		<div slot="header">
+			<ui5-button id="first-focusable">I am in the header</ui5-button>
+		</div>
+
+		<ui5-list>
+			<ui5-li>Hello</ui5-li>
+			<ui5-li>World</ui5-li>
+			<ui5-li>Again</ui5-li>
+		</ui5-list>
+	</ui5-popover>
+
+
+	<ui5-popover id="quickViewCard" placement="End" height="500px">
 		<ui5-input id="searchInput" class="popover6auto">
 			<ui5-icon id="searchIcon" slot="icon" name="search"></ui5-icon>
 		</ui5-input>
@@ -354,7 +354,7 @@ z-index: 1;
 		<ui5-button id="btnOpenXRightWide">Open</ui5-button>
 	</div>
 
-	<ui5-popover id="popXRightWide" placement-type="Bottom" horizontal-align="End">
+	<ui5-popover id="popXRightWide" placement="Bottom" horizontal-align="End">
 		Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni architecto tenetur quia nam reprehenderit quas eveniet possimus similique quisquam culpa distinctio ex doloremque molestiae maxime sed harum, in exercitationem! Incidunt?
 	</ui5-popover>
 
@@ -363,7 +363,7 @@ z-index: 1;
 
 	<ui5-button id="firstBtn">First button</ui5-button>
 	<ui5-button id="secondBtn">Second button</ui5-button>
-	<ui5-popover id="popNoFocusableContent" placement-type="Bottom">Sample text for the ui5-popover</ui5-popover>
+	<ui5-popover id="popNoFocusableContent" placement="Bottom">Sample text for the ui5-popover</ui5-popover>
 
 	<br>
 	<br>
@@ -387,7 +387,7 @@ z-index: 1;
 		<ui5-button id="btnRightEdge">Popover on right edge of screen</ui5-button>
 	</div>
 
-	<ui5-popover header-text="Header" id="popoverRightEdge" placement-type="Top">
+	<ui5-popover header-text="Header" id="popoverRightEdge" placement="Top">
 		<ui5-label>Input field: </ui5-label>
 		<ui5-input></ui5-input>
 	</ui5-popover>
@@ -411,7 +411,7 @@ z-index: 1;
 			<ui5-li>Open chained popover 2</ui5-li>
 		</ui5-list>
 	</ui5-popover>
-	<ui5-popover id="chainedPopover2" placement-type="Bottom">
+	<ui5-popover id="chainedPopover2" placement="Bottom">
 		Chained Popover 2
 		<ui5-button id="closeChainedPopover2">Close chained popover 2</ui5-button>
 	</ui5-popover>
@@ -445,7 +445,7 @@ z-index: 1;
 		<div id="targetOpener" class="popover10auto">
 			<span>Target opener</span>
 		</div>
-		<ui5-popover id="popoverHorizontalAlign" placement-type="Top">
+		<ui5-popover id="popoverHorizontalAlign" placement="Top">
 			<span></span>
 		</ui5-popover>
 	</div>
@@ -618,7 +618,7 @@ z-index: 1;
 			button.textContent = "Focusable element";
 			popover.appendChild(button);
 			popover.setAttribute("id", "dynamic-popover");
-			popover.setAttribute("placement-type", "Bottom");
+			popover.setAttribute("placement", "Bottom");
 
 			document.body.appendChild(popover);
 

--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -18,12 +18,12 @@
 </head>
 
 <body class="sapUiSizeCompact">
-	<ui5-button id="myBtn1" data-placement-type="Start" class="myBtn">1</ui5-button>
-	<ui5-button id="myBtn2" data-placement-type="Start" data-vertical-align="Top" class="myBtn">2</ui5-button>
-	<ui5-button id="myBtn3" data-placement-type="Bottom" class="myBtn">3</ui5-button>
-	<ui5-button id="myBtn4" data-placement-type="Top" class="myBtn">4</ui5-button>
-	<ui5-button id="myBtn5" data-placement-type="Start" class="myBtn">5</ui5-button>
-	<ui5-button id="myBtn6" data-placement-type="Start" class="myBtn">6</ui5-button>
+	<ui5-button id="myBtn1" data-placement="Start" class="myBtn">1</ui5-button>
+	<ui5-button id="myBtn2" data-placement="Start" data-vertical-align="Top" class="myBtn">2</ui5-button>
+	<ui5-button id="myBtn3" data-placement="Bottom" class="myBtn">3</ui5-button>
+	<ui5-button id="myBtn4" data-placement="Top" class="myBtn">4</ui5-button>
+	<ui5-button id="myBtn5" data-placement="Start" class="myBtn">5</ui5-button>
+	<ui5-button id="myBtn6" data-placement="Start" class="myBtn">6</ui5-button>
 
 	<ui5-toggle-button id="customSizeBtn">Bigger Popover</ui5-toggle-button>
 
@@ -34,7 +34,7 @@
 
 		Array.from(document.querySelectorAll(".myBtn")).forEach(function (btn) {
 			btn.addEventListener("click", function() {
-				myPopover.placementType = btn.dataset.placementType;
+				myPopover.placement = btn.dataset.placement;
 				myPopover.verticalAlign = btn.dataset.verticalAlign;
 				myPopover.showAt(btn);
 			});

--- a/packages/main/test/pages/Popups.html
+++ b/packages/main/test/pages/Popups.html
@@ -28,7 +28,7 @@
 		<content id="popover"></content>
 	</div>
 
-	<ui5-popover placement-type="Bottom" horizontal-align="Stretch" hide-arrow initial-focus="input1" class="wcPopoverWithList">
+	<ui5-popover placement="Bottom" horizontal-align="Stretch" hide-arrow initial-focus="input1" class="wcPopoverWithList">
 		<ui5-list id="myList" indent separators="Inner" mode="MultiSelect" footer-text="Copyright" no-data-text="No data">
 			<!-- Header -->
 			<div class="popups3auto" slot="header">
@@ -81,7 +81,7 @@
 				<ui5-button class="wcBtnOpenNewDialog">Open New Dialog</ui5-button>
 				<ui5-button class="wcBtnCloseDialog">Close Dialog</ui5-button>
 
-				<ui5-popover placement-type="End" class="wcNewDialogPopover" header-text="Second Popover">
+				<ui5-popover placement="End" class="wcNewDialogPopover" header-text="Second Popover">
 					<ui5-button class="wcBtnOpenNewPopoverDialog1">Open New Popover </ui5-button>
 					<ui5-button class="wcBtnClosePopoverDialog1">Popover Button</ui5-button>
 				</ui5-popover>
@@ -101,7 +101,7 @@
 		<!--</div>-->
 		<h5>Web Component</h5>
 		<ui5-button class="wcBtnOpenPopover">Open Popover</ui5-button>
-		<ui5-popover placement-type="Top" class="wcPopover" header-text="Web Component Popover">
+		<ui5-popover placement="Top" class="wcPopover" header-text="Web Component Popover">
 			<div slot="header" class="popups4auto">
 				<div class="popups5auto">Custom Header</div>
 				<ui5-button icon="decline"></ui5-button>
@@ -111,7 +111,7 @@
 				<ui5-button>Accept</ui5-button>
 			</div>
 			<ui5-date-picker></ui5-date-picker>
-			<ui5-popover placement-type="End" class="wcNewPopover" header-text="Second Popover">
+			<ui5-popover placement="End" class="wcNewPopover" header-text="Second Popover">
 				<ui5-button class="wcBtnOpenNewPopover1">Open New Popover </ui5-button>
 				<ui5-button class="wcBtnClosePopover1">Popover Button</ui5-button>
 			</ui5-popover>

--- a/packages/main/test/pages/ResponsivePopover.html
+++ b/packages/main/test/pages/ResponsivePopover.html
@@ -109,7 +109,7 @@
 	</ui5-responsive-popover>
 
 	<ui5-button id="btnRpTopWithArrow">RP on Top with downward pointing arrow</ui5-button>
-	<ui5-responsive-popover placement-type="Top" id="rpTopWithArrow">
+	<ui5-responsive-popover placement="Top" id="rpTopWithArrow">
 		<div>text</div>
 	</ui5-responsive-popover>
 

--- a/packages/main/test/samples/AvatarGroup.sample.html
+++ b/packages/main/test/samples/AvatarGroup.sample.html
@@ -18,7 +18,7 @@
 <section>
 	<h4>Avatar Group - type "Individual"</h4>
 	<div class="snippet individual">
-		<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
+		<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement="Bottom" prevent-focus-restore>
 			<div class="avatar-slot" style="display: inline-block;">
 				<ui5-avatar id="popAvatar"></ui5-avatar>
 			</div>
@@ -29,7 +29,7 @@
 			</div>
 		</ui5-popover>
 
-		<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+		<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement="Bottom">
 			<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 		</ui5-popover>
 
@@ -135,13 +135,13 @@
 		</script>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement-type="Bottom" prevent-focus-restore>
+<ui5-popover header-text="Person Card" class="personPopover" style="width: 300px" placement="Bottom" prevent-focus-restore>
 	...
 	<ui5-avatar id="popAvatar"></ui5-avatar>
 	...
 </ui5-popover>
 
-<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement="Bottom">
 	...
 	<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 	...
@@ -194,7 +194,7 @@
 <section>
 	<h4>Avatar Group - type "Group"</h4>
 	<div class="snippet group">
-	    <ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+	    <ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement="Bottom">
 			<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 		</ui5-popover>
 
@@ -272,7 +272,7 @@
 		</script>
 	</div>
 	<pre class="prettyprint lang-html"><xmp>
-<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+<ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement="Bottom">
 	...
 	<div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
 	...

--- a/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListGroupItem/NotificationListGroupItem.stories.ts
@@ -214,7 +214,7 @@ InShellBar.decorators = [
 	notifications-count="6"
 ></ui5-shellbar>
 <ui5-popover
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	id="popover-with-notifications"
 >

--- a/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
+++ b/packages/playground/_stories/fiori/NotificationListItem/NotificationListItem.stories.ts
@@ -194,7 +194,7 @@ InShellBar.decorators = [
 	notifications-count="4"
 ></ui5-shellbar>
 <ui5-popover
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	id="popover-with-notifications"
 >

--- a/packages/playground/_stories/fiori/ProductSwitch/ProductSwitch.stories.ts
+++ b/packages/playground/_stories/fiori/ProductSwitch/ProductSwitch.stories.ts
@@ -40,7 +40,7 @@ WithShellBar.decorators = [
             show-co-pilot=""
         >
         </ui5-shellbar>
-        <ui5-popover id="productswitch-popover" placement-type="Bottom">
+        <ui5-popover id="productswitch-popover" placement="Bottom">
             ${story()}
         </ui5-popover>
         <script>

--- a/packages/playground/_stories/fiori/ShellBar/ShellBar.stories.ts
+++ b/packages/playground/_stories/fiori/ShellBar/ShellBar.stories.ts
@@ -95,7 +95,7 @@ export const Advanced: StoryFn = () => {
             <ui5-li slot="menuItems">Application 4</ui5-li>
             <ui5-li slot="menuItems">Application 5</ui5-li>
         </ui5-shellbar>
-        <ui5-popover id="action-popover-${index}" placement-type="Bottom">
+        <ui5-popover id="action-popover-${index}" placement="Bottom">
             <div class="action-popover-header">
                 <ui5-title style="padding: 0.25rem 1rem 0rem 1rem"
                     >An Kimura</ui5-title

--- a/packages/playground/_stories/main/AvatarGroup/TemplateGroupWithPopover.ts
+++ b/packages/playground/_stories/main/AvatarGroup/TemplateGroupWithPopover.ts
@@ -8,7 +8,7 @@ export default () => {
             header-text="My people"
             class="peoplePopover"
             style="width: 400px"
-            placement-type="Bottom"
+            placement="Bottom"
         >
             <div
                 class="placeholder"

--- a/packages/playground/_stories/main/AvatarGroup/TemplateIndividualWithPopover.ts
+++ b/packages/playground/_stories/main/AvatarGroup/TemplateIndividualWithPopover.ts
@@ -8,7 +8,7 @@ export default () => {
             header-text="Person Card"
             class="personPopover"
             style="width: 300px"
-            placement-type="Bottom"
+            placement="Bottom"
             prevent-focus-restore=""
         >
             <div class="avatar-slot" style="display: inline-block;">
@@ -23,7 +23,7 @@ export default () => {
             header-text="My people"
             class="peoplePopover"
             style="width: 400px"
-            placement-type="Bottom"
+            placement="Bottom"
         >
             <div
                 class="placeholder"

--- a/packages/playground/_stories/main/Popover/Popover.stories.ts
+++ b/packages/playground/_stories/main/Popover/Popover.stories.ts
@@ -30,7 +30,7 @@ const Template: UI5StoryArgs<Popover, StoryArgsSlots> = (args) => {
 	accessible-name-ref="${ifDefined(args.accessibleNameRef)}"
 	accessible-role="${ifDefined(args.accessibleRole)}"
 	header-text="${ifDefined(args.headerText)}"
-	placement-type="${ifDefined(args.placementType)}"
+	placement="${ifDefined(args.placement)}"
 	horizontal-align="${ifDefined(args.horizontalAlign)}"
 	vertical-align="${ifDefined(args.verticalAlign)}"
 	?modal="${ifDefined(args.modal)}"

--- a/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
+++ b/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
@@ -30,7 +30,7 @@ const Template: UI5StoryArgs<ResponsivePopover, StoryArgsSlots> = (args) => {
 	accessible-name-ref="${ifDefined(args.accessibleNameRef)}"
 	accessible-role="${ifDefined(args.accessibleRole)}"
 	header-text="${ifDefined(args.headerText)}"
-	placement-type="${ifDefined(args.placementType)}"
+	placement="${ifDefined(args.placement)}"
 	horizontal-align="${ifDefined(args.horizontalAlign)}"
 	vertical-align="${ifDefined(args.verticalAlign)}"
 	?modal="${ifDefined(args.modal)}"

--- a/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
@@ -19,7 +19,7 @@
 	notifications-count="6"
 ></ui5-shellbar>
 <ui5-popover
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	id="popover-with-notifications"
 >

--- a/packages/website/docs/_samples/fiori/NotificationListItem/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationListItem/InShellBar/sample.html
@@ -20,7 +20,7 @@
     <img slot="logo" src="../assets/images/sap-logo-svg.svg" />
 </ui5-shellbar>
 <ui5-popover
-	placement-type="Bottom"
+	placement="Bottom"
 	horizontal-align="End"
 	id="popover-with-notifications"
 >

--- a/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.html
@@ -15,7 +15,7 @@
         show-co-pilot>
         <img src="../assets/images/sap-logo-svg.svg" alt="SAP Logo" slot="logo" />
     </ui5-shellbar>
-    <ui5-popover id="productswitch-popover" placement-type="Bottom">
+    <ui5-popover id="productswitch-popover" placement="Bottom">
         <ui5-product-switch>
             <ui5-product-switch-item title-text="Home" subtitle-text="Central Home"
                 icon="home"></ui5-product-switch-item>

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
@@ -27,7 +27,7 @@
         <ui5-li slot="menuItems">Application 4</ui5-li>
         <ui5-li slot="menuItems">Application 5</ui5-li>
     </ui5-shellbar>
-    <ui5-popover id="action-popover" placement-type="Bottom">
+    <ui5-popover id="action-popover" placement="Bottom">
         <div class="action-popover-header">
             <ui5-title style="padding: 0.25rem 1rem 0rem 1rem">An Kimura</ui5-title>
         </div>

--- a/packages/website/docs/_samples/main/AvatarGroup/GroupWithPopover/sample.html
+++ b/packages/website/docs/_samples/main/AvatarGroup/GroupWithPopover/sample.html
@@ -12,7 +12,7 @@
     <!-- playground-fold-end -->
 
     <div class="group">
-        <ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement-type="Bottom">
+        <ui5-popover header-text="My people" class="peoplePopover" style="width: 400px" placement="Bottom">
             <div class="placeholder" style="display: flex; flex-wrap: wrap;"></div>
         </ui5-popover>
 

--- a/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.html
+++ b/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.html
@@ -16,7 +16,7 @@
             header-text="Person Card"
             class="personPopover"
             style="width: 300px"
-            placement-type="Bottom"
+            placement="Bottom"
             prevent-focus-restore=""
         >
             <div class="avatar-slot" style="display: inline-block;">
@@ -31,7 +31,7 @@
             header-text="My people"
             class="peoplePopover"
             style="width: 400px"
-            placement-type="Bottom"
+            placement="Bottom"
         >
             <div
                 class="placeholder"

--- a/packages/website/docs/_samples/main/Popover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/Popover/Placement/sample.html
@@ -45,7 +45,7 @@
         <ui5-button id="btn2">Open Popover to Left</ui5-button>
     </div>
    
-    <ui5-popover id="popover1" opener="btn1" header-text="Newsletter subscription" placement-type="Bottom">
+    <ui5-popover id="popover1" opener="btn1" header-text="Newsletter subscription" placement="Bottom">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
@@ -57,7 +57,7 @@
         </div>
     </ui5-popover>
 
-    <ui5-popover id="popover2" opener="btn2" header-text="Newsletter subscription" placement-type="Start">
+    <ui5-popover id="popover2" opener="btn2" header-text="Newsletter subscription" placement="Start">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>

--- a/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
@@ -45,7 +45,7 @@
         <ui5-button id="btn2">Open ResponsivePopover to Left</ui5-button>
     </div>
    
-    <ui5-responsive-popover  id="respPopover1" opener="btn1" header-text="Newsletter subscription" placement-type="Bottom">
+    <ui5-responsive-popover  id="respPopover1" opener="btn1" header-text="Newsletter subscription" placement="Bottom">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>
@@ -57,7 +57,7 @@
         </div>
     </ui5-responsive-popover>
 
-    <ui5-responsive-popover id="respPopover2" opener="btn2" header-text="Newsletter subscription" placement-type="Start">
+    <ui5-responsive-popover id="respPopover2" opener="btn2" header-text="Newsletter subscription" placement="Start">
         <div class="popover-content">
             <ui5-label for="emailInput" required show-colon>Email</ui5-label>
             <ui5-input id="emailInput" style="min-width: 150px;" placeholder="Enter Email"></ui5-input>


### PR DESCRIPTION
Renames the `placementType` property  of `ui5-popover`.
 Also renames the `PopoverPlacementType` enum to `PopoverPlacement`.

BREAKING CHANGE: The `placementType` property and the `PopoverPlacementType` enum have been renamed.
If you have previously used the `placementType` property and the `PopoverPlacementType` 
```html
<ui5-popover placement-type="Bottom"></ui5-popover>
```
```js
import PopoverPlacementType from "@ui5/webcomponents/dist/types/PopoverPlacementType.js";
```
Now use `placement` instead:
```html
<ui5-placement="Bottom"></ui5-popover>
```
```js
import PopoverPlacementType from "@ui5/webcomponents/dist/types/PopoverPlacement.js";
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461