### PR TITLE
fix(ui5-tab-separator): styling in overflow

### DIFF
--- a/packages/main/src/themes/TabSeparatorInOverflow.css
+++ b/packages/main/src/themes/TabSeparatorInOverflow.css
@@ -1,10 +1,10 @@
-.ui5-tc__separator {
+[ui5-li-custom].ui5-tc__separator {
 	min-height: 0.25rem;
 	border-bottom: 0.0625rem solid var(--sapGroup_TitleBorderColor);
 	margin-inline-start: calc(var(--_ui5-tab-indentation-level) * 0.5rem);
 	margin-inline-end: 0.5rem;
 }
 
-[ui5-list] > .ui5-tc__separator:first-child {
+[ui5-list] > [ui5-li-custom].ui5-tc__separator:first-child {
 	min-height: 0.5rem;
 }

--- a/packages/main/src/themes/TabSeparatorInStrip.css
+++ b/packages/main/src/themes/TabSeparatorInStrip.css
@@ -1,9 +1,9 @@
-.ui5-tc__separator {
+div.ui5-tc__separator {
 	position: relative;
 	width: 0.5625rem;
 }
 
-.ui5-tc__separator::before {
+div.ui5-tc__separator::before {
 	content: " ";
 	position: absolute;
 	width: 0.0625rem;


### PR DESCRIPTION
Unlike `ui5-tab`, `ui5-tab-separator` uses the same class name in both the strip and overflow, therefore it needs stronger selectors for both places.

This was an oversight from the popover API refactoring change, and is now fixed.