### PR TITLE
chore: property accessor should be looked up the prototype chain

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -87,6 +87,23 @@ function _invalidate(this: UI5Element, changeInfo: ChangeInfo) {
 }
 
 /**
+ * looks up a property descsriptor including in the prototype chain
+ * @param proto the starting prototype
+ * @param name the property to look for
+ * @returns the property descriptor if found directly or in the prototype chaing, undefined if not found
+ */
+function getPropertyDescriptor(proto: any, name: PropertyKey): PropertyDescriptor | undefined {
+	do {
+		const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+		if (descriptor) {
+			return descriptor;
+		}
+		// go up the prototype chain
+		proto = Object.getPrototypeOf(proto);
+	} while (proto);
+}
+
+/**
  * @class
  * Base class for all UI5 Web Components
  *
@@ -989,7 +1006,7 @@ abstract class UI5Element extends HTMLElement {
 				throw new Error(`Cannot set a default value for property "${prop}". All multiple properties are empty arrays by default.`);
 			}
 
-			const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+			const descriptor = getPropertyDescriptor(proto, prop);
 			// if the decorator is on a setter, proxy the new setter to it
 			let origSet: (v: any) => void;
 			if (descriptor?.set) {

--- a/packages/base/test/elements/AccessorBase.js
+++ b/packages/base/test/elements/AccessorBase.js
@@ -4,26 +4,29 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-import AccessorBase from "./AccessorBase.js";
+import UI5Element from "../../dist/UI5Element.js";
 import customElement from "../../dist/decorators/customElement.js";
 import property from "../../dist/decorators/property.js";
-import litRender, { html } from "../../dist/renderer/LitRenderer.js";
-let Accessor = class Accessor extends AccessorBase {
+let AccessorBase = class AccessorBase extends UI5Element {
     constructor() {
         super(...arguments);
+        this.storage = false;
     }
-    render() {
-        return html `<div>${this.myProp}</div>`;
+    set myProp(value) {
+        this.storage = value;
+    }
+    get myProp() {
+        return this.storage;
     }
 };
-Accessor = __decorate([
+__decorate([
+    property({type: Boolean})
+], AccessorBase.prototype, "myProp", null);
+AccessorBase = __decorate([
     customElement({
-        tag: "ui5-test-accessor",
-        renderer: litRender,
     })
-], Accessor);
-Accessor.define();
-export default Accessor;
+], AccessorBase);
+export default AccessorBase;
 
 /*
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";


### PR DESCRIPTION
When a property decorator is used in a base class, the generated getter/setter for the extending class should look up the accessors through the prototype chain and use them.