### PR TITLE
refactor(ui5-tab, ui5-tab-separator): rename getTabInStripDomRef to getDomRefInStrip

### DIFF
--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -198,11 +198,11 @@ class Tab extends UI5Element implements ITabbable {
 	static i18nBundle: I18nBundle;
 
 	set forcedTabIndex(val: string) {
-		this.getTabInStripDomRef()!.setAttribute("tabindex", val);
+		this.getDomRefInStrip()!.setAttribute("tabindex", val);
 	}
 
 	get forcedTabIndex() {
-		return this.getTabInStripDomRef()!.getAttribute("tabindex")!;
+		return this.getDomRefInStrip()!.getAttribute("tabindex")!;
 	}
 
 	get displayText() {
@@ -277,18 +277,14 @@ class Tab extends UI5Element implements ITabbable {
 	/**
 	 * Returns the DOM reference of the tab that is placed in the header.
 	 *
-	 * **Note:** Tabs, placed in the `items` slot of other tabs are not shown in the header. Calling this method on such tabs will return `null`.
+	 * **Note:** Tabs, placed in the `items` slot of other tabs are not shown in the header. Calling this method on such tabs will return `undefined`.
 	 *
 	 * **Note:** If you need a DOM ref to the tab content please use the `getDomRef` method.
 	 * @public
 	 * @since 1.0.0-rc.16
 	 */
-	getTabInStripDomRef(): HTMLElement | undefined {
-		if (this._getElementInStrip) {
-			return this._getElementInStrip();
-		}
-
-		return undefined;
+	getDomRefInStrip(): HTMLElement | undefined {
+		return this._getElementInStrip?.();
 	}
 
 	getFocusDomRef() {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -729,7 +729,7 @@ class TabContainer extends UI5Element {
 		await renderFinished();
 
 		const selectedTopLevel = this._getRootTab(this._selectedTab);
-		selectedTopLevel.getTabInStripDomRef()!.focus();
+		selectedTopLevel.getDomRefInStrip()!.focus();
 	}
 
 	/**
@@ -905,7 +905,7 @@ class TabContainer extends UI5Element {
 			return;
 		}
 
-		const itemsDomRefs = this.items.map(item => item.getTabInStripDomRef()!) as Array<TabInStrip | TabSeparatorInStrip>;
+		const itemsDomRefs = this.items.map(item => item.getDomRefInStrip()) as Array<TabInStrip | TabSeparatorInStrip>;
 
 		// make sure the overflows are hidden
 		this._getStartOverflow().setAttribute("hidden", "");
@@ -951,7 +951,7 @@ class TabContainer extends UI5Element {
 		// show end overflow
 		this._getEndOverflow().removeAttribute("hidden");
 		const selectedTab = this._getRootTab(this._selectedTab);
-		const selectedTabDomRef = selectedTab.getTabInStripDomRef()! as TabInStrip;
+		const selectedTabDomRef = selectedTab.getDomRefInStrip()! as TabInStrip;
 		const containerWidth = this._getTabStrip().offsetWidth;
 
 		const selectedItemIndexAndWidth = this._getSelectedItemIndexAndWidth(itemsDomRefs, selectedTabDomRef);
@@ -968,7 +968,7 @@ class TabContainer extends UI5Element {
 	_updateStartAndEndOverflow(itemsDomRefs: Array<TabInStrip | TabSeparatorInStrip>) {
 		let containerWidth = this._getTabStrip().offsetWidth;
 		const selectedTab = this._getRootTab(this._selectedTab);
-		const selectedTabDomRef = selectedTab.getTabInStripDomRef()! as TabInStrip;
+		const selectedTabDomRef = selectedTab.getDomRefInStrip()! as TabInStrip;
 		const selectedItemIndexAndWidth = this._getSelectedItemIndexAndWidth(itemsDomRefs, selectedTabDomRef);
 		const hasStartOverflow = this._hasStartOverflow(containerWidth, itemsDomRefs, selectedItemIndexAndWidth);
 		const hasEndOverflow = this._hasEndOverflow(containerWidth, itemsDomRefs, selectedItemIndexAndWidth);
@@ -1165,7 +1165,7 @@ class TabContainer extends UI5Element {
 		let endOverflowItemsCount = 0;
 
 		this._getTabs()
-			.map(tab => tab.getTabInStripDomRef()!)
+			.map(tab => tab.getDomRefInStrip()!)
 			.forEach(tab => {
 				if (tab.hasAttribute("start-overflow")) {
 					startOverflowItemsCount++;
@@ -1192,7 +1192,7 @@ class TabContainer extends UI5Element {
 		}
 
 		this._getTabs().forEach(tab => {
-			const ref = tab.getTabInStripDomRef();
+			const ref = tab.getDomRefInStrip();
 			const focusable = ref && !ref.hasAttribute("hidden");
 
 			if (focusable) {
@@ -1230,7 +1230,7 @@ class TabContainer extends UI5Element {
 	_getPopoverItemsFor(targetOwner: TabContainerPopoverOwner) {
 		if (targetOwner === "start-overflow") {
 			return this.items.filter(item => {
-				const stripRef = item.getTabInStripDomRef();
+				const stripRef = item.getDomRefInStrip();
 
 				return stripRef && stripRef.hasAttribute("start-overflow");
 			});
@@ -1238,7 +1238,7 @@ class TabContainer extends UI5Element {
 
 		if (targetOwner === "end-overflow") {
 			return this.items.filter(item => {
-				const stripRef = item.getTabInStripDomRef();
+				const stripRef = item.getDomRefInStrip();
 
 				return stripRef && stripRef.hasAttribute("end-overflow");
 			});

--- a/packages/main/src/TabSeparator.ts
+++ b/packages/main/src/TabSeparator.ts
@@ -65,15 +65,11 @@ class TabSeparator extends UI5Element {
 	/**
 	 * Returns the DOM reference of the separator that is placed in the header.
 	 *
-	 * **Note:** Tabs and separators, placed in the `items` slot of other tabs are not shown in the header. Calling this method on such tabs or separators will return `null`.
+	 * **Note:** Separators, placed in the `items` slot of other tabs are not shown in the header. Calling this method on such separators will return `undefined`.
 	 * @public
 	 */
-	getTabInStripDomRef(): HTMLElement | undefined {
-		if (this._getElementInStrip) {
-			return this._getElementInStrip();
-		}
-
-		return undefined;
+	getDomRefInStrip(): HTMLElement | undefined {
+		return this._getElementInStrip?.();
 	}
 
 	get stableDomRef() {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -260,22 +260,22 @@ describe("TabContainer general interaction", () => {
 		assert.strictEqual(await newlySelectedItem.getProperty("text"), "Thirteen", "The first item in the overflow is 13");
 	});
 
-	it("selecting a tab programatically will update the tab strip", async () => {
+	it("selecting a tab programmatically will update the tab strip", async () => {
 		// Setup
-		const getTabInStripDomRef = tab => tab.getTabInStripDomRef();
+		const getDomRefInStrip = tab => tab.getDomRefInStrip();
 		const getElementInBrowser = el => document.querySelector(el);
 
 		const tabContainer = await browser.$("#tcSmall");
 		await tabContainer.scrollIntoView();
 
 		const firstTab = await browser.execute(getElementInBrowser, "#firstTab");
-		const firstTabInStrip = await browser.$(await browser.execute(getTabInStripDomRef, firstTab));
+		const firstTabInStrip = await browser.$(await browser.execute(getDomRefInStrip, firstTab));
 
 		const lastTab = await browser.execute(getElementInBrowser, "#lastTab");
-		const lastTabInStrip = await browser.$(await browser.execute(getTabInStripDomRef, lastTab));
+		const lastTabInStrip = await browser.$(await browser.execute(getDomRefInStrip, lastTab));
 
 		const nestedTabParentTab = await browser.execute(getElementInBrowser, "#nestedTabParent");
-		const nestedTabParentInTabStrip = await browser.$(await browser.execute(getTabInStripDomRef, nestedTabParentTab));
+		const nestedTabParentInTabStrip = await browser.$(await browser.execute(getDomRefInStrip, nestedTabParentTab));
 
 		// Assert
 		assert.notOk(await lastTabInStrip.isDisplayed(), "last tab in strip is not visible");
@@ -333,7 +333,7 @@ describe("TabContainer general interaction", () => {
 		// Assert
 		assert.ok(productsTabDomRef.isEqual(productsTabStableDomRef) , "Stable dom ref of the tab is the same as its dom ref");
 
-		const productsTabDomRefInStrip = await browser.$(() => document.querySelector("[stable-dom-ref='products-ref']").getTabInStripDomRef());
+		const productsTabDomRefInStrip = await browser.$(() => document.querySelector("[stable-dom-ref='products-ref']").getDomRefInStrip());
 		const productsTabDomRefInStripExpected = await browser.$(() => document.getElementById("tabContainer1").getDomRef().querySelector(".ui5-tab-strip-item:first-child"));
 
 		// Assert
@@ -352,7 +352,7 @@ describe("TabContainer general interaction", () => {
 	it("test that tab can be focused right after is inserted in the tab container", async () => {
 		await browser.$("#insertAndFocusNewTab").click();
 		const isNewTabFocused = await browser.executeAsync((done) => {
-			const tabInStripDomRef = document.getElementById("newlyInsertedFocusedTab").getTabInStripDomRef();
+			const tabInStripDomRef = document.getElementById("newlyInsertedFocusedTab").getDomRefInStrip();
 			const activeElement = document.activeElement.shadowRoot.activeElement;
 
 			done(tabInStripDomRef === activeElement);


### PR DESCRIPTION
Renames Tab#getTabInsStripDomRef and TabSeparator#getTabInsStripDomRef to getDomRefInStrip.

BREAKING CHANGE: If previously you have used:
```js
someTab.getTabInsStripDomRef();
someTabSeparator.getTabInsStripDomRef();
```

Now use:

```js
someTab.getDomRefInStrip();
someTabSeparator.getDomRefInStrip();
```

Related to: https://github.com/SAP/ui5-webcomponents/issues/8461

