### PR TITLE
refactor(ui5-list): renamed busy, busyDelay to loading, loadingDelay

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -68,13 +68,13 @@
 		<span tabindex="-1" aria-hidden="true" class="ui5-list-end-marker"></span>
 	</div>
 
-	{{#if busy}}
-		<div class="ui5-list-busy-row">
+	{{#if loading}}
+		<div class="ui5-list-loading-row">
 			<ui5-busy-indicator
-				delay="{{busyDelay}}"
+				delay="{{loadingDelay}}"
 				active
-				class="ui5-list-busy-ind"
-				style="{{styles.busyInd}}"
+				class="ui5-list-loading-ind"
+				style="{{styles.loadingInd}}"
 				data-sap-focus-ref
 			></ui5-busy-indicator>
 		</div>

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -367,15 +367,15 @@ class List extends UI5Element {
 	 * @since 1.0.0-rc.6
 	 */
 	@property({ type: Boolean })
-	busy!: boolean;
+	loading!: boolean;
 
 	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will show up for this component.
+	 * Defines the delay in milliseconds, after which the loading indicator will show up for this component.
 	 * @default 1000
 	 * @public
 	 */
 	@property({ validator: Integer, defaultValue: 1000 })
-	busyDelay!: number;
+	loadingDelay!: number;
 
 	/**
 	 * Defines the accessible name of the component.
@@ -625,7 +625,7 @@ class List extends UI5Element {
 		return this.growingButtonText || List.i18nBundle.getText(LOAD_MORE_TEXT);
 	}
 
-	get busyIndPosition() {
+	get loadingIndPosition() {
 		if (!this.grows) {
 			return "absolute";
 		}
@@ -635,8 +635,8 @@ class List extends UI5Element {
 
 	get styles() {
 		return {
-			busyInd: {
-				position: this.busyIndPosition,
+			loadingInd: {
+				position: this.loadingIndPosition,
 			},
 		};
 	}

--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -16,11 +16,11 @@
 	border-bottom: 0;
 }
 
-:host([busy]) {
+:host([loading]) {
 	opacity: 0.72;
 }
 
-:host([busy]) .ui5-list-busy-row {
+:host([loading]) .ui5-list-loading-row {
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -29,7 +29,7 @@
 	outline: none;
 }
 
-:host([busy]) .ui5-list-busy-ind {
+:host([loading]) .ui5-list-loading-ind {
 	position: absolute;
 	top: 50%;
 	left: 50%;

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -468,11 +468,11 @@
 
 		infiniteScrollEx.addEventListener("ui5-load-more", function(e) {
 			var el = infiniteScrollEx;
-			el.busy = true;
+			el.loading = true;
 
 			setTimeout(function() {
 				insertItems(el, 3);
-				el.busy = false;
+				el.loading = false;
 				result.textContent = (++loadedCount) + " times " + (itemsLoadedTotal += itemsToLoad);
 			}, 1000);
 		});
@@ -480,11 +480,11 @@
 
 		infiniteScrollEx2.addEventListener("ui5-load-more", function(e) {
 			var el = infiniteScrollEx2;
-			el.busy = true;
+			el.loading = true;
 
 			setTimeout(function() {
 				insertItems(el, 3);
-				el.busy = false;
+				el.loading = false;
 				result.textContent = (++loadedCount) + " times " + (itemsLoadedTotal += itemsToLoad);
 			}, 1000);
 		});

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -27,10 +27,10 @@ describe("List Tests", () => {
 
 	it("List is rendered", async () => {
 		const list = await browser.$("#infiniteScrollEx").shadow$(".ui5-list-root");
-		const busyInd = await browser.$("#infiniteScrollEx").shadow$(".ui5-list-busy-row");
+		const loadingInd = await browser.$("#infiniteScrollEx").shadow$(".ui5-list-loading-row");
 
 		assert.ok(await list.isExisting(), "List is rendered");
-		assert.notOk(await busyInd.isExisting(), "Busy indicator is not rendered, when List is not busy");
+		assert.notOk(await loadingInd.isExisting(), "Busy indicator is not rendered, when List is not loading");
 	});
 
 	it("itemClick and selectionChange events are fired in Single selection", async () => {

--- a/packages/playground/_stories/main/List/List.stories.ts
+++ b/packages/playground/_stories/main/List/List.stories.ts
@@ -19,11 +19,11 @@ export default {
 const Template: UI5StoryArgs<List, StoryArgsSlots> = (args) => {
   return html` <ui5-list
     selection-mode="${ifDefined(args.selectionMode)}"
-    ?busy="${ifDefined(args.busy)}"
+    ?loading="${ifDefined(args.loading)}"
     ?indent="${ifDefined(args.indent)}"
     ?growing="${ifDefined(args.growing)}"
     growing-button-text="${ifDefined(args.growingButtonText)}"
-    busy-delay="${ifDefined(args.busyDelay)}"
+    loading-delay="${ifDefined(args.loadingDelay)}"
     separators="${ifDefined(args.separators)}"
     header-text="${ifDefined(args.headerText)}"
     footer-text="${ifDefined(args.footerText)}"
@@ -105,10 +105,10 @@ export const Growing: StoryFn = () =>
       }
       infiniteScrollEx.addEventListener("load-more", (e) => {
         var el = infiniteScrollEx;
-        el.busy = true;
+        el.loading = true;
         setTimeout(() => {
           insertItems(el, 5);
-          el.busy = false;
+          el.loading = false;
         }, 200);
       });
     </script>`;

--- a/packages/website/docs/_samples/main/List/Growing/main.js
+++ b/packages/website/docs/_samples/main/List/Growing/main.js
@@ -24,10 +24,10 @@ const insertItems = (list) => {
 }
 
 growingList.addEventListener("load-more", (e) => {
-    growingList.busy = true;
+    growingList.loading = true;
     
     setTimeout(() => {
         insertItems(growingList);
-        growingList.busy = false;
+        growingList.loading = false;
     }, 1500);
 });

--- a/packages/website/docs/_samples/main/List/Growing/sample.html
+++ b/packages/website/docs/_samples/main/List/Growing/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-list id="growingList" style="height: 300px" growing="Scroll" busy-delay="0">
+    <ui5-list id="growingList" style="height: 300px" growing="Scroll" loading-delay="0">
         <ui5-li icon="nutrition-activity" description="Tropical plant with an edible fruit" additional-text="In-stock"
             additional-text-state="Success">Pineapple</ui5-li>
         <ui5-li icon="nutrition-activity" description="Occurs between red and yellow" additional-text="Expires"

--- a/packages/website/docs/_samples/main/List/GrowingOnButtonPress/main.js
+++ b/packages/website/docs/_samples/main/List/GrowingOnButtonPress/main.js
@@ -24,10 +24,10 @@ const insertItems = (list) => {
 }
 
 growingList.addEventListener("load-more", (e) => {
-    growingList.busy = true;
+    growingList.loading = true;
     
     setTimeout(() => {
         insertItems(growingList);
-        growingList.busy = false;
+        growingList.loading = false;
     }, 1500);
 });

--- a/packages/website/docs/_samples/main/List/GrowingOnButtonPress/sample.html
+++ b/packages/website/docs/_samples/main/List/GrowingOnButtonPress/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-list id="growingList" style="height: 300px" growing="Button" busy-delay="0">
+    <ui5-list id="growingList" style="height: 300px" growing="Button" loading-delay="0">
         <ui5-li icon="nutrition-activity" description="Tropical plant with an edible fruit" additional-text="In-stock"
             additional-text-state="Success">Pineapple</ui5-li>
         <ui5-li icon="nutrition-activity" description="Occurs between red and yellow" additional-text="Expires"


### PR DESCRIPTION
Renames the `busy`, `busyDelay` property of the `ui5-list` to `loading` and `loadingDelay`.

BREAKING CHANGE: The `busy` property of the `ui5-list` is renamed.
If you have previously used the `busy`, `busyDelay` properties:
```html
<ui5-list busy busy-delay="500"></ui5-list>
```
now you must use  `loading` and `loadingDelay` properties:
```html
<ui5-list loading loading-delay="500"></ui5-list>
```

Related: #8461 #7887