### PR TITLE
feat: add shadowRootOptions for @customElement decorator

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -155,7 +155,8 @@ abstract class UI5Element extends HTMLElement {
 		this._upgradeAllProperties();
 
 		if (ctor._needsShadowDOM()) {
-			this.attachShadow({ mode: "open" });
+			const defaultOptions = { mode: "open" } as ShadowRootInit;
+			this.attachShadow({ ...defaultOptions, ...ctor.getMetadata().getShadowRootOptions() });
 		}
 	}
 

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -41,6 +41,7 @@ type Metadata = {
 	fastNavigation?: boolean,
 	themeAware?: boolean,
 	languageAware?: boolean,
+	shadowRootOptions?: Partial<ShadowRootInit>
 };
 
 type State = Record<string, PropertyValue | Array<SlotValue>>;
@@ -271,6 +272,10 @@ class UI5ElementMetadata {
 	 */
 	 isThemeAware(): boolean {
 		return !!this.metadata.themeAware;
+	}
+
+	getShadowRootOptions(): Partial<ShadowRootInit> {
+		return this.metadata.shadowRootOptions || {};
 	}
 
 	/**

--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -18,6 +18,7 @@ const customElement = (tagNameOrComponentSettings: string | {
 	languageAware?: boolean,
 	themeAware?: boolean,
 	fastNavigation?: boolean,
+	shadowRootOptions?: Partial<ShadowRootInit>,
 } = {}): ClassDecorator => {
 	return (target: any) => {
 		if (!Object.prototype.hasOwnProperty.call(target, "metadata")) {
@@ -34,6 +35,7 @@ const customElement = (tagNameOrComponentSettings: string | {
 			languageAware,
 			themeAware,
 			fastNavigation,
+			shadowRootOptions,
 		 } = tagNameOrComponentSettings;
 
 		target.metadata.tag = tag;
@@ -45,6 +47,9 @@ const customElement = (tagNameOrComponentSettings: string | {
 		}
 		if (fastNavigation) {
 			target.metadata.fastNavigation = fastNavigation;
+		}
+		if (shadowRootOptions) {
+			target.metadata.shadowRootOptions = shadowRootOptions;
 		}
 
 		["renderer", "template", "styles", "dependencies"].forEach((customElementEntity: string) => {

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -92,6 +92,7 @@ type AccessibilityAttributes = {
 	template: ButtonTemplate,
 	styles: buttonCss,
 	dependencies: [Icon],
+	shadowRootOptions: { delegatesFocus: true },
 })
 /**
  * Fired when the component is activated either with a

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -50,7 +50,7 @@
 
 	<ui5-input id="click-counter"></ui5-input>
 
-	<ui5-button class="button2auto" design="Emphasized">Action<br> <i>Bar</i><br> Button</ui5-button>
+	<ui5-button id="button-with-slot" class="button2auto" design="Emphasized">Action<br> <i>Bar</i><br> Button</ui5-button>
 	<ui5-button>Primary button</ui5-button>
 	<ui5-button design="Transparent">Secondary button</ui5-button>
 	<ui5-button disabled>Inactive</ui5-button>

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -64,8 +64,8 @@ describe("Button general interaction", () => {
 	it("tests clicking on disabled button whith Icon", async () => {
 		const button = await browser.$("#disabled-button-icon-only");
 		const buttonIcon = await button.shadow$("[ui5-icon]");
-		
-		
+
+
 		await button.click()
 
 		const field = await browser.$("#click-counter");
@@ -153,5 +153,12 @@ describe("Button general interaction", () => {
 		const button = await browser.$("#button1").shadow$("button");
 
 		assert.strictEqual(await button.getAttribute("role"), "button", "Attribute is reflected");
+	});
+
+	it("should be focused when the click is on a slotted element", async () => {
+		const button = await browser.$("#button-with-slot");
+		await button.click();
+
+		assert.ok(await button.matches(":focus"), "The button has received focus");
 	});
 });


### PR DESCRIPTION
The base class `UI5Element` calls `this.attachShadow({ mode: "open" });` and there is no way for components to change the mode or add other options.

This change adds a `shadowRootOptions` property to the `customElement` decorator.

### Usage example
```ts
@customElement({
	tag: "ui5-button",
	shadowRootOptions: { delegatesFocus: true },
```

full list of options on MDN:
https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#options

### delegatesFocus: true
The specific need for `delegatesFocus` is the way focus handling works with slots (in Chrome specifically).
```html
<ui5-button>
  text
  <span>slotted text</span>
  test
</ui5-button>
```

When the `text` nodes are clicked, the custom elements matches the `:focus` selector and any `focusin` handlers in the shadowRoot are called.

When the `slotted text` is clicked however, the custom element neither gets the `:focus` styling, nor do the `focusin` handlers get called.

This happens only in Chrome and using `delegatesFocus: true` makes the `slotted text` behave the same way as the `text` nodes.

FIXES: #8437