### PR TITLE
fix(Popup): prevent a rare runtime error

### DIFF
--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -454,7 +454,7 @@ abstract class Popup extends UI5Element {
 
 		if (this.isModal && !this.shouldHideBackdrop) {
 			// create static area item ref for block layer
-			this._getBlockingLayer.showPopover();
+			this._getBlockingLayer?.showPopover();
 			this._blockLayerHidden = false;
 			Popup.blockPageScrolling(this);
 		}
@@ -508,7 +508,7 @@ abstract class Popup extends UI5Element {
 
 		if (this.isModal) {
 			this._blockLayerHidden = true;
-			this._getBlockingLayer.hidePopover();
+			this._getBlockingLayer?.hidePopover();
 			Popup.unblockPageScrolling(this);
 		}
 


### PR DESCRIPTION
In 1.x it was possible to have this code:

```js
(new Dialog()).show()
```

without appending the dialog to the DOM tree, and it would work without throwing any errors (would just show the block layer) because the static area item was forced to be rendered even without the dialog itself being rendered.

In 2.x the same code throws a runtime error, because the blocking layer is not available before the component has been rendered (the shadow root is empty).

This fixes the error, although it is not a real use case.