### PR TITLE
fix(ui5-shellbar): assistant icon color fixed

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1145,6 +1145,7 @@ class ShellBar extends UI5Element {
 				},
 				copilot: {
 					"ui5-shellbar-hidden-button": this.isIconHidden(this._coPilotIcon),
+					"ui5-shellbar-coPilot-pressed": this._coPilotPressed,
 				},
 				overflow: {
 					"ui5-shellbar-hidden-button": this.isIconHidden("overflow"),

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -466,6 +466,11 @@ slot[name="profile"] {
 	height: 2.75rem;
 }
 
+.ui5-shellbar-coPilot-pressed,
+.ui5-shellbar-coPilot-pressed:hover {
+	color: var(--sapShell_Assistant_ForegroundColor);
+}
+
 ::slotted([ui5-button][slot="startButton"]) {
 	margin-inline: 0 0.5rem;
 	justify-content: center;


### PR DESCRIPTION
 ui5-shellbar assistant icon's color now has the accurate color, according to VD Spec.