### PR TITLE
fix: decorators stop searching for accessors when reaching HTMLElement

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -101,7 +101,7 @@ function getPropertyDescriptor(proto: any, name: PropertyKey): PropertyDescripto
 		}
 		// go up the prototype chain
 		proto = Object.getPrototypeOf(proto);
-	} while (proto);
+	} while (proto && proto !== HTMLElement.prototype);
 }
 
 /**

--- a/packages/base/test/elements/Accessor.js
+++ b/packages/base/test/elements/Accessor.js
@@ -22,6 +22,9 @@ Accessor = __decorate([
         renderer: litRender,
     })
 ], Accessor);
+__decorate([
+    property({ type: String, defaultValue: undefined })
+], Accessor.prototype, "title", void 0);
 Accessor.define();
 export default Accessor;
 
@@ -36,16 +39,8 @@ import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRender
 	renderer: litRender,
 })
 class Accessor extends UI5Element {
-	storage: boolean = false;
-
-	@property()
-	set myProp(value: boolean) {
-		this.storage = value;
-	}
-
-	get myProp() {
-		return this.storage;
-	}
+	@property({ type: String, defaultValue: undefined})
+	title!: string;
 
 	render() {
 		return html`<div>${this.myProp}</div>`;

--- a/packages/base/test/specs/Accessor.spec.js
+++ b/packages/base/test/specs/Accessor.spec.js
@@ -57,4 +57,16 @@ describe("Framework boot", async () => {
 		assert.strictEqual(res2[2], false, "internal storage is updated");
 	});
 
+	it("should stop searching for accessors when HTMLElement is reached", async () => {
+		const res = await browser.executeAsync( async (done) => {
+			const el = document.getElementById("accessor");
+			await window["sap-ui-webcomponents-bundle"].renderFinished();
+			// return as string, seems that WDIO changes return undefined to null
+			done([`${el.title}`]);
+		});
+
+		// HTMLElement.title will always return '', but if the getter is coming from the framework, it should return undefined
+		assert.strictEqual(res[0], "undefined", "getter is coming from field, not HTMLElement.(get title)");
+	});
+
 });


### PR DESCRIPTION
property decorators on accessors (getter/setter) introduced with #8587 and later modified to search accessors in the prototype chain with #8643 now have a problem when a property defined in a component has an accessor in HTMLElement.

For example, Link has a property `title`, HTMLElement has а `get title`. The current lookup finds the HTMLElement getter and starts using this. However having a class field `title` in the link means the component should use this one, especially for the default value. Setting `title = undefined` on the field works, but if there is a HTMLElement getter and it is used, it returns an empty string `''`.

This change stops searching for accessors when HTMLElement is reached. For the rest of the cases, TypeScript has a warning that a getter/setter pair cannot be overwritten by a field. In this particular case, the typescript definition for HTMLElement.title is simply as a string field, hence no error that an accessor is overwritten.
```ts
interface HTMLElement {
   title: string
}
```