### PR TITLE
refactor(ui5-wizard-tab): remove aria-disabled attribute

### DIFF
--- a/packages/fiori/src/WizardTab.hbs
+++ b/packages/fiori/src/WizardTab.hbs
@@ -4,7 +4,6 @@
 	aria-current="{{accInfo.ariaCurrent}}"
 	aria-setsize="{{accInfo.ariaSetsize}}"
 	aria-posinset="{{accInfo.ariaPosinset}}"
-	aria-disabled="{{accInfo.ariaDisabled}}"
 	aria-label="{{accInfo.ariaLabel}}"
 	@click="{{_onclick}}"
 	@keyup="{{_onkeyup}}"

--- a/packages/fiori/src/WizardTab.ts
+++ b/packages/fiori/src/WizardTab.ts
@@ -164,7 +164,6 @@ class WizardTab extends UI5Element implements ITabbable {
 			"ariaPosinset": this._wizardTabAccInfo && this._wizardTabAccInfo.ariaPosinset,
 			"ariaLabel": this._wizardTabAccInfo && this._wizardTabAccInfo.ariaLabel,
 			"ariaCurrent": this.selected ? "true" : undefined,
-			"ariaDisabled": this.disabled ? "true" : undefined,
 		};
 	}
 }


### PR DESCRIPTION
As part of Aria 1.2 support enhancement, aria-disabled attribute is no longer supported for elements with role="listitem". Remove aria-disabled attribute, which is used in disabled ui5-wizard-tab component.