### PR TITLE
chore(ui5-menu): fix unstable test

### DIFF
--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -143,32 +143,33 @@ describe("Menu interaction", () => {
 		assert.notEqual(eventLoggerValue.indexOf("close"), -1, "'close' event is fired");
 	});
 
-	// We need to investigate why this test is failing
-	// it("Menu and Menu items busy indication", async () => {
-	// 		await browser.url(`test/pages/Menu.html`);
-	// 		const openButton = await browser.$("#btnOpen");
-	// 		await openButton.click();
+	it("Menu and Menu items busy indication", async () => {
+			await browser.url(`test/pages/Menu.html`);
+			const openButton = await browser.$("#btnOpen");
+			await openButton.click();
 
-	// 		const menu = await browser.$("#menu");
-	// 		const menuPopover = await menu.shadow$("ui5-responsive-popover");
-	// 		const visualOpenItem = await menuPopover.$("ui5-menu-li[accessible-name='Open']");
-	// 		const visualCloseItem = await menuPopover.$("ui5-menu-li[accessible-name='Close']");
+			const menu = await browser.$("#menu");
+			const menuPopover = await menu.shadow$("ui5-responsive-popover");
+			const visualOpenItem = await menuPopover.$("ui5-menu-li[accessible-name='Open']");
+			const visualCloseItem = await menuPopover.$("ui5-menu-li[accessible-name='Close']");
 
-	// 		await visualOpenItem.click();
-	// 		const openSubmenuPopover = await menu.shadow$(".ui5-menu-submenus ui5-menu:last-of-type").shadow$("ui5-responsive-popover");
-	// 		const openMenuList = await openSubmenuPopover.$("ui5-list");
+			await visualOpenItem.click();
+			const openSubmenuPopover = await menu.shadow$(".ui5-menu-submenus ui5-menu:last-of-type").shadow$("ui5-responsive-popover");
+			const openMenuList = await openSubmenuPopover.$("ui5-list");
 
-	// 		// assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
-	// 		assert.strictEqual((await openMenuList.$$("ui5-menu-li")).length, 4, "Two additional nodes have been added.");
+			// assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
+			await browser.waitUntil(async () => {
+				return (await openMenuList.$$("ui5-menu-li")).length === 4;
+			}, 1500, "Two additional nodes have been added.");
 
-	// 		await visualCloseItem.click();
+			await visualCloseItem.click();
 
-	// 		const closeSubmenuPopover = await menu.shadow$(".ui5-menu-submenus ui5-menu:last-of-type").shadow$("ui5-responsive-popover");
-	// 		const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
-	// 		assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
-	// 		assert.strictEqual(await busyIndicator.getProperty("size"), "M", "Size attribute is properly set.");
-	// 		assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
-	// 	});
+			const closeSubmenuPopover = await menu.shadow$(".ui5-menu-submenus ui5-menu:last-of-type").shadow$("ui5-responsive-popover");
+			const busyIndicator = await closeSubmenuPopover.$("ui5-busy-indicator");
+			assert.ok(await busyIndicator.getProperty("active"), "Active attribute is properly set.");
+			assert.strictEqual(await busyIndicator.getProperty("size"), "M", "Size attribute is properly set.");
+			assert.strictEqual(await busyIndicator.getProperty("delay"), 100, "Delay attribute is properly set.");
+		});
 
 		it("Prevent menu closing on item press", async () => {
 			await browser.url(`test/pages/Menu.html`);


### PR DESCRIPTION
The failing test often asserts that there are **2** items instead of **4**

The reason is this code in `Menu.html`

```js
menu.addEventListener("ui5-before-open", function(event) {
			const item = event.detail.item;
			if (item && item.text === "Open" && !fetched) {
				setTimeout(function() {
					item.removeAttribute("busy");
					item.removeAttribute("busy-delay");
					let oneNode = document.createElement("ui5-menu-item");
					oneNode.setAttribute("text", "Open from Amazon Cloud");
					let twoNode = document.createElement("ui5-menu-item");
					twoNode.setAttribute("text", "Open from Google Cloud");
					item.append(oneNode, twoNode);
					fetched = true;
				}, 1000);
			}
		});
```

There is a timeout of **1000ms** that adds **2** more items, and thus the total number of items becomes **4**.

However, the test does not account for this timeout which causes failures.

The best practice when you have `setTimeout` in the test page is to use **waitUntil**: https://webdriver.io/docs/api/browser/waitUntil/

<img width="761" alt="image" src="https://github.com/SAP/ui5-webcomponents/assets/15844574/cb72fce2-e9f5-42b1-8671-3e328bc51c6b">
