### PR TITLE
docs: change to trailing slash urls to skip redirects

### DIFF
--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -39,6 +39,8 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: BASE_URL,
+  // github pages makes a redirect to a trailing slash url, which prevents pages from being crawled by google
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
docusaurus is building pages without a trailing slash, for example from the sitemap.xml
```xmls
<url>
  <loc>
    https://sap.github.io/ui5-webcomponents/components/Button
  </loc>
  <changefreq>weekly</changefreq>
  <priority>0.5</priority>
</url>
```

Then github makes a redirect to a trailing slash url:
<img width="336" alt="Screenshot 2024-04-10 at 21 03 07" src="https://github.com/SAP/ui5-webcomponents/assets/11073377/fd503333-d81e-48d9-9a1e-1438cfa8e645">
<img width="400" alt="Screenshot 2024-04-10 at 21 03 49" src="https://github.com/SAP/ui5-webcomponents/assets/11073377/155c6a92-2813-48ab-8aef-562a1e4fa8eb">

This in turn prevents google from indexing the pages
`Page is not indexed: Page with redirect`