### PR TITLE
fix(ui5-tree-item-custom): improved key handling

### DIFF
--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -1,6 +1,7 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import { isTabNext, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import TreeItemBase from "./TreeItemBase.js";
 
 // Template
@@ -48,6 +49,26 @@ class TreeItemCustom extends TreeItemBase {
 	 */
 	@slot()
 	content!: Array<HTMLElement>;
+
+	_onkeydown(e: KeyboardEvent) {
+		const isTab = isTabNext(e) || isTabPrevious(e);
+
+		if (!isTab && !this.focused) {
+			return;
+		}
+
+		super._onkeydown(e);
+	}
+
+	_onkeyup(e: KeyboardEvent) {
+		const isTab = isTabNext(e) || isTabPrevious(e);
+
+		if (!isTab && !this.focused) {
+			return;
+		}
+
+		super._onkeyup(e);
+	}
 
 	/**
 	 * @override


### PR DESCRIPTION
Previously it was impossible to properly use keyboard inside input elements nested in TreeItemCustom. Now the handling is similar to CustomListItem and input elements can be used as expected.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7566