### PR TITLE
chore: fix dev time error in ts checker

### DIFF
--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -41,7 +41,7 @@ const scripts = {
 	generateVersionInfo: `node "${versionScript}"`,
 	generateStyles: `node "${stylesScript}"`,
 	// these files are ignored in TS because the import in UI5Elments tries to load them from the dist and throws an error. create them empty here
-	generateSsrDom: `touch dist/ssr-dom.js dist/ssr-dom.d.ts`,
+	generateSsrDom: `yarn nodetouch dist/ssr-dom.js dist/ssr-dom.d.ts`,
 	generateTemplates: `mkdirp src/generated/templates && cross-env UI5_BASE=true UI5_TS=true node "${LIB}/hbs2ui5/index.js" -d test/elements -o src/generated/templates`,
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",

--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -15,7 +15,7 @@ const viteConfig = `-c "${require.resolve("@ui5/webcomponents-tools/components-p
 const scripts = {
 	clean: "rimraf src/generated && rimraf dist && rimraf .port",
 	lint: `eslint .`,
-	generate: "cross-env UI5_TS=true nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles generateTemplates",
+	generate: "cross-env UI5_TS=true nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles generateTemplates generateSsrDom",
 	prepare: "cross-env UI5_TS=true nps clean integrate copy generateAssetParameters generateVersionInfo generateStyles generateTemplates typescript integrate.no-remaining-require",
 	typescript: "tsc -b",
 	integrate: {
@@ -40,6 +40,8 @@ const scripts = {
 	generateAssetParameters: `node "${assetParametersScript}"`,
 	generateVersionInfo: `node "${versionScript}"`,
 	generateStyles: `node "${stylesScript}"`,
+	// these files are ignored in TS because the import in UI5Elments tries to load them from the dist and throws an error. create them empty here
+	generateSsrDom: `touch dist/ssr-dom.js dist/ssr-dom.d.ts`,
 	generateTemplates: `mkdirp src/generated/templates && cross-env UI5_BASE=true UI5_TS=true node "${LIB}/hbs2ui5/index.js" -d test/elements -o src/generated/templates`,
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -53,6 +53,7 @@
     "eslint": "^7.22.0",
     "mkdirp": "^1.0.4",
     "replace-in-file": "^6.3.5",
-    "resolve": "^1.20.0"
+    "resolve": "^1.20.0",
+    "touch": "^3.1.0"
   }
 }

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "include": ["src/**/*", "src/global.d.ts"],
-    // ssr-dom is imported with bare specifier so that conditional exports are used, but this treats it as input and output
-    "exclude": ["src/ssr-dom*.d.ts"],
+    // ssr-dom is imported with bare specifier so that conditional exports are used, but this treats it as input and output, so ignore it
+    "exclude": ["src/ssr-dom.ts"],
     "compilerOptions": {
       "target": "ES2021",
       "lib": ["DOM", "DOM.Iterable", "ES2023"],

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -100,7 +100,7 @@ const getScripts = (options) => {
 			props: `node "${LIB}/copy-and-watch/index.js" --silent "src/**/*.properties" dist/`,
 		},
 		watch: {
-			default: `${tsCrossEnv} concurrently "nps watch.templates" "nps watch.typescript" "nps watch.api" "nps watch.src" "nps watch.styles" "nps watch.i18n" "nps watch.props"`,
+			default: `${tsCrossEnv} concurrently "nps watch.templates" "nps watch.typescript" "nps watch.src" "nps watch.styles" "nps watch.i18n" "nps watch.props"`,
 			devServer: 'concurrently "nps watch.default" "nps watch.bundle"',
 			src: 'nps "copy.src --watch --safe --skip-initial-copy"',
 			typescript: tsWatchCommandStandalone,
@@ -113,7 +113,6 @@ const getScripts = (options) => {
 				componentStyles: `nps "build.styles.componentStyles -w"`,
 			},
 			templates: 'chokidar "src/**/*.hbs" -c "nps build.templates"',
-			api: 'nps generateAPI',
 			i18n: 'chokidar "src/i18n/messagebundle.properties" -c "nps build.i18n.defaultsjs"'
 		},
 		start: "nps prepare watch.devServer",
@@ -131,7 +130,7 @@ const getScripts = (options) => {
 				replace: `node "${LIB}/scoping/scope-test-pages.js" test/pages/scoped demo`,
 			},
 			watchWithBundle: 'concurrently "nps scope.watch" "nps scope.bundle" ',
-			watch: 'concurrently "nps watch.templates" "nps watch.api" "nps watch.src" "nps watch.props" "nps watch.styles"',
+			watch: 'concurrently "nps watch.templates" "nps watch.src" "nps watch.props" "nps watch.styles"',
 			bundle: `node ${LIB}/dev-server/dev-server.js ${viteConfig}`,
 		},
 		generateAPI: {

--- a/packages/tools/lib/dev-server/ssr-dom-shim-loader.js
+++ b/packages/tools/lib/dev-server/ssr-dom-shim-loader.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+
+/**
+ * UI5Elements loads the ssr-dom.js file with a package specifier to use the export conditions
+ * in the package.json so that a shim for the dom can be loaded from SSR environments
+ * This however makes the TS Checker plugin used for development try to load the file from dist as input
+ * This plugin loads an empty file and TS ignores the file completely
+ */
+
+const ssrDomShimLoader = async () => {
+	return {
+		name: 'ssr-dom-shim-loader',
+		resolveId(id) {
+			if (id === "@ui5/webcomponents-base/dist/ssr-dom.js") {
+				return "\0shim"
+			}
+		},
+		load(id) {
+			if (id === "\0shim") {
+				return "";
+			}
+		}
+	}
+};
+
+module.exports = ssrDomShimLoader;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('vite');
 const virtualIndex = require("@ui5/webcomponents-tools/lib/dev-server/virtual-index-html-plugin.js");
 const customHotUpdate = require("@ui5/webcomponents-tools/lib/dev-server/custom-hot-update-plugin.js");
+const ssrDomShimLoader = require("@ui5/webcomponents-tools/lib/dev-server/ssr-dom-shim-loader.js");
 const { existsSync } = require('fs');
 const { dirname, join, resolve } = require('path');
 const path = require('path');
@@ -68,16 +69,8 @@ const customResolver = (id, source, options) => {
 			}
 			return resolved;
 		}
-		
 	}
 
-	// The `base/package.json` has exports that resolves the absolute import to "dist/ssr-dom.js".
-	// However, in development, the file is not present in `dist`. Instead, load `ssr-dom.ts` from `src`.
-	if (id === "@ui5/webcomponents-base/dist/ssr-dom.js") {
-		return join("packages/base/src/ssr-dom.ts");
-	}
-
-	
 	// relative imports from fiori src that are to a folder starting with `illustrations` are in dist
 	if (source.includes("fiori/src/") && id.includes("/illustrations") && !id.includes("AllIllustrations") && id.startsWith(".")) {
 		let absoluteId = resolve(dirname(source), id);
@@ -108,7 +101,7 @@ module.exports = defineConfig(async () => {
 		build: {
 			emptyOutDir: false,
 		},
-		plugins: [await virtualIndex(), tsconfigPaths(), customHotUpdate(),
+		plugins: [await virtualIndex(), tsconfigPaths(), customHotUpdate(), ssrDomShimLoader(),
 			checker({
 				// e.g. use TypeScript check
 				typescript: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12762,11 +12762,6 @@ jsbn@1.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
   integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
-
 jscodeshift@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.15.1.tgz#6c7a9572acdfa4f54098e958f71a05716a4e546b"
@@ -15277,7 +15272,7 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
-nopt@1.0.10:
+nopt@1.0.10, nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
   integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
@@ -19386,6 +19381,13 @@ totalist@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
   integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
UI5Element imports a ssr-dom.js file via the package in order to use the export conditions for SSR and serve a shim.

This confuses TS in watch mode and it treats the file as both input and output throwing an error that it cannot be overwritten.

This change ignores the ssr-dom.js file in TS completely and generates it in dist and fixes the dev server to load an empty one.