### PR TITLE
fix(ui5-split-button): add correct opacity when disabled

### DIFF
--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -48,6 +48,7 @@
 
 :host([disabled]:not([hidden])) {
 	pointer-events: none;
+	opacity: var(--sapContent_DisabledOpacity);
 }
 
 :host([design="Positive"]:not([hidden])) {


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-webcomponents/issues/8615
