### PR TITLE
chore(OpenUI5Support): patch OpenUI5 Popup.js to support the Popover API

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -123,8 +123,8 @@ class OpenUI5Support {
 	}
 
 	static patchPopup(Popup: OpenUI5Popup) {
+		// 1. Patch open
 		const origOpen = Popup.prototype.open;
-		const origClose = Popup.prototype.close;
 		Popup.prototype.open = function (...args: any[]) {
 			origOpen.apply(this, args);
 			if (this.isOpen()) {
@@ -133,6 +133,9 @@ class OpenUI5Support {
 				el.showPopover();
 			}
 		};
+
+		// 2. Patch close
+		const origClose = Popup.prototype.close;
 		Popup.prototype.close = function (...args: any[]) {
 			origClose.apply(this, args);
 			if (!this.isOpen()) {
@@ -142,8 +145,9 @@ class OpenUI5Support {
 			}
 		};
 
+		// 3. Create the required CSS for the expected coordinate system
 		const stylesheet = new CSSStyleSheet();
-		stylesheet.replaceSync(`:popover-open { inset: unset; }`);
+		stylesheet.replaceSync(`.sapMPopup-CTX:popover-open { inset: unset; }`);
 		document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
 	}
 

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -1,3 +1,5 @@
+import patchPatcher from "./patchPatcher.js";
+import type { OpenUI5Patcher } from "./patchPatcher.js";
 import patchPopup from "./patchPopup.js";
 import type { OpenUI5Popup } from "./patchPopup.js";
 import { registerFeature } from "../FeaturesRegistry.js";
@@ -86,7 +88,7 @@ class OpenUI5Support {
 		return new Promise<void>(resolve => {
 			window.sap.ui.require(["sap/ui/core/Core"], async (Core: OpenUI5Core) => {
 				const callback = () => {
-					let deps: Array<string> = ["sap/ui/core/Popup", "sap/ui/core/LocaleData"];
+					let deps: Array<string> = ["sap/ui/core/Popup", "sap/ui/core/Patcher", "sap/ui/core/LocaleData"];
 					if (OpenUI5Support.isAtLeastVersion116()) { // for versions since 1.116.0 and onward, use the modular core
 						deps = [
 							...deps,
@@ -97,7 +99,8 @@ class OpenUI5Support {
 							"sap/ui/core/date/CalendarUtils",
 						];
 					}
-					window.sap.ui.require(deps, (Popup: OpenUI5Popup) => {
+					window.sap.ui.require(deps, (Popup: OpenUI5Popup, Patcher: OpenUI5Patcher) => {
+						patchPatcher(Patcher);
 						patchPopup(Popup);
 						resolve();
 					});

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -1,4 +1,3 @@
-/* eslint-disable func-names */
 import { registerFeature } from "../FeaturesRegistry.js";
 import { setTheme } from "../config/Theme.js";
 import { CLDRData } from "../asset-registries/LocaleData.js";
@@ -126,7 +125,7 @@ class OpenUI5Support {
 	static patchPopup(Popup: OpenUI5Popup) {
 		// 1. Patch open (show the popover before all animations have started)
 		const origOpen = Popup.prototype.open;
-		Popup.prototype.open = function (...args: any[]) {
+		Popup.prototype.open = function open(...args: any[]) {
 			origOpen.apply(this, args);
 			const topLayerAlreadyInUse = !!document.body.querySelector(":popover-open"); // check if there is already something in the top layer
 			const openingInitiated = ["OPENING", "OPEN"].includes(this.getOpenState());
@@ -139,7 +138,7 @@ class OpenUI5Support {
 
 		// 2. Patch _closed (hide the popover after all animations have ended)
 		const _origClosed = Popup.prototype._closed;
-		Popup.prototype._closed = function (...args: any[]) {
+		Popup.prototype._closed = function _closed(...args: any[]) {
 			_origClosed.apply(this, args);
 			const el = this.oContent?.getDomRef();
 			if (!el) {

--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 import { registerFeature } from "../FeaturesRegistry.js";
 import { setTheme } from "../config/Theme.js";
 import { CLDRData } from "../asset-registries/LocaleData.js";

--- a/packages/base/src/features/patchPatcher.ts
+++ b/packages/base/src/features/patchPatcher.ts
@@ -8,7 +8,9 @@ type OpenUI5Patcher = {
 const patchPatcher = (Patcher: OpenUI5Patcher) => {
 	const origOpenEnd = Patcher.prototype.openEnd;
 	Patcher.prototype.openEnd = function openEnd() {
-		delete this._mAttributes.popover; // The "popover" attribute will be managed externally, don't let Patcher remove it
+		if (this._mAttributes.popover) {
+			delete this._mAttributes.popover; // The "popover" attribute will be managed externally, don't let Patcher remove it
+		}
 		return origOpenEnd.apply(this);
 	};
 };

--- a/packages/base/src/features/patchPatcher.ts
+++ b/packages/base/src/features/patchPatcher.ts
@@ -1,0 +1,17 @@
+type OpenUI5Patcher = {
+	prototype: {
+		_mAttributes: { [key: string]: string },
+		openEnd: () => OpenUI5Patcher,
+	}
+};
+
+const patchPatcher = (Patcher: OpenUI5Patcher) => {
+	const origOpenEnd = Patcher.prototype.openEnd;
+	Patcher.prototype.openEnd = function openEnd() {
+		delete this._mAttributes.popover; // The "popover" attribute will be managed externally, don't let Patcher remove it
+		return origOpenEnd.apply(this);
+	};
+};
+
+export default patchPatcher;
+export type { OpenUI5Patcher };

--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -1,14 +1,17 @@
+// Mockup of OpenUI5's Element.js
+type Element = {
+	getDomRef: () => HTMLElement | null,
+	addDelegate: (delegate: DelegatesMap) => void,
+	removeDelegate: (delegate: DelegatesMap) => void,
+}
+
 // The lifecycle of Popup.js is open -> _opened -> close -> _closed, we're interested in the first (open) and last (_closed)
 type OpenUI5Popup = {
 	prototype: {
 		open: (...args: any[]) => void,
 		_closed: (...args: any[]) => void,
 		getOpenState: () => "CLOSED" | "CLOSING" | "OPEN" | "OPENING",
-		oContent: {
-			getDomRef: () => HTMLElement,
-			addDelegate: (delegate: DelegatesMap) => void,
-			removeDelegate: (delegate: DelegatesMap) => void,
-		},
+		getContent: () => Element, // this is the OpenUI5 Element/Control instance that opens the Popup (usually sap.m.Popover/sap.m.Dialog)
 	}
 };
 
@@ -17,30 +20,30 @@ const delegatesRegistry = new Map<HTMLElement, DelegatesMap>();
 
 /**
  * Ensures a unique delegate for each element, because removeDelegate expects the same object pased to addDelegate
- * @param el HTML element to use the popover API
+ * @param domRef HTML element to use the popover API
  */
-const getDelegate = (el: HTMLElement) => {
-	if (!delegatesRegistry.has(el)) {
+const getDelegate = (domRef: HTMLElement) => {
+	if (!delegatesRegistry.has(domRef)) {
 		const delegate = {
 			"onAfterRendering": () => {
-				openNativePopover(el);
+				openNativePopover(domRef);
 			},
 		};
-		delegatesRegistry.set(el, delegate);
+		delegatesRegistry.set(domRef, delegate);
 	}
 
-	return delegatesRegistry.get(el)!;
+	return delegatesRegistry.get(domRef)!;
 };
 
-const openNativePopover = (el: HTMLElement) => {
-	el.setAttribute("popover", "manual");
-	el.showPopover();
+const openNativePopover = (domRef: HTMLElement) => {
+	domRef.setAttribute("popover", "manual");
+	domRef.showPopover();
 };
 
-const closeNativePopover = (el: HTMLElement) => {
-	if (el.hasAttribute("popover")) {
-		el.hidePopover();
-		el.removeAttribute("popover");
+const closeNativePopover = (domRef: HTMLElement) => {
+	if (domRef.hasAttribute("popover")) {
+		domRef.hidePopover();
+		domRef.removeAttribute("popover");
 	}
 };
 
@@ -52,23 +55,29 @@ const patchPopup = (Popup: OpenUI5Popup) => {
 		const topLayerAlreadyInUse = !!document.body.querySelector(":popover-open"); // check if there is already something in the top layer
 		const openingInitiated = ["OPENING", "OPEN"].includes(this.getOpenState());
 		if (openingInitiated && topLayerAlreadyInUse) {
-			const el = this.oContent.getDomRef();
-			openNativePopover(el);
-			this.oContent.addDelegate(getDelegate(el)); // add onAfterRendering delegate to restore the "popover" attribute that will be removed by RenderManager on re-rendering
+			const element = this.getContent();
+			if (element) {
+				const domRef = element.getDomRef();
+				if (domRef) {
+					openNativePopover(domRef);
+					element.addDelegate(getDelegate(domRef)); // add onAfterRendering delegate to restore the "popover" attribute that will be removed by RenderManager on re-rendering
+				}
+			}
 		}
 	};
 
 	// 2. Patch _closed (hide the popover after all animations have ended)
 	const _origClosed = Popup.prototype._closed;
 	Popup.prototype._closed = function _closed(...args: any[]) {
-		const el = this.oContent.getDomRef();
-		if (delegatesRegistry.has(el)) {
-			this.oContent.removeDelegate(getDelegate(el)); // remove the onAfterRendering delegate before calling _close to avoid issues
-			delegatesRegistry.delete(el);
+		const element = this.getContent();
+		const domRef = element.getDomRef();
+		if (domRef && delegatesRegistry.has(domRef)) {
+			element.removeDelegate(getDelegate(domRef)); // remove the onAfterRendering delegate before calling _close to avoid issues
+			delegatesRegistry.delete(domRef);
 		}
 		_origClosed.apply(this, args); // only then call _close
-		if (el) {
-			closeNativePopover(el); // unset the popover attribute and close the native popover, but only if still in DOM
+		if (domRef) {
+			closeNativePopover(domRef); // unset the popover attribute and close the native popover, but only if still in DOM
 		}
 	};
 

--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -61,7 +61,7 @@ const patchOpen = (Popup: OpenUI5Popup) => {
 				const domRef = element.getDomRef();
 				if (domRef) {
 					openNativePopover(domRef);
-					element.addDelegate(getDelegate(domRef)); // add onAfterRendering delegate to restore the "popover" attribute that will be removed by RenderManager on re-rendering
+					// element.addDelegate(getDelegate(domRef)); // add onAfterRendering delegate to restore the "popover" attribute that will be removed by RenderManager on re-rendering
 				}
 			}
 		}
@@ -74,7 +74,7 @@ const patchClosed = (Popup: OpenUI5Popup) => {
 		const element = this.getContent();
 		const domRef = element.getDomRef();
 		if (domRef && delegatesRegistry.has(domRef)) {
-			element.removeDelegate(getDelegate(domRef)); // remove the onAfterRendering delegate before calling _close to avoid issues
+			// element.removeDelegate(getDelegate(domRef)); // remove the onAfterRendering delegate before calling _close to avoid issues
 			delegatesRegistry.delete(domRef);
 		}
 		_origClosed.apply(this, args); // only then call _close

--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -1,0 +1,82 @@
+// The lifecycle of Popup.js is open -> _opened -> close -> _closed, we're interested in the first (open) and last (_closed)
+type OpenUI5Popup = {
+	prototype: {
+		open: (...args: any[]) => void,
+		_closed: (...args: any[]) => void,
+		getOpenState: () => "CLOSED" | "CLOSING" | "OPEN" | "OPENING",
+		oContent: {
+			getDomRef: () => HTMLElement,
+			addDelegate: (delegate: DelegatesMap) => void,
+			removeDelegate: (delegate: DelegatesMap) => void,
+		},
+	}
+};
+
+type DelegatesMap = { [key: string]: () => void; }
+const delegatesRegistry = new Map<HTMLElement, DelegatesMap>();
+
+/**
+ * Ensures a unique delegate for each element, because removeDelegate expects the same object pased to addDelegate
+ * @param el HTML element to use the popover API
+ */
+const getDelegate = (el: HTMLElement) => {
+	if (!delegatesRegistry.has(el)) {
+		const delegate = {
+			"onAfterRendering": () => {
+				openNativePopover(el);
+			},
+		};
+		delegatesRegistry.set(el, delegate);
+	}
+
+	return delegatesRegistry.get(el)!;
+};
+
+const openNativePopover = (el: HTMLElement) => {
+	el.setAttribute("popover", "manual");
+	el.showPopover();
+};
+
+const closeNativePopover = (el: HTMLElement) => {
+	if (el.hasAttribute("popover")) {
+		el.hidePopover();
+		el.removeAttribute("popover");
+	}
+};
+
+const patchPopup = (Popup: OpenUI5Popup) => {
+	// 1. Patch open (show the popover before all animations have started)
+	const origOpen = Popup.prototype.open;
+	Popup.prototype.open = function open(...args: any[]) {
+		origOpen.apply(this, args); // call open first to initiate opening
+		const topLayerAlreadyInUse = !!document.body.querySelector(":popover-open"); // check if there is already something in the top layer
+		const openingInitiated = ["OPENING", "OPEN"].includes(this.getOpenState());
+		if (openingInitiated && topLayerAlreadyInUse) {
+			const el = this.oContent.getDomRef();
+			openNativePopover(el);
+			this.oContent.addDelegate(getDelegate(el)); // add onAfterRendering delegate to restore the "popover" attribute that will be removed by RenderManager on re-rendering
+		}
+	};
+
+	// 2. Patch _closed (hide the popover after all animations have ended)
+	const _origClosed = Popup.prototype._closed;
+	Popup.prototype._closed = function _closed(...args: any[]) {
+		const el = this.oContent.getDomRef();
+		if (delegatesRegistry.has(el)) {
+			this.oContent.removeDelegate(getDelegate(el)); // remove the onAfterRendering delegate before calling _close to avoid issues
+			delegatesRegistry.delete(el);
+		}
+		_origClosed.apply(this, args); // only then call _close
+		if (el) {
+			closeNativePopover(el); // unset the popover attribute and close the native popover, but only if still in DOM
+		}
+	};
+
+	// 3. Create the required CSS for the expected coordinate system
+	const stylesheet = new CSSStyleSheet();
+	stylesheet.replaceSync(`.sapMPopup-CTX:popover-open { inset: unset; }`);
+	document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
+};
+
+export default patchPopup;
+export type { OpenUI5Popup };

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -6,12 +6,6 @@
 
     <title>OpenUI5 Latest Stable + UI5 Web Components</title>
 
-	<style>
-		:popover-open {
-			inset: unset;
-		}
-	</style>
-
     <script id='sap-ui-bootstrap'
             src='https://openui5.hana.ondemand.com/resources/sap-ui-core.js'
             data-sap-ui-theme='sap_belize_hcb'
@@ -92,7 +86,10 @@
 	<ui5-popover id="popup" header-text="Popover"></ui5-popover>
 
 	<ui5-button id="componentPopoverOpener">Open a WC Popover that in turn opens an OpenUI5 popover</ui5-button>
-	<ui5-dialog id="componentPopover" opener="componentPopoverOpener" header-text="This is a ui5-dialog"></ui5-dialog>
+	<ui5-dialog id="componentPopover" opener="componentPopoverOpener" header-text="This is a ui5-dialog">
+		<ui5-title>Use the buttons in the footer to open UI5 controls</ui5-title>
+		<div id="componentPopoverFooter" slot="footer"></div>
+	</ui5-dialog>
 
 	<div id='content'></div>
 </body>
@@ -113,8 +110,12 @@
 		if (done) {
 			return;
 		}
-		const openButton = new sap.m.Button({text: "Open an OpenUI5 Popover"});
-		openButton.placeAt("componentPopover");
+		const openPopoverButton = new sap.m.Button({text: "Open an OpenUI5 Popover"});
+		const openDialogButton = new sap.m.Button({text: "Open an OpenUI5 Dialog"});
+		const toolbar = new sap.m.Toolbar({
+			content: [openPopoverButton, openDialogButton]
+		});
+		toolbar.placeAt("componentPopoverFooter");
 
 		const sapMPopover = new sap.m.Popover({
 			title: "This is a sap.m.Popover",
@@ -124,11 +125,20 @@
 			],
 		});
 
-		openButton.attachPress(() => {
-			sapMPopover.openBy(openButton);
-			// const domRef = sapMPopover.getDomRef();
-			// domRef.popover = "manual";
-			// domRef.showPopover();
+		const sapMDialog = new sap.m.Dialog({
+			title: "This is a sap.m.Dialog",
+			content: [
+				new sap.m.Label({text: "Some dialog content"}),
+				new sap.m.TimePicker()
+			],
+		});
+
+		openPopoverButton.attachPress(() => {
+			sapMPopover.openBy(openPopoverButton);
+		});
+
+		openDialogButton.attachPress(() => {
+			sapMDialog.open();
 		});
 		done = true;
 	});

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -87,9 +87,42 @@
 				},
 			});
 
+			const modal1 = new sap.m.Popover({
+				title: "Modal 1",
+				// modal: true,
+				contentWidth: "200px",
+				contentHeight: "200px"
+			});
+			const modal2 = new sap.m.Popover({
+				title: "Modal 2",
+				// modal: true,
+				contentWidth: "100px",
+				contentHeight: "300px"
+			});
+			const modal3 = new sap.m.Popover({
+				title: "Modal 3",
+				// modal: true,
+				contentWidth: "300px",
+				contentHeight: "100px"
+			});
+			const btnModal = new sap.m.Button("btnModal", {
+				text: "Open several modal sap.m.Popovers",
+				press: () => {
+					modal1.openBy(btnModal);
+					modal2.openBy(btnModal2);
+				}
+			});
+			const btnModal2 = new sap.m.Button("btnModal2", {
+				text: "Open several modal sap.m.Popovers",
+				press: () => {
+					modal2.openBy(btnModal2);
+				}
+			});
+
+
             const page = new sap.m.Page({
                 content: [
-                    dialog, dialog2, btn, btn2, btnSpecial
+                    dialog, dialog2, btn, btn2, btnSpecial, btnModal, btnModal2
                 ],
             });
 

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -92,7 +92,7 @@
 	<ui5-popover id="popup" header-text="Popover"></ui5-popover>
 
 	<ui5-button id="componentPopoverOpener">Open a WC Popover that in turn opens an OpenUI5 popover</ui5-button>
-	<ui5-popover id="componentPopover" opener="componentPopoverOpener" header-text="This is a ui5-popover"></ui5-popover>
+	<ui5-dialog id="componentPopover" opener="componentPopoverOpener" header-text="This is a ui5-dialog"></ui5-dialog>
 
 	<div id='content'></div>
 </body>
@@ -108,23 +108,29 @@
 		dg2.show();
 	})
 
+	let done = false;
 	componentPopover.addEventListener("after-open", () => {
+		if (done) {
+			return;
+		}
 		const openButton = new sap.m.Button({text: "Open an OpenUI5 Popover"});
 		openButton.placeAt("componentPopover");
 
 		const sapMPopover = new sap.m.Popover({
 			title: "This is a sap.m.Popover",
 			content: [
-				new sap.m.Label({text: "Some popover content"})
+				new sap.m.Label({text: "Some popover content"}),
+				new sap.m.DatePicker()
 			],
 		});
 
 		openButton.attachPress(() => {
 			sapMPopover.openBy(openButton);
-			const domRef = sapMPopover.getDomRef();
-			domRef.popover = "manual";
-			domRef.showPopover();
-		})
+			// const domRef = sapMPopover.getDomRef();
+			// domRef.popover = "manual";
+			// domRef.showPopover();
+		});
+		done = true;
 	});
 
 	componentPopoverOpener.addEventListener("click", () => {

--- a/packages/main/test/pages/OpenUI5.html
+++ b/packages/main/test/pages/OpenUI5.html
@@ -45,9 +45,51 @@
 				},
 			});
 
+			// Chain opening
+			const dialogSpecial = new sap.m.Dialog({
+				contentWidth: "1000px",
+				contentHeight: "1000px",
+				title: "sap.m.Dialog that opens ui5-dialog that opens sap.m.Popover",
+				content: [
+					new sap.ui.core.HTML({
+						content: `
+							<ui5-button id="btnChain">Open ui5-dialog</ui5-button>
+							<ui5-dialog header-text="This is ui5-dialog" id="dialogChain" opener="btnChain">
+
+							</ui5-dialog>
+						`
+					}),
+				]
+			});
+			const btnSpecial = new sap.m.Button({
+				text: "Chain opening",
+				press: function() {
+					dialogSpecial.open();
+					btnChain.addEventListener("click", () => {
+						dialogChain.addEventListener("after-open", () => {
+							const popoverChain = new sap.m.Popover({
+								title: "This is a sap.m.Popover",
+								content: [
+									new sap.m.Label({text: "Some popover content"}),
+									new sap.m.DatePicker()
+								],
+							})
+							const btnChain2 = new sap.m.Button("btnChain2", {
+								text: "Open sap.m.Popover",
+								press: function() {
+									popoverChain.openBy(btnChain2);
+								},
+							});
+							btnChain2.placeAt("dialogChain")
+						});
+						dialogChain.open = true;
+					})
+				},
+			});
+
             const page = new sap.m.Page({
                 content: [
-                    dialog, dialog2, btn, btn2
+                    dialog, dialog2, btn, btn2, btnSpecial
                 ],
             });
 


### PR DESCRIPTION
Background: UI5 Web Components popups use the popover API, therefore are always above OpenUI5 popups, which use the static area.

In order for OpenUI5 popups to be able to show on top of components popups, they must also use the popover API and top layer. This change adapts `Popup.js` to use the popover API.

How it works:
 - `OpenUI5Support` patches 2 functions of `sap/m/Popup.js` and injects a tiny bit of CSS into the document
 - If there is nothing in the **top layer**, OpenUI5 behaves normally (the patched functions don't do extra work)
 - But if the popover API has been used (there is somethin in the **top layer**), then OpenUI5 also uses the top layer for any consequent popups (popups open up to this point are unaffected)