### PR TITLE
fix(ui5-shellbar): assistant icon color fixed

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1152,6 +1152,7 @@ class ShellBar extends UI5Element {
 				},
 				copilot: {
 					"ui5-shellbar-hidden-button": this.isIconHidden(this._coPilotIcon),
+					"ui5-shellbar-co-pilot-pressed": this._coPilotPressed,
 				},
 				overflow: {
 					"ui5-shellbar-hidden-button": this.isIconHidden("overflow"),

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -466,6 +466,11 @@ slot[name="profile"] {
 	height: 2.75rem;
 }
 
+.ui5-shellbar-co-pilot-pressed,
+.ui5-shellbar-co-pilot-pressed:hover {
+	color: var(--sapShell_Assistant_ForegroundColor);
+}
+
 ::slotted([ui5-button][slot="startButton"]) {
 	margin-inline: 0 0.5rem;
 	justify-content: center;


### PR DESCRIPTION
As in the new VD spec the color of the assistant in the ui5-shellbar is corrected, when in toggle state "on".