### PR TITLE
fix(ui5-menu-item): apply scoping to internal `Icon`

### DIFF
--- a/packages/main/src/MenuListItem.ts
+++ b/packages/main/src/MenuListItem.ts
@@ -20,7 +20,7 @@ import menuListItemCss from "./generated/themes/MenuListItem.css.js";
 	tag: "ui5-menu-li",
 	template: MenuListItemTemplate,
 	styles: [CustomListItem.styles, menuListItemCss],
-	dependencies: [Icon],
+	dependencies: [...CustomListItem.dependencies, Icon],
 })
 class MenuListItem extends CustomListItem {
 	/**

--- a/packages/main/src/MenuListItem.ts
+++ b/packages/main/src/MenuListItem.ts
@@ -1,6 +1,7 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import CustomListItem from "./CustomListItem.js";
+import Icon from "./Icon.js";
 import MenuListItemTemplate from "./generated/templates/MenuListItemTemplate.lit.js";
 import MenuItem from "./MenuItem.js";
 import HasPopup from "./types/HasPopup.js";
@@ -19,6 +20,7 @@ import menuListItemCss from "./generated/themes/MenuListItem.css.js";
 	tag: "ui5-menu-li",
 	template: MenuListItemTemplate,
 	styles: [CustomListItem.styles, menuListItemCss],
+	dependencies: [Icon],
 })
 class MenuListItem extends CustomListItem {
 	/**


### PR DESCRIPTION
Fixes #8745

This PR fixes the scoping issue of the `MenuItem`. I'm not sure if there's more changes necessary, but locally and when patching `@ui5/webcomponents` inside the node_modules it solved the issue for me. If there are more adjustments required, please feel free to use this branch.