### PR TITLE
feat(ui5-barcode-scanner-dialog): add support for close and open events

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -81,6 +81,19 @@ type BarcodeScannerDialogScanErrorEventDetail = {
 		Button,
 	],
 })
+
+/**
+ * Fired after the component is opened.
+ * @public
+ */
+@event("open")
+
+/**
+ * Fired after the component is closed.
+ * @public
+ */
+@event("close")
+
 /**
  * Fires when the scan is completed successfuuly.
  * @param {string} text the scan result as string
@@ -216,12 +229,16 @@ class BarcodeScannerDialog extends UI5Element {
 		this.dialog = this._getDialog();
 		this.dialog.show();
 		this.open = true;
+
+		this.fireEvent("open");
 	}
 
 	_closeDialog() {
 		if (this.dialog && this.dialog.open) {
 			this.dialog.close();
 			this.open = false;
+
+			this.fireEvent("close");
 		}
 	}
 

--- a/packages/fiori/test/pages/BarcodeScannerDialog.html
+++ b/packages/fiori/test/pages/BarcodeScannerDialog.html
@@ -30,6 +30,8 @@
 		<ui5-label id="scanError"></ui5-label>
 	</div>
 
+	<p>Barcode scanner dialog <code>open</code> state: <span class="open-state">false</span></p>
+
 	<script>
 		const dlgScan = document.getElementById("dlgScan");
 		const btnScan = document.getElementById("btnScan");
@@ -48,6 +50,14 @@
 		dlgScan.addEventListener("ui5-scan-error", (event) => {
 			scanError.innerHTML = event.detail.message;
 			dlgScan.open = false;
+		});
+
+		dlgScan.addEventListener("ui5-open", (event) => {
+			document.querySelector(".open-state").textContent = `${dlgScan.open}`;
+		});
+
+		dlgScan.addEventListener("ui5-close", (event) => {
+			document.querySelector(".open-state").textContent = `${dlgScan.open}`;
 		});
 	</script>
 </body>

--- a/packages/website/docs/_samples/fiori/BardcodeScannerDialog/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/BardcodeScannerDialog/Basic/main.js
@@ -3,21 +3,21 @@ import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents-fiori/dist/BarcodeScannerDialog.js";
 import "@ui5/webcomponents-icons/dist/camera.js"
 
-const btnScan = document.getElementById("btnScan");
 const dlgScan = document.getElementById("dlgScan");
+const btnScan = document.getElementById("btnScan");
 const scanResult = document.getElementById("scanResult");
 const scanError = document.getElementById("scanError");
 
 btnScan.addEventListener("click", (event) => {
-    dlgScan.show();
+	dlgScan.open = true;
 });
 
-dlgScan.addEventListener("scan-success", (event) => {
-    scanResult.innerHTML = event.detail.text;
-    dlgScan.close();
+dlgScan.addEventListener("ui5-scan-success", (event) => {
+	scanResult.innerHTML = event.detail.text;
+	dlgScan.open = false;
 });
 
-dlgScan.addEventListener("scan-error", (event) => {
-    scanError.innerHTML = event.detail.message;
-    dlgScan.close();
+dlgScan.addEventListener("ui5-scan-error", (event) => {
+	scanError.innerHTML = event.detail.message;
+	dlgScan.open = false;
 });


### PR DESCRIPTION
This change adds support for `close` and `open` events to the barcode scanner dialog. Along with this change, the documentation and the sample have been updated.

Fixes #8695



