### PR TITLE
refactor(ui5-textarea): rename property growingMaxLines to growingMaxRows

### DIFF
--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -61,7 +61,7 @@ type ExceededText = {
  *
  * ### Overview
  *
- * The `ui5-textarea` component is used to enter multiple lines of text.
+ * The `ui5-textarea` component is used to enter multiple rows of text.
  *
  * When empty, it can hold a placeholder similar to a `ui5-input`.
  * You can define the rows of the `ui5-textarea` and also determine specific behavior when handling long texts.
@@ -172,7 +172,7 @@ class TextArea extends UI5Element implements IFormElement {
 	valueState!: `${ValueState}`;
 
 	/**
-	 * Defines the number of visible text lines for the component.
+	 * Defines the number of visible text rows for the component.
 	 *
 	 * **Notes:**
 	 *
@@ -216,12 +216,12 @@ class TextArea extends UI5Element implements IFormElement {
 	growing!: boolean;
 
 	/**
-	 * Defines the maximum number of lines that the component can grow.
+	 * Defines the maximum number of rows that the component can grow.
 	 * @default 0
 	 * @public
 	 */
 	@property({ validator: Integer, defaultValue: 0 })
-	growingMaxLines!: number;
+	growingMaxRows!: number;
 
 	/**
 	 * Determines the name with which the component will be submitted in an HTML form.
@@ -450,7 +450,7 @@ class TextArea extends UI5Element implements IFormElement {
 
 	_setCSSParams() {
 		this.style.setProperty("--_textarea_rows", this.rows ? String(this.rows) : "2");
-		this.style.setProperty("--_textarea_growing_max_lines", String(this.growingMaxLines));
+		this.style.setProperty("--_textarea_growing_max_rows", String(this.growingMaxRows));
 	}
 
 	toggleValueStateMessage(toggle: boolean) {

--- a/packages/main/src/themes/TextArea.css
+++ b/packages/main/src/themes/TextArea.css
@@ -178,26 +178,26 @@
 	min-height: calc(2 * var(--_ui5_textarea_line_height) * var(--sapFontSize) + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 }
 
-:host([growing]):not([growing-max-lines]) .ui5-textarea-inner {
+:host([growing]):not([growing-max-rows]) .ui5-textarea-inner {
 	max-height: 100%;
 }
 
-:host([growing-max-lines]) .ui5-textarea-mirror {
-	max-height: calc((var(--_textarea_growing_max_lines) * var(--_ui5_textarea_line_height)) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
+:host([growing-max-rows]) .ui5-textarea-mirror {
+	max-height: calc((var(--_textarea_growing_max_rows) * var(--_ui5_textarea_line_height)) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 }
 
 :host([rows="1"]) .ui5-textarea-inner {
 	min-height: calc(var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 }
 
-:host([growing-max-lines="1"]) .ui5-textarea-inner, :host([growing-max-lines="1"]) .ui5-textarea-mirror {
+:host([growing-max-rows="1"]) .ui5-textarea-inner, :host([growing-max-rows="1"]) .ui5-textarea-mirror {
 	max-height: calc(var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 	min-height: calc(var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 }
 
-:host([rows="1"][growing-max-lines]) .ui5-textarea-inner, :host([rows="1"][growing-max-lines]) .ui5-textarea-mirror {
+:host([rows="1"][growing-max-rows]) .ui5-textarea-inner, :host([rows="1"][growing-max-rows]) .ui5-textarea-mirror {
 	min-height: calc(var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
-	max-height: calc((var(--_textarea_growing_max_lines) * var(--_ui5_textarea_line_height)) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
+	max-height: calc((var(--_textarea_growing_max_rows) * var(--_ui5_textarea_line_height)) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top) + var(--_ui5_textarea_padding_bottom));
 }
 
 :host([rows="1"][value-state="Error"]:not([readonly]):not([disabled])) .ui5-textarea-inner,
@@ -213,8 +213,8 @@
 	min-height: calc(var(--_textarea_rows) * var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top_error_warning) + var(--_ui5_textarea_padding_bottom_error_warning));
 }
 
-:host([growing-max-lines="1"][value-state="Error"]) .ui5-textarea-inner, :host([growing-max-lines="1"][value-state="Error"]) .ui5-textarea-mirror
-:host([growing-max-lines="1"][value-state="Warning"]) .ui5-textarea-inner, :host([growing-max-lines="1"][value-state="Warning"]) .ui5-textarea-mirror {
+:host([growing-max-rows="1"][value-state="Error"]) .ui5-textarea-inner, :host([growing-max-rows="1"][value-state="Error"]) .ui5-textarea-mirror
+:host([growing-max-rows="1"][value-state="Warning"]) .ui5-textarea-inner, :host([growing-max-rows="1"][value-state="Warning"]) .ui5-textarea-mirror {
 	max-height: var(--_ui5_textarea_line_height) * var(--sapFontSize) + var(--_ui5_textarea_padding_top_error_warning) + var(--_ui5_textarea_padding_bottom_error_warning);
 	min-height: var(--_ui5_textarea_line_height) * var(--sapFontSize) + var(--_ui5_textarea_padding_top_error_warning) + var(--_ui5_textarea_padding_bottom_error_warning);
 }
@@ -230,7 +230,7 @@
 	min-height: calc(var(--_ui5_textarea_line_height) * var(--sapFontSize)  + var(--_ui5_textarea_padding_top_information) + var(--_ui5_textarea_padding_bottom_information));
 }
 
-:host([growing-max-lines="1"][value-state="Information"]) .ui5-textarea-inner, :host([growing-max-lines="1"][value-state="Information"]) .ui5-textarea-mirror {
+:host([growing-max-rows="1"][value-state="Information"]) .ui5-textarea-inner, :host([growing-max-rows="1"][value-state="Information"]) .ui5-textarea-mirror {
 	max-height: var(--_ui5_textarea_line_height) * var(--sapFontSize) + var(--_ui5_textarea_padding_top__ui5_textarea_padding_top_information) + var(--_ui5_textarea_padding_bottom__ui5_textarea_padding_top_information);
 	min-height: var(--_ui5_textarea_line_height) * var(--sapFontSize) + var(--_ui5_textarea_padding_top_error_warning) + var(--_ui5_textarea_padding_bottom_information);
 }

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -108,12 +108,12 @@
 
 	<section class="group">
 		<ui5-title>Text Area: Growing up to 4</ui5-title>
-		<ui5-textarea id="growing-ta-to-four" class="fixed-width" maxLength="100"  growing-max-lines="4" show-exceeded-text  growing placeholder="Growing Text Area"></ui5-textarea>
+		<ui5-textarea id="growing-ta-to-four" class="fixed-width" maxLength="100"  growing-max-rows="4" show-exceeded-text  growing placeholder="Growing Text Area"></ui5-textarea>
 	</section>
 
 	<section class="group">
 		<ui5-title>Text Area: Growing with initial rows 4 and growing up to 12</ui5-title>
-		<ui5-textarea class="fixed-width" placeholder="Growing Text Area" rows="4" growing-max-lines="12" growing></ui5-textarea>
+		<ui5-textarea class="fixed-width" placeholder="Growing Text Area" rows="4" growing-max-rows="12" growing></ui5-textarea>
 	</section>
 
 	<section class="group">
@@ -123,7 +123,7 @@
 
 	<section class="group">
 		<ui5-title>Text Area: max length 20 characters </ui5-title>
-		<ui5-textarea id="ta-exceeded-text" value="Text longer then twenty characters" class="fixed-width" maxlength="20" show-exceeded-text growing growing-max-lines="1" rows="1" placeholder="Everything"></ui5-textarea>
+		<ui5-textarea id="ta-exceeded-text" value="Text longer then twenty characters" class="fixed-width" maxlength="20" show-exceeded-text growing growing-max-rows="1" rows="1" placeholder="Everything"></ui5-textarea>
 	</section>
 
 	<section class="group">
@@ -162,23 +162,23 @@
 	</section>
 
 	<section class="group">
-		<ui5-title>Growing: growing-max-lines="1"</ui5-title>
+		<ui5-title>Growing: growing-max-rows="1"</ui5-title>
 		<br>
-		<ui5-textarea growing growing-max-lines="1" rows="1"></ui5-textarea>
+		<ui5-textarea growing growing-max-rows="1" rows="1"></ui5-textarea>
 
-		<ui5-title>Growing: growing-max-lines="4"</ui5-title>
+		<ui5-title>Growing: growing-max-rows="4"</ui5-title>
 		<br>
-		<ui5-textarea growing growing-max-lines="4"></ui5-textarea>
+		<ui5-textarea growing growing-max-rows="4"></ui5-textarea>
 	</section>
 
 	<section class="group sapUiSizeCompact">
-		<ui5-title>Growing: growing-max-lines="1" (compact)</ui5-title>
+		<ui5-title>Growing: growing-max-rows="1" (compact)</ui5-title>
 		<br>
-		<ui5-textarea growing growing-max-lines="1" rows="1"></ui5-textarea>
+		<ui5-textarea growing growing-max-rows="1" rows="1"></ui5-textarea>
 
-		<ui5-title>Growing: growing-max-lines="4" (compact)</ui5-title>
+		<ui5-title>Growing: growing-max-rows="4" (compact)</ui5-title>
 		<br>
-		<ui5-textarea growing growing-max-lines="4"></ui5-textarea>
+		<ui5-textarea growing growing-max-rows="4"></ui5-textarea>
 	</section>
 
 	<section class="aria-label and aria-labelledby">

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -206,7 +206,7 @@ describe("when enabled", () => {
 			await textAreaInner.addValue(`8`);
 
 			const sizeBeforeGrow = await textArea.getSize();
-			assert.strictEqual(initialSize.height, sizeBeforeGrow.height, "TextArea should not grow before it reaches its 8th line");
+			assert.strictEqual(initialSize.height, sizeBeforeGrow.height, "TextArea should not grow before it reaches its 8th row");
 
 			await textAreaInner.addValue(`\n9`);
 			const sizeAfterGrow = await textArea.getSize();
@@ -214,7 +214,7 @@ describe("when enabled", () => {
 			assert.isBelow(sizeBeforeGrow.height, sizeAfterGrow.height, "TextArea should grow");
 		});
 
-		it("Should grow up to 4 lines", async () => {
+		it("Should grow up to 4 rows", async () => {
 			const textArea = await browser.$("#growing-ta-to-four");
 			const textAreaInner = await browser.$("#growing-ta-to-four").shadow$("textarea");
 
@@ -229,9 +229,9 @@ describe("when enabled", () => {
 			await textAreaInner.addValue(`\n5\n6`);
 			const size6lines = await textArea.getSize();
 
-			assert.strictEqual(initialSize.height, size2lines.height, "TA should grow when having 2 lines of text");
-			assert.isBelow(size2lines.height, size4lines.height, "TA should grow up to 4 lines");
-			assert.strictEqual(size6lines.height, size4lines.height, "TA should not grow more than 4 lines");
+			assert.strictEqual(initialSize.height, size2lines.height, "TA should grow when having 2 rows of text");
+			assert.isBelow(size2lines.height, size4lines.height, "TA should grow up to 4 rows");
+			assert.strictEqual(size6lines.height, size4lines.height, "TA should not grow more than 4 rows");
 		});
 	});
 

--- a/packages/playground/_stories/main/TextArea/TextArea.stories.ts
+++ b/packages/playground/_stories/main/TextArea/TextArea.stories.ts
@@ -29,7 +29,7 @@ const Template: UI5StoryArgs<TextArea, StoryArgsSlots> = (args) => html`
 	maxlength="${ifDefined(args.maxlength)}"
 	?show-exceeded-text="${ifDefined(args.showExceededText)}"
 	?growing="${ifDefined(args.growing)}"
-	growing-max-lines="${ifDefined(args.growingMaxLines)}"
+	growing-max-rows="${ifDefined(args.growingMaxRows)}"
 	name="${ifDefined(args.name)}"
 	accessible-name="${ifDefined(args.accessibleName)}"
 	accessible-name-ref="${ifDefined(args.accessibleNameRef)}"

--- a/packages/website/docs/_samples/main/TextArea/Growing/sample.html
+++ b/packages/website/docs/_samples/main/TextArea/Growing/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 <!-- playground-fold-end -->
 
-<ui5-textarea growing growing-max-lines="5" placeholder="Enter new lines..."></ui5-textarea>
+<ui5-textarea growing growing-max-rows="5" placeholder="Enter new rows..."></ui5-textarea>
 <!-- playground-fold -->
     <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
Renames the `growingMaxLines` property of `ui5-textarea`.
If you have previously used the `growingMaxLines` property 
```html
<ui5-textarea growing growing-max-lines="5"></ui5-textarea>
```

Now use `growingMaxRows` instead:
```html
<ui5-textarea growing growing-max-rows="5"></ui5-textarea>
```

BREAKING CHANGE: The `growingMaxLines` property  have been renamed to `growingMaxRows`.


Related to: #8461 