### PR TITLE
feat(ui5-message-strip): introduce custom colors

### DIFF
--- a/packages/main/src/MessageStrip.ts
+++ b/packages/main/src/MessageStrip.ts
@@ -40,15 +40,6 @@ enum DesignClassesMapping {
 	ColorSet2 = "ui5-message-strip-root--color-set-2",
 }
 
-enum IconMappings {
-	Information = "information",
-	Positive = "sys-enter-2",
-	Negative = "error",
-	Warning = "alert",
-	ColorSet1 = "",
-	ColorSet2 = "",
-}
-
 type DesignTypeAnnouncemnt = Record<MessageStripDesign, string>;
 
 /**
@@ -207,7 +198,18 @@ class MessageStrip extends UI5Element {
 	}
 
 	get standardIconName() {
-		return IconMappings[this.design];
+		switch (this.design) {
+		case MessageStripDesign.Warning:
+			return "alert";
+		case MessageStripDesign.Positive:
+			return "sys-enter-2";
+		case MessageStripDesign.Negative:
+			return "error";
+		case MessageStripDesign.Information:
+			return "information";
+		default:
+			return null;
+		}
 	}
 
 	get designClasses() {

--- a/packages/main/src/MessageStrip.ts
+++ b/packages/main/src/MessageStrip.ts
@@ -111,6 +111,7 @@ class MessageStrip extends UI5Element {
 	 *
 	 * @default "1"
 	 * @public
+	 * @since 2.0
 	 */
 	@property({ defaultValue: "1" })
 	colorScheme!: string;

--- a/packages/main/src/MessageStrip.ts
+++ b/packages/main/src/MessageStrip.ts
@@ -118,6 +118,9 @@ class MessageStrip extends UI5Element {
 	/**
 	 * Defines whether the MessageStrip will show an icon in the beginning.
 	 * You can directly provide an icon with the `icon` slot. Otherwise, the default icon for the type will be used.
+	 *
+	 *  * **Note:** If <code>MessageStripDesign.ColorSet1</code> or <code>MessageStripDesign.ColorSet2</code> value is set to the <code>design</code> property, default icon will not be presented.
+	 *
 	 * @default false
 	 * @public
 	 * @since 1.0.0-rc.15

--- a/packages/main/src/MessageStrip.ts
+++ b/packages/main/src/MessageStrip.ts
@@ -25,6 +25,7 @@ import {
 	MESSAGE_STRIP_WARNING,
 	MESSAGE_STRIP_SUCCESS,
 	MESSAGE_STRIP_INFORMATION,
+	MESSAGE_STRIP_CUSTOM,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -35,13 +36,17 @@ enum DesignClassesMapping {
 	Positive = "ui5-message-strip-root--positive",
 	Negative = "ui5-message-strip-root--negative",
 	Warning = "ui5-message-strip-root--warning",
+	ColorSet1 = "ui5-message-strip-root--color-set-1",
+	ColorSet2 = "ui5-message-strip-root--color-set-2",
 }
 
-enum IconMapping {
+enum IconMappings {
 	Information = "information",
 	Positive = "sys-enter-2",
 	Negative = "error",
 	Warning = "alert",
+	ColorSet1 = "",
+	ColorSet2 = "",
 }
 
 type DesignTypeAnnouncemnt = Record<MessageStripDesign, string>;
@@ -109,6 +114,17 @@ class MessageStrip extends UI5Element {
 	design!: `${MessageStripDesign}`;
 
 	/**
+	 * Defines the color scheme of the component.
+	 * There are 10 predefined schemes.
+	 * To use one you can set a number from `"1"` to `"10"`. The `colorScheme` `"1"` will be set by default.
+	 *
+	 * @default "1"
+	 * @public
+	 */
+	@property({ defaultValue: "1" })
+	colorScheme!: string;
+
+	/**
 	 * Defines whether the MessageStrip will show an icon in the beginning.
 	 * You can directly provide an icon with the `icon` slot. Otherwise, the default icon for the type will be used.
 	 * @default false
@@ -158,6 +174,8 @@ class MessageStrip extends UI5Element {
 			Positive: getTranslation(MESSAGE_STRIP_SUCCESS),
 			Negative: getTranslation(MESSAGE_STRIP_ERROR),
 			Warning: getTranslation(MESSAGE_STRIP_WARNING),
+			ColorSet1: getTranslation(MESSAGE_STRIP_CUSTOM),
+			ColorSet2: getTranslation(MESSAGE_STRIP_CUSTOM),
 		};
 	}
 
@@ -189,7 +207,7 @@ class MessageStrip extends UI5Element {
 	}
 
 	get standardIconName() {
-		return IconMapping[this.design];
+		return IconMappings[this.design];
 	}
 
 	get designClasses() {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -247,6 +247,9 @@ MESSAGE_STRIP_SUCCESS=Success Information Bar
 #XACT: ARIA announcement for the MessageStrip's "Information" state
 MESSAGE_STRIP_INFORMATION=Information Bar
 
+#XACT: ARIA announcement for the MessageStrip's "Custom" state
+MESSAGE_STRIP_CUSTOM=Custom Information Bar
+
 #XFLD: MultiComboBox dialog button
 MULTICOMBOBOX_DIALOG_OK_BUTTON=OK
 

--- a/packages/main/src/themes/MessageStrip.css
+++ b/packages/main/src/themes/MessageStrip.css
@@ -89,3 +89,156 @@
 	top: var(--_ui5_message_strip_close_button_top);
 	inset-inline-end: var(--_ui5_message_strip_close_button_right);
 }
+
+:host([color-scheme="1"]) .ui5-message-strip-root--color-set-1,
+:host(:not([color-scheme])[design="ColorSet1"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_1_Background);
+	border-color: var(--sapIndicationColor_1_BorderColor);
+}
+
+:host([color-scheme="2"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_2_Background);
+	border-color: var(--sapIndicationColor_2_BorderColor);
+}
+
+:host([color-scheme="3"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_3_Background);
+	border-color: var(--sapIndicationColor_3_BorderColor);
+}
+
+:host([color-scheme="4"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_4_Background);
+	border-color: var(--sapIndicationColor_4_BorderColor);
+}
+
+:host([color-scheme="5"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_5_Background);
+	border-color: var(--sapIndicationColor_5_BorderColor);
+}
+
+:host([color-scheme="6"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_6_Background);
+	border-color: var(--sapIndicationColor_6_BorderColor);
+}
+
+:host([color-scheme="7"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_7_Background);
+	border-color: var(--sapIndicationColor_7_BorderColor);
+}
+
+:host([color-scheme="8"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_8_Background);
+	border-color: var(--sapIndicationColor_8_BorderColor);
+}
+
+:host([color-scheme="9"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_9_Background);
+	border-color: var(--sapIndicationColor_9_BorderColor);
+}
+
+:host([color-scheme="10"]) .ui5-message-strip-root--color-set-1 {
+	background-color: var(--sapIndicationColor_10_Background);
+	border-color: var(--sapIndicationColor_10_BorderColor);
+}
+
+:host([color-scheme="1"]) .ui5-message-strip-root--color-set-2,
+:host(:not([color-scheme])[design="ColorSet2"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_1_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_1_set_2_border_color)
+}
+
+:host([color-scheme="2"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_2_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_2_set_2_border_color);
+}
+
+:host([color-scheme="3"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_3_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_3_set_2_border_color);
+}
+
+:host([color-scheme="4"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_4_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_4_set_2_border_color);
+}
+
+:host([color-scheme="5"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_5_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_5_set_2_border_color);
+}
+
+:host([color-scheme="6"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_6_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_6_set_2_border_color);
+}
+
+:host([color-scheme="7"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_7_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_7_set_2_border_color);
+}
+
+:host([color-scheme="8"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_8_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_8_set_2_border_color);
+}
+
+:host([color-scheme="9"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_9_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_9_set_2_border_color);
+}
+
+:host([color-scheme="10"]) .ui5-message-strip-root--color-set-2 {
+	background-color: var(--_ui5_message_strip_scheme_10_set_2_background);
+	border-color: var(--_ui5_message_strip_scheme_10_set_2_border_color);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-root .ui5-message-strip-text {
+	color: var(--sapContent_ContrastTextColor);
+	text-shadow: var(--sapContent_ContrastTextShadow);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-root ::slotted([slot="icon"]){
+	color: var(--sapContent_ContrastIconColor);
+	text-shadow: var(--sapContent_ContrastTextShadow);
+}
+
+:host([design="ColorSet2"]) .ui5-message-strip-root .ui5-message-strip-text {
+	color: var(--sapTextColor);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-close-button {
+	color: var(--_ui5_message_strip_close_button_color_set_1_color);
+}
+
+:host([design="ColorSet2"]) .ui5-message-strip-close-button,
+:host([design="ColorSet2"]) .ui5-message-strip-root ::slotted([slot="icon"]) { 
+	color: var(--sapContent_IconColor);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-close-button:hover {
+	border-color: var(--sapContent_ContrastIconColor);
+	background-color: var(--_ui5_message_strip_close_button_color_set_1_background);
+	color: var(--_ui5_message_strip_close_button_color_set_1_hover_color);
+	text-shadow: var(--sapContent_ContrastTextShadow);
+}
+
+:host([design="ColorSet2"]) .ui5-message-strip-close-button:hover {
+	background-color: var(--_ui5_message_strip_close_button_color_set_2_background);
+	border-color: var(--sapContent_IconColor);
+	color: var(--sapContent_IconColor);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-close-button:active {
+	background: none;
+	border-color: var(--sapContent_ContrastIconColor);
+}
+
+:host([design="ColorSet2"]) .ui5-message-strip-close-button:active {
+	background: none;
+	border-color: var(--sapContent_IconColor);
+}
+
+:host([design="ColorSet1"]) .ui5-message-strip-close-button::part(button):after,
+:host([design="ColorSet1"]) .ui5-message-strip-close-button::part(button):before {
+	border-color: var(--sapContent_ContrastFocusColor);
+}

--- a/packages/main/src/themes/base/MessageStrip-parameters.css
+++ b/packages/main/src/themes/base/MessageStrip-parameters.css
@@ -15,7 +15,7 @@
 	--_ui5_message_strip_focus_offset: -2px;
 	--_ui5_message_strip_close_button_top: 0.125rem;
 	--_ui5_message_strip_close_button_right: 0.125rem;
-	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	/* Next two variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
 	--_ui5_message_strip_close_button_color_set_1_background: #eaecee4d;
 	--_ui5_message_strip_close_button_color_set_2_background: #eaecee80;
 	--_ui5_message_strip_close_button_color_set_1_color: var(--sapButton_Emphasized_TextColor);

--- a/packages/main/src/themes/base/MessageStrip-parameters.css
+++ b/packages/main/src/themes/base/MessageStrip-parameters.css
@@ -15,4 +15,29 @@
 	--_ui5_message_strip_focus_offset: -2px;
 	--_ui5_message_strip_close_button_top: 0.125rem;
 	--_ui5_message_strip_close_button_right: 0.125rem;
+	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	--_ui5_message_strip_close_button_color_set_1_background: #eaecee4d;
+	--_ui5_message_strip_close_button_color_set_2_background: #eaecee80;
+	--_ui5_message_strip_close_button_color_set_1_color: var(--sapButton_Emphasized_TextColor);
+	--_ui5_message_strip_close_button_color_set_1_hover_color: var(--sapButton_Emphasized_TextColor);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1b);
+	--_ui5_message_strip_scheme_1_set_2_border_color: var(--sapIndicationColor_1b_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2b);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2b_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3b);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3b_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4b);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4b_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5b);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5b_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6b);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6b_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7b);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7b_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8b);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8b_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9b);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9b_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10b);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10b_BorderColor);
 }

--- a/packages/main/src/themes/sap_belize_hcb/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcb/MessageStrip-parameters.css
@@ -6,4 +6,26 @@
 	--_ui5_message_strip_icon_top: 0.375rem;
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -2px;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/themes/sap_belize_hcw/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_belize_hcw/MessageStrip-parameters.css
@@ -6,4 +6,26 @@
 	--_ui5_message_strip_icon_top: 0.375rem;
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -2px;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/themes/sap_fiori_3/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/MessageStrip-parameters.css
@@ -1,0 +1,7 @@
+@import "../base/MessageStrip-parameters.css";
+
+:root{
+	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	--_ui5_message_strip_close_button_color_set_1_background: #ebf5fe4d;
+	--_ui5_message_strip_close_button_color_set_2_background: #ebf5fe80;
+}

--- a/packages/main/src/themes/sap_fiori_3/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/MessageStrip-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/MessageStrip-parameters.css";
 
 :root{
-	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	/* Next two variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
 	--_ui5_message_strip_close_button_color_set_1_background: #ebf5fe4d;
 	--_ui5_message_strip_close_button_color_set_2_background: #ebf5fe80;
 }

--- a/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
@@ -24,7 +24,7 @@
 @import "../base/ListItemBase-parameters.css";
 @import "../base/Menu-parameters.css";
 @import "./MonthPicker-parameters.css";
-@import "../base/MessageStrip-parameters.css";
+@import "./MessageStrip-parameters.css";
 @import "../base/Panel-parameters.css";
 @import "../base/Popover-parameters.css";
 @import "../base/PopupsCommon-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_dark/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/MessageStrip-parameters.css
@@ -1,10 +1,9 @@
 @import "../base/MessageStrip-parameters.css";
 
 :root{
-	--_ui5_message_strip_close_button_right: 0.1875rem;
 	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
-	--_ui5_message_strip_close_button_color_set_1_background: #222b351a;
-	--_ui5_message_strip_close_button_color_set_2_background: #222b3580;
+	--_ui5_message_strip_close_button_color_set_1_background: #062e4f1a;
+	--_ui5_message_strip_close_button_color_set_2_background: #062e4f80;
 	--_ui5_message_strip_close_button_color_set_1_color: var(--sapContent_ContrastIconColor);
 	--_ui5_message_strip_close_button_color_set_1_hover_color: var(--sapContent_ContrastIconColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_dark/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/MessageStrip-parameters.css
@@ -1,7 +1,7 @@
 @import "../base/MessageStrip-parameters.css";
 
 :root{
-	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	/* Next two variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
 	--_ui5_message_strip_close_button_color_set_1_background: #062e4f1a;
 	--_ui5_message_strip_close_button_color_set_2_background: #062e4f80;
 	--_ui5_message_strip_close_button_color_set_1_color: var(--sapContent_ContrastIconColor);

--- a/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -24,7 +24,7 @@
 @import "../base/ListItemBase-parameters.css";
 @import "../base/Menu-parameters.css";
 @import "./MonthPicker-parameters.css";
-@import "../base/MessageStrip-parameters.css";
+@import "./MessageStrip-parameters.css";
 @import "../base/Panel-parameters.css";
 @import "../base/Popover-parameters.css";
 @import "../base/PopupsCommon-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcb/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/MessageStrip-parameters.css
@@ -6,4 +6,26 @@
 	--_ui5_message_strip_icon_top: 0.375rem;
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -4px;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/MessageStrip-parameters.css
@@ -6,4 +6,26 @@
 	--_ui5_message_strip_icon_top: 0.375rem;
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -4px;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/themes/sap_horizon_dark/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/MessageStrip-parameters.css
@@ -2,7 +2,7 @@
 
 :root{
 	--_ui5_message_strip_close_button_right: 0.1875rem;
-	/* Next to variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
+	/* Next two variables below are hardcoded values of sapButton_Lite_Hover_Background parameter with specified opacity*/
 	--_ui5_message_strip_close_button_color_set_1_background: #222b351a;
 	--_ui5_message_strip_close_button_color_set_2_background: #222b3580;
 	--_ui5_message_strip_close_button_color_set_1_color: var(--sapContent_ContrastIconColor);

--- a/packages/main/src/themes/sap_horizon_hcb/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/MessageStrip-parameters.css
@@ -7,4 +7,26 @@
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -4px;
 	--_ui5_message_strip_close_button_right: 0.125rem;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/themes/sap_horizon_hcw/MessageStrip-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/MessageStrip-parameters.css
@@ -7,4 +7,26 @@
 	--_ui5_message_strip_focus_width: 0.125rem;
 	--_ui5_message_strip_focus_offset: -4px;
 	--_ui5_message_strip_close_button_right: 0.125rem;
+	--_ui5_message_strip_close_button_color_set_1_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_close_button_color_set_2_background: var(--sapButton_Lite_Hover_Background);
+	--_ui5_message_strip_scheme_1_set_2_background: var(--sapIndicationColor_1_Background);
+	--_ui5_message_strip_scheme_1_set_2_border_color:  var(--sapIndicationColor_1_BorderColor);
+	--_ui5_message_strip_scheme_2_set_2_background: var(--sapIndicationColor_2_Background);
+	--_ui5_message_strip_scheme_2_set_2_border_color: var(--sapIndicationColor_2_BorderColor);
+	--_ui5_message_strip_scheme_3_set_2_background: var(--sapIndicationColor_3_Background);
+	--_ui5_message_strip_scheme_3_set_2_border_color: var(--sapIndicationColor_3_BorderColor);
+	--_ui5_message_strip_scheme_4_set_2_background: var(--sapIndicationColor_4_Background);
+	--_ui5_message_strip_scheme_4_set_2_border_color: var(--sapIndicationColor_4_BorderColor);
+	--_ui5_message_strip_scheme_5_set_2_background: var(--sapIndicationColor_5_Background);
+	--_ui5_message_strip_scheme_5_set_2_border_color: var(--sapIndicationColor_5_BorderColor);
+	--_ui5_message_strip_scheme_6_set_2_background: var(--sapIndicationColor_6_Background);
+	--_ui5_message_strip_scheme_6_set_2_border_color: var(--sapIndicationColor_6_BorderColor);
+	--_ui5_message_strip_scheme_7_set_2_background: var(--sapIndicationColor_7_Background);
+	--_ui5_message_strip_scheme_7_set_2_border_color: var(--sapIndicationColor_7_BorderColor);
+	--_ui5_message_strip_scheme_8_set_2_background: var(--sapIndicationColor_8_Background);
+	--_ui5_message_strip_scheme_8_set_2_border_color: var(--sapIndicationColor_8_BorderColor);
+	--_ui5_message_strip_scheme_9_set_2_background: var(--sapIndicationColor_9_Background);
+	--_ui5_message_strip_scheme_9_set_2_border_color: var(--sapIndicationColor_9_BorderColor);
+	--_ui5_message_strip_scheme_10_set_2_background: var(--sapIndicationColor_10_Background);
+	--_ui5_message_strip_scheme_10_set_2_border_color: var(--sapIndicationColor_10_BorderColor);
 }

--- a/packages/main/src/types/MessageStripDesign.ts
+++ b/packages/main/src/types/MessageStripDesign.ts
@@ -28,13 +28,13 @@ enum MessageStripDesign {
 	Warning = "Warning",
 
 	/**
-	* Message is custom
+	* Message uses custom color set 1
 	* @public
 	*/
 	ColorSet1 = "ColorSet1",
 
 	/**
-	* Message is custom
+	*  Message uses custom color set 2
 	* @public
 	*/
 	ColorSet2 = "ColorSet2",

--- a/packages/main/src/types/MessageStripDesign.ts
+++ b/packages/main/src/types/MessageStripDesign.ts
@@ -26,6 +26,18 @@ enum MessageStripDesign {
 	 * @public
 	 */
 	Warning = "Warning",
+
+	/**
+	* Message is custom
+	* @public
+	*/
+	ColorSet1 = "ColorSet1",
+
+	/**
+	* Message is custom
+	* @public
+	*/
+	ColorSet2 = "ColorSet2",
 }
 
 export default MessageStripDesign;

--- a/packages/main/test/pages/MessageStrip.html
+++ b/packages/main/test/pages/MessageStrip.html
@@ -38,20 +38,22 @@
 	<ui5-message-strip hide-icon class="top" design="Information">Ea mollit nulla laborum et fugiat nulla excepteur ea. Duis et dolor enim Lorem laboris adipisicing cillum quis proident dolor veniam voluptate. Nostrud dolore ipsum anim voluptate enim dolore eiusmod aliqua et. Est eu ex dolor ea ipsum. Adipisicing duis aliquip ullamco culpa dolore exercitation ullamco cillum irure.</ui5-message-strip>
 	<ui5-message-strip hide-icon hide-close-button class="top" design="Information">Ea mollit nulla laborum et fugiat nulla excepteur ea. Duis et dolor enim Lorem laboris adipisicing cillum quis proident dolor veniam voluptate. Nostrud dolore ipsum anim voluptate enim dolore eiusmod aliqua et. Est eu ex dolor ea ipsum. Adipisicing duis aliquip ullamco culpa dolore exercitation ullamco cillum irure.</ui5-message-strip>
 	<ui5-message-strip hide-close-button class="top" design="Information">Ea mollit nulla laborum et fugiat nulla excepteur ea. Duis et dolor enim Lorem laboris adipisicing cillum quis proident dolor veniam voluptate. Nostrud dolore ipsum anim voluptate enim dolore eiusmod aliqua et. Est eu ex dolor ea ipsum. Adipisicing duis aliquip ullamco culpa dolore exercitation ullamco cillum irure.</ui5-message-strip>
+	<ui5-message-strip design="Warning" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Custom icon</ui5-message-strip>
+	<ui5-message-strip design="Positive" class="top"><img src="./img/loading.gif" width="16" height="16" slot="icon">Custom icon</ui5-message-strip>
 
-	<ui5-message-strip design="ColorSet1" class="top">Color Set 1 - no color-scheme, no icon</ui5-message-strip>
+	<ui5-message-strip id="defaultColorScheme" design="ColorSet1" class="top">Color Set 1 - no color-scheme, no icon</ui5-message-strip>
 	<ui5-message-strip design="ColorSet2" class="top">Color Set 2 - no color-scheme, no icon</ui5-message-strip>
-	<ui5-message-strip design="ColorSet1" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 1</ui5-message-strip>
+	<ui5-message-strip id="colorSet1ColorScheme1" design="ColorSet1" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 1</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="2" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 2</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="3" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 3</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="4" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 4</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="5" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 5</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="6" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 6</ui5-message-strip>
-	<ui5-message-strip design="ColorSet1" color-scheme="7" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 7</ui5-message-strip>
+	<ui5-message-strip id="colorScheme7" design="ColorSet1" color-scheme="7" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 7</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="8" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 8</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="9" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 9</ui5-message-strip>
 	<ui5-message-strip design="ColorSet1" color-scheme="10" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 10</ui5-message-strip>
-	<ui5-message-strip design="ColorSet2" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 1</ui5-message-strip>
+	<ui5-message-strip id="colorSet1ColorScheme2" design="ColorSet2" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 1</ui5-message-strip>
 	<ui5-message-strip design="ColorSet2" color-scheme="2" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 2</ui5-message-strip>
 	<ui5-message-strip design="ColorSet2" color-scheme="3" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 3</ui5-message-strip>
 	<ui5-message-strip design="ColorSet2" color-scheme="4" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 4</ui5-message-strip>

--- a/packages/main/test/pages/MessageStrip.html
+++ b/packages/main/test/pages/MessageStrip.html
@@ -39,9 +39,28 @@
 	<ui5-message-strip hide-icon hide-close-button class="top" design="Information">Ea mollit nulla laborum et fugiat nulla excepteur ea. Duis et dolor enim Lorem laboris adipisicing cillum quis proident dolor veniam voluptate. Nostrud dolore ipsum anim voluptate enim dolore eiusmod aliqua et. Est eu ex dolor ea ipsum. Adipisicing duis aliquip ullamco culpa dolore exercitation ullamco cillum irure.</ui5-message-strip>
 	<ui5-message-strip hide-close-button class="top" design="Information">Ea mollit nulla laborum et fugiat nulla excepteur ea. Duis et dolor enim Lorem laboris adipisicing cillum quis proident dolor veniam voluptate. Nostrud dolore ipsum anim voluptate enim dolore eiusmod aliqua et. Est eu ex dolor ea ipsum. Adipisicing duis aliquip ullamco culpa dolore exercitation ullamco cillum irure.</ui5-message-strip>
 
-    <ui5-message-strip design="Warning" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Custom icon</ui5-message-strip>
-
-    <ui5-message-strip design="Positive" class="top"><img src="./img/loading.gif" width="16" height="16" slot="icon">Custom icon</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" class="top">Color Set 1 - no color-scheme, no icon</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" class="top">Color Set 2 - no color-scheme, no icon</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 1</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="2" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 2</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="3" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 3</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="4" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 4</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="5" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 5</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="6" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 6</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="7" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 7</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="8" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 8</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="9" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 9</ui5-message-strip>
+	<ui5-message-strip design="ColorSet1" color-scheme="10" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 1 - color-scheme 10</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="1" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 1</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="2" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 2</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="3" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 3</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="4" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 4</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="5" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 5</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="6" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 6</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="7" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 7</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="8" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 8</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="9" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 9</ui5-message-strip>
+	<ui5-message-strip design="ColorSet2" color-scheme="10" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 10</ui5-message-strip>
 
 	<script>
 		var counter = 0;

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -18,6 +18,50 @@ describe("MessageStrip general interaction", () => {
 	});
 });
 
+describe("API", () => {
+	before(async () => {
+		await browser.url(`test/pages/MessageStrip.html`);
+	});
+
+	it("test design property", async () => {
+		// Arrange
+		const messageStripColorSet1 = await browser.$("#colorSet1ColorScheme1");
+		const messageStripColorSet2 = await browser.$("#colorSet1ColorScheme2");
+		let messageStripDesign1 = await messageStripColorSet1.getProperty("design");
+		let messageStripDesign2 = await messageStripColorSet2.getProperty("design");
+
+		// Assert
+		assert.strictEqual(messageStripDesign1, "ColorSet1", "Design property should be equal to 'ColorSet1'");
+		assert.strictEqual(messageStripDesign2, "ColorSet2", "Design property should be equal to 'ColorSet2'");
+
+		// Act
+		await messageStripColorSet1.setProperty("design", "Information");
+		let messageStripInformation = await messageStripColorSet1.getProperty("design");
+
+		// Assert
+		assert.strictEqual(messageStripInformation, "Information",  "Design property should be changed to 'Information'");
+	});
+
+	it("test colorScheme property", async () => {
+		// Arrange
+		const messageStripWithoutScheme = await browser.$("#defaultColorScheme");
+		const messageStripColorScheme = await browser.$("#colorScheme7");
+		let messageStripDefaultScheme = await messageStripWithoutScheme.getProperty("colorScheme");
+		let messageStripColorScheme7 = await messageStripColorScheme.getProperty("colorScheme");
+
+		// Assert
+		assert.strictEqual(messageStripDefaultScheme, "1", "colorScheme property should be equal to '1' by default");
+		assert.strictEqual(messageStripColorScheme7, "7", "colorScheme property should be equal to '7'");
+
+		// Act
+		await messageStripColorScheme.setProperty("colorScheme", "3");
+		let messageStripColorScheme3 = await messageStripColorScheme.getProperty("colorScheme");
+
+		// Assert
+		assert.strictEqual(messageStripColorScheme3, "3",  "colorScheme property should be equal to '3' by default'");
+	});
+});
+
 describe("ARIA Support", () => {
 	before(async () => {
 		await browser.url(`test/pages/MessageStrip.html`);
@@ -39,16 +83,22 @@ describe("ARIA Support", () => {
 	it("Test hidden text element content", async () => {
 
 		const messageStrip = await browser.$("#messageStrip");
+		const customMessageStrip = await browser.$("#colorSet1ColorScheme1");
 		let invisibleText = await messageStrip.shadow$(".ui5-hidden-text");
+		let customMessageStripInvisibleText = await customMessageStrip.shadow$(".ui5-hidden-text");
 		let resourceBundleText = null;
 
 		resourceBundleText = await browser.executeAsync(done => {
 			const messageStrip = document.getElementById("messageStrip");
 			const msgStripi18nBundle = messageStrip.constructor.i18nBundle;
-			done(`${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_INFORMATION)} ${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CLOSABLE)}`);
+			done({
+				information: `${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_INFORMATION)} ${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CLOSABLE)}`,
+				custom: `${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CUSTOM)} ${msgStripi18nBundle.getText(window["sap-ui-webcomponents-bundle"].defaultTexts.MESSAGE_STRIP_CLOSABLE)}`,
+			});
 		});
 
-		assert.strictEqual(await invisibleText.getText(), resourceBundleText, "Hidden element content is correct");
+		assert.strictEqual(await invisibleText.getText(), resourceBundleText.information, "Hidden element content is correct");
+		assert.strictEqual(await customMessageStripInvisibleText.getText(), resourceBundleText.custom, "Hidden element content is correct");
 	});
 });
 

--- a/packages/website/docs/_components_pages/main/MessageStrip.mdx
+++ b/packages/website/docs/_components_pages/main/MessageStrip.mdx
@@ -6,6 +6,7 @@ import Basic from "../../_samples/main/MessageStrip/Basic/Basic.md";
 import Design from "../../_samples/main/MessageStrip/Design/Design.md";
 import Custom from "../../_samples/main/MessageStrip/Custom/Custom.md";
 import HideIconAndButton from "../../_samples/main/MessageStrip/HideIconAndButton/HideIconAndButton.md";
+import CustomColors from "../../_samples/main/MessageStrip/CustomColors/CustomColors.md";
 
 <%COMPONENT_OVERVIEW%>
 
@@ -26,3 +27,6 @@ Use <b>hideIcon</b> and <b>hideCloseButton</b> properties to hide some parts of 
 
 ### Custom Icon
 <Custom />
+
+### Custom visualisation
+<CustomColors />

--- a/packages/website/docs/_samples/main/MessageStrip/CustomColors/CustomColors.md
+++ b/packages/website/docs/_samples/main/MessageStrip/CustomColors/CustomColors.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/MessageStrip/CustomColors/main.js
+++ b/packages/website/docs/_samples/main/MessageStrip/CustomColors/main.js
@@ -1,0 +1,2 @@
+import "@ui5/webcomponents/dist/MessageStrip.js";
+import "@ui5/webcomponents-icons/dist/palette.js";

--- a/packages/website/docs/_samples/main/MessageStrip/CustomColors/sample.html
+++ b/packages/website/docs/_samples/main/MessageStrip/CustomColors/sample.html
@@ -1,0 +1,21 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor)">
+    <!-- playground-fold-end -->
+
+    <ui5-message-strip design="ColorSet2">MessageStrip with default custom color without icon</ui5-message-strip><br><br>
+    <ui5-message-strip design="ColorSet1" color-scheme="8"><ui5-icon name="palette" slot="icon"></ui5-icon>MessageStrip with custom icon and color set</ui5-message-strip>
+    <!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->


### PR DESCRIPTION
With the following enhancement, the end user will be able to create message strips with custom colors from a predefined set of colors. That is achieved enhancing the `design` property enum `MessageStripDesign` with two new options `ColorSet1` and `ColorSet2` as well as the newly introduced property `colorScheme`.
Setting the `design` property value to `ColorSet1` or `ColorSet2`, then you are able to choose between 10 different colors for each using `colorScheme` property with values from "1" to "10".
