### PR TITLE
chore(ui5-barscanner-dialog): use declarative APIs

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.hbs
+++ b/packages/fiori/src/BarcodeScannerDialog.hbs
@@ -1,5 +1,6 @@
 <ui5-dialog stretch
 	class="ui5-barcode-scanner-dialog-root"
+	.open="{{_open}}"
 	@ui5-before-open={{_startReader}}
 	@ui5-after-close={{_resetReader}}>
 	<div class="ui5-barcode-scanner-dialog-video-wrapper">

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -83,13 +83,7 @@ type BarcodeScannerDialogScanErrorEventDetail = {
 })
 
 /**
- * Fired after the component is opened.
- * @public
- */
-@event("open")
-
-/**
- * Fired after the component is closed.
+ * Fired when the user closes the component.
  * @public
  */
 @event("close")

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -172,7 +172,9 @@ class BarcodeScannerDialog extends UI5Element {
 				return;
 			}
 
-			this.loading = true;
+			if (!this.permissionsGranted) {
+				this.loading = true;
+			}
 
 			this._getUserPermission()
 				.then(() => {

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -1,4 +1,4 @@
-import UI5Element, { ChangeInfo } from "@ui5/webcomponents-base/dist/UI5Element.js";
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -146,6 +146,14 @@ class BarcodeScannerDialog extends UI5Element {
 	@property({ type: Boolean })
 	loading!: boolean;
 
+	/**
+	 * Indicates whether the user has granted permissions to use the camera.
+	 * @default false
+	 * @private
+	 */
+	@property({ type: Boolean, noAttribute: true })
+	permissionsGranted!: boolean;
+
 	_codeReader: InstanceType<typeof BrowserMultiFormatReader>;
 	dialog?: Dialog;
 	static i18nBundle: I18nBundle;
@@ -159,50 +167,34 @@ class BarcodeScannerDialog extends UI5Element {
 		BarcodeScannerDialog.i18nBundle = await getI18nBundle("@ui5/webcomponents-fiori");
 	}
 
-	onInvalidation(changeInfo: ChangeInfo) {
-		if (changeInfo.type === "property" && changeInfo.name === "open") {
-			if (changeInfo.newValue) {
-				this.show();
-			} else {
-				this.close();
+	onAfterRendering() {
+		if (this.open) {
+			if (this.loading) {
+				return;
 			}
+
+			if (!this._hasGetUserMedia()) {
+				this.fireEvent<BarcodeScannerDialogScanErrorEventDetail>("scan-error", { message: "getUserMedia() is not supported by your browser" });
+				return;
+			}
+
+			this.loading = true;
+
+			this._getUserPermission()
+				.then(() => {
+					this.permissionsGranted = true;
+				})
+				.catch(err => {
+					this.fireEvent<BarcodeScannerDialogScanErrorEventDetail>("scan-error", { message: err });
+					this.loading = false;
+				});
+		} else {
+			this.loading = false;
 		}
 	}
 
-	/**
-	 * Shows a dialog with the camera videostream. Starts a scan session.
-	 * @public
-	 * @deprecated The method is deprecated in favour of <code>open</code> property.
-	 */
-	show(): void {
-		if (this.loading) {
-			console.warn("Barcode scanning is already in progress.");  // eslint-disable-line
-			return;
-		}
-
-		if (!this._hasGetUserMedia()) {
-			this.fireEvent<BarcodeScannerDialogScanErrorEventDetail>("scan-error", { message: "getUserMedia() is not supported by your browser" });
-			return;
-		}
-
-		this.loading = true;
-
-		this._getUserPermission()
-			.then(() => this._showDialog())
-			.catch(err => {
-				this.fireEvent<BarcodeScannerDialogScanErrorEventDetail>("scan-error", { message: err });
-				this.loading = false;
-			});
-	}
-
-	/**
-	 * Closes the dialog and the scan session.
-	 * @public
-	 * @deprecated The method is deprecated in favour of <code>open</code> property.
-	 */
-	close():void {
-		this._closeDialog();
-		this.loading = false;
+	get _open() {
+		return this.open && this.permissionsGranted;
 	}
 
 	/**
@@ -217,29 +209,13 @@ class BarcodeScannerDialog extends UI5Element {
 		return navigator.mediaDevices.getUserMedia(defaultMediaConstraints);
 	}
 
-	_getDialog() {
-		return this.shadowRoot!.querySelector<Dialog>("[ui5-dialog]")!;
-	}
-
 	_getVideoElement() {
 		return this.shadowRoot!.querySelector<HTMLVideoElement>(".ui5-barcode-scanner-dialog-video")!;
 	}
 
-	_showDialog() {
-		this.dialog = this._getDialog();
-		this.dialog.show();
-		this.open = true;
-
-		this.fireEvent("open");
-	}
-
 	_closeDialog() {
-		if (this.dialog && this.dialog.open) {
-			this.dialog.close();
-			this.open = false;
-
-			this.fireEvent("close");
-		}
+		this.open = false;
+		this.fireEvent("close");
 	}
 
 	_startReader() {

--- a/packages/fiori/test/pages/BarcodeScannerDialog.html
+++ b/packages/fiori/test/pages/BarcodeScannerDialog.html
@@ -22,7 +22,7 @@
 
 <body class="barcodescannerdialog1auto">
 
-	<ui5-barcode-scanner-dialog open id="dlgScan"></ui5-barcode-scanner-dialog>
+	<ui5-barcode-scanner-dialog id="dlgScan"></ui5-barcode-scanner-dialog>
 
 	<ui5-button id="btnScan" icon="camera" tooltip="Start Camera">Scan</ui5-button>
 	<div>

--- a/packages/fiori/test/pages/BarcodeScannerDialog.html
+++ b/packages/fiori/test/pages/BarcodeScannerDialog.html
@@ -22,7 +22,7 @@
 
 <body class="barcodescannerdialog1auto">
 
-	<ui5-barcode-scanner-dialog id="dlgScan"></ui5-barcode-scanner-dialog>
+	<ui5-barcode-scanner-dialog open id="dlgScan"></ui5-barcode-scanner-dialog>
 
 	<ui5-button id="btnScan" icon="camera" tooltip="Start Camera">Scan</ui5-button>
 	<div>
@@ -40,6 +40,7 @@
 
 		btnScan.addEventListener("click", (event) => {
 			dlgScan.open = true;
+			document.querySelector(".open-state").textContent = `${dlgScan.open}`;
 		});
 
 		dlgScan.addEventListener("ui5-scan-success", (event) => {
@@ -50,10 +51,6 @@
 		dlgScan.addEventListener("ui5-scan-error", (event) => {
 			scanError.innerHTML = event.detail.message;
 			dlgScan.open = false;
-		});
-
-		dlgScan.addEventListener("ui5-open", (event) => {
-			document.querySelector(".open-state").textContent = `${dlgScan.open}`;
 		});
 
 		dlgScan.addEventListener("ui5-close", (event) => {


### PR DESCRIPTION
Changes:
 - deleted the `open` event (events are only fired upon user interaction and there is only user interaction for `close`)
 - fixed the bug where the component would not work if the open property is set initially
 - fixed the bug where the `close` event is fired when the component is closed programmatically (not upon user interaction)
 - made use of declarative APIs.
 
 BREAKING CHANGE:

The `show` and `close` public methods have been removed. Use the public property `open` instead.

For example, if you used:

```js
d.show();
...
d.close();
```

use:

```js
d.open = true;
...
d.open = false;
```

instead.