### PR TITLE
Revert "fix(ui5-shellbar): aligned specs" 

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -52,23 +52,14 @@
 	word-spacing: inherit;
 }
 
-.ui5-shellbar-button[icon-only] {
-	color: var(--sapShell_InteractiveTextColor);
-}
-
-.ui5-shellbar-button[icon-only]:hover:not(:active) {
-	color: var(--sapShell_InteractiveTextColor);
-}
-
-
 ::slotted([ui5-button][slot="startButton"]) {
 	margin-inline-start: 0;
 }
 
-::slotted([ui5-button][slot="startButton"]:hover:not([active])),
-.ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:hover:not(:active),
-.ui5-shellbar-button:hover:not(:active),
-.ui5-shellbar-image-button:hover:not(:active) {
+::slotted([ui5-button][slot="startButton"]:hover),
+.ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:hover,
+.ui5-shellbar-button:hover,
+.ui5-shellbar-image-button:hover {
 	background: var(--sapShell_Hover_Background);
 	border-color: var(--sapButton_Lite_Hover_BorderColor);
 	color: var(--sapShell_TextColor);


### PR DESCRIPTION
Reverts SAP/ui5-webcomponents#8694
Seems that with this change the specificity of the selectors is getting too strong and this leads to redundant need for
adding the same specificity in other selectors, which complicates the css logic.
