### PR TITLE
refactor(ui5-menu): rename the busy and busy delay properties

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -50,12 +50,12 @@
 		<ui5-list
 			id="{{_id}}-menu-list"
 			selection-mode="None"
-			?busy="{{busy}}"
-			busy-delay="{{busyDelay}}"
+			?loading="{{loading}}"
+			loading-delay="{{loadingDelay}}"
 			separators="None"
 			accessible-role="menu"
 			@ui5-item-click={{_itemClick}}
-			@mouseover="{{_busyMouseOver}}"
+			@mouseover="{{_loadingMouseOver}}"
 		>
 		{{#each _currentItems}}
 			<ui5-menu-li
@@ -80,12 +80,12 @@
 			</ui5-menu-li>
 		{{/each}}
 		</ui5-list>
-	{{else if busy}}
+	{{else if loading}}
 		<ui5-busy-indicator
 			id="{{_id}}-menu-busy-indicator"
-			delay="{{busyDelay}}"
+			delay="{{loadingDelay}}"
 			class="ui5-menu-busy-indicator"
-			@mouseover="{{_busyMouseOver}}"
+			@mouseover="{{_loadingMouseOver}}"
 			active>
 		</ui5-busy-indicator>
 	{{/if}}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -241,16 +241,16 @@ class Menu extends UI5Element {
 	 * @since 1.13.0
 	 */
 	@property({ type: Boolean })
-	busy!: boolean;
+	loading!: boolean;
 
 	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover..
+	 * Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover..
 	 * @default 1000
 	 * @public
 	 * @since 1.13.0
 	 */
 	@property({ validator: Integer, defaultValue: 1000 })
-	busyDelay!: number;
+	loadingDelay!: number;
 
 	/**
 	 * Defines the ID or DOM Reference of the element that the menu is shown at
@@ -378,15 +378,15 @@ class Menu extends UI5Element {
 			item.item._siblingsWithIcon = itemsWithIcon;
 			const subMenu = item.item._subMenu;
 			const menuItem = item.item;
-			if (subMenu && subMenu.busy) {
+			if (subMenu && subMenu.loading) {
 				subMenu.innerHTML = "";
 				const fragment = this._clonedItemsFragment(menuItem);
 				subMenu.appendChild(fragment);
 			}
 
 			if (subMenu) {
-				subMenu.busy = item.item.busy;
-				subMenu.busyDelay = item.item.busyDelay;
+				subMenu.loading = item.item.loading;
+				subMenu.loadingDelay = item.item.loadingDelay;
 			}
 		});
 	}
@@ -416,10 +416,10 @@ class Menu extends UI5Element {
 			this._parentMenuItem = undefined;
 			this._opener = undefined;
 		}
-		const busyWithoutItems = !this._parentMenuItem?.items.length && this._parentMenuItem?.busy;
+		const loadingWithoutItems = !this._parentMenuItem?.items.length && this._parentMenuItem?.loading;
 		const popover = await this._createPopover();
 		popover.initialFocus = `${this._id}-menu-item-0`;
-		popover.showAt(opener, busyWithoutItems);
+		popover.showAt(opener, loadingWithoutItems);
 	}
 
 	/**
@@ -473,8 +473,8 @@ class Menu extends UI5Element {
 		subMenu.setAttribute("id", `submenu-${opener.id}`);
 		subMenu._parentMenuItem = item;
 		subMenu._opener = opener;
-		subMenu.busy = item.busy;
-		subMenu.busyDelay = item.busyDelay;
+		subMenu.loading = item.loading;
+		subMenu.loadingDelay = item.loadingDelay;
 		const fragment = this._clonedItemsFragment(item);
 		subMenu.appendChild(fragment);
 		this.shadowRoot!.querySelector(".ui5-menu-submenus")!.appendChild(subMenu);
@@ -585,7 +585,7 @@ class Menu extends UI5Element {
 		}
 	}
 
-	_busyMouseOver() {
+	_loadingMouseOver() {
 		if (this._parentMenuItem) {
 			this._parentMenuItem._preventSubMenuClose = true;
 		}

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -81,7 +81,7 @@ class MenuItem extends UI5Element {
 	disabled!: boolean;
 
 	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover.
+	 * Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
 	 *
 	 * **Note:** If set to `true` a `ui5-busy-indicator` component will be displayed into the related one to the current `ui5-menu-item` sub-menu popover.
 	 * @default false
@@ -89,16 +89,16 @@ class MenuItem extends UI5Element {
 	 * @since 1.13.0
 	 */
 	@property({ type: Boolean })
-	busy!: boolean;
+	loading!: boolean;
 
 	/**
-	 * Defines the delay in milliseconds, after which the busy indicator will be displayed inside the corresponding ui5-menu popover.
+	 * Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
 	 * @default 1000
 	 * @public
 	 * @since 1.13.0
 	 */
 	@property({ validator: Integer, defaultValue: 1000 })
-	busyDelay!: number;
+	loadingDelay!: number;
 
 	/**
 	 * Defines the accessible ARIA name of the component.
@@ -150,7 +150,7 @@ class MenuItem extends UI5Element {
 	items!: Array<MenuItem>;
 
 	get hasSubmenu() {
-		return !!(this.items.length || this.busy);
+		return !!(this.items.length || this.loading);
 	}
 
 	get hasDummyIcon() {

--- a/packages/main/src/MenuListItem.ts
+++ b/packages/main/src/MenuListItem.ts
@@ -68,7 +68,7 @@ class MenuListItem extends CustomListItem {
 	}
 
 	get hasSubmenu() {
-		return !!(this.associatedItem?.items.length || this.associatedItem?.busy);
+		return !!(this.associatedItem?.items.length || this.associatedItem?.loading);
 	}
 
 	get subMenuOpened() {

--- a/packages/main/src/NavigationMenu.hbs
+++ b/packages/main/src/NavigationMenu.hbs
@@ -50,11 +50,11 @@
 			accessible-role="tree"
 			id="{{_id}}-menu-list"
 			selection-mode="None"
-			?busy="{{busy}}"
-			busy-delay="{{busyDelay}}"
+			?loading="{{loading}}"
+			loading-delay="{{loadingDelay}}"
 			separators="None"
 			@ui5-item-click={{_itemClick}}
-			@mouseover="{{_busyMouseOver}}"
+			@mouseover="{{_loadingMouseOver}}"
 		>
 		{{#each _currentItems}}
 			{{#if this.item.href}}
@@ -133,12 +133,12 @@
 			{{/if}}
 		{{/each}}
 		</ui5-list>
-	{{else if busy}}
+	{{else if loading}}
 		<ui5-busy-indicator
 			id="{{_id}}-menu-busy-indicator"
-			delay="{{busyDelay}}"
+			delay="{{loadingDelay}}"
 			class="ui5-menu-busy-indicator"
-			@mouseover="{{_busyMouseOver}}"
+			@mouseover="{{_loadingMouseOver}}"
 			active>
 		</ui5-busy-indicator>
 	{{/if}}

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -17,7 +17,7 @@
 	<ui5-menu id="menu" header-text="My ui5-menu">
 		<ui5-menu-item text="New File(selection prevented)" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file - prevent default" icon="add-document"></ui5-menu-item>
 		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
-		<ui5-menu-item text="Open" icon="open-folder" starts-section busy-delay="100" busy>
+		<ui5-menu-item text="Open" icon="open-folder" starts-section loading-delay="100" loading>
 			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
 				<ui5-menu-item text="Open from C"></ui5-menu-item>
 				<ui5-menu-item text="Open from D"></ui5-menu-item>
@@ -33,7 +33,7 @@
 			</ui5-menu-item>
 			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
 		</ui5-menu-item>
-		<ui5-menu-item text="Close" additional-text="Ctrl+W" busy-delay="100" busy></ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W" loading-delay="100" loading></ui5-menu-item>
 		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
@@ -104,8 +104,8 @@
 			const item = event.detail.item;
 			if (item && item.text === "Open" && !fetched) {
 				setTimeout(function() {
-					item.removeAttribute("busy");
-					item.removeAttribute("busy-delay");
+					item.removeAttribute("loading");
+					item.removeAttribute("loading-delay");
 					let oneNode = document.createElement("ui5-menu-item");
 					oneNode.setAttribute("text", "Open from Amazon Cloud");
 					let twoNode = document.createElement("ui5-menu-item");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -157,7 +157,7 @@ describe("Menu interaction", () => {
 			const openSubmenuPopover = await menu.shadow$(".ui5-menu-submenus ui5-menu:last-of-type").shadow$("ui5-responsive-popover");
 			const openMenuList = await openSubmenuPopover.$("ui5-list");
 
-			// assert.ok(await openMenuList.getProperty("busy"), "Busy property is properly propagated to the ui5-list component.");
+			// assert.ok(await openMenuList.getProperty("loading"), "Busy property is properly propagated to the ui5-list component.");
 			await browser.waitUntil(async () => {
 				return (await openMenuList.$$("ui5-menu-li")).length === 4;
 			}, 1500, "Two additional nodes have been added.");

--- a/packages/playground/_stories/main/Menu/MenuItem/MenuItem.stories.ts
+++ b/packages/playground/_stories/main/Menu/MenuItem/MenuItem.stories.ts
@@ -19,8 +19,8 @@ const Template: UI5StoryArgs<MenuItem, StoryArgsSlots> = (args) => html`<ui5-men
 	<ui5-menu-item
     accessible-name="${ifDefined(args.accessibleName)}"
     additional-text="${ifDefined(args.additionalText)}"
-    ?busy="${ifDefined(args.busy)}"
-    busy-delay="${ifDefined(args.busyDelay)}"
+    ?loading="${ifDefined(args.loading)}"
+    loading-delay="${ifDefined(args.loadingDelay)}"
     ?disabled="${ifDefined(args.disabled)}"
     icon="${ifDefined(args.icon)}"
     ?starts-section="${ifDefined(args.startsSection)}"


### PR DESCRIPTION
Renames the `busy` and `busyDelay` properties of the `ui5-menu` and `ui5-menu-item` to `loading` and `loadingDelay`.

BREAKING CHANGE: The `busy` and `busyDelay` and properties of the `ui5-menu` and `ui5-menu-item` are renamed.
If you have previously used the `busy`, `busyDelay` properties:

```html
<ui5-menu header-text="My ui5-menu" busy busy-delay="100"><ui5-menu>
```

```html
<ui5-menu-item text="Open" icon="open-folder" busy busy-delay="100"><ui5-menu-item>
```
now you should use  `loading` and `loadingDelay` properties:

```html
<ui5-menu header-text="My ui5-menu" loading loading-delay="100"><ui5-menu>
```

```html
<ui5-menu-item text="Open" icon="open-folder" loading loading-delay="100"><ui5-menu-item>
```

Fixes: #8764