### PR TITLE
fix(ui5-split-button): restrict height manipulation from outside wrapper

### DIFF
--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -3,7 +3,7 @@
 
 :host(:not([hidden])) {
 	display: inline-flex;
-	max-height: var(--_ui5_button_base_height);
+	height: var(--_ui5_button_base_height);
 	border-radius: var(--_ui5_button_border_radius);
 	background-color: var(--sapButton_Background);
 	box-shadow: var(--_ui5_split_button_host_default_box_shadow);
@@ -115,6 +115,7 @@
 	display: inline-flex;
 	position: relative;
 	width: inherit;
+	height: 100%;
 }
 
 .ui5-split-button-root:focus,

--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -3,7 +3,7 @@
 
 :host(:not([hidden])) {
 	display: inline-flex;
-	height: 100%;
+	max-height: var(--_ui5_button_base_height);
 	border-radius: var(--_ui5_button_border_radius);
 	background-color: var(--sapButton_Background);
 	box-shadow: var(--_ui5_split_button_host_default_box_shadow);

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -14,10 +14,14 @@
 <link rel="stylesheet" type="text/css" href="./styles/SplitButton.css">
 </head>
 
-<body style="background-color: var(--sapBackgroundColor);">
+<body style="background-color: var(--sapBackgroundColor);" data-ui5-compact-size>
 	<header class="header">
 		<h3 class="header-title">Wrapped Split Buttons</h3>
 	</header>
+
+	<div style="border: 1px solid red; display: inline-block; width: 80px; height: 70px">
+		<ui5-split-button style="width: 100%; height: 100px;" icon="picture">Random Text</ui5-split-button>
+	</div>
 
 	<div style="border: 1px solid red; display: inline-block; width: 80px">
 		<ui5-split-button style="width: 100%" icon="picture">Random Text</ui5-split-button>

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -20,7 +20,7 @@
 	</header>
 
 	<div style="border: 1px solid red; display: inline-block; width: 80px; height: 70px">
-		<ui5-split-button style="width: 100%; height: 100px;" icon="picture">Random Text</ui5-split-button>
+		<ui5-split-button style="width: 100%;" icon="picture">Random Text</ui5-split-button>
 	</div>
 
 	<div style="border: 1px solid red; display: inline-block; width: 80px">

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" type="text/css" href="./styles/SplitButton.css">
 </head>
 
-<body style="background-color: var(--sapBackgroundColor);" data-ui5-compact-size>
+<body style="background-color: var(--sapBackgroundColor);">
 	<header class="header">
 		<h3 class="header-title">Wrapped Split Buttons</h3>
 	</header>


### PR DESCRIPTION
Previously when our `ui5-split-button` component was wrapped in a container with defined height, f.e:

	<div style="border: 1px solid red; height: 80px">
		<ui5-split-button style="width: 100%;" icon="picture">Random Text</ui5-split-button>
	</div>

The button was filling the whole space in the container, which wasn't the desired behaviour:

![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/c588a0d6-32f7-4635-a6b7-a96248541c3d)

Now the `ui5-split-button`'s height is not based on outside wrappers.

Fixes: #8705 
