### PR TITLE
fix(ui5-progress-indicator): removed redundant z-index

### DIFF
--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -44,7 +44,6 @@
 	box-sizing: border-box;
 	border: var(--_ui5_progress_indicator_bar_border_max);
 	border-radius: var(--_ui5_progress_indicator_bar_border_radius);
-	z-index: 1;
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-bar,


### PR DESCRIPTION
Removed redundant z-index which causes PI to overlap over some of its parent elements.

Fixes: #8303