### PR TITLE
refactor(ui5-split-button): remove `activeIcon` property

### DIFF
--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -50,7 +50,6 @@ import SplitButtonCss from "./generated/themes/SplitButton.css.js";
  * `ui5-split-button` consists two separate buttons:
  *
  * - for the first one (default action) you can define some `text` or an `icon`, or both.
- * Also, it is possible to define different icon for active state of this button - `activeIcon`.
  * - the second one (arrow action) contains only `slim-arrow-down` icon.
  *
  * You can choose a `design` from a set of predefined types (the same as for ui5-button) that offer
@@ -111,14 +110,6 @@ class SplitButton extends UI5Element {
 	 */
 	@property()
 	icon!: string;
-
-	/**
-	 * Defines the icon to be displayed in active state as graphical element within the component.
-	 * @default ""
-	 * @public
-	 */
-	@property()
-	activeIcon!: string;
 
 	/**
 	 * Defines whether the arrow button should have the active state styles or not.
@@ -245,7 +236,7 @@ class SplitButton extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		this._textButtonIcon = this.textButton && this.activeIcon !== "" && (this._textButtonActive) && !this._shiftOrEscapePressed ? this.activeIcon : this.icon;
+		this._textButtonIcon = this.icon;
 		if (this.disabled) {
 			this._tabIndex = "-1";
 		}
@@ -342,7 +333,7 @@ class SplitButton extends UI5Element {
 
 	_textButtonRelease() {
 		this._textButtonActive = false;
-		this._textButtonIcon = this.textButton && this.activeIcon !== "" && (this._textButtonActive) && !this._shiftOrEscapePressed ? this.activeIcon : this.icon;
+		this._textButtonIcon = this.icon;
 		this._tabIndex = "-1";
 	}
 

--- a/packages/main/test/pages/SplitButton.html
+++ b/packages/main/test/pages/SplitButton.html
@@ -60,8 +60,6 @@
 	</header>
 	<div class="samples-margin">
 		<ui5-split-button id="sbTextIcon" icon="add">Icon</ui5-split-button>
-		<ui5-split-button id="sbTextActiveIcon" active-icon="accept">Active Icon</ui5-split-button>
-		<ui5-split-button id="sbTextIconActiveIcon" icon="add" active-icon="accept">Icon + Active Icon</ui5-split-button>
 		<ui5-split-button icon="text-color"></ui5-split-button>
 	</div>
 

--- a/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
+++ b/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
@@ -19,7 +19,6 @@ const Template: UI5StoryArgs<SplitButton, StoryArgsSlots> = (args) => html`<ui5-
 	?disabled="${ifDefined(args.disabled)}"
 	design="${ifDefined(args.design)}"
 	icon="${ifDefined(args.icon)}"
-	active-icon="${ifDefined(args.activeIcon)}"
 	accessible-name="${ifDefined(args.accessibleName)}"
 >
 	${unsafeHTML(args.default)}


### PR DESCRIPTION
Removes `activeIcon` property in the `textButton` part of our  `<ui5-split-button>`.

BREAKING CHANGE: The `activeIcon` property is no longer present, as it is not available on any other button.

Previosuly the application developers could use `<ui5-split-button>` like so:

	<ui5-split-button id="sbTextActiveIcon" active-icon="accept">Active Icon</ui5-split-button>
	<ui5-split-button id="sbTextIconActiveIcon" icon="add" active-icon="accept">Icon + Active Icon</ui5-split-button>

Now application developers **won't** be able to use `active-icon` atribute, or `activeIcon` property respectively.

	<ui5-split-button id="sbTextActiveIcon">Active Icon</ui5-split-button>
	<ui5-split-button id="sbTextIconActiveIcon" icon="add">Icon + Active Icon</ui5-split-button>

Related to: #8461 