### PR TITLE
refactor(ui5-li): removes role property

### DIFF
--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -15,7 +15,6 @@
 	draggable="{{movable}}"
 	@dragstart="{{_ondragstart}}"
 	@dragend="{{_ondragend}}"
-	role="{{_accInfo.role}}"
 	aria-expanded="{{_accInfo.ariaExpanded}}"
 	title="{{_accInfo.tooltip}}"
 	aria-level="{{_accInfo.ariaLevel}}"

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -15,6 +15,7 @@
 	draggable="{{movable}}"
 	@dragstart="{{_ondragstart}}"
 	@dragend="{{_ondragend}}"
+	role="{{_accInfo.role}}"
 	aria-expanded="{{_accInfo.ariaExpanded}}"
 	title="{{_accInfo.tooltip}}"
 	aria-level="{{_accInfo.ariaLevel}}"

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -54,7 +54,7 @@ type PressEventDetail = {
 }
 
 type AccInfo = {
-	role: string;
+	accessibleRole: string;
 	ariaExpanded?: boolean;
 	ariaLevel?: number;
 	ariaLabel: string;
@@ -185,16 +185,6 @@ abstract class ListItem extends ListItemBase {
 	*/
 	@property({ type: Boolean })
 	actionable!: boolean;
-
-	/**
-	 * Used to define the role of the list item.
-	 * @private
-	 * @default "listitem"
-	 * @since 1.0.0-rc.9
-	 *
-	 */
-	@property({ defaultValue: "listitem" })
-	role!: string;
 
 	/**
 	 * Defines the description for the accessible role of the component.
@@ -513,7 +503,7 @@ abstract class ListItem extends ListItemBase {
 
 	get _accInfo(): AccInfo {
 		return {
-			role: this.accessibleRole || this.role,
+			accessibleRole: this.accessibleRole,
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -54,7 +54,7 @@ type PressEventDetail = {
 }
 
 type AccInfo = {
-	accessibleRole: string;
+	role: string;
 	ariaExpanded?: boolean;
 	ariaLevel?: number;
 	ariaLabel: string;
@@ -503,7 +503,7 @@ abstract class ListItem extends ListItemBase {
 
 	get _accInfo(): AccInfo {
 		return {
-			accessibleRole: this.accessibleRole,
+			role: this.accessibleRole,
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),


### PR DESCRIPTION
The `role` property  of  the `ui5-li` is removed.

Related to https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887