### PR TITLE
chore(ui5-media-gallery): update focus handling

### DIFF
--- a/packages/fiori/src/MediaGallery.ts
+++ b/packages/fiori/src/MediaGallery.ts
@@ -33,7 +33,6 @@ import MediaGalleryTemplate from "./generated/templates/MediaGalleryTemplate.lit
 interface IMediaGalleryItem extends HTMLElement, ITabbable {
 	selected: boolean,
 	disabled: boolean,
-	focused: boolean,
 	displayedContent: HTMLElement | null;
 	layout: `${MediaGalleryItemLayout}`
 }

--- a/packages/fiori/src/MediaGalleryItem.hbs
+++ b/packages/fiori/src/MediaGalleryItem.hbs
@@ -1,8 +1,6 @@
 <div class="ui5-media-gallery-item-root"
     tabindex="{{effectiveTabIndex}}"
     data-sap-focus-ref
-    @focusout="{{_onfocusout}}"
-    @focusin="{{_onfocusin}}"
     @keydown="{{_onkeydown}}"
     @keyup="{{_onkeyup}}"
     role="{{_role}}">

--- a/packages/fiori/src/MediaGalleryItem.ts
+++ b/packages/fiori/src/MediaGalleryItem.ts
@@ -104,12 +104,6 @@ class MediaGalleryItem extends UI5Element implements IMediaGalleryItem {
 	/**
 	 * @private
 	 */
-	@property({ type: Boolean })
-	focused!: boolean;
-
-	/**
-	 * @private
-	 */
 	@property()
 	forcedTabIndex!: string;
 
@@ -255,14 +249,6 @@ class MediaGalleryItem extends UI5Element implements IMediaGalleryItem {
 		if (isSpace(e)) {
 			this._fireItemClick();
 		}
-	}
-
-	_onfocusout() {
-		this.focused = false;
-	}
-
-	_onfocusin() {
-		this.focused = true;
 	}
 
 	_fireItemClick() {

--- a/packages/fiori/src/themes/MediaGalleryItem.css
+++ b/packages/fiori/src/themes/MediaGalleryItem.css
@@ -42,7 +42,7 @@
 }
 
 /* focused */
-:host([focused]) .ui5-media-gallery-item-root {
+.ui5-media-gallery-item-root:focus-within {
 	outline: var(--_ui5_media_gallery_thumbnail_focus_outline);
 	outline-offset: -1px;
 }
@@ -53,7 +53,7 @@
 }
 
 /* selected focused */
-:host([_thumbnail-design][focused][selected]) .ui5-media-gallery-item-root {
+:host([_thumbnail-design][selected]) .ui5-media-gallery-item-root:focus-within {
     outline-offset: -3px;
 }
 


### PR DESCRIPTION
Adjusted `ui5-media-gallery` focus display rules. On desktop, focus outline is always visible. For mobile, focus outline only appears with an external keyboard, it remains hidden for touch focus.

Related to: #8320
