### PR TITLE
refactor(ui5-li, ui5-list): changes accessibleRole type

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -35,7 +35,7 @@
 
 		<ul id="{{_id}}-listUl"
 			class="ui5-list-ul"
-			role="{{accessibleRole}}"
+			role="{{listAccessibleRole}}"
 			aria-label="{{ariaLabelTxt}}"
 			aria-labelledby="{{ariaLabelledBy}}"
 			aria-roledescription="{{accessibleRoleDescription}}"

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -30,6 +30,7 @@ import Orientation from "@ui5/webcomponents-base/dist/types/Orientation.js";
 import MovePlacement from "@ui5/webcomponents-base/dist/types/MovePlacement.js";
 import ListSelectionMode from "./types/ListSelectionMode.js";
 import ListGrowingMode from "./types/ListGrowingMode.js";
+import ListAccessibleRole from "./types/ListAccessibleRole.js";
 import ListItemBase from "./ListItemBase.js";
 import DropIndicator from "./DropIndicator.js";
 import type ListItem from "./ListItem.js";
@@ -402,8 +403,8 @@ class List extends UI5Element {
 	 * @default "list"
 	 * @since 1.0.0-rc.15
 	 */
-	@property({ defaultValue: "list" })
-	accessibleRole!: string;
+	@property({ type: ListAccessibleRole, defaultValue: ListAccessibleRole.List })
+	accessibleRole!: `${ListAccessibleRole}`;
 
 	/**
 	 * Defines the description for the accessible role of the component.
@@ -686,6 +687,10 @@ class List extends UI5Element {
 				position: this.loadingIndPosition,
 			},
 		};
+	}
+
+	get listAccessibleRole() {
+		return this.accessibleRole.toLowerCase();
 	}
 
 	get classes(): ClassMap {

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -400,7 +400,7 @@ class List extends UI5Element {
 	/**
 	 * Defines the accessible role of the component.
 	 * @public
-	 * @default "list"
+	 * @default "List"
 	 * @since 1.0.0-rc.15
 	 */
 	@property({ type: ListAccessibleRole, defaultValue: ListAccessibleRole.List })

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -199,11 +199,11 @@ abstract class ListItem extends ListItemBase {
 	/**
 	 * Used to define the role of the list item.
 	 * @private
-	 * @default ""
+	 * @default "ListItem"
 	 * @since 1.3.0
 	 *
 	 */
-	@property({ type: ListItemAccessibleRole })
+	@property({ type: ListItemAccessibleRole, defaultValue: ListItemAccessibleRole.ListItem })
 	accessibleRole!: `${ListItemAccessibleRole}`;
 
 	@property({ type: ListSelectionMode, defaultValue: ListSelectionMode.None })

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -471,7 +471,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	get listItemAccessibleRole() {
-		return this.accessibleRole?.toLowerCase();
+		return this.accessibleRole.toLowerCase();
 	}
 
 	get ariaSelectedText() {

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -27,6 +27,7 @@ import {
 	LIST_ITEM_SELECTED,
 	LIST_ITEM_NOT_SELECTED,
 } from "./generated/i18n/i18n-defaults.js";
+import ListItemAccessibleRole from "./types/ListItemAccessibleRole.js";
 
 // Styles
 import styles from "./generated/themes/ListItem.css.js";
@@ -202,8 +203,8 @@ abstract class ListItem extends ListItemBase {
 	 * @since 1.3.0
 	 *
 	 */
-	@property()
-	accessibleRole!: string;
+	@property({ type: ListItemAccessibleRole })
+	accessibleRole!: `${ListItemAccessibleRole}`;
 
 	@property({ type: ListSelectionMode, defaultValue: ListSelectionMode.None })
 	_selectionMode!: `${ListSelectionMode}`;
@@ -469,6 +470,10 @@ abstract class ListItem extends ListItemBase {
 		return undefined;
 	}
 
+	get listItemAccessibleRole() {
+		return this.accessibleRole?.toLowerCase();
+	}
+
 	get ariaSelectedText() {
 		let ariaSelectedText;
 
@@ -503,7 +508,7 @@ abstract class ListItem extends ListItemBase {
 
 	get _accInfo(): AccInfo {
 		return {
-			role: this.accessibleRole,
+			role: this.listItemAccessibleRole,
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -53,7 +53,7 @@
 			?loading="{{loading}}"
 			loading-delay="{{loadingDelay}}"
 			separators="None"
-			accessible-role="menu"
+			accessible-role="Menu"
 			@ui5-item-click={{_itemClick}}
 			@mouseover="{{_loadingMouseOver}}"
 		>
@@ -64,7 +64,7 @@
 				id="{{../_id}}-menu-item-{{@index}}"
 				.icon="{{this.item.icon}}"
 				accessible-name={{this.item.ariaLabelledByText}}
-				accessible-role="menuitem"
+				accessible-role="MenuItem"
 				.additionalText="{{this.item._additionalText}}"
 				tooltip="{{this.item.tooltip}}"
 				selected="{{this.item.subMenuOpened}}"

--- a/packages/main/src/NavigationMenu.hbs
+++ b/packages/main/src/NavigationMenu.hbs
@@ -47,7 +47,7 @@
 	>
 	{{#if _currentItems.length}}
 		<ui5-list
-			accessible-role="tree"
+			accessible-role="Tree"
 			id="{{_id}}-menu-list"
 			selection-mode="None"
 			?loading="{{loading}}"
@@ -63,7 +63,7 @@
 					id="{{../_id}}-menu-item-{{@index}}"
 					.icon="{{this.item.icon}}"
 					accessible-name={{this.item.ariaLabelledByText}}
-					accessible-role="none"
+					accessible-role="None"
 					.additionalText="{{this.item._additionalText}}"
 					.ariaHasPopup={{this.ariaHasPopup}}
 					?disabled={{this.item.disabled}}
@@ -104,7 +104,7 @@
 					id="{{../_id}}-menu-item-{{@index}}"
 					.icon="{{this.item.icon}}"
 					accessible-name={{this.item.ariaLabelledByText}}
-					accessible-role="treeitem"
+					accessible-role="TreeItem"
 					.additionalText="{{this.item._additionalText}}"
 					.ariaHasPopup={{this.ariaHasPopup}}
 					?disabled={{this.item.disabled}}

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -15,6 +15,7 @@ import type TreeItemBase from "./TreeItemBase.js";
 import TreeItemCustom from "./TreeItemCustom.js";
 import TreeList from "./TreeList.js";
 import ListSelectionMode from "./types/ListSelectionMode.js";
+import ListAccessibleRole from "./types/ListAccessibleRole.js";
 import type {
 	TreeItemBaseToggleEventDetail,
 	TreeItemBaseStepInEventDetail,
@@ -336,7 +337,7 @@ class Tree extends UI5Element {
 	}
 
 	get _role() {
-		return "tree";
+		return ListAccessibleRole.Tree;
 	}
 
 	get _label() {

--- a/packages/main/src/types/ListAccessibleRole.ts
+++ b/packages/main/src/types/ListAccessibleRole.ts
@@ -1,0 +1,33 @@
+/**
+ * List accessible roles.
+ * @public
+ */
+enum ListAccessibleRole {
+
+	/**
+	 * Represents the ARIA role "list". (by default)
+	 * @public
+	 */
+	List = "List",
+
+	/**
+	 * Represents the ARIA role "menu".
+	 * @public
+	 */
+	Menu = "Menu",
+
+	/**
+	 * Represents the ARIA role "tree".
+	 * @public
+	 */
+	Tree = "Tree",
+
+	/**
+	 * Represents the ARIA role "listbox".
+	 * @public
+	 */
+	ListBox = "ListBox"
+
+}
+
+export default ListAccessibleRole;

--- a/packages/main/src/types/ListAccessibleRole.ts
+++ b/packages/main/src/types/ListAccessibleRole.ts
@@ -1,6 +1,7 @@
 /**
  * List accessible roles.
  * @public
+ * @since 2.0.0
  */
 enum ListAccessibleRole {
 

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -1,0 +1,39 @@
+/**
+ * ListItem accessible roles.
+ * @public
+ */
+enum ListItemAccessibleRole {
+
+	/**
+	 * Represents the ARIA role "listitem". (by default)
+	 * @public
+	 */
+	ListItem = "ListItem",
+
+	/**
+	 * Represents the ARIA role "menuitem".
+	 * @public
+	 */
+	MenuItem = "MenuItem",
+
+	/**
+	 * Represents the ARIA role "treeitem".
+	 * @public
+	 */
+	TreeItem = "TreeItem",
+
+	/**
+	 * Represents the ARIA role "option".
+	 * @public
+	 */
+	Option = "Option",
+
+	/**
+	 * Represents the ARIA role "none".
+	 * @public
+	 */
+	None = "None"
+
+}
+
+export default ListItemAccessibleRole;

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -1,6 +1,7 @@
 /**
  * ListItem accessible roles.
  * @public
+ * @since 2.0.0
  */
 enum ListItemAccessibleRole {
 

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -213,8 +213,8 @@ describe("Menu Accessibility", () => {
 		const list = await popover.$("ui5-list");
 		const listItems = await popover.$("ui5-list").$$("ui5-menu-li");
 
-		assert.strictEqual(await list.getAttribute("accessible-role"), "menu", "There is proper 'menu' role for the menu list");
-		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "menuitem", "There is proper 'menuitem' role for the menu list items");
+		assert.strictEqual(await list.getAttribute("accessible-role"), "Menu", "There is proper 'menu' role for the menu list");
+		assert.strictEqual(await listItems[0].getAttribute("accessible-role"), "MenuItem", "There is proper 'menuitem' role for the menu list items");
 		assert.strictEqual(await listItems[0].getAttribute("tooltip"), "Select a file - prevent default", "There is a tooltip");
 		assert.strictEqual(await listItems[2].shadow$(".ui5-li-root").getAttribute("aria-haspopup"), "menu", "There is an aria-haspopup attribute");
 		assert.strictEqual(


### PR DESCRIPTION
Changes the type of `accessibleRole` property  for both `ui5-li` and `ui5-list`.

BREAKING CHANGE: The `accessibleRole` property for both `ui5-li` and `ui5-list` has been updated from a string type to an enum type. 
Additionally, the new enums `ListItemAccessibleRole` and `ListAccessibleRole` have been introduced for these properties respectively.
The available options for the `ui5-li`:
	`ListItem`- Represents the ARIA role "listitem". (by default)
	`MenuItem`  -  Represents the ARIA role "menuitem".
	`TreeItem ` -  Represents the ARIA role "treeitem".
	`Option ` -  Represents the ARIA role "option".
	`None` - Represents the ARIA role "none".

The available options for the `ui5-list`:
	`List`- Represents the ARIA role "list".  (by default)
	`Menu`  -  Represents the ARIA role "menu".
	`Tree` -  Represents the ARIA role "tree".
	`ListBox` - Represents the ARIA role "listbox".
If you have previously used:
```html
<ui5-li accessible-role="menuitem"> List Item</ui5-li>
<ui5-list accessible-role="tree"> List </ui5-list>
```
Now use:
```html
<ui5-li accessible-role="MenuItem"> List Item</ui5-li>
<ui5-list accessible-role="Tree"> List </ui5-list>
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887