### PR TITLE
feature(ui5-option): tooltip property added

### DIFF
--- a/packages/main/src/Option.ts
+++ b/packages/main/src/Option.ts
@@ -30,13 +30,13 @@ class Option extends UI5Element implements IOption {
 	selected!: boolean;
 
 	/**
-	 * Defines the tooltip of the component.
+	 * Defines the text of the tooltip that would be displayed for the option component.
 	 * @default ""
-	 * @private
-	 * @since 1.1.0
+	 * @public
+	 * @since 2.0.0
 	 */
 	@property()
-	title!: string;
+	tooltip!: string;
 
 	/**
 	 * Defines the `icon` source URI.

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -78,7 +78,7 @@ import type { SelectMenuOptionClick, SelectMenuChange } from "./SelectMenu.js";
  */
 interface IOption extends UI5Element {
 	selected: boolean,
-	title: string,
+	tooltip: string,
 	icon?: string | null,
 	value: string,
 	additionalText?: string,
@@ -596,7 +596,7 @@ class Select extends UI5Element implements IFormElement {
 				icon: opt.icon,
 				value: opt.value,
 				textContent: opt.textContent,
-				title: opt.title,
+				tooltip: opt.tooltip,
 				additionalText: opt.additionalText,
 				id: opt._id,
 				stableDomRef: opt.stableDomRef,

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -51,7 +51,7 @@
 					icon="{{this.icon}}"
 					?selected="{{this.selected}}"
 					?focused="{{this._focused}}"
-					title="{{this.title}}"
+					tooltip="{{this.tooltip}}"
 					additional-text="{{this.additionalText}}"
 					?aria-selected="{{this.selected}}"
 					data-ui5-stable="{{this.stableDomRef}}"

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -77,7 +77,7 @@
 
 	<h2>Select with tooltip for each option</h2>
 	<ui5-select id="selectTooltip">
-		<ui5-option tooltip="Cozy">Cozy</ui5-option>
+		<ui5-option tooltip="Cozy" stable-dom-ref="tooltip-test-option">Cozy</ui5-option>
 		<ui5-option tooltip="Compact">Compact</ui5-option>
 		<ui5-option selected tooltip="Condensed">Condensed</ui5-option>
 	</ui5-select>

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -75,6 +75,12 @@
 		<ui5-option>Condensed</ui5-option>
 	</ui5-select>
 
+	<h2>Select with tooltip for each option</h2>
+	<ui5-select id="selectTooltip">
+		<ui5-option tooltip="Cozy">Cozy</ui5-option>
+		<ui5-option tooltip="Compact">Compact</ui5-option>
+		<ui5-option selected tooltip="Condensed">Condensed</ui5-option>
+	</ui5-select>
 
 	<h2> Input with suggestions</h2>
 	<ui5-input id="myInput" show-suggestions placeholder="Search for a country ..."></ui5-input>

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -615,14 +615,6 @@ describe("Select general interaction", () => {
 		const selectedOption = await popover.$("ui5-list").$("ui5-li[selected]");
 		assert.ok(await selectedOption.isClickable(), "Selected option is visible in the viewport.");
 	});
-
-	it("tests tooltip property of ui5-option", async () => {
-		const firstOption = await browser.$("#selectTooltip ui5-option:first-child");
-		const initialValue = "Cozy";
-		let tooltipValue = await firstOption.getProperty("tooltip");
-
-		assert.strictEqual(tooltipValue, initialValue, "The tooltip of ui5-option is correctly set");
-	});
 });
 
 describe("Attributes propagation", () => {
@@ -639,4 +631,18 @@ describe("Attributes propagation", () => {
 		assert.strictEqual(await firstOption.getProperty("additionalText"), EXPECTED_ADDITIONAL_TEXT, "The additional text is set");
 		assert.strictEqual(await firstItem.getProperty("additionalText"), EXPECTED_ADDITIONAL_TEXT, "The additional text is correct");
  	});
+
+	it("Tooltip propagation", async () => {
+		const select = await browser.$("#selectTooltip");
+		const tooltip = "Cozy"
+
+		await select.click();
+
+		const popover = await select.shadow$("[ui5-responsive-popover]");
+		const option = await select.$("[ui5-option]");
+		const listItem = await popover.$("[data-ui5-stable='tooltip-test-option']")
+
+		assert.strictEqual(await option.getProperty("tooltip"), tooltip, "Tooltip is correct");
+		assert.strictEqual(await listItem.getProperty("tooltip"), tooltip, "Tooltip is correctly propagated");
+	});
 });

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -622,13 +622,6 @@ describe("Select general interaction", () => {
 		let tooltipValue = await firstOption.getProperty("tooltip");
 
 		assert.strictEqual(tooltipValue, initialValue, "The tooltip of ui5-option is correctly set");
-
-		const newValue = "New Value";
-		await firstOption.setProperty("tooltip", newValue);
-		tooltipValue = await firstOption.getProperty("tooltip");
-
-		assert.strictEqual(tooltipValue, newValue, "The tooltip of ui5-option is correctly changed");
-
 	});
 });
 

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -615,6 +615,21 @@ describe("Select general interaction", () => {
 		const selectedOption = await popover.$("ui5-list").$("ui5-li[selected]");
 		assert.ok(await selectedOption.isClickable(), "Selected option is visible in the viewport.");
 	});
+
+	it("tests tooltip property of ui5-option", async () => {
+		const firstOption = await browser.$("#selectTooltip ui5-option:first-child");
+		const initialValue = "Cozy";
+		let tooltipValue = await firstOption.getProperty("tooltip");
+
+		assert.strictEqual(tooltipValue, initialValue, "The tooltip of ui5-option is correctly set");
+
+		const newValue = "New Value";
+		await firstOption.setProperty("tooltip", newValue);
+		tooltipValue = await firstOption.getProperty("tooltip");
+
+		assert.strictEqual(tooltipValue, newValue, "The tooltip of ui5-option is correctly changed");
+
+	});
 });
 
 describe("Attributes propagation", () => {

--- a/packages/playground/_stories/main/Select/Option/Option.stories.ts
+++ b/packages/playground/_stories/main/Select/Option/Option.stories.ts
@@ -23,6 +23,7 @@ const Template: UI5StoryArgs<Option, StoryArgsSlots> = (args) => {
    icon="${ifDefined(args.icon)}"
    ?selected="${ifDefined(args.selected)}"
    value="${ifDefined(args.value)}"
+   tooltip="${ifDefined(args.tooltip)}"
    >${unsafeHTML(args.default)}</ui5-option>
 </ui5-select> `;
 };


### PR DESCRIPTION
The private `title` property, previously available in the `ui5-option` component, has been removed. 
It is replaced by a new property named `tooltip`, used for defining the text of the tooltip that would be displayed for the `ui5-option` component.
Now, you can set the tooltip of the `ui5-option` as it follows:
```html
<ui5-select id="selectTooltip">
    <ui5-option tooltip="Cozy">Cozy</ui5-option>
    <ui5-option tooltip="Compact">Compact</ui5-option>
    <ui5-option selected tooltip="Condensed">Condensed</ui5-option>
</ui5-select>
```

Related to: https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887