### PR TITLE
chore(ui5-shellbar): update focus handling

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -23,6 +23,7 @@ import type { IButton } from "@ui5/webcomponents/dist/Button.js";
 import HasPopup from "@ui5/webcomponents/dist/types/HasPopup.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import "@ui5/webcomponents-icons/dist/search.js";
 import "@ui5/webcomponents-icons/dist/bell.js";
 import "@ui5/webcomponents-icons/dist/overflow.js";
@@ -801,6 +802,10 @@ class ShellBar extends UI5Element {
 
 	onEnterDOM() {
 		ResizeHandler.register(this, this._handleResize);
+
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
 	}
 
 	onExitDOM() {

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -74,7 +74,8 @@
 	color: var(--_ui5_shellbar_button_active_color);
 }
 
-.ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:focus {
+:host([desktop]) .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:focus-within,
+.ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:focus-visible {
 	outline: var(--_ui5_shellbar_logo_outline);
 	outline-offset: var(--_ui5_shellbar_outline_offset);
 }
@@ -208,7 +209,8 @@ slot[name="profile"] {
 	max-height: 2rem;
 }
 
-.ui5-shellbar-logo:focus {
+:host([desktop]) .ui5-shellbar-logo:focus-within,
+.ui5-shellbar-logo:focus-visible {
 	outline: var(--_ui5_shellbar_logo_outline);
 	outline-offset: var(--_ui5_shellbar_logo_outline_offset);
 	border-radius: var(--_ui5_shellbar_logo_border_radius);
@@ -452,6 +454,7 @@ slot[name="profile"] {
 	box-shadow: var(--_ui5_shellbar_search_field_box_shadow_hover);
 }
 
+/* Todo: modify this selector after ui5-input is updated */
 ::slotted([ui5-input][focused]) {
 	outline: var(--_ui5_shellbar_search_field_outline_focused);
 }


### PR DESCRIPTION
Adjusted `ui5-shellbar` focus display rules. On desktop, focus outline is always visible. For mobile, focus outline only appears with an external keyboard, it remains hidden for touch focus.

Related to: #8320
