### PR TITLE
chore: fix the lint scoping tool

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -454,7 +454,7 @@ slot[name="profile"] {
 	box-shadow: var(--_ui5_shellbar_search_field_box_shadow_hover);
 }
 
-/* Todo: modify this selector after Input.ts is updated */
+/* Todo: modify this selector after ui5-input is updated */
 ::slotted([ui5-input][focused]) {
 	outline: var(--_ui5_shellbar_search_field_outline_focused);
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -454,7 +454,7 @@ slot[name="profile"] {
 	box-shadow: var(--_ui5_shellbar_search_field_box_shadow_hover);
 }
 
-/* Todo: modify this selector after ui5-input is updated */
+/* Todo: modify this selector after Input.ts is updated */
 ::slotted([ui5-input][focused]) {
 	outline: var(--_ui5_shellbar_search_field_outline_focused);
 }

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1848,7 +1848,7 @@ class MultiComboBox extends UI5Element {
 	get _innerInput(): HTMLInputElement {
 		if (isPhone()) {
 			if (this._getRespPopover()?.open) {
-				return this._getRespPopover().querySelector("ui5-input")!.shadowRoot!.querySelector("input")!;
+				return this._getRespPopover().querySelector("[ui5-input]")!.shadowRoot!.querySelector("input")!;
 			}
 		}
 

--- a/packages/tools/lib/scoping/lint-src.js
+++ b/packages/tools/lib/scoping/lint-src.js
@@ -11,7 +11,7 @@ glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
 	let content = String(fs.readFileSync(file));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`(^|[^\.\-_A-Za-z0-9"\[])(${tag})([^\-_A-Za-z0-9]|$)`, "g"))) {
-			errors.push(`Warning! ${tag} found in ${file}`);
+			errors.push(`${tag} found in ${file}`);
 		}
 	});
 });
@@ -20,12 +20,11 @@ glob.sync(path.join(process.cwd(), "src/**/*.ts")).forEach(file => {
 	let content = String(fs.readFileSync(file));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`querySelector[A-Za-z]*..${tag}`, "g"))) {
-			errors.push(`Warning! querySelector for ${tag} found in ${file}`);
+			errors.push(`querySelector for ${tag} found in ${file}`);
 		}
 	});
 });
 
 if (errors.length) {
-	errors.forEach(error => console.log(error));
-	throw new Error("Errors found.");
+	throw new Error(`Scoping-related errors found (f.e. used ui5-input instead of [ui5-input]): \n ${errors.join("\n")}`);
 }

--- a/packages/tools/lib/scoping/lint-src.js
+++ b/packages/tools/lib/scoping/lint-src.js
@@ -16,7 +16,7 @@ glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
 	});
 });
 
-glob.sync(path.join(process.cwd(), "src/**/*.js")).forEach(file => {
+glob.sync(path.join(process.cwd(), "src/**/*.ts")).forEach(file => {
 	let content = String(fs.readFileSync(file));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`querySelector[A-Za-z]*..${tag}`, "g"))) {

--- a/packages/tools/lib/scoping/lint-src.js
+++ b/packages/tools/lib/scoping/lint-src.js
@@ -7,8 +7,10 @@ const tags = getAllTags(process.cwd());
 
 const errors = [];
 
+const removeComments = str => str.replaceAll(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, "");
+
 glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
-	let content = String(fs.readFileSync(file));
+	let content = removeComments(String(fs.readFileSync(file)));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`(^|[^\.\-_A-Za-z0-9"\[])(${tag})([^\-_A-Za-z0-9]|$)`, "g"))) {
 			errors.push(`${tag} found in ${file}`);
@@ -17,7 +19,7 @@ glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
 });
 
 glob.sync(path.join(process.cwd(), "src/**/*.ts")).forEach(file => {
-	let content = String(fs.readFileSync(file));
+	let content = removeComments(String(fs.readFileSync(file)));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`querySelector[A-Za-z]*..${tag}`, "g"))) {
 			errors.push(`querySelector for ${tag} found in ${file}`);


### PR DESCRIPTION
 - made the tool work with `.ts` files (it was still set for `.js` and wasn't working until now)
 - mede the tool strip all comments first so we now allow to mention tag names in comments without causing lint errors
 - fixed a scoping issue