### PR TITLE
chore: stop generating unused files

### DIFF
--- a/packages/website/build-scripts/api-reference-generation/types.mjs
+++ b/packages/website/build-scripts/api-reference-generation/types.mjs
@@ -28,12 +28,10 @@ import DocCardList from '@theme/DocCardList';
             declaration._implementations = findAllImplementations(declaration);
 
             await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
-            await fs.writeFile(path.join(`./docs/components/${packageName}/interfaces`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
         })
 
         enums.forEach(async (declaration) => {
             await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `${declaration.name}.mdx`), parseDeclaration(declaration, packageName))
-            await fs.writeFile(path.join(`./docs/components/${packageName}/enums`, `_${declaration.name}Declaration.json`), JSON.stringify(declaration))
         })
     })
 }


### PR DESCRIPTION
JSON file for each interface / enum with metadata was previously generated. With this PR the generation is stopped because these files are no longer needed.