### PR TITLE
fix(ui5-time-picker): fix buttons announcements in value help dialog

### DIFF
--- a/packages/main/src/ToggleSpinButton.hbs
+++ b/packages/main/src/ToggleSpinButton.hbs
@@ -6,5 +6,4 @@
 	aria-valuemax="{{valueMax}}"
 	aria-valuenow="{{valueNow}}"
 	aria-valuetext="{{valueText}}"
-	role="spinbutton"
 {{/inline}}

--- a/packages/main/src/ToggleSpinButton.ts
+++ b/packages/main/src/ToggleSpinButton.ts
@@ -64,7 +64,7 @@ class ToggleSpinButton extends ToggleButton {
 	_onclick() {}
 
 	/**
-	 * Override of the getter in order to set proper role to the button
+	 * Override
 	 */
 	get buttonAccessibleRole() {
 		return "spinbutton";

--- a/packages/main/src/ToggleSpinButton.ts
+++ b/packages/main/src/ToggleSpinButton.ts
@@ -62,6 +62,13 @@ class ToggleSpinButton extends ToggleButton {
 	 * Override of the handler in order to prevent button toggle functionality
 	 */
 	_onclick() {}
+
+	/**
+	 * Override of the getter in order to set proper role to the button
+	 */
+	get buttonAccessibleRole() {
+		return "spinbutton";
+	}
 }
 
 ToggleSpinButton.define();


### PR DESCRIPTION
The SR announcement of the top buttons (hours/minutes/seconds) in TimePicker/DateTimePicker wasn't correct because of wrong role of these buttons - it was "button" but must be "spinbutton".

This PR solves the issue.

Fixes: #7980