### PR TITLE
fix(ui5-dialog): state icon no longer shrinks when title is too long

### DIFF
--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -75,6 +75,7 @@
 
 .ui5-dialog-value-state-icon {
 	margin-inline-end: 0.5rem;
+	flex-shrink: 0;
 }
 
 :host([state="Error"]) .ui5-dialog-value-state-icon {


### PR DESCRIPTION
Downport of https://github.com/SAP/ui5-webcomponents/pull/8839
