### PR TITLE
fix(ui5-multi-input): focus tokens on BACKSPACE for inputs of type 'Number' and 'Email'

### DIFF
--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -290,7 +290,11 @@ class MultiInput extends Input {
 		const tokens = this.tokens;
 		const lastToken = tokens.length && tokens[tokens.length - 1];
 
-		if (cursorPosition === 0 && lastToken) {
+		// Selection is only permitted with text/search, URL, tel and password.
+		// The likely reason that selection has been disabled for inputs of type number
+		// is that on some devices, or under some circumstances (e.g., when the input
+		// has been is presented as a short list), there might not be a caret.
+		if ((((this.type === "Number" || this.type === "Email") && !this.value) || cursorPosition === 0) && lastToken) {
 			e.preventDefault();
 			lastToken.focus();
 			this.tokenizer._itemNav.setCurrentItem(lastToken);

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -289,12 +289,10 @@ class MultiInput extends Input {
 		const cursorPosition = this.getDomRef()!.querySelector(`input`)!.selectionStart;
 		const tokens = this.tokens;
 		const lastToken = tokens.length && tokens[tokens.length - 1];
+		const isNumberOrEmail = this.type === "Number" || this.type === "Email";
 
 		// Selection is only permitted with text/search, URL, tel and password.
-		// The likely reason that selection has been disabled for inputs of type number
-		// is that on some devices, or under some circumstances (e.g., when the input
-		// has been is presented as a short list), there might not be a caret.
-		if ((((this.type === "Number" || this.type === "Email") && !this.value) || cursorPosition === 0) && lastToken) {
+		if (((isNumberOrEmail && !this.value) || cursorPosition === 0) && lastToken) {
 			e.preventDefault();
 			lastToken.focus();
 			this.tokenizer._itemNav.setCurrentItem(lastToken);

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -289,10 +289,9 @@ class MultiInput extends Input {
 		const cursorPosition = this.getDomRef()!.querySelector(`input`)!.selectionStart;
 		const tokens = this.tokens;
 		const lastToken = tokens.length && tokens[tokens.length - 1];
-		const isNumberOrEmail = this.type === "Number" || this.type === "Email";
 
-		// Selection is only permitted with text/search, URL, tel and password.
-		if (((isNumberOrEmail && !this.value) || cursorPosition === 0) && lastToken) {
+		// selectionStart property applies only to inputs of types text, search, URL, tel, and password
+		if (((cursorPosition === null && !this.value) || cursorPosition === 0) && lastToken) {
 			e.preventDefault();
 			lastToken.focus();
 			this.tokenizer._itemNav.setCurrentItem(lastToken);

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -544,6 +544,21 @@ describe("Keyboard handling", () => {
 		assert.equal(await input.getProperty("focused"), true, "The input is focused");
 	});
 
+	it("should focus token on backspace for inputs of type 'Number' and 'Email'", async () => {
+		const input = await browser.$("#two-tokens");
+		const innerInput = await input.shadow$("input");
+		const lastToken = await browser.$("#two-tokens ui5-token#secondToken");
+
+		// Act
+		await input.setProperty("value", "");
+		await input.setProperty("type", "Number");
+
+		await innerInput.click();
+		await browser.keys("Backspace");
+
+		assert.ok(await lastToken.getProperty("focused"), "The last token is focused on Backspace");
+	});
+
 	it("should delete token on backspace", async () => {
 		const input = await browser.$("#two-tokens");
 		const innerInput = await input.shadow$("input");


### PR DESCRIPTION

related to #8712

**Note:**

To determine whether or not to focus the last token we rely on the JS's `.selectionStart` to check if the caret is at the start of the input (right before the tokens). However, [Selection is only permitted with text/search, URL, tel and password](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#do-not-apply). The likely reason that selection has been disabled for inputs of type number is that on some devices, or under some circumstances (e.g., when the input has been is presented as a short list), there might not be a caret.

So to determine if we should focus the last token in cases of inputs of type 'Number' and 'Email' now we check if there is a text value or not. This means that the (edge) case when there is a value and the user moves the caret to the start of it and then presses 'Backspace'/'Left Arrow' still won't work. IMO the issue doesn't seem to has a clean complete solution.