### PR TITLE
chore: add missing properties to ui5-segmented-button-item

### DIFF
--- a/packages/main/src/SegmentedButtonItem.ts
+++ b/packages/main/src/SegmentedButtonItem.ts
@@ -76,6 +76,24 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 	tooltip!: string;
 
 	/**
+	 * Defines the accessible ARIA name of the component.
+	 * @default undefined
+	 * @public
+	 * @since 1.0.0-rc.15
+	 */
+	@property({ defaultValue: undefined })
+	accessibleName?: string;
+
+	/**
+	 * Receives id(or many ids) of the elements that label the component.
+	 * @default ""
+	 * @public
+	 * @since 1.1.0
+	 */
+	@property({ defaultValue: "" })
+	accessibleNameRef!: string;
+
+	/**
 	 * Defines the icon, displayed as graphical element within the component.
 	 * The SAP-icons font provides numerous options.
 	 *

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -181,6 +181,17 @@
 		<ui5-button id="progSetButton4">Press first item</ui5-button>
 	</section>
 
+	<section>
+		<h3>Accessibility</h3>
+		<ui5-segmented-button>
+			<ui5-segmented-button-item  id="accBtn1" accessible-name="accessible text">First</ui5-segmented-button-item>
+			<ui5-segmented-button-item  id="accBtn2" accessible-name-ref="accRefText">Second</ui5-segmented-button-item>
+			<ui5-segmented-button-item>Third</ui5-segmented-button-item>
+		</ui5-segmented-button>
+
+		<span id="accRefText">accessible ref text</span>
+	</section>
+
 	<script>
 
 		progSetButton1.addEventListener("click", function() {

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -134,3 +134,23 @@ describe("SegmentedButton general interaction", () => {
 		assert.ok(await secondSegmentedButtonItem.getProperty("selected"), "Second SegmentedButtonItem should be selected");
 	});
 });
+
+describe.only("SegmentedButton accessibility", () => {
+	before(async () => {
+		await browser.url(`test/pages/SegmentedButton.html`);
+	});
+
+	it ("aria-label is correctly set from accessibleName attr", async () => {
+		const item = await browser.$("#accBtn1"),
+			itemRoot = item.shadow$(".ui5-segmented-button-item-root");
+
+		assert.equal(await itemRoot.getAttribute("aria-label"), await item.getAttribute("accessible-name"), "aria-label should be set according to accessibleName property");
+	});
+
+	it("aria-label is correctly set from accessibleNameRef attr", async () => {
+		const button = await browser.$("#accBtn2").shadow$(".ui5-segmented-button-item-root");
+
+		assert.strictEqual(await button.getAttribute("aria-label"), "accessible ref text", "aria-label should be set according to accessibleNameRef property");
+	});
+});
+


### PR DESCRIPTION
With #8669 `ui5-segmented-button-item` was separated from `ui5-toggle-button`. During the separation few properties were missed.