### PR TITLE
chore: update slug in Table*.mdx

### DIFF
--- a/packages/website/docs/_components_pages/compat/Table/Table.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/Table.mdx
@@ -1,5 +1,5 @@
 ---
-slug: ../../Table
+slug: ../Table
 ---
 
 import Basic from "../../../_samples/compat/Table/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/compat/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/TableCell.mdx
@@ -1,5 +1,5 @@
 ---
-slug: ../../TableCell
+slug: ../TableCell
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/compat/Table/TableColumn.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/TableColumn.mdx
@@ -1,5 +1,5 @@
 ---
-slug: ../../TableColumn
+slug: ../TableColumn
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/compat/Table/TableGroupRow.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/TableGroupRow.mdx
@@ -1,5 +1,5 @@
 ---
-slug: ../../TableGroupRow
+slug: ../TableGroupRow
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/compat/Table/TableRow.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/TableRow.mdx
@@ -1,5 +1,5 @@
 ---
-slug: ../../TableRow
+slug: ../TableRow
 ---
 
 <%COMPONENT_OVERVIEW%>


### PR DESCRIPTION
The Table page url still hinting as it's part of the main package - `components/Table`
while it should be `components/compat/Table`.
