### PR TITLE
refactor(ui5-label): wrap text by default

### DIFF
--- a/packages/fiori/src/UploadCollectionItem.hbs
+++ b/packages/fiori/src/UploadCollectionItem.hbs
@@ -39,6 +39,7 @@
 					<div class="ui5-uci-progress-labels">
 						<ui5-label
 							show-colon
+							wrapping-type="None"
 						>{{_progressText}}</ui5-label>
 						<ui5-label>{{progress}}%</ui5-label>
 					</div>

--- a/packages/fiori/test/pages/F6TestPage.html
+++ b/packages/fiori/test/pages/F6TestPage.html
@@ -48,7 +48,7 @@
 		<ui5-button>3</ui5-button>
 		<ui5-button>4</ui5-button>
 		<ui5-button>5</ui5-button>
-		<ui5-label wrapping-type="Normal">
+		<ui5-label>
 			<span>
 				Lorem ipsum dolor sit amet, tamquam invidunt cu sed, unum regione mel ea, quo ea alia novum. Ne qui
 				illud zril

--- a/packages/fiori/test/pages/FCL.html
+++ b/packages/fiori/test/pages/FCL.html
@@ -66,7 +66,7 @@
 				<ui5-wizard-step title-text="Product Information">
 					<div class="fcl9auto">
 						<ui5-title>2. Product Information</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 
@@ -104,7 +104,7 @@
 					<div class="fcl10auto">
 						<ui5-title>3. Options</ui5-title><br>
 
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>
@@ -144,7 +144,7 @@
 				<ui5-wizard-step title-text="Pricing">
 					<div class="fcl10auto">
 						<ui5-title>4. Pricing</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>

--- a/packages/fiori/test/pages/Wizard.html
+++ b/packages/fiori/test/pages/Wizard.html
@@ -33,7 +33,7 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-message-strip><br>
 
-				<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+				<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 				</ui5-label>
 				<ui5-button id="btnOpenDialog" class="wizard4auto">Open Wizard Dialog</ui5-button>
 			</div>
@@ -44,7 +44,7 @@
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
 			<div class="wizard5auto">
 				<ui5-title>2. Product Information</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -82,7 +82,7 @@
 			<div class="wizard6auto">
 				<ui5-title>3. Options</ui5-title><br>
 
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -122,7 +122,7 @@
 		<ui5-wizard-step title-text="Pricing" selected>
 			<div class="wizard6auto">
 				<ui5-title>4. Pricing</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -161,7 +161,7 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-message-strip><br>
 
-				<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+				<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 				</ui5-label>
 				<ui5-button class="wizard4auto">Open Wizard Dialog</ui5-button>
 			</div>
@@ -170,7 +170,7 @@
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" disabled>
 			<div class="wizard5auto">
 				<ui5-title>2. Product Information</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -207,7 +207,7 @@
 			<div class="wizard6auto">
 				<ui5-title>3. Options</ui5-title><br>
 
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -247,7 +247,7 @@
 		<ui5-wizard-step title-text="Pricing" disabled>
 			<div class="wizard6auto">
 				<ui5-title>4. Pricing</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -277,7 +277,7 @@
 		<ui5-wizard-step title-text="Final" selected disabled>
 			<div class="wizard6auto">
 				<ui5-title>5. Final</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -315,7 +315,7 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-message-strip><br>
 
-				<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+				<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 				</ui5-label>
 				<ui5-button class="wizard4auto">Open Wizard Dialog</ui5-button>
 			</div>
@@ -324,7 +324,7 @@
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected disabled>
 			<div class="wizard5auto">
 				<ui5-title>2. Product Information</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -362,7 +362,7 @@
 			<div class="wizard6auto">
 				<ui5-title>3. Options</ui5-title><br>
 
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -399,7 +399,7 @@
 		<ui5-wizard-step title-text="Pricing" selected disabled>
 			<div class="wizard6auto">
 				<ui5-title>4. Pricing</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -437,7 +437,7 @@
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-message-strip><br>
 
-				<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+				<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 				</ui5-label>
 			</div>
 		</ui5-wizard-step>
@@ -445,7 +445,7 @@
 		<ui5-wizard-step title-text="Product Information" subtitle-text="(Optional)" selected>
 			<div class="wizard5auto">
 				<ui5-title>2. Product Information</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -483,7 +483,7 @@
 			<div class="wizard6auto">
 				<ui5-title>3. Options</ui5-title><br>
 
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -520,7 +520,7 @@
 		<ui5-wizard-step title-text="Pricing" selected disabled>
 			<div class="wizard6auto">
 				<ui5-title>4. Pricing</ui5-title><br>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 
@@ -555,7 +555,7 @@
 						The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 					</ui5-message-strip><br>
 
-					<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+					<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 					</ui5-label>
 				</div>
 
@@ -565,7 +565,7 @@
 			<ui5-wizard-step title-text="Product Information" selected>
 				<div class="wizard5auto">
 					<ui5-title>2. Product Information</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 
@@ -603,7 +603,7 @@
 				<div class="wizard6auto">
 					<ui5-title>3. Options</ui5-title><br>
 
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>
@@ -643,7 +643,7 @@
 			<ui5-wizard-step title-text="Pricing" disabled>
 				<div class="wizard6auto">
 					<ui5-title>4. Pricing</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>

--- a/packages/fiori/test/pages/WizardPageMode_test.html
+++ b/packages/fiori/test/pages/WizardPageMode_test.html
@@ -25,7 +25,7 @@
 						user to work with.
 					</ui5-message-strip><br>
 
-					<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
+					<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
 						sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper,
 						volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend
 						tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec
@@ -40,7 +40,7 @@
 			<ui5-wizard-step id="dialogStep2" title-text="Product Information" disabled>
 				<div class="wizard_test5auto">
 					<ui5-title>2. Product Information</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero
 						sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo
 						sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus,
@@ -82,7 +82,7 @@
 				<div class="wizard_test6auto">
 					<ui5-title>3. Options</ui5-title><br>
 
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero
 						sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo
 						sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus,
@@ -128,7 +128,7 @@
 			<ui5-wizard-step id="dialogStep4" title-text="Pricing" disabled>
 				<div class="wizard_test6auto">
 					<ui5-title>4. Pricing</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero
 						sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo
 						sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus,

--- a/packages/fiori/test/pages/Wizard_test.html
+++ b/packages/fiori/test/pages/Wizard_test.html
@@ -25,7 +25,7 @@
 						The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 					</ui5-message-strip><br>
 
-					<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+					<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 					</ui5-label>
 
 					<ui5-input id="inpStepChangeCounter"></ui5-input>
@@ -48,7 +48,7 @@
 			<ui5-wizard-step  id="st2" title-text="Product Information" disabled>
 				<div class="wizard_test5auto">
 					<ui5-title>2. Product Information</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 
@@ -92,7 +92,7 @@
 				<div class="wizard_test6auto">
 					<ui5-title>3. Options</ui5-title><br>
 
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>
@@ -135,7 +135,7 @@
 			<ui5-wizard-step  id="st4" title-text="Pricing" disabled>
 				<div class="wizard_test6auto">
 					<ui5-title>4. Pricing</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>
@@ -166,7 +166,7 @@
 			<ui5-wizard-step  id="st5" title-text="Optional step to finish the example with very long, long, long, long, long, long, long, long, long text" subtitle-text="(Optional)" disabled>
 				<div class="wizard_test6auto">
 					<ui5-title>5. Optional step</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>
@@ -180,7 +180,7 @@
 			<ui5-wizard-step  id="st5" title-text="Final step to finish the example with very long, long, long, long, long, long, long, long, long text" disabled>
 				<div class="wizard_test6auto">
 					<ui5-title>6. Final step</ui5-title><br>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>
@@ -203,7 +203,7 @@
 								The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 							</ui5-message-strip><br>
 
-							<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+							<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 							</ui5-label>
 
 							<ui5-input></ui5-input>
@@ -215,7 +215,7 @@
 					<ui5-wizard-step title-text="Product Information">
 						<div class="wizard_test5auto">
 							<ui5-title>2. Product Information</ui5-title><br>
-							<ui5-label wrapping-type="Normal">
+							<ui5-label>
 								Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 							</ui5-label>
 
@@ -257,7 +257,7 @@
 						<div class="wizard_test6auto">
 							<ui5-title>3. Options</ui5-title><br>
 
-							<ui5-label wrapping-type="Normal">
+							<ui5-label>
 								Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 							</ui5-label>
 							<ui5-message-strip>
@@ -297,7 +297,7 @@
 					<ui5-wizard-step title-text="Pricing">
 						<div class="wizard_test6auto">
 							<ui5-title>4. Pricing</ui5-title><br>
-							<ui5-label wrapping-type="Normal">
+							<ui5-label>
 								Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 							</ui5-label>
 							<ui5-message-strip>

--- a/packages/fiori/test/pages/Wizard_test_mobile.html
+++ b/packages/fiori/test/pages/Wizard_test_mobile.html
@@ -29,7 +29,7 @@
 				<ui5-wizard-step title-text="Product Information">
 					<div class="wizard_test_mobile5auto">
 						<ui5-title>2. Product Information</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 					</div>
@@ -37,7 +37,7 @@
 
 				<ui5-wizard-step title-text="Options">
 						<ui5-title>3. Options</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>
@@ -47,7 +47,7 @@
 
 				<ui5-wizard-step title-text="Pricing" selected>
 						<ui5-title>4. Pricing</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>
@@ -69,7 +69,7 @@
 				<ui5-wizard-step title-text="Product Information" disabled>
 					<div class="wizard_test_mobile5auto">
 						<ui5-title>2. Product Information</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 					</div>
@@ -77,7 +77,7 @@
 
 				<ui5-wizard-step title-text="Options" disabled>
 						<ui5-title>3. Options</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>
@@ -87,7 +87,7 @@
 
 				<ui5-wizard-step title-text="Pricing" selected>
 						<ui5-title>4. Pricing</ui5-title><br>
-						<ui5-label wrapping-type="Normal">
+						<ui5-label>
 							Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 						</ui5-label>
 						<ui5-message-strip>

--- a/packages/main/src/BusyIndicator.hbs
+++ b/packages/main/src/BusyIndicator.hbs
@@ -33,7 +33,7 @@
 
 {{#*inline "busy-text"}}
 	{{#if text}}
-		<ui5-label id="{{_id}}-label" class="ui5-busy-indicator-text" wrapping-type="Normal">
+		<ui5-label id="{{_id}}-label" class="ui5-busy-indicator-text">
 			{{text}}
 		</ui5-label>
 	{{/if}}

--- a/packages/main/src/Label.ts
+++ b/packages/main/src/Label.ts
@@ -81,10 +81,10 @@ class Label extends UI5Element {
 	 * Defines how the text of a component will be displayed when there is not enough space.
 	 *
 	 * **Note:** for option "Normal" the text will wrap and the words will not be broken based on hyphenation.
-	 * @default "None"
+	 * @default "Normal"
 	 * @public
 	 */
-	@property({ type: WrappingType, defaultValue: WrappingType.None })
+	@property({ type: WrappingType, defaultValue: WrappingType.Normal })
 	wrappingType!: `${WrappingType}`;
 
 	static i18nBundle: I18nBundle;

--- a/packages/main/src/themes/Label.css
+++ b/packages/main/src/themes/Label.css
@@ -16,16 +16,19 @@
 	cursor: inherit;
 }
 
-:host([wrapping-type="Normal"]) .ui5-label-root {
+:host {
 	white-space: normal;
 }
 
-:host(:not([wrapping-type="Normal"])) .ui5-label-root {
-	display: inline-flex;
+:host([wrapping-type="None"]) {
 	white-space: nowrap;
 }
 
-:host(:not([wrapping-type="Normal"])) .ui5-label-text-wrapper {
+:host([wrapping-type="None"]) .ui5-label-root {
+	display: inline-flex;
+}
+
+:host([wrapping-type="None"]) .ui5-label-text-wrapper {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	display: inline-block;

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -501,8 +501,8 @@
 		</section>
 
 		<section class="row row-centered">
-			<ui5-label>This is a long long even longer text defined via the ui5-label and it truncates by default</ui5-label>
-			<ui5-label wrapping-type="Normal">This is a long long even longer text defined via the ui5-label, but this one wraps</ui5-label>
+			<ui5-label>This is a long long even longer text defined via the ui5-label and it wraps by default</ui5-label>
+			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but it truncates</ui5-label>
 		</section>
 	</div>
 	<script src="./kitchen-scripts.js" type="module"></script>

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -502,7 +502,7 @@
 
 		<section class="row row-centered">
 			<ui5-label>This is a long long even longer text defined via the ui5-label and it wraps by default</ui5-label>
-			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but it truncates</ui5-label>
+			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but it's truncated</ui5-label>
 		</section>
 	</div>
 	<script src="./kitchen-scripts.js" type="module"></script>

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -434,8 +434,8 @@
 		</section>
 
 		<section class="row row-centered">
-			<ui5-label>This is a long long even longer text defined via the ui5-label and it truncates by default</ui5-label>
-			<ui5-label wrapping-type="Normal">This is a long long even longer text defined via the ui5-label, but this one wraps</ui5-label>
+			<ui5-label>This is a long long even longer text defined via the ui5-label and it wraps by default</ui5-label>
+			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but this one truncates</ui5-label>
 		</section>
 	</div>
 	<script src="./kitchen-scripts.js" type="module"></script>

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -435,7 +435,7 @@
 
 		<section class="row row-centered">
 			<ui5-label>This is a long long even longer text defined via the ui5-label and it wraps by default</ui5-label>
-			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but this one truncates</ui5-label>
+			<ui5-label wrapping-type="None">This is a long long even longer text defined via the ui5-label, but this one is truncated</ui5-label>
 		</section>
 	</div>
 	<script src="./kitchen-scripts.js" type="module"></script>

--- a/packages/main/test/pages/Label.html
+++ b/packages/main/test/pages/Label.html
@@ -12,12 +12,7 @@
 		}
 	</script>
 
-	<script>// delete Document.prototype.adoptedStyleSheets;</script>
-
-
 	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
-
-
 	<script src="./modules/LabelPageCustomElement.js" type="module" defer></script>
 	<script src="./modules/LabelPage.js" type="module" defer></script>
 	<link rel="stylesheet" type="text/css" href="./styles/Label.css">
@@ -45,19 +40,20 @@
 
 		<h2>Required labels</h2>
 		<ui5-label id="required-label" required>Required</ui5-label><span>native span</span>
-		<ui5-label id="required-label-2" required show-colon>Required semi-colon</ui5-label><span>native span</span>
-		<ui5-label class="label2auto" id="required-label-3" required show-colon wrapping-type="Normal">Required semi-colon wrapped</ui5-label><span>native span</span>
+		<ui5-label class="label2auto" id="required-label-3" required show-colon>Required semi-colon</ui5-label><span>native span</span>
+		<ui5-label class="label2auto" id="required-label-2" required show-colon wrapping-type="None">Required semi-colon truncated</ui5-label><span>native span</span>
 	</section>
 
 	<section class="group vertical more-space">
 		<h2>Wrapping</h2>
 		<ui5-label class="label3auto" id="wrapping-label-1">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
 		<ui5-label class="label3auto" id="wrapping-label-2" show-colon>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
-		<ui5-label class="label3auto" id="wrapping-label" wrapping-type="Normal">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
-		<ui5-label class="label3auto" id="wrapping-label-3" wrapping-type="Normal" required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
-		<ui5-label class="label2auto" id="truncated-label" required >Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
-		<ui5-label class="label2auto" id="truncated-label-2" show-colon required >Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
-		<ui5-label class="label2auto" id="truncated-label-3" show-colon required wrapping-type="Normal">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label3auto" id="wrapping-label-3" required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label3auto" id="wrapping-label-4" show-colon required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label2auto" id="truncated-label-1" wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label2auto" id="truncated-label-2" show-colon wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label2auto" id="truncated-label-3" required wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
+		<ui5-label class="label2auto" id="truncated-label-4" show-colon required wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur.</ui5-label>
 		<div>
 			<ui5-label class="label4auto" id="wrapping-label-4" wrapping-type="Normal">Must be right-aligned using `text-align: right` and wrapping-type="Normal".</ui5-label>
 		</div>
@@ -70,35 +66,35 @@
 	<section class="group">
 		<h2>label + input</h2>
 		<div class="label5auto">
-			<ui5-label id="label-for-ui5-input" for="form-ui5-input" class="label2auto" required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+			<ui5-label id="label-for-ui5-input" for="form-ui5-input" class="label2auto" required wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 			<ui5-input class="label6auto" id="form-ui5-input"></ui5-input>
 		</div>
 
 		<br>
 
 		<div class="label5auto">
-			<ui5-label id="label-for-native-input" for="native-input" class="label2auto" show-colon wrapping-type="Normal" required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+			<ui5-label id="label-for-native-input" for="native-input" class="label2auto" show-colon required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 			<input class="label6auto" id="native-input"/>
 		</div>
 
 		<br>
 
 		<div class="label5auto">
-			<ui5-label id="label-for-ui5-textarea" for="ui5-textarea" class="label2auto" show-colon>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+			<ui5-label id="label-for-ui5-textarea" for="ui5-textarea" class="label2auto" show-colon wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 			<ui5-textarea class="label6auto" id="ui5-textarea"></ui5-textarea>
 		</div>
 
 		<br>
 
 		<div class="label5auto">
-			<ui5-label id="label-for-native-textarea" for="native-textarea" class="label2auto" required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+			<ui5-label id="label-for-native-textarea" for="native-textarea" class="label2auto" required wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 			<textarea class="label6auto" id="native-textarea"></textarea>
 		</div>
 
 		<br>
 
 		<div class="label5auto">
-			<ui5-label id="label-for-ui5-datepicker" for="ui5-datepicker" class="label2auto" show-colon required>Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+			<ui5-label id="label-for-ui5-datepicker" for="ui5-datepicker" class="label2auto" show-colon required wrapping-type="None">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 			<ui5-date-picker class="label6auto" id="ui5-datepicker"></ui5-date-picker>
 		</div>
 	</section>
@@ -108,8 +104,8 @@
 		<ui5-list>
 			<ui5-li-custom>
 				<div class="label7auto">
-					<ui5-label class="label3auto"> Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
-					<ui5-label wrapping-type="Normal" class="label3auto">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+					<ui5-label wrapping-type="None" class="label3auto"> Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
+					<ui5-label class="label3auto">Reprehenderit amet cillum tempor ex eu dolor adipisicing reprehenderit pariatur</ui5-label>
 				</div>
 			</ui5-li-custom>
 		</ui5-list>
@@ -117,34 +113,34 @@
 
 	<section class="group vertical label3auto">
 		<h2>Italic Label</h2>
-		<ui5-label class="label8auto">Short labelH</ui5-label>
-		<ui5-label class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label required class="label8auto">Short labelH</ui5-label>
-		<ui5-label required class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label show-colon class="label8auto">Short labelH</ui5-label>
-		<ui5-label show-colon class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label required show-colon class="label8auto">Short labelH</ui5-label>
-		<ui5-label required show-colon class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label wrapping-type="Normal" class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" required class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" show-colon class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" required show-colon class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label wrapping-type="None" class="label8auto">Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" required class="label8auto">Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" required class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" show-colon class="label8auto">Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" show-colon class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" required show-colon class="label8auto">Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" required show-colon class="label8auto">Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label required class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label show-colon class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label required show-colon class="label8auto">Long label - Reprehenderit amet cillum temporH</ui5-label>
 	</section>
 
 	<section class="group vertical label3auto">
 		<h2>Standard Label</h2>
-		<ui5-label>Short labelH</ui5-label>
-		<ui5-label>Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label required>Short labelH</ui5-label>
-		<ui5-label required>Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label show-colon>Short labelH</ui5-label>
-		<ui5-label show-colon>Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label required show-colon>Short labelH</ui5-label>
-		<ui5-label required show-colon>Long label - Reprehenderit amet cillum tempor</ui5-label>
-		<ui5-label wrapping-type="Normal">Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" required>Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" show-colon>Long label - Reprehenderit amet cillum temporH</ui5-label>
-		<ui5-label wrapping-type="Normal" required show-colon>Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label wrapping-type="None">Short labelH</ui5-label>
+		<ui5-label wrapping-type="None">Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" required>Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" required>Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" show-colon>Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" show-colon>Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label wrapping-type="None" required show-colon>Short labelH</ui5-label>
+		<ui5-label wrapping-type="None" required show-colon>Long label - Reprehenderit amet cillum tempor</ui5-label>
+		<ui5-label>Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label required>Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label show-colon>Long label - Reprehenderit amet cillum temporH</ui5-label>
+		<ui5-label required show-colon>Long label - Reprehenderit amet cillum temporH</ui5-label>
 	</section>
 
 	<section class="group">
@@ -153,7 +149,10 @@
 	</section>
 	<div>
 		<ui5-label>Short labelH</ui5-label>
-		<ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label><ui5-label>Short labelH</ui5-label>
+		<ui5-label>Short labelH</ui5-label>
+		<ui5-label>Short labelH</ui5-label>
+		<ui5-label>Short labelH</ui5-label>
+		<ui5-label>Short labelH</ui5-label>
 	</div>
 
 	<section class="group" id="differentLanguages">
@@ -167,19 +166,19 @@
 			<ui5-option id="zh-Hant">zh-Hant (Traditional Chinese)</ui5-option>
 		</ui5-select>
 		<div>
-			<ui5-label show-colon></ui5-label>
+			<ui5-label wrapping-type="None" show-colon></ui5-label>
 			<ui5-input></ui5-input>
 		</div>
 		<div>
-			<ui5-label show-colon required></ui5-label>
+			<ui5-label wrapping-type="None" show-colon required></ui5-label>
 			<ui5-input></ui5-input>
 		</div>
 		<div>
-			<ui5-label show-colon class="width50px"></ui5-label>
+			<ui5-label wrapping-type="None" show-colon class="width50px"></ui5-label>
 			<ui5-input></ui5-input>
 		</div>
 		<div>
-			<ui5-label show-colon required class="width50px"></ui5-label>
+			<ui5-label wrapping-type="None" show-colon required class="width50px"></ui5-label>
 			<ui5-input></ui5-input>
 		</div>
 	</section>

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -42,8 +42,8 @@ describe("General API", () => {
 	});
 
 	it("should wrap the text of the label", async () => {
-		const wrappingLabel = await browser.$("#wrapping-label");
-		const truncatingLabel = await browser.$("#truncated-label");
+		const wrappingLabel = await browser.$("#wrapping-label-1");
+		const truncatingLabel = await browser.$("#truncated-label-1");
 
 		assert.isAbove((await wrappingLabel.getSize()).height, (await truncatingLabel.getSize()).height);
 		assert.strictEqual((await truncatingLabel.getSize()).height, 16, "truncated label should be single line");

--- a/packages/playground/_stories/fiori/Wizard/Wizard.stories.ts
+++ b/packages/playground/_stories/fiori/Wizard/Wizard.stories.ts
@@ -21,7 +21,7 @@ export const Basic: StoryFn = () => html`
 				<ui5-message-strip>
 					The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 				</ui5-message-strip><br/>
-				<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+				<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 				</ui5-label>
 			</div>
 			<ui5-button id="wiz-${index}-toStep2" design="Emphasized">Step 2</ui5-button>
@@ -29,7 +29,7 @@ export const Basic: StoryFn = () => html`
 		<ui5-wizard-step icon="hint" title-text="Product Information" disabled="">
 			<div style="display: flex;flex-direction: column">
 				<ui5-title>2. Product Information</ui5-title><br/>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<div style="display: flex; flex-direction: column;">
@@ -60,7 +60,7 @@ export const Basic: StoryFn = () => html`
 		<ui5-wizard-step icon="action-settings" title-text="Options" disabled="">
 			<div style="display: flex; flex-direction: column;">
 				<ui5-title>3. Options</ui5-title><br/>
-				<ui5-label wrapping-type="Normal">
+				<ui5-label>
 					Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 				</ui5-label>
 				<ui5-message-strip>
@@ -133,14 +133,14 @@ export const PageMode: StoryFn = () => html`
 					<ui5-message-strip>
 						The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 					</ui5-message-strip><br/>
-					<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+					<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 					</ui5-label>
 				</div>
 			</ui5-wizard-step>
 			<ui5-wizard-step icon="hint" title-text="Product Information" disabled="">
 				<div style="display: flex;flex-direction: column">
 					<ui5-title>2. Product Information</ui5-title><br/>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<div style="display: flex; flex-direction: column;">
@@ -170,7 +170,7 @@ export const PageMode: StoryFn = () => html`
 			<ui5-wizard-step icon="action-settings" title-text="Options" disabled="">
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>3. Options</ui5-title><br/>
-					<ui5-label wrapping-type="Normal">
+					<ui5-label>
 						Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien corper eu, posuere malesuada nisl. Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec pulvinar, sapien
 					</ui5-label>
 					<ui5-message-strip>

--- a/packages/playground/_stories/fiori/Wizard/WizardStep/WizardStep.stories.ts
+++ b/packages/playground/_stories/fiori/Wizard/WizardStep/WizardStep.stories.ts
@@ -42,7 +42,7 @@ Basic.args = {
 	<ui5-message-strip>
 		The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to work with.
 	</ui5-message-strip><br/>
-	<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
+	<ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 	</ui5-label>
 </div>
 <ui5-button design="Emphasized">Step 2</ui5-button>`

--- a/packages/playground/_stories/main/Panel/Panel.stories.ts
+++ b/packages/playground/_stories/main/Panel/Panel.stories.ts
@@ -50,9 +50,9 @@ Basic.args = {
 	headerText: "Both expandable and expanded",
 	default: `
 	<ui5-title level="H1"> I am a heading! </ui5-title>
-	<ui5-label wrapping-type="Normal">Short text.</ui5-label>
+	<ui5-label>Short text.</ui5-label>
 	<br/>
-	<ui5-label wrapping-type="Normal">Another text.</ui5-label>
+	<ui5-label>Another text.</ui5-label>
 	<p class="content-color">Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
 		Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
 		commodo Lorem laboris nisi Lorem.

--- a/packages/website/docs/_components_pages/main/Label.mdx
+++ b/packages/website/docs/_components_pages/main/Label.mdx
@@ -17,16 +17,16 @@ import CustomStyling from "../../_samples/main/Label/CustomStyling/CustomStyling
 ## More Samples
 
 ### Text Truncation and Wrapping
-The Label wraps by default. To make it truncate - set <b>wrapping-type="None"</b>.
+The ui5-label wraps by default. To truncate it - set <b>wrapping-type="None"</b>.
 
 <TextWrapping />
 
 ### Label with Input
-The Labels' <b>for</b>, <b>required</b> and <b>showColon</b> properties can be used to reference inputs.
+The labels <b>for</b>, <b>required</b> and <b>showColon</b> properties can be used to reference inputs.
 
 <UsageWithInputs />
 
 ### Custom Styling
-The Labels can be customized with pure CSS, applied on the tag.
+The labels can be customized with pure CSS, applied on the tag.
 
 <CustomStyling />

--- a/packages/website/docs/_components_pages/main/Label.mdx
+++ b/packages/website/docs/_components_pages/main/Label.mdx
@@ -17,16 +17,16 @@ import CustomStyling from "../../_samples/main/Label/CustomStyling/CustomStyling
 ## More Samples
 
 ### Text Truncation and Wrapping
-The Label truncates by default. To make it wrap - set <b>wrapping-type="Normal"</b>.
+The Label wraps by default. To make it truncate - set <b>wrapping-type="None"</b>.
 
 <TextWrapping />
 
 ### Label with Input
-The Labes' <b>for</b>, <b>required</b> and <b>showColon</b> properties can be used to reference inputs.
+The Labels' <b>for</b>, <b>required</b> and <b>showColon</b> properties can be used to reference inputs.
 
 <UsageWithInputs />
 
 ### Custom Styling
-The Labes can be customized with pure CSS, applied on the tag.
+The Labels can be customized with pure CSS, applied on the tag.
 
 <CustomStyling />

--- a/packages/website/docs/_samples/fiori/Wizard/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/Wizard/Basic/sample.html
@@ -20,7 +20,7 @@
                     The Wizard control is supposed to break down large tasks, into smaller steps, easier for the user to
                     work with.
                 </ui5-message-strip><br />
-                <ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
+                <ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
                     sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat
                     diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor
                     lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim
@@ -35,7 +35,7 @@
         <ui5-wizard-step icon="hint" title-text="Product Information" disabled="">
             <div style="display: flex;flex-direction: column">
                 <ui5-title>2. Product Information</ui5-title><br />
-                <ui5-label wrapping-type="Normal">
+                <ui5-label>
                     Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem.
                     Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet
                     dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a
@@ -75,7 +75,7 @@
         <ui5-wizard-step icon="action-settings" title-text="Options" disabled="">
             <div style="display: flex; flex-direction: column;">
                 <ui5-title>3. Options</ui5-title><br />
-                <ui5-label wrapping-type="Normal">
+                <ui5-label>
                     Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem.
                     Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo sit amet
                     dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus, molestie a

--- a/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.html
+++ b/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.html
@@ -20,7 +20,7 @@
                         The Wizard control is supposed to break down large tasks, into smaller steps, easier for the
                         user to work with.
                     </ui5-message-strip><br />
-                    <ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
+                    <ui5-label>Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus
                         sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper,
                         volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend
                         tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec
@@ -34,7 +34,7 @@
             <ui5-wizard-step icon="hint" title-text="Product Information" disabled="">
                 <div style="display: flex;flex-direction: column">
                     <ui5-title>2. Product Information</ui5-title><br />
-                    <ui5-label wrapping-type="Normal">
+                    <ui5-label>
                         Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero
                         sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo
                         sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus,
@@ -74,7 +74,7 @@
             <ui5-wizard-step icon="action-settings" title-text="Options" disabled="">
                 <div style="display: flex; flex-direction: column;">
                     <ui5-title>3. Options</ui5-title><br />
-                    <ui5-label wrapping-type="Normal">
+                    <ui5-label>
                         Integer pellentesque leo sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero
                         sem. Suspendisse arcu metus, molestie a turpis a, molestie aliquet dui. Donec ppellentesque leo
                         sit amet dui vehicula, quis ullamcorper est pulvinar. Nam in libero sem. Suspendisse arcu metus,

--- a/packages/website/docs/_samples/main/Label/TextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/Label/TextWrapping/sample.html
@@ -12,9 +12,9 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-label for="myInputWrapping" class="w200">Label that demonstrates truncation, the long labels till truncate.</ui5-label>
+    <ui5-label class="w200">Label that demonstrates how the long labels could be wrapped. To test the truncation, use wrapping-type="None"</ui5-label>
     <br><br>
-    <ui5-label for="myInputWrapping" wrapping-type="Normal" class="w200">Label that demonstrates how, if set to wrapping-type="Normal", the long labels could be wrapped. To test the truncation, use 'wrapping-type="None"</ui5-label>
+    <ui5-label class="w200" wrapping-type="None">Label that demonstrates truncation, the long labels will truncate.</ui5-label>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>
 </body>

--- a/packages/website/docs/_samples/main/Label/TextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/Label/TextWrapping/sample.html
@@ -14,7 +14,7 @@
 
     <ui5-label class="w200">Label that demonstrates how the long labels could be wrapped. To test the truncation, use wrapping-type="None"</ui5-label>
     <br><br>
-    <ui5-label class="w200" wrapping-type="None">Label that demonstrates truncation, the long labels will truncate.</ui5-label>
+    <ui5-label class="w200" wrapping-type="None">Label that demonstrates truncation, the long labels will be truncated.</ui5-label>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>
 </body>

--- a/packages/website/docs/_samples/main/Panel/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Panel/Basic/sample.html
@@ -14,7 +14,7 @@
 
     <ui5-panel header-text="Panel">
         <ui5-title level="H5">Heading!</ui5-title>
-	    <ui5-label wrapping-type="Normal">
+	    <ui5-label>
             Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
 		    Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
 		    commodo Lorem laboris nisi Lorem.

--- a/packages/website/docs/_samples/main/Panel/CustomHeader/sample.html
+++ b/packages/website/docs/_samples/main/Panel/CustomHeader/sample.html
@@ -34,7 +34,7 @@
             </div>
 
             <ui5-title level="H5">Heading!</ui5-title>
-            <ui5-label wrapping-type="Normal">
+            <ui5-label>
                 Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
                 Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
                 commodo Lorem laboris nisi Lorem.

--- a/packages/website/docs/_samples/main/Panel/Fixed/sample.html
+++ b/packages/website/docs/_samples/main/Panel/Fixed/sample.html
@@ -14,7 +14,7 @@
 
     <ui5-panel header-text="Collapsed, Fixed Panel" fixed collapsed>
         <ui5-title level="H5">Heading!</ui5-title>
-	    <ui5-label wrapping-type="Normal">
+	    <ui5-label>
             Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
 		    Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
 		    commodo Lorem laboris nisi Lorem.
@@ -25,7 +25,7 @@
 
     <ui5-panel header-text="Expanded, Fixed Panel" fixed>
         <ui5-title level="H5">Heading!</ui5-title>
-	    <ui5-label wrapping-type="Normal">
+	    <ui5-label>
             Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
 		    Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
 		    commodo Lorem laboris nisi Lorem.

--- a/packages/website/docs/_samples/main/Panel/StickyHeader/sample.html
+++ b/packages/website/docs/_samples/main/Panel/StickyHeader/sample.html
@@ -15,7 +15,7 @@
     <div style="height: 250px; overflow: scroll;">
         <ui5-panel header-text="Sticky header" sticky-header>
             <ui5-title level="H5">Heading!</ui5-title>
-            <ui5-label wrapping-type="Normal">
+            <ui5-label>
                 Aute ullamco officia fugiat culpa do tempor tempor aute excepteur magna.
                 Quis velit adipisicing excepteur do eu duis elit. Sunt ea pariatur nulla est laborum proident sunt labore
                 commodo Lorem laboris nisi Lorem.


### PR DESCRIPTION
The text of `ui5-label` now wraps by default.

BREAKING CHANGE: `wrapping-type` property default value has changed from `None` to `Normal`.
Before: 
```html
<ui5-label>some very very very long label</ui5-label> <!-- would truncate the text if there is not enough space -->
```

Now:
```html
<ui5-label>some very very very long label</ui5-title> <!-- would let the text wrap if there is not enough space -->
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461
