### PR TITLE
fix(ui5-side-navigation): menu in collapsed mode width is not longer stretched unnecessary

### DIFF
--- a/packages/main/src/themes/NavigationMenu.css
+++ b/packages/main/src/themes/NavigationMenu.css
@@ -42,7 +42,6 @@
 
 .ui5-menu-rp.ui5-navigation-menu {
     box-shadow: var(--_ui5_side_navigation_popup_box_shadow);
-    width: auto;
     min-width: 10rem;
     height: auto;
     background: var(--sapGroup_ContentBackground);


### PR DESCRIPTION
Background:
After making the `ui5-responsive-popover` a native popover, `width: auto` stretches it to take the whole available space width.

Solution:
Make it take only as much as it needs by leveraging its default width `fit-content`.

Related to: https://github.com/SAP/ui5-webcomponents/issues/8739