### PR TITLE
refactor(ui5-popover): remove hideBackdrop property

### DIFF
--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -271,10 +271,6 @@ class Dialog extends Popup {
 		return true;
 	}
 
-	get shouldHideBackdrop() {
-		return false;
-	}
-
 	get _ariaLabelledBy() {
 		let ariaLabelledById;
 

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -139,15 +139,6 @@ class Popover extends Popup {
 	modal!: boolean;
 
 	/**
-	 * Defines whether the block layer will be shown if modal property is set to true.
-	 * @default false
-	 * @public
-	 * @since 1.0.0-rc.10
-	 */
-	@property({ type: Boolean })
-	hideBackdrop!: boolean;
-
-	/**
 	 * Determines whether the component arrow is hidden.
 	 * @default false
 	 * @public
@@ -751,10 +742,6 @@ class Popover extends Popup {
 
 	get isModal() { // Required by Popup.js
 		return this.modal;
-	}
-
-	get shouldHideBackdrop() { // Required by Popup.js
-		return this.hideBackdrop;
 	}
 
 	get _ariaLabelledBy() { // Required by Popup.js

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -276,7 +276,7 @@ abstract class Popup extends UI5Element {
 
 		this._opened = true;
 
-		if (this.isModal && !this.shouldHideBackdrop) {
+		if (this.isModal) {
 			Popup.blockPageScrolling(this);
 		}
 
@@ -555,12 +555,6 @@ abstract class Popup extends UI5Element {
 	 * @protected
 	 */
 	abstract get isModal(): boolean
-
-	/**
-	 * Implement this getter with relevant logic in order to hide the block layer (f.e. based on a public property)
-	 * @protected
-	 */
-	abstract get shouldHideBackdrop(): boolean
 
 	/**
 	 * Return the ID of an element in the shadow DOM that is going to label this popup

--- a/packages/main/src/themes/Popover.css
+++ b/packages/main/src/themes/Popover.css
@@ -90,7 +90,7 @@
 	transform: rotate(-45deg);
 }
 
-:host([modal]:not([hide-backdrop]))::backdrop {
+:host([modal])::backdrop {
 	background-color: var(--_ui5_popup_block_layer_background);
 }
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -177,7 +177,7 @@ z-index: 1;
 
 	<ui5-button id="btnPopModalNoLayer">Opens modal popover with no block layer!</ui5-button>
 
-	<ui5-popover id="modalPopoverNoLayer" modal header-text="Modal popover" hide-backdrop>
+	<ui5-popover id="modalPopoverNoLayer" modal header-text="Modal popover" class="hidebackdrop">
 		<ui5-list>
 			<ui5-li>Hello</ui5-li>
 			<ui5-li>Again</ui5-li>

--- a/packages/main/test/pages/styles/Popover.css
+++ b/packages/main/test/pages/styles/Popover.css
@@ -79,3 +79,7 @@ ui5-date-picker,
     justify-content: space-between;
 }
 
+.hidebackdrop::backdrop {
+	background: transparent;
+}
+

--- a/packages/playground/_stories/main/Popover/Popover.stories.ts
+++ b/packages/playground/_stories/main/Popover/Popover.stories.ts
@@ -34,7 +34,6 @@ const Template: UI5StoryArgs<Popover, StoryArgsSlots> = (args) => {
 	horizontal-align="${ifDefined(args.horizontalAlign)}"
 	vertical-align="${ifDefined(args.verticalAlign)}"
 	?modal="${ifDefined(args.modal)}"
-	?hide-backdrop="${ifDefined(args.hideBackdrop)}"
 	?hire-arrow="${ifDefined(args.hideArrow)}"
 	?allow-target-overlap="${ifDefined(args.allowTargetOverlap)}"
 	opener="${ifDefined(args.opener)}"

--- a/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
+++ b/packages/playground/_stories/main/ResponsivePopover/ResponsivePopover.stories.ts
@@ -34,7 +34,6 @@ const Template: UI5StoryArgs<ResponsivePopover, StoryArgsSlots> = (args) => {
 	horizontal-align="${ifDefined(args.horizontalAlign)}"
 	vertical-align="${ifDefined(args.verticalAlign)}"
 	?modal="${ifDefined(args.modal)}"
-	?hide-backdrop="${ifDefined(args.hideBackdrop)}"
 	?hire-arrow="${ifDefined(args.hideArrow)}"
 	?allow-target-overlap="${ifDefined(args.allowTargetOverlap)}"
 	opener="${ifDefined(args.opener)}"


### PR DESCRIPTION
Remove the hideBackdrop property

BREAKING CHANGE: Property `hideBackdrop` is removed.

Previously the application developers could define a modal popover without visible backdrop as follows:

```
<ui5-popover modal hide-backdrop>
```
Now the application developers can use the standard [`::backdrop` CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)


```

<style>
.transparentBackdrop::backdrop {
  background: transparent;
}
</style>

...

<ui5-popover modal class="transparentBackdrop">
```

Related to #8461