### PR TITLE
fix(ui5-side-navigation): overflow menu items are now displayed

### DIFF
--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -9,7 +9,7 @@ import Menu from "./Menu.js";
 import type { MenuItemClickEventDetail } from "./Menu.js";
 import StandardListItem from "./StandardListItem.js";
 import MenuItem from "./MenuItem.js";
-import type NavigationMenuItem from "./NavigationMenuItem.js";
+import NavigationMenuItem from "./NavigationMenuItem.js";
 import menuTemplate from "./generated/templates/NavigationMenuTemplate.lit.js";
 
 // Styles

--- a/packages/main/src/themes/NavigationMenu.css
+++ b/packages/main/src/themes/NavigationMenu.css
@@ -43,7 +43,6 @@
 .ui5-menu-rp.ui5-navigation-menu {
     box-shadow: var(--_ui5_side_navigation_popup_box_shadow);
     min-width: 10rem;
-    height: auto;
     background: var(--sapGroup_ContentBackground);
     border: none;
     border-radius: 0.75rem;


### PR DESCRIPTION
Problem: `NavigationMenuItem` was not proper dependency of `SideNavigation`, therefore the private `ui5-navigation-menu-item` elements were not upgraded.

Solution: Import `NavigationMenuItem`.

Also fixes height issue that appeared after Popover API adoption.

Fixes https://github.com/SAP/ui5-webcomponents/issues/8242
