### PR TITLE
fix(ui5-popup): remove popup from the tab chain

### DIFF
--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -5,6 +5,7 @@
 	style="{{styles.root}}"
 	class="{{classes.root}}"
 	role="{{_role}}"
+    tabindex="-1"
 	aria-modal="{{_ariaModal}}"
 	aria-label="{{_ariaLabel}}"
 	aria-labelledby="{{_ariaLabelledBy}}"

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -6,7 +6,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import { isChrome, isSafari, isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
+import { isChrome, isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import { getFirstFocusableElement, getLastFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AriaLabelHelper.js";
 import getEffectiveScrollbarStyle from "@ui5/webcomponents-base/dist/util/getEffectiveScrollbarStyle.js";
@@ -227,6 +227,8 @@ abstract class Popup extends UI5Element {
 		if (isDesktop()) {
 			this.setAttribute("desktop", "");
 		}
+
+		this.tabIndex = -1;
 	}
 
 	onExitDOM() {
@@ -368,10 +370,6 @@ abstract class Popup extends UI5Element {
 	}
 
 	_onmousedown(e: MouseEvent) {
-		if (!isSafari()) { // Remove when adopting native dialog
-			this._root.removeAttribute("tabindex");
-		}
-
 		if (this.shadowRoot!.contains(e.target as HTMLElement)) {
 			this._shouldFocusRoot = true;
 		} else {
@@ -380,10 +378,6 @@ abstract class Popup extends UI5Element {
 	}
 
 	_onmouseup() {
-		if (!isSafari()) { // Remove when adopting native dialog
-			this._root.tabIndex = -1;
-		}
-
 		if (this._shouldFocusRoot) {
 			if (isChrome()) {
 				this._root.focus();
@@ -454,9 +448,6 @@ abstract class Popup extends UI5Element {
 		element = element || await getFirstFocusableElement(this) || this._root; // in case of no focusable content focus the root
 
 		if (element) {
-			if (element === this._root) {
-				element.tabIndex = -1;
-			}
 			element.focus();
 		}
 	}


### PR DESCRIPTION
Now the popup has tabindex=-1 and it is not a part of the page tab chain