### PR TITLE
fix(ui5-side-navigation-item): click event is no longer fired twice

### DIFF
--- a/packages/fiori/src/SideNavigationSelectableItemBase.ts
+++ b/packages/fiori/src/SideNavigationSelectableItemBase.ts
@@ -162,6 +162,8 @@ class SideNavigationSelectableItemBase extends SideNavigationItemBase {
 	}
 
 	_activate(e: KeyboardEvent | PointerEvent) {
+		e.stopPropagation();
+
 		if (this.isOverflow) {
 			this.fireEvent("click");
 		} else {

--- a/packages/fiori/test/pages/SideNavigation.html
+++ b/packages/fiori/test/pages/SideNavigation.html
@@ -54,6 +54,7 @@
 				<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
 			</ui5-side-navigation-item>
 			<ui5-side-navigation-item disabled id="item1" text="Home" icon="home" title="Home tooltip"></ui5-side-navigation-item>
+			<ui5-side-navigation-item id="toggle" text="Toggle" icon="menu"></ui5-side-navigation-item>
 
 			<!-- Fixed Items -->
 			<ui5-side-navigation-item id="fixedItem1" slot="fixedItems" text="Useful Links" icon="chain-link" title="Useful links tooltip">
@@ -96,8 +97,12 @@
 			sideNavigation.collapsed = !sideNavigation.collapsed;
 		});
 
+		document.getElementById("toggle").addEventListener("click", () => {
+			sideNavigation.collapsed = !sideNavigation.collapsed;
+		});
+
 		document.querySelectorAll("ui5-side-navigation-item").forEach(function (item) {
-			item.addEventListener("ui5-click", function (event) {
+			item.addEventListener("click", function (event) {
 				clickInput.value = ++clickCounter;
 			});
 		});

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -226,9 +226,9 @@ describe("Component Behavior", () => {
 
 			// fixed items
 			assert.strictEqual(await sideNavigationFixedTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation fixed tree element is correctly set");
-			assert.notExists(await items[8].getAttribute("aria-roledescription"), "Role description of the SideNavigation fixed tree item is not set");
-			assert.strictEqual(await items[8].getAttribute("aria-haspopup"), "tree", "There is 'aria-haspopup' with correct value");
-			assert.notExists(await items[9].getAttribute("aria-haspopup"), "There is no 'aria-haspopup'");
+			assert.notExists(await items[9].getAttribute("aria-roledescription"), "Role description of the SideNavigation fixed tree item is not set");
+			assert.strictEqual(await items[9].getAttribute("aria-haspopup"), "tree", "There is 'aria-haspopup' with correct value");
+			assert.notExists(await items[10].getAttribute("aria-haspopup"), "There is no 'aria-haspopup'");
 
 			// popup
 			await browser.$("#item2").click();


### PR DESCRIPTION
Downport of [0dd36ca](https://github.com/SAP/ui5-webcomponents/commit/0dd36ca4b84c3b73fbb9c9cd44cee3d7b6e97d2a)
