### PR TITLE
fix(ui5-*): Make setAnimationMode() properly change modes

### DIFF
--- a/packages/base/src/config/AnimationMode.ts
+++ b/packages/base/src/config/AnimationMode.ts
@@ -22,7 +22,8 @@ const getAnimationMode = (): `${AnimationMode}` => {
  * @param { AnimationMode } animationMode
  */
 const setAnimationMode = (animationMode: `${AnimationMode}`) => {
-	if (animationMode in AnimationMode) {
+	const options: string[] = Object.values(AnimationMode);
+	if (options.includes(animationMode)) {
 		curAnimationMode = animationMode;
 	}
 };


### PR DESCRIPTION
As currently written, it is impossible to use `setAnimationMode()` to disable animations because it is impossible to set the current mode to a valid option.  The conditional statement `if (animationMode in AnimationMode)` checks if the the passed-in `animationMode` matches one of the property/key names of the `AnimationMode` enum (the uppercase strings "Full", "Basic", "Minimal", or "None") rather than the actual values (lowercase strings), which means the uppercase values are the only options the function recognizes and will change the current mode to.  However, when a component like the `ui5-progress-indicator` checks whether to use animations, it compares the current animation mode to the lowercase string "none", which means animations will always be used regardless of what is passed to `setAnimationMode()`.  By comparing to the enum values, `setAnimationMode()` will properly recognize the lowercase strings (as I believe was intended) and set the current mode to a valid option, making it possible to disable animation.

Fixes #8964