### PR TITLE
refactor(ui5-toast): rename event `after-close` to `close`

### DIFF
--- a/docs/Migrating to version 2.0 guide.md
+++ b/docs/Migrating to version 2.0 guide.md
@@ -600,6 +600,9 @@ it will no longer work for the component. Instead, do not render disabled option
 | Property                     | `horizontalAlign` | values have changed, f.e. `Left` to `Start` | 
 | Property                     | `placementType` | `placement` | 
 | `placement` type enumeration | `PopoverPlacementType` | `PopoverPlacement` | 
+| Event        | after-open  | open  | 
+| Event        | after-close  | close  | 
+
 
 - The `Left` and `Right` options have been renamed. If you previously used them to set the placement or the alignment of the popover:
 ```html
@@ -624,6 +627,23 @@ Now use `placement` instead:
 ```
 ```js
 import PopoverPlacement from "@ui5/webcomponents/dist/types/PopoverPlacement.js";
+```
+
+- The events `after-close` and `after-open`  have been renamed to `open` and `close` respectively.
+If you previously used the events like:
+
+```ts
+poover.addEventListener("after-open", (event) => {
+});
+poover.addEventListener("after-close", (event) => {
+});
+```
+Now you have to use it like:
+```ts
+poover.addEventListener("open", (event) => {
+});
+poover.addEventListener("close", (event) => {
+});
 ```
 
 ### ui5-progress-indicator
@@ -980,7 +1000,7 @@ Now you have to use it like:
 
 | Changed item | Old          | New    | 
 |--------------|--------------|--------|
-| event        | after-close  | close  | 
+| Event        | after-close  | close  | 
 
 - The event `after-close`  has been renamed to `close`. If you previously used it like:
 

--- a/docs/Migrating to version 2.0 guide.md
+++ b/docs/Migrating to version 2.0 guide.md
@@ -976,6 +976,24 @@ Now you have to use it like:
 <ui5-tree-item additional-text-state="Success"></ui5-tree-item>
 ```
 
+### ui5-toast
+
+| Changed item | Old          | New    | 
+|--------------|--------------|--------|
+| event        | after-close  | close  | 
+
+- The event `after-close`  has been renamed to `close`. If you previously used it like:
+
+```ts
+toast.addEventListener("after-close", (event) => {
+});
+```
+Now you have to use it like:
+```ts
+toast.addEventListener("close", (event) => {
+});
+```
+
 
 ## Fiori package (@ui5/webcomponents-fiori)
 

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -645,8 +645,8 @@ class Select extends UI5Element implements IFormInputElement {
 	}
 
 	attachMenuListeners(menu: HTMLElement) {
-		menu.addEventListener("ui5-after-close", this._onMenuClose);
-		menu.addEventListener("ui5-after-open", this._onMenuOpen);
+		menu.addEventListener("ui5-close", this._onMenuClose);
+		menu.addEventListener("ui5-open", this._onMenuOpen);
 		menu.addEventListener("ui5-before-open", this._onMenuBeforeOpen);
 		// @ts-ignore
 		menu.addEventListener("ui5-option-click", this._onMenuClick);
@@ -655,8 +655,8 @@ class Select extends UI5Element implements IFormInputElement {
 	}
 
 	detachMenuListeners(menu: HTMLElement) {
-		menu.removeEventListener("ui5-after-close", this._onMenuClose);
-		menu.removeEventListener("ui5-after-open", this._onMenuOpen);
+		menu.removeEventListener("ui5-close", this._onMenuClose);
+		menu.removeEventListener("ui5-open", this._onMenuOpen);
 		menu.removeEventListener("ui5-before-open", this._onMenuBeforeOpen);
 		// @ts-ignore
 		menu.removeEventListener("ui5-option-click", this._onMenuClick);

--- a/packages/main/src/SelectMenu.ts
+++ b/packages/main/src/SelectMenu.ts
@@ -79,8 +79,8 @@ type SelectMenuChange = {
 	},
 })
 @event("before-open")
-@event("after-open")
-@event("after-close")
+@event("open")
+@event("close")
 @event<SelectMenuChange>("menu-change", {
 	detail: {
 		text: { type: String },
@@ -222,11 +222,11 @@ class SelectMenu extends UI5Element {
 	}
 
 	_onAfterOpen() {
-		this.fireEvent<CustomEvent>("after-open");
+		this.fireEvent<CustomEvent>("open");
 	}
 
 	_onAfterClose() {
-		this.fireEvent<CustomEvent>("after-close");
+		this.fireEvent<CustomEvent>("close");
 	}
 
 	_onCloseBtnClick() {

--- a/packages/main/src/Toast.ts
+++ b/packages/main/src/Toast.ts
@@ -91,7 +91,7 @@ const handleGlobalKeydown = (e: KeyboardEvent) => {
  * @public
  * @since 2.0.0
  */
-@event("after-close")
+@event("close")
 
 class Toast extends UI5Element {
 	/**
@@ -226,7 +226,7 @@ class Toast extends UI5Element {
 		this.open = false;
 		this.focusable = false;
 		this.focused = false;
-		this.fireEvent("after-close");
+		this.fireEvent("close");
 	}
 
 	_onmouseover() {

--- a/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
+++ b/packages/playground/_stories/main/SplitButton/SplitButton.stories.ts
@@ -57,7 +57,7 @@ OpeningMenu.decorators = [
 		}
 	});
 	
-	menu.addEventListener("after-close", function() {
+	menu.addEventListener("close", function() {
 		splitBtn.activeArrowButton = false;
 	});
 	</script>`;}


### PR DESCRIPTION
ui5-toast:  rename event `after-close` to `close`

BREAKING CHANGE: The `after-close`  event has been renamed to `close`. If you previously used it like:
```ts
toast.addEventListener("after-close", (event) => {
});
```
Now you have to use it like:
```ts
toast.addEventListener("close", (event) => {
});
```

Related to: https://github.com/SAP/ui5-webcomponents/issues/8461