### PR TITLE
fix(ui5-calendar): respect component level calendarType in week calculation

### DIFF
--- a/packages/localization/src/dates/calculateWeekNumber.ts
+++ b/packages/localization/src/dates/calculateWeekNumber.ts
@@ -1,9 +1,10 @@
 import type Locale from "@ui5/webcomponents-base/dist/locale/Locale.js";
+import CalendarType from "@ui5/webcomponents-base/dist/types/CalendarType.js";
 import UniversalDate from "./UniversalDate.js";
 import type LocaleData from "../LocaleData.js";
 import type UI5Date from "./UI5Date.js";
 
-const calculateWeekNumber = (confFirstDayOfWeek: number | undefined, oDate: Date | UI5Date, iYear: number, oLocale: Locale, oLocaleData: LocaleData) => {
+const calculateWeekNumber = (confFirstDayOfWeek: number | undefined, oDate: Date | UI5Date, iYear: number, oLocale: Locale, oLocaleData: LocaleData, calendarType: CalendarType) => {
 	let iWeekNum = 0;
 	let iWeekDay = 0;
 	const iFirstDayOfWeek = Number.isInteger(confFirstDayOfWeek) ? confFirstDayOfWeek! : oLocaleData.getFirstDayOfWeek();
@@ -17,12 +18,12 @@ const calculateWeekNumber = (confFirstDayOfWeek: number | undefined, oDate: Date
 			* The first week of the year starts with January 1st. But Dec. 31 is still in the last year
 			* So the week beginning in December and ending in January has 2 week numbers
 			*/
-		const oJanFirst = new UniversalDate(oDate.getTime());
+		const oJanFirst = UniversalDate.getInstance(oDate, calendarType);
 		oJanFirst.setUTCFullYear(iYear, 0, 1);
 		iWeekDay = oJanFirst.getUTCDay();
 
 		// get the date for the same weekday like jan 1.
-		const oCheckDate = new UniversalDate(oDate.getTime());
+		const oCheckDate = UniversalDate.getInstance(oDate, calendarType);
 		oCheckDate.setUTCDate(oCheckDate.getUTCDate() - oCheckDate.getUTCDay() + iWeekDay);
 
 		iWeekNum = Math.round((oCheckDate.getTime() - oJanFirst.getTime()) / 86400000 / 7) + 1;
@@ -30,19 +31,19 @@ const calculateWeekNumber = (confFirstDayOfWeek: number | undefined, oDate: Date
 		// normally the first week of the year is the one where the first Thursday of the year is
 		// find Thursday of this week
 		// if the checked day is before the 1. day of the week use a day of the previous week to check
-		const oThursday = new UniversalDate(oDate.getTime());
+		const oThursday = UniversalDate.getInstance(oDate, calendarType);
 		oThursday.setUTCDate(oThursday.getUTCDate() - iFirstDayOfWeek);
 		iWeekDay = oThursday.getUTCDay();
 		oThursday.setUTCDate(oThursday.getUTCDate() - iWeekDay + 4);
 
-		const oFirstDayOfYear = new UniversalDate(oThursday.getTime());
+		const oFirstDayOfYear = UniversalDate.getInstance(new Date(oThursday.getTime()), calendarType);
 		oFirstDayOfYear.setUTCMonth(0, 1);
 		iWeekDay = oFirstDayOfYear.getUTCDay();
 		let iAddDays = 0;
 		if (iWeekDay > 4) {
 			iAddDays = 7; // first day of year is after Thursday, so first Thursday is in the next week
 		}
-		const oFirstThursday = new UniversalDate(oFirstDayOfYear.getTime());
+		const oFirstThursday = UniversalDate.getInstance(new Date(oFirstDayOfYear.getTime()), calendarType);
 		oFirstThursday.setUTCDate(1 - iWeekDay + 4 + iAddDays);
 
 		iWeekNum = Math.round((oThursday.getTime() - oFirstThursday.getTime()) / 86400000 / 7) + 1;

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -312,7 +312,7 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 
 			if (dayOfTheWeek === DAYS_IN_WEEK - 1) { // 0-indexed so 6 is the last day of the week
 				week.unshift({
-					weekNum: calculateWeekNumber(getFirstDayOfWeek(), tempDate.toUTCJSDate(), tempDate.getYear(), getLocale(), localeData),
+					weekNum: calculateWeekNumber(getFirstDayOfWeek(), tempDate.toUTCJSDate(), tempDate.getYear(), getLocale(), localeData, this._primaryCalendarType as CalendarType),
 					isHidden: this.shouldHideWeekNumbers,
 				});
 			}


### PR DESCRIPTION
Previously when a `calendarType` was being set to `Islamic` or `Buddhist` in the document configuration, and a `primary-calendar-type="Gregorian"` on a date component level where week numbering is present, for example `<ui5-date-picker primary-calendar-type="Gregorian">`, `<ui5-calendar primary-calendar-type="Gregorian"`, etc the week numbers were calculated wrong.

```js
	<script data-ui5-config type="application/json">
	{
          "language": "en_US",
          "rtl": false,
          "calendarType": "Islamic"
        }
	</script>
```

```html
<ui5-date-picker primary-calendar-type="Gregorian"></ui5-date-picker>
```
	

![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/864f273d-25ea-47cf-8879-879a539cddbb)


After the change, the weeks are calculated correctly now.

![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/09dcf52e-fb04-4e65-b8ec-fd69033a9fd2)

Fixes: #6835