### PR TITLE
fix(dynamic-page): final review visual issues

### DIFF
--- a/packages/fiori/src/DynamicPage.hbs
+++ b/packages/fiori/src/DynamicPage.hbs
@@ -42,12 +42,17 @@
 </div>
 
 {{#*inline "header-actions"}}
-	<ui5-dynamic-page-header-actions
-		?snapped="{{headerSnapped}}"
-		?pinned="{{headerPinned}}"
-		?hide-pin-button="{{hidePinButton}}"
-		.accessibilityAttributes="{{_accAttributesForHeaderActions}}"
-		@ui5-expand-button-click={{onExpandClick}}
-		@ui5-pin-button-click={{onPinClick}}>
-	</ui5-dynamic-page-header-actions>
+	{{#if showHeaderActions}}
+		<ui5-dynamic-page-header-actions
+			?snapped="{{headerSnapped}}"
+			?pinned="{{headerPinned}}"
+			?hide-pin-button="{{hidePinButton}}"
+			.accessibilityAttributes="{{_accAttributesForHeaderActions}}"
+			@ui5-expand-button-click={{onExpandClick}}
+			@ui5-pin-button-click={{onPinClick}}
+			@ui5-expand-button-hover-in={{onExpandHoverIn}}
+			@ui5-expand-button-hover-out={{onExpandHoverOut}}
+			>
+		</ui5-dynamic-page-header-actions>
+	{{/if}}
 {{/inline}}

--- a/packages/fiori/src/DynamicPage.hbs
+++ b/packages/fiori/src/DynamicPage.hbs
@@ -1,5 +1,5 @@
 <div class="ui5-dynamic-page-root">
-	<div class="ui5-dynamic-page-scroll-container" @scroll="{{snapOnScroll}}">
+	<div  class="ui5-dynamic-page-scroll-container" @scroll="{{snapOnScroll}}">
 		<header
 			class="ui5-dynamic-page-title-header-wrapper"
 			id="{{_id}}-header"
@@ -10,7 +10,7 @@
 		>
 			<slot name="titleArea"></slot>
 			{{#if headerInTitle}}
-				<slot name="headerArea"></slot>
+				<slot tabindex="{{headerTabIndex}}" ?aria-hidden="{{headerAriaHidden}}" name="headerArea"></slot>
 			{{/if}}
 
 			{{#if actionsInTitle}}
@@ -19,7 +19,7 @@
 		</header>
 
 		{{#if headerInContent}}
-			<slot name="headerArea"></slot>
+			<slot tabindex="{{headerTabIndex}}" ?aria-hidden="{{headerAriaHidden}}" name="headerArea"></slot>
 		{{/if}}
 
 		{{#unless actionsInTitle}}

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -96,7 +96,7 @@ const SCROLL_THRESHOLD = 10; // px
 	renderer: litRender,
 	styles: DynamicPageCss,
 	template: DynamicPageTemplate,
-	dependencies: [DynamicPageHeader, DynamicPageTitle, DynamicPageHeaderActions],
+	dependencies: [DynamicPageHeaderActions],
 })
 
 /**
@@ -220,6 +220,7 @@ class DynamicPage extends UI5Element {
 	onBeforeRendering() {
 		if (this.dynamicPageTitle) {
 			this.dynamicPageTitle.snapped = this.headerSnapped;
+			this.dynamicPageTitle.toggleAttribute("interactive", this.showHeaderActions);
 		}
 	}
 
@@ -275,6 +276,10 @@ class DynamicPage extends UI5Element {
 		return (this.headerSnapped || this.headerSnappedByInteraction);
 	}
 
+	get showHeaderActions() {
+		return this.headerArea.length > 0;
+	}
+
 	snapOnScroll() {
 		debounce(() => this.snapTitleByScroll(), SCROLL_DEBOUNCE_RATE);
 	}
@@ -294,8 +299,8 @@ class DynamicPage extends UI5Element {
 		this.headerSnappedByInteraction = false;
 
 		if (scrollTop > this.dynamicPageHeader.getBoundingClientRect().height) {
-			this.headerSnapped = true;
 			this.showHeaderInStickArea = false;
+			this.headerSnapped = true;
 		} else {
 			this.headerSnapped = false;
 		}
@@ -329,6 +334,7 @@ class DynamicPage extends UI5Element {
 		if (this.scrollContainer!.scrollTop === SCROLL_THRESHOLD) {
 			this.scrollContainer!.scrollTop = 0;
 		}
+
 		this.showHeaderInStickArea = !this.showHeaderInStickArea;
 		this.headerSnapped = !this.headerSnapped;
 		this.headerSnappedByInteraction = this.headerSnapped;
@@ -339,6 +345,16 @@ class DynamicPage extends UI5Element {
 		if (this.headerSnapped && this.scrollContainer!.scrollTop < SCROLL_THRESHOLD) {
 			this.scrollContainer!.scrollTop = SCROLL_THRESHOLD;
 		}
+	}
+
+	async onExpandHoverIn() {
+		this.dynamicPageTitle?.setAttribute("hovered", "");
+		await renderFinished();
+	}
+
+	async onExpandHoverOut() {
+		this.dynamicPageTitle?.removeAttribute("hovered");
+		await renderFinished();
 	}
 
 	updateMediaRange() {

--- a/packages/fiori/src/DynamicPageHeaderActions.hbs
+++ b/packages/fiori/src/DynamicPageHeaderActions.hbs
@@ -2,11 +2,13 @@
     <div class="ui5-dynamic-page-header-actions--wrapper">
         <ui5-button
             class="ui5-dynamic-page-header-action ui5-dynamic-page-header-action-expand"
-            @click="{{onExpandClick}}" 
+            @click="{{onExpandClick}}"
             icon="{{arrowButtonIcon}}"
             accessible-name="{{expandLabel}}"
             .accessibilityAttributes="{{accessibilityAttributes}}"
             title="{{expandLabel}}"
+            @mouseover="{{onExpandHoverIn}}"
+            @mouseout="{{onExpandHoverOut}}"
         ></ui5-button>
     {{#if showPinButton}}
         <ui5-toggle-button

--- a/packages/fiori/src/DynamicPageHeaderActions.ts
+++ b/packages/fiori/src/DynamicPageHeaderActions.ts
@@ -64,6 +64,13 @@ import {
  */
 @event("pin-button-click")
 
+/**
+ * Event that is being fired by hovering over the expand button.
+ *
+ * @protected
+ */
+@event("expand-button-hover")
+
 class DynamicPageHeaderActions extends UI5Element {
 	/**
 	 * Defines whether the header is pinned.
@@ -150,6 +157,14 @@ class DynamicPageHeaderActions extends UI5Element {
 
 	onPinClick() {
 		this.fireEvent("pin-button-click");
+	}
+
+	onExpandHoverIn() {
+		this.fireEvent("expand-button-hover-in");
+	}
+
+	onExpandHoverOut() {
+		this.fireEvent("expand-button-hover-out");
 	}
 
 	get showPinButton() {

--- a/packages/fiori/src/DynamicPageTitle.ts
+++ b/packages/fiori/src/DynamicPageTitle.ts
@@ -134,7 +134,7 @@ class DynamicPageTitle extends UI5Element {
 	 * @public
 	 */
 	@slot({ type: HTMLElement })
-	navigationActions!: HTMLElement[];
+	navigationActions!: Array<Toolbar>;
 
 	/**
 	 * Defines the content of the Dynamic page title.

--- a/packages/fiori/src/themes/DynamicPageTitle.css
+++ b/packages/fiori/src/themes/DynamicPageTitle.css
@@ -13,6 +13,10 @@
     border-bottom: var(--_ui5_dynamic_page_title_border);
 }
 
+:host(:not([interactive])) {
+    box-shadow: var(--_ui5_dynamic_page_header-box-shadow);
+}
+
 :host .ui5-dynamic-page-title-root {
     display: inherit;
     flex-direction: inherit;
@@ -20,7 +24,8 @@
     height: inherit;
 }
 
-:host(:hover) {
+:host:host([interactive]:hover),
+:host:host([interactive][hovered]) {
     background-color: var(--_ui5_dynamic_page_title_hover_background);
     cursor: pointer;
     border-bottom: var(--_ui5_dynamic_page_title_hover_border);

--- a/packages/fiori/test/pages/DynamicPage.html
+++ b/packages/fiori/test/pages/DynamicPage.html
@@ -47,7 +47,6 @@
                     <ui5-toolbar-button design="Transparent" icon="action-settings"></ui5-toolbar-button>
                 </ui5-toolbar>
             </ui5-dynamic-page-title>
-
             <ui5-dynamic-page-header slot="headerArea">
                 <div class="product-info">
                     <ui5-avatar id="avatar" shape="square" icon="laptop" color-scheme="Accent5" size="L"></ui5-avatar>
@@ -65,7 +64,6 @@
                     </div>
                 </div>
             </ui5-dynamic-page-header>
-
             <ui5-list header-text="Products (13)" mode="SingleSelect">
                 <ui5-li description="HT-2001" icon="slim-arrow-right" icon-end additional-text="47.00 EUR">10 inch Portable DVD</ui5-li>
                 <ui5-li description="HT-2001" icon="slim-arrow-right" icon-end additional-text="249.00 EUR">7 inch WidescreenPortable DVD Player w MP3</ui5-li>


### PR DESCRIPTION
Issues fixed:
1. Expand / collapse, pin buttons are visible even if header is not used
2. Title is missing visual separator (shadow) when header doesn't exist
3. If the header is snapped while the user is at the top of the page, it can't be expanded via scroll (deviation with openui5)
4. If the user starts to scroll from the position where header is snapped (basically around 0-5 top) and scroll a bit up the whole header appear.
5. Hovering expand / collapse button doesn't change ui5-dynamic-page-title background color
6. Only DynamicPageHeaderActions class should be described here since it's the only component of the family that is used directly in the hbs template.
7. why do we need to use querySelector here instead of this.navigationActions. In the documentation of the slot it's not described that we expect ui5-toolbar so if we do it we can describe the slot as:

	@slot({ type: HTMLElement })
	navigationActions!: Array<Toolbar>;
8. 