### PR TITLE
chore: add links to interfaces/class definitions

### DIFF
--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -232,7 +232,7 @@ class NotificationListItem extends NotificationListItemBase {
 	*
 	* **Note:** Use this for implementing actions.
 	*
-	* **Note:** Should be used instead `u5-notification-action`, which is deprecated as of version 2.0.
+	* **Note:** Should be used instead `ui5-notification-action`, which is deprecated as of version 2.0.
 	* @public
 	*/
 	@slot()

--- a/packages/website/build-scripts/api-reference-generation/autocomplete-hints.mjs
+++ b/packages/website/build-scripts/api-reference-generation/autocomplete-hints.mjs
@@ -2,7 +2,7 @@ import { getAutocompleteData } from "./manifest.mjs";
 import { writeFile } from "fs/promises";
 
 function generateAutocompleteHints() {
-    console.log(JSON.stringify(getAutocompleteData(), 2, 2));
+    // console.log(JSON.stringify(getAutocompleteData(), 2, 2));
     writeFile("src/components/Editor/ui5-autocomplete.json", JSON.stringify(getAutocompleteData(), 2, 2));
 }
 


### PR DESCRIPTION
With this change, link to the corresponding type is added for each property / slot type, if the type points interface or class.

![image](https://github.com/SAP/ui5-webcomponents/assets/31909318/1e3108c5-0117-43b9-9eea-0753b76d3a72)