### PR TITLE
fix(ui5-illustrated-mesasge): update subtitle color

### DIFF
--- a/packages/fiori/src/themes/IllustratedMessage.css
+++ b/packages/fiori/src/themes/IllustratedMessage.css
@@ -60,7 +60,7 @@
     font-size: var(--sapFontLargeSize);
     font-family: var(--sapFontFamily);
     line-height: 1.4;
-    color: var(--sapContent_LabelColor);
+    color: var(--sapTextColor);
     margin-bottom: 0.5rem;
     max-width: 61.9375rem;
 }


### PR DESCRIPTION
The specs have been updated and now the subtitle color should use `--sapTextColor` variable, instead of `--sapContent_LabelColor`.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/8984