### PR TITLE
chore: show form header line only if headerText or header slot

### DIFF
--- a/packages/main/src/Form.hbs
+++ b/packages/main/src/Form.hbs
@@ -1,11 +1,13 @@
 <div class="ui5-form-root" role="form" aria-labelledby="{{ariaLabelledByID}}">
-	<div class="ui5-form-header" part="header">
-		{{#if hasCustomHeader}}
-			<slot name="header"></slot>
-		{{else}}
-			<ui5-title id="{{_id}}-header-text" level="H4">{{ headerText }}</ui5-title>
-		{{/if}}
-	</div>
+	{{#if hasHeader}}
+		<div class="ui5-form-header" part="header">
+			{{#if hasCustomHeader}}
+				<slot name="header"></slot>
+			{{else}}
+				<ui5-title id="{{_id}}-header-text" level="H4">{{ headerText }}</ui5-title>
+			{{/if}}
+		</div>
+	{{/if}}
 
 	<div class="ui5-form-layout" part="layout">
 			{{#if this.hasGroupItems}}

--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -343,6 +343,10 @@ class Form extends UI5Element {
 		return this.items.some((item: IFormItem) => item.isGroup);
 	}
 
+	get hasHeader(): boolean {
+		return this.hasCustomHeader || !!this.headerText;
+	}
+
 	get hasCustomHeader(): boolean {
 		return !!this.header.length;
 	}


### PR DESCRIPTION
Form header line is displayed even if headerText="" empty string and looks strange. 
Show form header line only if non-empty headerText or header slot are present.