### PR TITLE
chore: allow setting string to Popover#opener in TS env

### DIFF
--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -251,20 +251,7 @@ class Popover extends Popup {
 			return;
 		}
 
-		let opener;
-
-		if (this.opener instanceof HTMLElement) {
-			opener = this.opener;
-		} else if (typeof this.opener === "string") {
-			const rootNode = this.getRootNode();
-			if (rootNode instanceof Document) {
-				opener = rootNode.getElementById(this.opener);
-			}
-
-			if (!opener) {
-				opener = document.getElementById(this.opener);
-			}
-		}
+		const opener = this.getOpenerHTMLElement(this.opener);
 
 		if (!opener) {
 			console.warn("Valid opener id is required. It must be defined before opening the popover."); // eslint-disable-line
@@ -313,6 +300,19 @@ class Popover extends Popup {
 		removeOpenedPopover(this);
 	}
 
+	getOpenerHTMLElement(opener: HTMLElement | string | undefined): HTMLElement | null | undefined {
+		if (opener === undefined || opener instanceof HTMLElement) {
+			return opener;
+		}
+
+		const rootNode = this.getRootNode();
+
+		if (rootNode instanceof Document) {
+			return rootNode.getElementById(opener);
+		}
+		return document.getElementById(opener);
+	}
+
 	shouldCloseDueToOverflow(placement: `${PopoverPlacement}`, openerRect: DOMRect): boolean {
 		const threshold = 32;
 		const limits = {
@@ -322,7 +322,8 @@ class Popover extends Popup {
 			"Bottom": openerRect.bottom,
 		};
 
-		const closedPopupParent = getClosedPopupParent(this._opener!);
+		const opener = this.getOpenerHTMLElement(this.opener);
+		const closedPopupParent = getClosedPopupParent(opener!);
 		let overflowsBottom = false;
 		let overflowsTop = false;
 
@@ -381,7 +382,7 @@ class Popover extends Popup {
 
 		if (this.open) {
 			// update opener rect if it was changed during the popover being opened
-			this._openerRect = this._opener!.getBoundingClientRect();
+			this._openerRect = this.getOpenerHTMLElement(this.opener)!.getBoundingClientRect();
 		}
 
 		if (this.shouldCloseDueToNoOpener(this._openerRect!) && this.isFocusWithin() && this._oldPlacement) {

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -205,7 +205,7 @@ class Popover extends Popup {
 	@slot({ type: HTMLElement })
 	footer!: Array<HTMLElement>;
 
-	_opener?: HTMLElement;
+	_opener?: HTMLElement | string;
 	_openerRect?: DOMRect;
 	_preventRepositionAndClose?: boolean;
 	_top?: number;
@@ -230,7 +230,7 @@ class Popover extends Popup {
 	 * @since 1.2.0
 	 */
 	@property({ validator: DOMReference })
-	set opener(value: HTMLElement) {
+	set opener(value: HTMLElement | string) {
 		if (this._opener === value) {
 			return;
 		}
@@ -242,7 +242,7 @@ class Popover extends Popup {
 		}
 	}
 
-	get opener(): HTMLElement | undefined {
+	get opener(): HTMLElement | string | undefined {
 		return this._opener;
 	}
 

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -460,7 +460,7 @@ class TextArea extends UI5Element implements IFormInputElement {
 	openPopover() {
 		this.valueStatePopover = this._getPopover();
 		if (this.valueStatePopover) {
-			this.valueStatePopover.opener = this.shadowRoot!.querySelector(".ui5-textarea-root .ui5-textarea-wrapper")!;
+			this.valueStatePopover.opener = this.shadowRoot!.querySelector<HTMLElement>(".ui5-textarea-root .ui5-textarea-wrapper")!;
 			this.valueStatePopover.open = true;
 		}
 	}


### PR DESCRIPTION
In TS env currently one can't set string id as opener declaratively as the TS type definition is restricted to HTMLElement.
With this change we include "string" into the accepted parameters for the "opener" property. Some of the code had to be adjusted as previously used to work with HTMLElement only.