### PR TITLE
refactor(ui5-link): wrap text by default

### DIFF
--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -52,6 +52,7 @@
 				class="ui5-nli-footer-showMore"
 				?hidden="{{hideShowMore}}"
 				@ui5-click="{{_onShowMoreClick}}"
+				wrapping-type="None"
 				href="#" {{!--without href ENTER does not trigger click --}}
 				showMore-btn
 			>

--- a/packages/fiori/src/TimelineItem.hbs
+++ b/packages/fiori/src/TimelineItem.hbs
@@ -30,7 +30,10 @@
 
 {{#*inline "name"}}
 	{{#if nameClickable}}
-		<ui5-link @ui5-click="{{onNamePress}}" class="ui5-tli-title-name-clickable">{{name}}&nbsp;</ui5-link>
+		<ui5-link
+		@ui5-click="{{onNamePress}}"
+		class="ui5-tli-title-name-clickable"
+		wrapping-type="None">{{name}}&nbsp;</ui5-link>
 	{{else}}
 		<span class="ui5-tli-title-name">{{name}}&nbsp;</span>
 	{{/if}}

--- a/packages/fiori/src/UploadCollectionItem.hbs
+++ b/packages/fiori/src/UploadCollectionItem.hbs
@@ -19,7 +19,10 @@
 					</div>
 				{{else }}
 					{{#if fileNameClickable}}
-						<ui5-link class="ui5-uci-file-name" @ui5-click="{{_onFileNameClick}}">{{fileName}}</ui5-link>
+						<ui5-link
+						class="ui5-uci-file-name"
+						@ui5-click="{{_onFileNameClick}}"
+						wrapping-type="None">{{fileName}}</ui5-link>
 					{{else}}
 						<span class="ui5-uci-file-name ui5-uci-file-name-text">{{fileName}}</span>
 					{{/if}}

--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -9,7 +9,8 @@
 			<ui5-link @ui5-click="{{_openRespPopover}}"
 				accessible-role="button"
 				accessible-name="{{_dropdownArrowAccessibleNameText}}"
-				.accessibilityAttributes="{{linkAccessibilityAttributes}}">
+				.accessibilityAttributes="{{linkAccessibilityAttributes}}"
+				wrapping-type="None">
 				<ui5-icon name="slim-arrow-down" title="{{_dropdownArrowAccessibleNameText}}"></ui5-icon>
 			</ui5-link>
 		</li>
@@ -24,7 +25,8 @@
 				id="{{this._id}}-link"
 				design="{{this._linkDesign}}"
 				accessible-name="{{this._accessibleNameText}}"
-				data-ui5-stable="{{this.stableDomRef}}">
+				data-ui5-stable="{{this.stableDomRef}}"
+				wrapping-type="None">
 				{{this.innerText}}
 			</ui5-link>
 

--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -167,11 +167,11 @@ class Link extends UI5Element implements ITabbable {
 	/**
 	 * Defines how the text of a component will be displayed when there is not enough space.
 	 *
-	 * **Note:** for option "Normal" the text will wrap and the words will not be broken based on hyphenation.
-	 * @default "None"
+	 * **Note:** for option "None" the text won't wrap and the words will be broken based on hyphenation.
+	 * @default "Normal"
 	 * @public
 	 */
-	@property({ type: WrappingType, defaultValue: WrappingType.None })
+	@property({ type: WrappingType, defaultValue: WrappingType.Normal })
 	wrappingType!: `${WrappingType}`;
 
 	/**

--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -167,7 +167,7 @@ class Link extends UI5Element implements ITabbable {
 	/**
 	 * Defines how the text of a component will be displayed when there is not enough space.
 	 *
-	 * **Note:** for option "None" the text won't wrap and the words will be broken based on hyphenation.
+	 * **Note:** By default the text will wrap. If "None" is set - the text will truncate.
 	 * @default "Normal"
 	 * @public
 	 */

--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -13,8 +13,8 @@
 	outline: none;
 	text-decoration: var(--_ui5_link_text_decoration);
 	text-shadow: var(--sapContent_TextShadow);
-	white-space: nowrap;
-	overflow-wrap: normal;
+	white-space: normal;
+	overflow-wrap: break-word;
 }
 
 :host(:hover) {
@@ -53,9 +53,9 @@
 	text-decoration: var(--_ui5_link_subtle_text_decoration_hover);
 }
 
-:host([wrapping-type="Normal"]) {
-	white-space: normal;
-	overflow-wrap: break-word;
+:host([wrapping-type="None"]) {
+	white-space: nowrap;
+	overflow-wrap: normal;
 }
 
 .ui5-link-root {

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -59,8 +59,8 @@
 
 	<section class="group">
 		<h2>Wrapping link</h2>
-		<ui5-link class="link2auto" id="wrapping-link" wrapping-type="Normal">Eu enim consectetur do amet elit.</ui5-link>
-		<ui5-link class="link2auto" id="non-wrapping-link">Eu enim consectetur do amet elit.</ui5-link>
+		<ui5-link class="link2auto" id="wrapping-link">Eu enim consectetur do amet elit Lorem ipsum dolor, sit amet consectetur adipisicing elit.</ui5-link>
+		<ui5-link class="link2auto" id="non-wrapping-link" wrapping-type="None">Eu enim consectetur do amet elit Lorem ipsum dolor, sit amet consectetur adipisicing elit.</ui5-link>
 	</section>
 
 	<section class="group">

--- a/packages/website/docs/_components_pages/main/Link.mdx
+++ b/packages/website/docs/_components_pages/main/Link.mdx
@@ -22,11 +22,11 @@ The Link supports <b>Default</b>, <b>Subtle</b> and <b>Emphasized</b> designs.
 <Design />
 
 ### Text Truncation and Wrapping
-The Label truncates by default. To make it wrap - set <b>wrapping-type="Normal"</b>.
+The ui5-link wraps by default. To truncate it - set <b>wrapping-type="None"</b>.
 
 <TextWrapping />
 
 ### Custom Styling
-The Labels can be customized with pure CSS, applied on the tag.
+The links can be customized with pure CSS, applied on the tag.
 
 <CustomStyling />

--- a/packages/website/docs/_samples/main/Link/TextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/Link/TextWrapping/sample.html
@@ -15,7 +15,7 @@
         This is a really long link. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     </ui5-link>
 
-    <ui5-link href="https://www.sap.com" target="_blank" wrapping-type="Normal" style="width: 8rem">
+    <ui5-link href="https://www.sap.com" target="_blank" wrapping-type="None" style="width: 8rem">
         This is a really long link. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     </ui5-link>
     <!-- playground-fold -->


### PR DESCRIPTION
The text of `ui5-link` now wraps by default.

BREAKING CHANGE: `wrapping-type` property default value has changed from `None` to `Normal`.
Before: 
```html
<ui5-link>some very very very long link</ui5-link> <!-- would truncate the text if there is not enough space -->
```

Now:
```html
<ui5-link>some very very very long link</ui5-link> <!-- would let the text wrap if there is not enough space -->
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461
