### PR TITLE
fix: register runtime in ssr usage

### DIFF
--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -40,14 +40,14 @@ const boot = async (): Promise<void> => {
 	}
 
 	const bootExecutor = async (resolve: PromiseResolve) => {
+		registerCurrentRuntime();
+
 		if (typeof document === "undefined") {
 			resolve();
 			return;
 		}
 
 		attachThemeRegistered(onThemeRegistered);
-
-		registerCurrentRuntime();
 
 		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
 		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isOpenUI5Detected() : false;


### PR DESCRIPTION
In SSR enviroments, regsterCurrentRuntime is skipped and the current runtime index does not get initialized. With nextjs SSR, hot reload loads two instances of the framework, which triggers the duplicate tags reporting logic, which breaks because it relies on the index being defined.

This fix runs the current runtime index initialization for all scenarios.

FIXES: #8886