### PR TITLE
fix(ui5-datetime-picker): change dateformat to datetime instance

### DIFF
--- a/packages/main/src/DateComponentBase.ts
+++ b/packages/main/src/DateComponentBase.ts
@@ -166,7 +166,6 @@ class DateComponentBase extends UI5Element {
 	}
 
 	getFormat() {
-		debugger;
 		return this._isPattern
 			? DateFormat.getDateInstance({
 				strictParsing: true,

--- a/packages/main/src/DateComponentBase.ts
+++ b/packages/main/src/DateComponentBase.ts
@@ -166,6 +166,7 @@ class DateComponentBase extends UI5Element {
 	}
 
 	getFormat() {
+		debugger;
 		return this._isPattern
 			? DateFormat.getDateInstance({
 				strictParsing: true,

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -9,6 +9,7 @@ import CalendarDate from "@ui5/webcomponents-localization/dist/dates/CalendarDat
 import type { IFormInputElement } from "@ui5/webcomponents-base/dist/features/InputElementsFormSupport.js";
 import "@ui5/webcomponents-icons/dist/date-time.js";
 import UI5Date from "@ui5/webcomponents-localization/dist/dates/UI5Date.js";
+import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 import Button from "./Button.js";
 import type ResponsivePopover from "./ResponsivePopover.js";
 import ToggleButton from "./ToggleButton.js";
@@ -39,7 +40,6 @@ import DateTimePickerTemplate from "./generated/templates/DateTimePickerTemplate
 import DateTimePickerCss from "./generated/themes/DateTimePicker.css.js";
 import DateTimePickerPopoverCss from "./generated/themes/DateTimePickerPopover.css.js";
 import CalendarPickersMode from "./types/CalendarPickersMode.js";
-import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 
 const PHONE_MODE_BREAKPOINT = 640; // px
 
@@ -398,7 +398,6 @@ class DateTimePicker extends DatePicker implements IFormInputElement {
 	}
 
 	getFormat() {
-		debugger;
 		return this._isPattern
 			? DateFormat.getDateTimeInstance({
 				strictParsing: true,

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -39,6 +39,7 @@ import DateTimePickerTemplate from "./generated/templates/DateTimePickerTemplate
 import DateTimePickerCss from "./generated/themes/DateTimePicker.css.js";
 import DateTimePickerPopoverCss from "./generated/themes/DateTimePickerPopover.css.js";
 import CalendarPickersMode from "./types/CalendarPickersMode.js";
+import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
 
 const PHONE_MODE_BREAKPOINT = 640; // px
 
@@ -394,6 +395,21 @@ class DateTimePicker extends DatePicker implements IFormInputElement {
 		}
 
 		return selectedDate;
+	}
+
+	getFormat() {
+		debugger;
+		return this._isPattern
+			? DateFormat.getDateTimeInstance({
+				strictParsing: true,
+				pattern: this._formatPattern,
+				calendarType: this._primaryCalendarType,
+			})
+			: DateFormat.getDateTimeInstance({
+				strictParsing: true,
+				style: this._formatPattern,
+				calendarType: this._primaryCalendarType,
+			});
 	}
 
 	/**


### PR DESCRIPTION
The DateTimePicker was calling an inherited getFormat method, which was creating an instance with getDateInstance method. 
Now we are using the correct format created with getDateTimeInstance method.