### PR TITLE
fix(ui5-side-navigation-item): "selected" is no longer announced on every focused item

### DIFF
--- a/packages/fiori/src/SideNavigationItem.hbs
+++ b/packages/fiori/src/SideNavigationItem.hbs
@@ -83,6 +83,7 @@
 			   tabindex="{{effectiveTabIndex}}"
 			   aria-expanded="{{_expanded}}"
 			   aria-current="{{_ariaCurrent}}"
+			   aria-selected="{{selected}}"
 			   title="{{_tooltip}}"
 			   aria-owns="{{_groupId}}"
 			   href="{{_href}}"
@@ -118,6 +119,7 @@
 				 tabindex="{{effectiveTabIndex}}"
 				 aria-expanded="{{_expanded}}"
 				 aria-current="{{_ariaCurrent}}"
+				 aria-selected="{{selected}}"
 				 title="{{_tooltip}}"
 				 aria-owns="{{_groupId}}"
 			>

--- a/packages/fiori/src/SideNavigationSubItem.hbs
+++ b/packages/fiori/src/SideNavigationSubItem.hbs
@@ -10,6 +10,7 @@
 			   @focusin="{{_onfocusin}}"
 			   tabindex="{{effectiveTabIndex}}"
 			   aria-current="{{_ariaCurrent}}"
+			   aria-selected="{{selected}}"
 			   title="{{_tooltip}}"
 			   href="{{_href}}"
 			   target="{{_target}}"
@@ -37,6 +38,7 @@
 				 @focusin="{{_onfocusin}}"
 				 tabindex="{{effectiveTabIndex}}"
 				 aria-current="{{_ariaCurrent}}"
+				 aria-selected="{{selected}}"
 				 title="{{_tooltip}}"
 			>
 				{{#if icon}}

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -187,9 +187,12 @@ describe("Component Behavior", () => {
 
 			assert.strictEqual(await sideNavigationTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation tree element is correctly set");
 			assert.notExists(await items[0].getAttribute("aria-roledescription"),"Role description of the SideNavigation tree item is not set");
+			assert.strictEqual(await items[0].getAttribute("aria-selected"), "false", "'aria-selected' is set explicitly");
 
 			assert.strictEqual(await sideNavigationTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation tree is correctly set");
 			assert.notExists(await items[1].getAttribute("aria-haspopup"), "There is no 'aria-haspopup'");
+
+			assert.strictEqual(await items[3].getAttribute("aria-selected"), "true", "'aria-selected' is set explicitly");
 
 			// fixed items
 			assert.strictEqual(await sideNavigationFixedTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation fixed tree element is correctly set");

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -187,12 +187,11 @@ describe("Component Behavior", () => {
 
 			assert.strictEqual(await sideNavigationTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation tree element is correctly set");
 			assert.notExists(await items[0].getAttribute("aria-roledescription"),"Role description of the SideNavigation tree item is not set");
-			assert.strictEqual(await items[0].getAttribute("aria-selected"), "false", "'aria-selected' is set explicitly");
-
+			assert.strictEqual(await items[0].getAttribute("aria-selected"), "true", "'aria-selected' is set explicitly");
 			assert.strictEqual(await sideNavigationTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation tree is correctly set");
 			assert.notExists(await items[1].getAttribute("aria-haspopup"), "There is no 'aria-haspopup'");
 
-			assert.strictEqual(await items[3].getAttribute("aria-selected"), "true", "'aria-selected' is set explicitly");
+			assert.strictEqual(await items[3].getAttribute("aria-selected"), "false", "'aria-selected' is set explicitly");
 
 			// fixed items
 			assert.strictEqual(await sideNavigationFixedTree.getAttribute("aria-roledescription"), roleDescription, "Role description of the SideNavigation fixed tree element is correctly set");


### PR DESCRIPTION
Downport of [8cd3f83](https://github.com/SAP/ui5-webcomponents/commit/8cd3f83e2fcc31d57ebcdd38ee2ceff36150e1d1)