### PR TITLE
chore: replace ui5-static-area with ui5-announcement-area

### DIFF
--- a/packages/base/src/StaticArea.ts
+++ b/packages/base/src/StaticArea.ts
@@ -1,7 +1,0 @@
-class StaticArea extends HTMLElement {}
-
-if (!customElements.get("ui5-static-area")) {
-	customElements.define("ui5-static-area", StaticArea);
-}
-
-export default StaticArea;

--- a/packages/base/src/util/InvisibleMessage.ts
+++ b/packages/base/src/util/InvisibleMessage.ts
@@ -34,8 +34,8 @@ attachBoot(() => {
 	setOutOfViewportStyles(politeSpan);
 	setOutOfViewportStyles(assertiveSpan);
 
-	getSingletonElementInstance("ui5-static-area").appendChild(politeSpan);
-	getSingletonElementInstance("ui5-static-area").appendChild(assertiveSpan);
+	getSingletonElementInstance("ui5-announcement-area").appendChild(politeSpan);
+	getSingletonElementInstance("ui5-announcement-area").appendChild(assertiveSpan);
 });
 
 /**


### PR DESCRIPTION
Previously the ui5-static-area custom element was used to host all popovers, but now it's being used only by the InvisibleMessage for accessibility needs to announce opening of popups, so we rename it to ui5-announcement-area to avoid confusion with the previous purpose of the element.