### PR TITLE
fix(ui5-select): popover scrolls to typed item

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -529,6 +529,7 @@ class Select extends UI5Element implements IFormInputElement {
 
 			if (currentIndex !== this._selectedIndex) {
 				this.itemSelectionAnnounce();
+				this._scrollSelectedItem();
 			}
 		}
 	}


### PR DESCRIPTION
Problem: When we type an item which is outside of the scroll viewport, the item is selected but the popover is not scrolled to it.

Solution: We make sure to scroll to the typed item.

Fixes: #8987