### PR TITLE
chore: enable test assets for `ai` test pages

### DIFF
--- a/packages/ai/src/Assets.ts
+++ b/packages/ai/src/Assets.ts
@@ -1,6 +1,6 @@
 // main package assets (transitively base, theming and icons)
 import "@ui5/webcomponents/dist/Assets.js";
 
-// own compat package assets
+// own ai package assets
 import "./generated/json-imports/Themes.js";
 import "./generated/json-imports/i18n.js";

--- a/packages/ai/src/Button.hbs
+++ b/packages/ai/src/Button.hbs
@@ -1,0 +1,3 @@
+<ui5-button icon="{{icon}}" end-icon="{{endIcon}}">
+	<slot></slot>
+</ui5-button>

--- a/packages/ai/src/Button.ts
+++ b/packages/ai/src/Button.ts
@@ -1,5 +1,17 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+
+// Deps
+import MainButton from "@ui5/webcomponents/dist/Button.js";
+
+// Template
+import template from "./generated/templates/ButtonTemplate.lit.js";
+
+// Styles
+import styles from "./generated/themes/Button.css.js";
+
 /**
  * @class
  * @constructor
@@ -7,8 +19,17 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
  */
 @customElement({
 	tag: "ui5-ai-button",
+	renderer: litRender,
+	template,
+	styles,
+	dependencies: [MainButton],
 })
 class Button extends UI5Element {
+	@property()
+	icon!: string;
+
+	@property()
+	endIcon!: string;
 }
 
 Button.define();

--- a/packages/ai/src/bundle.esm.ts
+++ b/packages/ai/src/bundle.esm.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import testAssets from "@ui5/webcomponents/dist/bundle.esm.js";
 
 // AI assets
 import "./Assets.js";
 
 import Button from "./Button.js";
+
+export default testAssets;

--- a/packages/ai/test/pages/Button.html
+++ b/packages/ai/test/pages/Button.html
@@ -13,13 +13,10 @@
 
 
 	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
-
-
-<link rel="stylesheet" type="text/css" href="./styles/Table-perf-pure.css">
 </head>
 
-<body class="table-perf-pure1auto">
-	<p>Here should come the AI Button once implemented..</p>
+<body>
+	<ui5-ai-button icon="da" end-icon="slim-arrow-down">Generate</ui5-ai-button>
 </body>
 
 </html>

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -15,9 +15,9 @@
     "importsNotUsedAsValues": "preserve",
     "ignoreDeprecations": "5.0",
     "paths": {
-      "@ui5/webcomponents-base/dist/*": ["../base/src/*"],
-      "@ui5/webcomponents/dist/*": ["../main/src/*"],
-      "@ui5/webcomponents-theming/dist/*": ["../theming/src/*"],
+        "@ui5/webcomponents-base/dist/*": ["../base/src/*"],
+        "@ui5/webcomponents/dist/*": ["../main/src/*"],
+        "@ui5/webcomponents-theming/dist/*": ["../theming/src/*"],
     },
   },
   "references": [


### PR DESCRIPTION
Icons and other test assets are now imported in the ai/bundle/esm.ts and available in test pages

<img width="574" alt="Screenshot 2024-05-23 at 16 13 55" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/6d6127e3-1a07-472c-b4cf-0ec69ea7e78a">
