### PR TITLE
fix(ui5-*): describe missing dependencies

### DIFF
--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -105,7 +105,9 @@ import ComboBoxFilter from "./types/ComboBoxFilter.js";
 import type FormSupportT from "./features/InputElementsFormSupport.js";
 import type ListItemBase from "./ListItemBase.js";
 import CheckBox from "./CheckBox.js";
-import Input, { InputEventDetail } from "./Input.js";
+import Input from "./Input.js";
+import type { InputEventDetail } from "./Input.js";
+import SuggestionItem from "./SuggestionItem.js";
 
 /**
  * Interface for components that may be slotted inside a `ui5-multi-combobox` as items
@@ -185,6 +187,7 @@ type MultiComboboxItemWithSelection = {
 		MultiComboBoxGroupItem,
 		Tokenizer,
 		Token,
+		Input,
 		Icon,
 		ResponsivePopover,
 		Popover,
@@ -194,6 +197,7 @@ type MultiComboboxItemWithSelection = {
 		ToggleButton,
 		Button,
 		CheckBox,
+		SuggestionItem,
 	],
 })
 /**

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -66,6 +66,7 @@ type MultiInputTokenDeleteEventDetail = {
 	styles: [Input.styles, styles],
 	dependencies: [
 		...Input.dependencies,
+		Input,
 		Tokenizer,
 		Token,
 		Icon,

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -48,7 +48,7 @@ import List from "./List.js";
 import DropIndicator from "./DropIndicator.js";
 import type Tab from "./Tab.js";
 import type { ListItemClickEventDetail, ListMoveEventDetail } from "./List.js";
-import type CustomListItem from "./CustomListItem.js";
+import CustomListItem from "./CustomListItem.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import TabContainerTabsPlacement from "./types/TabContainerTabsPlacement.js";
 import SemanticColor from "./types/SemanticColor.js";
@@ -180,6 +180,7 @@ interface TabContainerTabInOverflow extends CustomListItem {
 		List,
 		ResponsivePopover,
 		DropIndicator,
+		CustomListItem,
 	],
 })
 /**

--- a/packages/main/src/TimeSelectionClocks.ts
+++ b/packages/main/src/TimeSelectionClocks.ts
@@ -25,6 +25,7 @@ import TimePickerInternals from "./TimePickerInternals.js";
 import TimePickerClock from "./TimePickerClock.js";
 import ToggleSpinButton from "./ToggleSpinButton.js";
 import SegmentedButton from "./SegmentedButton.js";
+import SegmentedButtonItem from "./SegmentedButtonItem.js";
 import type { TimePickerClockChangeEventDetail } from "./TimePickerClock.js";
 
 // Template
@@ -64,6 +65,7 @@ import TimeSelectionClocksCss from "./generated/themes/TimeSelectionClocks.css.j
 		TimePickerClock,
 		ToggleSpinButton,
 		SegmentedButton,
+		SegmentedButtonItem,
 	],
 })
 

--- a/packages/main/src/TimeSelectionInputs.ts
+++ b/packages/main/src/TimeSelectionInputs.ts
@@ -11,6 +11,7 @@ import {
 import TimePickerInternals from "./TimePickerInternals.js";
 import Input from "./Input.js";
 import SegmentedButton from "./SegmentedButton.js";
+import SegmentedButtonItem from "./SegmentedButtonItem.js";
 
 import InputType from "./types/InputType.js";
 
@@ -51,6 +52,7 @@ import TimeSelectionInputsCss from "./generated/themes/TimeSelectionInputs.css.j
 	dependencies: [
 		Input,
 		SegmentedButton,
+		SegmentedButtonItem,
 	],
 })
 

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -43,6 +43,7 @@ import ResponsivePopover from "./ResponsivePopover.js";
 import List from "./List.js";
 import Title from "./Title.js";
 import Button from "./Button.js";
+import Icon from "./Icon.js";
 import StandardListItem from "./StandardListItem.js";
 import type Token from "./Token.js";
 import type { IToken } from "./MultiInput.js";
@@ -105,6 +106,7 @@ enum ClipboardDataOperation {
 		StandardListItem,
 		Title,
 		Button,
+		Icon,
 	],
 })
 


### PR DESCRIPTION
When a component is using another components in its template, used components must be added to its dependencies in order to get the same scoping. With this change dependencies are fulfilled as in: #8823

Fixes: https://github.com/SAP/ui5-webcomponents/issues/9030