### PR TITLE
fix(ui5-notification-list): improved accessibility

### DIFF
--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -17,8 +17,6 @@
 		title="{{toggleIconAccessibleName}}">
 		<ui5-icon
 			name={{groupCollapsedIcon}}
-			{{!-- show-tooltip="true"
-			accessible-name={{toggleIconAccessibleName}} --}}
 			class="ui5-nli-group-toggle-icon"
 			mode="Decorative"
 		></ui5-icon>

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -13,11 +13,12 @@
 		@keydown="{{_onkeydown}}"
 		role="button"
 		aria-expanded="{{_ariaExpanded}}"
-		aria-controls="{{_id}}-notificationsList">
+		aria-controls="{{_id}}-notificationsList"
+		title="{{toggleIconAccessibleName}}">
 		<ui5-icon
 			name={{groupCollapsedIcon}}
-			show-tooltip="true"
-			accessible-name={{toggleIconAccessibleName}}
+			{{!-- show-tooltip="true"
+			accessible-name={{toggleIconAccessibleName}} --}}
 			class="ui5-nli-group-toggle-icon"
 			mode="Decorative"
 		></ui5-icon>

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -30,6 +30,10 @@
 			{{titleText}}
 		</div>
 
+		{{#if isLoading}}
+			<span id="{{_id}}-loading" class="ui5-hidden-text">{{loadingText}}</span>
+		{{/if}}
+
 		<div class="ui5-nli-group-divider"></div>
 	</div>
 

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -21,7 +21,6 @@ import {
 	NOTIFICATION_LIST_GROUP_COLLAPSED,
 	NOTIFICATION_LIST_GROUP_EXPANDED,
 	NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_COLLAPSE_TITLE,
-	NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_EXPAND_TITLE,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Templates
@@ -134,10 +133,6 @@ class NotificationListGroupItem extends NotificationListItemBase {
 	}
 
 	get toggleIconAccessibleName() {
-		if (this.collapsed) {
-			return NotificationListGroupItem.i18nFioriBundle.getText(NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_EXPAND_TITLE);
-		}
-
 		return NotificationListGroupItem.i18nFioriBundle.getText(NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_COLLAPSE_TITLE);
 	}
 
@@ -159,8 +154,17 @@ class NotificationListGroupItem extends NotificationListItemBase {
 
 	get ariaLabelledBy() {
 		const id = this._id;
+		const ids = [];
 
-		return this.hasTitleText ? `${id}-title-text` : "";
+		if (this.isLoading) {
+			ids.push(`${id}-loading`);
+		}
+
+		if (this.hasTitleText) {
+			ids.push(`${id}-title-text`);
+		}
+
+		return ids.join(" ");
 	}
 
 	get _ariaExpanded() {

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -7,14 +7,13 @@
 	@click="{{_onclick}}"
 	tabindex="{{forcedTabIndex}}"
 	aria-labelledby="{{ariaLabelledBy}}"
-	aria-describedby="{{ariaDescribedBy}}"
 	aria-level="2"
 >
 
 	<div class="{{contentClasses}}">
 
 			{{#if hasImportance}}
-				<ui5-tag class="ui5-nli-importance" design="Set2" color-scheme="2">
+				<ui5-tag id="{{_id}}-importance" class="ui5-nli-importance" design="Set2" color-scheme="2">
 					<ui5-icon name="high-priority" slot="icon"></ui5-icon>
 					{{importanceText}}
 				</ui5-tag>
@@ -24,6 +23,8 @@
 				<ui5-icon
 					class="ui5-state-icon"
 					name="{{statusIconName}}"
+					show-tooltip="true"
+					accessible-name={{stateText}}
 					design="{{statusIconDesign}}">
 				</ui5-icon>
 			{{/if}}
@@ -33,6 +34,12 @@
 				{{titleText}}
 			</div>
 		</div>
+
+		{{#if isLoading}}
+			<span id="{{_id}}-loading" class="ui5-hidden-text">{{loadingText}}</span>
+		{{/if}}
+
+		<span id="{{_id}}-read" class="ui5-hidden-text">{{readText}}</span>
 
 		{{#if hasDesc}}
 			<div id="{{_id}}-description" class="ui5-nli-description">
@@ -54,12 +61,14 @@
 				@ui5-click="{{_onShowMoreClick}}"
 				href="#" {{!--without href ENTER does not trigger click --}}
 				showMore-btn
+				accessible-name="{{moreLinkAccessibleName}}"
+				accessible-role="Button"
+				.accessibilityAttributes={{accInfoLink.accessibilityAttributes}}
 			>
 				{{showMoreText}}
 			</ui5-link>
 		</div>
 
-		<span id="{{_id}}-invisibleText" class="ui5-hidden-text">{{accInvisibleText}}</span>
 	</div>
 
 	<div class="ui5-nli-actions">
@@ -70,7 +79,7 @@
 				@click="{{_onBtnMenuClick}}"
 				class="ui5-nli-menu-btn"
 				tooltip="{{menuBtnAccessibleName}}"
-				.accessibilityAttributes={{accInfo.accessibilityAttributes}}
+				.accessibilityAttributes={{accInfoButton.accessibilityAttributes}}
 			></ui5-button>
 		{{/if}}
 		{{#if showClose}}

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -31,7 +31,6 @@ import "@ui5/webcomponents-icons/dist/message-warning.js";
 
 // Texts
 import {
-	NOTIFICATION_LIST_ITEM_TXT,
 	NOTIFICATION_LIST_ITEM_READ,
 	NOTIFICATION_LIST_ITEM_UNREAD,
 	NOTIFICATION_LIST_ITEM_SHOW_MORE,
@@ -41,6 +40,8 @@ import {
 	NOTIFICATION_LIST_ITEM_NEGATIVE_STATUS_TXT,
 	NOTIFICATION_LIST_ITEM_CRITICAL_STATUS_TXT,
 	NOTIFICATION_LIST_ITEM_MENU_BTN_TITLE,
+	NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL,
+	NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE,
 	NOTIFICATION_LIST_ITEM_CLOSE_BTN_TITLE,
 	NOTIFICATION_LIST_ITEM_IMPORTANT_TXT,
 } from "./generated/i18n/i18n-defaults.js";
@@ -313,6 +314,10 @@ class NotificationListItem extends NotificationListItemBase {
 		return NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_MENU_BTN_TITLE);
 	}
 
+	get moreLinkAccessibleName() {
+		return this._showMorePressed ? NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE) : NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL);
+	}
+
 	get closeBtnAccessibleName() {
 		return NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_CLOSE_BTN_TITLE);
 	}
@@ -374,9 +379,19 @@ class NotificationListItem extends NotificationListItemBase {
 		const id = this._id;
 		const ids = [];
 
+		if (this.hasImportance) {
+			ids.push(`${id}-importance`);
+		}
+
 		if (this.hasTitleText) {
 			ids.push(`${id}-title-text`);
 		}
+
+		if (this.isLoading) {
+			ids.push(`${id}-loading`);
+		}
+
+		ids.push(`${id}-read`);
 
 		if (this.hasDesc) {
 			ids.push(`${id}-description`);
@@ -387,11 +402,6 @@ class NotificationListItem extends NotificationListItemBase {
 		}
 
 		return ids.join(" ");
-	}
-
-	get ariaDescribedBy() {
-		const id = this._id;
-		return `${id}-invisibleText`;
 	}
 
 	get itemClasses() {
@@ -445,18 +455,22 @@ class NotificationListItem extends NotificationListItemBase {
 		return "";
 	}
 
-	get accInvisibleText() {
-		const notificationText = NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_TXT);
-		const readText = this.read ? NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_READ) : NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_UNREAD);
-		const importanceText = this.importanceText;
-
-		return `${notificationText} ${importanceText} ${readText}`;
+	get readText() {
+		return this.read ? NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_READ) : NotificationListItem.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_UNREAD);
 	}
 
-	get accInfo() {
+	get accInfoButton() {
 		return {
 			accessibilityAttributes: {
 				hasPopup: "menu",
+			},
+		};
+	}
+
+	get accInfoLink() {
+		return {
+			accessibilityAttributes: {
+				expanded: this._showMorePressed,
 			},
 		};
 	}

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -6,6 +6,11 @@ import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 
+// Texts
+import {
+	NOTIFICATION_LIST_ITEM_LOADING,
+} from "./generated/i18n/i18n-defaults.js";
+
 /**
  * @class
  *
@@ -56,6 +61,14 @@ class NotificationListItemBase extends ListItemBase {
 
 	get hasTitleText() {
 		return !!this.titleText.length;
+	}
+
+	get loadingText() {
+		return NotificationListItemBase.i18nFioriBundle.getText(NOTIFICATION_LIST_ITEM_LOADING);
+	}
+
+	get isLoading() {
+		return this.loading;
 	}
 
 	/**

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -41,10 +41,10 @@ NOTIFICATION_LIST_ITEM_SHOW_LESS=Less
 #XBUT: Tooltip text for 'Overflow' button in the NotificationListItem, that opens a menu with actions
 NOTIFICATION_LIST_ITEM_MENU_BTN_TITLE=Actions
 
-#XBUT: Label text for 'More' lin in the NotificationListItem, that shows the full text, if truncated
+#XBUT: Label text for 'More' link in the NotificationListItem, that shows the full texts of the title and the description, if truncated
 NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL=More button. Show the full texts
 
-#XBUT: Label text for 'More' lin in the NotificationListItem, that hides the truncated text
+#XBUT: Label text for 'More' link in the NotificationListItem, that truncates the texts (title and description)
 NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE=Less button. Show the texts with truncation
 
 #XBUT: Tooltip text for 'Close' button in the NotificationListItem

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -32,9 +32,6 @@ FCL_END_COLUMN_COLLAPSE_BUTTON_TOOLTIP=Collapse the last column
 #XTXT: Accessible name for the NotificationList
 NOTIFICATION_LIST_ACCESSIBLE_NAME=Notifications
 
-#XTXT: Text for the NotificationListGroupItem
-NOTIFICATION_LIST_ITEM_TXT=Notification
-
 #XTXT: Text for the 'ShowMore' link in the NotificationListItem
 NOTIFICATION_LIST_ITEM_SHOW_MORE=More
 
@@ -44,8 +41,17 @@ NOTIFICATION_LIST_ITEM_SHOW_LESS=Less
 #XBUT: Tooltip text for 'Overflow' button in the NotificationListItem, that opens a menu with actions
 NOTIFICATION_LIST_ITEM_MENU_BTN_TITLE=Actions
 
+#XBUT: Label text for 'More' lin in the NotificationListItem, that shows the full text, if truncated
+NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL=More button. Show the full text
+
+#XBUT: Label text for 'More' lin in the NotificationListItem, that hides the truncated text
+NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE=Less button. Show the text with truncation
+
 #XBUT: Tooltip text for 'Close' button in the NotificationListItem
 NOTIFICATION_LIST_ITEM_CLOSE_BTN_TITLE=Close
+
+#XTXT: Text for the NotificationListItem "loading" state
+NOTIFICATION_LIST_ITEM_LOADING=loading
 
 #XTXT: Text for the NotificationListItem "read" state
 NOTIFICATION_LIST_ITEM_READ=read
@@ -69,10 +75,7 @@ NOTIFICATION_LIST_GROUP_ITEM_TXT=Notification group
 NOTIFICATION_LIST_GROUP_ITEM_COUNTER_TXT=Counter
 
 #XBUT: accessible name for 'Toggle' icon in the NotificationListGroupItem
-NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_COLLAPSE_TITLE=Collapse
-
-#XBUT: accessible name for 'Toggle' icon in the NotificationListGroupItem
-NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_EXPAND_TITLE=Expand
+NOTIFICATION_LIST_GROUP_ITEM_TOGGLE_ICON_COLLAPSE_TITLE=Expand/Collapse
 
 #XTXT: The state of the NotificationListGroupItem
 NOTIFICATION_LIST_GROUP_COLLAPSED=Collapsed

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -42,10 +42,10 @@ NOTIFICATION_LIST_ITEM_SHOW_LESS=Less
 NOTIFICATION_LIST_ITEM_MENU_BTN_TITLE=Actions
 
 #XBUT: Label text for 'More' lin in the NotificationListItem, that shows the full text, if truncated
-NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL=More button. Show the full text
+NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_FULL=More button. Show the full texts
 
 #XBUT: Label text for 'More' lin in the NotificationListItem, that hides the truncated text
-NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE=Less button. Show the text with truncation
+NOTIFICATION_LIST_ITEM_MORE_LINK_LABEL_TRUNCATE=Less button. Show the texts with truncation
 
 #XBUT: Tooltip text for 'Close' button in the NotificationListItem
 NOTIFICATION_LIST_ITEM_CLOSE_BTN_TITLE=Close

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -186,8 +186,6 @@
 	<ui5-notification-list id="ACCtestGroup">
 
 		<ui5-li-notification-group
-			show-close
-			show-counter
 			title-text="Today"
 		>
 			<ui5-li-notification
@@ -229,8 +227,6 @@
 			</ui5-li-notification>
 		</ui5-li-notification-group>
 		<ui5-li-notification-group
-			show-close
-			show-counter
 			title-text="Yesterday"
 			collapsed="true"
 		>
@@ -266,6 +262,32 @@
 				<span slot="footnotes">Office</span>
 				<span slot="footnotes">3 Days</span>
 
+			</ui5-li-notification>
+		</ui5-li-notification-group>
+
+		<ui5-li-notification-group
+			loading
+			title-text="Last week"
+		>
+			<ui5-li-notification
+				importance="Important"
+				loading
+				title-text="Message 1"
+				state="Positive"
+				importance="Important"
+			>
+				Text with details.
+				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
+
+				<span slot="footnotes">Office</span>
+				<span slot="footnotes">3 Days</span>
+
+				<ui5-notification-action icon="accept" text="Accept-deprecated" slot="actions"></ui5-notification-action>
+
+				<ui5-menu slot="menu">
+					<ui5-menu-item icon="accept" text="Accept"></ui5-menu-item>
+					<ui5-menu-item icon="message-error" text="Reject"></ui5-menu-item>
+				</ui5-menu>
 			</ui5-li-notification>
 		</ui5-li-notification-group>
 	</ui5-notification-list>

--- a/packages/fiori/test/pages/NotificationList_test_page.html
+++ b/packages/fiori/test/pages/NotificationList_test_page.html
@@ -74,6 +74,7 @@
 
 				<ui5-li-notification
 					id="nli2"
+					read
 					show-close
 					title-text="New order #2202"
 					state="Critical"
@@ -168,6 +169,32 @@
 					</ui5-menu>
 				</ui5-li-notification>
 			</ui5-li-notification-group>
+
+			<ui5-li-notification-group
+			id="nlgi4"
+			title-text="Collapsed loading"
+			collapsed
+			loading
+		>
+			<ui5-li-notification
+				id="nli5"
+				wrapping-type="Normal"
+				show-close
+				title-text="New payment #2900"
+				state="Negative"
+			>
+				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
+				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
+
+				<span slot="footnotes">Office Notifications</span>
+				<span slot="footnotes">3 Days</span>
+
+				<ui5-menu slot="menu">
+					<ui5-menu-item icon="accept" text="Accept"></ui5-menu-item>
+					<ui5-menu-item icon="message-error" text="Reject"></ui5-menu-item>
+				</ui5-menu>
+			</ui5-li-notification>
+		</ui5-li-notification-group>
 		</ui5-notification-list>
 	</div>
 

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -207,32 +207,63 @@ describe("Notification List Item Tests", () => {
 		const firstItem = await browser.$("#nli1");
 		const firstItemRoot = await firstItem.shadow$(".ui5-nli-root");
 
+		const thirdItem = await browser.$("#nli3");
+		const thirdItemRoot = await thirdItem.shadow$(".ui5-nli-root");
+
+		const loadingItem = await browser.$("#nli4");
+		const loadingItemRoot = await loadingItem.shadow$(".ui5-nli-root");
+
 		const titleTextId = `${await firstItem.getProperty("_id")}-title-text`;
+		const readId = `${await firstItem.getProperty("_id")}-read`;
 		const descriptionId = `${await firstItem.getProperty("_id")}-description`;
 		const footerId = `${await firstItem.getProperty("_id")}-footer`;
-		const invisibleTextId = `${await firstItem.getProperty("_id")}-invisibleText`;
-		const EXPECTED_ARIA_LABELLED_BY = `${titleTextId} ${descriptionId} ${footerId}`;
+		const EXPECTED_ARIA_LABELLED_BY = `${titleTextId} ${readId} ${descriptionId} ${footerId}`;
+
+		const importantId3 = `${await thirdItem.getProperty("_id")}-importance`;
+		const titleTextId3 = `${await thirdItem.getProperty("_id")}-title-text`;
+		const readId3 = `${await thirdItem.getProperty("_id")}-read`;
+		const descriptionId3 = `${await thirdItem.getProperty("_id")}-description`;
+		const footerId3 = `${await thirdItem.getProperty("_id")}-footer`;
+		const EXPECTED_ARIA_LABELLED_BY3 = `${importantId3} ${titleTextId3} ${readId3} ${descriptionId3} ${footerId3}`;
+
+		const loadingId4 = `${await loadingItem.getProperty("_id")}-loading`;
+		const titleTextId4 = `${await loadingItem.getProperty("_id")}-title-text`;
+		const readId4 = `${await loadingItem.getProperty("_id")}-read`;
+		const descriptionId4 = `${await loadingItem.getProperty("_id")}-description`;
+		const footerId4 = `${await loadingItem.getProperty("_id")}-footer`;
+		const EXPECTED_ARIA_LABELLED_BY4 = `${titleTextId4} ${loadingId4} ${readId4} ${descriptionId4} ${footerId4}`;
 
 		// assert
 		assert.strictEqual(await firstItemRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY,
 			"The ariaLabelledBy text is correct.");
-		assert.strictEqual(await firstItemRoot.getAttribute("aria-describedby"), invisibleTextId,
-			"The ariaDescribedBy text is correct.");
 		assert.strictEqual(await firstItemRoot.getAttribute("aria-level"), "2",
 			"The ariaLevel text is correct.");
 
+		assert.strictEqual(await thirdItemRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY3,
+			"The ariaLabelledBy text is correct.");
+
+		assert.strictEqual(await loadingItemRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY4,
+			"The ariaLabelledBy text is correct.");
 	});
 
 	it("tests List Item ACC invisible texts", async () => {
-		const EXPECTED_RESULT_STATUS = "Status Positive";
-		const EXPECTED_RESULT_ITEM = "notification unread";
 		const firstItem = await browser.$("#nli1");
-		const invisibleTextStatus = await firstItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[0];
-		const invisibleTextItem = await firstItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[1];
+		const secondItem = await browser.$("#nli2");
+		const invisibleTextStatus1 = await firstItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[0];
+		const tooltipStatus1 = await firstItem.shadow$(".ui5-nli-root").$(".ui5-state-icon");
+		const invisibleTextItem1 = await firstItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[1];
+		const invisibleTextStatus2 = await secondItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[0];
+		const tooltipStatus2 = await secondItem.shadow$(".ui5-nli-root").$(".ui5-state-icon");
+		const invisibleTextItem2 = await secondItem.shadow$(".ui5-nli-root").$$(".ui5-hidden-text")[1];
 
 		// assert
-		assert.strictEqual((await invisibleTextStatus.getText()).toLowerCase(), EXPECTED_RESULT_STATUS.toLowerCase(), "The invisible text for the status is correct.");
-		assert.strictEqual((await invisibleTextItem.getText()).toLowerCase(), EXPECTED_RESULT_ITEM.toLowerCase(), "The invisible text for the Notification item  is correct.");
+		assert.strictEqual(await invisibleTextStatus1.getText(), "Status Positive", "The invisible text for the status is correct.");
+		assert.strictEqual(await invisibleTextItem1.getText(), "unread", "The invisible text for the Notification item  is correct.");
+		assert.strictEqual(await tooltipStatus1.getAttribute("accessible-name"), "Status Positive", "The tooltip (aria-label) text for the status is correct.");
+
+		assert.strictEqual(await invisibleTextStatus2.getText(), "Status Critical", "The invisible text for the status is correct.");
+		assert.strictEqual(await invisibleTextItem2.getText(), "read", "The invisible text for the Notification item  is correct.");
+		assert.strictEqual(await tooltipStatus2.getAttribute("accessible-name"), "Status Critical", "The tooltip (aria-label) text for the status is correct.");
 	});
 
 	it("tests Menu (actions / '...') button ACC attributes", async () => {
@@ -262,6 +293,27 @@ describe("Notification List Item Tests", () => {
 
 	});
 
+	it("tests click on ShowMore", async () => {
+		var firstItem = await browser.$("#nli3a");
+		var btnListItemShowMore = await firstItem.shadow$("[showMore-btn]");
+		var btnListItemShowMoreRoot = await btnListItemShowMore.shadow$(".ui5-link-root");
+
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'More button. Show the full text', "The aria-label is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("role"), 'button', "The role is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-expanded"), 'false', "The aria-expanded is correct.");
+
+		// act
+		await btnListItemShowMore.click();
+
+		firstItem = await browser.$("#nli3a");
+		btnListItemShowMore = await firstItem.shadow$("[showMore-btn]");
+		btnListItemShowMoreRoot = await btnListItemShowMore.shadow$(".ui5-link-root");
+
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'Less button. Show the text with truncation', "The aria-label is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("role"), 'button', "The role is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-expanded"), 'true', "The aria-expanded is correct.");
+	});
+
 	it("tests Group Header Text ACC attributes", async () => {
 		const firstGroupText = await browser.$("#nlgi1").shadow$(".ui5-nli-group-title-text");
 
@@ -272,9 +324,18 @@ describe("Notification List Item Tests", () => {
 	it("tests Group List aria-labelledby", async () => {
 		const firstGroupItem = await browser.$("#nlgi1");
 		const firstGroupList =  await browser.$("#nlgi1").shadow$(".ui5-nli-group-items");
+		const firstGroupRoot =  await browser.$("#nlgi1").shadow$(".ui5-nli-group-root");
 		const id = `${await firstGroupItem.getProperty("_id")}-title-text`;
 
+		const fourthGroupItem = await browser.$("#nlgi4");
+		const fourthGroupRoot =  await browser.$("#nlgi4").shadow$(".ui5-nli-group-root");
+		const loadingId =  `${await fourthGroupItem.getProperty("_id")}-loading`;
+		const titleId =  `${await fourthGroupItem.getProperty("_id")}-title-text`;
+		const EXPECTED_ARIA_LABELLED_BY = `${loadingId} ${titleId}`;
+		
 		assert.strictEqual(await firstGroupList.getAttribute("aria-labelledby"), id, "The aria-lebelledby is correct.");
+		assert.strictEqual(await firstGroupRoot.getAttribute("aria-labelledby"), id, "The aria-lebelledby is correct.");
+		assert.strictEqual(await fourthGroupRoot.getAttribute("aria-labelledby"), EXPECTED_ARIA_LABELLED_BY, "The aria-lebelledby is correct.");
 	});
 
 	it("tests Group Item 'aria-description' and 'aria-level'", async () => {
@@ -298,7 +359,7 @@ describe("Notification List Item Tests", () => {
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-expanded"), "true", "The aria-expanded value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-controls"), groupItemsList2ID, "The aria-controls value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("role"), "button", "The tooltip value is correct.");
-		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Collapse", "The aria-label of the icon is correct.");
+		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Expand/Collapse", "The aria-label of the icon is correct.");
 		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-hidden"), "true", "The aria-hidden of the icon is correct.");
 
 		// act
@@ -308,7 +369,7 @@ describe("Notification List Item Tests", () => {
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-expanded"), "false", "The aria-expanded value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-controls"), groupItemsList2ID, "The aria-controls value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("role"), "button", "The tooltip value is correct.");
-		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Expand", "The aria-label of the icon is correct.");
+		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Expand/Collapse", "The aria-label of the icon is correct.");
 		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-hidden"), "true", "The aria-hidden of the icon is correct.");
 
 		// reset

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -298,7 +298,7 @@ describe("Notification List Item Tests", () => {
 		var btnListItemShowMore = await firstItem.shadow$("[showMore-btn]");
 		var btnListItemShowMoreRoot = await btnListItemShowMore.shadow$(".ui5-link-root");
 
-		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'More button. Show the full text', "The aria-label is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'More button. Show the full texts', "The aria-label is correct.");
 		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("role"), 'button', "The role is correct.");
 		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-expanded"), 'false', "The aria-expanded is correct.");
 
@@ -309,7 +309,7 @@ describe("Notification List Item Tests", () => {
 		btnListItemShowMore = await firstItem.shadow$("[showMore-btn]");
 		btnListItemShowMoreRoot = await btnListItemShowMore.shadow$(".ui5-link-root");
 
-		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'Less button. Show the text with truncation', "The aria-label is correct.");
+		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-label"), 'Less button. Show the texts with truncation', "The aria-label is correct.");
 		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("role"), 'button', "The role is correct.");
 		assert.strictEqual(await btnListItemShowMoreRoot.getAttribute("aria-expanded"), 'true', "The aria-expanded is correct.");
 	});
@@ -359,7 +359,7 @@ describe("Notification List Item Tests", () => {
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-expanded"), "true", "The aria-expanded value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-controls"), groupItemsList2ID, "The aria-controls value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("role"), "button", "The tooltip value is correct.");
-		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Expand/Collapse", "The aria-label of the icon is correct.");
+		assert.strictEqual(await groupItemHeader.getAttribute("title"), "Expand/Collapse", "The title of the header is correct.");
 		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-hidden"), "true", "The aria-hidden of the icon is correct.");
 
 		// act
@@ -369,7 +369,7 @@ describe("Notification List Item Tests", () => {
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-expanded"), "false", "The aria-expanded value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("aria-controls"), groupItemsList2ID, "The aria-controls value is correct.");
 		assert.strictEqual(await groupItemHeader.getAttribute("role"), "button", "The tooltip value is correct.");
-		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-label"), "Expand/Collapse", "The aria-label of the icon is correct.");
+		assert.strictEqual(await groupItemHeader.getAttribute("title"), "Expand/Collapse", "The title of the header is correct.");
 		assert.strictEqual(await groupItemHeaderIcon.getAttribute("aria-hidden"), "true", "The aria-hidden of the icon is correct.");
 
 		// reset

--- a/packages/website/docs/_components_pages/fiori/NotificationListGroupItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/NotificationListGroupItem.mdx
@@ -10,8 +10,8 @@ import InShellBar from "../../_samples/fiori/NotificationListGroupItem/InShellBa
 
 ## More Samples
 
-### Notifcations in ShellBar
-The main usage of the Notifcations is in the ShellBar.
+### Notifications in ShellBar
+The main usage of the Notifications is in the ShellBar.
 Press the "notifications" icon on the right side of the ShellBar to show the Notifications.
 
 <InShellBar />

--- a/packages/website/docs/_samples/fiori/NotificationListGroupItem/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/NotificationListGroupItem/Basic/main.js
@@ -11,7 +11,7 @@ import "@ui5/webcomponents-icons/dist/message-error.js";
 import "@ui5/webcomponents-icons/dist/accept.js";
 import "@ui5/webcomponents-icons/dist/accept.js";
 
-var notificationList = document.querySelector("ui5-list");
+var notificationList = document.querySelector("ui5-notification-list");
 
 notificationList.addEventListener("item-close", e => {
     var visibleItems = 0;

--- a/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/main.js
+++ b/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/main.js
@@ -19,7 +19,7 @@ import "@ui5/webcomponents-icons/dist/accept.js";
 
 var shellbar = document.querySelector("ui5-shellbar");
 var notificationsPopover = document.querySelector("ui5-popover");
-var notificationList = document.querySelector("ui5-list");
+var notificationList = document.querySelector("ui5-notification-list");
 
 notificationList.addEventListener("item-close", e => {
     var visibleItems = 0;

--- a/packages/website/docs/_samples/fiori/NotificationListItem/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/NotificationListItem/Basic/main.js
@@ -6,7 +6,7 @@ import "@ui5/webcomponents/dist/Toast.js";
 import "@ui5/webcomponents-fiori/dist/NotificationList.js";
 import "@ui5/webcomponents-fiori/dist/NotificationListItem.js";
 
-var notificationList = document.querySelector("ui5-list");
+var notificationList = document.querySelector("ui5-notification-list");
 
 notificationList.addEventListener("item-close", e => {
     e.detail.item.hidden = true;


### PR DESCRIPTION
- read state is announced after the title (before it was at the end of the notification)
- "notification" word is removed from the description
- "important" should be announced before the title and the status text, since it is valuable information for the user and should be in the beginning
- status icon in the title should have tooltip
- there should be "loading" announcement (after the title) for items, which are in loading state
- ACC attributes are added for "More"/"Less" link, following the example of (openui5) sap.m.ExpandableText
- tooltip for the expand/collapse arrow in the group header is moved to the whole header
- tooltip for the group header is changed to static "Expand/Collapse" (doesn't change depending on the expand state of the group), following the example of ui5-panel component
- samples in website playground fixed (there was a bug, that the popover doesn't open in the notifications-in-shellbar sample)
- tests added