### PR TITLE
chore(ui5-list): update focus handling

### DIFF
--- a/packages/compat/src/themes/GrowingButton.css
+++ b/packages/compat/src/themes/GrowingButton.css
@@ -23,7 +23,7 @@
 	box-sizing: border-box;
 }
 
-[growing-button-inner]:focus {
+[growing-button-inner]:focus-visible {
 	outline: var(--_ui5_load_more_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	outline-offset: -0.125rem;
 	border-color: transparent;

--- a/packages/fiori/src/NotificationListGroupItem.hbs
+++ b/packages/fiori/src/NotificationListGroupItem.hbs
@@ -1,7 +1,6 @@
 <li
 	class="ui5-nli-group-root ui5-nli-focusable"
 	@focusin="{{_onfocusin}}"
-	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	tabindex="{{forcedTabIndex}}"
 	aria-labelledby="{{ariaLabelledBy}}"

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -189,11 +189,6 @@ class NotificationListGroupItem extends NotificationListItemBase {
 	}
 
 	async _onkeydown(e: KeyboardEvent) {
-		const isFocused = document.activeElement === this;
-		if (!isFocused) {
-			return;
-		}
-
 		await super._onkeydown(e);
 
 		const space = isSpace(e);

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -189,6 +189,11 @@ class NotificationListGroupItem extends NotificationListItemBase {
 	}
 
 	async _onkeydown(e: KeyboardEvent) {
+		const isFocused = document.activeElement === this;
+		if (!isFocused) {
+			return;
+		}
+
 		await super._onkeydown(e);
 
 		const space = isSpace(e);

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -189,7 +189,7 @@ class NotificationListGroupItem extends NotificationListItemBase {
 	}
 
 	async _onkeydown(e: KeyboardEvent) {
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 		if (!isFocused) {
 			return;
 		}

--- a/packages/fiori/src/NotificationListGroupItem.ts
+++ b/packages/fiori/src/NotificationListGroupItem.ts
@@ -191,7 +191,8 @@ class NotificationListGroupItem extends NotificationListItemBase {
 	async _onkeydown(e: KeyboardEvent) {
 		await super._onkeydown(e);
 
-		if (!this.focused) {
+		const isFocused = document.activeElement === this;
+		if (!isFocused) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.hbs
+++ b/packages/fiori/src/NotificationListItem.hbs
@@ -1,7 +1,6 @@
 <li
 	class="{{itemClasses}}"
 	@focusin="{{_onfocusin}}"
-	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	@keyup="{{_onkeyup}}"
 	@click="{{_onclick}}"

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -496,7 +496,8 @@ class NotificationListItem extends NotificationListItemBase {
 	}
 
 	focusSameItemOnNextRow(e: KeyboardEvent) {
-		if (this.focused || (!isUp(e) && !isDown(e))) {
+		const isFocused = document.activeElement === this;
+		if (isFocused || (!isUp(e) && !isDown(e))) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -497,7 +497,8 @@ class NotificationListItem extends NotificationListItemBase {
 			return;
 		}
 
-		if (!isUp(e) && !isDown(e)) {
+		const isFocused = document.activeElement === this;
+		if (isFocused || (!isUp(e) && !isDown(e))) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -497,8 +497,8 @@ class NotificationListItem extends NotificationListItemBase {
 			return;
 		}
 
-		const isFocused = this.matches(":focus");
-		if (isFocused || (!isUp(e) && !isDown(e))) {
+		const isFocusWithin = this.matches(":focus-within");
+		if (!isFocusWithin || (!isUp(e) && !isDown(e))) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -497,8 +497,7 @@ class NotificationListItem extends NotificationListItemBase {
 			return;
 		}
 
-		const isFocused = document.activeElement === this;
-		if (isFocused || (!isUp(e) && !isDown(e))) {
+		if (!isUp(e) && !isDown(e)) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -497,7 +497,7 @@ class NotificationListItem extends NotificationListItemBase {
 			return;
 		}
 
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 		if (isFocused || (!isUp(e) && !isDown(e))) {
 			return;
 		}

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -5,6 +5,7 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
+import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 
 /**
  * @class
@@ -70,11 +71,15 @@ class NotificationListItemBase extends ListItemBase {
 
 		if (isF2(e)) {
 			e.stopImmediatePropagation();
+
+			const activeElement = getActiveElement();
 			const focusDomRef = this.getHeaderDomRef()!;
-			if (this.focused) {
-				(await getFirstFocusableElement(focusDomRef))?.focus(); // start content editing
+
+			if (activeElement === focusDomRef) {
+				const firstFocusable = await getFirstFocusableElement(focusDomRef);
+				firstFocusable?.focus();
 			} else {
-				focusDomRef.focus(); // stop content editing
+				focusDomRef.focus();
 			}
 		}
 	}

--- a/packages/fiori/src/themes/NotificationListGroupItem.css
+++ b/packages/fiori/src/themes/NotificationListGroupItem.css
@@ -32,7 +32,7 @@
 }
 
 /* The focus is on the whole group but should be visualized on the Group Header */
-:host([focused]) .ui5-nli-focusable.ui5-nli-group-root .ui5-nli-group-header::before {
+.ui5-nli-focusable.ui5-nli-group-root:focus .ui5-nli-group-header::before {
 	content: "";
 	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	position: absolute;

--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -78,7 +78,7 @@
 	border-radius: var(--_ui5-notification_item-border-radius);
 }
 
-:host([focused]) .ui5-nli-root:active {
+.ui5-nli-root:focus:active {
 	background-color: var(--_ui5-notification_item-background-color-active);
 	border-radius: var(--_ui5-notification_item-border-radius);
 	border: var(--_ui5-notification_item-border-active);
@@ -180,7 +180,7 @@
 	margin-inline-end: 0.125rem;
 }
 
-:host([focused]) .ui5-nli-focusable:not(ui5-nli-group-root)::after {
+.ui5-nli-focusable:focus:not(.ui5-nli-group-root)::after {
 	border-radius: var(--_ui5-notification_item-border-radius);
 	top: var(--_ui5-notification_item-focus-offset);
 	right: var(--_ui5-notification_item-focus-offset);

--- a/packages/fiori/src/themes/NotificationListItemBase.css
+++ b/packages/fiori/src/themes/NotificationListItemBase.css
@@ -9,11 +9,11 @@
 }
 
 /*TODO after li is implemented*/
-:host([focused]) .ui5-nli-focusable {
+.ui5-nli-focusable:focus {
 	outline: none;
 }
 
-:host([focused]) .ui5-nli-focusable:not(.ui5-nli-group-root)::after {
+.ui5-nli-focusable:focus:not(.ui5-nli-group-root)::after {
 	content: "";
 	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	position: absolute;

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -388,7 +388,8 @@ describe("Keyboard navigation", () => {
 		assert.ok(res, "'show more' is focused.");
 	});
 
-	it("Focusing same item on next row", async () => {
+	// TODO: Fix after implementing focus styles in NotificationListItem
+	it.skip("Focusing same item on next row", async () => {
 		await browser.$("#nli1").click();
 		await browser.keys("Tab");
 		await browser.keys("ArrowDown");

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -418,8 +418,7 @@ describe("Keyboard navigation", () => {
 		assert.ok(res, "'show more' is focused.");
 	});
 
-	// TODO: Fix after implementing focus styles in NotificationListItem
-	it.skip("Focusing same item on next row", async () => {
+	it("Focusing same item on next row", async () => {
 		await browser.$("#nli1").click();
 		await browser.keys("Tab");
 		await browser.keys("ArrowDown");

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -54,7 +54,7 @@ class CustomListItem extends ListItem {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 
 		if (!isTab && !isFocused && !isF2(e)) {
 			return;
@@ -65,7 +65,7 @@ class CustomListItem extends ListItem {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 
 		if (!isTab && !isFocused && !isF2(e)) {
 			return;

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -54,8 +54,9 @@ class CustomListItem extends ListItem {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !this.focused && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 
@@ -64,8 +65,9 @@ class CustomListItem extends ListItem {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !this.focused) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -54,8 +54,9 @@ class CustomListItem extends ListItem {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 
@@ -64,8 +65,9 @@ class CustomListItem extends ListItem {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/CustomListItem.ts
+++ b/packages/main/src/CustomListItem.ts
@@ -54,9 +54,8 @@ class CustomListItem extends ListItem {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isFocused && !isF2(e)) {
+		if (!isTab && !isF2(e)) {
 			return;
 		}
 
@@ -65,9 +64,8 @@ class CustomListItem extends ListItem {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isFocused && !isF2(e)) {
+		if (!isTab && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -3,10 +3,12 @@ import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import {
 	isSpace, isEnter, isDelete, isF2,
 } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
-import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import type { AccessibilityAttributes, PassiveEventListenerObject } from "@ui5/webcomponents-base/dist/types.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
+import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
+import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
+import type { AccessibilityAttributes, PassiveEventListenerObject } from "@ui5/webcomponents-base/dist/types.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
@@ -233,6 +235,10 @@ abstract class ListItem extends ListItemBase {
 		document.addEventListener("mouseup", this.deactivate);
 		document.addEventListener("touchend", this.deactivate);
 		document.addEventListener("keyup", this.deactivateByKey);
+
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
 	}
 
 	onExitDOM() {
@@ -252,11 +258,14 @@ abstract class ListItem extends ListItemBase {
 		}
 
 		if (isF2(e)) {
+			const activeElement = getActiveElement();
 			const focusDomRef = this.getFocusDomRef()!;
-			if (this.focused) {
-				(await getFirstFocusableElement(focusDomRef))?.focus(); // start content editing
+
+			if (activeElement === focusDomRef) {
+				const firstFocusable = await getFirstFocusableElement(focusDomRef);
+				firstFocusable?.focus();
 			} else {
-				focusDomRef.focus(); // stop content editing
+				focusDomRef.focus();
 			}
 		}
 	}
@@ -292,7 +301,6 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	_onfocusout() {
-		super._onfocusout();
 		this.deactivate();
 	}
 
@@ -308,7 +316,7 @@ abstract class ListItem extends ListItemBase {
 		}
 	}
 
-	/*
+	/**
 	 * Called when selection components in Single (ui5-radio-button)
 	 * and Multi (ui5-checkbox) selection modes are used.
 	 */

--- a/packages/main/src/ListItemBase.hbs
+++ b/packages/main/src/ListItemBase.hbs
@@ -4,7 +4,6 @@
 	tabindex="{{_effectiveTabIndex}}"
 	class="{{classes.main}}"
 	@focusin="{{_onfocusin}}"
-	@focusout="{{_onfocusout}}"
 	@keyup="{{_onkeyup}}"
 	@keydown="{{_onkeydown}}"
 	draggable="{{movable}}"

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -106,12 +106,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 			return;
 		}
 
-		this.focused = true;
 		this.fireEvent("_focused", e);
-	}
-
-	_onfocusout() {
-		this.focused = false;
 	}
 
 	_onkeydown(e: KeyboardEvent) {
@@ -171,19 +166,19 @@ class ListItemBase extends UI5Element implements ITabbable {
 		}
 	}
 
-	/*
-	* Determines if th current list item either has no tabbable content or
-	* [Tab] is performed onto the last tabbale content item.
-	*/
+	/**
+	 * Determines if th current list item either has no tabbable content or
+	 * [Tab] is performed onto the last tabbale content item.
+	 */
 	shouldForwardTabAfter() {
 		const aContent = getTabbableElements(this.getFocusDomRef()!);
 
 		return aContent.length === 0 || (aContent[aContent.length - 1] === getActiveElement());
 	}
 
-	/*
-	* Determines if the current list item is target of [SHIFT+TAB].
-	*/
+	/**
+	 * Determines if the current list item is target of [SHIFT+TAB].
+	 */
 	shouldForwardTabBefore(target: HTMLElement) {
 		return this.getFocusDomRef() === target;
 	}

--- a/packages/main/src/ListItemGroupHeader.hbs
+++ b/packages/main/src/ListItemGroupHeader.hbs
@@ -3,7 +3,6 @@
 	tabindex="{{forcedTabIndex}}"
 	class="ui5-ghli-root {{classes.main}}"
 	@focusin="{{_onfocusin}}"
-	@focusout="{{_onfocusout}}"
 	@keydown="{{_onkeydown}}"
 	aria-label="{{ariaLabelText}}"
 	aria-roledescription="{{groupHeaderText}}"

--- a/packages/main/src/ListItemGroupHeader.ts
+++ b/packages/main/src/ListItemGroupHeader.ts
@@ -2,6 +2,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import ListItemBase from "./ListItemBase.js";
 
 import { GROUP_HEADER_TEXT } from "./generated/i18n/i18n-defaults.js";
@@ -59,6 +60,12 @@ class ListItemGroupHeader extends ListItemBase {
 
 	static async onDefine() {
 		ListItemGroupHeader.i18nBundle = await getI18nBundle("@ui5/webcomponents");
+	}
+
+	onEnterDOM() {
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
 	}
 }
 

--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -52,8 +52,9 @@ class TreeItemCustom extends TreeItemBase {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !this.focused && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 
@@ -62,8 +63,9 @@ class TreeItemCustom extends TreeItemBase {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !this.focused) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -52,7 +52,7 @@ class TreeItemCustom extends TreeItemBase {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 
 		if (!isTab && !isFocused && !isF2(e)) {
 			return;
@@ -63,7 +63,7 @@ class TreeItemCustom extends TreeItemBase {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
+		const isFocused = this.matches(":focus");
 
 		if (!isTab && !isFocused && !isF2(e)) {
 			return;

--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -52,8 +52,9 @@ class TreeItemCustom extends TreeItemBase {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 
@@ -62,8 +63,9 @@ class TreeItemCustom extends TreeItemBase {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
+		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isF2(e)) {
+		if (!isTab && !isFocused && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -52,9 +52,8 @@ class TreeItemCustom extends TreeItemBase {
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isFocused && !isF2(e)) {
+		if (!isTab && !isF2(e)) {
 			return;
 		}
 
@@ -63,9 +62,8 @@ class TreeItemCustom extends TreeItemBase {
 
 	_onkeyup(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);
-		const isFocused = document.activeElement === this;
 
-		if (!isTab && !isFocused && !isF2(e)) {
+		if (!isTab && !isF2(e)) {
 			return;
 		}
 

--- a/packages/main/src/themes/GrowingButton.css
+++ b/packages/main/src/themes/GrowingButton.css
@@ -23,7 +23,7 @@
 	box-sizing: border-box;
 }
 
-[growing-button-inner]:focus {
+[growing-button-inner]:focus-visible {
 	outline: var(--_ui5_load_more_outline_width) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	outline-offset: -0.125rem;
 	border-color: transparent;

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -175,12 +175,12 @@
 /* highlight */
 .ui5-li-highlight {
 	position: absolute;
-    width: 0.375rem;
-    bottom: 0;
-    left: 0;
-    top: 0;
-    border-inline-end: 0.0625rem solid var(--ui5-listitem-background-color);
-    box-sizing: border-box;
+	width: 0.375rem;
+	bottom: 0;
+	left: 0;
+	top: 0;
+	border-inline-end: 0.0625rem solid var(--ui5-listitem-background-color);
+	box-sizing: border-box;
 }
 
 :host([highlight="Negative"]) .ui5-li-highlight {

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -1,17 +1,15 @@
+:host {
+	height: var(--_ui5_list_item_base_height);
+	box-sizing: border-box;
+}
+
 :host(:not([hidden])) {
 	display: block;
 }
 
-:host {
-	height: var(--_ui5_list_item_base_height);
-	background: var(--ui5-listitem-background-color);
-	box-sizing: border-box;
-	border-bottom: 1px solid transparent;
-}
-
-/* selected */
-:host([selected]) {
-	background: var(--sapList_SelectionBackgroundColor);
+:host([disabled]) {
+	opacity: var(--_ui5-listitembase_disabled_opacity);
+	pointer-events: none;
 }
 
 /* actionable (type="Active" + desktop) */
@@ -19,43 +17,44 @@
 	cursor: pointer;
 }
 
-/* selected and hovered */
-:host([selected][actionable]:not([active]):not([data-moving]):hover) {
-	background : var(--sapList_Hover_SelectionBackground);
-}
-
-/* selected and active */
-:host([active][actionable]:not([data-moving])),
-:host([selected][active][actionable]:not([data-moving])) {
-	background: var(--sapList_Active_Background);
-}
-
-/* hovered */
-:host([actionable]:not([active]):not([selected]):hover) {
-	background : var(--sapList_Hover_Background);
-}
-
-/* focused */
-:host([active][actionable]) .ui5-li-root.ui5-li--focusable:focus,
-:host([active][actionable]) .ui5-li-root.ui5-li--focusable .ui5-li-content:focus {
-	outline-color: var(--sapContent_ContrastFocusColor);
-}
-
-:host([has-border]) {
+:host([has-border]) .ui5-li-root {
 	border-bottom: var(--ui5-listitem-border-bottom);
 }
 
-:host([selected]) {
+/* selected */
+:host([selected]) .ui5-li-root {
+	background-color: var(--sapList_SelectionBackgroundColor);
 	border-bottom: var(--ui5-listitem-selected-border-bottom);
 }
 
-:host(:not([focused])[selected][has-border]) {
-	border-bottom: var(--ui5-listitem-selected-border-bottom);
+/* hovered */
+:host([actionable]:not([active], [selected]):hover) .ui5-li-root {
+	background-color: var(--sapList_Hover_Background);
 }
 
-/* focused & selected */
-:host([focused][selected]) {
-	border-bottom: var(--ui5-listitem-focused-selected-border-bottom);
+/* selected and hovered */
+:host([actionable][selected]:not([active], [data-moving]):hover) .ui5-li-root {
+	background-color: var(--sapList_Hover_SelectionBackground);
+}
+
+/* selected and active */
+:host([active][actionable]:not([data-moving])) .ui5-li-root,
+:host([active][actionable][selected]:not([data-moving])) .ui5-li-root {
+	background-color: var(--sapList_Active_Background);
+}
+
+/* focused */
+:host([desktop]:not([data-moving])) .ui5-li-root.ui5-li--focusable:focus::after,
+:host([desktop][focused]:not([data-moving])) .ui5-li-root.ui5-li--focusable::after,
+:host(:not([data-moving])) .ui5-li-root.ui5-li--focusable:focus-visible::after,
+:host([desktop]:not([data-moving])) .ui5-li-root .ui5-li-content:focus::after,
+:host([desktop][focused]:not([data-moving])) .ui5-li-root .ui5-li-content::after,
+:host(:not([data-moving])) .ui5-li-root .ui5-li-content:focus-visible::after {
+	content: "";
+	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+	position: absolute;
+	inset: 0.125rem;
+	pointer-events: none;
 }
 
 .ui5-li-root {
@@ -66,7 +65,12 @@
 	height: 100%;
 	padding: var(--_ui5_list_item_base_padding);
 	box-sizing: border-box;
-	background: inherit;
+	background-color: var(--ui5-listitem-background-color);
+	border-bottom: 0.0625rem solid transparent;
+}
+
+.ui5-li-root.ui5-li--focusable {
+	outline: none;
 }
 
 .ui5-li-content {
@@ -74,6 +78,14 @@
 	align-items: center;
 	flex: auto;
 	overflow: hidden;
+	max-width: 100%;
+	font-family: "72override", var(--sapFontFamily);
+	color: var(--sapList_TextColor);
+}
+
+.ui5-li-content .ui5-li-title {
+	color: var(--sapList_TextColor);
+	font-size: var(--_ui5_list_item_title_size);
 }
 
 .ui5-li-text-wrapper {
@@ -83,49 +95,4 @@
 	flex: auto;
 	min-width: 1px;
 	line-height: normal;
-}
-
-/* focused */
-:host([focused]) .ui5-li-root.ui5-li--focusable {
-	outline: none;
-}
-
-:host([focused]:not([data-moving])) .ui5-li-root.ui5-li--focusable:after {
-	content: "";
-	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-	position: absolute;
-	border-radius: 0;
-	inset: 0.125rem;
-	pointer-events: none;
-}
-
-:host([focused]:not(data-moving)) .ui5-li-root .ui5-li-content:focus:after {
-	content: "";
-	border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	pointer-events: none;
-}
-
-:host([active][focused]) .ui5-li-root.ui5-li--focusable:after {
-	border-color: var(--ui5-listitem-active-border-color);
-}
-
-:host([disabled]) {
-	opacity: var(--_ui5-listitembase_disabled_opacity);
-	pointer-events: none;
-}
-
-.ui5-li-content {
-	max-width: 100%;
-	font-family: "72override", var(--sapFontFamily);
-	color: var(--sapList_TextColor);
-}
-
-.ui5-li-content .ui5-li-title {
-	color: var(--sapList_TextColor);
-	font-size: var(--_ui5_list_item_title_size);
 }

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -49,7 +49,7 @@
 			<ui5-li-group header-text="Products">
 				<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Negative">Laptop Lenovo</ui5-li>
 				<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Negative">IPhone 3</ui5-li>
-				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			</ui5-li-group>
 		</ui5-list>
 	</ui5-popover>
@@ -97,7 +97,7 @@
 			<ui5-li-group header-text="Products">
 				<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Negative">Laptop Lenovo</ui5-li>
 				<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Negative">IPhone 3</ui5-li>
-				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			</ui5-li-group>
 		</ui5-list>
 	</ui5-popover>

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -14,6 +14,32 @@
 </head>
 
 <body class="list1auto">
+	<div id="host">
+		<template shadowrootmode="open">
+		   <span>I'm in the shadow DOM</span>
+		   <ui5-list header-text="API: CustomListItem" selection-mode="SingleEnd">
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+		   </ui5-list>
+		</template>
+	</div>
+
 	<ui5-title>List growing="Scroll"</ui5-title>
 	<label class="list2auto">new items loaded:</label>
 	<label id="result" class="list2auto"> 0 times: 0</label>

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -26,9 +26,9 @@
 		</ui5-li-group>
 
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 
 		<ui5-li-group header-text="Discounted Items">
@@ -61,9 +61,9 @@
 		</ui5-li-group>
 
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 
 		<ui5-li-group header-text="Discounted Items">

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -14,6 +14,35 @@
 </head>
 
 <body class="list1auto">
+
+	<div id="host">
+		<template shadowrootmode="open">
+		   <span>I'm in the shadow DOM</span>
+		   <ui5-list header-text="API: CustomListItem" selection-mode="SingleEnd">
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+			  <ui5-li-custom>
+				 <div class="list5auto">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link>Go to SAP</ui5-link>
+				 </div>
+			  </ui5-li-custom>
+		   </ui5-list>
+		</template>
+	</div>
+
+	<br>
+
 	<ui5-title>List growing="Scroll"</ui5-title>
 	<label class="list2auto">new items loaded:</label>
 	<label id="result" class="list2auto"> 0 times: 0</label>

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -14,32 +14,6 @@
 </head>
 
 <body class="list1auto">
-	<div id="host">
-		<template shadowrootmode="open">
-		   <span>I'm in the shadow DOM</span>
-		   <ui5-list header-text="API: CustomListItem" selection-mode="SingleEnd">
-			  <ui5-li-custom>
-				 <div class="list5auto">
-					<ui5-button>Press me</ui5-button>
-					<ui5-link>Go to SAP</ui5-link>
-				 </div>
-			  </ui5-li-custom>
-			  <ui5-li-custom>
-				 <div class="list5auto">
-					<ui5-button>Press me</ui5-button>
-					<ui5-link>Go to SAP</ui5-link>
-				 </div>
-			  </ui5-li-custom>
-			  <ui5-li-custom>
-				 <div class="list5auto">
-					<ui5-button>Press me</ui5-button>
-					<ui5-link>Go to SAP</ui5-link>
-				 </div>
-			  </ui5-li-custom>
-		   </ui5-list>
-		</template>
-	</div>
-
 	<ui5-title>List growing="Scroll"</ui5-title>
 	<label class="list2auto">new items loaded:</label>
 	<label id="result" class="list2auto"> 0 times: 0</label>

--- a/packages/main/test/pages/ListGrowing_Button.html
+++ b/packages/main/test/pages/ListGrowing_Button.html
@@ -23,9 +23,9 @@
 			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		</ui5-li-group>
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 </ui5-list>
 

--- a/packages/main/test/pages/ListGrowing_Scroll.html
+++ b/packages/main/test/pages/ListGrowing_Scroll.html
@@ -24,11 +24,11 @@
 				<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Negative">Laptop Lenovo</ui5-li>
 				<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 			</ui5-li-group>
-			
+
 			<ui5-li-group header-text="Discounted Items">
-				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 				<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-				<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+				<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 			</ui5-li-group>
 		</ui5-list>
 	</section>
@@ -43,11 +43,11 @@
 			<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Negative">Laptop Lenovo</ui5-li>
 			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		</ui5-li-group>
-		
+
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 	</ui5-list>
 
@@ -61,9 +61,9 @@
 		</ui5-li-group>
 
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 	</ui5-list>
 

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -463,9 +463,9 @@
 			<ui5-li id="listItem" image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		</ui5-li-group>
 		<ui5-li-group header-text="Discounted Items">
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Positive">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Critical">DVD set</ui5-li>
+			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Required" additional-text-state="Critical">DVD set</ui5-li>
 		</ui5-li-group>
 	</ui5-list>
 

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -351,7 +351,7 @@ z-index: 1;
 			<ui5-li-group header-text="Products">
 				<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Negative">Laptop Lenovo</ui5-li>
 				<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Negative">IPhone 3</ui5-li>
-				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Negative">HP Monitor 24</ui5-li>
+				<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Required" additional-text-state="Negative">HP Monitor 24</ui5-li>
 			</ui5-li-group>
 		</ui5-list>
 	</ui5-popover>

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -549,7 +549,7 @@ describe("List Tests", () => {
 		await item1.click();
 		await item1.keys("ArrowDown");
 
-		assert.ok(await item3.getProperty("focused"), "disabled item is skipped");
+		assert.ok(await item3.isFocused(), "disabled item is skipped");
 	});
 
 	it('should include selected state text', async () => {

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -168,7 +168,7 @@ describe("Menu interaction", () => {
 			await menuItem.click();
 
 			assert.ok(await menuItem.getProperty("disabled"), "The menu item is disabled");
-			assert.ok(await menuItem.getProperty("focused"), "The menu item is focused");
+			assert.ok(await menuItem.matches(":focus"), "The menu item is focused");
 		});
 	});
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -469,13 +469,14 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await mcb.getProperty("value"), "c", "Value is autocompleted");
 		});
 
-		it ("should reset typeahead on item navigation and restore it on focus input", async () => {
+		it("should reset typeahead on item navigation and restore it on focus input", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
-			const mcb = await $("#mcb");
+			const mcb = await browser.$("#mcb");
 			const input = await mcb.shadow$("input");
 			const icon = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
 
 			await icon.click();
 			await mcb.keys("c");
@@ -483,14 +484,13 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Cosy", "The input value is autocompleted");
 
 			await mcb.keys("ArrowDown");
-			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
 
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 			assert.equal(await mcb.getProperty("value"), "c", "The input typeahead is cleared");
 
 			await input.keys("ArrowUp");
 
-			assert.equal(await listItem.getProperty("focused"), false, "The first item is not focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item is not focused");
 			assert.equal(await mcb.getProperty("value"), "Cosy", "The input value is autocompleted");
 		});
 
@@ -554,7 +554,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await tokens.length, 1, "should have one token");
 		});
 
-		it ("should prevent selection-change on CTRL+A", async () => {
+		it("should prevent selection-change on CTRL+A", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = $("#mcb-prevent");
@@ -572,10 +572,10 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await tokens.length, 1, "Should have 1 token.");
 		});
 
-		it ("should select all items", async () => {
-			const cb = await $("#mcb-select-all-vs");
+		it("should select all items", async () => {
+			const cb = await browser.$("#mcb-select-all-vs");
 			const arrow = await cb.shadow$(".inputIcon");
-			const spanRef = await $("#select-all-event");
+			const spanRef = await browser.$("#select-all-event");
 
 			await arrow.click();
 			await browser.keys("ArrowDown");
@@ -592,12 +592,12 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await spanRef.getText(), "Selected items count: 0");
 		});
 
-		it ("should select a few items and show Select All in selected items Popover", async () => {
+		it("should select a few items and show Select All in selected items Popover", async () => {
 			await browser.setWindowSize(1920, 1080);
 
-			const cb = await $("#mcb-select-all-vs");
+			const cb = await browser.$("#mcb-select-all-vs");
 			const arrow = await cb.shadow$(".inputIcon");
-			const spanRef = await $("#select-all-event");
+			const spanRef = await browser.$("#select-all-event");
 
 			await arrow.click();
 			await browser.keys("ArrowDown");
@@ -672,7 +672,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(tokens.length, 2, "2 tokens are visible");
 		});
 
-		it ("Value should be reset on ESC key", async () => {
+		it("Value should be reset on ESC key", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mCombo = await browser.$("#another-mcb");
@@ -707,7 +707,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await mCombo2.getProperty("value"), "", "Value should be cleared on escape even if the suggesitons are openjed");
 		});
 
-		it ("selects an item when enter is pressed and value matches a text of an item in the list", async () => {
+		it("selects an item when enter is pressed and value matches a text of an item in the list", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-with-placeholder");
@@ -734,13 +734,14 @@ describe("MultiComboBox general interaction", () => {
 			}, 2500, "expect value state to be different after 2.5 seconds");
 		});
 
-		it ("focuses the value state header and item on arrow down then the value state and the input on arrow up", async () => {
+		it("focuses the value state header and item on arrow down then the value state and the input on arrow up", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");
 			const input = await mcb.shadow$("input");
 			const icon = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
 
 			await icon.click();
 			await input.keys("ArrowDown");
@@ -752,51 +753,47 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await vsHeader.getHTML(), activeElementHTML, "The value state header should be focused");
 
 			await input.keys("ArrowDown");
-
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[0];
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), false, "The input should not be focused");
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 			assert.notEqual(await vsHeader.getHTML(), activeElementHTML, "The value state header should not be focused");
 
 			await input.keys("ArrowUp");
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), false, "The input should not be focused");
-			assert.equal(await listItem.getProperty("focused"), false, "The first item is no longer focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item is no longer focused");
 			assert.strictEqual(await vsHeader.getHTML(), activeElementHTML, "The value state header should be focused");
 
 			await input.keys("ArrowUp");
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), true, "The input should be focused");
-			assert.equal(await listItem.getProperty("focused"), false, "The first item should not be focused");
-			assert.notEqual(vsHeader.getHTML(), activeElementHTML, "The value state header or item should not be focused");
-			assert.notOk(await listItem.getProperty("focused"), "The value state header or item should not be focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item should not be focused");
+			assert.notEqual(await vsHeader.getHTML(), activeElementHTML, "The value state header or item should not be focused");
 		});
 
-		it ("focuses the first item on arrow down, then the input on arrow up", async () => {
+		it("focuses the first item on arrow down, then the input on arrow up", async () => {
 			const mcb = await browser.$("#mcb-with-placeholder");
 			const input = await mcb.shadow$("input");
 			const icon = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
 
 			await icon.click();
 			await mcb.keys("ArrowDown");
 
-			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
-
 			assert.equal(await mcb.getProperty("focused"), false, "The input should not be focused");
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 
 			await input.keys("ArrowUp");
 
 			assert.equal(await mcb.getProperty("focused"), true, "The input should be focused");
-			assert.equal(await listItem.getProperty("focused"), false, "The first item is not focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item is not focused");
 		});
 
-		it ("should navigate through the items with arrow keys when the picker is closed", async () => {
+		it("should navigate through the items with arrow keys when the picker is closed", async () => {
 			const mcb = await browser.$("#mcb");
 
 			await mcb.click();
@@ -814,7 +811,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Cosy", "The value remains the same when pressing arrow up while the first item is set");
 		});
 
-		it ("should only navigate through not already selected items with arrow keys when the picker is closed", async () => {
+		it("should only navigate through not already selected items with arrow keys when the picker is closed", async () => {
 			const mcb = await browser.$("#mcb-error");
 			const input = await mcb.shadow$("input");
 
@@ -830,7 +827,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Compact", "The only not selected item remains set");
 		});
 
-		it ("should reset current navigation state on user input", async () => {
+		it("should reset current navigation state on user input", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -856,7 +853,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Longest word in the world 2", "The last item is selected if there is a custom value in the input");
 		});
 
-		it ("arrow up when no item is selected should go to the last item", async () => {
+		it("arrow up when no item is selected should go to the last item", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -867,7 +864,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Longest word in the world 2", "Last value should be selected");
 		});
 
-		it ("should focus input after all tokens are deleted", async () => {
+		it("should focus input after all tokens are deleted", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-compact");
@@ -881,7 +878,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("focused"), true, "Input should be focused");
 		});
 
-		it ("first HOME should move caret to start of the input, second HOME should focus the first token, END should focus last token", async () => {
+		it("first HOME should move caret to start of the input, second HOME should focus the first token, END should focus last token", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");
@@ -908,29 +905,28 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("focused"), true, "The input is focused");
 		});
 
-		it ("CTRL + HOME focus the first item, CTRL + END should focus last item", async () => {
+		it("CTRL + HOME focus the first item, CTRL + END should focus last item", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
 			const input = await mcb.shadow$("input");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const firstItem = await popover.$("ui5-li");
+			const lastItem = await popover.$("ui5-li:last-child");
 
 			await input.click();
 			await mcb.keys("F4");
 			await mcb.keys("ArrowDown");
 			await mcb.keys(['Control','End']);
 
-			const lastItem = await popover.$("ui5-list").$$("ui5-li")[5];
-			assert.equal(await lastItem.getProperty("focused"), true, "The last item is focused");
+			assert.ok(await lastItem.matches(":focus"), "The last item is focused");
 
 			await mcb.keys(['Control','Home']);
 
-			const firstItem = await popover.$("ui5-list").$("ui5-li");
-			assert.equal(await firstItem.getProperty("focused"), true, "The first item is focused");
-
+			assert.ok(await firstItem.matches(":focus"), "The first item is focused");
 		});
 
-		it ("should close the picker and focus the next element on TAB", async () => {
+		it("should close the picker and focus the next element on TAB", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -958,7 +954,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("focused"), true, "The next control is focused");
 		});
 
-		it ("should close the picker and focus the next element on TAB over an item or value state header", async () => {
+		it("should close the picker and focus the next element on TAB over an item or value state header", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-warning");
@@ -990,7 +986,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("focused"), true, "The next control is focused after TAB on suggestion item");
 		});
 
-		it ("should select/unselect next/previous item on shift+arrow", async () => {
+		it("should select/unselect next/previous item on shift+arrow", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1012,7 +1008,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(tokens.length, 1, "should have two items selected");
 		});
 
-		it ("should move focus to the previous token with arrow left", async () => {
+		it("should move focus to the previous token with arrow left", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");
@@ -1032,7 +1028,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await tokens[0].getProperty("focused"), true, "First token should be focused");
 		});
 
-		it ("should navigate through the items with CTRL + arrow up/down keys when the picker is closed", async () => {
+		it("should navigate through the items with CTRL + arrow up/down keys when the picker is closed", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1052,15 +1048,16 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb.getProperty("value"), "Cosy", "The value remains the same when pressing arrow up while the first item is set");
 		});
 
-		it ("focuses the value state header and item on CTRL + arrow down then the value state and the input on CTRL + arrow up", async () => {
+		it("focuses the value state header and item on CTRL + arrow down then the value state and the input on CTRL + arrow up", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");
 			const icon = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
+
 			await icon.click();
 			await mcb.keys(["Control", "ArrowDown"]);
-
 
 			let activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 			const vsHeader = await popover.$(".ui5-responsive-popover-header");
@@ -1070,30 +1067,29 @@ describe("MultiComboBox general interaction", () => {
 
 			await mcb.keys(["Control", "ArrowDown"]);
 
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[0];
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), false, "The input should not be focused");
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 			assert.notEqual(activeElementHTML, await vsHeader.getHTML(), "The value state header should not be focused");
 
 			await mcb.keys(["Control", "ArrowUp"]);
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), false, "The input should not be focused");
-			assert.equal(await listItem.getProperty("focused"), false, "The first item is no longer focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item is no longer focused");
 			assert.equal(activeElementHTML, await vsHeader.getHTML(), "The value state header is focused again");
 
 			await mcb.keys(["Control", "ArrowUp"]);
 			activeElementHTML = await browser.execute(() => document.activeElement.shadowRoot.activeElement.outerHTML);
 
 			assert.equal(await mcb.getProperty("focused"), true, "The input should be focused");
-			assert.equal(await listItem.getProperty("focused"), false, "The first item should not be focused");
+			assert.notOk(await listItem.matches(":focus"), "The first item should not be focused");
 			assert.notEqual(activeElementHTML, await vsHeader.getHTML(), "The value state header or item should not be focused");
 			assert.notEqual(activeElementHTML, await listItem.getHTML(), "The value state header or item should not be focused");
 		});
 
-		it ("should select all filtered items on CTRL+A", async () => {
+		it("should select all filtered items on CTRL+A", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1128,7 +1124,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await tokens.length, 0, "All selected filtered items are deselected");
 		});
 
-		it ("should copy a token with CTRL+C and paste it with CTRL+V", async () => {
+		it("should copy a token with CTRL+C and paste it with CTRL+V", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi1");
@@ -1149,7 +1145,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("value"), "CondensedCondensed", "Pasting second time should append the as text");
 		});
 
-		it ("should not be able to paste token with CTRL+V in read only multi combo box", async () => {
+		it("should not be able to paste token with CTRL+V in read only multi combo box", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi1");
@@ -1167,7 +1163,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(mcb2Tokens.length, 0, "No token was created.");
 		});
 
-		it ("should cut a token with CTRL+X and paste it with CTRL+V", async () => {
+		it("should cut a token with CTRL+X and paste it with CTRL+V", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi1");
@@ -1187,7 +1183,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("value"), "Condensed", "Token is pasted into the second control");
 		});
 
-		it ("should cut a token with SHIFT+DELETE and paste it with SHIFT+INSERT", async () => {
+		it("should cut a token with SHIFT+DELETE and paste it with SHIFT+INSERT", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi1");
@@ -1207,7 +1203,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("value"), "Condensed", "Token is pasted into the second control");
 		});
 
-		it ("should copy a token with CTRL+INSERT and paste it with SHIFT+INSERT", async () => {
+		it("should copy a token with CTRL+INSERT and paste it with SHIFT+INSERT", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi1");
@@ -1223,7 +1219,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await mcb2.getProperty("value"), "Condensed", "Token is pasted into the second control");
 		});
 
-		it ("should select a token with CTRL+SPACE", async () => {
+		it("should select a token with CTRL+SPACE", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-error");
@@ -1238,7 +1234,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await tokens[2].getProperty("selected"), true, "Last token should be selected");
 		});
 
-		it ("CTRL+SPACE should do nothing when pressed in the input field", async () => {
+		it("CTRL+SPACE should do nothing when pressed in the input field", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1250,58 +1246,55 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await mcb.getProperty("value"), "", "Input field is empty");
 		});
 
-		it ("F4 should focus the selected item or the first one if there is no selected", async () => {
+		it("F4 should focus the selected item or the first one if there is no selected", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
+			const listItem2 = await popover.$$("ui5-li")[1];
 
 			await mcb.click();
 			await mcb.keys("F4");
 
-			const listItem = await popover.$("ui5-list").$("ui5-li");
-
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 
 			await mcb.keys("ArrowDown");
 			await mcb.keys("Space");
 			await mcb.keys("F4");
 			await mcb.keys("F4");
 
-			const listItem2 = await popover.$("ui5-list").$$("ui5-li")[1];
-
-			assert.equal(await listItem2.getProperty("focused"), true, "The second item is focused as it is selected");
+			assert.ok(await listItem2.matches(":focus"), "The second item is focused as it is selected");
 		});
 
-		it ("Alt + Down should focus the corresponding item to the token from which the combination is pressed", async () => {
+		it("Alt + Down should focus the corresponding item to the token from which the combination is pressed", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-items");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
-			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
+			const tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
+			const listItem = await popover.$$("ui5-li")[3];
 
 			await tokens[2].click();
 			await tokens[2].keys(["Alt", "ArrowDown"]);
 
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[3];
-
-			assert.equal(await listItem.getProperty("focused"), true, "The selected item corresponding to the token is focused");
+			assert.ok(await listItem.matches(":focus"), "The selected item corresponding to the token is focused");
 		});
 
-		it ("Alt + Down should focus the first item if no selected items are present", async () => {
+		it("Alt + Down should focus the first item if no selected items are present", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#multi-acv");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
+			const listItem = await popover.$("ui5-li");
 
 			await mcb.click();
 			await mcb.keys(["Alt", "ArrowDown"]);
 
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[0];
-			assert.equal(await listItem.getProperty("focused"), true, "The first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The first item is focused");
 		});
 
-		it ("Alt + Down should not filter items", async () => {
+		it("Alt + Down should not filter items", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1312,12 +1305,12 @@ describe("MultiComboBox general interaction", () => {
 			await input.keys(["a", "b"]);
 			await input.keys(["Alt", "ArrowDown"]);
 
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[0];
+			const listItem = await popover.$("ui5-li");
 
-			assert.equal(await listItem.getProperty("focused"), true, "The items are not filtered and the first item is focused");
+			assert.ok(await listItem.matches(":focus"), "The items are not filtered and the first item is focused");
 		});
 
-		it ("Alt + Down should focus the item corresponding to the text value", async () => {
+		it("Alt + Down should focus the item corresponding to the text value", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb");
@@ -1329,15 +1322,15 @@ describe("MultiComboBox general interaction", () => {
 			await input.keys("ArrowDown");
 			await input.keys(["Alt", "ArrowDown"]);
 
-			let listItem = await popover.$("ui5-list").$$("ui5-li")[1];
+			const listItem = await popover.$$("ui5-li")[1];
 
-			assert.equal(await listItem.getProperty("focused"), true, "The second item should be focused");
+			assert.ok(await listItem.matches(":focus"), "The second item is focused");
 		});
 
-		it ("Backspace deletes token and forwards the focus to the last token without collapsing the tokenizer", async () => {
+		it("Backspace deletes token and forwards the focus to the last token without collapsing the tokenizer", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
-			const mcb = await $("#n-more-many-items");
+			const mcb = await browser.$("#n-more-many-items");
 			const inner = await mcb.shadow$("input");
 			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
 
@@ -1354,8 +1347,8 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await tokens[tokens.length - 1].getProperty("focused"), "Last Token is focused");
 		});
 
-		it ("should open/close popover on keyboard combination ctrl + i", async () => {
-			const mcb = await $("#truncated-token");
+		it("should open/close popover on keyboard combination ctrl + i", async () => {
+			const mcb = await browser.$("#truncated-token");
 			const inner = await mcb.shadow$("input");
 			const rpo = await mcb.shadow$("ui5-responsive-popover");
 
@@ -1368,14 +1361,13 @@ describe("MultiComboBox general interaction", () => {
 		});
 
 		it("shouldn't open popover on keyboard combination ctrl + i when there are no tokens", async () => {
-			const mcb = await $("#mcb-no-typeahead");
+			const mcb = await browser.$("#mcb-no-typeahead");
 			const tokenizer = await mcb.shadow$("ui5-tokenizer");
 			const rpo = await tokenizer.shadow$("ui5-responsive-popover");
 
 			await mcb.click();
 			await mcb.keys(["Control", "i"]);
 			assert.notOk(await rpo.getProperty("open"), "n-more popover should be closed since no tokens");
-
 		});
 	});
 
@@ -1384,7 +1376,7 @@ describe("MultiComboBox general interaction", () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 		});
 
-		it ("tests text selection on focus", async () => {
+		it("tests text selection on focus", async () => {
 			const mcb = await browser.$("#multi-acv");
 			const mcb2 = await browser.$("#mcb-with-placeholder");
 
@@ -1406,22 +1398,20 @@ describe("MultiComboBox general interaction", () => {
 			await mcb2.keys(["Shift", "Tab"]);
 			assert.equal(await selectionStartIndex, 0, "The selection starts from the beginning of the value");
 			assert.equal(await selectionEndIndex, 3, "The whole value is selected");
-
-
 		});
 
-		it ("tests two-column layout", async () => {
+		it("tests two-column layout", async () => {
 			const mcb = await browser.$("#mcb-two-column-layout");
 			const icon = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$(".ui5-multi-combobox-all-items-responsive-popover");
-			const listItem = await popover.$("ui5-list").$$("ui5-li")[0];
+			const listItem = await popover.$("ui5-li");
 
 			await icon.click();
 			assert.strictEqual(await listItem.shadow$(".ui5-li-additional-text").getText(), "DZ", "Additional item text should be displayed");
 			await icon.click();
 		});
 
-		it ("placeholder tests", async () => {
+		it("placeholder tests", async () => {
 			const mcb1 = await browser.$("#another-mcb").shadow$("#ui5-multi-combobox-input");
 			const mcb2 = await browser.$("#mcb-with-placeholder").shadow$("#ui5-multi-combobox-input");
 
@@ -1457,7 +1447,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await innerInput2.getAttribute("placeholder"), "", "Shouldn't have placeholder as an item is programmatically selected");
 		});
 
-		it ("Should not open value state message when component is in readonly state", async () => {
+		it("Should not open value state message when component is in readonly state", async () => {
 			const mcb = await browser.$("#readonly-value-state-mcb");
 			const popover = await mcb.shadow$("ui5-popover");
 
@@ -1466,8 +1456,8 @@ describe("MultiComboBox general interaction", () => {
 		});
 
 		it("Should apply correct text to the tokens overflow indicator", async () => {
-			const mcNItems = await $("#mc-items");
-			const mcNMore = await $("#mc-more");
+			const mcNItems = await browser.$("#mc-items");
+			const mcNMore = await browser.$("#mc-more");
 			const tokenizerNItems = await mcNItems.shadow$("ui5-tokenizer");
 			const tokenizerNMore = await mcNMore.shadow$("ui5-tokenizer");
 			const nItemsLabel = await tokenizerNItems.shadow$(".ui5-tokenizer-more-text");
@@ -1485,10 +1475,10 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await nMoreLabel.getText(), resourceBundleText.mcNMoreLabelText, "Text should be 1 More");
 		});
 
-		it ("Should check clear icon availability", async () => {
+		it("Should check clear icon availability", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
-			const cb = await $("#clear-icon-cb");
+			const cb = await browser.$("#clear-icon-cb");
 			const inner = cb.shadow$("input");
 			const clearIcon = await cb.shadow$(".ui5-input-clear-icon-wrapper");
 
@@ -1500,10 +1490,10 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await cb.getProperty("_effectiveShowClearIcon"), "_effectiveShowClearIcon should be set to true upon typing");
 		});
 
-		it ("Should check clear icon events", async () => {
+		it("Should check clear icon events", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
-			const cb = await $("#clear-icon-cb");
+			const cb = await browser.$("#clear-icon-cb");
 
 			await cb.shadow$("input").click();
 			await cb.shadow$("input").keys("c");
@@ -1524,10 +1514,11 @@ describe("MultiComboBox general interaction", () => {
 		});
 
 		it("should truncate token when single token is in the multicombobox and open popover on click", async () => {
-			const mcb = await $("#truncated-token");
+			const mcb = await browser.$("#truncated-token");
 			const token = await mcb.shadow$("ui5-token");
 			const tokenizer = await mcb.shadow$("ui5-tokenizer");
 			const rpo = await tokenizer.shadow$("ui5-responsive-popover");
+			const listItem = await rpo.$("ui5-li");
 
 			assert.ok(await token.getProperty("singleToken"), "Single token property should be set");
 
@@ -1536,7 +1527,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await rpo.getProperty("open"), "More Popover should be open");
 			assert.ok(await token.getProperty("selected"), "Token should be selected");
 			assert.ok(await token.getProperty("singleToken"), "Token should be single (could be truncated)");
-			assert.ok(await rpo.$("ui5-li").getProperty("focused"), "Token's list item is focused");
+			assert.ok(await listItem.matches(":focus"), "Token's list item is focused");
 
 			await token.click();
 
@@ -1546,7 +1537,7 @@ describe("MultiComboBox general interaction", () => {
 		});
 
 		it("should close truncation popover and deselect selected tokens when clicked outside the component", async () => {
-			const mcb = await $("#truncated-token");
+			const mcb = await browser.$("#truncated-token");
 			const token = await mcb.shadow$("ui5-token");
 			const tokenizer = await mcb.shadow$("ui5-tokenizer");
 			const rpo = await tokenizer.shadow$("ui5-responsive-popover");
@@ -1555,14 +1546,14 @@ describe("MultiComboBox general interaction", () => {
 
 			await token.click();
 
-			await $("#dummy-btn").click();
+			await browser.$("#dummy-btn").click();
 
 			assert.notOk(await rpo.getProperty("open"), "More Popover should be closed");
 			assert.notOk(await token.getProperty("selected"), "Token should be deselected");
 		});
 
 		it("should close truncation popover and deselect selected tokens when clicked in input field", async () => {
-			const mcb = await $("#truncated-token");
+			const mcb = await browser.$("#truncated-token");
 			const token = await mcb.shadow$("ui5-token");
 			const tokenizer = await mcb.shadow$("ui5-tokenizer");
 			const rpo = await tokenizer.shadow$("ui5-responsive-popover");
@@ -1582,7 +1573,7 @@ describe("MultiComboBox general interaction", () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 		});
 
-		it ("aria-describedby value according to the tokens count and the value state", async () => {
+		it("aria-describedby value according to the tokens count and the value state", async () => {
 			const mcb = await browser.$("#mcb-error");
 			const innerInput = await mcb.shadow$("input");
 			let tokens = await mcb.shadow$$(".ui5-multi-combobox-token");
@@ -1594,7 +1585,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await innerInput.getAttribute("aria-describedby"), ariaDescribedBy, "aria-describedby has a reference for the value state and the tokens count");
 		});
 
-		it ("aria-describedby value according to the tokens count", async () => {
+		it("aria-describedby value according to the tokens count", async () => {
 			const mcb = await browser.$("#mcb-compact");
 
 			await mcb.scrollIntoView();
@@ -1645,7 +1636,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.ok(await ariaHiddenText.includes(resourceBundleText), "aria-describedby text is correct");
 		});
 
-		it ("Should apply aria-label from the accessibleName property", async () => {
+		it("Should apply aria-label from the accessibleName property", async () => {
 			const mcb = await browser.$("#multi1");
 			const innerInput = await mcb.shadow$("input");
 
@@ -1654,7 +1645,7 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await innerInput.getAttribute("aria-label"), "MultiComboBox with predefined values", "aria-label attribute is correct.");
 		});
 
-		it ("Should apply aria-label from the accessibleNameRef property", async () => {
+		it("Should apply aria-label from the accessibleNameRef property", async () => {
 			const mcb = await browser.$("#mcb-predefined-value");
 			const innerInput = await mcb.shadow$("input");
 			const mcbLabel = await browser.$("#mcbLabel");
@@ -1723,7 +1714,7 @@ describe("MultiComboBox general interaction", () => {
 	});
 
 	describe("Grouping", () => {
-		it ("Tests group filtering", async () => {
+		it("Tests group filtering", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-grouping");
@@ -1753,24 +1744,23 @@ describe("MultiComboBox general interaction", () => {
 			assert.equal(await popover.getProperty("open"), false, "Popover should not be open");
 		});
 
-		it ("Tests group item focusability", async () => {
+		it("Tests group item focusability", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-grouping");
 			const input = await mcb.shadow$("#ui5-multi-combobox-input");
 			const arrow = await mcb.shadow$(".inputIcon");
 			const popover = await mcb.shadow$("ui5-responsive-popover");
-			let groupItem;
 
 			await arrow.click();
 			await input.keys("ArrowDown");
 
-			groupItem = await popover.$("ui5-list").$$("ui5-li-group-header")[0];
+			const groupItem = await popover.$("ui5-li-group-header");
 
-			assert.equal(await groupItem.getProperty("focused"), true, "The first group header should be focused");
+			assert.ok(await groupItem.matches(":focus"), "The first group header should be focused");
 		});
 
-		it ("Group header keyboard handling", async () => {
+		it("Group header keyboard handling", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-grouping");
@@ -1782,27 +1772,31 @@ describe("MultiComboBox general interaction", () => {
 			await arrow.click();
 			await input.keys("ArrowDown");
 
+			groupItem = await popover.$("ui5-li-group-header");
 
-			groupItem = await popover.$("ui5-list").$$("ui5-li-group-header")[0];
 			await groupItem.keys("Enter");
 
-			assert.equal(await groupItem.getProperty("focused"), true, "The first group header should be focused");
+			assert.ok(await groupItem.matches(":focus"), "The first group header should be focused");
 			assert.equal(await popover.getProperty("open"), true, "Popover should not be open");
 			assert.strictEqual(await input.getValue(), "", "The value is not updated");
 
+			groupItem = await popover.$("ui5-li-group-header");
+
 			await groupItem.keys("Space");
 
-			assert.equal(await groupItem.getProperty("focused"), true, "The first group header should be focused");
+			assert.ok(await groupItem.matches(":focus"), "The first group header should be focused");
 			assert.equal(await popover.getProperty("open"), true, "Popover should not be open");
 			assert.strictEqual(await input.getValue(), "", "The value is not updated)");
 
+			groupItem = await popover.$("ui5-li-group-header");
+
 			await groupItem.keys("ArrowUp");
 
-			assert.equal(await groupItem.getProperty("focused"), false, "The first group header should be focused");
+			assert.notOk(await groupItem.matches(":focus"), "The first group header should not be focused");
 			assert.equal(await mcb.getProperty("focused"), true, "The first group header should be focused");
 		});
 
-		it ("Should not select group headers", async () => {
+		it("Should not select group headers", async () => {
 			await browser.url(`test/pages/MultiComboBox.html`);
 
 			const mcb = await browser.$("#mcb-grouping");

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -19,7 +19,7 @@ describe("MultiInput general interaction", () => {
 		assert.notOk(await basicTokenizer.getProperty("expanded"), "Tokenizer should not be expanded");
 	});
 
-	it ("tests opening of tokenizer Popover", async () => {
+	it("tests opening of tokenizer Popover", async () => {
 		const tokenizer = await browser.$("#basic-overflow").shadow$("ui5-tokenizer");
 		const nMoreLabel = await tokenizer.shadow$(".ui5-tokenizer-more-text");
 
@@ -30,7 +30,7 @@ describe("MultiInput general interaction", () => {
 		assert.ok(await rpo.getProperty("open"), "More Popover should be open");
 	});
 
-	it ("fires value-help-trigger on icon press", async () => {
+	it("fires value-help-trigger on icon press", async () => {
 		await browser.url(`test/pages/MultiInput.html`);
 
 		const label = await browser.$("#basic-event-listener");
@@ -47,7 +47,7 @@ describe("MultiInput general interaction", () => {
 
 	});
 
-	it ("fires value-help-trigger with F4 and Alt/Option + ArrowUp/Down", async () => {
+	it("fires value-help-trigger with F4 and Alt/Option + ArrowUp/Down", async () => {
 		const eventCounter = await browser.$("#value-help-trigger-counter");
 		const multiInputInner = await browser.$("#multi-with-value-help-icon").shadow$(".ui5-input-inner");
 
@@ -65,7 +65,7 @@ describe("MultiInput general interaction", () => {
 		assert.strictEqual(await eventCounter.getProperty("value"), "2", "value help press event is fired");
 	});
 
-	it ("adds a token to multi input", async () => {
+	it("adds a token to multi input", async () => {
 		const mi = await browser.$("#single-token");
 		const btn = await browser.$("#add-to-single");
 
@@ -83,7 +83,7 @@ describe("MultiInput general interaction", () => {
 		assert.notOk(await allTokens[1].getProperty("overflows"), "Token should not overflow");
 	});
 
-	it ("adds multiple tokens to multi input", async () => {
+	it("adds multiple tokens to multi input", async () => {
 		const mi = await browser.$("#no-tokens2");
 		const btn = await browser.$("#add-multiple-tokens");
 
@@ -97,7 +97,7 @@ describe("MultiInput general interaction", () => {
 		assert.notOk(await allTokens[1].getProperty("overflows"), "Token 2 should not overflow");
 	});
 
-	it ("adds an overflowing token to multi input", async () => {
+	it("adds an overflowing token to multi input", async () => {
 		const mi = await browser.$("#multiple-token");
 		const btn = await browser.$("#add-to-multiple");
 
@@ -224,7 +224,7 @@ describe("MultiInput Truncated Token", () => {
 		assert.ok(await rpo.getProperty("open"), "More Popover should be open");
 		assert.ok(await token.getProperty("selected"), "Token should be selected");
 		assert.ok(await token.getProperty("singleToken"), "Token should be single (could be truncated)");
-		assert.ok(await rpo.$("ui5-li").getProperty("focused"), "Token's list item is focused");
+		assert.ok(await rpo.$("ui5-li").matches(":focus"), "Token's list item is focused");
 
 		await token.click();
 
@@ -278,7 +278,7 @@ describe("MultiInput Truncated Token", () => {
 		await inner.keys("Enter");
 
 		const rpo = await tokenizer.shadow$("ui5-responsive-popover");
-
+		const listItem = await rpo.$("ui5-li");
 		const token = await mi.$("ui5-token");
 
 		assert.ok(await token.getProperty("singleToken"), "Single token property should be set");
@@ -287,7 +287,7 @@ describe("MultiInput Truncated Token", () => {
 
 		assert.ok(await rpo.getProperty("open"), "More Popover should be open");
 		assert.ok(await token.getProperty("selected"), "Token should be selected");
-		assert.ok(await rpo.$("ui5-li").getProperty("focused"), "Token's list item is focused");
+		assert.ok(await listItem.matches(":focus"), "Token's list item is focused");
 
 		const deleteIcon = await token.shadow$("ui5-icon");
 
@@ -311,7 +311,7 @@ describe("MultiInput Truncated Token", () => {
 });
 
 describe("ARIA attributes", () => {
-	it ("aria-describedby value according to the tokens count", async () => {
+	it("aria-describedby value according to the tokens count", async () => {
 		const mi = await browser.$("#no-tokens");
 		const innerInput = await mi.shadow$("input");
 		const btn = await browser.$("#add-tokens");
@@ -347,7 +347,7 @@ describe("ARIA attributes", () => {
 		assert.strictEqual(await invisibleText.getText(), "Contains 2 tokens", "aria-describedby text is correct");
 	});
 
-	it ("aria-describedby value according to the tokens and suggestions count", async () => {
+	it("aria-describedby value according to the tokens and suggestions count", async () => {
 		const mi = await browser.$("#suggestion-token");
 		const innerInput = await mi.shadow$("input");
 		const tokensCountITextId = `hiddenText-nMore`;
@@ -363,7 +363,7 @@ describe("ARIA attributes", () => {
 		assert.strictEqual(await innerInput.getAttribute("aria-describedby"), ariaDescribedBy, "aria-describedby attribute contains multiple references");
 	});
 
-	it ("aria-roledescription is set properly", async () => {
+	it("aria-roledescription is set properly", async () => {
 		const mi = await browser.$("#no-tokens");
 		const innerInput = await mi.shadow$("input");
 
@@ -485,7 +485,7 @@ describe("Keyboard handling", () => {
 		assert.strictEqual(await firstToken.getProperty("focused"), true, "The first token is focused");
 	});
 
-	it ("Should focus the input when all tokens are deleted", async () => {
+	it("Should focus the input when all tokens are deleted", async () => {
 		const input = await browser.$("#two-tokens");
 		const innerInput = await input.shadow$("input");
 

--- a/packages/main/test/specs/Tokenizer.mobile.spec.js
+++ b/packages/main/test/specs/Tokenizer.mobile.spec.js
@@ -71,7 +71,7 @@ describe("Deleting tokens", () => {
 
 		assert.ok(await nMoreDialog.getProperty("open"), "Popover should be opened.");
 		assert.strictEqual(await nMoreDialog.$$("ui5-li").length, 3, "3 items should be present");
-		assert.ok(await nMoreDialog.$$("ui5-li")[0].getProperty("focused"), "First item should be focused on open");
+		assert.ok(await nMoreDialog.$("ui5-li").matches(":focus"), "First item should be focused on open");
 	});
 
 	it("Should NOT fire the ui5-token-delete event when no items are deleted and OK is pressed", async () => {
@@ -121,6 +121,6 @@ describe("Deleting tokens", () => {
 
 		assert.ok(await nMoreDialog.getProperty("open"), "Popover should be opened.");
 		assert.strictEqual(await nMoreDialog.$$("ui5-li").length, 5, "All items should be present");
-		assert.ok(await nMoreDialog.$$("ui5-li")[0].getProperty("focused"), "First item should be focused on open");
+		assert.ok(await nMoreDialog.$("ui5-li").matches(":focus"), "First item should be focused on open");
 	});
 });

--- a/packages/main/test/specs/Tokenizer.spec.js
+++ b/packages/main/test/specs/Tokenizer.spec.js
@@ -11,7 +11,15 @@ async function getResourceBundleTexts(keys) {
 		done(texts);
 
 	}, keys);
-}
+};
+
+const isListItemFocused = async (listItem) => {
+	return await browser.execute(el => {
+		const pseudoElementStyle = window.getComputedStyle(el, ":after");
+		const hasBorder = pseudoElementStyle.getPropertyValue("border-style") !== "none";
+		return hasBorder;
+	}, listItem);
+};
 
 describe("General interaction", () => {
 	before(async () => {
@@ -62,11 +70,11 @@ describe("nMore Popover", () => {
 		await nMoreLabel.click();
 
 		const rpo = await tokenizer.shadow$("ui5-responsive-popover");
-		const firstListItem = await rpo.$("ui5-list").$$("ui5-li")[0];
+		const firstListItem = await rpo.$("ui5-list ui5-li");
 
 		assert.strictEqual(Math.floor(tokenizerScrollContainerScrollLeft), Math.floor(tokenizerScrollContainerScrollWidth - tokenizerScrollContainerClientWidth), "tokenizer is scrolled to end");
 		assert.ok(await rpo.getProperty("open"), "nMore Popover should be opened upon click of nMore label.");
-		assert.ok(await firstListItem.getProperty("focused"), "First list item should be focused, upon Popover open.");
+		assert.ok(await firstListItem.matches(":focus"), "First list item should be focused, upon Popover open.");
 
 		await browser.keys('Escape');
 
@@ -80,20 +88,21 @@ describe("nMore Popover", () => {
 		await nMoreLabel.click();
 
 		const rpo = await tokenizer.shadow$("ui5-responsive-popover");
-		const firstListItem = await rpo.$("ui5-list").$$("ui5-li")[0];
+		const firstListItem = await rpo.$("ui5-list ui5-li");
 		const itemDeleteButton = await firstListItem.shadow$('ui5-button');
 
 		assert.ok(await rpo.getProperty("open"), "nMore Popover should be opened upon click of nMore label.");
-		assert.ok(await firstListItem.getProperty("focused"), "First list item should be focused, upon Popover open.");
+		assert.ok(await firstListItem.matches(":focus"), "First list item should be focused, upon Popover open.");
 
 		await browser.keys('F7');
 
-		assert.notOk(await firstListItem.getProperty("focused"), "List item should no longer be focused.");
+		assert.ok(await itemDeleteButton.matches(":focus"), "Delete button should be focused upon F7 key press.");
+		assert.notOk(await isListItemFocused(firstListItem), "List item should no longer be focused.");
 
 		await browser.keys('F7');
 
-		assert.notOk(await itemDeleteButton.getProperty("focused"), "List item should be focused upon F7 key press.");
-		assert.ok(await firstListItem.getProperty("focused"), "Delete button should no longer be focused.");
+		assert.notOk(await itemDeleteButton.matches(":focus"), "Delete button should no longer be focused.");
+		assert.ok(await firstListItem.matches(":focus"), "List item should be focused upon F7 key press.");
 	});
 
 	it("tests item deletion via mouse", async () => {
@@ -108,11 +117,11 @@ describe("nMore Popover", () => {
 		const firstlistItemDeleteButton = await firstListItem.shadow$('.ui5-li-deletebtn ui5-button');
 
 		assert.ok(await rpo.getProperty("open"), "nMore Popover should be opened upon click of nMore label.");
-		assert.ok(await firstListItem.getProperty("focused"), "First list item should be focused, upon Popover open.");
+		assert.ok(await firstListItem.matches(":focus"), "First list item should be focused, upon Popover open.");
 
 		await firstlistItemDeleteButton.click();
 
-		assert.ok(await secondListItem.getProperty("focused"), "Second list item should be focused, after first item deletion.");
+		assert.ok(await secondListItem.matches(":focus"), "Second list item should be focused, after first item deletion.");
 	});
 
 	it("tests item deletion via keyboard", async () => {
@@ -126,11 +135,11 @@ describe("nMore Popover", () => {
 		const secondListItem = await rpo.$$("ui5-li")[1];
 
 		assert.ok(await rpo.getProperty("open"), "nMore Popover should be opened upon click of nMore label.");
-		assert.ok(await firstListItem.getProperty("focused"), "First list item should be focused, upon Popover open.");
+		assert.ok(await firstListItem.matches(":focus"), "First list item should be focused, upon Popover open.");
 
 		await browser.keys('Delete');
 
-		assert.ok(await secondListItem.getProperty("focused"), "Second list item should be focused, after first item deletion.");
+		assert.ok(await secondListItem.matches(":focus"), "Second list item should be focused, after first item deletion.");
 	});
 });
 
@@ -194,7 +203,7 @@ describe("Single token", () => {
 	});
 
 	it("should open popover on click of single token", async () => {
-		const tokenizer = await $("#single-token-tokenizer");
+		const tokenizer = await browser.$("#single-token-tokenizer");
 		const token = await tokenizer.$("ui5-token");
 		const rpo = await tokenizer.shadow$("ui5-responsive-popover");
 
@@ -202,10 +211,12 @@ describe("Single token", () => {
 
 		await token.click();
 
+		const listItem = await rpo.$("ui5-list ui5-li");
+
 		assert.ok(await rpo.getProperty("open"), "nMore Popover should be open");
 		assert.ok(await token.getProperty("selected"), "Token should be selected");
 		assert.ok(await token.getProperty("singleToken"), "Token should be single (could be truncated)");
-		assert.ok(await rpo.$("ui5-li").getProperty("focused"), "Token's list item is focused");
+		assert.ok(await listItem.matches(":focus"), "Token's list item is focused");
 
 		await token.click();
 


### PR DESCRIPTION
Adjusted the focus display rules for `ui5-list` and other derivative list items. On desktop, the focus outline is always visible. On mobile devices, the focus outline appears only when using an external keyboard and remains hidden for touch focus.

Related issues: #8320, #7858