### PR TITLE
feat(ui5-menu-item): add endContent slot

### DIFF
--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -426,6 +426,7 @@ class Button extends UI5Element implements IButton, IFormElement {
 		if (this._cancelAction) {
 			e.preventDefault();
 		}
+		markEvent(e, "button");
 
 		if (isSpace(e) || isEnter(e)) {
 			if (this.active) {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -115,6 +115,9 @@ class ListItemBase extends UI5Element implements ITabbable {
 	}
 
 	_onkeydown(e: KeyboardEvent) {
+		if (getEventMark(e) === "button") {
+			return;
+		}
 		if (isTabNext(e)) {
 			return this._handleTabNext(e);
 		}
@@ -133,6 +136,9 @@ class ListItemBase extends UI5Element implements ITabbable {
 	}
 
 	_onkeyup(e: KeyboardEvent) {
+		if (getEventMark(e) === "button") {
+			return;
+		}
 		if (isSpace(e)) {
 			this.fireItemPress(e);
 		}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -335,7 +335,7 @@ class Menu extends UI5Element {
 	}
 
 	_itemKeyDown(e: KeyboardEvent) {
-		if ((e.target as Node).nodeName.toLowerCase() !=="ui5-menu-item") {
+		if ((e.target as Node).nodeName.toLowerCase() !== "ui5-menu-item") {
 			return;
 		}
 

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -335,7 +335,7 @@ class Menu extends UI5Element {
 	}
 
 	_itemKeyDown(e: KeyboardEvent) {
-		if ((e.target as Node).nodeName.toLowerCase() !== "ui5-menu-item") {
+		if (!isLeft(e) && !isRight(e)) {
 			return;
 		}
 

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -335,6 +335,10 @@ class Menu extends UI5Element {
 	}
 
 	_itemKeyDown(e: KeyboardEvent) {
+		if ((e.target as Node).nodeName.toLowerCase() !=="ui5-menu-item") {
+			return;
+		}
+
 		const shouldCloseMenu = this.isRtl ? isRight(e) : isLeft(e);
 		const shouldOpenMenu = this.isRtl ? isLeft(e) : isRight(e);
 		const item = e.target as MenuItem;

--- a/packages/main/src/MenuItem.hbs
+++ b/packages/main/src/MenuItem.hbs
@@ -20,6 +20,8 @@
 			>
 			</ui5-icon>
 		</div>
+	{{else if hasEndContent}}
+		<slot name="endContent"></slot>
 	{{else if additionalText}}
 		<span part="additional-text" class="ui5-li-additional-text">{{additionalText}}</span>
 	{{/if}}

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -161,8 +161,7 @@ class MenuItem extends ListItem {
 	/**
 	 * Defines the components that should be displayed at the end of the menu item.
 	 *
-	 * **Note:** It is highly recommended to slot only components of type `ui5-button` (icon-only),
-	 * `ui5-link` or `ui5-icon` that don't take much place and are not layout components.
+	 * **Note:** It is highly recommended to slot only components of type `ui5-button`,`ui5-link` or `ui5-icon`.
 	 * @public
 	 */
 	@slot({ type: HTMLElement, invalidateOnChildChange: true })

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -280,24 +280,6 @@ class MenuItem extends ListItem {
 	_afterPopoverClose() {
 		this.fireEvent("close", {}, false, false);
 	}
-
-	/**
-	 * Prevents menu closing when pressing Enter or Space over components inside the endContent slot.
-	 */
-	async _onkeydown(e: KeyboardEvent): Promise<void> {
-		if ((e.target as Node).nodeName.toLowerCase() === "li") {
-			await super._onkeydown(e);
-		}
-	}
-
-	/**
-	 * Prevents menu closing when pressing Space over components inside the endContent slot.
-	 */
-	_onkeyup(e: KeyboardEvent): void {
-		if ((e.target as Node).nodeName.toLowerCase() === "li" && isSpace(e)) {
-			super._onkeyup(e);
-		}
-	}
 }
 
 MenuItem.define();

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -68,7 +68,11 @@ class MenuItem extends ListItem {
 	/**
 	 * Defines the `additionalText`, displayed in the end of the menu item.
 	 *
-	 * **Note:** The additional text would not be displayed if the item has a submenu.
+	 * **Note:** The additional text will not be displayed if there are items added in `items` slot or there are
+	 * components added to `endContent` slot.
+	 *
+	 * The priority of what will be displayed at the end of the menu item is as follows:
+	 * sub-menu arrow (if there are items added in `items` slot) -> components added in `endContent` -> text set to `additionalText`.
 	 * @default ""
 	 * @public
 	 * @since 1.8.0
@@ -153,6 +157,13 @@ class MenuItem extends ListItem {
 
 	/**
 	 * Defines the items of this component.
+	 *
+	 * **Note:** If there are items added to this slot, an arrow will be displayed at the end
+	 * of the item in order to indicate that there are items added. In that case components added
+	 * to `endContent` slot or `additionalText` content will not be displayed.
+	 *
+	 * The priority of what will be displayed at the end of the menu item is as follows:
+	 * sub-menu arrow (if there are items added in `items` slot) -> components added in `endContent` -> text set to `additionalText`.
 	 * @public
 	 */
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
@@ -161,10 +172,17 @@ class MenuItem extends ListItem {
 	/**
 	 * Defines the components that should be displayed at the end of the menu item.
 	 *
-	 * **Note:** It is highly recommended to slot only components of type `ui5-button`,`ui5-link` or `ui5-icon`.
+	 * **Note:** It is highly recommended to slot only components of type `ui5-button`,`ui5-link`
+	 * or `ui5-icon` in order to preserve the intended design. If there are components added to this slot,
+	 * and there is text set in `additionalText`, it will not be displayed. If there are items added to `items` slot,
+	 * nether `additionalText` nor components added to this slot would be displayed.
+	 *
+	 * The priority of what will be displayed at the end of the menu item is as follows:
+	 * sub-menu arrow (if there are items added in `items` slot) -> components added in `endContent` -> text set to `additionalText`.
 	 * @public
+	 * @since 2.0.0
 	 */
-	@slot({ type: HTMLElement, invalidateOnChildChange: true })
+	@slot({ type: HTMLElement })
 	endContent!: Array<HTMLElement>;
 
 	get placement(): `${PopoverPlacement}` {

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -20,6 +20,7 @@ import type { ResponsivePopoverBeforeCloseEventDetail } from "./ResponsivePopove
 
 // Styles
 import menuItemCss from "./generated/themes/MenuItem.css.js";
+import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 
 type MenuBeforeOpenEventDetail = { item?: MenuItem };
 type MenuBeforeCloseEventDetail = { escPressed: boolean };
@@ -158,6 +159,13 @@ class MenuItem extends ListItem {
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
 	items!: Array<MenuItem>;
 
+	/**
+	 * Defines the items of this component.
+	 * @public
+	 */
+	@slot({ type: HTMLElement, invalidateOnChildChange: true })
+	endContent!: Array<HTMLElement>;
+
 	get placement(): `${PopoverPlacement}` {
 		return this.isRtl ? "Start" : "End";
 	}
@@ -168,6 +176,10 @@ class MenuItem extends ListItem {
 
 	get hasSubmenu() {
 		return !!(this.items.length || this.loading);
+	}
+
+	get hasEndContent() {
+		return !!(this.endContent.length);
 	}
 
 	get hasIcon() {
@@ -267,6 +279,24 @@ class MenuItem extends ListItem {
 
 	_afterPopoverClose() {
 		this.fireEvent("close", {}, false, false);
+	}
+
+	/**
+	 * Prevents menu closing when pressing Enter or Space over components inside the endContent slot.
+	 */
+	async _onkeydown(e: KeyboardEvent): Promise<void> {
+		if ((e.target as Node).nodeName.toLowerCase() === "li") {
+			await super._onkeydown(e);
+		}
+	}
+
+	/**
+	 * Prevents menu closing when pressing Space over components inside the endContent slot.
+	 */
+	_onkeyup(e: KeyboardEvent): void {
+		if ((e.target as Node).nodeName.toLowerCase() === "li" && isSpace(e)) {
+			super._onkeyup(e);
+		}
 	}
 }
 

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -5,7 +5,6 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import AriaHasPopup from "@ui5/webcomponents-base/dist/types/AriaHasPopup.js";
-import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import ListItem from "./ListItem.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import PopoverPlacement from "./types/PopoverPlacement.js";

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -5,6 +5,7 @@ import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import AriaHasPopup from "@ui5/webcomponents-base/dist/types/AriaHasPopup.js";
+import { isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import ListItem from "./ListItem.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import PopoverPlacement from "./types/PopoverPlacement.js";
@@ -20,7 +21,6 @@ import type { ResponsivePopoverBeforeCloseEventDetail } from "./ResponsivePopove
 
 // Styles
 import menuItemCss from "./generated/themes/MenuItem.css.js";
-import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 
 type MenuBeforeOpenEventDetail = { item?: MenuItem };
 type MenuBeforeCloseEventDetail = { escPressed: boolean };

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -159,7 +159,10 @@ class MenuItem extends ListItem {
 	items!: Array<MenuItem>;
 
 	/**
-	 * Defines the items of this component.
+	 * Defines the components that should be displayed at the end of the menu item.
+	 *
+	 * **Note:** It is highly recommended to slot only components of type `ui5-button` (icon-only),
+	 * `ui5-link` or `ui5-icon` that don't take much place and are not layout components.
 	 * @public
 	 */
 	@slot({ type: HTMLElement, invalidateOnChildChange: true })

--- a/packages/main/src/themes/MenuItem.css
+++ b/packages/main/src/themes/MenuItem.css
@@ -82,7 +82,7 @@
 }
 
 :host::part(content) {
-	padding-inline-end: 0.5rem;
+	padding-inline-end: 0.25rem;
 }
 
 .ui5-menu-item-submenu-icon {

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -59,7 +59,8 @@
 	<ui5-title level="H5" class="header-title">Event logger</ui5-title>
 	<ui5-input id="eventLogger" style="width: 100%;"></ui5-input>
 
-	<ui5-button id="btnOpen2">Open Menu</ui5-button> <br/>
+	<ui5-title level="H5" class="header-title">Menu with disabled items that have popovers</ui5-title>
+	<ui5-button id="btnOpen2">Open Menu</ui5-button> <br/><br/>
 	<ui5-menu id="menu2" header-text="My ui5-menu">
 		<ui5-menu-item id="newFolder" text="New Folder" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
 		<ui5-menu-item text="Open" icon="open-folder" starts-section>
@@ -69,6 +70,37 @@
 		<ui5-menu-item id="preferences" text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
 		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
 	</ui5-menu>
+
+	<ui5-title level="H5" class="header-title">Menu with items that have endContent</ui5-title>
+	<ui5-button id="btnOpenEndContent">Open Menu</ui5-button>
+	<ui5-menu id="menuEndContent" header-text="My ui5-menu">
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file - prevent default" icon="add-document">
+			<ui5-button id="newLock" slot="endContent" icon="locked" design="Transparent"></ui5-button>
+			<ui5-button id="newUnlock" slot="endContent" icon="unlocked" design="Transparent"></ui5-button>
+			<ui5-button id="newFavorite" slot="endContent" icon="favorite" design="Transparent"></ui5-button>
+		</ui5-menu-item>
+		<ui5-menu-item text="New Folder with very long title for a menu item" additional-text="Ctrl+F" icon="add-folder" disabled></ui5-menu-item>
+		<ui5-menu-item text="Open" icon="open-folder" accessible-name="Choose platform" starts-section>
+			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K">
+				<ui5-menu-item text="Open from C"></ui5-menu-item>
+				<ui5-menu-item text="Open from D"></ui5-menu-item>
+				<ui5-menu-item text="Open from E" disabled></ui5-menu-item>
+			</ui5-menu-item>
+			<ui5-menu-item text="Open from SAP Cloud" additional-text="Ctrl+L"></ui5-menu-item>
+		</ui5-menu-item>
+		<ui5-menu-item text="Save with very long title for a menu item text inside" icon="save">
+			<ui5-menu-item text="Save Locally" icon="save">
+				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
+				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
+				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
+			</ui5-menu-item>
+			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
+		</ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W"></ui5-menu-item>
+		<ui5-menu-item text="Preferences" icon="action-settings" starts-section disabled></ui5-menu-item>
+		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
+	</ui5-menu>
+
 
 	<ui5-popover id="detailsPopover" initialFocus="detailsLink">
 			<div>
@@ -85,6 +117,11 @@
 		btnOpen.addEventListener("click", function() {
 			menu.opener = "btnOpen";
 			menu.open = !menu.open;
+		});
+
+		btnOpenEndContent.addEventListener("click", function() {
+			menuEndContent.opener = "btnOpenEndContent";
+			menuEndContent.open = !menu.open;
 		});
 
 		btnAddOpener.addEventListener("click", function() {
@@ -176,6 +213,24 @@
 					detailsPopover.open = false;
 				}
 			});
+		});
+
+		newLock.addEventListener("click", function(event) {
+			console.warn("Lock button clicked");
+			event.target.parentElement.disabled = true;
+		});
+
+		newUnlock.addEventListener("click", function(event) {
+			console.warn("Unlock button clicked");
+			event.target.parentElement.disabled = false;
+		});
+
+		newFavorite.addEventListener("click", function(event) {
+			console.warn("Favorite button clicked");
+		});
+
+		menuEndContent.addEventListener("ui5-item-click", function(event) {
+			console.warn("Item clicked: " + event.detail.item.text);
 		});
 
 	</script>

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -182,9 +182,9 @@ describe("Menu interaction", () => {
 			const lockButton = await endContent[0];
 			await lockButton.click();
 
-			assert.equal(endContent.length, 3, "The menu item has 3 components in the 'endContent' slot");
-			assert.ok(menuItem.disabled, "The menu item is disabled");
-			assert.ok(menu.open, "The menu remains open");
+			assert.equal(await endContent.length, 3, "The menu item has 3 components in the 'endContent' slot");
+			assert.ok(await menuItem.getProperty("disabled"), "The menu item is disabled");
+			assert.ok(await menu.getProperty("open"), "The menu remains open");
 		});
 	});
 

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -170,6 +170,22 @@ describe("Menu interaction", () => {
 			assert.ok(await menuItem.getProperty("disabled"), "The menu item is disabled");
 			assert.ok(await menuItem.getProperty("focused"), "The menu item is focused");
 		});
+
+		it("Add endContent to a menu item", async () => {
+			await browser.url(`test/pages/Menu.html`);
+			const openButton = await browser.$("#btnOpenEndContent");
+			await openButton.click();
+
+			const menu = await browser.$("#menuEndContent");
+			const menuItem = await browser.$("#menuEndContent > ui5-menu-item[text='New File']");
+			const endContent = await menuItem.$$("[ui5-button]");
+			const lockButton = await endContent[0];
+			await lockButton.click();
+
+			assert.equal(endContent.length, 3, "The menu item has 3 components in the 'endContent' slot");
+			assert.ok(menuItem.disabled, "The menu item is disabled");
+			assert.ok(menu.open, "The menu remains open");
+		});
 	});
 
 describe("Menu Accessibility", () => {

--- a/packages/website/docs/_components_pages/main/Menu/Menu.mdx
+++ b/packages/website/docs/_components_pages/main/Menu/Menu.mdx
@@ -5,6 +5,7 @@ slug: ../../Menu
 import Basic from "../../../_samples/main/Menu/Basic/Basic.md";
 import SubMenu from "../../../_samples/main/Menu/SubMenu/SubMenu.md";
 import AditionalText from "../../../_samples/main/Menu/AditionalText/AditionalText.md";
+import MenuEndContent from "../../../_samples/main/Menu/MenuEndContent/MenuEndContent.md";
 
 <%COMPONENT_OVERVIEW%>
 
@@ -23,3 +24,7 @@ You can nest menu items to create sub menus.
 ### Menu Item with Additional Text
 
 <AditionalText />
+
+### Menu Item with End Content
+
+<MenuEndContent />

--- a/packages/website/docs/_samples/main/Menu/MenuEndContent/MenuEndContent.md
+++ b/packages/website/docs/_samples/main/Menu/MenuEndContent/MenuEndContent.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Menu/MenuEndContent/main.js
+++ b/packages/website/docs/_samples/main/Menu/MenuEndContent/main.js
@@ -1,0 +1,36 @@
+import "@ui5/webcomponents/dist/Menu.js";
+import "@ui5/webcomponents/dist/MenuItem.js";
+import "@ui5/webcomponents/dist/Button.js";
+
+import "@ui5/webcomponents-icons/dist/add-document.js";
+import "@ui5/webcomponents-icons/dist/add-folder.js";
+import "@ui5/webcomponents-icons/dist/open-folder.js";
+import "@ui5/webcomponents-icons/dist/action-settings.js";
+import "@ui5/webcomponents-icons/dist/journey-arrive.js";
+import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
+import "@ui5/webcomponents-icons/dist/add.js";
+import "@ui5/webcomponents-icons/dist/hint.js";
+import "@ui5/webcomponents-icons/dist/favorite.js";
+
+const btnOpenEndContent = document.getElementById("btnOpenEndContent");
+const menuEndContent = document.getElementById("menuEndContent");
+const btnNewAdd = document.getElementById("newAdd");
+const btnNewHint = document.getElementById("newHint");
+const btnNewFavorite = document.getElementById("newFavorite");
+
+btnOpenEndContent.addEventListener("click", function(event) {
+	menuEndContent.opener = btnOpenEndContent;
+	menuEndContent.open = !menuEndContent.open;
+});
+
+btnNewAdd.addEventListener("click", function(event) {
+	alert("Add button pressed");
+});
+
+btnNewHint.addEventListener("click", function(event) {
+	alert("Hint button pressed");
+});
+
+btnNewFavorite.addEventListener("click", function(event) {
+	alert("Favorite button pressed");
+});

--- a/packages/website/docs/_samples/main/Menu/MenuEndContent/sample.html
+++ b/packages/website/docs/_samples/main/Menu/MenuEndContent/sample.html
@@ -1,0 +1,41 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor); height: 350px">
+    <!-- playground-fold-end -->
+
+	<ui5-button id="btnOpenEndContent">Open Menu</ui5-button>
+
+	<ui5-menu id="menuEndContent" header-text="My ui5-menu">
+		<ui5-menu-item text="New File" accessible-name="Opens a file explorer" additional-text="Ctrl+Alt+Shift+N" tooltip="Select a file - prevent default" icon="add-document">
+			<ui5-button id="newAdd" slot="endContent" icon="add" design="Transparent"></ui5-button>
+			<ui5-button id="newHint" slot="endContent" icon="hint" design="Transparent"></ui5-button>
+			<ui5-button id="newFavorite" slot="endContent" icon="favorite" design="Transparent"></ui5-button>
+		</ui5-menu-item>
+		<ui5-menu-item text="New Folder" additional-text="Ctrl+F" icon="add-folder"></ui5-menu-item>
+		<ui5-menu-item text="Open" icon="open-folder" accessible-name="Choose platform" starts-section>
+			<ui5-menu-item text="Open Locally" icon="open-folder" additional-text="Ctrl+K"></ui5-menu-item>
+			<ui5-menu-item text="Open from SAP Cloud" additional-text="Ctrl+L"></ui5-menu-item>
+		</ui5-menu-item>
+		<ui5-menu-item text="Save with very long title for a menu item text inside" icon="save">
+			<ui5-menu-item text="Save Locally" icon="save"></ui5-menu-item>
+			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
+		</ui5-menu-item>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W"></ui5-menu-item>
+		<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
+		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
+	</ui5-menu>
+
+    <!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->


### PR DESCRIPTION
New slot `endContent` is introduced in `ui5-menu-item` component. This slot accepts components that are displayed at the end of the Menu Item if it does not have sub-menu. If there are components slotted and also additionalText is being set, the additionalText will not be shown as well. 

It is strongly recommended  to slot only icon-only `ui5-button`, `ui5-icon` or `ui5-link` components.

BGSOFUIBALKAN-8160
#6350