### PR TITLE
fix(ui5-button): adjust ui5-button menu button samples to use open/opener

### DIFF
--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -292,7 +292,8 @@
 		});
 
 		function showMenu(target) {
-			menu.showAt(target);
+			menu.opener = target;
+			menu.open = true;
 		}
 
 		menuButtonText.addEventListener("click", function(event) {

--- a/packages/website/docs/_samples/main/Button/MenuButton/main.js
+++ b/packages/website/docs/_samples/main/Button/MenuButton/main.js
@@ -29,7 +29,8 @@ myMenu.addEventListener("close", function() {
 
 function openMenu(menu, opener) {
 	opener.accessibilityAttributes.expanded = true;
-	menu.showAt(opener);
+	menu.opener = opener;
+	menu.open = true;
 }
 
 function closeMenu(opener) {


### PR DESCRIPTION
MenuButton samples were published while open/opener wasn't introduced for `ui5-menu`. Now these samples (Dev and Playground) are fixed to work with open/opener.