### PR TITLE
fix(ui5-special-date): respect format-pattern

### DIFF
--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -404,7 +404,8 @@ class Calendar extends CalendarPart {
 		const uniqueSpecialDates: Array<SpecialCalendarDateT> = [];
 
 		validSpecialDates.forEach(date => {
-			const dateFromValue = UI5Date.getInstance(date.value);
+			const parsedDate = this.getFormat().parse(date.value) as Date | UI5Date;
+			const dateFromValue = UI5Date.getInstance(parsedDate);
 			const timestamp = dateFromValue.getTime();
 
 			if (!uniqueDates.has(timestamp)) {


### PR DESCRIPTION
Previously our `<ui5-special-date>` didn't respect the `format-pattern` (if provided), and was able to work only with formats, supported by the JavaScript's Date class.

With this change, our `<ui5-special-date>` now takes the provided `format-pattern` property in account.

Fixes: #9067