### PR TITLE
feat(ui5-time-picker): introduce `open` and `close` events

### DIFF
--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -390,23 +390,11 @@ class TimePicker extends UI5Element implements IFormInputElement {
 
 	onResponsivePopoverAfterClose() {
 		this.open = false;
-		const isEventPrevented = !this.fireEvent("close", {}, true);
-
-		if (isEventPrevented) {
-			return;
-		}
-
-		this.fireEvent("close", {}, true);
+		this.fireEvent("close");
 	}
 
 	onResponsivePopoverAfterOpen() {
-		const isEventPrevented = !this.fireEvent("open", {}, true);
-
-		if (isEventPrevented) {
-			return;
-		}
-
-		this.fireEvent("open", {}, true);
+		this.fireEvent("open");
 	}
 
 	/**

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -189,11 +189,13 @@ type TimePickerInputEventDetail = TimePickerChangeInputEventDetail;
 })
 /**
  * Fired after the value-help dialog of the component is opened.
+ * @since 2.0.0
  * @public
  */
 @event("open")
 /**
  * Fired after the value-help dialog of the component is closed.
+ * @since 2.0.0
  * @public
  */
 @event("close")

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -187,6 +187,16 @@ type TimePickerInputEventDetail = TimePickerChangeInputEventDetail;
 		},
 	},
 })
+/**
+ * Fired after the value-help dialog of the component is opened.
+ * @public
+ */
+@event("open")
+/**
+ * Fired after the value-help dialog of the component is closed.
+ * @public
+ */
+@event("close")
 class TimePicker extends UI5Element implements IFormInputElement {
 	/**
 	 * Defines a formatted time value.
@@ -380,6 +390,23 @@ class TimePicker extends UI5Element implements IFormInputElement {
 
 	onResponsivePopoverAfterClose() {
 		this.open = false;
+		const isEventPrevented = !this.fireEvent("close", {}, true);
+
+		if (isEventPrevented) {
+			return;
+		}
+
+		this.fireEvent("close", {}, true);
+	}
+
+	onResponsivePopoverAfterOpen() {
+		const isEventPrevented = !this.fireEvent("open", {}, true);
+
+		if (isEventPrevented) {
+			return;
+		}
+
+		this.fireEvent("open", {}, true);
 	}
 
 	/**

--- a/packages/main/src/TimePickerPopover.hbs
+++ b/packages/main/src/TimePickerPopover.hbs
@@ -9,6 +9,7 @@
 	_hide-header
 	hide-arrow
 	@ui5-close="{{onResponsivePopoverAfterClose}}"
+	@ui5-open="{{onResponsivePopoverAfterOpen}}"
 	@wheel="{{_handleWheel}}"
 	@keydown="{{_onkeydown}}"
 >


### PR DESCRIPTION
As we introduced a declaritive property `open` which controls wether the value-help dialog of the `<ui5-timepicker>` is open or not, we are now introducing `open` and `close` events fired **after** the value-help dialog is opened or closed.

Fixes: #9076