### PR TITLE
fix(ui5-option-custom): show focus outline

### DIFF
--- a/packages/main/src/Option.ts
+++ b/packages/main/src/Option.ts
@@ -4,6 +4,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import { IOption } from "./Select.js";
 import ListItemBase from "./ListItemBase.js";
+import Icon from "./Icon.js";
 
 // Template
 import OptionTemplate from "./generated/templates/OptionTemplate.lit.js";
@@ -36,6 +37,9 @@ import listItemAdditionalTextCss from "./generated/themes/ListItemAdditionalText
 		listItemAdditionalTextCss,
 		listItemIconCss,
 		optionBaseCss,
+	],
+	dependencies: [
+		Icon,
 	],
 })
 class Option extends ListItemBase implements IOption {

--- a/packages/main/src/OptionCustom.ts
+++ b/packages/main/src/OptionCustom.ts
@@ -1,7 +1,7 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
-
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import { IOption } from "./Select.js";
 import ListItemBase from "./ListItemBase.js";
 
@@ -72,6 +72,12 @@ class OptionCustom extends ListItemBase implements IOption {
 	 */
 	@property({ type: String })
 	tooltip!: string;
+
+	onEnterDOM() {
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
+	}
 
 	get effectiveDisplayText() {
 		return this.displayText || this.textContent || "";


### PR DESCRIPTION
The selectors for focus outline don't match as the desktop attribute was missing, not set for the OptionCustom (as in the Option)


Before

<img width="704" alt="Screenshot 2024-06-01 at 11 51 13" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/13e93c6d-5f28-4b5d-aa59-c1985a841f66">

After
<img width="480" alt="Screenshot 2024-06-01 at 11 51 22" src="https://github.com/SAP/ui5-webcomponents/assets/15702139/d26ecc93-df5e-4390-bb37-48b7e9e364ee">

- there is console error for missing dependency as the Option uses the Icon in its template