### PR TITLE
refactor(ui5-radio-button): wrap text by default

### DIFF
--- a/packages/fiori/src/NotificationList.ts
+++ b/packages/fiori/src/NotificationList.ts
@@ -128,7 +128,7 @@ class NotificationList extends UI5Element {
 	}
 
 	get innerList() {
-		return this.shadowRoot?.querySelector("ui5-notification-list-internal") as NotificationListInternal;
+		return this.shadowRoot?.querySelector("[ui5-notification-list-internal]") as NotificationListInternal;
 	}
 
 	_onItemClick(e: CustomEvent<ListItemClickEventDetail>) {

--- a/packages/main/src/RadioButton.ts
+++ b/packages/main/src/RadioButton.ts
@@ -178,10 +178,10 @@ class RadioButton extends UI5Element implements IFormInputElement {
 	 * Defines whether the component text wraps when there is not enough space.
 	 *
 	 * **Note:** for option "Normal" the text will wrap and the words will not be broken based on hyphenation.
-	 * @default "None"
+	 * @default "Normal"
 	 * @public
 	 */
-	@property({ type: WrappingType, defaultValue: WrappingType.None })
+	@property({ type: WrappingType, defaultValue: WrappingType.Normal })
 	wrappingType!: `${WrappingType}`;
 
 	/**

--- a/packages/main/src/themes/RadioButton.css
+++ b/packages/main/src/themes/RadioButton.css
@@ -175,7 +175,7 @@
 }
 
 .ui5-radio-root {
-	height: var(--_ui5_radio_button_height);
+	height: auto;
 	position: relative;
 	display: inline-flex;
 	flex-wrap: nowrap;
@@ -217,21 +217,21 @@
 	display: flex;
 	align-items: center;
 	padding-inline-end: var(--_ui5_radio_button_label_offset);
+	padding-block: var(--_ui5_radio_button_label_side_padding);
 	vertical-align: top;
 	max-width: 100%;
-	text-overflow: ellipsis;
-	overflow: hidden;
 	pointer-events: none;
 	color: var(--_ui5_radio_button_label_color);
-}
-
-:host([wrapping-type="Normal"][text]) .ui5-radio-root {
-	height: auto;
-}
-
-:host([wrapping-type="Normal"][text]) [ui5-label].ui5-radio-label {
-	padding: var(--_ui5_radio_button_label_side_padding) 0;
 	overflow-wrap: break-word;
+}
+
+:host([wrapping-type="None"][text]) .ui5-radio-root {
+	height: var(--_ui5_radio_button_height);
+}
+
+:host([wrapping-type="None"][text]) [ui5-label].ui5-radio-label {
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 /* SVG */

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -236,7 +236,7 @@
 			<ui5-radio-button id="myRb6" value-state="Critical" checked text="warning"></ui5-radio-button>
 			<ui5-radio-button id="myRb7" value-state="Negative" checked text="error"></ui5-radio-button>
 			<ui5-radio-button id="myRb6" value-state="Critical" text="warning"></ui5-radio-button>
-			<ui5-radio-button id="myRb7" value-state="Negative" text="error long text should truncate"></ui5-radio-button>
+			<ui5-radio-button id="myRb7" wrapping-type="None" value-state="Negative" text="error long text should truncate"></ui5-radio-button>
 		</section>
 
 		<section class="row row-centered">

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -218,7 +218,7 @@
 			<ui5-radio-button id="myRb6" value-state="Critical" checked text="warning"></ui5-radio-button>
 			<ui5-radio-button id="myRb7" value-state="Negative" checked text="error"></ui5-radio-button>
 			<ui5-radio-button id="myRb6" value-state="Critical" text="warning"></ui5-radio-button>
-			<ui5-radio-button id="myRb7" value-state="Negative" text="error long text should truncate"></ui5-radio-button>
+			<ui5-radio-button id="myRb7" wrapping-type="None" value-state="Negative" text="error long text should truncate"></ui5-radio-button>
 		</section>
 
 		<section class="row row-centered">

--- a/packages/main/test/pages/RadioButton.html
+++ b/packages/main/test/pages/RadioButton.html
@@ -32,7 +32,7 @@
 	<div aria-labelledby="radioGroupTitle3" role="radiogroup" class="radio-section">
 		<ui5-title id="radioGroupTitle3">Group 3</ui5-title>
 		<ui5-input id="tabField"></ui5-input>
-		<ui5-radio-button id="groupRb1" name="a" checked text="Option A long long should shrink long long text text text text text text text text"></ui5-radio-button>
+		<ui5-radio-button id="groupRb1" name="a" wrapping-type="None" checked text="Option A long long should shrink long long text text text text text text text text"></ui5-radio-button>
 		<ui5-radio-button id="groupRb2" name="a" disabled text="Option C"></ui5-radio-button>
 		<ui5-radio-button id="groupRb3" name="a" text="Option D"></ui5-radio-button>
 		<ui5-radio-button id="groupRbReadOnly" name="a" readonly text="Option E"></ui5-radio-button>
@@ -40,7 +40,7 @@
 
 	<div aria-labelledby="radioGroupTitle4" role="radiogroup" class="radio-section">
 		<ui5-title id="radioGroupTitle4">Group 4</ui5-title>
-		<ui5-radio-button id="groupRb4" name="b" checked text="Option A long long should shrink long long text text text text text text text text"></ui5-radio-button>
+		<ui5-radio-button id="groupRb4" name="b" wrapping-type="None" checked text="Option A long long should shrink long long text text text text text text text text"></ui5-radio-button>
 		<ui5-radio-button id="groupRb5" name="b" disabled text="Option C"></ui5-radio-button>
 		<ui5-radio-button id="groupRb6" name="b" text="Option D"></ui5-radio-button>
 	</div>
@@ -81,7 +81,7 @@
 		<ui5-radio-button id="rb2" text="Option B"></ui5-radio-button>
 		<ui5-radio-button id="rb3" wrapping-type="Normal" text="Option C"></ui5-radio-button>
 		<ui5-radio-button id="rb4" disabled text="Option D"></ui5-radio-button>
-		<ui5-radio-button id="truncatingRb" text="Long long long long long long long long long long text that should truncate at some point"></ui5-radio-button>
+		<ui5-radio-button id="truncatingRb" wrapping-type="None" text="Long long long long long long long long long long text that should truncate at some point"></ui5-radio-button>
 		<br/>
 		<ui5-radio-button id="wrappingRb" wrapping-type="Normal" text="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s." class="radiobutton2auto"></ui5-radio-button>
 		<ui5-input id="field"></ui5-input>

--- a/packages/website/docs/_components_pages/main/RadioButton.mdx
+++ b/packages/website/docs/_components_pages/main/RadioButton.mdx
@@ -21,6 +21,6 @@ The RadioButton supports several semantic value states, readonly, disabled, etc.
 <States />
 
 ### Text Truncation and Wrapping
-The RadioButton text truncates by default. To make it wrap - set <b>wrapping-type="Normal"</b>.
+The RadioButton text wraps by default. To make it truncate - set <b>wrapping-type="None"</b>.
 
 <TextWrapping />

--- a/packages/website/docs/_samples/main/RadioButton/TextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/RadioButton/TextWrapping/sample.html
@@ -12,6 +12,7 @@
     <!-- playground-fold-end -->
 
     <ui5-radio-button
+        wrapping-type="None"
         text="Truncating text when 'wrapping-type=None' set and long text"
         style="width: 200px"
         name="wrapping">
@@ -20,7 +21,6 @@
     <br>
 
     <ui5-radio-button
-        wrapping-type="Normal"
         text="Wrapping text when 'wrapping-type=Normal' set with long text"
         style="width: 200px"
         name="wrapping">


### PR DESCRIPTION
The text of `ui5-radio-button` now wraps by default.

BREAKING CHANGE: `wrapping-type` property default value has changed from `None` to `Normal`. Before:
```html
<ui5-radio-button text="Option A with long long text"></ui5-radio-button>
<!-- would truncate the text if there is not enough space -->
```

Now:
```html
<ui5-radio-button text="Option A with long long text"></ui5-radio-button>
<!-- would let the text wrap if there is not enough space -->
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461