### PR TITLE
feat(ui5-select): introduced 'popover' part

### DIFF
--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -186,17 +186,6 @@ class Popover extends Popup {
 	@property({ type: PopoverPlacement, defaultValue: PopoverPlacement.End })
 	actualPlacement!: `${PopoverPlacement}`;
 
-	/**
-	 * Defines the maximum height of the popover in px.
-	 *
- 	 * **Note:** If omitted, the maximum height will be calculated automatically so the popover spans through
-	 * the remaining visible part of the viewport.
-	 * @default undefined
-	 * @public
-	 */
-	@property({ validator: Integer })
-	maxHeight?: number;
-
 	@property({ validator: Integer, noAttribute: true })
 	_maxHeight?: number;
 
@@ -585,9 +574,6 @@ class Popover extends Popup {
 		}
 
 		this._maxHeight = Math.round(maxHeight - Popover.VIEWPORT_MARGIN);
-		if (this.maxHeight && this.maxHeight < this._maxHeight) {
-			this._maxHeight = this.maxHeight;
-		}
 		this._maxWidth = Math.round(maxWidth - Popover.VIEWPORT_MARGIN);
 
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -186,6 +186,17 @@ class Popover extends Popup {
 	@property({ type: PopoverPlacement, defaultValue: PopoverPlacement.End })
 	actualPlacement!: `${PopoverPlacement}`;
 
+	/**
+	 * Defines the maximum height of the popover in px.
+	 *
+ 	 * **Note:** If omitted, the maximum height will be calculated automatically so the popover spans through
+	 * the remaining visible part of the viewport.
+	 * @default undefined
+	 * @public
+	 */
+	@property({ validator: Integer })
+	maxHeight?: number;
+
 	@property({ validator: Integer, noAttribute: true })
 	_maxHeight?: number;
 
@@ -574,6 +585,9 @@ class Popover extends Popup {
 		}
 
 		this._maxHeight = Math.round(maxHeight - Popover.VIEWPORT_MARGIN);
+		if (this.maxHeight && this.maxHeight < this._maxHeight) {
+			this._maxHeight = this.maxHeight;
+		}
 		this._maxWidth = Math.round(maxWidth - Popover.VIEWPORT_MARGIN);
 
 		if (this._left === undefined || Math.abs(this._left - left) > 1.5) {

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -257,6 +257,17 @@ class Select extends UI5Element implements IFormInputElement {
 	accessibleNameRef!: string;
 
 	/**
+	 * Defines the maximum height of the Select's dropdown/popover in px.
+	 *
+ 	 * **Note:** If omitted, the maximum height will be calculated automatically so the popover spans through
+	 * the remaining visible part of the viewport.
+	 * @default undefined
+	 * @public
+	 */
+	@property({ validator: Integer })
+	popoverMaxHeight?: number;
+
+	/**
 	 * @private
 	 */
 	@property({ type: Boolean, noAttribute: true })

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -124,6 +124,7 @@ type SelectLiveChangeEventDetail = {
  * @constructor
  * @extends UI5Element
  * @public
+ * @csspart popover - Used to style the popover element
  * @since 0.8.0
  */
 @customElement({
@@ -255,17 +256,6 @@ class Select extends UI5Element implements IFormInputElement {
 	 */
 	@property()
 	accessibleNameRef!: string;
-
-	/**
-	 * Defines the maximum height of the Select's dropdown/popover in px.
-	 *
- 	 * **Note:** If omitted, the maximum height will be calculated automatically so the popover spans through
-	 * the remaining visible part of the viewport.
-	 * @default undefined
-	 * @public
-	 */
-	@property({ validator: Integer })
-	popoverMaxHeight?: number;
 
 	/**
 	 * @private

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -2,6 +2,7 @@
 	<ui5-responsive-popover
 		hide-arrow
 		prevent-initial-focus
+		max-height={{popoverMaxHeight}}
 		placement="Bottom"
 		class="ui5-select-popover {{classes.popover}}"
 		horizontal-align="Start"

--- a/packages/main/src/SelectPopover.hbs
+++ b/packages/main/src/SelectPopover.hbs
@@ -2,7 +2,7 @@
 	<ui5-responsive-popover
 		hide-arrow
 		prevent-initial-focus
-		max-height={{popoverMaxHeight}}
+		part="popover"
 		placement="Bottom"
 		class="ui5-select-popover {{classes.popover}}"
 		horizontal-align="Start"
@@ -53,6 +53,7 @@
 
 {{#if shouldOpenValueStateMessagePopover}}
 	<ui5-popover
+		part="popover"
 		skip-registry-update
 		prevent-initial-focus
 		prevent-focus-restore

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -14,6 +14,11 @@
 
 
 <link rel="stylesheet" type="text/css" href="./styles/Select.css">
+<style>
+	#selectPopoverMaxHeight[ui5-select]::part(popover) {
+		max-height: 120px;
+	}
+</style>
 </head>
 
 <body class="select1auto">
@@ -178,39 +183,8 @@
 	</section>
 
 	<section>
-		<h2>Popover Max Height prop (200px)</h2>
-		<ui5-select id="selectPopoverMaxHeight" popover-max-height="200">
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
-			<ui5-option>Compact</ui5-option>
+		<h2>popover max-height changed with 'popover' part (120px)</h2>
+		<ui5-select id="selectPopoverMaxHeight">
 			<ui5-option>Compact</ui5-option>
 			<ui5-option>Compact</ui5-option>
 			<ui5-option>Compact</ui5-option>

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -177,6 +177,89 @@
 		<ui5-button id="btnSetInvalidValue">select.value = "NAN"</ui5-button>
 	</section>
 
+	<section>
+		<h2>Popover Max Height prop (200px)</h2>
+		<ui5-select id="selectPopoverMaxHeight" popover-max-height="200">
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option>Compact</ui5-option>
+			<ui5-option selected>Condensed</ui5-option>
+		</ui5-select>
+	</section>
 </body>
 <script>
 	var countries =  [{ key: "Aus", text: "Australia" }, { key: "Aruba", text: "Aruba" }, { key: "Antigua", text: "Antigua and Barbuda" }, { key: "Bel", text: "Belgium" }, { key: "Bg", text: "Bulgaria" }, { key: "Bra", text: "Brazil" }];


### PR DESCRIPTION
Introduced `popover` `csspart` to the Select.

Now we can alter the popover styles (its max-height for example) with the following CSS:


```
	#selectPopoverMaxHeight[ui5-select]::part(popover) {
		max-height: 120px;
	}
```

Implements: #4503
