### PR TITLE
refactor(ui5-li-notification): wrap text by default

### DIFF
--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -165,11 +165,10 @@ const ICON_PER_STATUS_DESIGN = {
 
 class NotificationListItem extends NotificationListItemBase {
 	/**
-	* Defines if the `titleText` and `description` should wrap,
-	* they wrap by default.
-	*
-	* **Note:** when the property is set ot "None" and the texts truncate
-	* a `More/Less` button would be displayed.
+	* Defines if the `titleText` and `description` should wrap when there is not enough space.
+	* The possible values are:
+	* - "Normal" (default) - the texts should wrap.
+	* - "None" – the texts should truncate, and a `More/Less` button should be displayed.
 	* @default "Normal"
 	* @public
 	* @since 1.0.0-rc.15

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -166,15 +166,15 @@ const ICON_PER_STATUS_DESIGN = {
 class NotificationListItem extends NotificationListItemBase {
 	/**
 	* Defines if the `titleText` and `description` should wrap,
-	* they truncate by default.
+	* they wrap by default.
 	*
-	* **Note:** by default the `titleText` and `description`,
-	* and a `ShowMore/Less` button would be displayed.
-	* @default "None"
+	* **Note:** when the property is set ot "None" and the texts truncate
+	* a `More/Less` button would be displayed.
+	* @default "Normal"
 	* @public
 	* @since 1.0.0-rc.15
 	*/
-	@property({ type: WrappingType, defaultValue: WrappingType.None })
+	@property({ type: WrappingType, defaultValue: WrappingType.Normal })
 	wrappingType!: `${WrappingType}`;
 
 	/**

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -167,8 +167,8 @@ class NotificationListItem extends NotificationListItemBase {
 	/**
 	* Defines if the `titleText` and `description` should wrap when there is not enough space.
 	* The possible values are:
-	* - "Normal" (default) - the texts should wrap.
-	* - "None" – the texts should truncate, and a `More/Less` button should be displayed.
+	* - `Normal` (default) - the texts should wrap.
+	* - `None` – the texts should truncate, and a `More/Less` button should be displayed.
 	* @default "Normal"
 	* @public
 	* @since 1.0.0-rc.15

--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -1,14 +1,14 @@
 @import "./NotificationListItemBase.css";
 @import "./NotificationStateIcon.css";
 
-:host(:not([wrapping-type="Normal"])) .ui5-nli-title-text {
+:host([wrapping-type="None"]) .ui5-nli-title-text {
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }
 
-:host(:not([wrapping-type="Normal"])) .ui5-nli-description {
+:host([wrapping-type="None"]) .ui5-nli-description {
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;

--- a/packages/fiori/test/pages/NotificationListGroupItem.html
+++ b/packages/fiori/test/pages/NotificationListGroupItem.html
@@ -32,6 +32,7 @@
 				priority="Low"
 				state="Critical"
 				importance="Important"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" shape="Square" slot="avatar"></ui5-avatar>
@@ -52,6 +53,7 @@
 				show-close
 				title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="Information"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
@@ -85,6 +87,7 @@
 				show-close
 				title-text="New order (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="Negative"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -101,6 +104,7 @@
 				show-close
 				title-text="New order (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="Negative"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -117,6 +121,7 @@
 				show-close
 				title-text="New order (#29003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="Negative"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -141,6 +146,7 @@
 				title-text="New order (#35001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="Negative"
 				read
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -153,6 +159,7 @@
 				title-text="New order (#35002) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				state="None"
 				read
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -169,6 +176,7 @@
 				show-close
 				title-text="New order (#35003) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 				read
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -214,6 +222,7 @@
 				read
 				title-text="Message 2"
 				state="Negative"
+				wrapping-type="None"
 			>
 				And with a very long description and long labels of the action buttons
 				<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -24,6 +24,7 @@
 			state="Positive"
 			importance="Important"
 			title-text="When 'priority' and 'state' are set at the same time - we need to see the status icon Success (Positive) from the 'state'"
+			wrapping-type="None"
 		>Notification with several actions.
 
 			<ui5-avatar size="XS" slot="avatar" shape="Square" initials="JS"></ui5-avatar>
@@ -46,6 +47,7 @@
 			show-close
 			priority="Medium"
 			title-text="When 'priority' (deprecated) is set to 'Medium' we shouldn't see it"
+			wrapping-type="None"
 		>Notification with one action.
 
 			<ui5-avatar size="XS" slot="avatar">
@@ -65,6 +67,7 @@
 			show-close
 			state="Information"
 			title-text="When 'state' is set to 'Information' we need to see it"
+			wrapping-type="None"
 		>Notification with Menu and Notification actions (deprecated) - overflow button should open Menu with 4 options
 
 			<ui5-avatar size="XS" slot="avatar">
@@ -112,6 +115,7 @@
 			loading
 			show-close
 			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			wrapping-type="None"
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 
@@ -133,6 +137,7 @@
 			show-close
 			state="Negative"
 			title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
+			wrapping-type="None"
 		>
 			And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 			<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -148,6 +153,7 @@
 		<ui5-li-notification
 			title-text="New order (#2565) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
 			state="Critical"
+			wrapping-type="None"
 			>
 				Short description
 			<ui5-avatar initials="JS" size="XS" slot="avatar"></ui5-avatar>
@@ -162,7 +168,7 @@
 			</ui5-menu>
 		</ui5-li-notification>
 
-		<ui5-li-notification title-text="New order (#2523)">
+		<ui5-li-notification title-text="New order (#2523)" wrapping-type="None">
 			<div>And with a very long description - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.</div>
 
 			<span slot="footnotes">John SMith</span>

--- a/packages/fiori/test/pages/NotificationList_test_page.html
+++ b/packages/fiori/test/pages/NotificationList_test_page.html
@@ -59,6 +59,7 @@
 					show-close
 					title-text="New order #2201"
 					state="Positive"
+					wrapping-type="None"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 					<ui5-avatar icon="employee" size="XS" shape="Square" slot="avatar"></ui5-avatar>
@@ -78,6 +79,7 @@
 					show-close
 					title-text="New order #2202"
 					state="Critical"
+					wrapping-type="None"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 					<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -99,7 +101,6 @@
 				<ui5-li-notification
 					id="nli3"
 					importance="Important"
-					wrapping-type="Normal"
 					title-text="New payment #2900 and more more more more more more more more more more more more more more more text to make the title truncate"
 					state="Negative"
 				>
@@ -116,6 +117,7 @@
 					importance="Important"
 					title-text="New payment #2900 and more more more more more more more more more more more more more more more text to make the title truncate"
 					state="Information"
+					wrapping-type="None"
 				>
 					And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 					<ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -515,3 +515,34 @@ describe("Keyboard navigation", () => {
 	});
 });
 
+
+describe("Wrapping", () => {
+	before(async () => {
+		await browser.url(`test/pages/NotificationList_test_page.html`);
+	});
+
+	it("tests if title and description texts wrap - default wrappingType", async () => {
+		const notificationTitle = await browser.$("#nli3").shadow$(".ui5-nli-title-text");
+		const notificationDescription = await browser.$("#nli3").shadow$(".ui5-nli-description");
+
+		assert.strictEqual((await notificationTitle.getCSSProperty("overflow")).value, "visible", "notification title is wrapped");
+		assert.strictEqual((await notificationDescription.getCSSProperty("overflow")).value, "visible", "notification description is wrapped");
+	});
+
+	it("tests if title and description texts wrap - wrappingType Normal", async () => {
+		const notificationTitle = await browser.$("#nli5").shadow$(".ui5-nli-title-text");
+		const notificationDescription = await browser.$("#nli5").shadow$(".ui5-nli-description");
+
+		assert.strictEqual((await notificationTitle.getCSSProperty("overflow")).value, "visible", "notification title is wrapped");
+		assert.strictEqual((await notificationDescription.getCSSProperty("overflow")).value, "visible", "notification description is wrapped");
+	});
+
+	it("tests if title and description texts wrap - wrappingType None", async () => {
+		const notificationTitle = await browser.$("#nli3a").shadow$(".ui5-nli-title-text");
+		const notificationDescription = await browser.$("#nli3a").shadow$(".ui5-nli-description");
+
+		assert.strictEqual((await notificationTitle.getCSSProperty("overflow")).value, "hidden", "notification title is truncated");
+		assert.strictEqual((await notificationDescription.getCSSProperty("overflow")).value, "hidden", "notification description is truncated");
+	});
+});
+

--- a/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationListGroupItem/InShellBar/sample.html
@@ -33,7 +33,8 @@
     <ui5-li-notification-group title-text="Orders" >
         <ui5-li-notification show-close
             title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
-            state="Positive">
+            state="Positive"
+            wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>
@@ -48,7 +49,8 @@
 
         <ui5-li-notification show-close
             title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
-            state="Critical">
+            state="Critical"
+            wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>
@@ -64,7 +66,8 @@
     <ui5-li-notification-group title-text="Deliveries" collapsed>
         <ui5-li-notification show-close
             title-text="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
-            state="Information">
+            state="Information"
+            wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>
@@ -78,7 +81,8 @@
 
         <ui5-li-notification show-close
             title-text="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
-            state="None">
+            state="None"
+            wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>
@@ -93,7 +97,7 @@
 
     <ui5-li-notification-group collapsed
         title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.">
-        <ui5-li-notification show-close title-text="New meeting at Building (#35001)" state="Positive" read>
+        <ui5-li-notification show-close title-text="New meeting at Building (#35001)" state="Positive" read wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>
@@ -102,7 +106,7 @@
             nec elementum lectus turpis at nunc.
         </ui5-li-notification>
 
-        <ui5-li-notification show-close title-text="New meeting at Building (#35001)" state="Negative"read>
+        <ui5-li-notification show-close title-text="New meeting at Building (#35001)" state="Negative"read wrapping-type="None">
             <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
             <span slot="footnotes">Office Notifications</span>
             <span slot="footnotes">3 Days</span>


### PR DESCRIPTION
The title and description of `ui5-li-notification` now wrap by default.

BREAKING CHANGE: `wrapping-type` property default value has changed from `None` to `Normal`. Before:
```html
<ui5-li-notification title-text="Message 1">
	Description with details.
</ui5-li-notification>
<!-- would truncate the title and description if there is not enough space -->
```

Now:
```html
<ui5-li-notification title-text="Message 1">
	Description with details.
</ui5-li-notification>

<!-- would let the title and description wrap if there is not enough space -->
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461