### PR TITLE
fix(ui5-input, ui5-combobox, ui5-multi-combobox): prevent native input autocomplete

### DIFF
--- a/packages/main/src/ComboBox.hbs
+++ b/packages/main/src/ComboBox.hbs
@@ -24,6 +24,7 @@
 		aria-describedby="value-state-description"
 		aria-label="{{ariaLabelText}}"
 		aria-required="{{required}}"
+		autocomplete="off"
 		data-sap-focus-ref
 	/>
 

--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -28,6 +28,7 @@
 			aria-expanded="{{accInfo.input.ariaExpanded}}"
 			aria-label="{{accInfo.input.ariaLabel}}"
 			aria-required="{{required}}"
+			autocomplete="off"
 			@input="{{_handleInput}}"
 			@change="{{_handleChange}}"
 			@keydown="{{_onkeydown}}"

--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -58,6 +58,7 @@
 		aria-describedby="{{ariaDescribedByText}}"
 		aria-required="{{required}}"
 		aria-label="{{ariaLabelText}}"
+		autocomplete="off"
 		data-sap-focus-ref
 	/>
 


### PR DESCRIPTION
FIXES: #9081 
FIXES: #8706 