### PR TITLE
fix(ui5-date): remove circular dependency

### DIFF
--- a/packages/main/src/CalendarDate.ts
+++ b/packages/main/src/CalendarDate.ts
@@ -1,7 +1,7 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import { ICalendarSelectedDates } from "./Calendar.js";
+import type { ICalendarSelectedDates } from "./Calendar.js";
 
 /**
  * @class


### PR DESCRIPTION
`ICalendarSelectedDates` was imported in CalendarDate.ts without type keyword and this results into import of Calendar component making circular dependency.