### PR TITLE
fix(ui5-input, ui5-combobox, ui5-multi-combobox): prevent native input autocomplete

### DIFF
--- a/packages/main/src/ComboBox.hbs
+++ b/packages/main/src/ComboBox.hbs
@@ -24,6 +24,7 @@
 		aria-describedby="value-state-description"
 		aria-label="{{ariaLabelText}}"
 		aria-required="{{required}}"
+		autocomplete="off"
 		data-sap-focus-ref
 	/>
 

--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -27,6 +27,7 @@
 			aria-expanded="{{accInfo.input.ariaExpanded}}"
 			aria-label="{{accInfo.input.ariaLabel}}"
 			aria-required="{{required}}"
+			autocomplete="off"
 			@input="{{_handleInput}}"
 			@change="{{_handleChange}}"
 			@keydown="{{_onkeydown}}"

--- a/packages/main/src/MultiComboBox.hbs
+++ b/packages/main/src/MultiComboBox.hbs
@@ -58,6 +58,7 @@
 		aria-describedby="{{ariaDescribedByText}}"
 		aria-required="{{required}}"
 		aria-label="{{ariaLabelText}}"
+		autocomplete="off"
 		data-sap-focus-ref
 	/>
 


### PR DESCRIPTION
Adding `autocomplete="off"` to input fields is crucial due to security risks, as browsers may store sensitive data locally or in the cloud. Browser-specific implementation create inconsistent and unpredictable user experiences. Varying event handling across browsers can lead to significant functionality issues. UI5 web components already provides effective solutions making browser-based autocomplete unnecessary.