### PR TITLE
chore(tools): add more validation in cem generation

### DIFF
--- a/packages/fiori/src/SideNavigationSelectableItemBase.ts
+++ b/packages/fiori/src/SideNavigationSelectableItemBase.ts
@@ -17,7 +17,7 @@ import SideNavigationItemBase from "./SideNavigationItemBase.js";
  * Base class for the navigation items that support actions.
  *
  * @constructor
- * @extends UI5Element
+ * @extends SideNavigationItemBase
  * @abstract
  * @public
  * @since 1.24.0

--- a/packages/main/src/SegmentedButtonItem.ts
+++ b/packages/main/src/SegmentedButtonItem.ts
@@ -35,7 +35,8 @@ import segmentedButtonItemCss from "./generated/themes/SegmentedButtonItem.css.j
  * `import "@ui5/webcomponents/dist/SegmentedButtonItem.js";`
  * @constructor
  * @extends UI5Element
- * @implements { ISegmentedButtonItem, IButton }
+ * @implements { ISegmentedButtonItem }
+ * @implements { IButton }
  * @public
  */
 @customElement({

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -129,7 +129,7 @@ enum ClipboardDataOperation {
  * `import "@ui5/webcomponents/dist/Tokenizer.js";`
  *
  * @constructor
- * @extends sap.ui.webc.base.UI5Element
+ * @extends UI5Element
  * @public
  * @since 2.0.0
  */


### PR DESCRIPTION
Add validation that checks correct usage of `@extends` and `@implements` JSDoc tags. Validations also check whether the tag has same value in heritage clause.

Example:
```
 | === ERROR: Problem found in file: src/SuggestionItem.ts:
 | 	- @interface { IInputSuggestionItem } tag is used, but the class doesn't implement the corresponding interface
 | === ERROR: Problem found in file: src/Tokenizer.ts:
 | 	- @extends sap.ui.webc.base.UI5Element is used, but the class doesn't extend the corresponding superclass
```