### PR TITLE
fix(ui5-button): fix tab chaining in lists

### DIFF
--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -426,7 +426,10 @@ class Button extends UI5Element implements IButton, IFormElement {
 		if (this._cancelAction) {
 			e.preventDefault();
 		}
-		markEvent(e, "button");
+
+		if (isSpace(e)) {
+			markEvent(e, "button");
+		}
 
 		if (isSpace(e) || isEnter(e)) {
 			if (this.active) {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -110,9 +110,6 @@ class ListItemBase extends UI5Element implements ITabbable {
 	}
 
 	_onkeydown(e: KeyboardEvent) {
-		if (getEventMark(e) === "button") {
-			return;
-		}
 		if (isTabNext(e)) {
 			return this._handleTabNext(e);
 		}


### PR DESCRIPTION
[feat(ui5-menu-item): add endContent slot](https://github.com/SAP/ui5-webcomponents/pull/9077) PR introduces a regression in Tab chaining in lists because of improper marking of `keyup` event in `ui5-button` component. It was marked always but should be marked only if event is fired by Space key. In addition, there is redundant check in ListItemBase which is removed now.