### PR TITLE
docs(ui5-form): enhance IFormItem interface

### DIFF
--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -24,6 +24,11 @@ const StepColumn = {
 	"XL": 6,
 };
 
+/**
+ * Interface for components that can be slotted inside `ui5-form` as items.
+ * @public
+ * @since 2.0.0
+ */
 interface IFormItem extends HTMLElement {
 	labelSpan: string
 	itemSpacing: `${FormItemSpacing}`;

--- a/packages/main/src/FormGroup.ts
+++ b/packages/main/src/FormGroup.ts
@@ -30,6 +30,7 @@ import FormItemSpacing from "./types/FormItemSpacing.js";
  * - import @ui5/webcomponents/dist/FormGroup.js";
  *
  * @public
+ * @implements {IFormItem}
  * @since 2.0.0
  * @extends UI5Element
  */

--- a/packages/main/src/FormItem.ts
+++ b/packages/main/src/FormItem.ts
@@ -35,6 +35,7 @@ import FormItemSpacing from "./types/FormItemSpacing.js";
  * @csspart content - Used to style the content part of the form item.
  *
  * @constructor
+ * @implements {IFormItem}
  * @public
  * @since 2.0.0
  * @extends UI5Element


### PR DESCRIPTION
Mark `IFormItem` as public to display which items might be used inside default slot of `ui5-form` element.