### PR TITLE
chore: describe correct dependencies

### DIFF
--- a/packages/main/src/Grid.ts
+++ b/packages/main/src/Grid.ts
@@ -149,7 +149,11 @@ type GridRowClickEventDetail = {
 	styles: GridStyles,
 	template: GridTemplate,
 	fastNavigation: true,
-	dependencies: [BusyIndicator, GridCell],
+	dependencies: [
+		BusyIndicator,
+		GridCell,
+		GridRow,
+	],
 })
 
 /**

--- a/packages/main/src/Grid.ts
+++ b/packages/main/src/Grid.ts
@@ -254,7 +254,7 @@ class Grid extends UI5Element {
 	 * @default false
 	 * @public
 	 */
-	@property({ type: Boolean, defaultValue: false })
+	@property({ type: Boolean })
 	loading!: boolean;
 
 	/**
@@ -304,6 +304,7 @@ class Grid extends UI5Element {
 	}
 
 	onBeforeRendering(): void {
+		this.style.setProperty(getScopedVarName("--ui5_grid_sticky_top"), this.stickyTop);
 		this._refreshPopinState();
 	}
 

--- a/packages/main/src/GridHeaderRow.ts
+++ b/packages/main/src/GridHeaderRow.ts
@@ -71,13 +71,6 @@ class GridHeaderRow extends GridRowBase {
 	@property({ type: Boolean })
 	sticky!: boolean;
 
-	onBeforeRendering() {
-		super.onBeforeRendering();
-		if (this._grid) {
-			this.style.top = this._grid.stickyTop;
-		}
-	}
-
 	isHeaderRow() {
 		return true;
 	}

--- a/packages/main/src/themes/GridHeaderRow.css
+++ b/packages/main/src/themes/GridHeaderRow.css
@@ -10,7 +10,7 @@
 
 :host([sticky]) {
     position: sticky;
-    top: 0;
+    top: var(--ui5_grid_sticky_top, 0);
     z-index: 1;
 }
 


### PR DESCRIPTION
When a component is using another components in its template, used components must be added to its dependencies in order to get the same scoping.