### PR TITLE
docs: add documentation for CalendarDateRange

### DIFF
--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -52,6 +52,12 @@ interface ICalendarPicker {
 	_lastYear?: number,
 }
 
+/**
+ * Interface for components that may be slotted inside a `ui5-calendar`.
+ *
+ * **Note:** Use directly with `ui5-calendar-date` or `ui5-calendar-date-range`. Implementing the interface does not guarantee that the class can work as a calendar date selection type.
+ * @public
+ */
 interface ICalendarSelectedDates extends UI5Element {
 	value?: string,
 	startValue?: string,

--- a/packages/main/src/CalendarDate.ts
+++ b/packages/main/src/CalendarDate.ts
@@ -11,6 +11,7 @@ import type { ICalendarSelectedDates } from "./Calendar.js";
  * The `ui5-date` component defines a calendar date to be used inside `ui5-calendar`
  * @constructor
  * @extends UI5Element
+ * @implements {ICalendarSelectedDates}
  * @abstract
  * @public
  */

--- a/packages/main/src/CalendarDateRange.ts
+++ b/packages/main/src/CalendarDateRange.ts
@@ -11,6 +11,7 @@ import type { ICalendarSelectedDates } from "./Calendar.js";
  * The `ui5-date-range` component defines a range of dates to be used inside `ui5-calendar`
  * @constructor
  * @extends UI5Element
+ * @implements {ICalendarSelectedDates}
  * @abstract
  * @public
  * @since 2.0

--- a/packages/website/docs/_components_pages/main/Calendar/CalendarDateRange.mdx
+++ b/packages/website/docs/_components_pages/main/Calendar/CalendarDateRange.mdx
@@ -1,0 +1,7 @@
+---
+slug: ../../CalendarDateRange
+---
+
+<%COMPONENT_OVERVIEW%>
+
+<%COMPONENT_METADATA%>


### PR DESCRIPTION
Adding documentation for CalendarDateRange, and ICalendarSelectedDates.

<img width="1046" alt="Screenshot 2024-06-11 at 2 37 58 PM" src="https://github.com/SAP/ui5-webcomponents/assets/25314788/cfd284ee-c1db-4ce2-ba3e-88eb3afb025f">
<img width="1046" alt="Screenshot 2024-06-11 at 2 38 14 PM" src="https://github.com/SAP/ui5-webcomponents/assets/25314788/617d8069-03e8-47e0-bcdf-0b88f1a0ab07">
 