### PR TITLE
fix(ui5-segmented-button-item): add padding to icon when item is not in icon-only mode

### DIFF
--- a/packages/main/src/themes/SegmentedButtonItem.css
+++ b/packages/main/src/themes/SegmentedButtonItem.css
@@ -60,11 +60,11 @@
 .ui5-segmented-button-item-icon {
 	color: inherit;
 	flex-shrink: 0;
-	padding-right: 0.375rem;
+	padding-inline-end: 0.375rem;
 }
 
 :host([icon-only]) .ui5-segmented-button-item-icon {
-	padding-right: 0;
+	padding-inline-end: 0;
 }
 
 :host([icon-only]) .ui5-segmented-button-item-root {

--- a/packages/main/src/themes/SegmentedButtonItem.css
+++ b/packages/main/src/themes/SegmentedButtonItem.css
@@ -60,6 +60,11 @@
 .ui5-segmented-button-item-icon {
 	color: inherit;
 	flex-shrink: 0;
+	padding-right: 0.375rem;
+}
+
+:host([icon-only]) .ui5-segmented-button-item-icon {
+	padding-right: 0;
 }
 
 :host([icon-only]) .ui5-segmented-button-item-root {

--- a/packages/main/test/pages/SegmentedButton.html
+++ b/packages/main/test/pages/SegmentedButton.html
@@ -162,8 +162,8 @@
 		</ui5-segmented-button>
 		<ui5-button id="button2">Press</ui5-button>
 		<ui5-segmented-button id="testSB2">
-			<ui5-segmented-button-item icon="employee"></ui5-segmented-button-item>
-			<ui5-segmented-button-item id="testSB2ToggleBtn" icon="menu" selected></ui5-segmented-button-item>
+			<ui5-segmented-button-item icon="employee">1</ui5-segmented-button-item>
+			<ui5-segmented-button-item id="testSB2ToggleBtn" icon="menu" selected>2</ui5-segmented-button-item>
 			<ui5-segmented-button-item icon="accept"></ui5-segmented-button-item>
 		</ui5-segmented-button>
 	</section>


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-webcomponents/issues/9172

Previous state:
![image](https://github.com/SAP/ui5-webcomponents/assets/11508737/fd4e3dae-167c-47e4-b0a9-b52c7a16663e)

State with the fix: 
![image](https://github.com/SAP/ui5-webcomponents/assets/11508737/0bad1325-c20b-409f-9400-29a283fb585b)
