### PR TITLE
chore: split bundle

### DIFF
--- a/packages/compat/src/bundle.esm.ts
+++ b/packages/compat/src/bundle.esm.ts
@@ -1,9 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import testAssets from "@ui5/webcomponents/dist/bundle.esm.js";
-import * as defaultFioriTexts from "./generated/i18n/i18n-defaults.js";
+import testAssets from "@ui5/webcomponents/dist/bundle.common.bootstrap.js";
 
 // Compat assets
 import "./Assets.js";
+
+import Avatar from "@ui5/webcomponents/dist/Avatar.js";
+import Button from "@ui5/webcomponents/dist/Button.js";
+import Input from "@ui5/webcomponents/dist/Input.js";
+import Label from "@ui5/webcomponents/dist/Label.js";
+import Title from "@ui5/webcomponents/dist/Title.js";
+
+import * as defaultFioriTexts from "./generated/i18n/i18n-defaults.js";
 
 import Table from "./Table.js";
 import TableColumn from "./TableColumn.js";

--- a/packages/main/src/bundle.common.bootstrap.ts
+++ b/packages/main/src/bundle.common.bootstrap.ts
@@ -1,3 +1,128 @@
 import { setRuntimeAlias } from "@ui5/webcomponents-base/dist/Runtimes.js";
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// OpenUI5 integration
+import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
+
+// Assets
+import "./Assets.js";
+
+// Icons
+import "@ui5/webcomponents-icons/dist/Assets.js";
+import "@ui5/webcomponents-icons/dist/AllIcons.js";
+
+// TNT Icons
+import "@ui5/webcomponents-icons-tnt/dist/Assets.js";
+import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";
+
+// SAP Business Suite Icons
+import "@ui5/webcomponents-icons-business-suite/dist/Assets.js";
+import "@ui5/webcomponents-icons-business-suite/dist/AllIcons.js";
+
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
+import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "@ui5/webcomponents-base/dist/Theming.js";
+// import "./customI18n.js";
+
+import "./bundle.common.bootstrap.js"; // code that needs to be executed before other modules
+
+// Calendars
+import "@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Japanese.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Persian.js";
+
+// CLDR
+import getLocaleData from "@ui5/webcomponents-localization/dist/locale/getLocaleData.js";
+
+// import { registerCustomThemePropertiesLoader } from "@ui5/webcomponents-base/dist/AssetRegistry.js";
+// import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
+// const customThemeLoader = theme => Promise.resolve(`:root {
+// 	${getScopedVarName("--_ui5_button_base_height")}: 4rem;
+// 	${getScopedVarName("--_ui5_button_base_padding")}: 2rem;
+// }`);
+// registerCustomThemePropertiesLoader("@ui5/webcomponents", "my_custom_theme", customThemeLoader);
+
+// Uncomment to test the registration of custom properties and JSON bundles - use the TextArea test page
+// import { registerI18nLoader } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";
+// import parse from "@ui5/webcomponents-base/dist/PropertiesFileFormat.js";
+
+// const bg = "https://sdk.openui5.org/resources/sap/ui/core/messagebundle_bg.properties";
+// registerI18nLoader("@ui5/webcomponents", "bg", async (localeId) => {
+// 	const props = await (await fetch(bg)).text();
+// 	return parse(props);
+// });
+// registerI18nLoader("@ui5/webcomponents", "fr", async (localeId) => {
+// 	return await (await fetch("fr")).json();
+// });
+
+// used in test pages
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
+
+import { sanitizeHTML, URLListValidator } from "@ui5/webcomponents-base/dist/util/HTMLSanitizer.js";
+
+import { getAnimationMode, setAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
+import { getTheme, setTheme, isLegacyThemeFamily } from "@ui5/webcomponents-base/dist/config/Theme.js";
+import { getThemeRoot, setThemeRoot } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
+import { getTimezone, setTimezone } from "@ui5/webcomponents-base/dist/config/Timezone.js";
+import { getLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+import getEffectiveIconCollection from "@ui5/webcomponents-base/dist/asset-registries/util/getIconCollectionByTheme.js";
+import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
+import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
+import { _getRegisteredNames as getIconNames, getIconAccessibleName } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
+import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
+import { attachDirectionChange } from "@ui5/webcomponents-base/dist/locale/directionChange.js";
+import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
+import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
+import { ignoreCustomElements, shouldIgnoreCustomElement } from "@ui5/webcomponents-base/dist/IgnoreCustomElements.js";
+
+import * as defaultTexts from "./generated/i18n/i18n-defaults.js";
+
 setRuntimeAlias("UI5 Web Components Playground");
+
+// @ts-ignore
+window.sanitizeHTML = sanitizeHTML;
+// @ts-ignore
+window.URLListValidator = URLListValidator;
+
+ignoreCustomElements("app-");
+ignoreCustomElements("my-");
+
+const testAssets = {
+	configuration: {
+		getAnimationMode,
+		setAnimationMode,
+		getTheme,
+		setTheme,
+		getThemeRoot,
+		setThemeRoot,
+		isLegacyThemeFamily,
+		getLanguage,
+		setLanguage,
+		setNoConflict,
+		getFirstDayOfWeek,
+		getTimezone,
+		setTimezone,
+	},
+	invisibleMessage: {
+		announce,
+	},
+	getLocaleData,
+	applyDirection,
+	attachDirectionChange,
+	ResizeHandler,
+	addCustomCSS,
+	attachThemeLoaded,
+	detachThemeLoaded,
+	getIconNames,
+	getIconAccessibleName,
+	renderFinished,
+	defaultTexts,
+	getEffectiveIconCollection,
+	ignoreCustomElements,
+	shouldIgnoreCustomElement,
+};
+
+// @ts-ignore
+window["sap-ui-webcomponents-bundle"] = testAssets;
+
+export default testAssets;

--- a/packages/main/src/bundle.common.bootstrap.ts
+++ b/packages/main/src/bundle.common.bootstrap.ts
@@ -23,8 +23,6 @@ import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "@ui5/webcomponents-base/dist/Theming.js";
 // import "./customI18n.js";
 
-import "./bundle.common.bootstrap.js"; // code that needs to be executed before other modules
-
 // Calendars
 import "@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js";
 import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js";

--- a/packages/main/src/bundle.esm.ts
+++ b/packages/main/src/bundle.esm.ts
@@ -1,77 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// OpenUI5 integration
-import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
 
-// Assets
-import "./Assets.js";
+// eslint-disable-next-line
+import testAssetsCommon from "./bundle.common.bootstrap.js"; // code that needs to be executed before other modules
 
-// Icons
-import "@ui5/webcomponents-icons/dist/Assets.js";
-import "@ui5/webcomponents-icons/dist/AllIcons.js";
-
-// TNT Icons
-import "@ui5/webcomponents-icons-tnt/dist/Assets.js";
-import "@ui5/webcomponents-icons-tnt/dist/AllIcons.js";
-
-// SAP Business Suite Icons
-import "@ui5/webcomponents-icons-business-suite/dist/Assets.js";
-import "@ui5/webcomponents-icons-business-suite/dist/AllIcons.js";
-
-import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
-import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "@ui5/webcomponents-base/dist/Theming.js";
-// import "./customI18n.js";
-
-import "./bundle.common.bootstrap.js"; // code that needs to be executed before other modules
-
-// Calendars
-import "@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js";
-import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js";
-import "@ui5/webcomponents-localization/dist/features/calendar/Japanese.js";
-import "@ui5/webcomponents-localization/dist/features/calendar/Persian.js";
-
-// CLDR
-import getLocaleData from "@ui5/webcomponents-localization/dist/locale/getLocaleData.js";
-
-// import { registerCustomThemePropertiesLoader } from "@ui5/webcomponents-base/dist/AssetRegistry.js";
-// import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
-// const customThemeLoader = theme => Promise.resolve(`:root {
-// 	${getScopedVarName("--_ui5_button_base_height")}: 4rem;
-// 	${getScopedVarName("--_ui5_button_base_padding")}: 2rem;
-// }`);
-// registerCustomThemePropertiesLoader("@ui5/webcomponents", "my_custom_theme", customThemeLoader);
-
-// Uncomment to test the registration of custom properties and JSON bundles - use the TextArea test page
-// import { registerI18nLoader } from "@ui5/webcomponents-base/dist/asset-registries/i18n.js";
-// import parse from "@ui5/webcomponents-base/dist/PropertiesFileFormat.js";
-
-// const bg = "https://sdk.openui5.org/resources/sap/ui/core/messagebundle_bg.properties";
-// registerI18nLoader("@ui5/webcomponents", "bg", async (localeId) => {
-// 	const props = await (await fetch(bg)).text();
-// 	return parse(props);
-// });
-// registerI18nLoader("@ui5/webcomponents", "fr", async (localeId) => {
-// 	return await (await fetch("fr")).json();
-// });
-
-// used in test pages
-import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
-
-import { sanitizeHTML, URLListValidator } from "@ui5/webcomponents-base/dist/util/HTMLSanitizer.js";
-
-import { getAnimationMode, setAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
-import { getTheme, setTheme, isLegacyThemeFamily } from "@ui5/webcomponents-base/dist/config/Theme.js";
-import { getThemeRoot, setThemeRoot } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
-import { getTimezone, setTimezone } from "@ui5/webcomponents-base/dist/config/Timezone.js";
-import { getLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
-import getEffectiveIconCollection from "@ui5/webcomponents-base/dist/asset-registries/util/getIconCollectionByTheme.js";
-import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
-import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
-import { _getRegisteredNames as getIconNames, getIconAccessibleName, registerIconLoader } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
-import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
-import { attachDirectionChange } from "@ui5/webcomponents-base/dist/locale/directionChange.js";
-import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
-import { ignoreCustomElements, shouldIgnoreCustomElement } from "@ui5/webcomponents-base/dist/IgnoreCustomElements.js";
+import { registerIconLoader } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 
 // SAP Icons
 import accept, { getPathData } from "@ui5/webcomponents-icons/dist/accept.js";
@@ -85,7 +17,6 @@ import actorv3 from "@ui5/webcomponents-icons-tnt/dist/v3/actor.js";
 import icon3d from "@ui5/webcomponents-icons-business-suite/dist/3d.js";
 import icon3dv1 from "@ui5/webcomponents-icons-business-suite/dist/v1/3d.js";
 import icon3dv2 from "@ui5/webcomponents-icons-business-suite/dist/v2/3d.js";
-import * as defaultTexts from "./generated/i18n/i18n-defaults.js";
 
 // The SAP Icons V4 icon collection is set by default in sap_fiori_3,
 // but it's configurable:
@@ -184,50 +115,12 @@ import ListItemGroup from "./ListItemGroup.js";
 import "./features/ColorPaletteMoreColors.js";
 import "./features/InputSuggestions.js";
 
-// @ts-ignore
-window.sanitizeHTML = sanitizeHTML;
-// @ts-ignore
-window.URLListValidator = URLListValidator;
-ignoreCustomElements("app-");
-ignoreCustomElements("my-");
-
 const icons = [accept, acceptv4, acceptv5, actor, actorv2, actorv3, icon3d, icon3dv1, icon3dv2];
 
 const testAssets = {
-	configuration: {
-		getAnimationMode,
-		setAnimationMode,
-		getTheme,
-		setTheme,
-		getThemeRoot,
-		setThemeRoot,
-		isLegacyThemeFamily,
-		getLanguage,
-		setLanguage,
-		setNoConflict,
-		getFirstDayOfWeek,
-		getTimezone,
-		setTimezone,
-	},
-	invisibleMessage: {
-		announce,
-	},
-	getLocaleData,
-	applyDirection,
-	attachDirectionChange,
-	ResizeHandler,
-	addCustomCSS,
-	attachThemeLoaded,
-	detachThemeLoaded,
-	getIconNames,
-	getIconAccessibleName,
+	...testAssetsCommon,
 	getAcceptIconPathData: getPathData,
-	renderFinished,
-	defaultTexts,
 	getExportedIconsValues: () => icons,
-	getEffectiveIconCollection,
-	ignoreCustomElements,
-	shouldIgnoreCustomElement,
 };
 
 registerIconLoader("my-icons", () => {


### PR DESCRIPTION
Split the button into two parts:

- All common imports related to configuration, etc.
- Component imports

Before, `bundle.esm.ts` was used as import in `bundle.esm.ts` compat. This caused a conflict when `ui5-grid` component were renamed to `ui5-table`, which is blocking the renaming.

With this change, we only use configuration imports and explicitly import only the components we need from other packages in `bundle.esm.ts` compat.