### PR TITLE
fix(ui5-barcode-scanner-dialog): properly fire 'close' event

### DIFF
--- a/packages/fiori/src/BarcodeScannerDialog.hbs
+++ b/packages/fiori/src/BarcodeScannerDialog.hbs
@@ -2,6 +2,7 @@
 	class="ui5-barcode-scanner-dialog-root"
 	.open="{{_open}}"
 	@ui5-before-open={{_startReader}}
+	@ui5-before-close={{_fireCloseEvent}}
 	@ui5-close={{_resetReader}}>
 	<div class="ui5-barcode-scanner-dialog-video-wrapper">
 		<video class="ui5-barcode-scanner-dialog-video"></video>

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -211,6 +211,10 @@ class BarcodeScannerDialog extends UI5Element {
 
 	_closeDialog() {
 		this.open = false;
+	}
+
+	_fireCloseEvent() {
+		this.open = false;
 		this.fireEvent("close");
 	}
 


### PR DESCRIPTION
Issue is fixed where when closing the BarcodeScannerDialog with 'ESC' key, the 'close' event isn't fired.

Now 'close' event is properly fired regardless of the way the dialog is closed.

Fixes: #9177