### PR TITLE
chore: rearrange RTL related variables

### DIFF
--- a/packages/main/src/themes/sap_horizon/ProgressIndicatorLayout-parameters.css
+++ b/packages/main/src/themes/sap_horizon/ProgressIndicatorLayout-parameters.css
@@ -1,8 +1,3 @@
-[dir="rtl"] {
-	--_ui5_progress_indicator_bar_border_radius: 0.5rem;
-    --_ui5_progress_indicator_remaining_bar_border_radius: 0.25rem;
-}
-
 :root {
     --_ui5_progress_indicator_icon_visibility: inline-block;
 

--- a/packages/main/src/themes/sap_horizon/rtl-parameters.css
+++ b/packages/main/src/themes/sap_horizon/rtl-parameters.css
@@ -3,4 +3,6 @@
 [dir="rtl"] {
 	--_ui5_segmented_btn_item_border_left: 0.0625rem;
 	--_ui5_segmented_btn_item_border_right: 0.0625rem;
+	--_ui5_progress_indicator_bar_border_radius: 0.5rem;
+	--_ui5_progress_indicator_remaining_bar_border_radius: 0.25rem;
 }


### PR DESCRIPTION
RTL parameters should be added as described in `rtl-parameters.css`. Otherwise, it might cause issues when PostCSS processes the CSS files.

For example, CSS variables that control icon appearance are broken because `[dir="rtl"]` is moved before the `:root` selector after PostCSS preprocessing:
![image](https://github.com/SAP/ui5-webcomponents/assets/31909318/f7c8e203-b338-416c-ad4d-219e297dd078)

Related to: #9133