### PR TITLE
fix(ui5-busy-indicator): add block layer

### DIFF
--- a/packages/main/src/BusyIndicator.ts
+++ b/packages/main/src/BusyIndicator.ts
@@ -118,6 +118,13 @@ class BusyIndicator extends UI5Element {
 	@property({ type: Boolean })
 	_isBusy!: boolean;
 
+	/**
+	 * Defines if the busy indicator is over component (default slot is used).
+	 * @private
+	 */
+	@property({ type: Boolean })
+	_isOverComponent!: boolean;
+
 	_keydownHandler: (e: KeyboardEvent) => void;
 	_preventEventHandler: (e: KeyboardEvent) => void;
 	_busyTimeoutId?: Timeout;
@@ -194,6 +201,10 @@ class BusyIndicator extends UI5Element {
 			}
 			this._isBusy = false;
 		}
+	}
+
+	onAfterRendering() {
+		this._isOverComponent = this.shadowRoot!.querySelector("slot")!.assignedElements().length > 0;
 	}
 
 	_handleKeydown(e: KeyboardEvent) {

--- a/packages/main/src/BusyIndicator.ts
+++ b/packages/main/src/BusyIndicator.ts
@@ -118,13 +118,6 @@ class BusyIndicator extends UI5Element {
 	@property({ type: Boolean })
 	_isBusy!: boolean;
 
-	/**
-	 * Defines if the busy indicator is over component (default slot is used).
-	 * @private
-	 */
-	@property({ type: Boolean })
-	_isOverComponent!: boolean;
-
 	_keydownHandler: (e: KeyboardEvent) => void;
 	_preventEventHandler: (e: KeyboardEvent) => void;
 	_busyTimeoutId?: Timeout;
@@ -201,10 +194,6 @@ class BusyIndicator extends UI5Element {
 			}
 			this._isBusy = false;
 		}
-	}
-
-	onAfterRendering() {
-		this._isOverComponent = this.shadowRoot!.querySelector("slot")!.assignedElements().length > 0;
 	}
 
 	_handleKeydown(e: KeyboardEvent) {

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -89,6 +89,10 @@
 	flex-direction: column;
 }
 
+:host([_is-over-component]) .ui5-busy-indicator-busy-area {
+	background-color: var(--_ui5_busy_indicator_block_layer);
+}
+
 :host([desktop]) .ui5-busy-indicator-busy-area:focus,
 .ui5-busy-indicator-busy-area:focus-visible {
 	outline: var(--_ui5_busy_indicator_focus_outline);

--- a/packages/main/src/themes/BusyIndicator.css
+++ b/packages/main/src/themes/BusyIndicator.css
@@ -89,7 +89,7 @@
 	flex-direction: column;
 }
 
-:host([_is-over-component]) .ui5-busy-indicator-busy-area {
+:host(:not(:empty)) .ui5-busy-indicator-busy-area {
 	background-color: var(--_ui5_busy_indicator_block_layer);
 }
 

--- a/packages/main/src/themes/base/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/base/BusyIndicator-parameters.css
@@ -2,5 +2,5 @@
 	--_ui5_busy_indicator_color: var(--sapContent_IconColor);
 	--_ui5_busy_indicator_focus_outline:  var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	--_ui5_busy_indicator_focus_border_radius: 0px;
-	--_ui5_busy_indicator_block_layer: rgba(0, 0, 0, 0.2); /* --sapBlockLayer_Background with 0.2 opacity*/
+	--_ui5_busy_indicator_block_layer: color-mix(in oklch, transparent, var(--sapBlockLayer_Background) 20%);
 }

--- a/packages/main/src/themes/base/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/base/BusyIndicator-parameters.css
@@ -2,4 +2,5 @@
 	--_ui5_busy_indicator_color: var(--sapContent_IconColor);
 	--_ui5_busy_indicator_focus_outline:  var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	--_ui5_busy_indicator_focus_border_radius: 0px;
+	--_ui5_busy_indicator_block_layer: rgba(0, 0, 0, 0.2); /* --sapBlockLayer_Background with 0.2 opacity*/
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/BusyIndicator-parameters.css
@@ -1,6 +1,5 @@
 @import "../base/BusyIndicator-parameters.css";
 
 :root {
-	--_ui5_busy_indicator_color: var(--sapContent_BusyColor);
 	--_ui5_busy_indicator_block_layer: rgba(0, 0, 0, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/BusyIndicator-parameters.css
@@ -1,5 +1,5 @@
 @import "../base/BusyIndicator-parameters.css";
 
 :root {
-	--_ui5_busy_indicator_block_layer: rgba(0, 0, 0, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
+	--_ui5_busy_indicator_block_layer: color-mix(in oklch, transparent, var(--sapBlockLayer_Background) 30%);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -3,7 +3,7 @@
 @import "./Tag-parameters.css";
 @import "./Bar-parameters.css";
 @import "../base/BrowserScrollbar-parameters.css";
-@import "../base/BusyIndicator-parameters.css";
+@import "./BusyIndicator-parameters.css";
 @import "./Button-parameters.css";
 @import "../base/CalendarLegend-parameters.css";
 @import "../base/CalendarLegendItem-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcw/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/BusyIndicator-parameters.css
@@ -1,6 +1,5 @@
 @import "../base/BusyIndicator-parameters.css";
 
 :root {
-	--_ui5_busy_indicator_color: var(--sapContent_BusyColor);
 	--_ui5_busy_indicator_block_layer: rgba(255, 255, 255, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/BusyIndicator-parameters.css
@@ -1,5 +1,5 @@
 @import "../base/BusyIndicator-parameters.css";
 
 :root {
-	--_ui5_busy_indicator_block_layer: rgba(255, 255, 255, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
+	--_ui5_busy_indicator_block_layer: color-mix(in oklch, transparent, var(--sapBlockLayer_Background) 30%);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -2,7 +2,7 @@
 @import "../base/AvatarGroup-parameters.css";
 @import "./Tag-parameters.css";
 @import "../base/BrowserScrollbar-parameters.css";
-@import "../base/BusyIndicator-parameters.css";
+@import "./BusyIndicator-parameters.css";
 @import "./Button-parameters.css";
 @import "../base/CalendarLegend-parameters.css";
 @import "../base/CalendarLegendItem-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcb/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/BusyIndicator-parameters.css
@@ -2,5 +2,5 @@
 
 :root {
 	--_ui5_busy_indicator_color: var(--sapContent_BusyColor);
-	--_ui5_busy_indicator_block_layer: rgba(0, 0, 0, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
+	--_ui5_busy_indicator_block_layer: color-mix(in oklch, transparent, var(--sapBlockLayer_Background) 30%);
 }

--- a/packages/main/src/themes/sap_horizon_hcw/BusyIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/BusyIndicator-parameters.css
@@ -2,5 +2,5 @@
 
 :root {
 	--_ui5_busy_indicator_color: var(--sapContent_BusyColor);
-	--_ui5_busy_indicator_block_layer: rgba(255, 255, 255, 0.3); /* --sapBlockLayer_Background with 0.3 opacity*/
+	--_ui5_busy_indicator_block_layer: color-mix(in oklch, transparent, var(--sapBlockLayer_Background) 30%);
 }


### PR DESCRIPTION
According to the design if busy indicator is used over some component there should be transparent background as overlay.

fixes #9079