### PR TITLE
chore: (ListItemBase): ensure desktop attribute is set for focus styles

### DIFF
--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -3,7 +3,6 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getTabbableElements } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
-import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
@@ -73,12 +72,6 @@ class NotificationListItemBase extends ListItemBase {
 
 	get isLoading() {
 		return this.loading;
-	}
-
-	onEnterDOM() {
-		if (isDesktop()) {
-			this.setAttribute("desktop", "");
-		}
 	}
 
 	/**

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -5,7 +5,6 @@ import {
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 import type { AccessibilityAttributes, PassiveEventListenerObject } from "@ui5/webcomponents-base/dist/types.js";
@@ -232,13 +231,10 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	onEnterDOM() {
+		super.onEnterDOM();
 		document.addEventListener("mouseup", this.deactivate);
 		document.addEventListener("touchend", this.deactivate);
 		document.addEventListener("keyup", this.deactivateByKey);
-
-		if (isDesktop()) {
-			this.setAttribute("desktop", "");
-		}
 	}
 
 	onExitDOM() {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -6,6 +6,7 @@ import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import { getTabbableElements } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import {
 	isEnter,
 	isSpace,
@@ -95,6 +96,12 @@ class ListItemBase extends UI5Element implements ITabbable {
 	 */
 	@property({ type: Boolean })
 	actionable!: boolean;
+
+	onEnterDOM() {
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
+	}
 
 	onBeforeRendering(): void {
 		this.actionable = true;

--- a/packages/main/src/ListItemGroupHeader.ts
+++ b/packages/main/src/ListItemGroupHeader.ts
@@ -2,7 +2,6 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import ListItemBase from "./ListItemBase.js";
 
 import { GROUP_HEADER_TEXT } from "./generated/i18n/i18n-defaults.js";
@@ -60,12 +59,6 @@ class ListItemGroupHeader extends ListItemBase {
 
 	static async onDefine() {
 		ListItemGroupHeader.i18nBundle = await getI18nBundle("@ui5/webcomponents");
-	}
-
-	onEnterDOM() {
-		if (isDesktop()) {
-			this.setAttribute("desktop", "");
-		}
 	}
 }
 

--- a/packages/main/src/Option.ts
+++ b/packages/main/src/Option.ts
@@ -1,7 +1,6 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
-import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import type { IOption } from "./Select.js";
 import ListItemBase from "./ListItemBase.js";
 import Icon from "./Icon.js";
@@ -90,12 +89,6 @@ class Option extends ListItemBase implements IOption {
 	 */
 	@property({ type: String, defaultValue: "" })
 	tooltip!: string;
-
-	onEnterDOM() {
-		if (isDesktop()) {
-			this.setAttribute("desktop", "");
-		}
-	}
 
 	get displayIconBegin(): boolean {
 		return !!this.icon;

--- a/packages/main/src/OptionCustom.ts
+++ b/packages/main/src/OptionCustom.ts
@@ -1,7 +1,6 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
-import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import type { IOption } from "./Select.js";
 import ListItemBase from "./ListItemBase.js";
 
@@ -72,12 +71,6 @@ class OptionCustom extends ListItemBase implements IOption {
 	 */
 	@property({ type: String })
 	tooltip!: string;
-
-	onEnterDOM() {
-		if (isDesktop()) {
-			this.setAttribute("desktop", "");
-		}
-	}
 
 	get effectiveDisplayText() {
 		return this.displayText || this.textContent || "";


### PR DESCRIPTION
The `ListItemBase` component now manages its focus styles, but previously required subclasses to set the `desktop` attribute. This update modifies `ListItemBase.ts` to directly set the `desktop` attribute, and thus completes the focus functionality.