### PR TITLE
feat(ui5-table): adding horizontal column alignment

### DIFF
--- a/packages/main/src/Grid.ts
+++ b/packages/main/src/Grid.ts
@@ -306,6 +306,7 @@ class Grid extends UI5Element {
 	onBeforeRendering(): void {
 		this.style.setProperty(getScopedVarName("--ui5_grid_sticky_top"), this.stickyTop);
 		this._refreshPopinState();
+		this._refreshAlignment();
 	}
 
 	onAfterRendering(): void {
@@ -414,6 +415,17 @@ class Grid extends UI5Element {
 				const cell = row.cells[index];
 				if (cell && cell._popin !== header._popin) {
 					cell._popin = header._popin;
+				}
+			});
+		});
+	}
+
+	_refreshAlignment() {
+		this.headerRow[0].cells.forEach((header, index) => {
+			this.rows.forEach(row => {
+				const cell = row.cells[index];
+				if (cell && cell.hAlign !== header.hAlign) {
+					cell.hAlign = header.hAlign;
 				}
 			});
 		});

--- a/packages/main/src/GridCellBase.ts
+++ b/packages/main/src/GridCellBase.ts
@@ -31,6 +31,9 @@ abstract class GridCellBase extends UI5Element {
 	@property({ type: Boolean })
 	_popin!: boolean;
 
+	@property({ type: String, defaultValue: "Left" })
+	hAlign!: string;
+
 	protected ariaRole: string = "gridcell";
 
 	static i18nBundle: I18nBundle;

--- a/packages/main/src/themes/GridCell.css
+++ b/packages/main/src/themes/GridCell.css
@@ -1,3 +1,7 @@
+:host {
+    justify-content: var(--_ui5-grid-cell-base-hAlign, left);
+}
+
 :host([_popin]) {
     padding-inline-start: 0;
     padding-inline-end: 0;

--- a/packages/main/src/themes/GridCellBase.css
+++ b/packages/main/src/themes/GridCellBase.css
@@ -19,3 +19,22 @@
     width: auto;
     min-width: auto;
 }
+:host([h-align="left"]) {
+    --_ui5-grid-cell-base-hAlign: left;
+}
+
+:host([h-align="right"]) {
+    --_ui5-grid-cell-base-hAlign: right;
+}
+
+:host([h-align="middle"]) {
+    --_ui5-grid-cell-base-hAlign: center;
+}
+
+:host([h-align="end"]) {
+    --_ui5-grid-cell-base-hAlign: end;
+}
+
+:host([h-align="center"]) {
+    --_ui5-grid-cell-base-hAlign: center;
+}

--- a/packages/main/src/themes/GridHeaderCell.css
+++ b/packages/main/src/themes/GridHeaderCell.css
@@ -1,6 +1,7 @@
 :host {
     font-family: var(--sapFontSemiboldDuplexFamily);
     color: var(--sapList_HeaderTextColor);
+    justify-content: var(--_ui5-grid-cell-base-hAlign);
 }
 
 :host(:empty) {

--- a/packages/main/test/pages/Grid.html
+++ b/packages/main/test/pages/Grid.html
@@ -29,14 +29,14 @@
 		<ui5-grid-growing id="growing" type="Scroll" slot="features"></ui5-grid-growing>
 		<ui5-grid-selection id="selection" selected="0 2" slot="features"></ui5-grid-selection>
 		<ui5-grid-header-row slot="headerRow">
-			<ui5-grid-header-cell id="produtCol" width="300px"><span>Product</span></ui5-grid-header-cell>
+			<ui5-grid-header-cell id="produtCol" width="300px" h-align="end"><span>Product</span></ui5-grid-header-cell>
 			<ui5-grid-header-cell id="supplierCol">Supplier</ui5-grid-header-cell>
 			<ui5-grid-header-cell id="dimensionsCol" importance="-1" min-width="300px">Dimensions</ui5-grid-header-cell>
-			<ui5-grid-header-cell id="weightCol" popin-text="Weight">Weight</ui5-grid-header-cell>
-			<ui5-grid-header-cell id="priceCol" min-width="220px">Price</ui5-grid-header-cell>
+			<ui5-grid-header-cell id="weightCol" h-align="end" popin-text="Weight">Weight</ui5-grid-header-cell>
+			<ui5-grid-header-cell id="priceCol" h-align="middle" min-width="220px">Price</ui5-grid-header-cell>
 		</ui5-grid-header-row>
 		<ui5-grid-row key="0">
-			<ui5-grid-cell><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-grid-cell>
+			<ui5-grid-cell h-align="left"><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-grid-cell>
 			<ui5-grid-cell><ui5-label>Very Best Screens</ui5-label></ui5-grid-cell>
 			<ui5-grid-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-grid-cell>
 			<ui5-grid-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-grid-cell>


### PR DESCRIPTION
Introduction of a new property `hAlign`. `hAlign` is used to configure the horizontal alignment in GridCells. The idea is to configure the horizontal alignment on the header level of the GridTable and then automatically adjust the alignment of the cells according to their header cell.