### PR TITLE
fix(ui5-message-strip): Remove icon when design changes to a color set

### DIFF
--- a/packages/main/src/MessageStrip.hbs
+++ b/packages/main/src/MessageStrip.hbs
@@ -4,7 +4,7 @@
 	aria-labelledby="{{_id}}"
 >
 
-	{{#unless hideIcon}}
+	{{#unless shouldHideIcon}}
 		<div
 		class="ui5-message-strip-icon-wrapper"
 		aria-hidden="true"

--- a/packages/main/src/MessageStrip.ts
+++ b/packages/main/src/MessageStrip.ts
@@ -178,6 +178,14 @@ class MessageStrip extends UI5Element {
 		return `${MessageStrip.designAnnouncementMappings()[this.design]} ${this.hideCloseButton ? "" : this._closableText}`;
 	}
 
+	get shouldHideIcon() {
+		if (this.designClasses === DesignClassesMapping.ColorSet1 || this.designClasses === DesignClassesMapping.ColorSet2) {
+			return this.hideIcon || this.icon.length === 0;
+		}
+
+		return this.hideIcon;
+	}
+
 	get _closeButtonText() {
 		return MessageStrip.i18nBundle.getText(MESSAGE_STRIP_CLOSE_BUTTON);
 	}
@@ -190,7 +198,7 @@ class MessageStrip extends UI5Element {
 		return {
 			root: {
 				"ui5-message-strip-root": true,
-				"ui5-message-strip-root-hide-icon": this.hideIcon,
+				"ui5-message-strip-root-hide-icon": this.shouldHideIcon,
 				"ui5-message-strip-root-hide-close-button": this.hideCloseButton,
 				[this.designClasses]: true,
 			},

--- a/packages/main/test/pages/MessageStrip.html
+++ b/packages/main/test/pages/MessageStrip.html
@@ -59,10 +59,23 @@
 	<ui5-message-strip design="ColorSet2" color-scheme="9" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 9</ui5-message-strip>
 	<ui5-message-strip design="ColorSet2" color-scheme="10" class="top"><ui5-icon name="palette" slot="icon"></ui5-icon>Color Set 2 - color-scheme 10</ui5-message-strip>
 
+	<br />
+	<br />
+	<ui5-button id="btn" /> Change design</ui5-button>
+	<br />
+	<br />
+	<ui5-message-strip id="ms">MessageStrip w/ default properties</ui5-message-strip>
+
 	<script>
 		var counter = 0;
 		messageStrip.addEventListener("ui5-close", function() {
 			inputField.value = ++counter;
+		});
+
+		const mStrip = document.getElementById('ms');
+		document.getElementById('btn').addEventListener('click', () => {
+			mStrip.design = 'ColorSet1';
+			mStrip.colorScheme = '1';
 		});
 	</script>
 </body>

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -102,3 +102,18 @@ describe("ARIA Support", () => {
 	});
 });
 
+describe("Change properties dynamically", () => {
+	before(async () => {
+		await browser.url(`test/pages/MessageStrip.html`);
+	});
+
+	it("Message strip is rendered ", async () => {
+		const messageStrip = await browser.$("#ms");
+		const btn = await browser.$("#btn");
+
+		await btn.click();
+
+		assert.strictEqual(await messageStrip.shadow$(".ui5-message-strip-icon").isExisting(), false, "Message strip does not rendere icon");
+	});
+});
+

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -213,7 +213,7 @@ code {
   padding: 0.125rem 0.25rem;
   box-sizing: border-box;
   font-size: 0.75rem;
-  content: "Experimental";
+  content: "exp";
   background: #a100c2;
   pointer-events: none;
 }
@@ -227,7 +227,7 @@ code {
   padding: 0.125rem 0.25rem;
   box-sizing: border-box;
   font-size: 0.75rem;
-  content: "New";
+  content: "new";
   background: #334eff;
   pointer-events: none;
 }

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -174,7 +174,7 @@ code {
 }
 
 /* Make top level menu items bold (main,fiori,etc.) */
-.theme-doc-sidebar-item-category-level-1.menu__list-item > .menu__list-item-collapsible > a[href*="components"] {
+.theme-doc-sidebar-item-category-level-1.menu__list-item > .menu__list-item-collapsible > a[href*="\/components"] {
   font-weight: bold;
 }
 


### PR DESCRIPTION
Changing design from value-states to color-set does remove the value state icon.

Fixes #9181

