### PR TITLE
chore: adapt OpenUI5 version check

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -68,6 +68,9 @@ type Locale = {
 
 class OpenUI5Support {
 	static isAtLeastVersion116() {
+		if (!window.sap.ui!.version) {
+			return true; // sap.ui.version will be removed in newer OpenUI5 versions
+		}
 		const version = window.sap.ui!.version as string;
 		const parts = version.split(".");
 		if (!parts || parts.length < 2) {


### PR DESCRIPTION
`sap.ui.version` will be removed in future OpenUI5 versions and will cause the code to break.