### PR TITLE
chore(ui5-combobox, ui5-multi-combobox): comply with latest aria spec

### DIFF
--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -68,6 +68,7 @@
 		@ui5-item-focused={{_onItemFocus}}
 		@mousedown={{_itemMousedown}}
 		mode="SingleSelect"
+		accessible-role="listbox"
 	>
 		{{#each _filteredItems}}
 			{{#if isGroupItem}}
@@ -127,6 +128,7 @@
 			?selected={{this.selected}}
 			?focused={{this.focused}}
 			data-ui5-stable="{{this.stableDomRef}}"
+			accessible-role="option"
 	>
 		{{this.text}}
 	</ui5-li>

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -68,7 +68,7 @@
 	{{/unless}}
 
 	{{#if filterSelected}}
-		<ui5-list separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list">
+		<ui5-list separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list" accessible-role="listbox">
 			{{#each selectedItems}}
 				{{#if isGroupItem}}
 					<ui5-li-groupheader data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">{{ this.text }}</ui5-li-groupheader>
@@ -78,7 +78,7 @@
 			{{/each}}
 		</ui5-list>
 	{{else}}
-		<ui5-list separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list">
+		<ui5-list separators="None" mode="MultiSelect" class="ui5-multi-combobox-all-items-list" accessible-role="listbox">
 			{{#each _filteredItems}}
 				{{#if isGroupItem}}
 					<ui5-li-groupheader data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">{{ this.text }}</ui5-li-groupheader>
@@ -135,6 +135,7 @@
 		data-ui5-token-id="{{this._id}}"
 		data-ui5-stable="{{this.stableDomRef}}"
 		@keydown="{{../_onItemKeydown}}"
+		accessible-role="option"
 	>
 		{{this.text}}
 	</ui5-li>


### PR DESCRIPTION
With the following change `ui5-combobox` and `ui5-multicombobox` are now compliant with the Aria 1.2 specification.
