### PR TITLE
chore: remove husky:lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "release": "node ./.github/actions/release.js",
     "prepare": "husky install",
     "husky:commit-msg": "commitlint -e",
-    "husky:lint": "yarn lint && yarn lint:scope",
-    "husky:pre-push": "npm-run-all --sequential husky:commit-msg husky:lint",
+    "husky:pre-push": "npm-run-all --sequential husky:commit-msg",
     "postinstall": "patch-package"
   },
   "devDependencies": {


### PR DESCRIPTION
`eslint` runs slow on Windows machines. On average it takes from 100 to 300 seconds to complete, sometimes even more.
