### PR TITLE
fix(ui5-tab-container): enhance documentation page

### DIFF
--- a/packages/main/src/BusyIndicator.ts
+++ b/packages/main/src/BusyIndicator.ts
@@ -118,6 +118,13 @@ class BusyIndicator extends UI5Element {
 	@property({ type: Boolean })
 	_isBusy!: boolean;
 
+	/**
+	 * Defines if the busy indicator is over component (default slot is used).
+	 * @private
+	 */
+	@property({ type: Boolean })
+	_isOverComponent!: boolean;
+
 	_keydownHandler: (e: KeyboardEvent) => void;
 	_preventEventHandler: (e: KeyboardEvent) => void;
 	_busyTimeoutId?: Timeout;
@@ -194,6 +201,10 @@ class BusyIndicator extends UI5Element {
 			}
 			this._isBusy = false;
 		}
+	}
+
+	onAfterRendering() {
+		this._isOverComponent = this.shadowRoot!.querySelector("slot")!.assignedElements().length > 0;
 	}
 
 	_handleKeydown(e: KeyboardEvent) {

--- a/packages/main/src/BusyIndicator.ts
+++ b/packages/main/src/BusyIndicator.ts
@@ -118,13 +118,6 @@ class BusyIndicator extends UI5Element {
 	@property({ type: Boolean })
 	_isBusy!: boolean;
 
-	/**
-	 * Defines if the busy indicator is over component (default slot is used).
-	 * @private
-	 */
-	@property({ type: Boolean })
-	_isOverComponent!: boolean;
-
 	_keydownHandler: (e: KeyboardEvent) => void;
 	_preventEventHandler: (e: KeyboardEvent) => void;
 	_busyTimeoutId?: Timeout;
@@ -201,10 +194,6 @@ class BusyIndicator extends UI5Element {
 			}
 			this._isBusy = false;
 		}
-	}
-
-	onAfterRendering() {
-		this._isOverComponent = this.shadowRoot!.querySelector("slot")!.assignedElements().length > 0;
 	}
 
 	_handleKeydown(e: KeyboardEvent) {

--- a/packages/website/docs/_components_pages/main/TabContainer/TabContainer.mdx
+++ b/packages/website/docs/_components_pages/main/TabContainer/TabContainer.mdx
@@ -5,7 +5,9 @@ slug: ../../TabContainer
 import Basic from "../../../_samples/main/TabContainer/Basic/Basic.md";
 import TextOnlyTabs from "../../../_samples/main/TabContainer/TextOnlyTabs/TextOnlyTabs.md";
 import TabLayout from "../../../_samples/main/TabContainer/TabLayout/TabLayout.md";
+import TabLayoutInline from "../../../_samples/main/TabContainer/TabLayoutInline/TabLayoutInline.md";
 import OverflowMode from "../../../_samples/main/TabContainer/OverflowMode/OverflowMode.md";
+import OverflowModeStartAndEnd from "../../../_samples/main/TabContainer/OverflowModeStartAndEnd/OverflowModeStartAndEnd.md";
 import NestedTabs from "../../../_samples/main/TabContainer/NestedTabs/NestedTabs.md";
 import ReorderTabs from "../../../_samples/main/TabContainer/ReorderTabs/ReorderTabs.md";
 import ReorderTabsMaxNestingLevel from "../../../_samples/main/TabContainer/ReorderTabsMaxNestingLevel/ReorderTabsMaxNestingLevel.md";
@@ -20,7 +22,12 @@ import ReorderTabsMaxNestingLevel from "../../../_samples/main/TabContainer/Reor
 ## More Samples
 
 ### Tab Layout
+
+The tabLayout is "Standard" by default:
 <TabLayout />
+
+It can be switched to "Inline":
+<TabLayoutInline />
 
 ### Text-only Tabs
 <TextOnlyTabs />
@@ -29,7 +36,12 @@ import ReorderTabsMaxNestingLevel from "../../../_samples/main/TabContainer/Reor
 <NestedTabs />
 
 ### Tabs Overflow Mode
+
+The overflowMode is "End" by default:
 <OverflowMode />
+
+It can be switched to "StartAndEnd":
+<OverflowModeStartAndEnd />
 
 ### Reorder Tabs
 <ReorderTabs />

--- a/packages/website/docs/_components_pages/main/TabContainer/TabContainer.mdx
+++ b/packages/website/docs/_components_pages/main/TabContainer/TabContainer.mdx
@@ -25,7 +25,7 @@ import ReorderTabsMaxNestingLevel from "../../../_samples/main/TabContainer/Reor
 
 The tabLayout is "Standard" by default:
 <TabLayout />
-
+<br />
 It can be switched to "Inline":
 <TabLayoutInline />
 
@@ -39,7 +39,7 @@ It can be switched to "Inline":
 
 The overflowMode is "End" by default:
 <OverflowMode />
-
+<br />
 It can be switched to "StartAndEnd":
 <OverflowModeStartAndEnd />
 

--- a/packages/website/docs/_samples/main/TabContainer/NestedTabs/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/NestedTabs/sample.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sample</title>
 </head>
-<body style="background-color: var(--sapBackgroundColor);">
+<body style="background-color: var(--sapBackgroundColor); height: 250px;">
 <!-- playground-fold-end -->
 
 <ui5-tabcontainer>

--- a/packages/website/docs/_samples/main/TabContainer/OverflowMode/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowMode/sample.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sample</title>
 </head>
-<body style="background-color: var(--sapBackgroundColor);">
+<body style="background-color: var(--sapBackgroundColor); height: 250px;">
 <!-- playground-fold-end -->
 
 <ui5-tabcontainer overflow-mode="End" collapsed>
@@ -35,32 +35,6 @@
     <ui5-tab text="Tab 23"></ui5-tab>
 </ui5-tabcontainer>
 
-<br>
-<ui5-tabcontainer overflow-mode="StartAndEnd" collapsed>
-    <ui5-tab text="Tab 1"></ui5-tab>
-    <ui5-tab text="Tab 2"></ui5-tab>
-    <ui5-tab text="Tab 3"></ui5-tab>
-    <ui5-tab text="Tab 4"></ui5-tab>
-    <ui5-tab text="Tab 5"></ui5-tab>
-    <ui5-tab text="Tab 6"></ui5-tab>
-    <ui5-tab text="Tab 7"></ui5-tab>
-    <ui5-tab text="Tab 8"></ui5-tab>
-    <ui5-tab text="Tab 9"></ui5-tab>
-    <ui5-tab text="Tab 10"></ui5-tab>
-    <ui5-tab text="Tab 11"></ui5-tab>
-    <ui5-tab text="Tab 12"></ui5-tab>
-    <ui5-tab text="Tab 13" selected></ui5-tab>
-    <ui5-tab text="Tab 14"></ui5-tab>
-    <ui5-tab text="Tab 15"></ui5-tab>
-    <ui5-tab text="Tab 16"></ui5-tab>
-    <ui5-tab text="Tab 17"></ui5-tab>
-    <ui5-tab text="Tab 18"></ui5-tab>
-    <ui5-tab text="Tab 19"></ui5-tab>
-    <ui5-tab text="Tab 20"></ui5-tab>
-    <ui5-tab text="Tab 21"></ui5-tab>
-    <ui5-tab text="Tab 22"></ui5-tab>
-    <ui5-tab text="Tab 23"></ui5-tab>
- </ui5-tabcontainer>
 <!-- playground-fold -->
     <script type="module" src="main.js"></script>
 </body>

--- a/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/OverflowModeStartAndEnd.md
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/OverflowModeStartAndEnd.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/main.js
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/main.js
@@ -1,0 +1,2 @@
+import "@ui5/webcomponents/dist/TabContainer.js";
+import "@ui5/webcomponents/dist/Tab.js";

--- a/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/sample.html
@@ -1,0 +1,41 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+<body style="background-color: var(--sapBackgroundColor); height: 250px;">
+<!-- playground-fold-end -->
+
+<ui5-tabcontainer overflow-mode="StartAndEnd" collapsed>
+    <ui5-tab text="Tab 1"></ui5-tab>
+    <ui5-tab text="Tab 2"></ui5-tab>
+    <ui5-tab text="Tab 3"></ui5-tab>
+    <ui5-tab text="Tab 4"></ui5-tab>
+    <ui5-tab text="Tab 5"></ui5-tab>
+    <ui5-tab text="Tab 6"></ui5-tab>
+    <ui5-tab text="Tab 7"></ui5-tab>
+    <ui5-tab text="Tab 8"></ui5-tab>
+    <ui5-tab text="Tab 9"></ui5-tab>
+    <ui5-tab text="Tab 10"></ui5-tab>
+    <ui5-tab text="Tab 11"></ui5-tab>
+    <ui5-tab text="Tab 12"></ui5-tab>
+    <ui5-tab text="Tab 13" selected></ui5-tab>
+    <ui5-tab text="Tab 14"></ui5-tab>
+    <ui5-tab text="Tab 15"></ui5-tab>
+    <ui5-tab text="Tab 16"></ui5-tab>
+    <ui5-tab text="Tab 17"></ui5-tab>
+    <ui5-tab text="Tab 18"></ui5-tab>
+    <ui5-tab text="Tab 19"></ui5-tab>
+    <ui5-tab text="Tab 20"></ui5-tab>
+    <ui5-tab text="Tab 21"></ui5-tab>
+    <ui5-tab text="Tab 22"></ui5-tab>
+    <ui5-tab text="Tab 23"></ui5-tab>
+ </ui5-tabcontainer>
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/TabContainer/TabLayout/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayout/sample.html
@@ -9,14 +9,6 @@
 <body style="background-color: var(--sapBackgroundColor);">
 <!-- playground-fold-end -->
 
-<ui5-tabcontainer tab-layout="Inline" collapsed>
-    <ui5-tab icon="laptop" text="Monitors" additional-text="10"></ui5-tab>
-    <ui5-tab icon="video" text="Cameras" additional-text="2" selected></ui5-tab>
-    <ui5-tab icon="home" text="Rooms" additional-text="16"></ui5-tab>
-</ui5-tabcontainer>
-
-<br>
-
 <ui5-tabcontainer tab-layout="Standard" collapsed>
     <ui5-tab icon="laptop" text="Monitors" additional-text="10"></ui5-tab>
     <ui5-tab icon="video" text="Cameras" additional-text="2" selected></ui5-tab>

--- a/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/TabLayoutInline.md
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/TabLayoutInline.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/main.js
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/main.js
@@ -1,0 +1,5 @@
+import "@ui5/webcomponents/dist/TabContainer.js";
+import "@ui5/webcomponents/dist/Tab.js";
+import "@ui5/webcomponents-icons/dist/laptop.js";
+import "@ui5/webcomponents-icons/dist/video.js";
+import "@ui5/webcomponents-icons/dist/home.js";

--- a/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/sample.html
@@ -1,0 +1,22 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+<body style="background-color: var(--sapBackgroundColor);">
+<!-- playground-fold-end -->
+
+<ui5-tabcontainer tab-layout="Inline" collapsed>
+    <ui5-tab icon="laptop" text="Monitors" additional-text="10"></ui5-tab>
+    <ui5-tab icon="video" text="Cameras" additional-text="2" selected></ui5-tab>
+    <ui5-tab icon="home" text="Rooms" additional-text="16"></ui5-tab>
+</ui5-tabcontainer>
+
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/TabContainer/TextOnlyTabs/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/TextOnlyTabs/sample.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sample</title>
 </head>
-<body style="background-color: var(--sapBackgroundColor);">
+<body style="background-color: var(--sapBackgroundColor); height: 250px;">
 <!-- playground-fold-end -->
 
 <ui5-tabcontainer>


### PR DESCRIPTION
The documentation page with the samples now have descriptions added,
the samples are bigger in height and every sample contains only one TabContainer.

fixes: #9248