### PR TITLE
chore(ui5-li-group-header): change default actionable state to false

### DIFF
--- a/packages/main/src/ListItemGroupHeader.ts
+++ b/packages/main/src/ListItemGroupHeader.ts
@@ -42,6 +42,11 @@ class ListItemGroupHeader extends ListItemBase {
 
 	static i18nBundle: I18nBundle;
 
+	onBeforeRendering(): void {
+		super.onBeforeRendering();
+		this.actionable = false;
+	}
+
 	get groupItem() {
 		return true;
 	}


### PR DESCRIPTION
According to the List's specification, group headers are meant to be non-interactive. Therefore, the actionable state inherited by the ListItemBase needs to be defaulted to false.