### PR TITLE
fix(ui5-tab-container): change display

### DIFF
--- a/packages/main/src/themes/TabContainer.css
+++ b/packages/main/src/themes/TabContainer.css
@@ -4,7 +4,7 @@
 /* Global Base parameters        */
 /* ============================= */
 :host(:not([hidden])) {
-	display: inline-block;
+	display: block;
 	width: 100%;
 }
 


### PR DESCRIPTION
When display was "inline-block" there was a small gap on the top of the TabContainer. 
Now display is changed to "block" and this gap is gone. 
In addition display "block" is most suitable for the tab-container.

BREAKING CHANGE: the `display` CSS property of the `tab-container` is changed from `inline-block` to `block`

related to: #9248