### PR TITLE
chore: display readonly information

### DIFF
--- a/packages/website/build-scripts/api-reference-generation/component-file.mjs
+++ b/packages/website/build-scripts/api-reference-generation/component-file.mjs
@@ -43,6 +43,11 @@ No properties available for this component.`
 | Type        | ${processType(property.type)}               |
 | Default     | ${property.default}                         |`
 
+
+        if (property.readonly) {
+            propertyResult += `\n| Readonly | true |`
+        }
+
         if (property._ui5since) {
             propertyResult += `\n| Since | ${property._ui5since} |`
         }


### PR DESCRIPTION
Currently, `custom-elements.json` contains information whether the property is readonly but this information is not displayed in the component documentation pages. With this change the information is displayed.