### PR TITLE
fix: template result comparison

### DIFF
--- a/packages/tools/lib/hbs2ui5/index.js
+++ b/packages/tools/lib/hbs2ui5/index.js
@@ -36,7 +36,7 @@ const processFile = async (file, outputDir) => {
 	const componentNameMatcher = /(\w+)(\.hbs)/gim;
 	const componentName = componentNameMatcher.exec(file)[1];
 	const componentHasTypes = hasTypes(file, componentName);
-	if (!componentHasTypes) { 
+	if (!componentHasTypes) {
 		if (!missingTypesReported) {
 			console.warn("[Warn] The following templates do not have a corresponging .ts or .d.ts file and won't be type checked:")
 			missingTypesReported = true;
@@ -98,7 +98,7 @@ const writeRenderers = async (outputDir, controlName, fileContent) => {
 
 		let existingFileContent = "";
 		try {
-			existingFileContent = await fs.readFile(compiledFilePath);
+			existingFileContent = (await fs.readFile(compiledFilePath)).toString();
 		} catch (e) {}
 
 		if (existingFileContent !== fileContentUnix) {


### PR DESCRIPTION
Template generation has code that checks if the same content is produced and does not write the file to skip a refresh from the dev server.

This logic was broken and comparing a Buffer to a String leading to always refreshing the file content even if it is the same

FIXES: #9276
RELATED: #8824