### PR TITLE
chore: improve unstable test

### DIFF
--- a/packages/main/test/pages/TableLoading.html
+++ b/packages/main/test/pages/TableLoading.html
@@ -10,7 +10,7 @@
 <body>
 	<div class="section">
 		<input id="before-table1">
-		<ui5-table id="table1" loading loadingDelay="0">
+		<ui5-table id="table1" loading loading-delay="0">
 			<ui5-table-header-row slot="headerRow">
 				<ui5-table-header-cell id="colA"><span>ColumnA</span></ui5-table-header-cell>
 			</ui5-table-header-row>

--- a/packages/main/test/specs/TableLoading.spec.js
+++ b/packages/main/test/specs/TableLoading.spec.js
@@ -16,7 +16,6 @@ describe("Table - loading", async () => {
 		await before.click();
 		assert.ok(await before.isFocused(), "The input before the table1 is focused.");
 
-
 		// let the busy indicator render before pressing tab
 		await browser.pause(100);
 		await before.keys("Tab");

--- a/packages/main/test/specs/TableLoading.spec.js
+++ b/packages/main/test/specs/TableLoading.spec.js
@@ -16,7 +16,11 @@ describe("Table - loading", async () => {
 		await before.click();
 		assert.ok(await before.isFocused(), "The input before the table1 is focused.");
 
+
+		// let the busy indicator render before pressing tab
+		await browser.pause(100);
 		await before.keys("Tab");
+
 		const res = await browser.executeAsync(done => {
 			// ui5-busy-indicator has a setTimeout using the delay property and this is not awaited automatically by the test
 			setTimeout(() => {

--- a/packages/main/test/specs/TableLoading.spec.js
+++ b/packages/main/test/specs/TableLoading.spec.js
@@ -16,15 +16,13 @@ describe("Table - loading", async () => {
 		await before.click();
 		assert.ok(await before.isFocused(), "The input before the table1 is focused.");
 
+		// ui5-busy-indicator has a setTimeout using the delay property and this is not awaited automatically by the test
 		// let the busy indicator render before pressing tab
 		await browser.pause(100);
 		await before.keys("Tab");
 
 		const res = await browser.executeAsync(done => {
-			// ui5-busy-indicator has a setTimeout using the delay property and this is not awaited automatically by the test
-			setTimeout(() => {
-				done(document.getElementById("table1").shadowRoot.querySelector("#loading").matches(":focus"));
-			}, 100);
+			done(document.getElementById("table1").shadowRoot.querySelector("#loading").matches(":focus"));
 		});
 		assert.ok(res, "Busy indicator is focused");
 


### PR DESCRIPTION
- correct loading-delay attribute, it was not applied and 1000 default was used
- set 100ms timeout before pressing tab, so that the busy indicator has time to render