### PR TITLE
fix(Popup): correct "open" event

### DIFF
--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -326,7 +326,9 @@ abstract class Popup extends UI5Element {
 		// initial focus, if focused element is dynamically created
 		await this.applyInitialFocus();
 
-		this.fireEvent("open", {}, false, false);
+		if (this.isConnected) {
+			this.fireEvent("open", {}, false, false);
+		}
 	}
 
 	_resize() {


### PR DESCRIPTION
Before, the `ui5-open` event is fired even if the component was not part of the DOM. Now, the `ui5-open` event is fired only if the component is still in the DOM tree.

Example:
Component is detach from the DOM during execution of `openPopup` function which is waiting `renderFinished` to be done.