### PR TITLE
chore(ui5-table): remove selection import & rename key

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -16,7 +16,7 @@ import TableRow from "./TableRow.js";
 import type TableHeaderRow from "./TableHeaderRow.js";
 import type TableHeaderCell from "./TableHeaderCell.js";
 import TableExtension from "./TableExtension.js";
-import TableSelection from "./TableSelection.js";
+import type TableSelection from "./TableSelection.js";
 import TableOverflowMode from "./types/TableOverflowMode.js";
 import TableNavigation from "./TableNavigation.js";
 import {
@@ -24,6 +24,7 @@ import {
 } from "./generated/i18n/i18n-defaults.js";
 import BusyIndicator from "./BusyIndicator.js";
 import TableCell from "./TableCell.js";
+import { isFeature } from "./TableUtils.js";
 
 /**
  * Interface for components that can be slotted inside the <code>features</code> slot of the <code>ui5-table</code>.
@@ -31,6 +32,7 @@ import TableCell from "./TableCell.js";
  * @public
  */
 interface ITableFeature extends UI5Element {
+	readonly _identifier: string;
 	/**
 	 * Called when the table is activated.
 	 * @param table table instance
@@ -339,12 +341,8 @@ class Table extends UI5Element {
 		this.features.forEach(feature => feature.onTableRendered?.());
 	}
 
-	_getFeature<Klass>(klass: any): Klass | undefined {
-		return this.features.find(feature => feature instanceof klass) as Klass;
-	}
-
 	_getSelection(): TableSelection | undefined {
-		return this._getFeature(TableSelection);
+		return this.features.find(feature => isFeature<TableSelection>(feature, "TableSelection")) as TableSelection;
 	}
 
 	_onEvent(e: Event) {

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -32,7 +32,7 @@ import { isFeature } from "./TableUtils.js";
  * @public
  */
 interface ITableFeature extends UI5Element {
-	readonly _identifier: string;
+	readonly identifier: string;
 	/**
 	 * Called when the table is activated.
 	 * @param table table instance

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -82,6 +82,7 @@ type TableRowClickEventDetail = {
  *
  * The `ui5-table` can be enhanced in its functionalities by applying different features.
  * Features can be slotted into the `features` slot, to enable them in the component.
+ * Features need to be imported separately, as they are not enabled by default.
  *
  * The following features are currently available:
  *

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -123,7 +123,7 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	@property({ type: Boolean })
 	_activeState = false;
 
-	readonly _identifier = "TableGrowing";
+	readonly identifier = "TableGrowing";
 	_table?: Table;
 	_observer?: IntersectionObserver;
 	_individualSlot?: string;

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -123,6 +123,7 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	@property({ type: Boolean })
 	_activeState = false;
 
+	readonly _identifier = "TableGrowing";
 	_table?: Table;
 	_observer?: IntersectionObserver;
 	_individualSlot?: string;

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -52,13 +52,13 @@ class TableRow extends TableRowBase {
 	cells!: Array<TableCell>;
 
 	/**
-	 * Unique identifier of the component.
+	 * Unique identifier of the row.
 	 *
 	 * @default ""
 	 * @public
 	 */
 	@property()
-	rowId = "";
+	rowKey = "";
 
 	/**
 	 * Defines the interactive state of the row.

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -58,7 +58,7 @@ class TableRow extends TableRowBase {
 	 * @public
 	 */
 	@property()
-	key = "";
+	rowId = "";
 
 	/**
 	 * Defines the interactive state of the row.

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -26,7 +26,7 @@ import { isSelectionCheckbox, isHeaderSelector, findRowInPath } from "./TableUti
  * * Multiple - select multiple rows.
  * * None - no selection active.
  *
- * As the selection is key-based, `ui5-table-row` components need to define a unique `key` property.
+ * As the selection is key-based, `ui5-table-row` components need to define a unique `row-id` property.
  *
  * ### Usage
  *
@@ -77,6 +77,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 	@property()
 	selected = "";
 
+	readonly _identifier = "TableSelection";
 	_table?: Table;
 	_rangeSelection?: {selected: boolean, isUp: boolean | null, rows: TableRow[], isMouse: boolean, shiftPressed: boolean} | null;
 
@@ -108,7 +109,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 	}
 
 	getRowIdentifier(row: TableRow): string {
-		return row.key;
+		return row.rowId;
 	}
 
 	isSelected(row: TableRowBase): boolean {
@@ -287,7 +288,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 			// a visual inconsistency.
 			row.shadowRoot?.querySelector("#selection-component")?.toggleAttribute("checked", true);
 
-			if (startIndex === -1 || endIndex === -1 || row.key === startRow.key || row.key === this._rangeSelection.rows[this._rangeSelection.rows.length - 1].key) {
+			if (startIndex === -1 || endIndex === -1 || row.rowId === startRow.rowId || row.rowId === this._rangeSelection.rows[this._rangeSelection.rows.length - 1].rowId) {
 				return;
 			}
 

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -77,7 +77,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 	@property()
 	selected = "";
 
-	readonly _identifier = "TableSelection";
+	readonly identifier = "TableSelection";
 	_table?: Table;
 	_rangeSelection?: {selected: boolean, isUp: boolean | null, rows: TableRow[], isMouse: boolean, shiftPressed: boolean} | null;
 

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -26,7 +26,7 @@ import { isSelectionCheckbox, isHeaderSelector, findRowInPath } from "./TableUti
  * * Multiple - select multiple rows.
  * * None - no selection active.
  *
- * As the selection is key-based, `ui5-table-row` components need to define a unique `row-id` property.
+ * As the selection is key-based, `ui5-table-row` components need to define a unique `row-key` property.
  *
  * ### Usage
  *
@@ -109,7 +109,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 	}
 
 	getRowIdentifier(row: TableRow): string {
-		return row.rowId;
+		return row.rowKey;
 	}
 
 	isSelected(row: TableRowBase): boolean {
@@ -288,7 +288,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 			// a visual inconsistency.
 			row.shadowRoot?.querySelector("#selection-component")?.toggleAttribute("checked", true);
 
-			if (startIndex === -1 || endIndex === -1 || row.rowId === startRow.rowId || row.rowId === this._rangeSelection.rows[this._rangeSelection.rows.length - 1].rowId) {
+			if (startIndex === -1 || endIndex === -1 || row.rowKey === startRow.rowKey || row.rowKey === this._rangeSelection.rows[this._rangeSelection.rows.length - 1].rowKey) {
 				return;
 			}
 

--- a/packages/main/src/TableUtils.ts
+++ b/packages/main/src/TableUtils.ts
@@ -18,7 +18,7 @@ const findRowInPath = (composedPath: Array<EventTarget>) => {
 };
 
 const isFeature = <T>(element: any, identifier: string): element is T => {
-	return element._identifier === identifier;
+	return element.identifier === identifier;
 };
 
 export {

--- a/packages/main/src/TableUtils.ts
+++ b/packages/main/src/TableUtils.ts
@@ -17,9 +17,14 @@ const findRowInPath = (composedPath: Array<EventTarget>) => {
 	return composedPath.find((el: EventTarget) => el instanceof HTMLElement && el.hasAttribute("ui5-table-row")) as TableRow;
 };
 
+const isFeature = <T>(element: any, identifier: string): element is T => {
+	return element._identifier === identifier;
+};
+
 export {
 	isInstanceOfTable,
 	isSelectionCheckbox,
 	isHeaderSelector,
 	findRowInPath,
+	isFeature,
 };

--- a/packages/main/src/bundle.esm.ts
+++ b/packages/main/src/bundle.esm.ts
@@ -54,6 +54,7 @@ import Table from "./Table.js";
 import TableHeaderCell from "./TableHeaderCell.js";
 import TableHeaderRow from "./TableHeaderRow.js";
 import TableGrowing from "./TableGrowing.js";
+import TableSelection from "./TableSelection.js";
 import Icon from "./Icon.js";
 import Input from "./Input.js";
 import MultiInput from "./MultiInput.js";

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -35,49 +35,49 @@
 			<ui5-table-header-cell id="weightCol" popin-text="Weight">Weight</ui5-table-header-cell>
 			<ui5-table-header-cell id="priceCol" min-width="220px">Price</ui5-table-header-cell>
 		</ui5-table-header-row>
-		<ui5-table-row row-id="0" navigated>
+		<ui5-table-row row-key="0" navigated>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="1">
+		<ui5-table-row row-key="1">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 16</b><br><a href="#">HT-1001</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-input value="29 x 17 x 3.1 cm" accessible-name-ref="dimensionsCol"></ui5-input></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="2" interactive>
+		<ui5-table-row row-key="2" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br><a href="#">HT-1002</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="3">
+		<ui5-table-row row-key="3">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br><a href="#">HT-1003</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="4">
+		<ui5-table-row row-key="4">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 19</b><br><a href="#">HT-1004</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="5">
+		<ui5-table-row row-key="5">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 20</b><br><a href="#">HT-1005</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="6" interactive>
+		<ui5-table-row row-key="6" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 21</b><br><a href="#">HT-1006</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
@@ -96,7 +96,7 @@
 			table.style.width = `${e.target.value}%`;
 		});
 		table.addEventListener("row-click", (e) => {
-			console.log(`${Date.now()}: Row with the row-id ${e.detail.row.row-id} is clicked`);
+			console.log(`${Date.now()}: Row with the row-key ${e.detail.row.row-key} is clicked`);
 		});
 
 		const growing = document.getElementById("growing");
@@ -106,7 +106,7 @@
 			// add 10 more additional rows to the ui5-table element by utilizing a loop
 			for (let i = 0; i < 10; i++) {
 				const newRow = document.createElement("ui5-table-row");
-				newRow.setAttribute("row-id", table.rows.length + i);
+				newRow.setAttribute("row-key", table.rows.length + i);
 				newRow.innerHTML = `
 					<ui5-table-cell><ui5-label><b>Notebook Basic ${15 + table.rows.length + i}</b><br><a href="#">HT-100${table.rows.length + i}</a></ui5-label></ui5-table-cell>
 					<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -35,49 +35,49 @@
 			<ui5-table-header-cell id="weightCol" popin-text="Weight">Weight</ui5-table-header-cell>
 			<ui5-table-header-cell id="priceCol" min-width="220px">Price</ui5-table-header-cell>
 		</ui5-table-header-row>
-		<ui5-table-row key="0" navigated>
+		<ui5-table-row row-id="0" navigated>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="1">
+		<ui5-table-row row-id="1">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 16</b><br><a href="#">HT-1001</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-input value="29 x 17 x 3.1 cm" accessible-name-ref="dimensionsCol"></ui5-input></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="2" interactive>
+		<ui5-table-row row-id="2" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br><a href="#">HT-1002</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="3">
+		<ui5-table-row row-id="3">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br><a href="#">HT-1003</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="4">
+		<ui5-table-row row-id="4">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 19</b><br><a href="#">HT-1004</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="5">
+		<ui5-table-row row-id="5">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 20</b><br><a href="#">HT-1005</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="6" interactive>
+		<ui5-table-row row-id="6" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 21</b><br><a href="#">HT-1006</a></ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
@@ -96,7 +96,7 @@
 			table.style.width = `${e.target.value}%`;
 		});
 		table.addEventListener("row-click", (e) => {
-			console.log(`${Date.now()}: Row with the key ${e.detail.row.key} is clicked`);
+			console.log(`${Date.now()}: Row with the row-id ${e.detail.row.row-id} is clicked`);
 		});
 
 		const growing = document.getElementById("growing");
@@ -106,7 +106,7 @@
 			// add 10 more additional rows to the ui5-table element by utilizing a loop
 			for (let i = 0; i < 10; i++) {
 				const newRow = document.createElement("ui5-table-row");
-				newRow.setAttribute("key", table.rows.length + i);
+				newRow.setAttribute("row-id", table.rows.length + i);
 				newRow.innerHTML = `
 					<ui5-table-cell><ui5-label><b>Notebook Basic ${15 + table.rows.length + i}</b><br><a href="#">HT-100${table.rows.length + i}</a></ui5-label></ui5-table-cell>
 					<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>

--- a/packages/main/test/pages/TableSelection.html
+++ b/packages/main/test/pages/TableSelection.html
@@ -25,61 +25,61 @@
 			<ui5-table-header-cell id="colC">Column C</ui5-table-header-cell>
 			<ui5-table-header-cell id="colD">Column D</ui5-table-header-cell>
 		</ui5-table-header-row>
-		<ui5-table-row row-id="0">
+		<ui5-table-row row-key="0">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="1">
+		<ui5-table-row row-key="1">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="2">
+		<ui5-table-row row-key="2">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="3">
+		<ui5-table-row row-key="3">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="4">
+		<ui5-table-row row-key="4">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="5">
+		<ui5-table-row row-key="5">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="6">
+		<ui5-table-row row-key="6">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="7">
+		<ui5-table-row row-key="7">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="8">
+		<ui5-table-row row-key="8">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row row-id="9">
+		<ui5-table-row row-key="9">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>

--- a/packages/main/test/pages/TableSelection.html
+++ b/packages/main/test/pages/TableSelection.html
@@ -25,61 +25,61 @@
 			<ui5-table-header-cell id="colC">Column C</ui5-table-header-cell>
 			<ui5-table-header-cell id="colD">Column D</ui5-table-header-cell>
 		</ui5-table-header-row>
-		<ui5-table-row key="0">
+		<ui5-table-row row-id="0">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="1">
+		<ui5-table-row row-id="1">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="2">
+		<ui5-table-row row-id="2">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="3">
+		<ui5-table-row row-id="3">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="4">
+		<ui5-table-row row-id="4">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="5">
+		<ui5-table-row row-id="5">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="6">
+		<ui5-table-row row-id="6">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="7">
+		<ui5-table-row row-id="7">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="8">
+		<ui5-table-row row-id="8">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell D</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="9">
+		<ui5-table-row row-id="9">
 			<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Cell C</ui5-label></ui5-table-cell>

--- a/packages/main/test/specs/TableSelection.spec.js
+++ b/packages/main/test/specs/TableSelection.spec.js
@@ -27,7 +27,7 @@ describe("Mode - None", async () => {
 	it("selection should be not active", async () => {
 		const table = await browser.$("#table0");
 		const headerRow = await table.$("ui5-table-header-row");
-		const row = await table.$('ui5-table-row[key="0"]');
+		const row = await table.$('ui5-table-row[row-id="0"]');
 		const selection = await browser.$("#selection");
 
 		assert.ok(await table.isExisting(), "Table exists");
@@ -137,7 +137,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 		it("Correct boxes are shown", async () => {
 			const table = await browser.$("#table0");
 			const headerRow = await table.$("ui5-table-header-row");
-			const row = await table.$('ui5-table-row[key="0"]');
+			const row = await table.$('ui5-table-row[row-id="0"]');
 
 			assert.ok(await table.isExisting(), "Table exists");
 			assert.ok(await headerRow.isExisting(), "Header row exists");
@@ -153,72 +153,72 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 		it("select row via SPACE", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[key="0"]');
-			const row4 = await table.$('ui5-table-row[key="4"]');
+			const row0 = await table.$('ui5-table-row[row-id="0"]');
+			const row4 = await table.$('ui5-table-row[row-id="4"]');
 
 			await row0.click();
 			await row0.keys("Space");
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.SPACE.space_0, `Rows with keys ${testConfig.cases.SPACE.space_0} selected`);
+			assert.equal(selected, testConfig.cases.SPACE.space_0, `Rows with row-ids ${testConfig.cases.SPACE.space_0} selected`);
 
 			await row4.click();
 			await row4.keys("Space");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.SPACE.space_4, `Rows with keys ${testConfig.cases.SPACE.space_4} selected`);
+			assert.equal(selected, testConfig.cases.SPACE.space_4, `Rows with row-ids ${testConfig.cases.SPACE.space_4} selected`);
 		});
 
 		it("select row via arrows (radio focus)", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[key="0"]');
+			const row0 = await table.$('ui5-table-row[row-id="0"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_initial, `Rows with keys ${testConfig.cases.ARROWS_BOX.arrow_initial} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_initial, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_initial} selected`);
 
 			await browser.keys("ArrowDown");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_down, `Rows with keys ${testConfig.cases.ARROWS_BOX.arrow_down} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_down, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_down} selected`);
 
 			await browser.keys("ArrowUp");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_up, `Rows with keys ${testConfig.cases.ARROWS_BOX.arrow_up} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_up, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_up} selected`);
 		});
 
 		it("select row via mouse", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[key="0"]');
-			const row4 = await table.$('ui5-table-row[key="4"]');
+			const row0 = await table.$('ui5-table-row[row-id="0"]');
+			const row4 = await table.$('ui5-table-row[row-id="4"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.MOUSE.mouse_0, `Rows with keys ${testConfig.cases.MOUSE.mouse_0} selected`);
+			assert.equal(selected, testConfig.cases.MOUSE.mouse_0, `Rows with row-ids ${testConfig.cases.MOUSE.mouse_0} selected`);
 
 			const checkbox4 = await row4.shadow$("#selection-component");
 			await checkbox4.click();
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.MOUSE.mouse_4, `Rows with keys ${testConfig.cases.MOUSE.mouse_4} selected`);
+			assert.equal(selected, testConfig.cases.MOUSE.mouse_4, `Rows with row-ids ${testConfig.cases.MOUSE.mouse_4} selected`);
 		});
 
 		it("range selection with mouse", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[key="0"]');
-			const row4 = await table.$('ui5-table-row[key="4"]');
+			const row0 = await table.$('ui5-table-row[row-id="0"]');
+			const row4 = await table.$('ui5-table-row[row-id="4"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			const checkbox4 = await row4.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_initial, `Rows with keys ${testConfig.cases.RANGE_MOUSE.range_mouse_initial} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_initial, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_initial} selected`);
 
 			await browser.performActions([{
 				type: "key",
@@ -228,7 +228,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 			await checkbox4.click();
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_final, `Rows with keys ${testConfig.cases.RANGE_MOUSE.range_mouse_final} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_final, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_final} selected`);
 
 			await browser.performActions([{
 				type: "key",
@@ -239,24 +239,24 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 
 			await browser.releaseActions();
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_edge, `Rows with keys ${testConfig.cases.RANGE_MOUSE.range_mouse_edge} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_edge, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_edge} selected`);
 		});
 
 		it("range selection with keyboard", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[key="0"]');
+			const row0 = await table.$('ui5-table-row[row-id="0"]');
 
 			await row0.click();
 			await row0.keys("Space");
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.initial, `Rows with keys ${testConfig.cases.RANGE_MOUSE.initial} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.initial, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.initial} selected`);
 
 			await browser.keys(["Shift", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowUp"]);
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_1, `Rows with keys ${testConfig.cases.RANGE_KEYBOARD.block_1} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_1, `Rows with row-ids ${testConfig.cases.RANGE_KEYBOARD.block_1} selected`);
 
 			await browser.keys("ArrowDown");
 			await browser.keys("ArrowDown");
@@ -265,7 +265,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 			await browser.keys(["Shift", "ArrowDown", "ArrowDown", "ArrowDown"]);
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_2, `Rows with keys ${testConfig.cases.RANGE_KEYBOARD.block_2} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_2, `Rows with row-ids ${testConfig.cases.RANGE_KEYBOARD.block_2} selected`);
 		});
 	});
 });

--- a/packages/main/test/specs/TableSelection.spec.js
+++ b/packages/main/test/specs/TableSelection.spec.js
@@ -27,7 +27,7 @@ describe("Mode - None", async () => {
 	it("selection should be not active", async () => {
 		const table = await browser.$("#table0");
 		const headerRow = await table.$("ui5-table-header-row");
-		const row = await table.$('ui5-table-row[row-id="0"]');
+		const row = await table.$('ui5-table-row[row-key="0"]');
 		const selection = await browser.$("#selection");
 
 		assert.ok(await table.isExisting(), "Table exists");
@@ -137,7 +137,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 		it("Correct boxes are shown", async () => {
 			const table = await browser.$("#table0");
 			const headerRow = await table.$("ui5-table-header-row");
-			const row = await table.$('ui5-table-row[row-id="0"]');
+			const row = await table.$('ui5-table-row[row-key="0"]');
 
 			assert.ok(await table.isExisting(), "Table exists");
 			assert.ok(await headerRow.isExisting(), "Header row exists");
@@ -153,72 +153,72 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 		it("select row via SPACE", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[row-id="0"]');
-			const row4 = await table.$('ui5-table-row[row-id="4"]');
+			const row0 = await table.$('ui5-table-row[row-key="0"]');
+			const row4 = await table.$('ui5-table-row[row-key="4"]');
 
 			await row0.click();
 			await row0.keys("Space");
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.SPACE.space_0, `Rows with row-ids ${testConfig.cases.SPACE.space_0} selected`);
+			assert.equal(selected, testConfig.cases.SPACE.space_0, `Rows with row-keys ${testConfig.cases.SPACE.space_0} selected`);
 
 			await row4.click();
 			await row4.keys("Space");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.SPACE.space_4, `Rows with row-ids ${testConfig.cases.SPACE.space_4} selected`);
+			assert.equal(selected, testConfig.cases.SPACE.space_4, `Rows with row-keys ${testConfig.cases.SPACE.space_4} selected`);
 		});
 
 		it("select row via arrows (radio focus)", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[row-id="0"]');
+			const row0 = await table.$('ui5-table-row[row-key="0"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_initial, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_initial} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_initial, `Rows with row-keys ${testConfig.cases.ARROWS_BOX.arrow_initial} selected`);
 
 			await browser.keys("ArrowDown");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_down, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_down} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_down, `Rows with row-keys ${testConfig.cases.ARROWS_BOX.arrow_down} selected`);
 
 			await browser.keys("ArrowUp");
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_up, `Rows with row-ids ${testConfig.cases.ARROWS_BOX.arrow_up} selected`);
+			assert.equal(selected, testConfig.cases.ARROWS_BOX.arrow_up, `Rows with row-keys ${testConfig.cases.ARROWS_BOX.arrow_up} selected`);
 		});
 
 		it("select row via mouse", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[row-id="0"]');
-			const row4 = await table.$('ui5-table-row[row-id="4"]');
+			const row0 = await table.$('ui5-table-row[row-key="0"]');
+			const row4 = await table.$('ui5-table-row[row-key="4"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.MOUSE.mouse_0, `Rows with row-ids ${testConfig.cases.MOUSE.mouse_0} selected`);
+			assert.equal(selected, testConfig.cases.MOUSE.mouse_0, `Rows with row-keys ${testConfig.cases.MOUSE.mouse_0} selected`);
 
 			const checkbox4 = await row4.shadow$("#selection-component");
 			await checkbox4.click();
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.MOUSE.mouse_4, `Rows with row-ids ${testConfig.cases.MOUSE.mouse_4} selected`);
+			assert.equal(selected, testConfig.cases.MOUSE.mouse_4, `Rows with row-keys ${testConfig.cases.MOUSE.mouse_4} selected`);
 		});
 
 		it("range selection with mouse", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[row-id="0"]');
-			const row4 = await table.$('ui5-table-row[row-id="4"]');
+			const row0 = await table.$('ui5-table-row[row-key="0"]');
+			const row4 = await table.$('ui5-table-row[row-key="4"]');
 
 			const checkbox0 = await row0.shadow$("#selection-component");
 			const checkbox4 = await row4.shadow$("#selection-component");
 			await checkbox0.click();
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_initial, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_initial} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_initial, `Rows with row-keys ${testConfig.cases.RANGE_MOUSE.range_mouse_initial} selected`);
 
 			await browser.performActions([{
 				type: "key",
@@ -228,7 +228,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 			await checkbox4.click();
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_final, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_final} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_final, `Rows with row-keys ${testConfig.cases.RANGE_MOUSE.range_mouse_final} selected`);
 
 			await browser.performActions([{
 				type: "key",
@@ -239,24 +239,24 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 
 			await browser.releaseActions();
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_edge, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.range_mouse_edge} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_MOUSE.range_mouse_edge, `Rows with row-keys ${testConfig.cases.RANGE_MOUSE.range_mouse_edge} selected`);
 		});
 
 		it("range selection with keyboard", async () => {
 			const table = await browser.$("#table0");
 			const selection = await browser.$("#selection");
-			const row0 = await table.$('ui5-table-row[row-id="0"]');
+			const row0 = await table.$('ui5-table-row[row-key="0"]');
 
 			await row0.click();
 			await row0.keys("Space");
 
 			let selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.initial, `Rows with row-ids ${testConfig.cases.RANGE_MOUSE.initial} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.initial, `Rows with row-keys ${testConfig.cases.RANGE_MOUSE.initial} selected`);
 
 			await browser.keys(["Shift", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowUp"]);
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_1, `Rows with row-ids ${testConfig.cases.RANGE_KEYBOARD.block_1} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_1, `Rows with row-keys ${testConfig.cases.RANGE_KEYBOARD.block_1} selected`);
 
 			await browser.keys("ArrowDown");
 			await browser.keys("ArrowDown");
@@ -265,7 +265,7 @@ Object.entries(testConfig).forEach(([mode, testConfig]) => {
 			await browser.keys(["Shift", "ArrowDown", "ArrowDown", "ArrowDown"]);
 
 			selected = await selection.getProperty("selected");
-			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_2, `Rows with row-ids ${testConfig.cases.RANGE_KEYBOARD.block_2} selected`);
+			assert.equal(selected, testConfig.cases.RANGE_KEYBOARD.block_2, `Rows with row-keys ${testConfig.cases.RANGE_KEYBOARD.block_2} selected`);
 		});
 	});
 });

--- a/packages/website/docs/_samples/main/Table/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Table/Basic/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <div class="section">
 <!-- playground-fold-end -->
-		<ui5-table id="table">
+		<ui5-table id="table" overflow-mode="Popin">
 			<ui5-table-header-row slot="headerRow">
 				<ui5-table-header-cell id="produtCol" width="300px"><span>Product</span></ui5-table-header-cell>
 				<ui5-table-header-cell id="supplierCol" width="200px">Supplier</ui5-table-header-cell>

--- a/packages/website/docs/_samples/main/Table/Growing/sample.html
+++ b/packages/website/docs/_samples/main/Table/Growing/sample.html
@@ -21,21 +21,21 @@
 				<ui5-table-header-cell id="weightCol">Weight</ui5-table-header-cell>
 				<ui5-table-header-cell id="priceCol">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
-			<ui5-table-row key="0">
+			<ui5-table-row row-key="0">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="1">
+			<ui5-table-row row-key="1">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="2">
+			<ui5-table-row row-key="2">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>

--- a/packages/website/docs/_samples/main/Table/Interactive/sample.html
+++ b/packages/website/docs/_samples/main/Table/Interactive/sample.html
@@ -21,21 +21,21 @@
 			<ui5-table-header-cell id="priceCol" width="220px">Price</ui5-table-header-cell>
 		</ui5-table-header-row>
 <!-- playground-fold-end -->
-		<ui5-table-row key="a" interactive>
+		<ui5-table-row row-key="a" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="b">
+		<ui5-table-row row-key="b">
 			<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
 		</ui5-table-row>
-		<ui5-table-row key="c" interactive>
+		<ui5-table-row row-key="c" interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.html
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.html
@@ -21,21 +21,21 @@
 				<ui5-table-header-cell id="weightCol">Weight</ui5-table-header-cell>
 				<ui5-table-header-cell id="priceCol">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
-			<ui5-table-row key="0">
+			<ui5-table-row row-key="0">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="1">
+			<ui5-table-row row-key="1">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="2">
+			<ui5-table-row row-key="2">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>

--- a/packages/website/docs/_samples/main/Table/Selection/sample.html
+++ b/packages/website/docs/_samples/main/Table/Selection/sample.html
@@ -27,21 +27,21 @@
 				<ui5-table-header-cell id="weightCol" popin-text="Weight">Weight</ui5-table-header-cell>
 				<ui5-table-header-cell id="priceCol" min-width="220px" style="text-align: end;">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
-			<ui5-table-row key="0">
+			<ui5-table-row row-key="0">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell style="text-align: end;"><ui5-label style="text-align: end;"><b>956</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="1">
+			<ui5-table-row row-key="1">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-input value="29 x 17 x 3.1 cm" accessible-name-ref="dimensionsCol"></ui5-input></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell style="text-align: end;"><ui5-label style="text-align: end;"><b>1249</b> EUR</ui5-label></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row key="2">
+			<ui5-table-row row-key="2">
 				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>


### PR DESCRIPTION
Table.ts imported TableSelection.ts, although it is not a base functionality.
Therefore, the selection has been removed as import and the code has been refactored to accomodate for that.

Additionaly, key is a reserved keyword in React, which is why the row key has been renamed to row-id.