### PR TITLE
refactor(ui5-illustrated-message): rename IllustrationMessageSize enum

### DIFF
--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -121,7 +121,7 @@ class IllustratedMessage extends UI5Element {
 	* elements of the component are displayed differently on the different breakpoints/illustration designs.
 	* @default "Auto"
 	* @public
-	* @since 1.5.0
+	* @since 2.0.0
 	*/
 	@property()
 	design: `${IllustrationMessageDesign}` = "Auto";

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -11,7 +11,7 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import Title from "@ui5/webcomponents/dist/Title.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import type { IButton } from "@ui5/webcomponents/dist/Button.js";
-import IllustrationMessageSize from "./types/IllustrationMessageSize.js";
+import IllustrationMessageDesign from "./types/IllustrationMessageDesign.js";
 import IllustrationMessageType from "./types/IllustrationMessageType.js";
 import "./illustrations/BeforeSearch.js";
 
@@ -124,7 +124,7 @@ class IllustratedMessage extends UI5Element {
 	* @since 1.5.0
 	*/
 	@property()
-	design: `${IllustrationMessageSize}` = "Auto";
+	design: `${IllustrationMessageDesign}` = "Auto";
 
 	/**
 	* Defines the subtitle of the component.
@@ -300,7 +300,7 @@ class IllustratedMessage extends UI5Element {
 		this.illustrationTitle = IllustratedMessage.i18nBundle.getText(illustrationData!.title);
 		this.illustrationSubtitle = IllustratedMessage.i18nBundle.getText(illustrationData!.subtitle);
 
-		if (this.design !== IllustrationMessageSize.Auto) {
+		if (this.design !== IllustrationMessageDesign.Auto) {
 			this._handleCustomSize();
 		}
 	}
@@ -314,7 +314,7 @@ class IllustratedMessage extends UI5Element {
 	}
 
 	handleResize() {
-		if (this.design !== IllustrationMessageSize.Auto) {
+		if (this.design !== IllustrationMessageDesign.Auto) {
 			this._adjustHeightToFitContainer();
 			return;
 		}
@@ -393,16 +393,16 @@ class IllustratedMessage extends UI5Element {
 	 */
 	_handleCustomSize() {
 		switch (this.design) {
-		case IllustrationMessageSize.Base:
+		case IllustrationMessageDesign.Base:
 			this.media = IllustratedMessage.MEDIA.BASE;
 			return;
-		case IllustrationMessageSize.Dot:
+		case IllustrationMessageDesign.Dot:
 			this.media = IllustratedMessage.MEDIA.DOT;
 			return;
-		case IllustrationMessageSize.Spot:
+		case IllustrationMessageDesign.Spot:
 			this.media = IllustratedMessage.MEDIA.SPOT;
 			return;
-		case IllustrationMessageSize.Dialog:
+		case IllustrationMessageDesign.Dialog:
 			this.media = IllustratedMessage.MEDIA.DIALOG;
 			return;
 		default:

--- a/packages/fiori/src/types/IllustrationMessageDesign.ts
+++ b/packages/fiori/src/types/IllustrationMessageDesign.ts
@@ -1,9 +1,9 @@
 /**
- * Different types of IllustrationMessageSize.
+ * Different types of IllustrationMessageDesign.
  * @public
  * @since 1.5.0
  */
-enum IllustrationMessageSize {
+enum IllustrationMessageDesign {
 	/**
 	 * Automatically decides the <code>Illustration</code> size (<code>Base</code>, <code>Dot</code>, <code>Spot</code>,
 	 * <code>Dialog</code>, or <code>Scene</code>) depending on the <code>IllustratedMessage</code> container width.
@@ -47,4 +47,4 @@ enum IllustrationMessageSize {
 	Scene = "Scene",
 }
 
-export default IllustrationMessageSize;
+export default IllustrationMessageDesign;

--- a/packages/fiori/src/types/IllustrationMessageDesign.ts
+++ b/packages/fiori/src/types/IllustrationMessageDesign.ts
@@ -1,7 +1,7 @@
 /**
  * Different types of IllustrationMessageDesign.
  * @public
- * @since 1.5.0
+ * @since 2.0.0
  */
 enum IllustrationMessageDesign {
 	/**


### PR DESCRIPTION
As follow up of #8605 the enumeration of the design property is renamed to IllustrationMessageDesign

Additionally, since tags are adjusted to 2.0.0

BREAKING CHANGE: The enum `IllustrationMessageSize` is renamed to `IllustrationMessageDesign`.
If you have previously imported the enum:

```js
import IllustrationMessageSize from "@ui5/webcomponents-base/dist/types/IllustrationMessageSize.js";
```

Now import IllustrationMessageDesign instead:

```js
import IllustrationMessageDesign from "@ui5/webcomponents-base/dist/types/IllustrationMessageDesign.js";
```

Related to https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887

