### PR TITLE
refactor(ui5-combobox, ui5-multi-combobox): prepare for physical list items

### DIFF
--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -91,7 +91,8 @@ const SKIP_ITEMS_SIZE = 10;
  * @public
  */
 interface IComboBoxItem extends UI5Element {
-	text: string,
+	text?: string,
+	headerText?: string,
 	focused: boolean,
 	isGroupItem?: boolean,
 	selected?: boolean,
@@ -697,7 +698,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 	}
 
 	_startsWithMatchingItems(str: string): Array<IComboBoxItem> {
-		const allItems:Array<IComboBoxItem> = this._getItems();
+		const allItems:Array<IComboBoxItem> = this._getItems().filter(item => !isInstanceOfComboBoxItemGroup(item));
 		return Filters.StartsWith(str, allItems, "text");
 	}
 
@@ -780,13 +781,13 @@ class ComboBox extends UI5Element implements IFormInputElement {
 
 		if (this.open) {
 			this._itemFocused = true;
-			this.value = isGroupItem ? "" : currentItem.text;
+			this.value = isGroupItem ? "" : currentItem.text!;
 			this.focused = false;
 
 			currentItem.focused = true;
 		} else {
 			this.focused = true;
-			this.value = isGroupItem ? nextItem.text : currentItem.text;
+			this.value = isGroupItem ? nextItem.text! : currentItem.text!;
 			currentItem.focused = false;
 		}
 
@@ -1065,7 +1066,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		const matchingItems: Array<IComboBoxItem> = (this._startsWithMatchingItems(current).filter(item => !isInstanceOfComboBoxItemGroup(item)));
+		const matchingItems: Array<IComboBoxItem> = this._startsWithMatchingItems(current);
 
 		if (matchingItems.length) {
 			return matchingItems[0];
@@ -1168,7 +1169,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 		const groupHeaderText = ComboBox.i18nBundle.getText(LIST_ITEM_GROUP_HEADER);
 
 		if (isGroupItem) {
-			announce(`${groupHeaderText} ${currentItem.text}`, InvisibleMessageMode.Polite);
+			announce(`${groupHeaderText} ${currentItem.headerText}`, InvisibleMessageMode.Polite);
 		} else {
 			announce(`${currentItemAdditionalText} ${itemPositionText}`.trim(), InvisibleMessageMode.Polite);
 		}

--- a/packages/main/src/ComboBoxItemGroup.ts
+++ b/packages/main/src/ComboBoxItemGroup.ts
@@ -23,7 +23,7 @@ class ComboBoxItemGroup extends UI5Element implements IComboBoxItem {
 		 * @public
 		 */
 		@property()
-		text = "";
+		headerText = "";
 
 		/**
 		 * Indicates whether the item is focused

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -81,7 +81,7 @@
 		{{#each _filteredItems}}
 			{{#if isGroupItem}}
 				{{#if _isVisible}}
-					<ui5-li-group header-text="{{ this.text }}" ?focused={{ this.focused }}>
+					<ui5-li-group header-text="{{this.headerText}}" ?focused={{this.focused}}>
 						{{#each this.items}}
 							{{#if _isVisible}}
 								{{> listItem}}

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -112,7 +112,8 @@ import SuggestionItem from "./SuggestionItem.js";
  * @public
  */
 interface IMultiComboBoxItem extends UI5Element {
-	text: string,
+	text?: string,
+	headerText?: string,
 	selected: boolean,
 	isGroupItem?: boolean,
 	stableDomRef: string,
@@ -508,7 +509,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			formData.append(this.name, this.value);
 
 			for (let i = 0; i < selectedItems.length; i++) {
-				formData.append(this.name, selectedItems[i].text);
+				formData.append(this.name, selectedItems[i].text!);
 			}
 
 			return formData;
@@ -854,7 +855,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 
 	_handleTokenCreationUponPaste(pastedText: string, e: KeyboardEvent | ClipboardEvent) {
 		const separatedText = pastedText.split(/\r\n|\r|\n|\t/g).filter(t => !!t);
-		const matchingItems = this._getItems().filter(item => separatedText.includes(item.text) && !item.selected);
+		const matchingItems = this._getItems().filter(item => !item.isGroupItem && !item.selected && separatedText.includes(item.text!));
 
 		if (matchingItems.length > 1) {
 			e.preventDefault();
@@ -881,7 +882,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 		const selectedItem = this._getSelectedItems()[0];
 		const focusedToken = this._tokenizer.tokens.find(token => token.focused);
 		const value = this.value;
-		const matchingItem = this._getItems().find(item => item.text.localeCompare(value, undefined, { sensitivity: "base" }) === 0);
+		const matchingItem = this._getItems().find(item => item.text?.localeCompare(value, undefined, { sensitivity: "base" }) === 0);
 
 		e.preventDefault();
 
@@ -1207,9 +1208,9 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		this.value = currentItem.text;
-		this._innerInput.value = currentItem.text;
-		this._innerInput.setSelectionRange(0, currentItem.text.length);
+		this.value = currentItem.text!;
+		this._innerInput.value = currentItem.text!;
+		this._innerInput.setSelectionRange(0, currentItem.text!.length);
 	}
 
 	_navigateToPrevItem() {
@@ -1244,14 +1245,14 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		this.value = currentItem.text;
-		this._innerInput.value = currentItem.text;
-		this._innerInput.setSelectionRange(0, currentItem.text.length);
+		this.value = currentItem.text!;
+		this._innerInput.value = currentItem.text!;
+		this._innerInput.setSelectionRange(0, currentItem.text!.length);
 	}
 
 	_handleEnter() {
 		const lowerCaseValue = this.value.toLowerCase();
-		const matchingItem = this._getItems().find(item => (item.text.toLowerCase() === lowerCaseValue && !item.isGroupItem));
+		const matchingItem = this._getItems().find(item => (!item.isGroupItem && item.text!.toLowerCase() === lowerCaseValue));
 		const oldValueState = this.valueState;
 		const innerInput = this._innerInput;
 
@@ -1281,7 +1282,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 				}
 			}
 
-			innerInput.setSelectionRange(matchingItem.text.length, matchingItem.text.length);
+			innerInput.setSelectionRange(matchingItem.text!.length, matchingItem.text!.length);
 			this._getRespPopover().open = false;
 		}
 	}
@@ -1542,10 +1543,10 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 		const innerInput = this._innerInput;
 
 		filterValue = filterValue || "";
-		this.value = value;
+		this.value = value!;
 
-		innerInput.value = value;
-		innerInput.setSelectionRange(filterValue.length, value.length);
+		innerInput.value = value!;
+		innerInput.setSelectionRange(filterValue.length, value!.length);
 
 		this._shouldAutocomplete = false;
 	}
@@ -1555,7 +1556,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		const matchingItems = this._startsWithMatchingItems(current).filter(item => !item.isGroupItem && !item.selected);
+		const matchingItems = this._startsWithMatchingItems(current).filter(item => !item.selected);
 
 		if (matchingItems.length) {
 			return matchingItems[0];
@@ -1563,7 +1564,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 	}
 
 	_startsWithMatchingItems(str: string) {
-		return Filters.StartsWith(str, this._getItems(), "text");
+		return Filters.StartsWith(str, this._getItems().filter(item => !item.isGroupItem), "text");
 	}
 
 	_revertSelection() {

--- a/packages/main/src/MultiComboBoxItemGroup.ts
+++ b/packages/main/src/MultiComboBoxItemGroup.ts
@@ -35,7 +35,7 @@ class MultiComboBoxItemGroup extends UI5Element implements IMultiComboBoxItem {
 		invalidateOnChildChange: true,
 		type: HTMLElement,
 	})
-	items!: Array<IMultiComboBoxItem>;
+	items!: Array<MultiComboBoxItem>;
 
 	/**
 	 * Used to avoid tag name checks

--- a/packages/main/src/MultiComboBoxItemGroup.ts
+++ b/packages/main/src/MultiComboBoxItemGroup.ts
@@ -24,7 +24,7 @@ class MultiComboBoxItemGroup extends UI5Element implements IMultiComboBoxItem {
 	 * @public
 	 */
 	@property()
-	text = "";
+	headerText = "";
 
 	/**
 	 * Defines the items of the <code>ui5-mcb-item-group</code>.
@@ -35,7 +35,7 @@ class MultiComboBoxItemGroup extends UI5Element implements IMultiComboBoxItem {
 		invalidateOnChildChange: true,
 		type: HTMLElement,
 	})
-	items!: Array<MultiComboBoxItem>;
+	items!: Array<IMultiComboBoxItem>;
 
 	/**
 	 * Used to avoid tag name checks

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -71,7 +71,7 @@
 		<ui5-list separators="None" selection-mode="Multiple" class="ui5-multi-combobox-all-items-list" accessible-role="ListBox">
 			{{#each selectedItems}}
 				{{#if isGroupItem}}
-					<ui5-li-group header-text="{{this.text}}" data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">
+					<ui5-li-group header-text="{{this.headerText}}" data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">
 						{{#each this.items}}
 							{{#if _isVisible}}
 								{{> listItem}}
@@ -87,7 +87,7 @@
 		<ui5-list separators="None" selection-mode="Multiple" class="ui5-multi-combobox-all-items-list" accessible-role="ListBox">
 			{{#each _filteredItems}}
 				{{#if isGroupItem}}
-					<ui5-li-group header-text="{{this.text}}" data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">
+					<ui5-li-group header-text="{{this.headerText}}" data-ui5-stable="{{this.stableDomRef}}" @keydown="{{../_onItemKeydown}}">
 						{{#each this.items}}
 							{{#if _isVisible}}
 								{{> listItem}}

--- a/packages/main/test/pages/ComboBox.html
+++ b/packages/main/test/pages/ComboBox.html
@@ -87,20 +87,20 @@
 		<ui5-label id="combo-vs-grouping-label">Items with grouping and value state:</ui5-label>
 
 		<ui5-combobox id="value-state-grouping" value-state="Critical">
-			<ui5-cb-item-group text="A">
+			<ui5-cb-item-group header-text="A">
 				<ui5-cb-item text="Argentina"></ui5-cb-item>
 				<ui5-cb-item text="Australia"></ui5-cb-item>
 				<ui5-cb-item text="Austria"></ui5-cb-item>
 				<ui5-cb-item text="Bolivia"></ui5-cb-item>
 			</ui5-cb-item-group>
 
-			<ui5-cb-item-group text="B">
+			<ui5-cb-item-group header-text="B">
 				<ui5-cb-item text="Bahrain"></ui5-cb-item>
 				<ui5-cb-item text="Belgium"></ui5-cb-item>
 				<ui5-cb-item text="Brazil"></ui5-cb-item>
 			</ui5-cb-item-group>
 
-			<ui5-cb-item-group text="C">
+			<ui5-cb-item-group header-text="C">
 				<ui5-cb-item text="Canada"></ui5-cb-item>
 				<ui5-cb-item text="Chile"></ui5-cb-item>
 			</ui5-cb-item-group>
@@ -111,23 +111,23 @@
 	<div class="demo-section">
 		<ui5-label id="combo-grouping-label">Items with grouping:</ui5-label>
 		<ui5-combobox filter="StartsWith" id="combo-grouping" class="combobox2auto" aria-label="Select destination:">
-			<ui5-cb-item-group text="A">
+			<ui5-cb-item-group header-text="A">
 				<ui5-cb-item text="Algeria"></ui5-cb-item>
 				<ui5-cb-item text="Argentina"></ui5-cb-item>
 				<ui5-cb-item text="Australia"></ui5-cb-item>
 				<ui5-cb-item text="Austria"></ui5-cb-item>
 			</ui5-cb-item-group>
-			<ui5-cb-item-group text="Donut">
+			<ui5-cb-item-group header-text="Donut">
 				<ui5-cb-item text="Bahrain"></ui5-cb-item>
 				<ui5-cb-item text="Belgium"></ui5-cb-item>
 				<ui5-cb-item text="Bosnia and Herzegovina"></ui5-cb-item>
 				<ui5-cb-item text="Brazil"></ui5-cb-item>
 			</ui5-cb-item-group>
-			<ui5-cb-item-group text="C">
+			<ui5-cb-item-group header-text="C">
 				<ui5-cb-item text="Canada"></ui5-cb-item>
 				<ui5-cb-item text="Chile"></ui5-cb-item>
 			</ui5-cb-item-group>
-			<ui5-cb-item-group text="Random Group Item Text">
+			<ui5-cb-item-group header-text="Random Group Item Text">
 				<ui5-cb-item text="Zimbabve"></ui5-cb-item>
 				<ui5-cb-item text="Albania"></ui5-cb-item>
 				<ui5-cb-item text="Madagascar"></ui5-cb-item>

--- a/packages/main/test/pages/MultiComboBox.html
+++ b/packages/main/test/pages/MultiComboBox.html
@@ -363,19 +363,19 @@
 
 		<br>
 		<ui5-multi-combobox id="mcb-grouping" no-validation placeholder="Select a country">
-			<ui5-mcb-item-group text="Asia">
+			<ui5-mcb-item-group header-text="Asia">
 				<ui5-mcb-item text="Afghanistan"></ui5-mcb-item>
 				<ui5-mcb-item text="China"></ui5-mcb-item>
 				<ui5-mcb-item text="India"></ui5-mcb-item>
 				<ui5-mcb-item text="Indonesia"></ui5-mcb-item>
 			</ui5-mcb-item-group>
-			<ui5-mcb-item-group text="Europe">
+			<ui5-mcb-item-group header-text="Europe">
 				<ui5-mcb-item text="Austria"></ui5-mcb-item>
 				<ui5-mcb-item text="Bulgaria"></ui5-mcb-item>
 				<ui5-mcb-item text="Germany"></ui5-mcb-item>
 				<ui5-mcb-item text="Italy"></ui5-mcb-item>
 			</ui5-mcb-item-group>
-			<ui5-mcb-item-group text="North America">
+			<ui5-mcb-item-group header-text="North America">
 				<ui5-mcb-item text="Canada"></ui5-mcb-item>
 				<ui5-mcb-item text="Granada"></ui5-mcb-item>
 				<ui5-mcb-item text="Haiti"></ui5-mcb-item>

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -1773,7 +1773,7 @@ describe("MultiComboBox general interaction", () => {
 
 			let firstItem = await popover.$("ui5-list").$("ui5-li");
 
-			assert.ok(await firstItem.matches(":focus"), "The first group header should be focused");
+			assert.ok(await firstItem.matches(":focus"), "The first item inside the first group should be focused");
 		});
 
 		it("Group header keyboard handling", async () => {

--- a/packages/website/docs/_samples/main/ComboBox/Grouping/sample.html
+++ b/packages/website/docs/_samples/main/ComboBox/Grouping/sample.html
@@ -13,17 +13,17 @@
 
 
   <ui5-combobox placeholder="Grouping of items">
-    <ui5-cb-item-group text="A">
+    <ui5-cb-item-group header-text="A">
       <ui5-cb-item text="Argentina"></ui5-cb-item>
       <ui5-cb-item text="Australia"></ui5-cb-item>
       <ui5-cb-item text="Austria"></ui5-cb-item>
     </ui5-cb-item-group>
-    <ui5-cb-item-group text="B">
+    <ui5-cb-item-group header-text="B">
       <ui5-cb-item text="Bahrain"></ui5-cb-item>
       <ui5-cb-item text="Belgium"></ui5-cb-item>
       <ui5-cb-item text="Brazil"></ui5-cb-item>
     </ui5-cb-item-group>
-    <ui5-cb-item-group text="C">
+    <ui5-cb-item-group header-text="C">
       <ui5-cb-item text="Canada"></ui5-cb-item>
       <ui5-cb-item text="Chile"></ui5-cb-item>
     </ui5-cb-item-group>

--- a/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxGrouping/sample.html
+++ b/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxGrouping/sample.html
@@ -12,20 +12,20 @@
     <!-- playground-fold-end -->
 
     <ui5-multi-combobox placeholder="Select a country">
-        <ui5-mcb-item-group text="Asia">
+        <ui5-mcb-item-group header-text="Asia">
             <ui5-mcb-item text="Afghanistan"></ui5-mcb-item>
             <ui5-mcb-item text="China"></ui5-mcb-item>
             <ui5-mcb-item text="India"></ui5-mcb-item>
             <ui5-mcb-item text="Indonesia"></ui5-mcb-item>
         </ui5-mcb-item-group>
-        <ui5-mcb-item-group text="Europe">
+        <ui5-mcb-item-group header-text="Europe">
             <ui5-mcb-item text="Austria"></ui5-mcb-item>
             <ui5-mcb-item text="Bulgaria"></ui5-mcb-item>
             <ui5-mcb-item text="Germany"></ui5-mcb-item>
             <ui5-mcb-item text="Italy"></ui5-mcb-item>
             <ui5-mcb-item text="The United Kingdom of Great Britain and Northern Ireland"></ui5-mcb-item>
         </ui5-mcb-item-group>
-        <ui5-mcb-item-group text="North America">
+        <ui5-mcb-item-group header-text="North America">
             <ui5-mcb-item text="Canada"></ui5-mcb-item>
             <ui5-mcb-item text="Granada"></ui5-mcb-item>
             <ui5-mcb-item text="Haiti"></ui5-mcb-item>


### PR DESCRIPTION
As the `ui5-multi-combobox` & `ui5-combobox` will use physical items, additional adjustments need to be performed in order to have a smooth and backward compatible transition.

This change renames the `text` property of the `ui5-cb-item-group` & `ui5-mcb-item-group` to `header-text` in consistency to the `ui5-li-group` which the `ComboBoxItemGroup` and `MultiComboBoxItemGroup` will extend once transitioning to physical items in the list.

After the transition from `IComboBoxItem`/`IMultiComboBoxItem` to `ListItemGroup` for the group items code clean up of the non-null assertion operator can be performed as well.


BREAKING CHANGE:  The `ui5-cb-item-group` & `ui5-mcb-item-group` `text` property is renamed to `header-text`.
If you previously used the `text` property:
```html
<ui5-cb-item-group text="A">
   <ui5-cb-item text="Algeria"></ui5-cb-item>
</ui5-cb-item-group>
```
```html
<ui5-mcb-item-group text="A">
   <ui5-mcb-item text="Afghanistan"></ui5-mcb-item>
</ui5-mcb-item-group>
```

Now you must rename it to `header-text`:
```html
<ui5-cb-item-group header-text="A">
   <ui5-cb-item text="Algeria"></ui5-cb-item>
</ui5-cb-item-group>
```
```html
<ui5-mcb-item-group header-text="A">
   <ui5-mcb-item text="Afghanistan"></ui5-mcb-item>
</ui5-mcb-item-group>
```

Related to: #8461 
