### PR TITLE
refactor: align different properties

### DIFF
--- a/packages/ai/src/Button.ts
+++ b/packages/ai/src/Button.ts
@@ -165,7 +165,7 @@ class Button extends UI5Element {
 			button.style.width = `${buttonWidth}px`;
 			hiddenButton.icon = newStateObject.icon;
 			hiddenButton.endIcon = newStateObject.endIcon;
-			hiddenButton.textContent = newStateObject.text;
+			hiddenButton.textContent = newStateObject.text || null;
 
 			await renderFinished();
 			const hiddenButtonWidth = hiddenButton.offsetWidth;

--- a/packages/ai/src/ButtonState.ts
+++ b/packages/ai/src/ButtonState.ts
@@ -31,19 +31,19 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 class ButtonState extends UI5Element {
 	/**
 	 * Defines the name of the button state.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	name!: string;
+	name?: string;
 
 	/**
 	 * Defines the text of the button in this state.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text!: string;
+	text?: string;
 
 	/**
 	 * Defines the icon to be displayed as graphical element within the component before the text.
@@ -52,11 +52,11 @@ class ButtonState extends UI5Element {
 	 * **Example:**
 	 *
 	 * See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	icon!: string;
+	icon?: string;
 
 	/**
 	 * Defines the icon to be displayed as graphical element within the component after the text.
@@ -65,11 +65,11 @@ class ButtonState extends UI5Element {
 	 * **Example:**
 	 *
 	 * See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	endIcon!: string;
+	endIcon?: string;
 }
 
 ButtonState.define();

--- a/packages/compat/src/TableColumn.ts
+++ b/packages/compat/src/TableColumn.ts
@@ -39,7 +39,7 @@ class TableColumn extends UI5Element {
 	 * @public
 	 */
 	@property({ type: Number })
-	minWidth = Infinity;
+	minWidth: number = Infinity;
 
 	/**
 	 * The text for the column when it pops in.

--- a/packages/fiori/src/FilterItem.ts
+++ b/packages/fiori/src/FilterItem.ts
@@ -33,7 +33,7 @@ class FilterItem extends UI5Element {
 
 	/**
 	 * Defines the additional text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -25,7 +25,7 @@ import {
 class NotificationListItemBase extends ListItemBase {
 	/**
 	 * Defines the `titleText` of the item.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/Card.ts
+++ b/packages/main/src/Card.ts
@@ -52,7 +52,7 @@ class Card extends UI5Element {
 	 * Defines the accessible name of the component, which is used as the name of the card region and should be unique per card.
 	 *
 	 * **Note:** `accessibleName` should be always set, unless `accessibleNameRef` is set.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.16
 	*/
@@ -61,7 +61,7 @@ class Card extends UI5Element {
 
 	/**
 	 * Defines the IDs of the elements that label the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.16
 	*/

--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -97,7 +97,7 @@ let activeCb: CheckBox;
 class CheckBox extends UI5Element implements IFormInputElement {
 	/**
 	 * Receives id(or many ids) of the elements that label the component
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.1.0
 	 */
@@ -107,7 +107,7 @@ class CheckBox extends UI5Element implements IFormInputElement {
 	/**
 	 * Defines the accessible ARIA name of the component.
 	 * @public
-	 * @default ""
+	 * @default undefined
 	 * @since 1.1.0
 	 */
 	@property()
@@ -219,7 +219,7 @@ class CheckBox extends UI5Element implements IFormInputElement {
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
 	 *
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -343,7 +343,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Defines the accessible ARIA name of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */
@@ -352,7 +352,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Receives id(or many ids) of the elements that label the component
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -306,7 +306,7 @@ class DatePicker extends DateComponentBase implements IFormInputElement {
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
 	 *
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
@@ -335,7 +335,7 @@ class DatePicker extends DateComponentBase implements IFormInputElement {
 
 	/**
 	 * Defines the aria-label attribute for the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */
@@ -344,7 +344,7 @@ class DatePicker extends DateComponentBase implements IFormInputElement {
 
 	/**
 	 * Receives id(or many ids) of the elements that label the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -378,7 +378,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
 	 *
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/ListItemCustom.ts
+++ b/packages/main/src/ListItemCustom.ts
@@ -45,12 +45,12 @@ class ListItemCustom extends ListItem {
 	 * Defines the text alternative of the component.
 	 *
 	 * **Note**: If not provided a default text alternative will be set, if present.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */
 	@property()
-	declare accessibleName
+	declare accessibleName?: string;
 
 	async _onkeydown(e: KeyboardEvent) {
 		const isTab = isTabNext(e) || isTabPrevious(e);

--- a/packages/main/src/ListItemGroup.ts
+++ b/packages/main/src/ListItemGroup.ts
@@ -40,10 +40,10 @@ class ListItemGroup extends UI5Element {
 	/**
 	 * Defines the header text of the <code>ui5-li-group</code>.
 	 * @public
-	 * @default ""
+	 * @default undefined
 	 */
 	@property()
-	headerText = "";
+	headerText?: string;
 
 	/**
 	 * Defines the accessible name of the header.

--- a/packages/main/src/ListItemStandard.ts
+++ b/packages/main/src/ListItemStandard.ts
@@ -122,7 +122,7 @@ class ListItemStandard extends ListItem implements IAccessibleListItem {
 	 * @since 1.0.0-rc.15
 	 */
 	@property()
-	declare accessibleName: string;
+	declare accessibleName?: string;
 
 	/**
 	 * Defines if the text of the component should wrap, they truncate by default.

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -229,7 +229,7 @@ class Menu extends UI5Element {
 	 * When using this attribute in a declarative way, you must only use the `id` (as a string) of the element at which you want to show the popover.
 	 * You can only set the `opener` attribute to a DOM Reference when using JavaScript.
 	 * @public
-	 * @default ""
+	 * @default undefined
 	 * @since 1.10.0
 	 */
 	@property({ converter: DOMReferenceConverter })

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -74,12 +74,12 @@ class MenuItem extends ListItem implements IMenuItem {
 	 *
 	 * The priority of what will be displayed at the end of the menu item is as follows:
 	 * sub-menu arrow (if there are items added in `items` slot) -> components added in `endContent` -> text set to `additionalText`.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.8.0
 	 */
 	@property()
-	additionalText = "";
+	additionalText?: string;
 
 	/**
 	 * Defines the icon to be displayed as graphical element within the component.
@@ -126,12 +126,12 @@ class MenuItem extends ListItem implements IMenuItem {
 
 	/**
 	 * Defines the accessible ARIA name of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.7.0
 	 */
 	@property()
-	accessibleName = "";
+	accessibleName?: string;
 
 	/**
 	 * Defines the text of the tooltip for the menu item.

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -265,7 +265,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
 	 * **Note:** When the component is used inside a form element,
 	 * the value is sent as the first element in the form data, even if it's empty.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 2.0.0
 	 */
@@ -284,11 +284,11 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 	/**
 	 * Defines a short hint intended to aid the user with data entry when the
 	 * component has no value.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	placeholder = "";
+	placeholder?: string;
 
 	/**
 	 * Defines if the user input will be prevented, if no matching item has been found
@@ -714,7 +714,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			return "";
 		}
 
-		return this.placeholder;
+		return this.placeholder || "";
 	}
 
 	_handleArrowLeft() {

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -122,7 +122,7 @@ class MultiInput extends Input implements IFormInputElement {
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
 	 * **Note:** When the component is used inside a form element,
 	 * the value is sent as the first element in the form data, even if it's empty.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/RadioButton.ts
+++ b/packages/main/src/RadioButton.ts
@@ -186,7 +186,7 @@ class RadioButton extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Defines the accessible ARIA name of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.6.0
 	 */

--- a/packages/main/src/RangeSlider.ts
+++ b/packages/main/src/RangeSlider.ts
@@ -134,6 +134,10 @@ class RangeSlider extends SliderBase implements IFormInputElement {
 	get formFormattedValue() {
 		const formData = new FormData();
 
+		if (!this.name) {
+			return formData;
+		}
+
 		formData.append(this.name, this.startValue.toString());
 		formData.append(this.name, this.endValue.toString());
 

--- a/packages/main/src/RatingIndicator.ts
+++ b/packages/main/src/RatingIndicator.ts
@@ -132,7 +132,7 @@ class RatingIndicator extends UI5Element {
 
 	/**
 	 * Defines the accessible ARIA name of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */
@@ -141,7 +141,7 @@ class RatingIndicator extends UI5Element {
 
 	/**
 	 * Receives id(or many ids) of the elements that label the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.15.0
 	 */

--- a/packages/main/src/SegmentedButtonItem.ts
+++ b/packages/main/src/SegmentedButtonItem.ts
@@ -69,7 +69,7 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 	 * Defines the tooltip of the component.
 	 *
 	 * **Note:** A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.2.0
 	 */
@@ -87,7 +87,7 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 
 	/**
 	 * Receives id(or many ids) of the elements that label the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 1.1.0
 	 */
@@ -100,7 +100,7 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 	 *
 	 * Example:
 	 * See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/SliderBase.ts
+++ b/packages/main/src/SliderBase.ts
@@ -61,12 +61,12 @@ abstract class SliderBase extends UI5Element {
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
 	 *
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 2.0.0
 	 */
 	@property()
-	name = "";
+	name?: string;
 
 	/**
 	 * Defines the size of the slider's selection intervals (e.g. min = 0, max = 10, step = 5 would result in possible selection of the values 0, 5, 10).

--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -105,7 +105,7 @@ class SplitButton extends UI5Element {
 	 * Example:
 	 *
 	 * See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/SuggestionItem.ts
+++ b/packages/main/src/SuggestionItem.ts
@@ -33,12 +33,12 @@ class SuggestionItem extends ListItemBase implements IInputSuggestionItemSelecta
 
 	/**
 	 * Defines the `additionalText`, displayed in the end of the item.
-	 * @default ""
+	 * @default undefined
 	 * @since 1.0.0-rc.15
 	 * @public
 	 */
 	@property()
-	additionalText = "";
+	additionalText?: string;
 
 	/**
 	 * Defines the markup text that will be displayed as suggestion.

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -215,12 +215,12 @@ class TimePicker extends UI5Element implements IFormInputElement {
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
 	 *
 	 * **Note:** This property is only applicable within the context of an HTML Form element.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 * @since 2.0.0
 	 */
 	@property()
-	name = "";
+	name?: string;
 
 	/**
 	 * Defines the value state of the component.

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -112,7 +112,7 @@ class ToolbarButton extends ToolbarItem {
 
 	/**
 	 * Receives id(or many ids) of the elements that label the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -141,7 +141,7 @@ class TreeItemBase extends ListItem {
 	* @since 1.1.0
 	*/
 	@property({ type: Boolean })
-	declare indeterminate
+	declare indeterminate: boolean;
 
 	/**
 	 * Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
@@ -173,7 +173,7 @@ class TreeItemBase extends ListItem {
 	 * @since 1.8.0
 	 */
 	@property()
-	declare accessibleName
+	declare accessibleName?: string;
 
 	/**
 	 * @private

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -392,7 +392,7 @@ class Suggestions {
 		this.accInfo = {
 			isGroup: isGroupItem,
 			currentPos: items.indexOf(currentItem) + 1,
-			itemText: isGroupItem ? (selectedItem as SuggestionItemGroup).headerText : (selectedItem as IInputSuggestionItemSelectable).text,
+			itemText: (isGroupItem ? (selectedItem as SuggestionItemGroup).headerText : (selectedItem as IInputSuggestionItemSelectable).text) || "",
 		};
 
 		if (currentItem.hasAttribute("ui5-suggestion-item") || currentItem.hasAttribute("ui5-suggestion-item-custom")) {


### PR DESCRIPTION
With the introduction of property initializers (https://github.com/SAP/ui5-webcomponents/pull/8846) many properties have changed they default values or types but on some places:
- JSDoc wasn't changed
- Properties with declared `declare` keyword were using wrong type

This change fixes most of the things until custom element analyzer plugin is adjusted to generate correct output