### PR TITLE
chore: stabilize table's failing test

### DIFF
--- a/packages/main/test/specs/TableLoading.cy.js
+++ b/packages/main/test/specs/TableLoading.cy.js
@@ -1,5 +1,12 @@
 import { html } from 'lit';
 
+Cypress.on('fail', (err, runnable) => {
+	// console.log(document.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement.shadowRoot?.activeElement?.outerHTML)
+	throw new Error(document.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement.shadowRoot?.activeElement?.outerHTML)
+	return false
+})
+
+
 describe("Table - loading", () => {
 	it("tests busy indicator is displayed", () => {
 		cy.mount(html`
@@ -27,15 +34,9 @@ describe("Table - loading", () => {
 
 		cy.realPress("Tab");
 
-		cy.focused()
-			.invoke("prop", "tagName")
-			.should("equal", "DIV")
-
 		cy.get("[ui5-table]")
 			.shadow()
 			.find("#loading")
-			.shadow()
-			.find("[data-sap-focus-ref]")
 			.should("be.focused")
 
 		cy.realPress("Tab");

--- a/packages/main/test/specs/TableLoading.cy.js
+++ b/packages/main/test/specs/TableLoading.cy.js
@@ -1,12 +1,5 @@
 import { html } from 'lit';
 
-Cypress.on('fail', (err, runnable) => {
-	// console.log(document.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement.shadowRoot?.activeElement?.outerHTML)
-	throw new Error(document.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement?.outerHTML, document.activeElement.shadowRoot?.activeElement.shadowRoot?.activeElement?.outerHTML)
-	return false
-})
-
-
 describe("Table - loading", () => {
 	it("tests busy indicator is displayed", () => {
 		cy.mount(html`

--- a/packages/main/test/specs/TableLoading.cy.js
+++ b/packages/main/test/specs/TableLoading.cy.js
@@ -28,14 +28,15 @@ describe("Table - loading", () => {
 		cy.realPress("Tab");
 
 		cy.focused()
-		// .should("have.class", "ui5-busy-indicator-busy-area")
-		.invoke("prop", "tagName")
-		.should("equal", "DIV")
+			.invoke("prop", "tagName")
+			.should("equal", "DIV")
 
 		cy.get("[ui5-table]")
 			.shadow()
 			.find("#loading")
-			.should("be.focused");
+			.shadow()
+			.find("[data-sap-focus-ref]")
+			.should("be.focused")
 
 		cy.realPress("Tab");
 

--- a/packages/main/test/specs/TableLoading.cy.js
+++ b/packages/main/test/specs/TableLoading.cy.js
@@ -27,6 +27,11 @@ describe("Table - loading", () => {
 
 		cy.realPress("Tab");
 
+		cy.focused()
+		// .should("have.class", "ui5-busy-indicator-busy-area")
+		.invoke("prop", "tagName")
+		.should("equal", "DIV")
+
 		cy.get("[ui5-table]")
 			.shadow()
 			.find("#loading")

--- a/packages/main/test/specs/TableLoading.cy.js
+++ b/packages/main/test/specs/TableLoading.cy.js
@@ -35,9 +35,13 @@ describe("Table - loading", () => {
 		cy.realPress("Tab");
 
 		cy.get("[ui5-table]")
+			.should("be.focused")
+
+		cy.get("[ui5-table]")
 			.shadow()
 			.find("#loading")
-			.should("be.focused")
+			.should("exist")
+			.and("be.focused");
 
 		cy.realPress("Tab");
 


### PR DESCRIPTION
Stabilize `ui5-table` regularly failing test.

Since the focus is inside `ui5-table` it should also match focus assertion. Once the table is focused we need to check if the busy indicator exist and if it exist to check if it is focused.