### PR TITLE
fix(ui5-link): remove the space between `end-icon` and text in long links

### DIFF
--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -72,7 +72,7 @@
 }
 
 /* For cases when the text wraps, the icon should be displayed at the last row */
-:host([end-icon]) .ui5-link-root {
+:host([wrapping-type="None"][end-icon]) .ui5-link-root {
 	display: inline-flex;
 	align-items: end;
 }
@@ -94,8 +94,8 @@
 }
 
 .ui5-link-end-icon {
-	float: inline-end;
 	margin-inline-start: 0.125rem;
+	vertical-align: bottom;
 }
 
 .ui5-link-text {

--- a/packages/main/test/pages/Link.html
+++ b/packages/main/test/pages/Link.html
@@ -69,6 +69,9 @@
 		<ui5-link id="linkWithIcon" design="Subtle" icon="employee">View employee profile</ui5-link> <br> <br>
 		<ui5-link id="non-wrapping-link" end-icon="cloud">Weather today</ui5-link> <br>
 		<ui5-link class="link2auto" id="linkWithEndIcon" end-icon="cloud" wrapping-type="None">Weather today</ui5-link>
+
+		<h2>Wrapping link with end-icon</h2>
+		<ui5-link class="link2auto" end-icon="cloud" id="wrapping-link">Eu enim consectetur do amet elit Lorem ipsum dolor, sit amet consectetur adipisicing elit adipisicing.</ui5-link>
 	</section>
 
 	<section class="group">


### PR DESCRIPTION
Previously when having an exceptionally long `<ui5-link>`, wrapping on multiple lines and with specified `end-icon` property, the icon of it was often displayed far away from the text, due to the `display: inline-flex` CSS property.

### Before
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/9a4648fb-703d-45f2-8751-97e769723517)

With this change the icon is always displayed right after the text of the `<ui5-link>`.

### After
![image](https://github.com/SAP/ui5-webcomponents/assets/88034608/a355c295-3e29-48b3-96ef-dfe59a3ccdd0)

Fixes: #9210 