### PR TITLE
fix(ui5-checkbox): adjust focus outline in wrapped mode

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -62,7 +62,7 @@
 }
 
 :host([wrapping-type="Normal"]) .ui5-checkbox-root:focus::before {
-	bottom: var(--_ui5_checkbox_wrapped_focus_left_top_bottom_position);
+	inset-block-end: var(--_ui5_checkbox_wrapped_focus_inset_block_end);
 }
 
 /* value states */

--- a/packages/main/src/themes/base/CheckBox-parameters.css
+++ b/packages/main/src/themes/base/CheckBox-parameters.css
@@ -41,12 +41,11 @@
 --_ui5_checkbox_inner_background: var(--sapField_Background);
 --_ui5_checkbox_wrapped_focus_padding: .375rem;
 --_ui5_checkbox_wrapped_content_margin_top: .125rem;
---_ui5_checkbox_wrapped_focus_left_top_bottom_position: .5625rem;
+--_ui5_checkbox_wrapped_focus_inset_block_end: .5625rem;
 --_ui5_checkbox_compact_wrapper_padding: .5rem;
 --_ui5_checkbox_compact_width_height: 2rem;
 --_ui5_checkbox_compact_inner_size: 1rem;
 --_ui5_checkbox_compact_focus_position: .375rem;
---_ui5_checkbox_compact_wrapped_label_margin_top: -1px;
 --_ui5_checkbox_label_color: var(--sapContent_LabelColor);
 --_ui5_checkbox_label_offset: var(--_ui5_checkbox_wrapper_padding);
 --_ui5_checkbox_disabled_label_color: var(--sapContent_LabelColor);

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -177,8 +177,7 @@
 
 	/* CheckBox */
 	--_ui5_checkbox_root_side_padding: var(--_ui5_checkbox_wrapped_focus_padding);
-	--_ui5_checkbox_wrapped_content_margin_top: var(--_ui5_checkbox_compact_wrapped_label_margin_top);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: var(--_ui5_checkbox_compact_focus_position);
+	--_ui5_checkbox_wrapped_focus_inset_block_end: .25rem;
 	--_ui5_checkbox_width_height: var(--_ui5_checkbox_compact_width_height);
 	--_ui5_checkbox_wrapper_padding: var(--_ui5_checkbox_compact_wrapper_padding);
 	--_ui5_checkbox_focus_position: var(--_ui5_checkbox_compact_focus_position);

--- a/packages/main/src/themes/sap_fiori_3/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/CheckBox-parameters.css
@@ -9,5 +9,4 @@
 	--_ui5_checkbox_wrapped_content_margin_top: 0;
 	--_ui5_checkbox_wrapped_focus_padding: .5rem;
 	--_ui5_checkbox_inner_readonly_border: 1px solid var(--sapField_ReadOnly_BorderColor);
-	--_ui5_checkbox_compact_wrapped_label_margin_top: -0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3/parameters-bundle.css
@@ -55,5 +55,5 @@
 @import "./MultiComboBox-parameters.css";
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
-@import "../base/sizes-parameters.css";
+@import "./sizes-parameters.css";
 @import "../base/rtl-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3/sizes-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/sizes-parameters.css
@@ -1,0 +1,8 @@
+@import "../base/sizes-parameters.css";
+
+[data-ui5-compact-size],
+.ui5-content-density-compact,
+.sapUiSizeCompact {
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block_end: .375rem;
+}

--- a/packages/main/src/themes/sap_fiori_3_dark/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/CheckBox-parameters.css
@@ -9,5 +9,4 @@
 	--_ui5_checkbox_wrapped_content_margin_top: 0;
 	--_ui5_checkbox_wrapped_focus_padding: .5rem;
 	--_ui5_checkbox_inner_readonly_border: 1px solid var(--sapField_ReadOnly_BorderColor);
-	--_ui5_checkbox_compact_wrapped_label_margin_top: -0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -54,5 +54,5 @@
 @import "./MultiComboBox-parameters.css";
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
-@import "../base/sizes-parameters.css";
+@import "./sizes-parameters.css";
 @import "../base/rtl-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_dark/sizes-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/sizes-parameters.css
@@ -1,0 +1,8 @@
+@import "../base/sizes-parameters.css";
+
+[data-ui5-compact-size],
+.ui5-content-density-compact,
+.sapUiSizeCompact {
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block_end: .375rem;
+}

--- a/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
@@ -40,5 +40,6 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
+	--_ui5_checkbox_wrapped_focus_inset_block_end: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_content_margin_top: 0;
 }

--- a/packages/main/src/themes/sap_horizon/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon/sizes-parameters.css
@@ -49,6 +49,10 @@
 	--_ui5_color-palette-item-after-focus-offset: -0.125rem;
 	--_ui5_color_picker_slider_container_margin_top: -9px;
 
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block_end: 0.125rem;
+	--_ui5_checkbox_wrapped_content_margin_top: 0.125rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;

--- a/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
@@ -40,4 +40,6 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_focus_inset_block_end: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_content_margin_top: 0;
 }

--- a/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
@@ -46,6 +46,10 @@
 	--_ui5_color-palette-item-after-focus-offset: -0.125rem;
 	--_ui5_color_picker_slider_container_margin_top: -9px;
 
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block_end: 0.125rem;
+	--_ui5_checkbox_wrapped_content_margin_top: 0.125rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;

--- a/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
@@ -42,4 +42,6 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_focus_inset_block_end: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_content_margin_top: 0;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/sizes-parameters.css
@@ -7,6 +7,11 @@
 	--_ui5_split_button_text_button_width: 2.25rem;
 	--_ui5_color_picker_slider_container_margin_top: -10px;
 
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.3125rem;
+	--_ui5_checkbox_wrapped_focus_inset_block_end: 0.125rem;
+	--_ui5_checkbox_wrapped_content_margin_top: 0.125rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;

--- a/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
@@ -42,4 +42,7 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_focus_inset_block_end: var(--_ui5_checkbox_focus_position);
+	--_ui5_checkbox_wrapped_content_margin_top: 0;
+
 }

--- a/packages/main/src/themes/sap_horizon_hcw/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/sizes-parameters.css
@@ -7,6 +7,11 @@
 	--_ui5_split_button_text_button_width: 2.25rem;
 	--_ui5_color_picker_slider_container_margin_top: -10px;
 
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.3125rem;
+	--_ui5_checkbox_wrapped_focus_inset_block_end: 0.125rem;
+	--_ui5_checkbox_wrapped_content_margin_top: 0.125rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;


### PR DESCRIPTION
This commit adjusts the focus outline in wrapped mode for the CheckBox component. It address the initial concern that the focus outline was out of place in compact density mode, but also improves the overall focus outline in all density modes.

Themes that were checked:
- sap_horizon
- sap_horizon_dark
- sap_horizon_hcb
- sap_horizon_hcw
- sap_fiori_3
- sap_fiori_3_dark
- sap_fiori_3_hcb
- sap_fiori_3_hcw
- sap_belize

Fixes: #9254 
