### PR TITLE
fix(ui5-checkbox): adjust focus outline in wrapped mode

### DIFF
--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -51,19 +51,14 @@
 	padding-bottom: var(--_ui5_checkbox_root_side_padding);
 }
 
-:host(:not([wrapping-type="None"])[text]) .ui5-checkbox-root .ui5-checkbox-inner,
-:host(:not([wrapping-type="None"])[text]) .ui5-checkbox-root .ui5-checkbox-label {
-	margin-top: var(--_ui5_checkbox_wrapped_content_margin_top);
-}
-
 :host(:not([wrapping-type="None"])[text]) .ui5-checkbox-root .ui5-checkbox-label {
 	overflow-wrap: break-word;
 	align-self: center;
 }
 
-:host([desktop]:not([wrapping-type="None"])) .ui5-checkbox-root:focus::before,
-.ui5-checkbox-root:focus-visible::before {
-	bottom: var(--_ui5_checkbox_wrapped_focus_left_top_bottom_position);
+:host([desktop][text]:not([wrapping-type="None"])) .ui5-checkbox-root:focus::before,
+.ui5-checkbox-root[text]:focus-visible::before {
+	inset-block: var(--_ui5_checkbox_wrapped_focus_inset_block);
 }
 
 /* value states */

--- a/packages/main/src/themes/base/CheckBox-parameters.css
+++ b/packages/main/src/themes/base/CheckBox-parameters.css
@@ -12,7 +12,7 @@
 --_ui5_checkbox_inner_warning_color: var(--sapField_WarningColor);
 --_ui5_checkbox_inner_information_color: currentColor;
 --_ui5_checkbox_checkmark_color: var(--sapSelectedColor);
---_ui5_checkbox_focus_position: .6875rem;
+--_ui5_checkbox_focus_position: .5625rem;
 --_ui5_checkbox_focus_outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 --_ui5_checkbox_focus_border_radius: 0;
 --_ui5_checkbox_outer_hover_background: transparent;
@@ -40,13 +40,11 @@
 --_ui5_checkbox_inner_readonly_border: 0.125rem solid var(--sapField_ReadOnly_BorderColor);
 --_ui5_checkbox_inner_background: var(--sapField_Background);
 --_ui5_checkbox_wrapped_focus_padding: .375rem;
---_ui5_checkbox_wrapped_content_margin_top: .125rem;
---_ui5_checkbox_wrapped_focus_left_top_bottom_position: .5625rem;
+--_ui5_checkbox_wrapped_focus_inset_block: var(--_ui5_checkbox_focus_position);
 --_ui5_checkbox_compact_wrapper_padding: .5rem;
 --_ui5_checkbox_compact_width_height: 2rem;
 --_ui5_checkbox_compact_inner_size: 1rem;
 --_ui5_checkbox_compact_focus_position: .375rem;
---_ui5_checkbox_compact_wrapped_label_margin_top: -1px;
 --_ui5_checkbox_label_color: var(--sapContent_LabelColor);
 --_ui5_checkbox_label_offset: var(--_ui5_checkbox_wrapper_padding);
 --_ui5_checkbox_disabled_label_color: var(--sapContent_LabelColor);

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -184,11 +184,10 @@
 
 	/* CheckBox */
 	--_ui5_checkbox_root_side_padding: var(--_ui5_checkbox_wrapped_focus_padding);
-	--_ui5_checkbox_wrapped_content_margin_top: var(--_ui5_checkbox_compact_wrapped_label_margin_top);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: var(--_ui5_checkbox_compact_focus_position);
 	--_ui5_checkbox_width_height: var(--_ui5_checkbox_compact_width_height);
 	--_ui5_checkbox_wrapper_padding: var(--_ui5_checkbox_compact_wrapper_padding);
 	--_ui5_checkbox_focus_position: var(--_ui5_checkbox_compact_focus_position);
+	--_ui5_checkbox_wrapped_focus_inset_block: var(--_ui5_checkbox_focus_position);
 	--_ui5_checkbox_inner_width_height: var(--_ui5_checkbox_compact_inner_size);
 	--_ui5_checkbox_icon_size: .75rem;
 	--_ui5_checkbox_partially_icon_size: .5rem;

--- a/packages/main/src/themes/sap_fiori_3/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3/CheckBox-parameters.css
@@ -4,10 +4,7 @@
 	--_ui5_checkbox_wrapper_padding: .6875rem;
 	--_ui5_checkbox_width_height: 2.75rem;
 	--_ui5_checkbox_inner_border: .0625rem solid var(--sapField_BorderColor);
-	--_ui5_checkbox_focus_position: 0.5625rem;
 	--_ui5_checkbox_inner_border_radius: .125rem;
-	--_ui5_checkbox_wrapped_content_margin_top: 0;
 	--_ui5_checkbox_wrapped_focus_padding: .5rem;
 	--_ui5_checkbox_inner_readonly_border: 1px solid var(--sapField_ReadOnly_BorderColor);
-	--_ui5_checkbox_compact_wrapped_label_margin_top: -0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_dark/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_dark/CheckBox-parameters.css
@@ -4,10 +4,7 @@
 	--_ui5_checkbox_wrapper_padding: .6875rem;
 	--_ui5_checkbox_width_height: 2.75rem;
 	--_ui5_checkbox_inner_border: .0625rem solid var(--sapField_BorderColor);
-	--_ui5_checkbox_focus_position: 0.5625rem;
 	--_ui5_checkbox_inner_border_radius: .125rem;
-	--_ui5_checkbox_wrapped_content_margin_top: 0;
 	--_ui5_checkbox_wrapped_focus_padding: .5rem;
 	--_ui5_checkbox_inner_readonly_border: 1px solid var(--sapField_ReadOnly_BorderColor);
-	--_ui5_checkbox_compact_wrapped_label_margin_top: -0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/CheckBox-parameters.css
@@ -10,4 +10,5 @@
 --_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 --_ui5_checkbox_hover_background: var(--sapSelectedColor);
 --_ui5_checkbox_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);
+--_ui5_checkbox_wrapped_focus_inset_block: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -55,5 +55,5 @@
 @import "../base/MultiComboBox-parameters.css";
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
-@import "../base/sizes-parameters.css";
+@import "./sizes-parameters.css";
 @import "../base/rtl-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcb/sizes-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/sizes-parameters.css
@@ -3,6 +3,10 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.3125rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.1875rem;
+
 	/* SplitButton */
 	--_ui5_split_button_text_button_width: 2.25rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/CheckBox-parameters.css
@@ -10,4 +10,5 @@
 --_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 --_ui5_checkbox_hover_background: var(--sapSelectedColor);
 --_ui5_checkbox_focus_outline: 0.125rem dotted var(--sapContent_FocusColor);
+--_ui5_checkbox_wrapped_focus_inset_block: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -54,5 +54,5 @@
 @import "../base/MultiComboBox-parameters.css";
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
-@import "../base/sizes-parameters.css";
+@import "./sizes-parameters.css";
 @import "../base/rtl-parameters.css";

--- a/packages/main/src/themes/sap_fiori_3_hcw/sizes-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/sizes-parameters.css
@@ -3,6 +3,10 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.3125rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.1875rem;
+
 	/* SplitButton */
 	--_ui5_split_button_text_button_width: 2.25rem;
 }

--- a/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
@@ -40,5 +40,4 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
 }

--- a/packages/main/src/themes/sap_horizon/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon/sizes-parameters.css
@@ -36,6 +36,9 @@
 	--_ui5_slider_handle_top: -.5rem;
 	--_ui5_slider_tooltip_height: 1.375rem;
 
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.125rem;
+
 	/* ColorPalette */
 	--_ui5_color-palette-item-height: 1.25rem;
 	--_ui5_color-palette-item-focus-height: 1rem;

--- a/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
@@ -40,5 +40,4 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
 }

--- a/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
@@ -33,6 +33,9 @@
 	--_ui5_split_button_middle_separator_top: 0.3125rem;
 	--_ui5_split_button_middle_separator_height: 1rem;
 
+	/* CheckBox */
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.125rem;
+
 	/* ColorPalette */
 	--_ui5_color-palette-item-height: 1.25rem;
 	--_ui5_color-palette-item-focus-height: 1rem;

--- a/packages/main/src/themes/sap_horizon_exp/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/CheckBox-parameters.css
@@ -41,5 +41,4 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
@@ -42,5 +42,5 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/sizes-parameters.css
@@ -7,6 +7,10 @@
 	--_ui5_split_button_text_button_width: 2.25rem;
 	--_ui5_color_picker_slider_container_margin_top: -10px;
 
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.25rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.1875rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;

--- a/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
@@ -42,5 +42,5 @@
 	--_ui5_checkbox_focus_position: 0.3125rem;
 	--_ui5_checkbox_focus_border_radius: 0.5rem;
 	--_ui5_checkbox_right_focus_distance: var(--_ui5_checkbox_focus_position);
-	--_ui5_checkbox_wrapped_focus_left_top_bottom_position: 0.1875rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.4375rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/sizes-parameters.css
@@ -7,6 +7,10 @@
 	--_ui5_split_button_text_button_width: 2.25rem;
 	--_ui5_color_picker_slider_container_margin_top: -10px;
 
+	/* CheckBox */
+	--_ui5_checkbox_focus_position: 0.25rem;
+	--_ui5_checkbox_wrapped_focus_inset_block: 0.1875rem;
+
 	/* DayPicker */
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.3125rem;


### PR DESCRIPTION
This commit adjusts the focus outline in wrapped mode for the CheckBox component. It address the initial concern that the focus outline was out of place in compact density mode, but also improves the overall focus outline in all density modes.

Themes that were checked:

- sap_horizon
- sap_horizon_dark
- sap_horizon_hcb
- sap_horizon_hcw
- sap_fiori_3
- sap_fiori_3_dark
- sap_fiori_3_hcb
- sap_fiori_3_hcw

Fixes: #9254
