### PR TITLE
fix(ui5-color-palette-popover): enable navigation over the swatches

### DIFF
--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -234,14 +234,6 @@ class ColorPalette extends UI5Element {
 			this.recentColorsElements[0].selected = true;
 			this.recentColorsElements[0].focus();
 		}
-
-		if (this.popupMode) {
-			if (this.showDefaultColor) {
-				this.focusFirstFocusableElement();
-			} else {
-				this.focusFirstDisplayColorElement();
-			}
-		}
 	}
 
 	selectColor(item: ColorPaletteItem) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -473,14 +473,6 @@ class ColorPalette extends UI5Element {
 		itemNavigation._focusCurrentItem();
 	}
 
-	focusFirstDisplayColorElement() {
-		this.focusColorElement(this.displayedColors[0], this._itemNavigation);
-	}
-
-	focusFirstFocusableElement() {
-		this.firstFocusableElement.focus();
-	}
-
 	get firstFocusableElement() {
 		return this.colorPaletteNavigationElements[0];
 	}


### PR DESCRIPTION
Issue:
- The `ui5-color-palette` gets re-rendered on each keyboard navigation in the swatches grid.
In the `onAfterRendering` hook there was a logic active only when in `ui5-color-palette-popover`,
which sets the focused element to the first swatch. As a result the keyboard navigation in the grid
was't possible.

