### PR TITLE
chore: align property types and default values to framework

### DIFF
--- a/packages/fiori/src/FilterItem.ts
+++ b/packages/fiori/src/FilterItem.ts
@@ -25,11 +25,11 @@ import type FilterItemOption from "./FilterItemOption.js";
 class FilterItem extends UI5Element {
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the additional text of the component.

--- a/packages/fiori/src/FilterItemOption.ts
+++ b/packages/fiori/src/FilterItemOption.ts
@@ -23,11 +23,11 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 class FilterItemOption extends UI5Element {
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines if the component is selected.

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -54,7 +54,7 @@ class ShellBarItem extends UI5Element {
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the count displayed in the top-right corner.

--- a/packages/fiori/src/SortItem.ts
+++ b/packages/fiori/src/SortItem.ts
@@ -23,11 +23,11 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 class SortItem extends UI5Element {
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines if the component is selected.

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -613,9 +613,9 @@ class ViewSettingsDialog extends UI5Element {
 	get eventsParams() {
 		const _currentSortOrderSelected = this._currentSettings.sortOrder.filter(item => item.selected)[0],
 			_currentSortBySelected = this._currentSettings.sortBy.filter(item => item.selected)[0],
-			sortOrder = _currentSortOrderSelected && _currentSortOrderSelected.text || "",
+			sortOrder = _currentSortOrderSelected && (_currentSortOrderSelected.text || ""),
 			sortDescending = !this._currentSettings.sortOrder[0].selected,
-			sortBy = _currentSortBySelected && _currentSortBySelected.text || "",
+			sortBy = _currentSortBySelected && (_currentSortBySelected.text || ""),
 			sortByElementIndex = _currentSortBySelected && _currentSortBySelected.index,
 			sortByItem = this.sortItems[sortByElementIndex];
 		return {

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -66,7 +66,7 @@ type ViewSettingsDialogCancelEventDetail = VSDSettings & {
 }
 
 // Common properties for several VSDInternalSettings fields
-type VSDItem = {text: string, selected: boolean}
+type VSDItem = {text?: string, selected: boolean}
 
 // Used for the private properties _initialSettings, _confirmedSettings and _currentSettings
 type VSDInternalSettings = {
@@ -446,11 +446,11 @@ class ViewSettingsDialog extends UI5Element {
 			sortBy: JSON.parse(JSON.stringify(this.initSortByItems)),
 			filters: this.filterItems.map(item => {
 				return {
-					text: item.text,
+					text: item.text || "",
 					selected: false,
 					filterOptions: item.values.map(optionValue => {
 						return {
-							text: optionValue.text,
+							text: optionValue.text || "",
 							selected: optionValue.selected,
 						};
 					}),
@@ -613,9 +613,9 @@ class ViewSettingsDialog extends UI5Element {
 	get eventsParams() {
 		const _currentSortOrderSelected = this._currentSettings.sortOrder.filter(item => item.selected)[0],
 			_currentSortBySelected = this._currentSettings.sortBy.filter(item => item.selected)[0],
-			sortOrder = _currentSortOrderSelected && _currentSortOrderSelected.text,
+			sortOrder = _currentSortOrderSelected && _currentSortOrderSelected.text || "",
 			sortDescending = !this._currentSettings.sortOrder[0].selected,
-			sortBy = _currentSortBySelected && _currentSortBySelected.text,
+			sortBy = _currentSortBySelected && _currentSortBySelected.text || "",
 			sortByElementIndex = _currentSortBySelected && _currentSortBySelected.index,
 			sortByItem = this.sortItems[sortByElementIndex];
 		return {
@@ -635,13 +635,13 @@ class ViewSettingsDialog extends UI5Element {
 
 			filter.filterOptions.forEach(option => {
 				if (option.selected) {
-					selectedOptions.push(option.text);
+					selectedOptions.push(option.text || "");
 				}
 			});
 
 			if (selectedOptions.length) {
 				result.push({});
-				result[result.length - 1][filter.text] = selectedOptions;
+				result[result.length - 1][filter.text || ""] = selectedOptions;
 			}
 		});
 
@@ -748,7 +748,7 @@ class ViewSettingsDialog extends UI5Element {
 
 				for (let i = 0; i < tempSettings.filters.length; i++) {
 					for (let j = 0; j < tempSettings.filters[i].filterOptions.length; j++) {
-						if (inputFilters[tempSettings.filters[i].text] && inputFilters[tempSettings.filters[i].text].indexOf(tempSettings.filters[i].filterOptions[j].text) > -1) {
+						if (inputFilters[tempSettings.filters[i].text || ""] && inputFilters[tempSettings.filters[i].text || ""].indexOf(tempSettings.filters[i].filterOptions[j].text || "") > -1) {
 							tempSettings.filters[i].filterOptions[j].selected = true;
 						} else {
 							tempSettings.filters[i].filterOptions[j].selected = false;

--- a/packages/main/src/CheckBox.ts
+++ b/packages/main/src/CheckBox.ts
@@ -190,11 +190,11 @@ class CheckBox extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the value state of the component.

--- a/packages/main/src/ColorPaletteItem.ts
+++ b/packages/main/src/ColorPaletteItem.ts
@@ -37,11 +37,11 @@ class ColorPaletteItem extends UI5Element implements IColorPaletteItem {
 	 * Defines the colour of the component.
 	 *
 	 * **Note:** The value should be a valid CSS color.
-	 * @default undefined
+	 * @default ""
 	 * @public
 	 */
 	@property()
-	value?: string;
+	value = ""
 
 	/**
 	 * Defines if the component is selected.

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -95,7 +95,7 @@ class ColorPicker extends UI5Element implements IFormInputElement {
 	 * @public
 	 */
 	@property()
-	value = "rgba(255, 255, 255, 1)";
+	value = "rgba(255,255,255,1)";
 
 	/**
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
@@ -212,7 +212,7 @@ class ColorPicker extends UI5Element implements IFormInputElement {
 	onBeforeRendering() {
 		// we have the color & ._mainValue properties here
 		this._value = getRGBColor(this.value);
-		const tempColor = `rgba(${this._value.r}, ${this._value.g}, ${this._value.b}, 1)`;
+		const tempColor = `rgba(${this._value.r},${this._value.g},${this._value.b},1)`;
 		this._setHex();
 		this._setValues();
 		this.style.setProperty(getScopedVarName("--ui5_Color_Picker_Progress_Container_Color"), tempColor);

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -91,7 +91,7 @@ class ColorPicker extends UI5Element implements IFormInputElement {
 	 * Defines the currently selected color of the component.
 	 *
 	 * **Note**: use HEX, RGB, RGBA, HSV formats or a CSS color name when modifying this property.
-	 * @default "rgba(255, 255, 255, 1)"
+	 * @default "rgba(255,255,255,1)"
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -1124,7 +1124,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 	_selectItem(e: CustomEvent<ListItemClickEventDetail>) {
 		const listItem = e.detail.item as ComboBoxListItem;
 
-		this._selectedItemText = listItem.mappedItem.text;
+		this._selectedItemText = listItem.mappedItem.text || "";
 		this._selectionPerformed = true;
 
 		const sameItemSelected = this.value === this._selectedItemText;

--- a/packages/main/src/ComboBoxItem.ts
+++ b/packages/main/src/ComboBoxItem.ts
@@ -16,11 +16,11 @@ import type { IComboBoxItem } from "./ComboBox.js";
 class ComboBoxItem extends UI5Element implements IComboBoxItem {
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the additional text of the component.

--- a/packages/main/src/DateComponentBase.ts
+++ b/packages/main/src/DateComponentBase.ts
@@ -53,17 +53,17 @@ class DateComponentBase extends UI5Element {
 
 	/**
 	 * Determines the format, displayed in the input field.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	formatPattern = "";
+	formatPattern?: string;
 
 	/**
 	 * Determines the minimum date available for selection.
 	 *
 	 * **Note:** If the formatPattern property is not set, the minDate value must be provided in the ISO date format (YYYY-MM-dd).
-	 * @default undefined
+	 * @default ""
 	 * @since 1.0.0-rc.6
 	 * @public
 	 */

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -222,11 +222,11 @@ class DateTimePicker extends DatePicker implements IFormInputElement {
 	}
 
 	get _formatPattern() {
-		const hasHours = !!this.formatPattern.match(/H/i);
+		const hasHours = !!(this.formatPattern || "").match(/H/i);
 		const fallback = !this.formatPattern || !hasHours;
 
 		const localeData = getCachedLocaleDataInstance(getLocale());
-		return fallback ? localeData.getCombinedDateTimePattern("medium", "medium", this._primaryCalendarType) : this.formatPattern;
+		return fallback ? localeData.getCombinedDateTimePattern("medium", "medium", this._primaryCalendarType) : (this.formatPattern || "");
 	}
 
 	get _calendarTimestamp() {

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -148,13 +148,13 @@ class FileUploader extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Defines the name/names of the file/files to upload.
-	 * @default undefined
+	 * @default ""
 	 * @formEvents change
 	 * @formProperty
 	 * @public
 	 */
 	@property()
-	value?: string;
+	value = "";
 
 	/**
 	 * Defines the value state of the component.

--- a/packages/main/src/Filters.ts
+++ b/packages/main/src/Filters.ts
@@ -16,8 +16,8 @@ const StartsWithPerTerm = <T>(value: string, items: Array<T>, propName: string) 
 	});
 };
 
-const StartsWith = <T>(value: string, items: Array<T>, propName: string): Array<T> => items.filter(item => (item[propName as keyof typeof item] as string).toLowerCase().startsWith(value.toLowerCase()));
-const Contains = <T>(value: string, items: Array<T>, propName: string): Array<T> => items.filter(item => (item[propName as keyof typeof item] as string).toLowerCase().includes(value.toLowerCase()));
+const StartsWith = <T>(value: string, items: Array<T>, propName: string): Array<T> => items.filter(item => (item[propName as keyof typeof item] as string || "").toLowerCase().startsWith(value.toLowerCase()));
+const Contains = <T>(value: string, items: Array<T>, propName: string): Array<T> => items.filter(item => (item[propName as keyof typeof item] as string || "").toLowerCase().includes(value.toLowerCase()));
 const None = <T>(_: string, items: Array<T>): Array<T> => items;
 
 export {

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -99,7 +99,7 @@ interface IInputSuggestionItem extends UI5Element {
 }
 
 interface IInputSuggestionItemSelectable extends IInputSuggestionItem {
-	text: string;
+	text?: string;
 	selected: boolean;
 }
 
@@ -632,7 +632,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	_highlightSuggestionItem(item: SuggestionItem) {
-		item.markupText = this.typedInValue ? this.Suggestions?.hightlightInput((item.text), this.typedInValue) : encodeXML(item.text || "");
+		item.markupText = this.typedInValue ? this.Suggestions?.hightlightInput((item.text || ""), this.typedInValue) : encodeXML(item.text || "");
 	}
 
 	_isGroupItem(item: IInputSuggestionItem) {
@@ -814,7 +814,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 		});
 
 		if (matchingItem) {
-			const itemText = matchingItem.text;
+			const itemText = matchingItem.text || "";
 
 			innerInput.setSelectionRange(itemText.length, itemText.length);
 			if (!suggestionItemPressed) {
@@ -1242,7 +1242,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	updateValueOnSelect(item: IInputSuggestionItem) {
 		const itemValue = this._isGroupItem(item) ? this.valueBeforeSelectionStart : (item as IInputSuggestionItemSelectable).text;
 
-		this.value = itemValue;
+		this.value = itemValue || "";
 		this._performTextSelection = true;
 	}
 

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -344,7 +344,7 @@ class Menu extends UI5Element {
 		if (!item._popover) {
 			const prevented = !this.fireEvent<MenuItemClickEventDetail>("item-click", {
 				"item": item,
-				"text": item.text,
+				"text": item.text || "",
 			}, true, false);
 
 			if (!prevented && this._popover) {

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -60,11 +60,11 @@ class MenuItem extends ListItem implements IMenuItem {
 
 	/**
 	 * Defines the text of the tree item.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the `additionalText`, displayed in the end of the menu item.

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -31,7 +31,7 @@ import type {
 } from "./Input.js";
 
 interface IToken extends HTMLElement, ITabbable {
-	text: string;
+	text?: string;
 	readonly: boolean,
 	selected: boolean,
 	isTruncatable: boolean,
@@ -153,7 +153,7 @@ class MultiInput extends Input implements IFormInputElement {
 			formData.append(this.name, this.value);
 
 			for (let i = 0; i < tokens.length; i++) {
-				formData.append(this.name, tokens[i].text);
+				formData.append(this.name, (tokens[i].text || ""));
 			}
 
 			return formData;

--- a/packages/main/src/RadioButton.ts
+++ b/packages/main/src/RadioButton.ts
@@ -168,11 +168,11 @@ class RadioButton extends UI5Element implements IFormInputElement {
 	 * Defines the form value of the component.
 	 * When a form with a radio button group is submitted, the group's value
 	 * will be the value of the currently selected radio button.
-	 * @default undefined
+	 * @default ""
 	 * @public
 	 */
 	@property()
-	value?: string;
+	value = "";
 
 	/**
 	 * Defines whether the component text wraps when there is not enough space.

--- a/packages/main/src/SuggestionItem.ts
+++ b/packages/main/src/SuggestionItem.ts
@@ -25,11 +25,11 @@ import styles from "./generated/themes/SuggestionItem.css.js";
 class SuggestionItem extends ListItemBase implements IInputSuggestionItemSelectable {
 	/**
 	 * Defines the text of the component.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the `additionalText`, displayed in the end of the item.

--- a/packages/main/src/SuggestionItemCustom.ts
+++ b/packages/main/src/SuggestionItemCustom.ts
@@ -35,11 +35,11 @@ class SuggestionItemCustom extends ListItemBase implements IInputSuggestionItemS
 	/**
 	 * Defines the text of the `ui5-suggestion-item-custom`.
 	 * **Note:** The text property is considered only for autocomplete.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the content of the component.

--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -203,13 +203,13 @@ type TimePickerInputEventDetail = TimePickerChangeInputEventDetail;
 class TimePicker extends UI5Element implements IFormInputElement {
 	/**
 	 * Defines a formatted time value.
-	 * @default undefined
+	 * @default ""
 	 * @formEvents change input
 	 * @formProperty
 	 * @public
 	 */
 	@property()
-	value?: string;
+	value = ""
 
 	/**
 	 * Determines the name by which the component will be identified upon submission in an HTML form.
@@ -344,7 +344,7 @@ class TimePicker extends UI5Element implements IFormInputElement {
 	 * @default null
 	 */
 	get dateValue(): Date | Date[] | null {
-		return this.getFormat().parse(this._effectiveValue as string);
+		return this.getFormat().parse(this._effectiveValue);
 	}
 
 	/**
@@ -630,7 +630,7 @@ class TimePicker extends UI5Element implements IFormInputElement {
 	}
 
 	_modifyValueBy(amount: number, unit: string) {
-		const date = this.getFormat().parse(this._effectiveValue as string) as Date;
+		const date = this.getFormat().parse(this._effectiveValue) as Date;
 		if (!date) {
 			return;
 		}

--- a/packages/main/src/Token.ts
+++ b/packages/main/src/Token.ts
@@ -76,11 +76,11 @@ type TokenDeleteEventDetail = {
 class Token extends UI5Element implements IToken {
 	/**
 	 * Defines the text of the token.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines whether the component is selected or not.

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -141,10 +141,10 @@ class ToolbarButton extends ToolbarItem {
 	/**
 	 * Button text
 	 * @public
-	 * @default ""
+	 * @default undefined
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the width of the button.

--- a/packages/main/src/TreeItem.ts
+++ b/packages/main/src/TreeItem.ts
@@ -37,7 +37,7 @@ class TreeItem extends TreeItemBase {
 	 * @default undefined
 	 */
 	@property()
-	text = "";
+	text?: string;
 
 	/**
 	 * Defines the `additionalText`, displayed in the end of the tree item.

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -226,7 +226,7 @@ class Suggestions {
 			isGroup: item.hasAttribute("ui5-suggestion-item-group"),
 			currentPos: nonGroupItems.indexOf(item) + 1,
 			listSize: nonGroupItems.length,
-			itemText: item.text,
+			itemText: item.text || "",
 			additionalText: item.additionalText,
 		};
 

--- a/packages/main/test/specs/FormSupport.spec.js
+++ b/packages/main/test/specs/FormSupport.spec.js
@@ -32,7 +32,7 @@ describe("Form support", () => {
 		await submitBtn.click();
 
 		const hrefIsSame = await browser.executeAsync(done => {
-			done(location.href.endsWith("FormSupport.html?color_picker3=rgba%28255%2C+255%2C+255%2C+1%29&color_picker4=blue"));
+			done(location.href.endsWith("FormSupport.html?color_picker3=rgba%28255%2C255%2C255%2C1%29&color_picker4=blue"));
 		});
 		assert.ok(hrefIsSame, "Form was submitted with correct parameters");
 	});


### PR DESCRIPTION
With the introduction of property initializers (https://github.com/SAP/ui5-webcomponents/pull/8846) many properties have changed they default values or types but on some places:
- JSDoc wasn't changed
- Properties with declared `declare` keyword were using wrong type

This change fixes most of the things until custom element analyzer plugin is adjusted to generate correct output