### PR TITLE
chore(ui5-illustrated-message): type of name property changed to enum

### DIFF
--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -112,7 +112,7 @@ class IllustratedMessage extends UI5Element {
 	* @public
 	*/
 	@property()
-	name = "BeforeSearch";
+	name: `${IllustrationMessageType}` = "BeforeSearch";
 
 	/**
 	* Determines which illustration breakpoint variant is used.


### PR DESCRIPTION
This PR changes the type of the property `name` of the `ui5-illustrated-message` from string to the enum `IllustratedMessageType` values.