### PR TITLE
refactor: remove cloned property from slot decorator

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -365,10 +365,9 @@ abstract class UI5Element extends HTMLElement {
 		}
 
 		const canSlotText = metadata.canSlotText();
-		const hasClonedSlot = Object.keys(metadata.getSlots()).some(slotName => metadata.getSlots()[slotName].cloned);
 		const mutationObserverOptions = {
 			childList: true,
-			subtree: canSlotText || hasClonedSlot,
+			subtree: canSlotText,
 			characterData: canSlotText,
 		};
 		observeDOMNode(this, this._processChildren.bind(this) as MutationCallback, mutationObserverOptions);
@@ -406,7 +405,7 @@ abstract class UI5Element extends HTMLElement {
 
 		// Init the _state object based on the supported slots and store the previous values
 		for (const [slotName, slotData] of Object.entries(slotsMap)) { // eslint-disable-line
-			const propertyName = slotData.propertyName || slotName;
+			const propertyName = slotName;
 			propertyNameToSlotMap.set(propertyName, slotName);
 			slotsCachedContentMap.set(propertyName, [...(this._state[propertyName] as Array<SlotValue>)]);
 			this._clearSlot(slotName, slotData);

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -405,7 +405,7 @@ abstract class UI5Element extends HTMLElement {
 
 		// Init the _state object based on the supported slots and store the previous values
 		for (const [slotName, slotData] of Object.entries(slotsMap)) { // eslint-disable-line
-			const propertyName = slotName;
+			const propertyName = slotData.propertyName || slotName;
 			propertyNameToSlotMap.set(propertyName, slotName);
 			slotsCachedContentMap.set(propertyName, [...(this._state[propertyName] as Array<SlotValue>)]);
 			this._clearSlot(slotName, slotData);

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -13,7 +13,6 @@ type Slot = {
 	propertyName?: string,
 	individualSlots?: boolean,
 	invalidateOnChildChange?: boolean | SlotInvalidation,
-	cloned?: boolean,
 };
 
 type SlotValue = Node;


### PR DESCRIPTION
The `cloned` field of `@slot` decorator was introduced to invalidate component slot content was cloned to static area. https://github.com/SAP/ui5-webcomponents/pull/7882

Now, when the Popover API is integrated in all of the components, the field is obsolete.