### PR TITLE
chore(ui5-avatar): remove _size proeprty

### DIFF
--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -164,12 +164,6 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	size: `${AvatarSize}` = "S";
 
 	/**
-	 * @private
-	 */
-	@property()
-	_size: `${AvatarSize}` = "S";
-
-	/**
 	 * Defines the background color of the desired image.
 	 * @default "Accent6"
 	 * @public
@@ -259,7 +253,7 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	 */
 	get effectiveSize(): AvatarSize {
 		// we read the attribute, because the "size" property will always have a default value
-		return this.getAttribute("size") as AvatarSize || this._size;
+		return this.getAttribute("size") as AvatarSize;
 	}
 
 	/**

--- a/packages/main/test/specs/AvatarGroup.spec.js
+++ b/packages/main/test/specs/AvatarGroup.spec.js
@@ -39,7 +39,7 @@ describe("avatar-group rendering", () => {
 				index = 1;
 			}
 
-			assert.strictEqual(avatarBackgroundColor, `Accent${index}`, "AvatarGroup _color-scheme property is assigned to avatars _size property");
+			assert.strictEqual(avatarBackgroundColor, `Accent${index}`, "AvatarGroup _color-scheme property is assigned to avatars");
 		});
 	});
 


### PR DESCRIPTION
Ever since the deprecation of the avatar's group `avatarSize` property (https://github.com/SAP/ui5-webcomponents/pull/3229) the `_size` property of the avatar is not used. Since recent changes those underscored properties are showing as the attributes of the component. This causes the avatar size to be displayed incorrectly duo to the default value of the `_size` proeprty. 

![image](https://github.com/SAP/ui5-webcomponents/assets/22766569/6f4e3e72-8af8-4df2-b307-12917b5b9db6)


The property is removed as is not used anymore.