### PR TITLE
chore(ui5-popover): fix samples

### DIFF
--- a/packages/website/docs/_samples/main/Popover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/Popover/Placement/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <style>
         body {
-            height: 400px;
+            height: 420px;
         }
 
         .popover-content {

--- a/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
+++ b/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <style>
         body {
-            height: 400px;
+            height: 420px;
         }
 
         .popover-content {


### PR DESCRIPTION
The height of the sample is enlarged in order to avoid scrollbar in the popover shown to bottom of the button.