### PR TITLE
feat(ui5-calendar): allow overstyling

### DIFF
--- a/packages/main/src/Calendar.hbs
+++ b/packages/main/src/Calendar.hbs
@@ -19,6 +19,7 @@
 			?hide-week-numbers="{{hideWeekNumbers}}"
 			@ui5-change="{{onSelectedDatesChange}}"
 			@ui5-navigate="{{onNavigate}}"
+			exportparts="day-cell, day-cell-selected, day-cell-selected-between"
 		></ui5-daypicker>
 
 		<ui5-monthpicker

--- a/packages/main/src/Calendar.hbs
+++ b/packages/main/src/Calendar.hbs
@@ -35,6 +35,7 @@
 			timestamp="{{_timestamp}}"
 			@ui5-change="{{onSelectedMonthChange}}"
 			@ui5-navigate="{{onNavigate}}"
+			exportparts="month-cell, month-cell-selected"
 		></ui5-monthpicker>
 
 		<ui5-yearpicker
@@ -50,6 +51,7 @@
 			timestamp="{{_timestamp}}"
 			@ui5-change="{{onSelectedYearChange}}"
 			@ui5-navigate="{{onNavigate}}"
+			exportparts="year-cell, year-cell-selected"
 		></ui5-yearpicker>
 	</div>
 	<div class="ui5-calheader">

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -177,6 +177,13 @@ type SpecialCalendarDateT = {
  * @constructor
  * @extends CalendarPart
  * @public
+ * @csspart day-cell - Used to style the day cells.
+ * @csspart day-cell-selected - Used to style the day cells when selected.
+ * @csspart day-cell-selected-between - Used to style the day cells in between of selected dates in range.
+ * @csspart month-cell - Used to style the month cells.
+ * @csspart month-cell-selected - Used to style the month cells when selected.
+ * @csspart year-cell - Used to style the year cells.
+ * @csspart year-cell-selected - Used to style the year cells when selected.
  * @since 1.0.0-rc.11
  */
 @customElement({

--- a/packages/main/src/DayPicker.hbs
+++ b/packages/main/src/DayPicker.hbs
@@ -35,7 +35,8 @@
 								aria-selected="{{this.ariaSelected}}"
 								aria-label="{{this.ariaLabel}}"
 								aria-disabled="{{this.ariaDisabled}}"
-								class="{{this.classes}}">
+								class="{{this.classes}}"
+								part="{{this.parts}}">
 									<span
 										class="ui5-dp-daytext"
 										data-sap-timestamp="{{this.timestamp}}"

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -76,6 +76,7 @@ type Day = {
 	weekNum?: number,
 	isHidden?: boolean,
 	type?: string,
+	parts: string,
 }
 
 type WeekNumber = {
@@ -263,6 +264,7 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 				ariaDisabled: isOtherMonth ? "true" : undefined,
 				disabled: isDisabled,
 				type: specialDayType,
+				parts: "day-cell",
 			};
 
 			if (isFirstDayOfWeek) {
@@ -271,10 +273,13 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 
 			if (isSelected) {
 				day.classes += " ui5-dp-item--selected";
+				day.parts += " day-cell-selected";
 			}
 
 			if (isSelectedBetween) {
 				day.classes += " ui5-dp-item--selected-between";
+
+				day.parts += " day-cell-selected-between";
 			}
 
 			if (isToday) {

--- a/packages/main/src/MonthPicker.hbs
+++ b/packages/main/src/MonthPicker.hbs
@@ -17,6 +17,7 @@
 					tabindex={{this._tabIndex}}
 					?data-sap-focus-ref="{{this.focusRef}}"
 					class="{{this.classes}}"
+					part="{{this.parts}}"
 					role="gridcell"
 					aria-selected="{{this.ariaSelected}}"
 				>

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -163,7 +163,7 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 				nameInSecType: this.hasSecondaryCalendarType && this._getDisplayedSecondaryMonthText(timestamp).text,
 				disabled: isDisabled,
 				classes: "ui5-mp-item",
-				parts: "month-cell"
+				parts: "month-cell",
 			};
 
 			if (isSelected) {

--- a/packages/main/src/MonthPicker.ts
+++ b/packages/main/src/MonthPicker.ts
@@ -47,6 +47,7 @@ type Month = {
 	nameInSecType: string,
 	disabled: boolean,
 	classes: string,
+	parts: string,
 }
 
 type MonthInterval = Array<Array<Month>>;
@@ -162,10 +163,12 @@ class MonthPicker extends CalendarPart implements ICalendarPicker {
 				nameInSecType: this.hasSecondaryCalendarType && this._getDisplayedSecondaryMonthText(timestamp).text,
 				disabled: isDisabled,
 				classes: "ui5-mp-item",
+				parts: "month-cell"
 			};
 
 			if (isSelected) {
 				month.classes += " ui5-mp-item--selected";
+				month.parts += " month-cell-selected";
 			}
 
 			if (isDisabled) {

--- a/packages/main/src/YearPicker.hbs
+++ b/packages/main/src/YearPicker.hbs
@@ -16,6 +16,7 @@
 					tabindex="{{this._tabIndex}}"
 					?data-sap-focus-ref="{{this.focusRef}}"
 					class="{{this.classes}}"
+					part="{{this.parts}}"
 					role="gridcell"
 					aria-selected="{{this.ariaSelected}}"
 				>

--- a/packages/main/src/YearPicker.ts
+++ b/packages/main/src/YearPicker.ts
@@ -173,7 +173,7 @@ class YearPicker extends CalendarPart implements ICalendarPicker {
 				yearInSecType: textInSecType,
 				disabled: isDisabled,
 				classes: "ui5-yp-item",
-				parts: "year-cell"
+				parts: "year-cell",
 			};
 
 			if (isSelected) {

--- a/packages/main/src/YearPicker.ts
+++ b/packages/main/src/YearPicker.ts
@@ -43,6 +43,7 @@ type Year = {
 	yearInSecType: string | undefined;
 	disabled: boolean;
 	classes: string;
+	parts: string;
 }
 
 type YearInterval = Array<Array<Year>>;
@@ -172,10 +173,12 @@ class YearPicker extends CalendarPart implements ICalendarPicker {
 				yearInSecType: textInSecType,
 				disabled: isDisabled,
 				classes: "ui5-yp-item",
+				parts: "year-cell"
 			};
 
 			if (isSelected) {
 				year.classes += " ui5-yp-item--selected";
+				year.parts += " year-cell-selected";
 			}
 
 			if (isDisabled) {

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -225,7 +225,6 @@
 
 .ui5-dp-item.ui5-dp-item--selected-between .ui5-dp-daytext {
 	border-radius: var(--_ui5_daypicker_item_border_radius);
-	/* color: var(--sapTextColor); */
 	font-weight: var(--_ui5_daypicker_item_selected_between_text_font);
 }
 

--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -225,7 +225,7 @@
 
 .ui5-dp-item.ui5-dp-item--selected-between .ui5-dp-daytext {
 	border-radius: var(--_ui5_daypicker_item_border_radius);
-	color: var(--sapTextColor);
+	/* color: var(--sapTextColor); */
 	font-weight: var(--_ui5_daypicker_item_selected_between_text_font);
 }
 

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -20,9 +20,6 @@
 
 
 	<link rel="stylesheet" type="text/css" href="./styles/Calendar.css">
-
-	<style>
-	</style>
 </head>
 <body class="calendar1auto">
 

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -21,6 +21,20 @@
 
 	<link rel="stylesheet" type="text/css" href="./styles/Calendar.css">
 
+	<style>
+		/* [ui5-calendar]::part(day-cell) {
+			background-color: wheat;
+			color: slateblue;
+			border: 1px solid slateblue;
+		}
+
+		[ui5-calendar]::part(day-cell day-cell-selected-between) {
+			background-color: rgb(241, 175, 53);
+			color: lightskyblue;
+			border: 1px solid slateblue;
+			font-weight: bold;
+		} */
+	</style>
 </head>
 <body class="calendar1auto">
 

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -22,18 +22,6 @@
 	<link rel="stylesheet" type="text/css" href="./styles/Calendar.css">
 
 	<style>
-		/* [ui5-calendar]::part(day-cell) {
-			background-color: wheat;
-			color: slateblue;
-			border: 1px solid slateblue;
-		}
-
-		[ui5-calendar]::part(day-cell day-cell-selected-between) {
-			background-color: rgb(241, 175, 53);
-			color: lightskyblue;
-			border: 1px solid slateblue;
-			font-weight: bold;
-		} */
 	</style>
 </head>
 <body class="calendar1auto">


### PR DESCRIPTION
Adding new CSS shadow parts to enable overstyling of cells in the Calendar component.
- `day-cell` - Used to style the day cells.
- `day-cell-selected` - Used to style the day cells when selected.
- `day-cell-selected-between` - Used to style the day cells in between of selected dates in range.
- `month-cell` - Used to style the month cells.
- `month-cell-selected`- Used to style the month cells when selected.
- `year-cell` - Used to style the year cells.
- `year-cell-selected` - Used to style the year cells when selected.

Example how to use it if you want to style the calendars selected date:
```CSS
[ui5-calendar]::part(day-cell day-cell-selected) {
	background-color: rgb(241, 175, 53);
	color: white;
	border: 1px solid slateblue;
	font-weight: bold;
}
```

fixes: https://github.com/SAP/ui5-webcomponents/issues/9209