### PR TITLE
chore: update cypress config path for windows

### DIFF
--- a/packages/main/config/cypress.config.js
+++ b/packages/main/config/cypress.config.js
@@ -1,7 +1,8 @@
 import cypressConfig from "@ui5/webcomponents-tools/components-package/cypress.config.js";
 import path from "path";
 
-const __dirname = path.parse(import.meta.url)['dir'].replace('file:///','');
+const isWin = process.platform === "win32";
+const __dirname = isWin ? path.parse(import.meta.url)['dir'].replace('file:///','') : path.dirname(new URL(import.meta.url).pathname);
 cypressConfig.component.supportFile = path.join(__dirname, "cypress/support/component.js");
 
 export default cypressConfig;

--- a/packages/main/config/cypress.config.js
+++ b/packages/main/config/cypress.config.js
@@ -1,8 +1,7 @@
 import cypressConfig from "@ui5/webcomponents-tools/components-package/cypress.config.js";
 import path from "path";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-
+const __dirname = path.parse(import.meta.url)['dir'].replace('file:///','');
 cypressConfig.component.supportFile = path.join(__dirname, "cypress/support/component.js");
 
 export default cypressConfig;


### PR DESCRIPTION
The cypress config's `path `module adds a leading slash to the dirname like "/C:/..." which results in error on Windows