### PR TITLE
chore: add alert for missing type in cem generation

### DIFF
--- a/packages/main/src/DateRangePicker.ts
+++ b/packages/main/src/DateRangePicker.ts
@@ -71,7 +71,7 @@ class DateRangePicker extends DatePicker implements IFormInputElement {
 	 * @public
 	 */
 	@property()
-	delimiter = DEFAULT_DELIMITER;
+	delimiter = "-";
 
 	 /**
 	 * The first date in the range during selection (this is a temporary value, not the first date in the value range)

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -96,7 +96,7 @@ class FileUploader extends UI5Element implements IFormInputElement {
 	 * Comma-separated list of file types that the component should accept.
 	 *
 	 * **Note:** Please make sure you are adding the `.` in front on the file type, e.g. `.png` in case you want to accept png's only.
-	 * @default ""
+	 * @default undefined
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -255,7 +255,7 @@ class Tokenizer extends UI5Element {
 	 * You can only set the `opener` attribute to a DOM Reference when using JavaScript.
 	 * **Note:** Used inside MultiInput and MultiComboBox components.
 	 * @private
-	 * @default ""
+	 * @default undefined
 	 */
 	@property({
 		converter: DOMReferenceConverter,

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -122,7 +122,7 @@ class TreeItemBase extends ListItem {
 	 * @since 2.0.0
 	 */
 	@property({ type: Boolean })
-	movable!: boolean;
+	movable = false;
 
 	/**
 	* Defines whether the selection of a tree node is displayed as partially selected.

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -130,6 +130,10 @@ function processClass(ts, classNode, moduleDoc) {
 	currClass.events = findAllDecorators(classNode, "event")
 		?.map(event => processEvent(ts, event, classNode, moduleDoc));
 
+	const filename = classNode.getSourceFile().fileName;
+	const sourceFile = typeProgram.getSourceFile(filename);
+	const tsProgramClassNode = sourceFile.statements.find(statement => ts.isClassDeclaration(statement) && statement.name?.text === classNode.name?.text);
+
 	// Slots (with accessor), methods and fields
 	for (let i = 0; i < (currClass.members?.length || 0); i++) {
 		const member = currClass.members[i];
@@ -184,20 +188,21 @@ function processClass(ts, classNode, moduleDoc) {
 				const propertyDecorator = findDecorator(classNodeMember, "property");
 
 				if (propertyDecorator) {
-					member._ui5validator = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => ["validator", "type"].includes(property.name.text))?.initializer?.text || "String";
 					member._ui5noAttribute = propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "noAttribute")?.initializer?.kind === ts.SyntaxKind.TrueKeyword || undefined;
 				}
 
-				if (currClass.customElement && member.privacy === "public" && !propertyDecorator?.expression?.arguments[0]?.properties?.find(property => property.name.text === "multiple") && !["object"].includes(member._ui5validator?.toLowerCase())) {
-					const filename = classNode.getSourceFile().fileName;
-					const sourceFile = typeProgram.getSourceFile(filename);
-					const tsProgramClassNode = sourceFile.statements.find(statement => ts.isClassDeclaration(statement) && statement.name?.text === classNode.name?.text);
+				if (currClass.customElement && member.privacy === "public") {
 					const tsProgramMember = tsProgramClassNode.members.find(m => ts.isPropertyDeclaration(m) && m.name?.text === member.name);
 					const attributeValue = typeChecker.typeToString(typeChecker.getTypeAtLocation(tsProgramMember), tsProgramMember);
 
 					if (attributeValue === "boolean" && member.default === "true") {
 						logDocumentationError(moduleDoc.path, `Boolean properties must be initialzed to false. [${member.name}] property of class [${className}] is intialized to \`true\``)
 					}
+
+					if (!member.type) {
+						logDocumentationError(moduleDoc.path, `Public properties must have type. The type of [${member.name}] property is not determinated automatically. Please check it.`)
+					}
+
 					currClass.attributes.push({
 						description: member.description,
 						name: toKebabCase(member.name),


### PR DESCRIPTION
Add alert when custom element generator can't determinate the type of the property. Also align some property default value tags with they initializer value.