### PR TITLE
fix(ui5-table): correct font weight

### DIFF
--- a/packages/main/src/themes/sap_horizon/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: var(--sapContent_FocusWidth);
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_font_family:  var(--sapFontSemiboldDuplexFamily);
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;

--- a/packages/main/src/themes/sap_horizon/TableColumn-parameters.css
+++ b/packages/main/src/themes/sap_horizon/TableColumn-parameters.css
@@ -1,5 +1,0 @@
-@import "../base/TableColumn-parameters.css";
-
-:root {
-	--ui5_table_header_row_font_weight: bold;
-}

--- a/packages/main/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon/parameters-bundle.css
@@ -57,7 +57,6 @@
 @import "./SliderBase-parameters.css";
 @import "./ValueStateMessage-parameters.css";
 @import "./Table-parameters.css";
-@import "./TableColumn-parameters.css";
 @import "./TableRow-parameters.css";
 @import "./TableGroupRow-parameters.css";
 @import "../base/Toolbar-parameters.css";

--- a/packages/main/src/themes/sap_horizon_dark/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: var(--sapContent_FocusWidth);
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_font_family:  var(--sapFontSemiboldDuplexFamily);
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;

--- a/packages/main/src/themes/sap_horizon_dark/TableColumn-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/TableColumn-parameters.css
@@ -1,5 +1,0 @@
-@import "../base/TableColumn-parameters.css";
-
-:root {
-	--ui5_table_header_row_font_weight: bold;
-}

--- a/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -57,7 +57,6 @@
 @import "./SliderBase-parameters.css";
 @import "./ValueStateMessage-parameters.css";
 @import "./Table-parameters.css";
-@import "./TableColumn-parameters.css";
 @import "./TableRow-parameters.css";
 @import "./TableGroupRow-parameters.css";
 @import "./StepInput-parameters.css";

--- a/packages/main/src/themes/sap_horizon_dark_exp/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark_exp/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: var(--sapContent_FocusWidth);
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;
 }

--- a/packages/main/src/themes/sap_horizon_dark_exp/TableColumn-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark_exp/TableColumn-parameters.css
@@ -1,5 +1,0 @@
-@import "../base/TableColumn-parameters.css";
-
-:root {
-	--ui5_table_header_row_font_weight: bold;
-}

--- a/packages/main/src/themes/sap_horizon_dark_exp/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_dark_exp/parameters-bundle.css
@@ -56,7 +56,6 @@
 @import "./SliderBase-parameters.css";
 @import "./ValueStateMessage-parameters.css";
 @import "./Table-parameters.css";
-@import "./TableColumn-parameters.css";
 @import "./TableRow-parameters.css";
 @import "./TableGroupRow-parameters.css";
 @import "./StepInput-parameters.css";

--- a/packages/main/src/themes/sap_horizon_exp/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: var(--sapContent_FocusWidth);
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;
 }

--- a/packages/main/src/themes/sap_horizon_exp/TableColumn-parameters.css
+++ b/packages/main/src/themes/sap_horizon_exp/TableColumn-parameters.css
@@ -1,5 +1,0 @@
-@import "../base/TableColumn-parameters.css";
-
-:root {
-	--ui5_table_header_row_font_weight: bold;
-}

--- a/packages/main/src/themes/sap_horizon_exp/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_exp/parameters-bundle.css
@@ -56,7 +56,6 @@
 @import "./SliderBase-parameters.css";
 @import "./ValueStateMessage-parameters.css";
 @import "./Table-parameters.css";
-@import "./TableColumn-parameters.css";
 @import "./TableRow-parameters.css";
 @import "./TableGroupRow-parameters.css";
 @import "./StepInput-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcb/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: 0.125rem;
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_font_family:  var(--sapFontSemiboldDuplexFamily);
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcb_exp/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb_exp/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: 0.125rem;
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;
 	--ui5_table_header_row_border_width: 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcw/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: 0.125rem;
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_font_family:  var(--sapFontSemiboldDuplexFamily);
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcw_exp/Table-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw_exp/Table-parameters.css
@@ -2,7 +2,6 @@
 
 :root {
 	--ui5_table_header_row_outline_width: 0.125rem;
-	--ui5_table_header_row_font_weight: bold;
 	--ui5_table_header_row_border_bottom_color: var(--sapList_HeaderBorderColor);
 	--ui5_table_focus_outline_offset: -0.1875rem;
 	--ui5_table_header_row_border_width: 0.1875rem;


### PR DESCRIPTION
"72-SemiboldDuplex", "72-SemiboldDuplexfull" fonts look broken in Safari browser when its font weight is set to bold.
![image](https://github.com/SAP/ui5-webcomponents/assets/31909318/8b927aea-da58-4a73-916b-5ce8dd8ff91e)

With this the specification of `ui5-table-column` was updated and now, the column's font weight should be set to normal. With this PR the styles are align to the specification.

Fixes: #9046