### PR TITLE
fix(ui5-dialog): fix draggable dialog header focusing with mouse

### DIFF
--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -425,8 +425,6 @@ class Dialog extends Popup {
 			return;
 		}
 
-		e.preventDefault();
-
 		const {
 			top,
 			left,

--- a/packages/main/src/Popup.hbs
+++ b/packages/main/src/Popup.hbs
@@ -5,7 +5,6 @@
 	style="{{styles.root}}"
 	class="{{classes.root}}"
 	role="{{_role}}"
-	tabindex="-1"
 	aria-modal="{{_ariaModal}}"
 	aria-label="{{_ariaLabel}}"
 	aria-labelledby="{{_ariaLabelledBy}}"

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -479,6 +479,9 @@ abstract class Popup extends UI5Element {
 		element = element || await getFirstFocusableElement(this) || this._root; // in case of no focusable content focus the root
 
 		if (element) {
+			if (element === this._root) {
+				element.tabIndex = -1;
+			}
 			element.focus();
 		}
 	}


### PR DESCRIPTION
Reported from the exploratory testing.

In Chrome and Edge there is still issue, if "header" slot is used, because of https://issues.chromium.org/issues/41420461