### PR TITLE
chore(ui5-breadcrumbs): current location hybrid

### DIFF
--- a/packages/main/src/Breadcrumbs.hbs
+++ b/packages/main/src/Breadcrumbs.hbs
@@ -29,12 +29,27 @@
 				wrapping-type="None">
 				{{this.innerText}}
 			</ui5-link>
-
-			{{#unless this._isCurrentPageItem}}
+			{{#if this._needsSeparator}}
 				<span class="ui5-breadcrumbs-separator" aria-hidden="true"></span>
-			{{/unless}}
+			{{/if}}
 		</li>
 		{{/each}}
+		{{#unless _endsWithCurrentLinkItem }}
+			{{#if _endsWithCurrentLocation}}
+				<li class="ui5-breadcrumbs-current-location" @click="{{../_onLabelPress}}">
+
+					<span aria-current="page"
+						aria-label="{{_currentLocationAccName}}"
+						role="link"
+						id="{{this._id}}-labelWrapper">
+
+						<ui5-label>
+							{{_currentLocationText}}
+						</ui5-label>
+					</span>
+				</li>
+			{{/if}}
+		{{/unless}}
 	</ol>
 </nav>
 

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -12,6 +12,7 @@ import type { AccessibilityAttributes } from "@ui5/webcomponents-base/dist/types
 import {
 	isSpace,
 	isShow,
+	isEnter,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -30,6 +31,7 @@ import {
 } from "./generated/i18n/i18n-defaults.js";
 import Link from "./Link.js";
 import type { LinkClickEventDetail } from "./Link.js";
+import Label from "./Label.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import List from "./List.js";
 import type { ListSelectionChangeEventDetail } from "./List.js";
@@ -51,6 +53,11 @@ type BreadcrumbsItemClickEventDetail = {
 	ctrlKey: boolean;
 	metaKey: boolean;
 	shiftKey: boolean;
+}
+
+type FocusAdaptor = ITabbable & {
+	getlabelWrapper: () => Element | null;
+	forcedTabIndex: string;
 }
 
 /**
@@ -91,6 +98,7 @@ type BreadcrumbsItemClickEventDetail = {
 	dependencies: [
 		BreadcrumbsItem,
 		Link,
+		Label,
 		ResponsivePopover,
 		List,
 		ListItemStandard,
@@ -179,6 +187,7 @@ class Breadcrumbs extends UI5Element {
 	_breadcrumbItemWidths = new WeakMap<BreadcrumbsItem, number>();
 	// the width of the interactive element that opens the overflow
 	_dropdownArrowLinkWidth = 0;
+	_labelFocusAdaptor: FocusAdaptor;
 	responsivePopover?: ResponsivePopover;
 	static i18nBundle: I18nBundle;
 
@@ -191,6 +200,19 @@ class Breadcrumbs extends UI5Element {
 		});
 
 		this._onResizeHandler = this._updateOverflow.bind(this);
+
+		this._labelFocusAdaptor = {
+			id: `${this._id}-labelWrapper`,
+			getlabelWrapper: this.getCurrentLocationLabelWrapper.bind(this),
+			set forcedTabIndex(value: string) {
+				const wrapper = this.getlabelWrapper();
+				wrapper && wrapper.setAttribute("tabindex", value);
+			},
+			get forcedTabIndex() {
+				const wrapper = this.getlabelWrapper();
+				return wrapper?.getAttribute("tabindex") || "";
+			},
+		};
 	}
 
 	onInvalidation(changeInfo: ChangeInfo) {
@@ -249,11 +271,17 @@ class Breadcrumbs extends UI5Element {
 			items.unshift(this._dropdownArrowLink);
 		}
 
+		if (this._endsWithCurrentLocation && !this._endsWithCurrentLinkItem) {
+			items.push(this._labelFocusAdaptor);
+		}
+
 		return items;
 	}
 
 	_onfocusin(e: FocusEvent) {
-		const currentItem = e.target as Link;
+		const target = e.target,
+			labelWrapper = this.getCurrentLocationLabelWrapper(),
+			currentItem = (target === labelWrapper) ? this._labelFocusAdaptor : target as Link;
 
 		this._itemNavigation.setCurrentItem(currentItem);
 	}
@@ -268,6 +296,10 @@ class Breadcrumbs extends UI5Element {
 		}
 		if (isSpace(e) && isDropdownArrowFocused && !this._isOverflowEmpty && !this._isPickerOpen) {
 			e.preventDefault();
+			return;
+		}
+		if ((isEnter(e) || isSpace(e)) && this._isCurrentLocationLabelFocused) {
+			this._onLabelPress(e);
 		}
 	}
 
@@ -283,12 +315,19 @@ class Breadcrumbs extends UI5Element {
 	 */
 	_cacheWidths() {
 		const map = this._breadcrumbItemWidths,
-			items = this._getItems();
+			  items = this._getItems(),
+			  label = this._currentLocationLabel;
 
 		for (let i = this._overflowSize; i < items.length; i++) {
 			const item = items[i],
 				link = this.shadowRoot!.querySelector<HTMLElement>(`#${item._id}-link-wrapper`)!;
 			map.set(item, this._getElementWidth(link));
+		}
+
+		if (items.length && this._endsWithCurrentLocation && label) {
+			const item = items[items.length - 1];
+
+			map.set(item, this._getElementWidth(label));
 		}
 
 		if (!this._isOverflowEmpty) {
@@ -371,12 +410,26 @@ class Breadcrumbs extends UI5Element {
 			shiftKey,
 		}, true)) {
 			e.preventDefault();
-			return;
 		}
+	}
 
-		if (item._isCurrentPageItem) {
-			locationReload();
-		}
+	_onLabelPress(e: MouseEvent | KeyboardEvent) {
+		const items = this._getItems(),
+			item = items[items.length - 1],
+			{
+				altKey,
+				ctrlKey,
+				metaKey,
+				shiftKey,
+			} = e;
+
+		this.fireEvent<BreadcrumbsItemClickEventDetail>("item-click", {
+			item,
+			altKey,
+			ctrlKey,
+			metaKey,
+			shiftKey,
+		});
 	}
 
 	_onOverflowListItemSelect(e: CustomEvent<ListSelectionChangeEventDetail>) {
@@ -451,18 +504,47 @@ class Breadcrumbs extends UI5Element {
 		return text;
 	}
 
+	getCurrentLocationLabelWrapper() {
+		return this.shadowRoot!.querySelector<HTMLElement>(".ui5-breadcrumbs-current-location > span");
+	}
+
 	get _visibleItems() {
 		return this._getItems()
 			.slice(this._overflowSize)
 			.filter(i => this._isItemVisible(i));
 	}
 
-	get _endsWithCurrentPageItem() {
+	get _endsWithCurrentLinkItem() {
+		const items = this._getItems();
+		return (items.length && items[items.length - 1].href);
+	}
+
+	get _endsWithCurrentLocation() {
 		return this.design === BreadcrumbsDesign.Standard;
+	}
+
+	get _currentLocationText() {
+		const items = this._getItems();
+		if (this._endsWithCurrentLocation && items.length) {
+			const item = items[items.length - 1];
+			if (this._isItemVisible(item)) {
+				return item.innerText;
+			}
+		}
+		return "";
+	}
+
+	get _currentLocationLabel() {
+		return this.shadowRoot!.querySelector<Label>(".ui5-breadcrumbs-current-location [ui5-label]");
 	}
 
 	get _isDropdownArrowFocused() {
 		return this._dropdownArrowLink.forcedTabIndex === "0";
+	}
+
+	get _isCurrentLocationLabelFocused() {
+		const label = this.getCurrentLocationLabelWrapper();
+		return label && label.tabIndex === 0;
 	}
 
 	/**
@@ -498,14 +580,41 @@ class Breadcrumbs extends UI5Element {
 	 */
 	get _linksData() {
 		const items = this._visibleItems;
-		const itemsCount = items.length;
+		const itemsCount = items.length; // get size before removing of current location
+
+		if (this._endsWithCurrentLocation && !this._endsWithCurrentLinkItem) {
+			items.pop();
+		}
 
 		return items
 			.map((item, index) => {
 				item._accessibleNameText = this._getItemAccessibleName(item, index + 1, itemsCount);
-				item._isCurrentPageItem = index === (itemsCount - 1) && this._endsWithCurrentPageItem;
+				item._isCurrentPageItem = index === (itemsCount - 1) && this._endsWithCurrentLocation;
+				item._needsSeparator = !item._isCurrentPageItem;
 				return item;
 			});
+	}
+
+	/**
+	 * Getter for accessible name of the current location. Includes the position of the current location and the size of the breadcrumbs
+	 */
+	get _currentLocationAccName() {
+		const items = this._visibleItems;
+
+		const positionText = this._getItemPositionText(items.length, items.length);
+		const lastItem = items[items.length - 1];
+
+		if (!lastItem) {
+			return positionText;
+		}
+
+		const lastItemText = lastItem.textContent || "";
+
+		if (lastItem.accessibleName) {
+			return `${lastItemText.trim()} ${lastItem.accessibleName} ${positionText}`;
+		}
+
+		return `${lastItemText.trim()} ${positionText}`;
 	}
 
 	/**

--- a/packages/main/src/BreadcrumbsItem.ts
+++ b/packages/main/src/BreadcrumbsItem.ts
@@ -65,6 +65,7 @@ class BreadcrumbsItem extends UI5Element {
 
 	_accessibleNameText?: string;
 	_isCurrentPageItem?: boolean;
+	_needsSeparator?: boolean;
 
 	get stableDomRef() {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;

--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -22,6 +22,19 @@
     display: inline;
 }
 
+.ui5-breadcrumbs-current-location {
+    min-width: 1%;
+    flex: 1 1 auto;
+    /* Fix extra height in ul -> li element */
+    font-size: 0;
+    align-self: center;
+}
+
+.ui5-breadcrumbs-current-location > span:focus {
+    outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+    border-radius: var(--_ui5_breadcrumbs_current_location_focus_border_radius);
+}
+
 .ui5-breadcrumbs-dropdown-arrow-link-wrapper[hidden] {
     display: none
 }

--- a/packages/main/test/pages/Breadcrumbs.html
+++ b/packages/main/test/pages/Breadcrumbs.html
@@ -64,7 +64,7 @@
 		<ui5-breadcrumbs-item href="#">Link5</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link6</ui5-breadcrumbs-item>
 		<ui5-breadcrumbs-item href="#">Link7</ui5-breadcrumbs-item>
-		<ui5-breadcrumbs-item>Location</ui5-breadcrumbs-item>
+		<ui5-breadcrumbs-item href="#">Location</ui5-breadcrumbs-item>
 	</ui5-breadcrumbs>
 
 	<h2>Breadcrumbs with no current location</h2>
@@ -151,7 +151,7 @@
 	<div class="breadcrumbs9auto">
 		<h2>Empty Breadcrumbs with Location only</h2>
 		<ui5-breadcrumbs id="breadcrumbsWithSingleItem">
-			<ui5-breadcrumbs-item>Location</ui5-breadcrumbs-item>
+			<ui5-breadcrumbs-item href="#someHref">Location</ui5-breadcrumbs-item>
 		</ui5-breadcrumbs>
 	</div>
 


### PR DESCRIPTION
Regarding to recent feedback we move back the variant with breadcrumbs current item implemented as a text and kept the functionality to visualise it as a link if a href is passed to the last breadcrumbs item.