### PR TITLE
fix(ui5-table): access interactive content inside popin cell

### DIFF
--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -199,7 +199,7 @@ class TableRow extends UI5Element implements ITableRow {
 		const target = e.target as HTMLElement;
 		const checkboxPressed = target.classList.contains("ui5-multi-select-checkbox");
 		const rowElements = Array.from(this.shadowRoot!.querySelectorAll("tr") || []);
-		const elements = rowElements.map(getLastTabbableElement);
+		const elements = rowElements.map(getLastTabbableElement).filter(Boolean);
 		const lastFocusableElement = elements.pop();
 
 		if (isTabNext(e) && activeElement === (lastFocusableElement || this.root)) {

--- a/packages/main/test/pages/TableAllPopin.html
+++ b/packages/main/test/pages/TableAllPopin.html
@@ -24,6 +24,7 @@
 
 <body class="tableallpopin1auto">
 
+	<ui5-button id="beforeEl">Before element</ui5-button>
 	<ui5-table class="demo-table" id="tbl">
 		<!-- Columns -->
 		<ui5-table-column class="title-column" slot="columns">
@@ -51,7 +52,7 @@
 
 		<ui5-table-row id="row1">
 			<ui5-table-cell class="title-cell">Notebook Basic 15</ui5-table-cell>
-			<ui5-table-cell>Very Best Screens</ui5-table-cell>
+			<ui5-table-cell><ui5-link href="#" id="focusedEl">I'm focus</ui5-link></ui5-table-cell>
 			<ui5-table-cell>30 x 18 x 3 cm</ui5-table-cell>
 			<ui5-table-cell>4.2 KG</ui5-table-cell>
 			<ui5-table-cell class="price-cell">956 EUR</ui5-table-cell>
@@ -59,7 +60,8 @@
 
 		<ui5-table-row id="row2">
 			<ui5-table-cell class="title-cell">Notebook Basic 17</ui5-table-cell>
-			<ui5-table-cell>Very Best Screens</ui5-table-cell>
+			
+			<ui5-table-cell><ui5-link href="#">I'm focus</ui5-link></ui5-table-cell>
 			<ui5-table-cell>40 x 18 x 3 cm</ui5-table-cell>
 			<ui5-table-cell>4.6 KG</ui5-table-cell>
 			<ui5-table-cell class="price-cell">1956 EUR</ui5-table-cell>
@@ -67,13 +69,15 @@
 
 		<ui5-table-row id="row3">
 			<ui5-table-cell class="title-cell">Notebook Basic 19</ui5-table-cell>
-			<ui5-table-cell>Very Best Screens</ui5-table-cell>
+			
+			<ui5-table-cell><ui5-link href="#">I'm focus</ui5-link></ui5-table-cell>
 			<ui5-table-cell>50 x 18 x 3 cm</ui5-table-cell>
 			<ui5-table-cell>4.9 KG</ui5-table-cell>
 			<ui5-table-cell class="price-cell">2956 EUR</ui5-table-cell>
 		</ui5-table-row>
 
 	</ui5-table>
+	<ui5-button id="afterEl">After element</ui5-button>
 
 	<br>
 	<br>

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -133,24 +133,47 @@ describe("Table general interaction", () => {
 				"The aria-label value is correct when there is an empty cell in the row.");
 		});
 
-		it("Should have correct focus handling when having popin rows", async () => {
-			await browser.url(`test/pages/TableAllPopin.html`);
-			await browser.setWindowSize(500, 1200);
+		describe("Keyboard handling when popin", async () => {
+			before(async () => {
+				await browser.url(`test/pages/TableAllPopin.html`);
+				await browser.setWindowSize(500, 1200);
+			})
 
-			const input = await $("#tbl2 #interactive");
-			const btn = await $("#btn-focused");
-			const secondInput = await $("#input-second-focused");
+			it("Should have correct focus handling when having popin rows", async () => {
+				const beforeBtn = await browser.$("#beforeEl");
+				const link = await browser.$("#focusedEl");
+				const afterBtn = await browser.$("#afterEl");
 
-			await input.click();
-			await browser.keys("Tab");
+				await beforeBtn.click();
+				await browser.keys("Tab");
+				await browser.keys("Tab");
 
-			assert.equal(await btn.getProperty("focused"), true, "Button is focused")
+				assert.equal(await link.getProperty("focused"), true, "Link is focused")
 
-			await browser.keys("Tab");
-			assert.equal(await secondInput.getProperty("focused"), true, "Input is focused")
+				await browser.keys("Tab");
+				assert.equal(await afterBtn.getProperty("focused"), true, "Button is focused")
+			});
 
-			await browser.setWindowSize(1600, 1200);
-		});
+			it("Should have correct focus handling when having popin rows", async () => {
+				const input = await browser.$("#tbl2 #interactive");
+				const btn = await browser.$("#btn-focused");
+				const secondInput = await browser.$("#input-second-focused");
+
+				await input.click();
+				await browser.keys("Tab");
+
+				assert.equal(await btn.getProperty("focused"), true, "Button is focused")
+
+				await browser.keys("Tab");
+				assert.equal(await secondInput.getProperty("focused"), true, "Input is focused")
+			});
+
+			after(async () => {
+				await browser.setWindowSize(1600, 1200);
+			})
+		})
+
+
 	});
 
 	describe("Growing Table on 'More' button press", async () => {


### PR DESCRIPTION
Pressing `Tab` key was moving the focus to the interactive content only if it was placed inside was popin cell. With this change the focus is moved to the interactive content without the need to know in which popin cell it is placed.

Fixes: #9288