### PR TITLE
fix(ui5-tabcontainer): fix selected sub items screen readers announcement

### DIFF
--- a/packages/main/src/TabInOverflow.hbs
+++ b/packages/main/src/TabInOverflow.hbs
@@ -3,8 +3,8 @@
 	class="{{this.overflowClasses}}"
 	style="{{this._forcedStyleInOverflow}}"
 	type="{{this.overflowState}}"
-	aria-disabled="{{this.effectiveDisabled}}"
-	aria-selected="{{this.effectiveSelected}}"
+	disabled="{{this.effectiveDisabled}}"
+	?selected="{{this.selected}}"
 	?movable="{{this.movable}}"
 	.realTabReference="{{this}}"
 >

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -398,6 +398,25 @@ describe("TabContainer general interaction", () => {
 
 		assert.ok(isTabInOverflowFocused, "Tab in overflow should be focused");
 	});
+
+	it("test sub items selection", async () => {
+		const tabContainer = await browser.$("#tabContainerNestedTabs");
+		const item = tabContainer.shadow$$(".ui5-tab-strip-item")[3];
+
+		await browser.$("#tabContainerNestedTabs").scrollIntoView();
+		await item.click();
+		await browser.keys("ArrowDown");
+
+		const listItem = await browser.$$(">>>#tabContainerNestedTabs [ui5-li-custom]")[3];
+
+		assert.notOk(await listItem.getProperty("selected"), "tab is not selected");
+		await listItem.click();
+
+		await browser.keys("Escape");
+		await browser.keys("ArrowDown");
+
+		assert.ok(await listItem.getProperty("selected"), "tab is selected");
+	});
 });
 
 describe("TabContainer keyboard handling", () => {


### PR DESCRIPTION
Selected sub item was read as “not selected” by screen readers.