### PR TITLE
fix(ui5-table): correct load-more event on mode change

### DIFF
--- a/packages/compat/src/Table.ts
+++ b/packages/compat/src/Table.ts
@@ -931,6 +931,7 @@ class Table extends UI5Element {
 	onInvalidation(change: ChangeInfo) {
 		if (change.type === "property" && change.name === "growing") {
 			this.tableEndObserved = false;
+			this.getIntersectionObserver().disconnect();
 		}
 	}
 

--- a/packages/compat/src/Table.ts
+++ b/packages/compat/src/Table.ts
@@ -1,4 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import type { ChangeInfo } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
@@ -925,6 +926,12 @@ class Table extends UI5Element {
 			this._onLoadMoreClick();
 		}
 		this._loadMoreActive = false;
+	}
+
+	onInvalidation(change: ChangeInfo) {
+		if (change.type === "property" && change.name === "growing") {
+			this.tableEndObserved = false;
+		}
 	}
 
 	_onLoadMoreClick() {


### PR DESCRIPTION
If the `ui5-table` is made with `mode=Growing`, and then the mode is changed to `None` and back to `Growing`, the `load-more` event is not fired anymore. This is because the observed element by IntersectionObserver is not in the DOM anymore because it is conditionally rendered. To fix this, we reset the `tableEndObserved` flag when the mode changes, so the observed element is set again correctly when the DOM is ready.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/8052