### PR TITLE
fix(ui5-table): correct announced row count

### DIFF
--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -101,7 +101,7 @@
 {{/inline}}
 
 {{#*inline "tableEndRow"}}
-	<tr tabindex="-1" class="ui5-table-end-row">
+	<tr tabindex="-1" aria-hidden="true" class="ui5-table-end-row">
 		<td tabindex="-1">
 			<span tabindex="-1" aria-hidden="true" class="ui5-table-end-marker"></span>
 		</td>


### PR DESCRIPTION
Table row added for loading more functionality was read out by the screen readers. With this PR, the row is excluded from the accessibility tree.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/9243