### PR TITLE
fix(ui5-toolbar): prevent child events bubble

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -498,6 +498,7 @@ class Toolbar extends UI5Element {
 	}
 
 	onInteract(e: CustomEvent) {
+		e.stopImmediatePropagation();
 		const target = e.target as HTMLElement;
 		const item = target.closest<ToolbarItem>(".ui5-tb-item") || target.closest<ToolbarItem>(".ui5-tb-popover-item");
 

--- a/packages/main/test/pages/Toolbar.html
+++ b/packages/main/test/pages/Toolbar.html
@@ -15,13 +15,14 @@
 	<div id="toolbars-container">
 		<ui5-title level="H3">Basic</ui5-title>
 		<br /><br />
-		<ui5-toolbar>
-			<ui5-toolbar-button icon="add" text="Left 1 (long)"></ui5-toolbar-button>
-			<ui5-toolbar-button icon="decline" text="Left 2"></ui5-toolbar-button>
+		<ui5-toolbar id="clickCountToolbar">
+			<ui5-toolbar-button icon="add" text="Left 1 (long)" id="clickCounter"></ui5-toolbar-button>
+			<ui5-toolbar-button icon="decline" text="Left 2" id="clearCounter"></ui5-toolbar-button>
 			<ui5-toolbar-button icon="employee" text="Left 3"></ui5-toolbar-button>
 			<ui5-toolbar-separator></ui5-toolbar-separator>
 			<ui5-toolbar-button icon="decline" text="Left 4"></ui5-toolbar-button>
 		</ui5-toolbar>
+		<ui5-input id="input" value="0"></ui5-input>
 
 		<br /><br />
 
@@ -288,6 +289,7 @@
 		const items = document.querySelectorAll("ui5-toolbar-button");
 		const select = document.getElementById("toolbar-select");
 		const toolbarSlider = document.getElementById("toolbarSlider");
+		const input = document.getElementById("input");
 
 		items.forEach(item => {
 			item.addEventListener("ui5-click", e => {
@@ -305,6 +307,15 @@
 
 		select.addEventListener("ui5-close", e => {
 			console.log("Closed", e);
+		});
+
+		document.querySelector('body').addEventListener('click', (e) => {
+			if (e.target.id === "clearCounter") {
+				input.setAttribute("value", "0");
+			} else  {
+				let clickCounter = parseInt(input.getAttribute("value"));
+				input.setAttribute("value", `${++clickCounter}`);
+			}
 		});
 
 		toolbarSlider.addEventListener("input", e => {

--- a/packages/main/test/specs/Toolbar.spec.js
+++ b/packages/main/test/specs/Toolbar.spec.js
@@ -61,4 +61,18 @@ describe("Toolbar general interaction", () => {
 		assert.strictEqual(await popover.getProperty("open"), true, "Popover is opened");
 	});
 
+	it("Should call child events only once", async () => {
+		const toolbar = await browser.$("#clickCountToolbar");
+		const countButton = await toolbar.shadow$("#clickCounter");
+		const clearButton = await toolbar.shadow$("#clearCounter");
+		const input = await browser.$("#input");
+
+		await clearButton.click();
+		await countButton.click();
+
+		assert.strictEqual(await input.getProperty("value"), "1", "Button click event only called once");
+		await clearButton.click();
+	});
+
+
 });


### PR DESCRIPTION
Prevent child controls of the ui5-toolbar`s events from bubbling.

Fixes: #9444 