### PR TITLE
feat: enhance feature initialization

### DIFF
--- a/packages/base/src/FeaturesRegistry.ts
+++ b/packages/base/src/FeaturesRegistry.ts
@@ -39,7 +39,7 @@ const getComponentFeature = <T>(name: string): T => {
 
 const subscribeForFeatureLoad = (name: string, klass: typeof UI5Element, callback: () => void) => {
 	const subscriber = subscribers.get(klass);
-	const isSubscribed = subscriber?.includes(name)
+	const isSubscribed = subscriber?.includes(name);
 
 	if (isSubscribed) {
 		return;

--- a/packages/base/src/FeaturesRegistry.ts
+++ b/packages/base/src/FeaturesRegistry.ts
@@ -1,4 +1,20 @@
+import EventProvider from "./EventProvider";
+import type UI5Element from "./UI5Element";
+
+abstract class ComponentFeature {
+	constructor(...args: any[]) {}
+	static define?: () => Promise<void>;
+	static dependencies?: Array<typeof UI5Element>
+}
+
 const features = new Map<string, any>();
+const componentFeatures = new Map<string, ComponentFeature>();
+const subscribers = new WeakSet<typeof UI5Element>();
+
+const EVENT_NAME = "componentFeatureLoad";
+const eventProvider = new EventProvider<undefined, void>();
+
+const featureLoadEventName = (name: string) => `${EVENT_NAME}_${name}`;
 
 const registerFeature = (name: string, feature: object) => {
 	features.set(name, feature);
@@ -8,7 +24,49 @@ const getFeature = <T>(name: string): T => {
 	return features.get(name) as T;
 };
 
+const registerComponentFeature = async (name: string, feature: typeof ComponentFeature) => {
+	console.log("registerComponentFeature1")
+	await Promise.all(feature.dependencies?.map(dep => dep.define()) || []);
+	await feature.define?.();
+
+	console.log("registerComponentFeature2")
+
+	componentFeatures.set(name, feature);
+
+	console.log("registerComponentFeature3")
+
+	notifyForFeatureLoad(name);
+};
+
+const getComponentFeature = <T>(name: string): T => {
+	return componentFeatures.get(name) as T;
+};
+
+const subscribeForFeatureLoad = (name: string, klass: typeof UI5Element) => {
+	let isSubscribed = subscribers.has(klass);
+
+	if (isSubscribed) {
+		return;
+	}
+
+	subscribers.add(klass);
+
+	eventProvider.attachEvent(featureLoadEventName(name),() => {
+		console.log(featureLoadEventName(name))
+		klass.cacheUniqueDependencies();
+		debugger
+	})
+}
+
+const notifyForFeatureLoad = (name: string) => {
+	eventProvider.fireEvent(featureLoadEventName(name), undefined)
+}
+
 export {
 	registerFeature,
 	getFeature,
+	registerComponentFeature,
+	getComponentFeature,
+	subscribeForFeatureLoad,
+	ComponentFeature
 };

--- a/packages/base/src/FeaturesRegistry.ts
+++ b/packages/base/src/FeaturesRegistry.ts
@@ -1,7 +1,8 @@
-import EventProvider from "./EventProvider";
-import type UI5Element from "./UI5Element";
+import EventProvider from "./EventProvider.js";
+import type UI5Element from "./UI5Element.js";
 
 abstract class ComponentFeature {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-empty-function
 	constructor(...args: any[]) {}
 	static define?: () => Promise<void>;
 	static dependencies?: Array<typeof UI5Element>
@@ -25,16 +26,10 @@ const getFeature = <T>(name: string): T => {
 };
 
 const registerComponentFeature = async (name: string, feature: typeof ComponentFeature) => {
-	console.log("registerComponentFeature1")
 	await Promise.all(feature.dependencies?.map(dep => dep.define()) || []);
 	await feature.define?.();
 
-	console.log("registerComponentFeature2")
-
 	componentFeatures.set(name, feature);
-
-	console.log("registerComponentFeature3")
-
 	notifyForFeatureLoad(name);
 };
 
@@ -43,7 +38,7 @@ const getComponentFeature = <T>(name: string): T => {
 };
 
 const subscribeForFeatureLoad = (name: string, klass: typeof UI5Element) => {
-	let isSubscribed = subscribers.has(klass);
+	const isSubscribed = subscribers.has(klass);
 
 	if (isSubscribed) {
 		return;
@@ -51,16 +46,14 @@ const subscribeForFeatureLoad = (name: string, klass: typeof UI5Element) => {
 
 	subscribers.add(klass);
 
-	eventProvider.attachEvent(featureLoadEventName(name),() => {
-		console.log(featureLoadEventName(name))
+	eventProvider.attachEvent(featureLoadEventName(name), () => {
 		klass.cacheUniqueDependencies();
-		debugger
-	})
-}
+	});
+};
 
 const notifyForFeatureLoad = (name: string) => {
-	eventProvider.fireEvent(featureLoadEventName(name), undefined)
-}
+	eventProvider.fireEvent(featureLoadEventName(name), undefined);
+};
 
 export {
 	registerFeature,
@@ -68,5 +61,5 @@ export {
 	registerComponentFeature,
 	getComponentFeature,
 	subscribeForFeatureLoad,
-	ComponentFeature
+	ComponentFeature,
 };

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -37,6 +37,7 @@ import type {
 } from "./types.js";
 import { attachFormElementInternals, setFormValue } from "./features/InputElementsFormSupport.js";
 import type { IFormInputElement } from "./features/InputElementsFormSupport.js";
+import { subscribeForFeatureLoad } from "./FeaturesRegistry.js";
 
 const DEV_MODE = true;
 let autoId = 0;
@@ -1215,6 +1216,12 @@ abstract class UI5Element extends HTMLElement {
 		]);
 
 		const tag = this.getMetadata().getTag();
+
+		const features = this.getMetadata().getFeatures();
+
+		features.forEach(feature => {
+			subscribeForFeatureLoad(feature, this, this.cacheUniqueDependencies.bind(this))
+		})
 
 		const definedLocally = isTagRegistered(tag);
 		const definedGlobally = customElements.get(tag);

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1168,6 +1168,11 @@ abstract class UI5Element extends HTMLElement {
 		return [];
 	}
 
+	static cacheUniqueDependencies(this: typeof UI5Element): void {
+		const filtered = this.dependencies.filter((dep, index, deps) => deps.indexOf(dep) === index);
+		uniqueDependenciesCache.set(this, filtered);
+	}
+
 	/**
 	 * Returns a list of the unique dependencies for this UI5 Web Component
 	 *
@@ -1175,8 +1180,7 @@ abstract class UI5Element extends HTMLElement {
 	 */
 	static getUniqueDependencies(this: typeof UI5Element): Array<typeof UI5Element> {
 		if (!uniqueDependenciesCache.has(this)) {
-			const filtered = this.dependencies.filter((dep, index, deps) => deps.indexOf(dep) === index);
-			uniqueDependenciesCache.set(this, filtered);
+			this.cacheUniqueDependencies()
 		}
 
 		return uniqueDependenciesCache.get(this) || [];

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1180,7 +1180,7 @@ abstract class UI5Element extends HTMLElement {
 	 */
 	static getUniqueDependencies(this: typeof UI5Element): Array<typeof UI5Element> {
 		if (!uniqueDependenciesCache.has(this)) {
-			this.cacheUniqueDependencies()
+			this.cacheUniqueDependencies();
 		}
 
 		return uniqueDependenciesCache.get(this) || [];

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1220,8 +1220,8 @@ abstract class UI5Element extends HTMLElement {
 		const features = this.getMetadata().getFeatures();
 
 		features.forEach(feature => {
-			subscribeForFeatureLoad(feature, this, this.cacheUniqueDependencies.bind(this))
-		})
+			subscribeForFeatureLoad(feature, this, this.cacheUniqueDependencies.bind(this));
+		});
 
 		const definedLocally = isTagRegistered(tag);
 		const definedGlobally = customElements.get(tag);

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -41,6 +41,7 @@ type Metadata = {
 	languageAware?: boolean,
 	formAssociated?: boolean,
 	shadowRootOptions?: Partial<ShadowRootInit>
+	features?: Array<string>
 };
 
 type State = Record<string, PropertyValue | Array<SlotValue>>;
@@ -94,6 +95,14 @@ class UI5ElementMetadata {
 	 */
 	getPureTag(): string {
 		return this.metadata.tag || "";
+	}
+
+	/**
+	 * Returns the tag of the UI5 Element without the scope
+	 * @private
+	 */
+	getFeatures(): Array<string> {
+		return this.metadata.features || [];
 	}
 
 	/**

--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -40,7 +40,7 @@ const customElement = (tagNameOrComponentSettings: string | {
 			fastNavigation,
 			formAssociated,
 			shadowRootOptions,
-			features
+			features,
 		 } = tagNameOrComponentSettings;
 
 		target.metadata.tag = tag;
@@ -49,9 +49,9 @@ const customElement = (tagNameOrComponentSettings: string | {
 		}
 
 		if (features) {
-			features.forEach((feature) => {
-				subscribeForFeatureLoad(feature, target)
-			})
+			features.forEach(feature => {
+				subscribeForFeatureLoad(feature, target as typeof UI5Element);
+			});
 		}
 
 		if (themeAware) {

--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -2,6 +2,7 @@ import type UI5Element from "../UI5Element.js";
 import type { Renderer } from "../UI5Element.js";
 import type { TemplateFunction as Template } from "../renderer/executeTemplate.js";
 import type { ComponentStylesData as Styles } from "../types.js";
+import { subscribeForFeatureLoad } from "../FeaturesRegistry.js";
 
 /**
  * Returns a custom element class decorator.
@@ -20,6 +21,7 @@ const customElement = (tagNameOrComponentSettings: string | {
 	fastNavigation?: boolean,
 	formAssociated?: boolean,
 	shadowRootOptions?: Partial<ShadowRootInit>,
+	features?: Array<string>,
 } = {}): ClassDecorator => {
 	return (target: any) => {
 		if (!Object.prototype.hasOwnProperty.call(target, "metadata")) {
@@ -38,12 +40,20 @@ const customElement = (tagNameOrComponentSettings: string | {
 			fastNavigation,
 			formAssociated,
 			shadowRootOptions,
+			features
 		 } = tagNameOrComponentSettings;
 
 		target.metadata.tag = tag;
 		if (languageAware) {
 			target.metadata.languageAware = languageAware;
 		}
+
+		if (features) {
+			features.forEach((feature) => {
+				subscribeForFeatureLoad(feature, target)
+			})
+		}
+
 		if (themeAware) {
 			target.metadata.themeAware = themeAware;
 		}

--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -2,7 +2,6 @@ import type UI5Element from "../UI5Element.js";
 import type { Renderer } from "../UI5Element.js";
 import type { TemplateFunction as Template } from "../renderer/executeTemplate.js";
 import type { ComponentStylesData as Styles } from "../types.js";
-import { subscribeForFeatureLoad } from "../FeaturesRegistry.js";
 
 /**
  * Returns a custom element class decorator.
@@ -49,9 +48,7 @@ const customElement = (tagNameOrComponentSettings: string | {
 		}
 
 		if (features) {
-			features.forEach(feature => {
-				subscribeForFeatureLoad(feature, target as typeof UI5Element);
-			});
+			target.metadata.features = features;
 		}
 
 		if (themeAware) {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -17,7 +17,7 @@ import {
 	isUp,
 	isTabNext,
 } from "@ui5/webcomponents-base/dist/Keys.js";
-import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { getComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import ColorPaletteTemplate from "./generated/templates/ColorPaletteTemplate.lit.js";
 import ColorPaletteItem from "./ColorPaletteItem.js";
 import Button from "./Button.js";
@@ -73,10 +73,11 @@ type ColorPaletteItemClickEventDetail = {
 @customElement({
 	tag: "ui5-color-palette",
 	renderer: litRender,
+	features: ["ColorPaletteMoreColors"],
 	template: ColorPaletteTemplate,
 	styles: [ColorPaletteCss, ColorPaletteDialogCss],
 	get dependencies() {
-		const colorPaletteMoreColors = getFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
+		const colorPaletteMoreColors = getComponentFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
 		return ([ColorPaletteItem, Button] as Array<typeof UI5Element>).concat(colorPaletteMoreColors ? colorPaletteMoreColors.dependencies : []);
 	},
 })
@@ -172,19 +173,14 @@ class ColorPalette extends UI5Element {
 	_itemNavigation: ItemNavigation;
 	_itemNavigationRecentColors: ItemNavigation;
 	_recentColors: Array<string>;
-	moreColorsFeature: ColorPaletteMoreColors | Record<string, any> = {};
+	moreColorsFeature?: ColorPaletteMoreColors;
 	_currentlySelected?: ColorPaletteItem;
 	_shouldFocusRecentColors = false;
 
 	static i18nBundle: I18nBundle;
 
 	static async onDefine() {
-		const colorPaletteMoreColors = getFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
-
-		[ColorPalette.i18nBundle] = await Promise.all([
-			getI18nBundle("@ui5/webcomponents"),
-			colorPaletteMoreColors ? colorPaletteMoreColors.init() : Promise.resolve(),
-		]);
+		ColorPalette.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 
 	constructor() {
@@ -218,15 +214,18 @@ class ColorPalette extends UI5Element {
 		});
 
 		if (this.showMoreColors) {
-			const ColorPaletteMoreColorsClass = getFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
+			const ColorPaletteMoreColorsClass = getComponentFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
 			if (ColorPaletteMoreColorsClass) {
+				console.trace("onBeforeRendering")
 				this.moreColorsFeature = new ColorPaletteMoreColorsClass();
-			} else {
-				throw new Error(`You have to import "@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js" module to use the more-colors functionality.`);
 			}
 		}
 
 		this.onPhone = isPhone();
+	}
+
+	get _effectiveShowMoreColors() {
+		return !!(this.showMoreColors && this.moreColorsFeature)
 	}
 
 	onAfterRendering() {
@@ -526,6 +525,18 @@ class ColorPalette extends UI5Element {
 
 	get allColorsInPalette() {
 		return [...this.effectiveColorItems, ...this.recentColorsElements];
+	}
+
+	get colorPaletteDialogTitle() {
+		return this.moreColorsFeature?.colorPaletteDialogTitle
+	}
+
+	get colorPaletteDialogOKButton() {
+		return this.moreColorsFeature?.colorPaletteDialogOKButton
+	}
+
+	get colorPaletteCancelButton() {
+		return this.moreColorsFeature?.colorPaletteCancelButton
 	}
 
 	/**

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -216,7 +216,6 @@ class ColorPalette extends UI5Element {
 		if (this.showMoreColors) {
 			const ColorPaletteMoreColorsClass = getComponentFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
 			if (ColorPaletteMoreColorsClass) {
-				console.trace("onBeforeRendering")
 				this.moreColorsFeature = new ColorPaletteMoreColorsClass();
 			}
 		}
@@ -225,7 +224,7 @@ class ColorPalette extends UI5Element {
 	}
 
 	get _effectiveShowMoreColors() {
-		return !!(this.showMoreColors && this.moreColorsFeature)
+		return !!(this.showMoreColors && this.moreColorsFeature);
 	}
 
 	onAfterRendering() {
@@ -528,15 +527,15 @@ class ColorPalette extends UI5Element {
 	}
 
 	get colorPaletteDialogTitle() {
-		return this.moreColorsFeature?.colorPaletteDialogTitle
+		return this.moreColorsFeature?.colorPaletteDialogTitle;
 	}
 
 	get colorPaletteDialogOKButton() {
-		return this.moreColorsFeature?.colorPaletteDialogOKButton
+		return this.moreColorsFeature?.colorPaletteDialogOKButton;
 	}
 
 	get colorPaletteCancelButton() {
-		return this.moreColorsFeature?.colorPaletteCancelButton
+		return this.moreColorsFeature?.colorPaletteCancelButton;
 	}
 
 	/**

--- a/packages/main/src/ColorPaletteDialog.hbs
+++ b/packages/main/src/ColorPaletteDialog.hbs
@@ -1,20 +1,20 @@
-{{#if _showMoreColors}}
-<ui5-dialog
-    header-text="{{moreColorsFeature.colorPaletteDialogTitle}}"
->
-    <div class="ui5-cp-dialog-content">
-        <ui5-color-picker></ui5-color-picker>
-    </div>
+{{#if _effectiveShowMoreColors}}
+    <ui5-dialog
+        header-text="{{colorPaletteDialogTitle}}"
+    >
+        <div class="ui5-cp-dialog-content">
+            <ui5-color-picker></ui5-color-picker>
+        </div>
 
-    <div slot="footer" class="ui5-cp-dialog-footer">
-        <ui5-button
-            design="Emphasized"
-            @click="{{_chooseCustomColor}}"
-        >{{moreColorsFeature.colorPaletteDialogOKButton}}</ui5-button>
-        <ui5-button
-            design="Transparent"
-            @click="{{_closeDialog}}"
-        >{{moreColorsFeature.colorPaletteCancelButton}}</ui5-button>
-    </div>
-</ui5-dialog>
+        <div slot="footer" class="ui5-cp-dialog-footer">
+            <ui5-button
+                design="Emphasized"
+                @click="{{_chooseCustomColor}}"
+            >{{colorPaletteDialogOKButton}}</ui5-button>
+            <ui5-button
+                design="Transparent"
+                @click="{{_closeDialog}}"
+            >{{colorPaletteCancelButton}}</ui5-button>
+        </div>
+    </ui5-dialog>
 {{/if}}

--- a/packages/main/src/Input.hbs
+++ b/packages/main/src/Input.hbs
@@ -59,7 +59,7 @@
 
 		{{> postContent }}
 
-		{{#if showSuggestions}}
+		{{#if _effectiveShowSuggestions}}
 			<span id="suggestionsText" class="ui5-hidden-text">{{suggestionsText}}</span>
 			<span id="selectionText" class="ui5-hidden-text" aria-live="polite" role="status"></span>
 			<span id="suggestionsCount" class="ui5-hidden-text" aria-live="polite">{{availableSuggestionsCount}}</span>

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -16,7 +16,7 @@ import {
 	isAndroid,
 } from "@ui5/webcomponents-base/dist/Device.js";
 import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
-import { getFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { getComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import {
 	isUp,
 	isDown,
@@ -51,7 +51,7 @@ import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import "@ui5/webcomponents-icons/dist/information.js";
 import type SuggestionItem from "./SuggestionItem.js";
 import type { SuggestionComponent } from "./features/InputSuggestions.js";
-import type InputSuggestions from "./features/InputSuggestions.js";
+import InputSuggestions from "./features/InputSuggestions.js";
 import type { PopupScrollEventDetail } from "./Popup.js";
 import InputType from "./types/InputType.js";
 import Popover from "./Popover.js";
@@ -200,8 +200,9 @@ type InputSuggestionScrollEventDetail = {
 		ValueStateMessageCss,
 		SuggestionsCss,
 	],
+	features: ["InputSuggestions"],
 	get dependencies() {
-		const Suggestions = getFeature<typeof InputSuggestions>("InputSuggestions");
+		const Suggestions = getComponentFeature<typeof InputSuggestions>("InputSuggestions");
 		return ([Popover, ResponsivePopover, Icon] as Array<typeof UI5Element>).concat(Suggestions ? Suggestions.dependencies : []);
 	},
 })
@@ -569,6 +570,10 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 		return Input.i18nBundle.getText(FORM_TEXTFIELD_REQUIRED);
 	}
 
+	get _effectiveShowSuggestions() {
+		return !!(this.showSuggestions && this.Suggestions);
+	}
+
 	get formValidity(): ValidityStateFlags {
 		return { valueMissing: this.required && !this.value };
 	}
@@ -700,7 +705,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	onAfterRendering() {
 		const innerInput = this.getInputDOMRefSync()!;
 
-		if (this.Suggestions && this.showSuggestions && this.Suggestions._getPicker()) {
+		if (this.showSuggestions && this.Suggestions?._getPicker()) {
 			this._listWidth = this.Suggestions._getListWidth();
 		}
 
@@ -782,13 +787,13 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	_handleUp(e: KeyboardEvent) {
-		if (this.Suggestions && this.Suggestions.isOpened()) {
+		if (this.Suggestions?.isOpened()) {
 			this.Suggestions.onUp(e);
 		}
 	}
 
 	_handleDown(e: KeyboardEvent) {
-		if (this.Suggestions && this.Suggestions.isOpened()) {
+		if (this.Suggestions?.isOpened()) {
 			this.Suggestions.onDown(e);
 		}
 	}
@@ -807,7 +812,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_handleEnter(e: KeyboardEvent) {
 		// if a group item is focused, this is false
-		const suggestionItemPressed = !!(this.Suggestions && this.Suggestions.onEnter(e));
+		const suggestionItemPressed = !!(this.Suggestions?.onEnter(e));
 		const innerInput = this.getInputDOMRefSync()!;
 		const matchingItem = this._selectableItems.find(item => {
 			return item.text === this.value;
@@ -843,7 +848,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_handlePageUp(e: KeyboardEvent) {
 		if (this._isSuggestionsFocused) {
-			this.Suggestions!.onPageUp(e);
+			this.Suggestions?.onPageUp(e);
 		} else {
 			e.preventDefault();
 		}
@@ -851,7 +856,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_handlePageDown(e: KeyboardEvent) {
 		if (this._isSuggestionsFocused) {
-			this.Suggestions!.onPageDown(e);
+			this.Suggestions?.onPageDown(e);
 		} else {
 			e.preventDefault();
 		}
@@ -859,13 +864,13 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_handleHome(e: KeyboardEvent) {
 		if (this._isSuggestionsFocused) {
-			this.Suggestions!.onHome(e);
+			this.Suggestions?.onHome(e);
 		}
 	}
 
 	_handleEnd(e: KeyboardEvent) {
 		if (this._isSuggestionsFocused) {
-			this.Suggestions!.onEnd(e);
+			this.Suggestions?.onEnd(e);
 		}
 	}
 
@@ -882,7 +887,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 			return;
 		}
 
-		if (isOpen && this.Suggestions!._isItemOnTarget()) {
+		if (isOpen && this.Suggestions?._isItemOnTarget()) {
 			// Restore the value.
 			this.value = this.typedInValue || this.valueBeforeSelectionStart;
 
@@ -953,8 +958,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 		this._isValueStateFocused = false;
 		this.hasSuggestionItemSelected = false;
 
-		this.Suggestions._deselectItems();
-		this.Suggestions._clearItemFocus();
+		this.Suggestions?._deselectItems();
+		this.Suggestions?._clearItemFocus();
 	}
 
 	_click() {
@@ -1194,12 +1199,9 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 			return;
 		}
 
-		const Suggestions = getFeature<typeof InputSuggestions>("InputSuggestions");
-
+		const Suggestions = getComponentFeature<typeof InputSuggestions>("InputSuggestions");
 		if (Suggestions) {
 			this.Suggestions = new Suggestions(this, "suggestionItems", true, false);
-		} else {
-			throw new Error(`You have to import "@ui5/webcomponents/dist/features/InputSuggestions.js" module to use ui5-input suggestions`);
 		}
 	}
 
@@ -1315,7 +1317,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 			return Promise.resolve(false);
 		}
 
-		return this.Suggestions._isScrollable();
+		return this.Suggestions?._isScrollable();
 	}
 
 	onItemMouseDown(e: MouseEvent) {
@@ -1545,7 +1547,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	get availableSuggestionsCount() {
-		if (this.showSuggestions && (this.value || this.Suggestions!.isOpened())) {
+		if (this.showSuggestions && (this.value || this.Suggestions?.isOpened())) {
 			const nonGroupItems = this._selectableItems;
 
 			switch (nonGroupItems.length) {
@@ -1572,7 +1574,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	get _isSuggestionsFocused() {
-		return !this.focused && this.Suggestions && this.Suggestions.isOpened();
+		return !this.focused && this.Suggestions?.isOpened();
 	}
 
 	/**
@@ -1655,12 +1657,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	static async onDefine() {
-		const Suggestions = getFeature<typeof InputSuggestions>("InputSuggestions");
-
-		[Input.i18nBundle] = await Promise.all([
-			getI18nBundle("@ui5/webcomponents"),
-			Suggestions ? Suggestions.init() : Promise.resolve(),
-		]);
+		Input.i18nBundle = await getI18nBundle("@ui5/webcomponents")
 	}
 }
 

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -51,7 +51,7 @@ import "@ui5/webcomponents-icons/dist/sys-enter-2.js";
 import "@ui5/webcomponents-icons/dist/information.js";
 import type SuggestionItem from "./SuggestionItem.js";
 import type { SuggestionComponent } from "./features/InputSuggestions.js";
-import InputSuggestions from "./features/InputSuggestions.js";
+import type InputSuggestions from "./features/InputSuggestions.js";
 import type { PopupScrollEventDetail } from "./Popup.js";
 import InputType from "./types/InputType.js";
 import Popover from "./Popover.js";
@@ -1657,7 +1657,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	static async onDefine() {
-		Input.i18nBundle = await getI18nBundle("@ui5/webcomponents")
+		Input.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 }
 

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -1,4 +1,4 @@
-{{#if showSuggestions}}
+{{#if _effectiveShowSuggestions}}
 	<ui5-responsive-popover
 		class="{{classes.popover}}"
 		hide-arrow

--- a/packages/main/src/features/ColorPaletteMoreColors.ts
+++ b/packages/main/src/features/ColorPaletteMoreColors.ts
@@ -1,4 +1,4 @@
-import { registerFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { ComponentFeature, registerComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 
@@ -12,7 +12,7 @@ import {
 	COLOR_PALETTE_DIALOG_TITLE,
 } from "../generated/i18n/i18n-defaults.js";
 
-class ColorPaletteMoreColors {
+class ColorPaletteMoreColors extends ComponentFeature {
 	static get dependencies() {
 		return [
 			Dialog,
@@ -23,7 +23,7 @@ class ColorPaletteMoreColors {
 
 	static i18nBundle: I18nBundle;
 
-	static async init() {
+	static async define() {
 		ColorPaletteMoreColors.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 
@@ -40,6 +40,6 @@ class ColorPaletteMoreColors {
 	}
 }
 
-registerFeature("ColorPaletteMoreColors", ColorPaletteMoreColors);
+registerComponentFeature("ColorPaletteMoreColors", ColorPaletteMoreColors);
 
 export default ColorPaletteMoreColors;

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -1,6 +1,5 @@
 import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import { registerComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
-import { ComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { ComponentFeature, registerComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import generateHighlightedMarkup from "@ui5/webcomponents-base/dist/util/generateHighlightedMarkup.js";

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -1,5 +1,6 @@
 import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import { registerFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { registerComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
+import { ComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegistry.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import generateHighlightedMarkup from "@ui5/webcomponents-base/dist/util/generateHighlightedMarkup.js";
@@ -45,7 +46,7 @@ type SuggestionsAccInfo = {
  * @class
  * @private
  */
-class Suggestions {
+class Suggestions extends ComponentFeature {
 	component: SuggestionComponent;
 	slotName: string;
 	handleFocus: boolean;
@@ -60,6 +61,7 @@ class Suggestions {
 	static SCROLL_STEP = 60;
 
 	constructor(component: SuggestionComponent, slotName: string, highlight: boolean, handleFocus: boolean) {
+		super();
 		// The component, that the suggestion would plug into.
 		this.component = component;
 
@@ -551,13 +553,13 @@ class Suggestions {
 		];
 	}
 
-	static async init() {
+	static async define() {
 		Suggestions.i18nBundle = await getI18nBundle("@ui5/webcomponents");
 	}
 }
 
 // Add suggestions support to the global features registry so that Input.js can use it
-registerFeature("InputSuggestions", Suggestions);
+registerComponentFeature("InputSuggestions", Suggestions);
 
 export default Suggestions;
 


### PR DESCRIPTION
Previously, feature loading depended on the import order, requiring features to be imported before the component definition. This caused issues in some situations, especially when creating chunks because the imports can be reordered by the build tools.

With this change, we have split the features into two types: library-specific and component-specific. Library-specific features need to be imported before the boot process, otherwise, it can cause serious issues, because the need to re-render all components and manipulate the DOM (including scripts, styles, and meta tags). Component-specific features can now be imported without a specific order, and components that depend on these features will automatically update, enabling the feature on the next rendering of the component.

Fixes: #8175