### PR TITLE
feat(framework): add configuration to prevent font loading

### DIFF
--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -16,6 +16,7 @@ There are several configuration settings that affect all UI5 Web Components glob
 | [noConflict](#noConflict)                     | `true`, `false`                                                                                                                                                                                                                                                                                | `false`               | When set to true, all events will be fired with a `ui5-` prefix only   | Components that fire events (most do)                          |
 | [formatSettings](#formatSettings)             | See the [Format settings](#formatSettings) section below                                                                                                                                                                                                                                       | `{}`                  | Allows to override locale-specific configuration                       | Date/time components (`ui5-date-picker`, etc.)                 |
 | [fetchDefaultLanguage](#fetchDefaultLanguage) | `true`, `false`                                                                                                                                                                                                                                                                                | `false`               | Whether to fetch assets even for the default language                  | Framework                                                      |
+| [fetchDefaultFontFaces](#fetchDefaultFontFaces) | `true`, `false`                                                                                                                                                                                                                                                                                | `true`               | Whether to fetch default font faces                  | Framework                                                      |
 | [timezone](#timezone)                         | `Asia/Tokyo`, `Pacific/Apia`, `Asia/Kolkata`, `Europe/Sofia` and etc.                                                                                                                                                                                                                          | Your local time zone. | Allows to override your local time zone.                               | Date/time components (`ui5-date-picker`, etc.)                 |
 | [themeRoot](#themeRoot)                       | String to a URL - see the [themeRoot](#themeRoot) section below                                                                                                                                                                                                                                | N/A                   | Allows to set a URL to a Theme-designer-created custom theme.          | All components                                                 |
 
@@ -217,6 +218,21 @@ Example:
 }
 </script>
 ```
+### fetchDefaultFontFaces
+<a name="fetchDefaultFontFaces"></a>
+Font faces used in the UI5 Web Components are fetched over the network.
+
+Normally, you would never want to change that setting, but if for technical reasons you prefer even the default font faces to be fetched
+over the network, then set `fetchDefaultFontFaces` this to `false`
+
+Example:
+```html
+<script data-ui5-config type="application/json">
+{
+	"fetchDefaultFontFaces": false
+}
+</script>
+```
 ### timezone
 <a name="timezone"></a>
 
@@ -273,7 +289,8 @@ Example:
 		"events": ["selection-change", "header-click"]
 	},
 	"fetchDefaultLanguage": true,
-	"timezone": "Europe/Sofia"
+	"timezone": "Europe/Sofia",
+	fetchDefaultFontFaces
 }
 </script>
 ```
@@ -325,6 +342,12 @@ import { getFirstDayOfWeek } from "@ui5/webcomponents-base/dist/config/FormatSet
 
 ```js
 import { getFetchDefaultLanguage, setFetchDefaultLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+```
+
+ - `fetchDefaultFontFaces`
+
+```js
+import { getFetchDefaultFontFaces, setFetchDefaultFontFaces } from "@ui5/webcomponents-base/dist/config/Fonts.js";
 ```
  - `timezone` - can only be set initially in the configuration script.
 

--- a/packages/base/src/FontFace.ts
+++ b/packages/base/src/FontFace.ts
@@ -3,12 +3,13 @@ import { getFeature } from "./FeaturesRegistry.js";
 import fontFaceCSS from "./generated/css/FontFace.css.js";
 import overrideFontFaceCSS from "./generated/css/OverrideFontFace.css.js";
 import type OpenUI5Support from "./features/OpenUI5Support.js";
+import { getFetchDefaultFontFaces } from "./config/Fonts.js";
 
 const insertFontFace = () => {
 	const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
 
 	// Only set the main font if there is no OpenUI5 support, or there is, but OpenUI5 is not loaded
-	if (!openUI5Support || !openUI5Support.isOpenUI5Detected()) {
+	if ((!openUI5Support || !openUI5Support.isOpenUI5Detected())) {
 		insertMainFontFace();
 	}
 
@@ -17,6 +18,10 @@ const insertFontFace = () => {
 };
 
 const insertMainFontFace = () => {
+	if (getFetchDefaultFontFaces()) {
+		return;
+	}
+
 	if (!hasStyle("data-ui5-font-face")) {
 		createStyle(fontFaceCSS, "data-ui5-font-face");
 	}

--- a/packages/base/src/InitialConfiguration.ts
+++ b/packages/base/src/InitialConfiguration.ts
@@ -21,6 +21,7 @@ type InitialConfig = {
 	noConflict: boolean,
 	formatSettings: FormatSettings,
 	fetchDefaultLanguage: boolean,
+	fetchDefaultFontFaces: boolean,
 };
 
 let initialConfig: InitialConfig = {
@@ -35,6 +36,7 @@ let initialConfig: InitialConfig = {
 	noConflict: false, // no URL
 	formatSettings: {},
 	fetchDefaultLanguage: false,
+	fetchDefaultFontFaces: true,
 };
 
 /* General settings */
@@ -71,6 +73,11 @@ const getFetchDefaultLanguage = () => {
 const getNoConflict = () => {
 	initConfiguration();
 	return initialConfig.noConflict;
+};
+
+const getFetchDefaultFontFaces = () => {
+	initConfiguration();
+	return initialConfig.fetchDefaultFontFaces;
 };
 
 /**
@@ -217,4 +224,5 @@ export {
 	getSecondaryCalendarType,
 	getTimezone,
 	getFormatSettings,
+	getFetchDefaultFontFaces,
 };

--- a/packages/base/src/config/Fonts.ts
+++ b/packages/base/src/config/Fonts.ts
@@ -1,0 +1,32 @@
+import { getFetchDefaultFontFaces as getConfiguredFetchDefaultFontFaces } from "../InitialConfiguration.js";
+
+let fetchDefaultFontFaces: boolean;
+
+/**
+ * Returns if the "fetchDefaultFontFaces" configuration is set.
+ * @public
+ * @returns { boolean }
+ */
+const getFetchDefaultFontFaces = (): boolean => {
+	if (fetchDefaultFontFaces === undefined) {
+		fetchDefaultFontFaces = getConfiguredFetchDefaultFontFaces();
+	}
+
+	return fetchDefaultFontFaces;
+};
+
+/**
+ * Sets the "fetchDefaultFontFaces".
+ * - When "true" (default value), all used font faces are fetched over the network
+ * - When "false", all used font faces are not fetch by default and need to be handled separately
+ * @public
+ * @param { fetchDefaultFontFaces } boolean
+ */
+const setFetchDefaultFontFaces = (fetchDefaultFontFacesData: boolean) => {
+	fetchDefaultFontFaces = fetchDefaultFontFacesData;
+};
+
+export {
+	getFetchDefaultFontFaces,
+	setFetchDefaultFontFaces,
+};


### PR DESCRIPTION
Previously, default fonts could be prevented from loading using a `<style>` tag with the `data-ui5-font-face` attribute. However, recent changes have standardized style additions using adopted stylesheets, which are widely supported by major browsers. This eliminates the need to check for the existence of style elements for validation purposes. Additionally, frameworks like Nuxt.js have raised concerns about empty attributes in these style elements, making the previous solution less optimal.

To address this, we have introduced the `fetchDefaultFontFaces` configuration option. This provides a more straightforward approach for users who wish to prevent the default font faces from loading and manage this process themselves.

Example usage:

```html
<script data-ui5-config type="application/json">
{
    "fetchDefaultFontFaces": false
}
</script>
```

Setting `"fetchDefaultFontFaces": false` will prevent the default font faces from being automatically loaded, allowing users to handle font loading according to their specific requirements.