### PR TITLE
fix(ui5-select): prevent unnecessary live-change event

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -570,14 +570,15 @@ class Select extends UI5Element implements IFormInputElement {
 	}
 
 	_select(index: number) {
+		const selectedIndex = this._selectedIndex;
 		if (index < 0 || index >= this.options.length || this.options.length === 0) {
 			return;
 		}
-		if (this.options[this._selectedIndex]) {
-			this.options[this._selectedIndex].selected = false;
+		if (this.options[selectedIndex]) {
+			this.options[selectedIndex].selected = false;
 		}
 
-		if (this._selectedIndex !== index) {
+		if (selectedIndex !== index) {
 			this.fireEvent<SelectLiveChangeEventDetail>("live-change", { selectedOption: this.options[index] });
 		}
 


### PR DESCRIPTION
When closing the select's popover with 'ESC' key without previously navigating through items, the 'ui5-live-change' is wrongly fired. This issue is now fixed.
