### PR TITLE
fix(ui5-multi-combobox, ui5-combobox, ui5-input): improve popup announcement

### DIFF
--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -49,6 +49,7 @@ import {
 	VALUE_STATE_TYPE_ERROR,
 	VALUE_STATE_TYPE_WARNING,
 	INPUT_SUGGESTIONS_TITLE,
+	COMBOBOX_AVAILABLE_OPTIONS,
 	SELECT_OPTIONS,
 	LIST_ITEM_POSITION,
 	LIST_ITEM_GROUP_HEADER,
@@ -1115,6 +1116,10 @@ class ComboBox extends UI5Element {
 
 	get _headerTitleText() {
 		return ComboBox.i18nBundle.getText(INPUT_SUGGESTIONS_TITLE);
+	}
+
+	get _popupLabel() {
+		return ComboBox.i18nBundle.getText(COMBOBOX_AVAILABLE_OPTIONS);
 	}
 
 	get _iconAccessibleNameText() {

--- a/packages/main/src/ComboBoxPopover.hbs
+++ b/packages/main/src/ComboBoxPopover.hbs
@@ -6,6 +6,7 @@
 	style="{{styles.suggestionsPopover}}"
 	@ui5-after-open={{_afterOpenPopover}}
 	@ui5-after-close={{_afterClosePopover}}
+	accessible-name="{{_popupLabel}}"
 >
 	<ui5-busy-indicator
 		?active={{loading}}

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -71,6 +71,7 @@ import {
 	VALUE_STATE_TYPE_INFORMATION,
 	VALUE_STATE_TYPE_ERROR,
 	VALUE_STATE_TYPE_WARNING,
+	INPUT_AVALIABLE_VALUES,
 	INPUT_SUGGESTIONS,
 	INPUT_SUGGESTIONS_TITLE,
 	INPUT_SUGGESTIONS_ONE_HIT,
@@ -1468,6 +1469,10 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 
 	get _headerTitleText() {
 		return Input.i18nBundle.getText(INPUT_SUGGESTIONS_TITLE);
+	}
+
+	get _popupLabel() {
+		return Input.i18nBundle.getText(INPUT_AVALIABLE_VALUES);
 	}
 
 	get clearIconAccessibleName() {

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -9,6 +9,7 @@
 		@ui5-after-open="{{_afterOpenPopover}}"
 		@ui5-after-close="{{_afterClosePopover}}"
 		@ui5-scroll="{{_scroll}}"
+		accessible-name="{{_popupLabel}}"
 	>
 	{{#if _isPhone}}
 		<div slot="header" class="ui5-responsive-popover-header">

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -86,6 +86,7 @@ import {
 	SELECT_OPTIONS,
 	SHOW_SELECTED_BUTTON,
 	MULTICOMBOBOX_DIALOG_OK_BUTTON,
+	COMBOBOX_AVAILABLE_OPTIONS,
 	VALUE_STATE_ERROR_ALREADY_SELECTED,
 	MCB_SELECTED_ITEMS,
 	INPUT_CLEAR_ICON_ACC_NAME,
@@ -1865,6 +1866,10 @@ class MultiComboBox extends UI5Element {
 
 	get _headerTitleText() {
 		return MultiComboBox.i18nBundle.getText(INPUT_SUGGESTIONS_TITLE);
+	}
+
+	get _popupLabel() {
+		return MultiComboBox.i18nBundle.getText(COMBOBOX_AVAILABLE_OPTIONS);
 	}
 
 	get _iconAccessibleNameText() {

--- a/packages/main/src/MultiComboBoxPopover.hbs
+++ b/packages/main/src/MultiComboBoxPopover.hbs
@@ -5,6 +5,7 @@
 	hide-arrow
 	_disable-initial-focus
 	style="{{styles.suggestionsPopover}}"
+	accessible-name="{{_popupLabel}}"
 	@ui5-selection-change={{_listSelectionChange}}
 	@ui5-after-close={{_afterClosePicker}}
 	@ui5-before-open={{_beforeOpen}}

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -259,6 +259,12 @@ MESSAGE_STRIP_INFORMATION=Information Bar
 #XFLD: MultiComboBox dialog button
 MULTICOMBOBOX_DIALOG_OK_BUTTON=OK
 
+#XACT: ARIA announcement for Combo Box and Multi Combo Box available options
+COMBOBOX_AVAILABLE_OPTIONS=Available Options
+
+#XACT: ARIA announcement for suggestions popup
+INPUT_AVALIABLE_VALUES=Available Values
+
 #XMSG: Text used for reporting that a radio button group requires one of the radio buttons to be checked
 RADIO_BUTTON_GROUP_REQUIRED=Select one of the available options.
 


### PR DESCRIPTION
When a header, nor a label is provided to an element with role dialog JAWS reads out the <title> element of the html document as a dialog header, once a dialog is opened/focused. In order to overcome this side effect and future announcemnt deviations the suggestion popover elements are now labelled following the existing pattern from UI5.

FIXES: https://github.com/SAP/ui5-webcomponents/issues/9116