### PR TITLE
chore(watch.templates): ignore src/generated

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -117,7 +117,7 @@ const getScripts = (options) => {
 				themes: 'nps "build.styles.themes -w"',
 				components: `nps "build.styles.components -w"`,
 			},
-			templates: 'chokidar "src/**/*.hbs" -c "nps build.templates"',
+			templates: 'chokidar "src/**/*.hbs" -i "src/generated" -c "nps build.templates"',
 			i18n: 'chokidar "src/i18n/messagebundle.properties" -c "nps build.i18n.defaultsjs"'
 		},
 		start: "nps prepare watch.devServer",


### PR DESCRIPTION
Ignore the "src/generated" folder, in order to avoid issue on Windows, where this `chokidar` process's memory consumption  grows drastically.

Related to https://github.com/SAP/ui5-webcomponents/issues/8824