### PR TITLE
chore: display tag / since information in playground

### DIFF
--- a/packages/website/build-scripts/api-reference-generation/component-file.mjs
+++ b/packages/website/build-scripts/api-reference-generation/component-file.mjs
@@ -317,7 +317,7 @@ const parseComponentDeclaration = (declaration, fileContent) => {
     let additionalInfo;
 
     if (declaration.customElement) {
-        additionalInfo = `\`${declaration.tagName}\``;
+        additionalInfo = `\`\<${declaration.tagName}\>\``;
     }
 
     if (declaration._ui5since) {

--- a/packages/website/build-scripts/api-reference-generation/component-file.mjs
+++ b/packages/website/build-scripts/api-reference-generation/component-file.mjs
@@ -314,6 +314,23 @@ const parseComponentDeclaration = (declaration, fileContent) => {
         return "";
     }
 
+    let additionalInfo;
+
+    if (declaration.customElement) {
+        additionalInfo = `\`${declaration.tagName}\``;
+    }
+
+    if (declaration._ui5since) {
+        additionalInfo = additionalInfo ? `${additionalInfo} | <span className="badge badge--primary">Since ${declaration._ui5since}</span>`
+        : `<span className="badge badge--primary">Since ${declaration._ui5since}</span>`;
+    }
+
+    if (additionalInfo) {
+        fileContent = fileContent.replace("<%COMPONENT_OVERVIEW%>", `<div className="componentAdditionalInfo">${additionalInfo}</div>
+
+<%COMPONENT_OVERVIEW%>`)
+    }
+
     if (declaration._ui5experimental) {
         fileContent = addExperimentalClassName(fileContent, declaration);
 

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -243,3 +243,8 @@ code {
   background: #334eff;
   pointer-events: none;
 }
+
+.componentAdditionalInfo {
+  margin-top: calc(-1 * calc(var(--ifm-h1-vertical-rhythm-bottom) * var(--ifm-leading))) !important;
+  margin-bottom: var(--ifm-leading);
+}


### PR DESCRIPTION
Display component tag name and since information in playgorund.

![image](https://github.com/user-attachments/assets/1c7be223-cf79-4138-b944-9d81b01857d9)

