### PR TITLE
fix(ui5-timepicker): fix error thrown upon selection from the clock

### DIFF
--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -222,7 +222,7 @@ class TimePickerClock extends UI5Element {
 	 * Keeps variables used in interaction calculations.
 	 */
 	@property({ type: Object })
-	_dimensionParameters!: TimePickerClockDimensions = {
+	_dimensionParameters: TimePickerClockDimensions = {
 		radius: 0,
 		centerX: 0,
 		centerY: 0,

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -234,7 +234,7 @@ class TimePickerClock extends UI5Element {
 		innerMin: 0,
 		offsetX: 0,
 		offsetY: 0,
-	};;
+	};
 
 	/**
 	 * Mousedown or Touchstart event flag.

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -222,7 +222,19 @@ class TimePickerClock extends UI5Element {
 	 * Keeps variables used in interaction calculations.
 	 */
 	@property({ type: Object })
-	_dimensionParameters!: TimePickerClockDimensions;
+	_dimensionParameters: TimePickerClockDimensions = {
+		radius: 0,
+		centerX: 0,
+		centerY: 0,
+		dotHeight: 0,
+		numberHeight: 0,
+		outerMax: 0,
+		outerMin: 0,
+		innerMax: 0,
+		innerMin: 0,
+		offsetX: 0,
+		offsetY: 0,
+	};;
 
 	/**
 	 * Mousedown or Touchstart event flag.
@@ -704,7 +716,7 @@ class TimePickerClock extends UI5Element {
 				this._movSelectedValue = 0 + this._selectedValue;
 			}
 		} else if (evt.type === "mousemove") {
-			if (!this._dimensionParameters) {
+			if (!this._dimensionParameters.radius) {
 				this._calculateDimensions();
 			}
 			this._calculatePosition((evt as MouseEvent).pageX, (evt as MouseEvent).pageY);

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -222,7 +222,7 @@ class TimePickerClock extends UI5Element {
 	 * Keeps variables used in interaction calculations.
 	 */
 	@property({ type: Object })
-	_dimensionParameters: TimePickerClockDimensions = {
+	_dimensionParameters!: TimePickerClockDimensions = {
 		radius: 0,
 		centerX: 0,
 		centerY: 0,

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -704,7 +704,7 @@ class TimePickerClock extends UI5Element {
 				this._movSelectedValue = 0 + this._selectedValue;
 			}
 		} else if (evt.type === "mousemove") {
-			if (!this._dimensionParameters.radius) {
+			if (!this._dimensionParameters) {
 				this._calculateDimensions();
 			}
 			this._calculatePosition((evt as MouseEvent).pageX, (evt as MouseEvent).pageY);


### PR DESCRIPTION
Previously when selecting a time from the clock there was an error being thrown due to a check in the `TimePickerClock` class.
The reason an error was thrown was due to a check if a `radius` property was absent from an internal object, which in some cases was yet `undefined`, therefore trying to access that property resulted in an error.

Fixes: #9531 
Fixes: #9579