### PR TITLE
docs: fix code completion color on dark

### DIFF
--- a/packages/website/docs/_samples/base/UI5Element/Basic/main.ts
+++ b/packages/website/docs/_samples/base/UI5Element/Basic/main.ts
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 

--- a/packages/website/src/components/Editor/examples/counter/main.js
+++ b/packages/website/src/components/Editor/examples/counter/main.js
@@ -1,6 +1,5 @@
 export default `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
-import Integer from "@ui5/webcomponents-base/dist/types/Integer.js";
 import { customElement, property } from "@ui5/webcomponents-base/dist/decorators.js";
 
 @customElement({

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -83,7 +83,8 @@
     --playground-code-selection-background: var(--sys-color-primary-transparent);
 }
 
-[data-theme='dark'] playground-file-editor {
+[data-theme='dark'] {
+  --playground-code-cursor-color: #fff;
   --playground-code-background: #212121;
   --playground-code-default-color: #eeffff;
   --playground-code-keyword-color: #c792ea;


### PR DESCRIPTION
Before
<img width="438" alt="Screenshot 2024-07-25 at 19 00 45" src="https://github.com/user-attachments/assets/c66aef43-776a-4411-aeeb-8cfe609d7395">
<img width="351" alt="Screenshot 2024-07-25 at 19 00 56" src="https://github.com/user-attachments/assets/3baa89fc-bf16-4b70-bb9e-082dbbe2604e">


After
<img width="515" alt="Screenshot 2024-07-25 at 19 00 09" src="https://github.com/user-attachments/assets/aca16a7c-3bcf-4142-9152-0cdb6d1dddcc">
<img width="372" alt="Screenshot 2024-07-25 at 18 59 59" src="https://github.com/user-attachments/assets/2fb65eb5-7b60-4972-959e-d7fd48ee12ce">

Fixes: https://github.com/SAP/ui5-webcomponents/issues/8777