### PR TITLE
fix(ui5-dynamic-page): fixed wrong overlapping in header area

### DIFF
--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -2,7 +2,7 @@
     position: sticky;
     top: 0;
      /* We need the z-index to be higher than in the header actions, to avoid overlapping by snap on scroll */
-    z-index: 2;
+    z-index: 3;
 }
 
 :host {

--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -2,7 +2,7 @@
     position: sticky;
     top: 0;
      /* We need the z-index to be higher than in the header actions, to avoid overlapping by snap on scroll */
-    z-index: 3;
+    z-index: 110;
 }
 
 :host {
@@ -45,7 +45,7 @@
     position: sticky;
     bottom: 0.5rem;
     box-sizing: border-box;
-    z-index: 1;
+    z-index: 110;
     opacity: 0;
     transform: translateY(100%);
     transition: opacity 0.35s ease-in-out, transform 0.35s ease-in-out;


### PR DESCRIPTION
There was a problem where the handle of the Slider components was overlapping over the Dynamic Page header area. This was due to equal z-index of both the handle and the Dynamic Page header wrapper.

This change increases the z-index of the header wrapper making sure that the handle of the slider is always rendered under it and not overlapping.

Fixes: #9560
