### PR TITLE
fix(ui5-menu): provide accessible name to the popover

### DIFF
--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -9,7 +9,7 @@
 	prevent-initial-focus
 	hide-arrow
 	allow-target-overlap
-	accessible-name={{menuAccessibleName}}
+	accessible-name={{acessibleNameText}}
 	@ui5-before-open={{_beforePopoverOpen}}
 	@ui5-open={{_afterPopoverOpen}}
 	@ui5-before-close={{_beforePopoverClose}}

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -9,6 +9,7 @@
 	prevent-initial-focus
 	hide-arrow
 	allow-target-overlap
+	accessible-name={{menuAccessibleName}}
 	@ui5-before-open={{_beforePopoverOpen}}
 	@ui5-open={{_afterPopoverOpen}}
 	@ui5-before-close={{_beforePopoverClose}}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -31,6 +31,7 @@ import type {
 import menuTemplate from "./generated/templates/MenuTemplate.lit.js";
 import {
 	MENU_CLOSE_BUTTON_ARIA_LABEL,
+	MENU_POPOVER_ACCESSIBLE_NAME,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -267,6 +268,10 @@ class Menu extends UI5Element {
 
 	get _menuItems() {
 		return this.items.filter((item): item is MenuItem => !item.isSeparator);
+	}
+
+	get menuAccessibleName() {
+		return Menu.i18nBundle.getText(MENU_POPOVER_ACCESSIBLE_NAME);
 	}
 
 	onBeforeRendering() {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -270,7 +270,7 @@ class Menu extends UI5Element {
 		return this.items.filter((item): item is MenuItem => !item.isSeparator);
 	}
 
-	get menuAccessibleName() {
+	get acessibleNameText() {
 		return Menu.i18nBundle.getText(MENU_POPOVER_ACCESSIBLE_NAME);
 	}
 

--- a/packages/main/src/MenuItem.hbs
+++ b/packages/main/src/MenuItem.hbs
@@ -52,6 +52,7 @@
 		sub-menu
 		placement={{placement}}
 		vertical-align="Top"
+		accessible-name={{menuAccessibleName}}
 		@ui5-before-open={{_beforePopoverOpen}}
 		@ui5-open={{_afterPopoverOpen}}
 		@ui5-before-close={{_beforePopoverClose}}

--- a/packages/main/src/MenuItem.hbs
+++ b/packages/main/src/MenuItem.hbs
@@ -52,7 +52,7 @@
 		sub-menu
 		placement={{placement}}
 		vertical-align="Top"
-		accessible-name={{menuAccessibleName}}
+		accessible-name={{acessibleNameText}}
 		@ui5-before-open={{_beforePopoverOpen}}
 		@ui5-open={{_afterPopoverOpen}}
 		@ui5-before-close={{_beforePopoverClose}}

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -17,6 +17,7 @@ import MenuItemTemplate from "./generated/templates/MenuItemTemplate.lit.js";
 import {
 	MENU_BACK_BUTTON_ARIA_LABEL,
 	MENU_CLOSE_BUTTON_ARIA_LABEL,
+	MENU_POPOVER_ACCESSIBLE_NAME,
 } from "./generated/i18n/i18n-defaults.js";
 import type { ResponsivePopoverBeforeCloseEventDetail } from "./ResponsivePopover.js";
 import type { IMenuItem } from "./Menu.js";
@@ -226,6 +227,10 @@ class MenuItem extends ListItem implements IMenuItem {
 
 	get ariaLabelledByText() {
 		return `${this.text} ${this.accessibleName}`.trim();
+	}
+
+	get menuAccessibleName() {
+		return MenuItem.i18nBundle.getText(MENU_POPOVER_ACCESSIBLE_NAME);
 	}
 
 	get menuHeaderTextPhone() {

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -229,10 +229,6 @@ class MenuItem extends ListItem implements IMenuItem {
 		return `${this.text} ${this.accessibleName}`.trim();
 	}
 
-	get menuAccessibleName() {
-		return MenuItem.i18nBundle.getText(MENU_POPOVER_ACCESSIBLE_NAME);
-	}
-
 	get menuHeaderTextPhone() {
 		return this.text;
 	}
@@ -247,6 +243,10 @@ class MenuItem extends ListItem implements IMenuItem {
 
 	get labelClose() {
 		return MenuItem.i18nBundle.getText(MENU_CLOSE_BUTTON_ARIA_LABEL);
+	}
+
+	get acessibleNameText() {
+		return MenuItem.i18nBundle.getText(MENU_POPOVER_ACCESSIBLE_NAME);
 	}
 
 	get isSeparator(): boolean {

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -508,7 +508,7 @@ MENU_BACK_BUTTON_ARIA_LABEL=Back
 #XACT: ARIA announcement for the Menu Close button aria-label attribute
 MENU_CLOSE_BUTTON_ARIA_LABEL=Decline
 
-#XACT: Aria information for the Menu popover
+#XACT: ARIA information for the Menu popover
 MENU_POPOVER_ACCESSIBLE_NAME=Select an option from the menu
 
 #XTXT: Text for the Navigation Menu Popover hidden text

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -508,6 +508,9 @@ MENU_BACK_BUTTON_ARIA_LABEL=Back
 #XACT: ARIA announcement for the Menu Close button aria-label attribute
 MENU_CLOSE_BUTTON_ARIA_LABEL=Decline
 
+#XACT: Aria information for the Menu popover
+MENU_POPOVER_ACCESSIBLE_NAME=Select an option from the menu
+
 #XTXT: Text for the Navigation Menu Popover hidden text
 NAVIGATION_MENU_POPOVER_HIDDEN_TEXT=Navigation
 

--- a/packages/main/test/specs/Menu.cy.js
+++ b/packages/main/test/specs/Menu.cy.js
@@ -386,5 +386,31 @@ describe("Menu interaction", () => {
 				.find("li .ui5-li-additional-text")
 				.should("have.attr", "aria-hidden", "true", "aria-hidden attribute is set to true")
 		});
+
+		it("Menu popover has an accessible name", () => {
+			cy.mount(html`<ui5-button id="btnOpen">Open Menu</ui5-button>
+			<ui5-menu open opener="btnOpen">
+				<ui5-menu-item text="Item 1.0" icon="open-folder">
+					<ui5-menu-item text="1.1"></ui5-menu-item>
+				</ui5-menu-item>
+			</ui5-menu>`)
+	
+			cy.get("[ui5-menu]")
+				.ui5MenuOpened();
+
+			cy.get("[ui5-menu]")
+				.shadow()
+				.find("[ui5-responsive-popover]")
+				.should("have.attr", "accessible-name", "Select an option from the menu", "test accessible name");
+	
+			cy.get("[ui5-menu-item][text='Item 1.0']")
+				.as("item")
+				.ui5MenuItemClick();
+	
+			cy.get("@item")
+				.shadow()
+				.find("[ui5-responsive-popover]")
+				.should("have.attr", "accessible-name", "Select an option from the menu", "test accessible name");
+		});
 	})
 })


### PR DESCRIPTION
Issue:
- Every popover should have an accessible name
according to the accessibility standard.

Fixes: #9313