### PR TITLE
fix(ui5-avatar-group): prevent console error when no items are present

### DIFF
--- a/packages/main/src/AvatarGroup.ts
+++ b/packages/main/src/AvatarGroup.ts
@@ -369,7 +369,7 @@ class AvatarGroup extends UI5Element {
 	}
 
 	get firstAvatarSize() {
-		return this.items[0].size;
+		return this.items[0]?.size ?? AvatarSize.S;
 	}
 
 	get classes() {


### PR DESCRIPTION
Added a null-check in the `firstAvatarSize` getter to prevent a TypeError when the component is initialized without items. This ensures that the component behaves correctly and does not throw errors in the console when it is first loaded or when no items are present.

Fixes #9581 
