### PR TITLE
feat(core): fire PascalCase events for easier react usage

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -22,7 +22,7 @@ import { registerTag, isTagRegistered, recordTagRegistrationFailure } from "./Cu
 import { observeDOMNode, unobserveDOMNode } from "./DOMObserver.js";
 import { skipOriginalEvent } from "./config/NoConflict.js";
 import getEffectiveDir from "./locale/getEffectiveDir.js";
-import { kebabToCamelCase, camelToKebabCase } from "./util/StringHelper.js";
+import { kebabToCamelCase, camelToKebabCase, kebabToPascalCase } from "./util/StringHelper.js";
 import isValidPropertyName from "./util/isValidPropertyName.js";
 import { getSlotName, getSlottedNodesList } from "./util/SlotsHelper.js";
 import arraysAreEqual from "./util/arraysAreEqual.js";
@@ -934,10 +934,14 @@ abstract class UI5Element extends HTMLElement {
 	 */
 	fireEvent<T>(name: string, data?: T, cancelable = false, bubbles = true): boolean {
 		const eventResult = this._fireEvent(name, data, cancelable, bubbles);
-		const camelCaseEventName = kebabToCamelCase(name);
+		const pascalCaseEventName = kebabToPascalCase(name);
 
-		if (camelCaseEventName !== name) {
-			return eventResult && this._fireEvent(camelCaseEventName, data, cancelable, bubbles);
+		// pascal events are more convinient for native react usage
+		// live-change:
+		//	 Before: onlive-change
+		//	 After: onLiveChange
+		if (pascalCaseEventName !== name) {
+			return eventResult && this._fireEvent(pascalCaseEventName, data, cancelable, bubbles);
 		}
 
 		return eventResult;

--- a/packages/base/src/util/StringHelper.ts
+++ b/packages/base/src/util/StringHelper.ts
@@ -1,5 +1,6 @@
 const kebabToCamelMap = new Map<string, string>();
 const camelToKebabMap = new Map<string, string>();
+const kebabToPascalMap = new Map<string, string>();
 
 const kebabToCamelCase = (string: string) => {
 	if (!kebabToCamelMap.has(string)) {
@@ -23,4 +24,16 @@ const toCamelCase = (parts: Array<string>) => {
 	}).join("");
 };
 
-export { kebabToCamelCase, camelToKebabCase };
+const kebabToPascalCase = (src: string) => {
+	const cachedName = kebabToPascalMap.get(src);
+	if (cachedName) {
+		return cachedName;
+	}
+
+	const camelStr = kebabToCamelCase(src);
+	const result = camelStr.charAt(0).toUpperCase() + camelStr.slice(1);
+	kebabToPascalMap.set(src, result);
+	return result;
+};
+
+export { kebabToCamelCase, camelToKebabCase, kebabToPascalCase };


### PR DESCRIPTION
React 19 supports web components natively, but events look weird

`live-change` event can be used directly by prepending `on`
```
onlive-change
```

With this change, a PascalCase event is always fired in addition, so `live-change` can be used as `LiveChange` resulting in the following react JSX code:
```
onLiveChange
```