### PR TITLE
fix(ui5-step-input): apply overstyling correctly

### DIFF
--- a/packages/main/src/themes/StepInput.css
+++ b/packages/main/src/themes/StepInput.css
@@ -31,6 +31,7 @@
 
 :host .ui5-step-input-input {
 	text-align: inherit;
+	height: inherit;
 }
 
 :host(:not([value-state]):not([readonly]):not([disabled])){
@@ -166,6 +167,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
+	height: inherit;
 }
 
 :host .ui5-step-input-input[text-align=left] {


### PR DESCRIPTION
the input control wasn't correctly inheriting the styles from step input overstyling.

Before:
<img width="307" alt="image" src="https://github.com/user-attachments/assets/ea28d648-c441-40cb-ac5d-685514a363d3">

After:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/2e7d74dc-3428-4373-8f66-92b85e79776f">

fixes: https://github.com/SAP/ui5-webcomponents/issues/9365