### PR TITLE
fix(ui5-timepicker): align input with timepicker styles

### DIFF
--- a/packages/main/src/themes/TimePicker.css
+++ b/packages/main/src/themes/TimePicker.css
@@ -12,6 +12,7 @@
 
 :host {
 	min-width: calc(var(--_ui5_input_min_width) + var(--_ui5_input_icon_width));
+	height: var(--sapElement_Height);
 	color: var(--sapField_TextColor);
 	background-color: var(--sapField_Background);
 	border-radius: var(--_ui5-time_picker_border_radius);

--- a/packages/main/src/themes/TimePicker.css
+++ b/packages/main/src/themes/TimePicker.css
@@ -34,6 +34,7 @@
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
+	height: inherit;
 }
 
 :host .ui5-time-picker-input {
@@ -44,4 +45,5 @@
 	letter-spacing: inherit;
 	word-spacing: inherit;
 	margin: inherit;
+	height: inherit;
 }

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -11,12 +11,6 @@
 
 
 		<script src="%VITE_BUNDLE_PATH%" type="module"></script>
-
-		<style>
-			[ui5-time-picker] {
-				height: 3rem;
-			}
-		</style>
 	</head>
 	<body class="timepicker1auto">
 

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -12,7 +12,11 @@
 
 		<script src="%VITE_BUNDLE_PATH%" type="module"></script>
 
-
+		<style>
+			[ui5-time-picker] {
+				height: 3rem;
+			}
+		</style>
 	</head>
 	<body class="timepicker1auto">
 


### PR DESCRIPTION
the ui5-input wasn't correctly inheriting the height from ui5-timepicker host.

Before:
<img width="206" alt="image" src="https://github.com/user-attachments/assets/a2739298-21ec-4d56-8661-fc9d2f63444b">

After:
<img width="205" alt="image" src="https://github.com/user-attachments/assets/cb8761aa-52f7-4f05-857c-35350c2c99c5">

fixes: https://github.com/SAP/ui5-webcomponents/issues/9366