### PR TITLE
fix(ui5-shellbar): add missing icon dependency

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -25,6 +25,7 @@ import "@ui5/webcomponents-icons/dist/search.js";
 import "@ui5/webcomponents-icons/dist/bell.js";
 import "@ui5/webcomponents-icons/dist/overflow.js";
 import "@ui5/webcomponents-icons/dist/grid.js";
+import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 import type { Timeout, ClassMap, AccessibilityAttributes } from "@ui5/webcomponents-base/dist/types.js";
 import type ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import type PopoverHorizontalAlign from "@ui5/webcomponents/dist/types/PopoverHorizontalAlign.js";

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/main.js
@@ -27,6 +27,8 @@ import "@ui5/webcomponents-icons/dist/ipad.js";
 import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/menu.js";
 import "@ui5/webcomponents-icons/dist/slim-arrow-right.js";
+import "@ui5/webcomponents-icons/dist/full-screen.js";
+import "@ui5/webcomponents-icons/dist/add.js";
 
 let midFullScreen = false;
 let endFullScreen = false;


### PR DESCRIPTION
An icon used by the shellbar template was not imported as dependecy. 
Additionally the FCL's sample was also using some icons that were not imported in the JS file.

Closes: https://github.com/SAP/ui5-webcomponents/issues/9580, https://github.com/SAP/ui5-webcomponents/issues/9534