### PR TITLE
fix(ui5-shellbar): remove aria attribute from search button

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1298,7 +1298,6 @@ class ShellBar extends UI5Element {
 				"title": this._searchText,
 				"accessibilityAttributes": {
 					hasPopup: this._searchHasPopup,
-					expanded: this.showSearchField,
 				},
 			},
 			overflow: {


### PR DESCRIPTION
The aria-expanded attribute on the search button inside the ui5-shellbar component causes an unnecessary announcement.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7123