### PR TITLE
fix(ui5-timeline): fix javascript error

### DIFF
--- a/packages/fiori/src/Timeline.ts
+++ b/packages/fiori/src/Timeline.ts
@@ -217,11 +217,17 @@ class Timeline extends UI5Element {
 		this.items.forEach(item => {
 			if (!item.isGroupItem) {
 				navigatableItems.push(item);
-			} else {
-				navigatableItems.push(item.shadowRoot!.querySelector<ToggleButton>("[ui5-toggle-button]")!);
+				
+				return;
+			} 
+
+			const navigatableItem = item.shadowRoot!.querySelector<ToggleButton>("[ui5-toggle-button]");
+
+			if (navigatableItem) {
+				navigatableItems.push(navigatableItem);
 			}
 
-			if (item.isGroupItem && !item.collapsed) {
+			if (!item.collapsed) {
 				item.items?.forEach(groupItem => {
 					navigatableItems.push(groupItem);
 				});

--- a/packages/fiori/src/Timeline.ts
+++ b/packages/fiori/src/Timeline.ts
@@ -217,9 +217,9 @@ class Timeline extends UI5Element {
 		this.items.forEach(item => {
 			if (!item.isGroupItem) {
 				navigatableItems.push(item);
-				
+
 				return;
-			} 
+			}
 
 			const navigatableItem = item.shadowRoot!.querySelector<ToggleButton>("[ui5-toggle-button]");
 


### PR DESCRIPTION
Issue: On init of item navigation, the shadowdom of the timeline group item was not filled, and when searching for toggle button inside, it wasn't available, so we pushed null into the array and the item navigation was failing to set the `forcedIndex` property of `null`.

Solution: We've added check to verify that the `navigatableItems` array is filled only with valid items.

Addition: A global solution can be researched, that handles such cases. Searching for elements in `ShadowDom` in the callback function that we pass to ItemNavigation on init trough `getItemsCallback`(When we have invalid items in `ItemNavigation`).
Should the init function wait for the shadow dom of the children to be rendered?

fixes: https://github.com/SAP/ui5-webcomponents/issues/9633