### PR TITLE
fix(ui5-toolbar): update ToolbarRegistry to use metadata tag instead …

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -540,7 +540,8 @@ class Toolbar extends UI5Element {
 
 	getItemsInfo(items: Array<ToolbarItem>) {
 		return items.map((item: ToolbarItem) => {
-			const ElementClass = getRegisteredToolbarItem(item.constructor.name);
+			const ctor = item.constructor as typeof ToolbarItem;
+			const ElementClass = getRegisteredToolbarItem(ctor.getMetadata().getPureTag());
 
 			if (!ElementClass) {
 				return null;

--- a/packages/main/src/ToolbarRegistry.ts
+++ b/packages/main/src/ToolbarRegistry.ts
@@ -5,7 +5,7 @@ import type ToolbarItem from "./ToolbarItem.js";
 const registry = getSharedResource<Map<string, typeof ToolbarItem>>("ToolbarItem.registry", new Map());
 
 const registerToolbarItem = (ElementClass: typeof ToolbarItem) => {
-	registry.set(ElementClass.name, ElementClass);
+	registry.set(ElementClass.getMetadata().getPureTag(), ElementClass);
 };
 
 const getRegisteredToolbarItem = (name: string) => {


### PR DESCRIPTION
This change updates the registration mechanism for toolbar items to use a metadata tag instead of the class name. 

#### Changes:
- In `Toolbar.ts`, updated the `getItemsInfo` method to retrieve the registered toolbar item using `ctor.getMetadata().getPureTag()` instead of `item.constructor.name`.
- In `ToolbarRegistry.ts`, modified the `registerToolbarItem` function to register items with `ElementClass.getMetadata().getPureTag()` instead of `ElementClass.name`.

#### Issue Addressed:
In production builds, webpack minifies class names which resulted in all toolbar buttons being registered under the same name ("i"). This caused all toolbar items to be registered as the last one registered due to name conflicts. By switching to a more stable identifier from the class metadata, we prevent such issues.

Related to: #9607