### PR TITLE
fix(ui5-flexible-column-layout): correct min-width constraint

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -61,7 +61,7 @@ const COLUMN = {
 	END: 2,
 } as const;
 
-const COLUMN_MIN_WIDTH = 312;
+const COLUMN_MIN_WIDTH = 248;
 
 type SeparatorMovementSession = {
 	separator: HTMLElement,

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -133,7 +133,7 @@ type UserDefinedColumnLayouts = {
  * The component would display 1 column for window size smaller than 599px, up to two columns between 599px and 1023px,
  * and 3 columns for sizes bigger than 1023px.
  *
- * **Note:** When the component displays more than one column, the minimal width of each column is 312px. Consequently, when the user drags a column separator to resize the columns, the minimal allowed width of any resized column is 312px.
+ * **Note:** When the component displays more than one column, the minimal width of each column is 248px. Consequently, when the user drags a column separator to resize the columns, the minimal allowed width of any resized column is 248px.
  *
  * ### Keyboard Handling
  *

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -37,6 +37,7 @@
 	border-inline-start: var(--_ui5_fcl_column_border);
 	border-inline-end: var(--_ui5_fcl_column_border);
 	position: relative;
+	box-sizing: border-box;
 }
 
 .ui5-fcl-separator:focus {

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -350,7 +350,7 @@ describe("Preserves column min-width", () => {
 	});
 
 	it("complies with min-width requiremet on smallest desktop", async () => {
-		await browser.setWindowSize(1045, 1080); // size is just above tablet
+		await browser.setWindowSize(1400, 1080);
 
 		const fcl = await browser.$("#fcl3"),
 			smallestDesktopWidth = 1024,
@@ -359,6 +359,12 @@ describe("Preserves column min-width", () => {
 		// set initial state
 		await fcl.setProperty("layout", "ThreeColumnsMidExpanded");
 		assert.strictEqual(await fcl.getProperty("layout"), "ThreeColumnsMidExpanded", "new layout set");
+
+		// set FCL width to the smallest desktop width
+		await browser.executeAsync(async (newWidth, done) => {
+			document.getElementById("fcl3").style.width = `${newWidth}px`;
+			done();
+		}, smallestDesktopWidth);
 
 		const startColumn = await fcl.shadow$(".ui5-fcl-column--start");
 		const startColumnWidth = await startColumn.getSize("width");

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -349,6 +349,26 @@ describe("Preserves column min-width", () => {
 		await browser.url(`test/pages/FCL.html?sap-ui-animationMode=none`);
 	});
 
+	it("complies with min-width requiremet on smallest desktop", async () => {
+		await browser.setWindowSize(1045, 1080); // size is just above tablet
+
+		const fcl = await browser.$("#fcl3"),
+			smallestDesktopWidth = 1024,
+			smallestColumnWidth = 248;
+
+		// set initial state
+		await fcl.setProperty("layout", "ThreeColumnsMidExpanded");
+		assert.strictEqual(await fcl.getProperty("layout"), "ThreeColumnsMidExpanded", "new layout set");
+
+		const startColumn = await fcl.shadow$(".ui5-fcl-column--start");
+		const startColumnWidth = await startColumn.getSize("width");
+		const fclWidth = await fcl.getSize("width");
+
+		// assert
+		assert.strictEqual(fclWidth, smallestDesktopWidth, "fcl is the smallest desktop width");
+		assert.strictEqual(startColumnWidth, smallestColumnWidth, "min-width is respected");
+	});
+
 	it("preserves min-width of begin column", async () => {
 		await browser.setWindowSize(1400, 1080);
 		

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -354,7 +354,7 @@ describe("Preserves column min-width", () => {
 		
 		const fcl = await browser.$("#fcl3"),
 			startSeparator = await fcl.shadow$(".ui5-fcl-separator-start"),
-			smallestColumnWidth = 312;
+			smallestColumnWidth = 248;
 
 		// set initial state
 		await fcl.setProperty("layout", "TwoColumnsMidExpanded");
@@ -375,7 +375,7 @@ describe("Preserves column min-width", () => {
 	it("preserves min-width of mid column in 2-column layout", async () => {
 		const fcl = await browser.$("#fcl3"),
 			startSeparator = await fcl.shadow$(".ui5-fcl-separator-start"),
-			smallestColumnWidth = 312;
+			smallestColumnWidth = 248;
 
 		// set initial state
 		await fcl.setProperty("layout", "TwoColumnsStartExpanded");
@@ -396,7 +396,7 @@ describe("Preserves column min-width", () => {
 	it("preserves min-width of mid column in 3-column layout", async () => {
 		const fcl = await browser.$("#fcl3"),
 			endSeparator = await fcl.shadow$(".ui5-fcl-separator-end"),
-			smallestColumnWidth = 312;
+			smallestColumnWidth = 248;
 
 		// set initial state
 		await fcl.setProperty("layout", "ThreeColumnsMidExpanded");
@@ -417,7 +417,7 @@ describe("Preserves column min-width", () => {
 	it("preserves min-width of end column", async () => {
 		const fcl = await browser.$("#fcl3"),
 			endSeparator = await fcl.shadow$(".ui5-fcl-separator-end"),
-			smallestColumnWidth = 312;
+			smallestColumnWidth = 248;
 
 		// set initial state
 		await fcl.setProperty("layout", "ThreeColumnsMidExpanded");
@@ -439,7 +439,7 @@ describe("Preserves column min-width", () => {
 		const fcl = await browser.$("#fcl3"),
 			endSeparator = await fcl.shadow$(".ui5-fcl-separator-end"),
 			endColumn = await fcl.shadow$(".ui5-fcl-column--end"),
-			smallestColumnWidth = 312;
+			smallestColumnWidth = 248;
 
 		// set initial state
 		await fcl.setProperty("layout", "ThreeColumnsMidExpandedEndHidden");


### PR DESCRIPTION
Fixes: #9682

Root cause: 
The smaller column was initially rendered with with smaller than the minimal allowed width.
This happens on smaller screens, as the current value of the column-min-width constraint (of 312px) is not properly aligned with the breakpoints of the FCL sizes. In particular, the current value (of 312px) is too large for the smallest tablet/desktop size (of 600px for tablet and 1024px for desktop) and cannot be attained when the maximum number of columns are shown.

Solution: 
1) Update the value of column-min-width to 25% of the available space of the smallest desktop width (of 1024px) when 3 columns are shown. So:
   column-min-width  = 25% of  ( 1024 - 2*16 )
- where 25% is the space reserved for the narrowest column in ThreeColumnMidExpanded (defaults to [25%, 50%, 25%] )
- where 2*16 is the space reserved for the two separators in ThreeColumnMidExpanded (as all the 3 columns are shown, respectively 2 separators are shown)
2) Also updated the separator CSS to ensure the separator takes no more than 1rem (16px).