### PR TITLE
fix(ui5-table): rendering empty table leads to no exception

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -415,7 +415,7 @@ class Table extends UI5Element {
 	 * @private
 	 */
 	_refreshPopinState() {
-		this.headerRow[0].cells.forEach((header, index) => {
+		this.headerRow[0]?.cells.forEach((header, index) => {
 			this.rows.forEach(row => {
 				const cell = row.cells[index];
 				if (cell && cell._popin !== header._popin) {
@@ -472,6 +472,10 @@ class Table extends UI5Element {
 	}
 
 	get _gridTemplateColumns() {
+		if (!this.headerRow[0]) {
+			return;
+		}
+
 		const widths = [];
 		const visibleHeaderCells = this.headerRow[0]._visibleCells as TableHeaderCell[];
 		if (this._getSelection()?.hasRowSelector()) {

--- a/packages/main/test/pages/TableEmpty.html
+++ b/packages/main/test/pages/TableEmpty.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+
+	<title>Table (in development)</title>
+	<meta name="viewport"
+		content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+</head>
+
+<body>
+	<input id="error"></input>
+	<script>
+		const error = document.getElementById("error");
+
+		window.addEventListener("unhandledrejection", function (event) {
+			error.value = "Exception was thrown!";
+		});
+
+		const table = document.createElement("ui5-table");
+		document.body.appendChild(table);
+		// an error will the thrown after this step
+		setTimeout(() => {
+			const row = document.createElement("ui5-table-header-row");
+			table.appendChild(row);
+		}, 100);
+	</script>
+</body>
+
+</html>

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -2,6 +2,29 @@ import { assert } from "chai";
 
 const ROLE_COLUMN_HEADER = "columnheader";
 
+describe("Table - Rendering", async () => {
+	it("tests if table is rendered", async () => {
+		await browser.url(`test/pages/Table.html`);
+
+		const table = await browser.$("#table");
+		assert.ok(table.isExisting(), "Table exists");
+
+		const headerRow = await table.$("ui5-table-header-row");
+		assert.ok(headerRow.isExisting(), "Header row exists");
+
+		const headerCells = await headerRow.$$("ui5-table-header-cell");
+		assert.equal(headerCells.length, 5, "5 columns exist");
+	});
+
+	it ("tests if initial empty table renders without errors", async () => {
+		await browser.url(`test/pages/TableEmpty.html`);
+
+		const errorInput = await browser.$("#error");
+		assert.ok(await errorInput.isExisting(), "Error input exists");
+		assert.equal(await errorInput.getValue(), "", "Exception was not thrown");
+	});
+});
+
 describe("Table - Popin Mode", async () => {
 	before(async () => {
 		await browser.url(`test/pages/TablePopin.html`);


### PR DESCRIPTION
When rendering an empty table (no header row, rows), there should be no exception thrown during initialisation of the table.
Therefore, added checks to see whether headerRow actually exists before accessing it.

Fixes: #9636