### PR TITLE
chore: switch to new headless mode for Chrome

### DIFF
--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -60,7 +60,7 @@ exports.config = {
 			// to run chrome headless the following flags are required
 			// (see https://developers.google.com/web/updates/2017/04/headless-chrome)
 			args: [
-				'--headless',
+				'--headless=new',
 				'--start-maximized',
 				'--no-sandbox',
 				'--disable-gpu',


### PR DESCRIPTION
Updated the WebdriverIO configuration to use the new unified headless mode for Chrome by adding the `'=new'` parameter to the `'--headless'` argument. This change leverages the more integrated headless implementation available from Chrome 112, which shares code with the headful browser, offering a more consistent and reliable testing environment.

Detailed information about the new headless mode can be found at:
[https://developer.chrome.com/docs/chromium/new-headless](https://developer.chrome.com/docs/chromium/new-headless)
