### PR TITLE
fix(ui5-flexible-column-layout): correct separator height

### DIFF
--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -78,10 +78,7 @@
 
 .ui5-fcl-separator:hover .ui5-fcl-grip:before,
 .ui5-fcl-separator:hover .ui5-fcl-grip:after {
-	height: 50%;
-}
-.ui5-fcl-separator:hover {
-	overflow: hidden;
+	height: calc(50% - 1rem);
 }
 
 [aria-hidden] ::slotted([slot="startColumn"]),


### PR DESCRIPTION
Fixes flickering in the following scenario:
1. Open https://sap.github.io/ui5-webcomponents/components/fiori/FlexibleColumnLayout/
2. Navigate to the "Basic sample"
3. Select a list-item to open the second column
4. Hover the mouse cursor around the columns separator
Expected: Nothing is changed until we click
Actual: A slight one-time flickering

The issue is due to incorrect height of the separator contents during hover. Fixed the height calculation by provisioning space for the grip icon