### PR TITLE
docs(ui5-table): fix sticky header example

### DIFF
--- a/packages/main/src/TableHeaderRow.ts
+++ b/packages/main/src/TableHeaderRow.ts
@@ -66,8 +66,7 @@ class TableHeaderRow extends TableRowBase {
 	/**
 	 * Sticks the `ui5-table-header-row` to the top of a table.
 	 *
-	 * Note: If used in combination with overflowMode "Scroll", the table needs a defined height
-	 * or needs to be inside of a container with a defined height for the sticky header to work as expected.
+	 * Note: If used in combination with overflowMode "Scroll", the table needs a defined height for the sticky header to work as expected.
 	 *
 	 * @default false
 	 * @public

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/StickyHeaderContainer.md
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/StickyHeaderContainer.md
@@ -1,6 +1,7 @@
 import html from '!!raw-loader!./sample.html';
 import js from '!!raw-loader!./main.js';
 
-If your table is located inside of a scrollable container and you have other sticky content, you can use `sticky-top` to define the header's top offset.
+If your table is located inside of a scrollable container, you have other sticky content and your table is in `Scroll` mode,
+provide a height for the table for the sticky header to work as expected.
 
 <Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.html
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.html
@@ -14,7 +14,7 @@
 		<ui5-bar id="toolbar" design="Header" accessible-name-ref="title" style="position: sticky; top: 0; z-index: 2; height: 50px;">
 			<ui5-title tabindsex="0" level="H3" id="title" slot="startContent">My Sticky Toolbar</ui5-title>
 		</ui5-bar>
-		<ui5-table id="table" sticky-top="50px">
+		<ui5-table id="table" style="height: 100px;">
 			<ui5-table-header-row slot="headerRow" sticky>
 				<ui5-table-header-cell id="produtCol"><span>Product</span></ui5-table-header-cell>
 				<ui5-table-header-cell id="supplierCol">Supplier</ui5-table-header-cell>
@@ -43,6 +43,7 @@
 				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+			</ui5-table-row>
 			<ui5-table-row>
 				<ui5-table-cell><ui5-label><b>Notebook Basic 19</b><br>HT-1003</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
@@ -63,6 +64,7 @@
 				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
 				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>
 	</div>


### PR DESCRIPTION
Due to a previous change with horizontal scrolling, the example with sticky headers broke. Added a fixed height to the table and adjusted end tags of ui5-table-row.
