### PR TITLE
fix(ui5-color-palette-popover): set opener attribute

### DIFF
--- a/packages/main/src/ColorPalettePopover.hbs
+++ b/packages/main/src/ColorPalettePopover.hbs
@@ -2,8 +2,8 @@
 	hide-arrow
 	content-only-on-desktop
 	placement="Bottom"
-	?open="{{_open}}"
 	.opener="{{opener}}"
+	?open="{{_open}}"
 	@ui5-close="{{onAfterClose}}"
 	@ui5-open="{{onAfterOpen}}"
 >


### PR DESCRIPTION
Issue:
- Based on the template the `open` is set before the `opener` attribute
resulting into a console warning.

Fixes: #9708