### PR TITLE
fix(ui5-list): adjust growing button padding

### DIFF
--- a/packages/main/src/themes/GrowingButton.css
+++ b/packages/main/src/themes/GrowingButton.css
@@ -57,7 +57,7 @@
 
 [growing-button-text] {
 	height: var(--_ui5_load_more_text_height);
-	padding: 0.875rem 1rem 0 1rem;
+	padding: 0.875rem 1rem 1rem;
 	font-size: var(--_ui5_load_more_text_font_size);
 	font-weight: bold;
 }


### PR DESCRIPTION
ui5-list: Corrected "More" Button Text Positioning

Issue: The "More" button text within the ui5-list component was not correctly aligned due to improper padding settings.

Solution: The padding for the growing-button-text class was adjusted in the CSS to ensure proper alignment of the text.

Fixes: [#9725](https://github.com/SAP/ui5-webcomponents/issues/9725)