### PR TITLE
chore: default texts are populated from translations

### DIFF
--- a/packages/compat/test/specs/TableGrouping.spec.js
+++ b/packages/compat/test/specs/TableGrouping.spec.js
@@ -20,16 +20,12 @@ describe("Table general interaction", () => {
 
 	it("ARIA - aria-label should be calculated correctly.", async () => {
 		const groupRows = await browser.$$("ui5-table-group-row");
-		const ariaText1 = "Group header row. Country: Bulgaria. 2 of 7";
+		const ariaText1 = "Group Header Row. Country: Bulgaria. 2 of 7";
 		const ariaLabel1 = await groupRows[0].shadow$("tr").getAttribute("aria-label");
-		const ariaText2 = "Group header row. Country: USA. 5 of 7";
+		const ariaText2 = "Group Header Row. Country: USA. 5 of 7";
 		const ariaLabel2 = await groupRows[1].shadow$("tr").getAttribute("aria-label");
 
 		assert.strictEqual(ariaLabel1, ariaText1, "Initially the aria-label is set correctly.");
 		assert.strictEqual(ariaLabel2, ariaText2, "Initially the aria-label is set correctly.");
-
-		// Sometimes fails with Initially the aria-label is set correctly:
-		// expected 'Group Header Row Country: Bulgaria. 1 of 6'
-		// to equal 'Group header row. Country: Bulgaria. 1 of 6'
 	});
 });

--- a/packages/compat/test/specs/TableGrouping.spec.js
+++ b/packages/compat/test/specs/TableGrouping.spec.js
@@ -20,9 +20,9 @@ describe("Table general interaction", () => {
 
 	it("ARIA - aria-label should be calculated correctly.", async () => {
 		const groupRows = await browser.$$("ui5-table-group-row");
-		const ariaText1 = "Group Header Row. Country: Bulgaria. 2 of 7";
+		const ariaText1 = "Group Header Row Country: Bulgaria. 2 of 7";
 		const ariaLabel1 = await groupRows[0].shadow$("tr").getAttribute("aria-label");
-		const ariaText2 = "Group Header Row. Country: USA. 5 of 7";
+		const ariaText2 = "Group Header Row Country: USA. 5 of 7";
 		const ariaLabel2 = await groupRows[1].shadow$("tr").getAttribute("aria-label");
 
 		assert.strictEqual(ariaLabel1, ariaText1, "Initially the aria-label is set correctly.");

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -258,11 +258,11 @@ describe("Notification List Item Tests", () => {
 
 		// assert
 		assert.strictEqual(await invisibleTextStatus1.getText(), "Status Positive", "The invisible text for the status is correct.");
-		assert.strictEqual(await invisibleTextItem1.getText(), "unread", "The invisible text for the Notification item  is correct.");
+		assert.strictEqual(await invisibleTextItem1.getText(), "Unread", "The invisible text for the Notification item  is correct.");
 		assert.strictEqual(await tooltipStatus1.getAttribute("accessible-name"), "Status Positive", "The tooltip (aria-label) text for the status is correct.");
 
 		assert.strictEqual(await invisibleTextStatus2.getText(), "Status Critical", "The invisible text for the status is correct.");
-		assert.strictEqual(await invisibleTextItem2.getText(), "read", "The invisible text for the Notification item  is correct.");
+		assert.strictEqual(await invisibleTextItem2.getText(), "Read", "The invisible text for the Notification item  is correct.");
 		assert.strictEqual(await tooltipStatus2.getAttribute("accessible-name"), "Status Critical", "The tooltip (aria-label) text for the status is correct.");
 	});
 
@@ -334,9 +334,9 @@ describe("Notification List Item Tests", () => {
 
 	it("tests Group Item 'aria-description' and 'aria-level'", async () => {
 		const firstGroupItemRoot = await browser.$("#nlgi1").shadow$(".ui5-nli-group-root");
-		const EXPECTED_TEXT_1 = "Notification group Expanded";
+		const EXPECTED_TEXT_1 = "Notification Group Expanded";
 		const thirdGroupItemRoot = await browser.$("#nlgi3").shadow$(".ui5-nli-group-root");
-		const EXPECTED_TEXT_3 = "Notification group Collapsed";
+		const EXPECTED_TEXT_3 = "Notification Group Collapsed";
 
 		assert.strictEqual(await firstGroupItemRoot.getAttribute("aria-description"), EXPECTED_TEXT_1, "The aria-description text is correct.");
 		assert.strictEqual(await thirdGroupItemRoot.getAttribute("aria-description"), EXPECTED_TEXT_3, "The aria-description text is correct.");

--- a/packages/main/test/specs/Text.spec.js
+++ b/packages/main/test/specs/Text.spec.js
@@ -34,6 +34,6 @@ describe("Text", () => {
 		const label = await browser.$("#emptyText").shadow$(".empty-indicator-aria-label");
 
 		assert.strictEqual(await text.getText(), "–", "'–' should be rendered");
-		assert.strictEqual(await label.getText(), "Empty value", "Aria label is properly set");
+		assert.strictEqual(await label.getText(), "Empty Value", "Aria label is properly set");
 	});
 });

--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -31,7 +31,8 @@ const generate = async () => {
 	// (2) as the messagebundle.properties file is always written in English,
 	// it makes sense to consider the messagebundle.properties content only when the default language is "en".
 	if (defaultLanguage === "en") {
-		defaultLanguageProperties = Object.assign({}, defaultLanguageProperties, properties);
+		// use messagebundle_en.properties to overwrite all developer properties, only the not translated ones will remain
+		defaultLanguageProperties = Object.assign({}, properties, defaultLanguageProperties);
 	}
 
 	/*


### PR DESCRIPTION
There are three files for english currently:
`messagebundle.properties` - written by developers and used as source format
`messagebundle_en.properties` - coming from translation system, used as fallback for en_US
`messagebundle_en_GB.properties` - coming from translation system

The default text `en` is inlined in the bundle and is not fetched from the network, unless the `fetchDefaultLanguage` configuration property is set.

The problem is when a browser with `en_US` is used, the locale is resolved to `en` and the inlined texts are used, but they are generated from `messagebundle.properties` instead of `messagebundle_en.properties`.

This change is using the translated file `messagebundle_en.properties` for generating the inlined texts. There is a timeframe when a text is only available in the development `.properties` file and it will be inline until it appears in the `messagebundle_en.properties` file.