### PR TITLE
chore: textarea scrollbar

### DIFF
--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -529,7 +529,7 @@ class TextArea extends UI5Element implements IFormInputElement {
 		return {
 			root: {
 				"ui5-textarea-root": true,
-				"ui5-content-custom-scrollbars": !getEffectiveScrollbarStyle(),
+				"ui5-content-custom-scrollbars": !!getEffectiveScrollbarStyle(),
 			},
 			valueStateMsg: {
 				"ui5-valuestatemessage-header": true,


### PR DESCRIPTION
Custom scrollbar class should be added if custom scrollbars should be applied to the page. This was changed in #9751 and it is meant to be used with `!!` instead of `!`