### PR TITLE
refactor(ui5-breadcrumbs): increase links touch area

### DIFF
--- a/packages/main/src/Link.hbs
+++ b/packages/main/src/Link.hbs
@@ -1,4 +1,5 @@
 <a
+	part="root"
 	class="ui5-link-root"
 	role="{{effectiveAccRole}}"
 	href="{{parsedRef}}"

--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -59,6 +59,12 @@
     bottom: 0;
 }
 
+.ui5-breadcrumbs-dropdown-arrow-link-wrapper [ui5-link]::part(root),
+.ui5-breadcrumbs-link-wrapper [ui5-link]::part(root) {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+}
+
 /* underline icon on hover */
 .ui5-breadcrumbs-dropdown-arrow-link-wrapper [ui5-link][focused] [ui5-icon]::after,
 .ui5-breadcrumbs-dropdown-arrow-link-wrapper:hover [ui5-icon]::after {
@@ -69,6 +75,10 @@
     left: 0;
     bottom: 1px;
     right: 0;
+}
+
+.ui5-breadcrumbs-popover {
+    margin-top: 0.25rem;
 }
 
 .ui5-breadcrumbs-popover-footer {


### PR DESCRIPTION
Top and bottom touch area spacings are aded because of non-intersecting target area requirement.
The positioning of the drop-down popover also is changed accordingly.

Internal reference: BGSOFUIPIRIN-6642
