### PR TITLE
fix(f6 navigation): work properly when multiple runtimes

### DIFF
--- a/packages/base/src/Runtimes.ts
+++ b/packages/base/src/Runtimes.ts
@@ -94,6 +94,20 @@ const compareRuntimes = (index1: number, index2: number) => {
 };
 
 /**
+ * Compares all registered runtimes and returns true if the current runtime is the latest one.
+ */
+const isLatestVersionRuntime = (): boolean => {
+	const currIdx = getCurrentRuntimeIndex();
+	const currentRuntimes = Runtimes.filter((runtime, idx) => compareRuntimes(idx, currIdx) > 0);
+
+	if (currentRuntimes.length > 0) {
+		return false;
+	}
+
+	return true;
+};
+
+/**
  * Set an alias for the the current app/library/microfrontend which will appear in debug messages and console warnings
  * @param alias
  */
@@ -106,6 +120,7 @@ const getAllRuntimes = () => {
 };
 
 export {
+	isLatestVersionRuntime,
 	getCurrentRuntimeIndex,
 	registerCurrentRuntime,
 	compareRuntimes,

--- a/packages/base/src/Runtimes.ts
+++ b/packages/base/src/Runtimes.ts
@@ -94,20 +94,6 @@ const compareRuntimes = (index1: number, index2: number) => {
 };
 
 /**
- * Compares all registered runtimes and returns true if the current runtime is the latest one.
- */
-const isLatestVersionRuntime = (): boolean => {
-	const currIdx = getCurrentRuntimeIndex();
-	const currentRuntimes = Runtimes.filter((runtime, idx) => compareRuntimes(idx, currIdx) > 0);
-
-	if (currentRuntimes.length > 0) {
-		return false;
-	}
-
-	return true;
-};
-
-/**
  * Set an alias for the the current app/library/microfrontend which will appear in debug messages and console warnings
  * @param alias
  */
@@ -120,7 +106,6 @@ const getAllRuntimes = () => {
 };
 
 export {
-	isLatestVersionRuntime,
 	getCurrentRuntimeIndex,
 	registerCurrentRuntime,
 	compareRuntimes,

--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -4,6 +4,7 @@ import { instanceOfUI5Element } from "../UI5Element.js";
 import { getFirstFocusableElement } from "../util/FocusableElements.js";
 import getFastNavigationGroups from "../util/getFastNavigationGroups.js";
 import isElementClickable from "../util/isElementClickable.js";
+import { isLatestVersionRuntime } from "../Runtimes.js";
 
 class F6Navigation {
 	static _instance: F6Navigation;
@@ -115,6 +116,13 @@ class F6Navigation {
 		if (!(forward || backward)) {
 			return;
 		}
+
+		// Only latest runtime should execute fast navigation
+		if (!isLatestVersionRuntime()) {
+			return;
+		}
+
+		event.stopImmediatePropagation();
 
 		this.updateGroups();
 

--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -4,7 +4,21 @@ import { instanceOfUI5Element } from "../UI5Element.js";
 import { getFirstFocusableElement } from "../util/FocusableElements.js";
 import getFastNavigationGroups from "../util/getFastNavigationGroups.js";
 import isElementClickable from "../util/isElementClickable.js";
-import { isLatestVersionRuntime } from "../Runtimes.js";
+import { getCurrentRuntimeIndex, compareRuntimes } from "../Runtimes.js";
+import getSharedResource from "../getSharedResource.js";
+
+type F6Registry = {
+	instance?: F6Navigation,
+}
+
+const currentRuntimeINdex = getCurrentRuntimeIndex();
+
+const shouldUpdate = (runtimeIndex: number | undefined) => {
+	if (runtimeIndex === undefined) {
+		return true;
+	}
+	return compareRuntimes(currentRuntimeINdex, runtimeIndex) === 1; // 1 means the current is newer, 0 means the same, -1 means the resource's runtime is newer
+};
 
 class F6Navigation {
 	static _instance: F6Navigation;
@@ -19,6 +33,10 @@ class F6Navigation {
 
 	attachEventListeners() {
 		document.addEventListener("keydown", this.keydownHandler);
+	}
+
+	removeEventListeners() {
+		document.removeEventListener("keydown", this.keydownHandler);
 	}
 
 	async groupElementToFocus(nextElement: HTMLElement) {
@@ -117,13 +135,6 @@ class F6Navigation {
 			return;
 		}
 
-		// Only latest runtime should execute fast navigation
-		if (!isLatestVersionRuntime()) {
-			return;
-		}
-
-		event.stopImmediatePropagation();
-
 		this.updateGroups();
 
 		if (this.groups.length < 1) {
@@ -157,10 +168,6 @@ class F6Navigation {
 		elementToFocus?.focus();
 	}
 
-	removeEventListeners() {
-		document.removeEventListener("keydown", this.keydownHandler);
-	}
-
 	updateGroups() {
 		this.setSelectedGroup();
 		this.groups = getFastNavigationGroups(document.body);
@@ -189,12 +196,19 @@ class F6Navigation {
 		this.removeEventListeners();
 	}
 
-	static init() {
-		if (!this._instance) {
-			this._instance = new F6Navigation();
-		}
+	get _ui5RuntimeIndex() {
+		return currentRuntimeINdex;
+	}
 
-		return this._instance;
+	static init() {
+		const f6Registry = getSharedResource<F6Registry>("F6Registry", {});
+
+		if (!f6Registry.instance) {
+			f6Registry.instance = new F6Navigation();
+		} else if (shouldUpdate(f6Registry.instance?._ui5RuntimeIndex)) {
+			f6Registry.instance?.destroy();
+			f6Registry.instance = new F6Navigation();
+		}
 	}
 }
 

--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -21,7 +21,6 @@ const shouldUpdate = (runtimeIndex: number | undefined) => {
 };
 
 class F6Navigation {
-	static _instance: F6Navigation;
 	keydownHandler: (event: KeyboardEvent) => void;
 	selectedGroup: HTMLElement | null = null;
 	groups: Array<HTMLElement> = [];


### PR DESCRIPTION
F6 navigation adds `keydown` handler to the body element that will move the focus to the previous / next group that has focusable element. If F6 navigation feature is enabled in multiple runtimes this handler will be attach multiple times.

With current change, we ensure that only one callback will be executed to move the focus to the correct element. This callback is coming from the latest registered runtime (newest version).

Fixes: https://github.com/SAP/ui5-webcomponents/issues/9795