### PR TITLE
fix(ui5-textarea): focus outline and border overlapping in readonly textarea

### DIFF
--- a/packages/main/src/themes/sap_horizon/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon/TextArea-parameters.css
@@ -15,7 +15,7 @@
 	--_ui5_textarea_focus_offset: 0;
 	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapField_Active_BorderColor);
-	--_ui5_textarea_value_state_focus_offset: 0;
+	--_ui5_textarea_value_state_focus_offset: 1px;
 	--_ui5_textarea_wrapper_padding: 0.0625rem;
 	--_ui5_textarea_success_wrapper_padding: 0.0625rem;
 	--_ui5_textarea_warning_error_wrapper_padding:  0.0625rem 0.0625rem 0.125rem 0.0625rem;

--- a/packages/main/src/themes/sap_horizon_dark/TextArea-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/TextArea-parameters.css
@@ -15,7 +15,7 @@
 	--_ui5_textarea_focus_offset: 0;
 	--_ui5_textarea_readonly_focus_offset: 1px;
 	--_ui5_textarea_focus_outline_color: var(--sapField_Active_BorderColor);
-	--_ui5_textarea_value_state_focus_offset: 0;
+	--_ui5_textarea_value_state_focus_offset: 1px;
 	--_ui5_textarea_wrapper_padding: 0.0625rem;
 	--_ui5_textarea_success_wrapper_padding: 0.0625rem;
 	--_ui5_textarea_warning_error_wrapper_padding:  0.0625rem 0.0625rem 0.125rem 0.0625rem;


### PR DESCRIPTION
Related to Issue #9741 (issue 2)

Hello @nnaydenow,

You had already reviewed this PR request, and I opened a new PR for a cleaner version. I made the changes you requested. Thank you.

Best regards,
tw4
