### PR TITLE
fix(ui5-multi-combobox): restore focus to input after value state header is removed

### DIFF
--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1318,6 +1318,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 			this._dialogInputValueState = valueState;
 			this.valueState = valueState;
 			this._validationTimeout = null;
+			this._innerInput.focus();
 
 			callback && callback();
 		}, 2000);

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -231,7 +231,7 @@ describe("MultiComboBox general interaction", () => {
 			}, 2500, "expect value state to be different after 2.5 seconds");
 		});
 
-		it("should remove the value state header after validation reset", async () => {
+		it.only("should remove the value state header after validation reset", async () => {
 			const mcb = await browser.$("#mcb-predefined-value");
 			const innerInput = await browser.$("#mcb-predefined-value").shadow$("#ui5-multi-combobox-input");
 			const icon = await mcb.shadow$(".inputIcon");
@@ -243,8 +243,8 @@ describe("MultiComboBox general interaction", () => {
 			assert.strictEqual(await innerInput.getAttribute("value-state"), "Negative", "Value state is changed to Negative");
 
 			await browser.waitUntil(async () => {
-				return await mcb.getAttribute("_dialog-input-value-state") === "None";
-			}, 2500, "expect _dialog-input-value-state to be reset after 2.5 seconds");
+				return await mcb.getAttribute("_dialog-input-value-state") === "None" && await mcb.hasAttribute("focused") === true;
+			}, 2500, "expect _dialog-input-value-state to be reset after 2.5 seconds and the MultiComboBox to be focused");
 		});
 
 		it("tests if entering valid text is possible while validation is triggered", async () => {

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -231,7 +231,7 @@ describe("MultiComboBox general interaction", () => {
 			}, 2500, "expect value state to be different after 2.5 seconds");
 		});
 
-		it.only("should remove the value state header after validation reset", async () => {
+		it("should remove the value state header after validation reset", async () => {
 			const mcb = await browser.$("#mcb-predefined-value");
 			const innerInput = await browser.$("#mcb-predefined-value").shadow$("#ui5-multi-combobox-input");
 			const icon = await mcb.shadow$(".inputIcon");


### PR DESCRIPTION
fixes: #9709

