### PR TITLE
docs: fix shortcut opens search while typing in playground editor

### DIFF
--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -299,6 +299,7 @@ ${fixAssetPaths(_js)}`,
     window.addEventListener("message", messageHandler);
 
     tabBarRef.current.project = projectRef.current;
+    fileEditorRef.current.isContentEditable = true; // algolia search opens the search on key `/` because this element is the event target but has no `isContentEditable`
     fileEditorRef.current.project = projectRef.current;
     previewRef.current.project = projectRef.current;
 

--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -299,9 +299,15 @@ ${fixAssetPaths(_js)}`,
     window.addEventListener("message", messageHandler);
 
     tabBarRef.current.project = projectRef.current;
-    fileEditorRef.current.isContentEditable = true; // algolia search opens the search on key `/` because this element is the event target but has no `isContentEditable`
     fileEditorRef.current.project = projectRef.current;
     previewRef.current.project = projectRef.current;
+	  
+    // algolia search opens the search on key `/` because this custom element is the event target but has no `isContentEditable`
+    Object.defineProperty(fileEditorRef.current, "isContentEditable", {
+        get() {
+            return true;
+        },
+    });
 
     tabBarRef.current.editor = fileEditorRef.current;
 


### PR DESCRIPTION
When typing `/`, the `@docsearch/react` package checks if the key is coming from an input/textarea and additionally from a `contenteditable` element. The editor however is inside the shadowroot of a custom element, so the event target is the custom element, not the actual contenteditable element.

This change adds a `isContentEditable` getter to the editor custom element, so typing `/` in the playground editor no longer opens the search box.