### PR TITLE
fix(ui5-table): add aria reference to growing btn sub text

### DIFF
--- a/packages/compat/src/Table.ts
+++ b/packages/compat/src/Table.ts
@@ -440,7 +440,6 @@ class Table extends UI5Element {
 	fnOnRowFocused: (e: CustomEvent) => void;
 	_handleResize: ResizeObserverCallback;
 
-	moreDataText?: string;
 	tableEndObserved: boolean;
 	visibleColumns: Array<TableColumn>;
 	visibleColumnsCount?: number;

--- a/packages/compat/src/Table.ts
+++ b/packages/compat/src/Table.ts
@@ -1161,7 +1161,7 @@ class Table extends UI5Element {
 	}
 
 	get loadMoreAriaLabelledBy(): string {
-		if (this.moreDataText) {
+		if (this.growingButtonSubtext) {
 			return `${this._id}-growingButton-text ${this._id}-growingButton-subtext`;
 		}
 


### PR DESCRIPTION
The `moreDataText` has never been assigned, probably a degradation in the past after `growingButtonSubText` was introduced. Due to this even if `growingButtonSubText` is set, the span ({this._id}-growingButton-subtext) that is internally created for a11y reasons has never been referenced and read out by screen readers.

Related to: https://github.com/SAP/ui5-webcomponents/issues/9807