### PR TITLE
fix(ui5-dynamic-side-content): fix scrollbar styling

### DIFF
--- a/packages/fiori/src/DynamicSideContent.ts
+++ b/packages/fiori/src/DynamicSideContent.ts
@@ -3,6 +3,7 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import getEffectiveScrollbarStyle from "@ui5/webcomponents-base/dist/util/getEffectiveScrollbarStyle.js";
 import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -109,7 +110,7 @@ type DynamicSideContentLayoutChangeEventDetail = {
 @customElement({
 	tag: "ui5-dynamic-side-content",
 	renderer: litRender,
-	styles: DynamicSideContentCss,
+	styles: [DynamicSideContentCss, getEffectiveScrollbarStyle()],
 	template: DynamicSideContentTemplate,
 })
 /**


### PR DESCRIPTION
Previously, when content was added to the `ui5-dynamic-side-content` component, a scrollbar would appear using the default browser scrollbar styles and sizes. 

Now, custom scrollbar styles have been added, which adapt to the current theme.

### Before
![2024-09-11_09-56-19](https://github.com/user-attachments/assets/e77a8a18-5348-4596-89f2-8e3bf92e0f9d)

### After
![2024-09-11_10-00-35](https://github.com/user-attachments/assets/c3a0e467-c0be-4dcd-8fb5-917f7e82eacc)
