### PR TITLE
fix(ui5-tabcontainer): prevent page scrolling when reordering tabs with home and end keys

### DIFF
--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -855,6 +855,7 @@ class TabContainer extends UI5Element {
 
 		if (isCtrl(e)) {
 			this._moveHeaderItem(tab.realTabReference, e);
+			e.preventDefault();
 			return;
 		}
 


### PR DESCRIPTION
BGSOFUIRODOPI-3147