### PR TITLE
chore: call customElements.define synchronously

### DIFF
--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -70,7 +70,7 @@ const boot = async (): Promise<void> => {
 		resolve();
 
 		booted = true;
-		await eventProvider.fireEventAsync("boot");
+		eventProvider.fireEvent("boot");
 	};
 
 	bootPromise = new Promise(bootExecutor as (resolve: PromiseResolve) => void);

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1203,12 +1203,6 @@ abstract class UI5Element extends HTMLElement {
 		return uniqueDependenciesCache.get(this) || [];
 	}
 
-	/**
-	 * Returns a promise that resolves whenever all dependencies for this UI5 Web Component have resolved
-	 */
-	static whenDependenciesDefined(): Promise<Array<typeof UI5Element>> {
-		return Promise.all(this.getUniqueDependencies().map(dep => dep.define()));
-	}
 
 	/**
 	 * Hook that will be called upon custom element definition
@@ -1220,7 +1214,7 @@ abstract class UI5Element extends HTMLElement {
 	}
 
 	static asyncFinished: boolean;
-	static definePromise: Promise<[void, (typeof UI5Element)[], void]> | undefined;
+	static definePromise: Promise<[void, void]> | undefined;
 
 	/**
 	 * Registers a UI5 Web Component in the browser window object
@@ -1229,7 +1223,6 @@ abstract class UI5Element extends HTMLElement {
 	static async define(): Promise<typeof UI5Element> {
 		this.definePromise = Promise.all([
 			boot(),
-			this.whenDependenciesDefined(),
 			this.onDefine(),
 		]);
 

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1203,7 +1203,6 @@ abstract class UI5Element extends HTMLElement {
 		return uniqueDependenciesCache.get(this) || [];
 	}
 
-
 	/**
 	 * Hook that will be called upon custom element definition
 	 *

--- a/packages/compat/src/TableGroupRow.ts
+++ b/packages/compat/src/TableGroupRow.ts
@@ -79,7 +79,7 @@ class TableGroupRow extends UI5Element implements ITableRow {
 	}
 
 	get ariaLabelText() {
-		return `${TableGroupRow.i18nBundle.getText(TABLE_GROUP_ROW_ARIA_LABEL)} ${this.innerText}. ${this.forcedAriaPosition}`;
+		return `${TableGroupRow.i18nBundle.getText(TABLE_GROUP_ROW_ARIA_LABEL)} ${this.textContent}. ${this.forcedAriaPosition}`;
 	}
 
 	visibleColCount(): number {

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -322,7 +322,10 @@ class Calendar extends CalendarPart {
 	}
 
 	static async onDefine() {
-		Calendar.i18nBundle = await getI18nBundle("@ui5/webcomponents");
+		[Calendar.i18nBundle] = await Promise.all([
+			getI18nBundle("@ui5/webcomponents"),
+			super.onDefine(),
+		]);
 	}
 
 	/**


### PR DESCRIPTION
Before this change, importing a component module calls the `UI5Element.define()` base class method, which triggers some async work before calling `customElements.define()`

This causes frameworks like vuejs and react that check for property existence via `prop in el` to run before the element is defined, this check returns false and such frameworks set attributes (most notably boolean) as string resulting in `checked="false"` being treated as `true` by the components

With this change, the async work is triggered in the beginning of the `define()` call, but not awaited and `customElements.define()` runs as soon as the component is imported. The async work (waiting for the theme and i18n assets to be fetched) is now awaited in the `connectedCallback` so that the component is rendered once with the correct theme and language.

It is no longer necessary to call `define()` on the dependencies and to await this, as the dependencies are imported for use in the decorator, so their `define()` calls would have been executed and the elements will be defined by that point, since they also have synchronous define.