### PR TITLE
fix(ui5-dynamic-page): action buttons reading fix

### DIFF
--- a/packages/fiori/src/DynamicPageHeaderActions.hbs
+++ b/packages/fiori/src/DynamicPageHeaderActions.hbs
@@ -6,7 +6,7 @@
             icon="{{arrowButtonIcon}}"
             accessible-name="{{expandLabel}}"
             .accessibilityAttributes="{{accessibilityAttributes}}"
-            title="{{expandLabel}}"
+            tooltip="{{expandLabel}}"
             @mouseover="{{onExpandHoverIn}}"
             @mouseout="{{onExpandHoverOut}}"
         ></ui5-button>
@@ -18,7 +18,7 @@
             ?pressed="{{pinned}}"
             .accessibilityAttributes="{{accessibilityAttributes}}"
             accessible-name="{{pinLabel}}"
-            title="{{pinLabel}}"
+            tooltip="{{pinLabel}}"
         ></ui5-toggle-button>
     {{/if}}
     </div>

--- a/packages/fiori/test/specs/DynamicPage.spec.js
+++ b/packages/fiori/test/specs/DynamicPage.spec.js
@@ -408,12 +408,12 @@ describe("ARIA attributes", () => {
 
         assert.strictEqual(await expandButton.getProperty("accessibleName"), "Snap Header",
             "expand button accessible-name is correct");
-        assert.strictEqual(await expandButton.getProperty("title"), "Snap Header",
+        assert.strictEqual(await expandButton.getProperty("tooltip"), "Snap Header",
             "expand button accessible-name is correct");
 
         assert.strictEqual(await pinButton.getProperty("accessibleName"), "Pin Header",
             "pin button accessible-name is correct");
-        assert.strictEqual(await pinButton.getProperty("title"), "Pin Header",
+        assert.strictEqual(await pinButton.getProperty("tooltip"), "Pin Header",
             "pin button accessible-name is correct");
     });
 
@@ -447,7 +447,7 @@ describe("ARIA attributes", () => {
         assert.ok(await expandButton.isExisting(), "expand button is rendered");
         assert.strictEqual(await expandButton.getProperty("accessibleName"), "Expand Header",
             "expand button accessible-name is correct");
-        assert.strictEqual(await expandButton.getProperty("title"), "Expand Header",
+        assert.strictEqual(await expandButton.getProperty("tooltip"), "Expand Header",
             "expand button tooltip is correct");
     });
 });


### PR DESCRIPTION
In regard to https://sap.github.io/ui5-webcomponents/docs/advanced/accessibility/#accessibility-apis , removing obsolete title property.

Fixes: [#9819](https://github.com/SAP/ui5-webcomponents/issues/9819)