### PR TITLE
fix(ui5-select): improve selection change handling

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -611,6 +611,8 @@ class Select extends UI5Element implements IFormInputElement {
 	 * @private
 	 */
 	_handleSelectionChange(index = this._selectedIndex) {
+		this._typedChars = "";
+
 		this._select(index);
 
 		this._toggleRespPopover();

--- a/packages/main/test/pages/Toolbar.html
+++ b/packages/main/test/pages/Toolbar.html
@@ -309,7 +309,7 @@
 			console.log("Closed", e);
 		});
 
-		document.querySelector('body').addEventListener('click', (e) => {
+		clickCountToolbar.addEventListener('click', (e) => {
 			if (e.target.id === "clearCounter") {
 				input.setAttribute("value", "0");
 			} else  {

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -628,4 +628,24 @@ describe("Select general interaction", () => {
 		const selectedOption = await browser.$("#warningSelect ui5-option[selected]");
 		assert.ok(await selectedOption.isClickable(), "Selected option is visible in the viewport.");
 	});
+
+	it("clears typed characters after selection is changed", async () => {
+		const select = await browser.$("#textAreaAriaLabel");
+		const selectText = await select.shadow$(".ui5-select-label-root");
+	
+		await select.click();
+		await select.keys("S");
+	
+		let selectTextHtml = await selectText.getHTML(false);
+		assert.include(selectTextHtml, "Second", "Typing 'S' should select 'Second'");
+	
+		await select.keys("Enter");
+	
+		await select.keys("T");
+		selectTextHtml = await selectText.getHTML(false);
+		assert.include(selectTextHtml, "Third", "Typing 'T' should select 'Third' after previous selection");
+	
+		assert.strictEqual(await select.getProperty("value"), "Third", "The selection changed and typed characters were cleared");
+	});
+	
 });


### PR DESCRIPTION
Issue: When changing the selection in the ui5-select, previously typed characters were cleared after a 1-second delay, which caused problems with quick successive selections.

Solution: Modified the selection change logic to clear typed characters immediately whenever the selection is updated, removing the 1-second delay and allowing users to change options quickly without interference from previous input.

Fixes: [#9757](https://github.com/SAP/ui5-webcomponents/issues/9757)