### PR TITLE
chore: simplify guided prompt sample for dialog

### DIFF
--- a/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/main.js
+++ b/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/main.js
@@ -148,7 +148,6 @@ sendButton.addEventListener("click", function() {
 		toast.open = true;
 		output.valueState = "None";
 		output.value = "";
-		aiDialogButton.state = "generate";
 	}
 });
 


### PR DESCRIPTION
This simplifies the sample for guided prompt in dialog, to avoid issue https://github.com/SAP/ui5-webcomponents/issues/9902 untill the issue is fixed.

Steps to reproduce the issue in the sample for AI GuidedPrompt with dialog:
1. Click the "Generate" ai-button to open a dialog
2. In the dialog, click "Apply" and wait [few seconds] until the generation ends and the ai-button text becomes "Revise"
3. Click the "Close" button to close the dialog
4. Click the "Send" button at the footer => the user is notified that the message is sent and the form is cleared
5. Repeat step 2 to re-open the dialog to compose new text
**Expected**: In the dialog, the text of the ai-button is "Apply"
**Actual**: the text of the ai-button is not entirely visible

With this change, clicking the footer "Send" button does **not** reset the state of the ai-button (as is also the case in the similar QuickPrompt sample) but the purpose of the sample is preserved.