### PR TITLE
fix(ui5-color-picker): add missing hex value to RGBtoHEX method

### DIFF
--- a/packages/base/src/util/ColorConversion.ts
+++ b/packages/base/src/util/ColorConversion.ts
@@ -332,7 +332,7 @@ const HEXToRGB = (hex: string): ColorRGB => {
  * @param {Object} color Receives an object with the properties for each of the main colors(r, g, b)
  */
 const RGBtoHEX = (color: ColorRGB): string => {
-	const hexMap = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E"];
+	const hexMap = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"];
 	let hexValue = "#";
 
 	let divisionNumber = color.r / 16;


### PR DESCRIPTION
There was a HEX value missing in the `RGBtoHEX()` method in the ColorConversion util.
With this change we added it.

### Before
```html
<div id="text"></div>

<script>
document.getElementById("text").innerHTML = RGBtoHEX({
  r: 207,
  b: 223,
  g: 255
});  // results in #CundefinedundefinedundefinedDundefined
</script>
```

### After

```html
<div id="text"></div>

<script>
document.getElementById("text").innerHTML = RGBtoHEX({
  r: 207,
  b: 223,
  g: 255
});  // results in #CFFFDF
</script>
```

Fixes: #9895
