### PR TITLE
docs: enhance Table docs

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -151,6 +151,7 @@ type TableRowClickEventDetail = {
  * This Table replaces the previous Table web component, that has been part of **@ui5/webcomponents** version 1.x.
  * For compatibility reasons, we moved the previous Table implementation to the **@ui5/webcomponents-compat** package
  * and will be maintained until the new Table is experimental.
+ * Keep in mind that you can use either the compat/Table, or the main/Table - you can't use them both as they both define the `ui5-table` tag name.
  */
 @customElement({
 	tag: "ui5-table",


### PR DESCRIPTION
Explain that the `compat/Table` and  the `main/Table` can't be used in parallel

Fixes: https://github.com/SAP/ui5-webcomponents/issues/9920