### PR TITLE
feat(ui5-carousel): on touch devices navigation arrows are always visible

### DIFF
--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -180,9 +180,6 @@ class Carousel extends UI5Element {
 	/**
 	 * Defines the visibility of the page indicator.
 	 * If set to true the page indicator will be hidden.
-	 *
-	 * **Note:** The navigation arrows are always displayed on touch devices
-	 * in the page indicator area.
 	 * @since 1.0.0-rc.15
 	 * @default false
 	 * @public
@@ -245,8 +242,6 @@ class Carousel extends UI5Element {
 	 *
 	 * - `Content` - the arrows are placed on the sides of the current page.
 	 * - `Navigation` - the arrows are placed on the sides of the page indicator.
-	 *
-	 * **Note:** On touch devices the arrows are always displayed in the page indicator area.
 	 * @default "Content"
 	 * @public
 	 */
@@ -309,7 +304,7 @@ class Carousel extends UI5Element {
 	}
 
 	onBeforeRendering() {
-		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation) {
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation || !isDesktop()) {
 			this._visibleNavigationArrows = true;
 		}
 
@@ -597,11 +592,7 @@ class Carousel extends UI5Element {
 			return false;
 		}
 
-		if (!isDesktop()) {
-			return true;
-		}
-
-		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows) {
+		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation && (!this.hideNavigationArrows || !isDesktop())) {
 			return true;
 		}
 
@@ -635,11 +626,11 @@ class Carousel extends UI5Element {
 				"ui5-carousel-content": true,
 				"ui5-carousel-content-no-animation": this.suppressAnimation,
 				"ui5-carousel-content-has-navigation": this.renderNavigation,
-				"ui5-carousel-content-has-navigation-and-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows,
+				"ui5-carousel-content-has-navigation-and-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && (!this.hideNavigationArrows || !isDesktop()),
 			},
 			navigation: {
 				"ui5-carousel-navigation-wrapper": true,
-				"ui5-carousel-navigation-with-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows,
+				"ui5-carousel-navigation-with-buttons": this.renderNavigation && this.arrowsPlacement === CarouselArrowsPlacement.Navigation && (!this.hideNavigationArrows || !isDesktop()),
 				[`ui5-carousel-navigation-wrapper-bg-${this.pageIndicatorBackgroundDesign.toLowerCase()}`]: true,
 				[`ui5-carousel-navigation-wrapper-border-${this.pageIndicatorBorderDesign.toLowerCase()}`]: true,
 			},
@@ -680,21 +671,10 @@ class Carousel extends UI5Element {
 	}
 
 	get showArrows() {
-		const displayArrows = this._visibleNavigationArrows && this.hasManyPages && isDesktop();
-		let showInContent;
-		let showInNavigation;
-
-		if (!isDesktop()) {
-			showInContent = false;
-			showInNavigation = this.hasManyPages;
-		} else {
-			showInContent = !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Content;
-			showInNavigation = !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation;
-		}
-
+		const displayArrows = this._visibleNavigationArrows && this.hasManyPages;
 		return {
-			content: showInContent,
-			navigation: showInNavigation,
+			content: (!this.hideNavigationArrows || !isDesktop()) && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Content,
+			navigation: (!this.hideNavigationArrows || !isDesktop()) && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation,
 		};
 	}
 

--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -56,7 +56,7 @@ type CarouselNavigateEventDetail = {
  * There are several ways to perform navigation:
  *
  * - on desktop - the user can navigate using the navigation arrows or with keyboard shortcuts.
- * - on mobile - the user can use swipe gestures.
+ * - on touch devices - the user can navigate using the navigation arrows (always visible) or can use swipe gestures.
  *
  * ### Usage
  *
@@ -169,8 +169,7 @@ class Carousel extends UI5Element {
 	 * Defines the visibility of the navigation arrows.
 	 * If set to true the navigation arrows will be hidden.
 	 *
-	 * **Note:** The navigation arrows are never displayed on touch devices.
-	 * In this case, the user can swipe to navigate through the items.
+	 * **Note:** The navigation arrows are always displayed on touch devices.
 	 * @since 1.0.0-rc.15
 	 * @default false
 	 * @public
@@ -181,6 +180,9 @@ class Carousel extends UI5Element {
 	/**
 	 * Defines the visibility of the page indicator.
 	 * If set to true the page indicator will be hidden.
+	 *
+	 * **Note:** The navigation arrows are always displayed on touch devices
+	 * in the page indicator area.
 	 * @since 1.0.0-rc.15
 	 * @default false
 	 * @public
@@ -243,6 +245,8 @@ class Carousel extends UI5Element {
 	 *
 	 * - `Content` - the arrows are placed on the sides of the current page.
 	 * - `Navigation` - the arrows are placed on the sides of the page indicator.
+	 *
+	 * **Note:** On touch devices the arrows are always displayed in the page indicator area.
 	 * @default "Content"
 	 * @public
 	 */
@@ -593,6 +597,10 @@ class Carousel extends UI5Element {
 			return false;
 		}
 
+		if (!isDesktop()) {
+			return true;
+		}
+
 		if (this.arrowsPlacement === CarouselArrowsPlacement.Navigation && !this.hideNavigationArrows) {
 			return true;
 		}
@@ -673,10 +681,20 @@ class Carousel extends UI5Element {
 
 	get showArrows() {
 		const displayArrows = this._visibleNavigationArrows && this.hasManyPages && isDesktop();
+		let showInContent;
+		let showInNavigation;
+
+		if (!isDesktop()) {
+			showInContent = false;
+			showInNavigation = this.hasManyPages;
+		} else {
+			showInContent = !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Content;
+			showInNavigation = !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation;
+		}
 
 		return {
-			content: !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Content,
-			navigation: !this.hideNavigationArrows && displayArrows && this.arrowsPlacement === CarouselArrowsPlacement.Navigation,
+			content: showInContent,
+			navigation: showInNavigation,
 		};
 	}
 

--- a/packages/main/src/themes/Carousel.css
+++ b/packages/main/src/themes/Carousel.css
@@ -157,6 +157,10 @@
     align-items: center;
 }
 
+.ui5-carousel-navigation:empty {
+    width: 1rem;
+}
+
 .ui5-carousel-navigation-dot {
     box-sizing: border-box;
     width: var(--ui5_carousel_inactive_dot_size);

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -427,10 +427,8 @@
 	<ui5-title>Carousel with one page</ui5-title>
 	<ui5-label>The arrows and dots are not displayed</ui5-label>
 
-	<ui5-carousel id="carousel6" items-per-page="S1 M3 L4 XL4">
+	<ui5-carousel id="carousel6">
 		<ui5-button>Button 1</ui5-button>
-		<ui5-button>Button 2</ui5-button>
-		<ui5-button>Button 3</ui5-button>
 	</ui5-carousel>
 
 	<ui5-carousel id="carousel8" items-per-page="S1 M4 L4 XL4">

--- a/packages/main/test/specs/Carousel.mobile.spec.js
+++ b/packages/main/test/specs/Carousel.mobile.spec.js
@@ -1,0 +1,60 @@
+import { assert } from "chai";
+
+describe("Carousel general interaction", () => {
+	before(async () => {
+		await browser.url(`test/pages/Carousel.html`);
+		await browser.emulateDevice('iPhone X');
+	});
+
+
+	it("Buttons (navigation arrows) are rendered in the navigation EVEN of they are set to be over the content (arrows-placement)", async () => {
+		const carousel = await browser.$("#carousel2");
+		await carousel.scrollIntoView();
+
+		// show both arrows by navigating to the right and focus the button
+		const carouselNextButton = await carousel.shadow$(".ui5-carousel-navigation-button[arrow-forward]");
+		await carouselNextButton.click();
+		await carousel.moveTo();
+
+		const buttons = await carousel.shadow$$(".ui5-carousel-navigation-arrows .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
+		assert.strictEqual(buttons.length, 0, "No arrows are rendered over the content");
+
+		await carousel.scrollIntoView();
+		const buttonsInNavigation = await carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
+		assert.strictEqual(buttonsInNavigation.length, 2, "Navigation is rendered");
+	});
+
+	it("Buttons (navigation arrows) are rendered in the navigation without hovering (arrows-placement)", async () => {
+		const carousel = await browser.$("#carousel3");
+		const carouselNextButton = await carousel.shadow$(".ui5-carousel-navigation-button[arrow-forward]");
+		await carouselNextButton.click();
+
+		await carousel.scrollIntoView();
+		const buttons = await carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
+
+		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
+	});
+
+	it("Buttons (navigation arrows) are rendered in the navigation EVEN if the page indicator and the arrows are hidden", async () => {
+		const carousel = await browser.$("#carouselHiddenPageIndicatorHiddenArrows");
+		const carouselNextButton = await carousel.shadow$(".ui5-carousel-navigation-button[arrow-forward]");
+		await carouselNextButton.click();
+
+		await carousel.scrollIntoView();
+		const buttons = await carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
+
+		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
+	});
+	
+
+	it("Arrows (navigation arrows) and Dots (page indicator) not displayed in case of single page", async () => {
+		const carousel = await browser.$("#carousel6");
+		const pages = await carousel.getProperty("pagesCount");
+		const pageIndicator = await carousel.shadow$(".ui5-carousel-navigation-wrapper");
+		const navigationArrows = await carousel.shadow$(".ui5-carousel-navigation-arrows");
+
+		assert.notOk(await pageIndicator.isExisting(), "Page indicator is not rendered");
+		assert.notOk(await navigationArrows.isExisting(), "Navigation arrows are not rendered");
+		assert.strictEqual(pages, 1, "There is only 1 page.");
+	});
+});

--- a/packages/main/test/specs/Carousel.mobile.spec.js
+++ b/packages/main/test/specs/Carousel.mobile.spec.js
@@ -7,21 +7,12 @@ describe("Carousel general interaction", () => {
 	});
 
 
-	it("Buttons (navigation arrows) are rendered in the navigation EVEN of they are set to be over the content (arrows-placement)", async () => {
+	it("Buttons (navigation arrows) are rendered in the content without hovering", async () => {
 		const carousel = await browser.$("#carousel2");
 		await carousel.scrollIntoView();
 
-		// show both arrows by navigating to the right and focus the button
-		const carouselNextButton = await carousel.shadow$(".ui5-carousel-navigation-button[arrow-forward]");
-		await carouselNextButton.click();
-		await carousel.moveTo();
-
 		const buttons = await carousel.shadow$$(".ui5-carousel-navigation-arrows .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
-		assert.strictEqual(buttons.length, 0, "No arrows are rendered over the content");
-
-		await carousel.scrollIntoView();
-		const buttonsInNavigation = await carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
-		assert.strictEqual(buttonsInNavigation.length, 2, "Navigation is rendered");
+		assert.strictEqual(buttons.length, 1, "Navigation arrow is rendered");
 	});
 
 	it("Buttons (navigation arrows) are rendered in the navigation without hovering (arrows-placement)", async () => {
@@ -32,7 +23,7 @@ describe("Carousel general interaction", () => {
 		await carousel.scrollIntoView();
 		const buttons = await carousel.shadow$$(".ui5-carousel-navigation-wrapper .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)");
 
-		assert.strictEqual(buttons.length, 2, "Navigation is rendered");
+		assert.strictEqual(buttons.length, 2, "Navigation arrows are rendered");
 	});
 
 	it("Buttons (navigation arrows) are rendered in the navigation EVEN if the page indicator and the arrows are hidden", async () => {


### PR DESCRIPTION
- The  main difference with desktop is that when the arrows are in the content (middle)
 they are not shown only on hover of the carousel, but always.
This relates to WCAG 2.2 - ACC-270.19 Alternative for Dragging
- The property "hideNavigationArrows" doesn't work on touch devices
- There is one exception - when there is only one page in the carousel no arrows are needed
- In addition the new design for hidden page indicator is implemented
(the arrows are near and no place for the page indicator is kept)

JIRA: BGSOFUIRODOPI-3314