### PR TITLE
docs(ui5-option): correct interface definition

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -68,14 +68,14 @@ import SelectPopoverCss from "./generated/themes/SelectPopover.css.js";
  * Interface for components that may be slotted inside `ui5-select` as options
  * @public
  */
-type IOption = ListItemBase & {
+interface IOption extends ListItemBase {
 	tooltip?: string,
 	icon?: string,
 	value?: string,
 	additionalText?: string,
-	focused?: boolean,
+	focused: boolean,
 	effectiveDisplayText: string,
-};
+}
 
 type SelectChangeEventDetail = {
 	selectedOption: IOption,


### PR DESCRIPTION
IOption interface is defined without interface keyword and this is leading to missing documentation.