### PR TITLE
fix(ui5-select): prevent close event from bubbling to parent components

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -722,7 +722,7 @@ class Select extends UI5Element implements IFormInputElement {
 			this._fireChangeEvent(this.options[this._selectedIndex]);
 			this._lastSelectedOption = this.options[this._selectedIndex];
 		}
-		this.fireEvent<CustomEvent>("close");
+		this.fireEvent("close", {}, false, false);
 	}
 
 	get hasCustomLabel() {


### PR DESCRIPTION
Issue: The close event from a ui5-select inside other components (such as dialogs or popovers) would incorrectly bubble up, triggering the parent component's close event.

Solution: Stopped the close event from bubbling when the ui5-select is closed, ensuring only the select component handles its own close event.

Fixes: [#9909](https://github.com/SAP/ui5-webcomponents/issues/9909)