### PR TITLE
docs: make Form samples theme-friendly

### DIFF
--- a/packages/website/docs/_samples/main/Form/LabelSpan/main.css
+++ b/packages/website/docs/_samples/main/Form/LabelSpan/main.css
@@ -1,6 +1,6 @@
 ui5-form-item::part(layout) {
-	background: #72c9e1;
+	background: var(--sapHoverColor);
 }
 ui5-form-item::part(content) {
-	background: #eef9fc;
+	background: var(--sapAvatar_1_Background);
 }

--- a/packages/website/docs/_samples/main/Form/Layout/main.css
+++ b/packages/website/docs/_samples/main/Form/Layout/main.css
@@ -1,3 +1,3 @@
 ui5-form::part(column) {
-	background: #eef9fc;
+	background: var(--sapHoverColor);
 }


### PR DESCRIPTION
Few samples did not look well in dark themes due to hard-coded backgrounds