### PR TITLE
fix(ui5-input): remove the width from the inner input

### DIFF
--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -7,7 +7,6 @@
 }
 
 :host {
-	width: var(--_ui5_input_width);
 	min-width: calc(var(--_ui5_input_min_width) + (var(--_ui5-input-icons-count)*var(--_ui5_input_icon_width)));
 	margin: var(--_ui5_input_margin_top_bottom) 0;
 	height: var(--_ui5_input_height);

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -7,6 +7,7 @@
 }
 
 :host {
+	width: var(--_ui5_input_width);
 	min-width: calc(var(--_ui5_input_min_width) + (var(--_ui5-input-icons-count)*var(--_ui5_input_icon_width)));
 	margin: var(--_ui5_input_margin_top_bottom) 0;
 	height: var(--_ui5_input_height);

--- a/packages/main/src/themes/Input.css
+++ b/packages/main/src/themes/Input.css
@@ -107,7 +107,6 @@
 	-moz-appearance: textfield;
 	padding: var(--_ui5_input_inner_padding);
 	box-sizing: border-box;
-	min-width: var(--_ui5_input_min_width);
 	width: 100%;
 	text-align: inherit;
 	text-overflow: ellipsis;

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -1,4 +1,5 @@
 :root {
+	--_ui5_input_width: 13.125rem;
 	--_ui5_input_min_width: 2.75rem;
 	--_ui5_input_height: var(--sapElement_Height);
 	--_ui5_input_compact_height: 1.625rem;

--- a/packages/main/src/themes/base/Input-parameters.css
+++ b/packages/main/src/themes/base/Input-parameters.css
@@ -1,5 +1,4 @@
 :root {
-	--_ui5_input_width: 13.125rem;
 	--_ui5_input_min_width: 2.75rem;
 	--_ui5_input_height: var(--sapElement_Height);
 	--_ui5_input_compact_height: 1.625rem;

--- a/packages/main/test/pages/styles/MultiInput.css
+++ b/packages/main/test/pages/styles/MultiInput.css
@@ -1,5 +1,5 @@
 ui5-multi-input {
-			/* width: 100%; */
+	width: 13.125rem;
 }
 
 .footer {

--- a/packages/main/test/pages/styles/MultiInput.css
+++ b/packages/main/test/pages/styles/MultiInput.css
@@ -1,5 +1,5 @@
 ui5-multi-input {
-	width: 13.125rem;
+    /* width: 100%; */
 }
 
 .footer {


### PR DESCRIPTION
There is no such visual requirement in the Fiori specifications for the` ui5-input` to have a min-width.
Moreover, it breaks components that use `ui5-input` as part of them, like `ui5-slider` and `ui5-range-slider`.