### PR TITLE
fix(ui5-flexible-column-layout): handle separator movement

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -510,7 +510,7 @@ class FlexibleColumnLayout extends UI5Element {
 			return;
 		}
 
-		const isTouch = e instanceof TouchEvent,
+		const isTouch = supportsTouch() && e instanceof TouchEvent,
 			cursorPositionX = this.getPageXValueFromEvent(e);
 
 		this.separatorMovementSession = this.initSeparatorMovementSession(pressedSeparator, cursorPositionX, isTouch);


### PR DESCRIPTION
Issue: In Firefox and Safari, the separator in the Flexible Column Layout is not moving as expected.

Solution: Improved the handling of touch events to ensure proper functionality across all browsers during separator movement.

Fixes: [#9932](https://github.com/SAP/ui5-webcomponents/issues/9932)