### PR TITLE
refactor(ui5-list-group-header):exclude group header from pointer and hover effects

### DIFF
--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -15,7 +15,7 @@
 }
 
 /* actionable (type="Active" + desktop) */
-:host([actionable]:not([disabled])) {
+:host([actionable]:not([disabled]):not(ui5-li-group-header)) {
 	cursor: pointer;
 }
 
@@ -30,8 +30,8 @@
 }
 
 /* hovered */
-:host([actionable]:not([active], [selected]):hover) {
-	background-color: var(--sapList_Hover_Background);
+:host([actionable]:not([active]):not([selected]):not(ui5-li-group-header):hover) {
+    background-color: var(--sapList_Hover_Background);
 }
 
 /* selected and hovered */

--- a/packages/main/src/themes/ListItemGroupHeader.css
+++ b/packages/main/src/themes/ListItemGroupHeader.css
@@ -10,6 +10,10 @@
 	border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
 }
 
+:host([actionable]:not([disabled])) {
+	cursor: default;
+}
+
 .ui5-li-root.ui5-ghli-root {
 	padding-top: 0.5rem;
 	color: currentColor;


### PR DESCRIPTION
Removed redundant hover background and cursor: pointer from the group header. The changes ensure that only actionable items receive these effects, improving clarity and consistency in styling.
