### PR TITLE
fix(ui5-table): Wrong indentation of  horizontalAlign example sections

### DIFF
--- a/packages/website/docs/_components_pages/main/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableCell.mdx
@@ -9,7 +9,7 @@ import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";
 
 <%COMPONENT_METADATA%>
 
-### Horizontal cell alignment
+## Horizontal cell alignment
 
 Control the horizontal alignment of cells by utilizing the `horizontalAlign` property.
 

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
@@ -19,7 +19,7 @@ import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";
 
 <Popin />
 
-### Horizontal cell alignment
+## Horizontal cell alignment
 
 Control the horizontal alignment of cells by utilizing the `horizontalAlign` property.
 


### PR DESCRIPTION
The titles of the example sections of the horizontalAlign property had the wrong indentation.