### PR TITLE
fix(ui5-split-button): adjust focus outline on keydown

### DIFF
--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -111,6 +111,24 @@
 	border-color: var(--sapContent_ContrastFocusColor);
 }
 
+:host([design="Emphasized"][desktop]) .ui5-split-button-root:focus-within .ui5-split-text-button[active]::part(button):after,
+:host([design="Emphasized"]) .ui5-split-button-root:focus-visible .ui5-split-text-button[active]::part(button):after {
+	content: "";
+	position: absolute;
+	box-sizing: border-box;
+	left: 0.0625rem;
+	top: 0.0625rem;
+	right: 0.0625rem;
+	bottom: 0.0625rem;
+	border: var(--_ui5_split_button_focused_border);
+	border-radius: var(--_ui5_split_button_focused_border_radius);
+}
+
+:host([design="Emphasized"][desktop]) .ui5-split-button-root:has(.ui5-split-text-button[active]):after,
+:host([design="Emphasized"]) .ui5-split-button-root:has(.ui5-split-text-button[active]):after {
+	border-color: transparent;
+}
+
 .ui5-split-button-root {
 	display: inline-flex;
 	position: relative;

--- a/packages/main/src/themes/base/SplitButton-parameters.css
+++ b/packages/main/src/themes/base/SplitButton-parameters.css
@@ -41,7 +41,6 @@
 
 	--_ui5_split_text_button_emphasized_border_width: 0.0625rem;
 
-
 	--_ui5_split_text_button_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_BorderColor);
 	--_ui5_split_text_button_emphasized_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_Emphasized_BorderColor);
 	--_ui5_split_text_button_positive_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_Accept_BorderColor);

--- a/packages/main/src/themes/base/SplitButton-parameters.css
+++ b/packages/main/src/themes/base/SplitButton-parameters.css
@@ -41,6 +41,7 @@
 
 	--_ui5_split_text_button_emphasized_border_width: 0.0625rem;
 
+
 	--_ui5_split_text_button_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_BorderColor);
 	--_ui5_split_text_button_emphasized_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_Emphasized_BorderColor);
 	--_ui5_split_text_button_positive_hover_border: var(--sapButton_BorderWidth) solid var(--sapButton_Accept_BorderColor);


### PR DESCRIPTION
Issue:
- The focus outline on key down wasn't clearly visible when the button is `Emphasized`.