### PR TITLE
fix(ui5-toolbar-*): ensure getDomRef() returns the actual DOM reference

### DIFF
--- a/packages/main/cypress/specs/Toolbar.cy.ts
+++ b/packages/main/cypress/specs/Toolbar.cy.ts
@@ -1,0 +1,43 @@
+import { html } from "lit";
+import "../../src/Toolbar.js";
+import "../../src/ToolbarButton.js";
+import "../../src/ToolbarSelect.js";
+import "../../src/ToolbarSelectOption.js";
+import "../../src/ToolbarSeparator.js";
+import type ToolbarItem from "../../src/ToolbarItem.js";
+
+describe("Toolbar general interaction", () => {
+	it("Should not return null upon calling getDomRef for all direct child items", () => {
+		cy.mount(html`
+			<ui5-toolbar id="otb_standard">
+				<ui5-toolbar-button text="Button 1"></ui5-toolbar-button>
+				<ui5-toolbar-button text="Button 2"></ui5-toolbar-button>
+				<ui5-toolbar-button text="Button 3"></ui5-toolbar-button>
+				<ui5-toolbar-select>
+					<ui5-toolbar-select-option>1</ui5-toolbar-select-option>
+					<ui5-toolbar-select-option>2</ui5-toolbar-select-option>
+					<ui5-toolbar-select-option>3</ui5-toolbar-select-option>
+				</ui5-toolbar-select>
+				<ui5-toolbar-separator></ui5-toolbar-separator>
+				<ui5-toolbar-button text="Button 4"></ui5-toolbar-button>
+				<ui5-toolbar-button text="Button 5"></ui5-toolbar-button>
+				<ui5-toolbar-button text="Button 6"></ui5-toolbar-button>
+			</ui5-toolbar>
+		`);
+
+		cy.get("#otb_standard")
+			.as("toolbar");
+
+		cy.get("@toolbar")
+			.should("exist");
+
+		cy.get("@toolbar")
+			.children()
+			.each($el => {
+				const toolbarItem = $el[0] as ToolbarItem;
+				cy.wrap(toolbarItem.getDomRef())
+					.should("not.be.null")
+					.should("not.be.undefined");
+			});
+	});
+});

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -333,6 +333,8 @@ class Toolbar extends UI5Element {
 	onBeforeRendering() {
 		this.detachListeners();
 		this.attachListeners();
+
+		this.preprocessItems();
 	}
 
 	async onAfterRendering() {
@@ -340,7 +342,6 @@ class Toolbar extends UI5Element {
 
 		this.storeItemsWidth();
 		this.processOverflowLayout();
-		this.preprocessItems();
 	}
 
 	/**

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -340,6 +340,7 @@ class Toolbar extends UI5Element {
 
 		this.storeItemsWidth();
 		this.processOverflowLayout();
+		this.preprocessItems();
 	}
 
 	/**
@@ -348,19 +349,19 @@ class Toolbar extends UI5Element {
 	 */
 	isOverflowOpen(): boolean {
 		const overflowPopover = this.getOverflowPopover();
-		return overflowPopover!.open;
+		return overflowPopover.open;
 	}
 
 	openOverflow(): void {
 		const overflowPopover = this.getOverflowPopover();
-		overflowPopover!.opener = this.overflowButtonDOM!;
-		overflowPopover!.open = true;
-		this.reverseOverflow = overflowPopover!.actualPlacement === "Top";
+		overflowPopover.opener = this.overflowButtonDOM!;
+		overflowPopover.open = true;
+		this.reverseOverflow = overflowPopover.actualPlacement === "Top";
 	}
 
 	closeOverflow() {
 		const overflowPopover = this.getOverflowPopover();
-		overflowPopover!.open = false;
+		overflowPopover.open = false;
 	}
 
 	toggleOverflow() {
@@ -371,8 +372,8 @@ class Toolbar extends UI5Element {
 		}
 	}
 
-	getOverflowPopover(): Popover | null {
-		return this.shadowRoot!.querySelector<Popover>(".ui5-overflow-popover");
+	getOverflowPopover(): Popover {
+		return this.shadowRoot!.querySelector<Popover>(".ui5-overflow-popover")!;
 	}
 
 	/**
@@ -615,6 +616,13 @@ class Toolbar extends UI5Element {
 
 	getRegisteredToolbarItemByID(id: string): HTMLElement | null {
 		return this.itemsDOM!.querySelector(`[data-ui5-external-action-item-id="${id}"]`);
+	}
+
+	preprocessItems() {
+		this.items.forEach(item => {
+			item._getRealDomRef = () => this.getDomRef()!.querySelector(`[data-ui5-stable*=${item.stableDomRef}]`)
+				?? this.getOverflowPopover().querySelector(`[data-ui5-stable*=${item.stableDomRef}]`)!;
+		});
 	}
 }
 

--- a/packages/main/src/ToolbarButton.hbs
+++ b/packages/main/src/ToolbarButton.hbs
@@ -13,7 +13,6 @@
 	?hidden="{{this.hidden}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 	data-ui5-stable="{{this.stableDomRef}}"
-	.refItemId="{{this._id}}"
 >
 		{{this.text}}
 </ui5-button>

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -156,6 +156,13 @@ class ToolbarButton extends ToolbarItem {
 	@property()
 	width?: string;
 
+	onEnterDOM() {
+		const toolbar = this.parentElement as HTMLElement;
+		this._getRealDomRef = () => {
+			return toolbar.shadowRoot!.querySelector<HTMLElement>(`[data-ui5-stable="${this.stableDomRef}"]`)!;
+		};
+	}
+
 	get styles() {
 		return {
 			width: this.width,

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -156,13 +156,6 @@ class ToolbarButton extends ToolbarItem {
 	@property()
 	width?: string;
 
-	onEnterDOM() {
-		const toolbar = this.parentElement as HTMLElement;
-		this._getRealDomRef = () => {
-			return toolbar.shadowRoot!.querySelector<HTMLElement>(`[data-ui5-stable="${this.stableDomRef}"]`)!;
-		};
-	}
-
 	get styles() {
 		return {
 			width: this.width,

--- a/packages/main/src/ToolbarPopoverSelect.hbs
+++ b/packages/main/src/ToolbarPopoverSelect.hbs
@@ -1,5 +1,6 @@
 <ui5-select 
 	class="ui5-tb-popover-item"
+	data-ui5-stable="{{this.stableDomRef}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 	value-state="{{this.valueState}}"
 	?disabled="{{this.disabled}}"

--- a/packages/main/src/ToolbarPopoverSeparator.hbs
+++ b/packages/main/src/ToolbarPopoverSeparator.hbs
@@ -1,5 +1,6 @@
 <div
 	class="ui5-tb-separator-in-overflow ui5-tb-popover-item"
+	data-ui5-stable="{{this.stableDomRef}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 	?visible="{{visible}}"
 ></div>

--- a/packages/main/src/ToolbarSelect.hbs
+++ b/packages/main/src/ToolbarSelect.hbs
@@ -1,6 +1,7 @@
 <ui5-select 
 	class="ui5-tb-item"
 	style="{{this.styles}}"
+	data-ui5-stable="{{this.stableDomRef}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 	value-state="{{this.valueState}}"
 	?disabled="{{this.disabled}}"

--- a/packages/main/src/ToolbarSeparator.hbs
+++ b/packages/main/src/ToolbarSeparator.hbs
@@ -1,4 +1,5 @@
 <div
 	class="ui5-tb-separator ui5-tb-item"
+	data-ui5-stable="{{this.stableDomRef}}"
 	data-ui5-external-action-item-id="{{this._id}}"
 ></div>

--- a/packages/main/test/pages/Toolbar.html
+++ b/packages/main/test/pages/Toolbar.html
@@ -29,7 +29,7 @@
 		<ui5-title level="H3">Standard Toolbar with ToolbarSelect</ui5-title>
 		<br />
 		<section>
-			<ui5-toolbar>
+			<ui5-toolbar id="otb_standard">
 				<ui5-toolbar-button icon="add" stable-dom-ref="otb_button_1" text="Left 1 (long)"></ui5-toolbar-button>
 				<ui5-toolbar-button icon="decline" text="Left 2"></ui5-toolbar-button>
 				<ui5-toolbar-button icon="employee" text="Left 3"></ui5-toolbar-button>

--- a/packages/main/test/specs/Toolbar.spec.js
+++ b/packages/main/test/specs/Toolbar.spec.js
@@ -73,5 +73,15 @@ describe("Toolbar general interaction", () => {
 		await input.setAttribute("value", "0");
 	});
 
+	it("Should not return null upon calling getDomRef for all direct child items", async () => {
+		await browser.setWindowSize(500, 1080);
 
+		const toolbar = await browser.$("#otb_standard");
+		const items = await toolbar.$$(":scope > *");
+
+		for (const item of items) {
+			const realDomRef = await browser.execute((el) => el.getDomRef(), item);
+			assert.isNotNull(realDomRef, "getDomRef should return a valid DOM reference");
+		}
+	});
 });

--- a/packages/main/test/specs/Toolbar.spec.js
+++ b/packages/main/test/specs/Toolbar.spec.js
@@ -72,16 +72,4 @@ describe("Toolbar general interaction", () => {
 		assert.strictEqual(await input.getProperty("value"), "1", "Button click event only called once");
 		await input.setAttribute("value", "0");
 	});
-
-	it("Should not return null upon calling getDomRef for all direct child items", async () => {
-		await browser.setWindowSize(500, 1080);
-
-		const toolbar = await browser.$("#otb_standard");
-		const items = await toolbar.$$(":scope > *");
-
-		for (const item of items) {
-			const realDomRef = await browser.execute((el) => el.getDomRef(), item);
-			assert.isNotNull(realDomRef, "getDomRef should return a valid DOM reference");
-		}
-	});
 });


### PR DESCRIPTION
### Bug Description

The `getDomRef()` method on `ui5-toolbar-*` items was returning `undefined` instead of a valid DOM reference. This limitation hindered developers from programmatically interacting with the toolbar items within the `ui5-toolbar` component.

### Fix Details

- Introduced a custom getDomRef() implementation tailored for ui5-toolbar items, ensuring that the method reliably returns the actual DOM reference of each rendered toolbar item.

### Outcome

Developers can now confidently access and interact with each toolbar item’s DOM element through the `getDomRef()` method, improving the overall developer experience and ensuring consistent functionality within applications.

Fixes: #9996
Related: #9997, #10126