### PR TITLE
fix(tools): revert tsconfig moduleResolution to node

### DIFF
--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -8,6 +8,8 @@
 		"outDir": "dist",
 		"experimentalDecorators": true,
 		"verbatimModuleSyntax": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [
 				"../base/src/*"

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -10,6 +10,8 @@
 		"composite": true,
 		"rootDir": "src",
 		"experimentalDecorators": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfobuild",
 		"paths": {
 			"@ui5/webcomponents-base/dist/ssr-dom.js": ["./src/ssr-dom.ts"],

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -8,6 +8,8 @@
 		"outDir": "dist",
 		"experimentalDecorators": true,
 		"verbatimModuleSyntax": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [
 				"../base/src/*"

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -11,6 +11,8 @@
 		"rootDir": "src",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"verbatimModuleSyntax": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [
 				"../base/src/*"

--- a/packages/icons-business-suite/tsconfig.json
+++ b/packages/icons-business-suite/tsconfig.json
@@ -10,6 +10,8 @@
 		"allowSyntheticDefaultImports": true,
 		"composite": true,
 		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/icons-tnt/tsconfig.json
+++ b/packages/icons-tnt/tsconfig.json
@@ -10,6 +10,8 @@
 		"allowSyntheticDefaultImports": true,
 		"composite": true,
 		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -10,6 +10,8 @@
 		"allowSyntheticDefaultImports": true,
 		"composite": true,
 		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/localization/tsconfig.json
+++ b/packages/localization/tsconfig.json
@@ -7,6 +7,8 @@
 		"outDir": "dist",
 		"composite": true,
 		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -10,6 +10,8 @@
 		"composite": true,
 		"rootDir": "src",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"verbatimModuleSyntax": true,
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/theming/tsconfig.json
+++ b/packages/theming/tsconfig.json
@@ -8,6 +8,8 @@
 		"experimentalDecorators": true,
 		"composite": true,
 		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": [

--- a/packages/tools/tsconfig.json
+++ b/packages/tools/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"module": "NodeNext",
 		"target": "ES2021",
 		"lib": [
 			"DOM",
@@ -12,5 +11,6 @@
 		"sourceMap": true,
 		"inlineSources": true,
 		"strict": true,
+		"moduleResolution": "node",
 	}
 }


### PR DESCRIPTION
The default TypeScript moduleResolution was changed to "NodeNext" with #9948 

This is the recommended setting for libraries that should run on nodejs and the browser, but it introduces stricter CJS/MJS checks and is incompatible for existing projects that do not use `"type": "module"` in their package.json

This change reverts the default module resolution and moves it in the individual packages.

More information here:
https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution-for-libraries