### PR TITLE
fix(ui5-range-slider): right click on the slider handle does not throw

### DIFF
--- a/packages/main/src/RangeSlider.ts
+++ b/packages/main/src/RangeSlider.ts
@@ -483,6 +483,10 @@ class RangeSlider extends SliderBase implements IFormInputElement {
 	 * @private
 	 */
 	_onmousedown(e: TouchEvent | MouseEvent) {
+		if ((e as MouseEvent)?.button && (e as MouseEvent)?.button !== 0) {
+			return;
+		}
+
 		// If step is 0 no interaction is available because there is no constant
 		// (equal for all user environments) quantitative representation of the value
 		if (this.disabled || this._effectiveStep === 0 || (e.target as HTMLElement).hasAttribute("ui5-input")) {


### PR DESCRIPTION
In some cases, right clicking on the slider handle throws an error because the mouse `move` event is being handled while the right mouse button is pressed.

This change prevents treating the mouse movement while the right mouse button is pressed as a valid (value affecting) drag interaction. 

