### PR TITLE
fix(ui5-input): properly change numeric input value using the arrow keys

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1032,7 +1032,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		const inputDomRef = this.getInputDOMRefSync();
 		const emptyValueFiredOnNumberInput = this.value && this.isTypeNumber && !inputDomRef!.value;
 		const eventType: string = (e as InputEvent).inputType
-			|| (e.detail as InputEventDetail).inputType
+			|| (e.detail && (e as CustomEvent<InputEventDetail>).detail.inputType)
 			|| "";
 		this._keepInnerValue = false;
 
@@ -1344,7 +1344,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 		this.valueBeforeItemPreview = inputValue;
 
 		if (isUserInput) { // input
-			const prevented = !this.fireEvent<InputEventDetail>(INPUT_EVENTS.INPUT, { inputType: e.inputType }, true);
+			const inputType = e.inputType || "";
+			const prevented = !this.fireEvent<InputEventDetail>(INPUT_EVENTS.INPUT, { inputType }, true);
 
 			if (prevented) {
 				this.value = valueBeforeInput;

--- a/packages/main/test/pages/Input.html
+++ b/packages/main/test/pages/Input.html
@@ -349,6 +349,7 @@
 
 	<h3>Test Backspace</h3>
 	<ui5-input id="input-number3" type="Number" value="4"></ui5-input><br>
+	<ui5-input id="input-number3-change-count" type="Number" value="0"></ui5-input><br />
 	<ui5-button id="input-number3-focusout">Click</ui5-button>
 
 	<ui5-input id="input-number31" type="Number" value="4.333"></ui5-input><br>
@@ -781,6 +782,11 @@
 
 		document.getElementById("prevent-input-event-clear-icon").addEventListener("ui5-input", event => {
 			event.preventDefault();
+		});
+
+		document.getElementById("input-number3").addEventListener("ui5-input", () => {
+			const inputNumber3ChangeCount = document.getElementById("input-number3-change-count");
+			inputNumber3ChangeCount.value = (parseInt(inputNumber3ChangeCount.value) + 1).toString();
 		});
 	</script>
 </body>

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -255,6 +255,21 @@ describe("Input general interaction", () => {
 		await input.keys("Enter");
 	});
 
+	it("Input event is fired when user uses arrow keys to increase/decrease numeric value", async () => {
+		await browser.url(`test/pages/Input.html`);
+
+		const input = await browser.$("#input-number3");
+		await input.scrollIntoView();
+		await input.click();
+
+		await input.keys("ArrowUp");
+		await input.keys("ArrowDown");
+
+		const inputChangeCount = await browser.$("#input-number3-change-count");
+
+		assert.strictEqual( await inputChangeCount.getProperty("value"), "2", "Input event is fired when navigating with arrow keys");
+	});
+
 	it("tests value removal when Input type is 'Number'", async () => {
 		const input = await browser.$("#input-number3");
 		const btn = await browser.$("#input-number3-focusout");

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -262,8 +262,8 @@ describe("Input general interaction", () => {
 		await input.scrollIntoView();
 		await input.click();
 
-		await input.keys("ArrowUp");
-		await input.keys("ArrowDown");
+		await browser.keys("ArrowUp");
+		await browser.keys("ArrowDown");
 
 		const inputChangeCount = await browser.$("#input-number3-change-count");
 


### PR DESCRIPTION
Downport #9616

Fire input event when user uses the arrow keys to increase or decrease the value of a numeric input

Fixes [#9785](https://github.com/SAP/ui5-webcomponents/issues/9785)
