### PR TITLE
fix(localization): legacy date customization

### DIFF
--- a/packages/localization/src/sap/base/i18n/Formatting.ts
+++ b/packages/localization/src/sap/base/i18n/Formatting.ts
@@ -1,0 +1,13 @@
+import { getLegacyDateCalendarCustomizing } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
+
+const emptyFn = () => {};
+
+/**
+ * OpenUI5 Formatting Shim
+ */
+const Formatting = {
+	getABAPDateFormat: emptyFn,
+	getCustomIslamicCalendarData: getLegacyDateCalendarCustomizing,
+};
+
+export default Formatting;

--- a/packages/localization/src/sap/ui/core/FormatSettings.ts
+++ b/packages/localization/src/sap/ui/core/FormatSettings.ts
@@ -1,5 +1,4 @@
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
-import { getLegacyDateCalendarCustomizing } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
 
 const emptyFn = () => {};
 
@@ -10,7 +9,6 @@ const FormatSettings = {
 	getFormatLocale: getLocale,
 	getLegacyDateFormat: emptyFn,
 	getCustomLocaleData: emptyFn,
-	getLegacyDateCalendarCustomizing,
 };
 
 export default FormatSettings;

--- a/packages/localization/used-modules.txt
+++ b/packages/localization/used-modules.txt
@@ -2,7 +2,6 @@
 
 # ./ui5loader-autoconfig.js
 # sap/base/Log.js
-sap/base/i18n/Formatting.js
 sap/base/assert.js
 # sap/base/config.js
 sap/base/config/MemoryConfigurationProvider.js

--- a/packages/main/test/pages/DatePicker_legacy_test_page.html
+++ b/packages/main/test/pages/DatePicker_legacy_test_page.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<script data-id="sap-ui-config" type="application/json">
+		{
+			"language": "EN",
+			"formatSettings": {
+				"legacyDateCalendarCustomizing": [
+					{
+						"dateFormat": "A",
+						"gregDate": "20240211",
+						"islamicMonthStart": "14450801"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240311",
+						"islamicMonthStart": "14450901"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240410",
+						"islamicMonthStart": "14451001"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240509",
+						"islamicMonthStart": "14451101"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240607",
+						"islamicMonthStart": "14451201"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240707",
+						"islamicMonthStart": "14460101"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240805",
+						"islamicMonthStart": "14460201"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20240904",
+						"islamicMonthStart": "14460301"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20241004",
+						"islamicMonthStart": "14460401"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20241103",
+						"islamicMonthStart": "14460501"
+					},
+					{
+						"dateFormat": "A",
+						"gregDate": "20241202",
+						"islamicMonthStart": "14460601"
+					}
+				]
+			}
+		}
+	</script>
+
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+
+	<link rel="stylesheet" type="text/css" href="./styles/DatePicker_test_page.css">
+</head>
+<body class="datepicker_test_page1auto">
+	<ui5-date-picker id="dp" value="Rab. I 9, 1446 AH" primary-calendar-type="Islamic"> </ui5-date-picker>
+</body>
+</html>

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1412,4 +1412,20 @@ describe("Date Picker Tests", () => {
 
 		await datepicker.closePicker();
 	});
+
+	describe("Legacy date customization", () => {
+		it.only("Customization of legacy dates in Islamic calendar", async () => {
+			// Based on Islamic calendar calculator Rab. I 9, 1446 AH should be displayed in
+			// Thursday but it need to be configurated using legacyDateCalendarCustomizing setting
+			datepicker.page = "test/pages/DatePicker_legacy_test_page.html";
+
+			await datepicker.open();
+
+			datepicker.id = "#dp";
+
+			const currentSelection = await datepicker.getDisplayedDay(11);
+
+			assert.strictEqual(await currentSelection.getText(), "9", "Legacy date customization is applied");
+		});
+	});
 });

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -1415,8 +1415,8 @@ describe("Date Picker Tests", () => {
 
 	describe("Legacy date customization", () => {
 		it.only("Customization of legacy dates in Islamic calendar", async () => {
-			// Based on Islamic calendar calculator Rab. I 9, 1446 AH should be displayed in
-			// Thursday but it need to be configurated using legacyDateCalendarCustomizing setting
+			// According to the Islamic calendar, Rab. I 9, 1446 AH should be displayed on Thursday,
+			// but it needs to be configured using the legacyDateCalendarCustomizing setting.
 			datepicker.page = "test/pages/DatePicker_legacy_test_page.html";
 
 			await datepicker.open();


### PR DESCRIPTION
With the update of OpenUI5 to version 1.120.17 (https://github.com/SAP/ui5-webcomponents/pull/9432), `Formatting.getLegacyDateCalendarCustomizing` was renamed to `Formatting.getCustomIslamicCalendarData`. Because of this change, `legacyDateCalendarCustomizing` stopped working. This PR fixes the mapping of `legacyDateCalendarCustomizing`, and now it works again.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/9980