### PR TITLE
fix(framework): always fire languageChange regardless of boot status

### DIFF
--- a/packages/base/src/config/Language.ts
+++ b/packages/base/src/config/Language.ts
@@ -43,8 +43,8 @@ const setLanguage = async (language: string): Promise<void> => {
 
 	curLanguage = language;
 
+	await fireLanguageChange(language);
 	if (isBooted()) {
-		await fireLanguageChange(language);
 		await reRenderAllUI5Elements({ languageAware: true });
 	}
 };


### PR DESCRIPTION
If the `language` changes dynamically after `fetchCldr` has been called, it's imperative to retrigger it for the new language (even if `boot` has not finished), otherwise an error will be thrown.