### PR TITLE
refactor(ui5-multi-combobox): change `close` event to non-bubbling

### DIFF
--- a/packages/main/cypress/specs/base/Events.cy.ts
+++ b/packages/main/cypress/specs/base/Events.cy.ts
@@ -6,6 +6,8 @@ import "../../../src/Input.js";
 import "../../../src/SuggestionItem.js";
 import "../../../src/features/InputSuggestions.js";
 import "../../../src/MessageStrip.js";
+import "../../../src/MultiComboBox.js";
+import "../../../src/MultiComboBoxItem.js";
 import "../../../src/Panel.js";
 import "../../../src/CheckBox.js";
 import "../../../src/Label.js";
@@ -124,7 +126,12 @@ describe("Event bubbling", () => {
 						<ui5-option>Hello</ui5-option>
 						<ui5-option>World</ui5-option>
 						<ui5-option>Hello</ui5-option>
-					</ui5-select>					
+					</ui5-select>	
+					
+					<ui5-multi-combobox id="myMCB">
+						<ui5-mcb-item text="Cosy"></ui5-mcb-item>
+						<ui5-mcb-item selected text="Compact"></ui5-mcb-item>
+					</ui5-multi-combobox>
 				</ui5-dialog>
 			</div>
 		`);
@@ -135,6 +142,8 @@ describe("Event bubbling", () => {
 			.as("dialog");
 		cy.get("[ui5-select]")
 			.as("select");
+		cy.get("[ui5-multi-combobox]")
+			.as("multiCombobox");
 
 		cy.get("@app")
 			.then(app => {
@@ -143,12 +152,17 @@ describe("Event bubbling", () => {
 
 		cy.get("@dialog")
 			.then(dialog => {
-				dialog.get(0).addEventListener("close", cy.stub().as("dialogClosed")); // non-bubbling
+				dialog.get(0).addEventListener("close", cy.stub().as("dialogClosed"));
 			});
 
 		cy.get("@select")
 			.then(select => {
-				select.get(0).addEventListener("close", cy.stub().as("selClosed")); // non-bubbling
+				select.get(0).addEventListener("close", cy.stub().as("selClosed"));
+			});
+
+		cy.get("@multiCombobox")
+			.then(multiCombobox => {
+				multiCombobox.get(0).addEventListener("close", cy.stub().as("mcbClosed"));
 			});
 
 		cy.get("@dialog").invoke("attr", "open", true);
@@ -162,8 +176,22 @@ describe("Event bubbling", () => {
 			.eq(1)
 			.realClick();
 
-		// assert - the close event of the Select does not bubble
+		// act - open and close MultiComboBox
+		cy.get("@multiCombobox")
+			.shadow()
+			.find(".inputIcon")
+			.realClick();
+
+		cy.get("@multiCombobox")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.realClick();
+
+		// assert - the close events of the Select and MultiComboBox do not bubble
 		cy.get("@selClosed")
+			.should("have.been.calledOnce");
+		cy.get("@mcbClosed")
 			.should("have.been.calledOnce");
 		cy.get("@dialogClosed")
 			.should("not.be.called");

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -237,9 +237,7 @@ type MultiComboboxItemWithSelection = {
  * @since 2.0.0
  * @public
  */
-@event("close", {
-	bubbles: true,
-})
+@event("close")
 
 /**
  * Fired when selection is changed by user interaction.

--- a/packages/main/test/pages/EventBubbling.html
+++ b/packages/main/test/pages/EventBubbling.html
@@ -22,6 +22,11 @@
 				<ui5-suggestion-item text="Condensed"></ui5-suggestion-item>
 			</ui5-input>
 
+			<ui5-multi-combobox id="myMcb">
+				<ui5-mcb-item text="Cosy"></ui5-mcb-item>
+				<ui5-mcb-item selected text="Compact"></ui5-mcb-item>
+			</ui5-multi-combobox>
+
 			<ui5-message-strip id="myMsgStrip">(Information) with default icon and close button:</ui5-message-strip>
 
 			<ui5-panel id="myPanel" header-text="Panel">
@@ -47,6 +52,9 @@
 	});
 	mySelect.addEventListener("close", function(e) {
 		console.log("Select on close")
+	});
+	myMcb.addEventListener("close", function(e) {
+		console.log("myMcb on close")
 	});
 	myInput.addEventListener("close", function(e) {
 		console.log("Input on close")


### PR DESCRIPTION
Agreed that popup events that are bubbling are causing more problems than helping. Same we did for the Select `close` event recently and will gradually do for the rest.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10006