### PR TITLE
refactor(ui5-form): change default columns number in XL and header text wrapping

### DIFF
--- a/packages/main/cypress/specs/Form.cy.ts
+++ b/packages/main/cypress/specs/Form.cy.ts
@@ -32,36 +32,28 @@ describe("General API", () => {
 			.as("form");
 
 		cy.get("@form")
-			.invoke("prop", "columnsS")
-			.should("be.equal", 1);
+			.should("have.prop", "columnsS", 1);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanS")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanS", 12);
 
 		cy.get("@form")
-			.invoke("prop", "columnsM")
-			.should("be.equal", 1);
+			.should("have.prop", "columnsM", 1);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanM")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanM", 4);
 
 		cy.get("@form")
-			.invoke("prop", "columnsL")
-			.should("be.equal", 2);
+			.should("have.prop", "columnsL", 2);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanL")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanL", 4);
 
 		cy.get("@form")
-			.invoke("prop", "columnsXl")
-			.should("be.equal", 3);
+			.should("have.prop", "columnsXl", 3);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanXl")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanXl", 4);
 	});
 
 	it("tests calculated state of Form with layout='S1 M2 L3 XL6' and label-span='S12 M4 L4 XL4'", () => {
@@ -92,36 +84,28 @@ describe("General API", () => {
 			.as("form");
 
 		cy.get("@form")
-			.invoke("prop", "columnsS")
-			.should("be.equal", 1);
+			.should("have.prop", "columnsS", 1);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanS")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanS", 12);
 
 		cy.get("@form")
-			.invoke("prop", "columnsM")
-			.should("be.equal", 2);
+			.should("have.prop", "columnsM", 2);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanM")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanM", 4);
 
 		cy.get("@form")
-			.invoke("prop", "columnsL")
-			.should("be.equal", 3);
+			.should("have.prop", "columnsL", 3);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanL")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanL", 4);
 
 		cy.get("@form")
-			.invoke("prop", "columnsXl")
-			.should("be.equal", 6);
+			.should("have.prop", "columnsXl", 6);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanXl")
-			.should("be.equal", 4);
+			.should("have.prop", "labelSpanXl", 4);
 	});
 
 	it("tests calculated state of Form with layout='S1 M2 L2 XL3' label-span='S12 M12 L12 XL12'", () => {
@@ -163,36 +147,28 @@ describe("General API", () => {
 			.as("form");
 
 		cy.get("@form")
-			.invoke("prop", "columnsS")
-			.should("be.equal", 1);
+			.should("have.prop", "columnsS", 1);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanS")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanS", 12);
 
 		cy.get("@form")
-			.invoke("prop", "columnsM")
-			.should("be.equal", 2);
+			.should("have.prop", "columnsM", 2);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanM")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanM", 12);
 
 		cy.get("@form")
-			.invoke("prop", "columnsL")
-			.should("be.equal", 2);
+			.should("have.prop", "columnsL", 2);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanL")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanL", 12);
 
 		cy.get("@form")
-			.invoke("prop", "columnsXl")
-			.should("be.equal", 3);
+			.should("have.prop", "columnsXl", 3);
 
 		cy.get("@form")
-			.invoke("prop", "labelSpanXl")
-			.should("be.equal", 12);
+			.should("have.prop", "labelSpanXl", 12);
 	});
 
 	it("tests calculated state of two FormGroups in layout='S1 M2 L3 XL4'", () => {
@@ -223,36 +199,28 @@ describe("General API", () => {
 			.as("formGr2");
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsL")
-			.should("be.equal", 2);
+			.should("have.prop", "colsL", 2);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 	});
 
 	it("tests calculated state of three FormGroups in layout='S1 M2 L3 XL6'", () => {
@@ -304,52 +272,40 @@ describe("General API", () => {
 			.as("formGr3");
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 	});
 
 	it("tests calculated state of three FormGroups in layout='S1 M2 L3 XL4'", () => {
@@ -391,51 +347,39 @@ describe("General API", () => {
 			.as("formGr3");
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsS")
-			.should("be.equal", 1);
+			.should("have.prop", "colsS", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsM")
-			.should("be.equal", 1);
+			.should("have.prop", "colsM", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsL")
-			.should("be.equal", 1);
+			.should("have.prop", "colsL", 1);
 
 		cy.get("@formGr1")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 1);
+			.should("have.prop", "colsXl", 1);
 
 		cy.get("@formGr2")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 2);
+			.should("have.prop", "colsXl", 2);
 
 		cy.get("@formGr3")
-			.invoke("prop", "colsXl")
-			.should("be.equal", 1);
+			.should("have.prop", "colsXl", 1);
 	});
 });

--- a/packages/main/cypress/specs/Form.cy.ts
+++ b/packages/main/cypress/specs/Form.cy.ts
@@ -4,6 +4,66 @@ import "../../src/FormItem.js";
 import "../../src/FormGroup.js";
 
 describe("General API", () => {
+	it("tests calculated state of Form with default layout and label-span", () => {
+		cy.mount(html`<ui5-form class="addressForm" header-text="Default form">
+			<ui5-form-group header-text="Address">
+				<ui5-form-item>
+					<span slot="labelContent">Name:</span>
+					<span class="text">Red Point Stores</span>
+				</ui5-form-item>
+			</ui5-form-group>
+
+			<ui5-form-group id="testFormGroup2" header-text="Contact">
+				<ui5-form-item>
+					<span slot="labelContent">Twitter:</span>
+					<span class="text">@sap</span>
+				</ui5-form-item>
+			</ui5-form-group>
+
+			<ui5-form-group id="testFormGroup3" header-text="Other info">
+				<ui5-form-item>
+					<span slot="labelContent">Name:</span>
+					<span class="text">Red Point Stores</span>
+				</ui5-form-item>
+			</ui5-form-group>
+		</ui5-form>`);
+
+		cy.get("[ui5-form]")
+			.as("form");
+
+		cy.get("@form")
+			.invoke("prop", "columnsS")
+			.should("be.equal", 1);
+
+		cy.get("@form")
+			.invoke("prop", "labelSpanS")
+			.should("be.equal", 12);
+
+		cy.get("@form")
+			.invoke("prop", "columnsM")
+			.should("be.equal", 1);
+
+		cy.get("@form")
+			.invoke("prop", "labelSpanM")
+			.should("be.equal", 4);
+
+		cy.get("@form")
+			.invoke("prop", "columnsL")
+			.should("be.equal", 2);
+
+		cy.get("@form")
+			.invoke("prop", "labelSpanL")
+			.should("be.equal", 4);
+
+		cy.get("@form")
+			.invoke("prop", "columnsXl")
+			.should("be.equal", 3);
+
+		cy.get("@form")
+			.invoke("prop", "labelSpanXl")
+			.should("be.equal", 4);
+	});
+
 	it("tests calculated state of Form with layout='S1 M2 L3 XL6' and label-span='S12 M4 L4 XL4'", () => {
 		cy.mount(html`<ui5-form class="addressForm" header-text="WebC :: Supplier 3gr (S1 M2 L3 XL6)" layout="S1 M2 L3 XL6">
 	<ui5-form-group header-text="Address">

--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -83,7 +83,7 @@ type ItemsInfo = {
  * - **S** (< 600px) – 1 column is recommended (default: 1)
  * - **M** (600px - 1022px) – up to 2 columns are recommended (default: 1)
  * - **L** (1023px - 1439px) - up to 3 columns are recommended (default: 2)
- * - **XL** (> 1439px) – up to 6 columns are recommended (default: 2)
+ * - **XL** (> 1439px) – up to 6 columns are recommended (default: 3)
  *
  * To change the layout, use the `layout` property - f.e. layout="S1 M2 L3 XL6".
  *
@@ -156,13 +156,13 @@ class Form extends UI5Element {
 	 * - `S` - 1 column by default (1 column is recommended)
 	 * - `M` - 1 column by default (up to 2 columns are recommended)
 	 * - `L` - 2 columns by default (up to 3 columns are recommended)
-	 * - `XL` - 2 columns by default (up to 6 columns  are recommended)
+	 * - `XL` - 3 columns by default (up to 6 columns  are recommended)
 	 *
 	 * @default "S1 M1 L2 XL2"
 	 * @public
 	 */
 	@property()
-	layout = "S1 M1 L2 XL2"
+	layout = "S1 M1 L2 XL3"
 
 	/**
 	 * Defines the width proportion of the labels and fields of a FormItem by breakpoint.
@@ -246,7 +246,7 @@ class Form extends UI5Element {
 	labelSpanL = 4;
 
 	@property({ type: Number })
-	columnsXl = 2;
+	columnsXl = 3;
 	@property({ type: Number })
 	labelSpanXl = 4;
 

--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -158,7 +158,7 @@ class Form extends UI5Element {
 	 * - `L` - 2 columns by default (up to 3 columns are recommended)
 	 * - `XL` - 3 columns by default (up to 6 columns  are recommended)
 	 *
-	 * @default "S1 M1 L2 XL2"
+	 * @default "S1 M1 L2 XL3"
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/FormGroup.ts
+++ b/packages/main/src/FormGroup.ts
@@ -83,6 +83,7 @@ class FormGroup extends UI5Element implements IFormItem {
 	@property()
 	itemSpacing: `${FormItemSpacing}` = "Normal";
 
+	@property()
 	labelSpan = "S12 M4 L4 XL4";
 
 	onBeforeRendering() {

--- a/packages/main/src/themes/Form.css
+++ b/packages/main/src/themes/Form.css
@@ -15,7 +15,7 @@
 
 .ui5-form-header {
 	display: flex;
-	height: 2.75rem;
+	min-height: 2.75rem;
 	align-items: center;
 	border-bottom: 1px solid var(--sapGroup_TitleBorderColor);
 	padding: 0 1rem 0 1rem;

--- a/packages/main/src/themes/Form.css
+++ b/packages/main/src/themes/Form.css
@@ -18,7 +18,8 @@
 	min-height: 2.75rem;
 	align-items: center;
 	border-bottom: 1px solid var(--sapGroup_TitleBorderColor);
-	padding: 0 1rem 0 1rem;
+	padding: 0.875rem 1rem;
+	box-sizing: border-box;
 }
 
 .ui5-form-layout {

--- a/packages/main/src/themes/FormLayout.css
+++ b/packages/main/src/themes/FormLayout.css
@@ -1,6 +1,6 @@
 /* 
 * The Form layout is divided into one or more columns. 
-* XL - max. 4 columns, L - max. 3 columns, M - max. 2 columns and S - 1 column.
+* XL - max. 6 columns, L - max. 3 columns, M - max. 2 columns and S - 1 column.
 */
 /* 
 * S max-width: 600px - container padding 24px
@@ -76,10 +76,10 @@
 	}
 }
 
-/* XL - 2 columns by default, up to 6 */
+/* XL - 3 columns by default, up to 6 */
 @container (min-width: 1441px) {
 	.ui5-form-layout {
-		grid-template-columns: repeat(2, 1fr);
+		grid-template-columns: repeat(3, 1fr);
 	}
 
 	:host([columns-xl="1"]) .ui5-form-layout {

--- a/packages/main/test/pages/form/FormGroups3.html
+++ b/packages/main/test/pages/form/FormGroups3.html
@@ -18,9 +18,9 @@
 	<script>
         sap.ui.getCore().attachInit(function() {
 			var oLayout1 = new sap.ui.layout.form.ColumnLayout("L1", {
-				// columnsM: 2,
-				// columnsL: 3,
-				// columnsXL: 4,
+				columnsM: 1,
+				columnsL: 2,
+				columnsXL: 3,
 			});
 			var oForm1 = new sap.ui.layout.form.Form("F1",{
 				title: "SAPUI5 Form :: Supplier",
@@ -127,8 +127,8 @@
 		<div class="controls">
 			<ui5-label>Column Layout:</ui5-label>
 			<ui5-select id="selLayout">
-				<ui5-option selected value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
 				<ui5-option value="S1 M2 L2 XL2">S1 M2 L2 XL2</ui5-option>
+				<ui5-option selected value="S1 M1 L2 XL3">S1 M1 L2 XL3</ui5-option>
 				<ui5-option value="S1 M2 L3 XL2">S1 M2 L3 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL3">S1 M2 L3 XL3</ui5-option>
 				<ui5-option value="S1 M2 L3 XL4">S1 M2 L3 XL4</ui5-option>

--- a/packages/main/test/pages/form/FormGroups4.html
+++ b/packages/main/test/pages/form/FormGroups4.html
@@ -18,9 +18,9 @@
 	<script>
         sap.ui.getCore().attachInit(function() {
 			var oLayout1 = new sap.ui.layout.form.ColumnLayout("L1", {
-				// columnsM: 2,
-				// columnsL: 3,
-				// columnsXL: 4,
+				columnsM: 1,
+				columnsL: 2,
+				columnsXL: 3,
 			});
 			var oForm1 = new sap.ui.layout.form.Form("F1",{
 				title: "SAPUI5 Form :: Supplier",
@@ -160,7 +160,8 @@
 		<div class="controls">
 			<ui5-label>Column Layout:</ui5-label>
 			<ui5-select id="selLayout">
-				<ui5-option selected value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option selected value="S1 M1 L2 XL3">S1 M1 L2 XL3</ui5-option>
 				<ui5-option value="S1 M2 L2 XL2">S1 M2 L2 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL2">S1 M2 L3 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL3">S1 M2 L3 XL3</ui5-option>

--- a/packages/main/test/pages/form/FormGroups5.html
+++ b/packages/main/test/pages/form/FormGroups5.html
@@ -18,9 +18,9 @@
 	<script>
         sap.ui.getCore().attachInit(function() {
 			var oLayout1 = new sap.ui.layout.form.ColumnLayout("L1", {
-				// columnsM: 2,
-				// columnsL: 3,
-				// columnsXL: 4,
+				columnsM: 1,
+				columnsL: 2,
+				columnsXL: 3,
 			});
 			var oForm1 = new sap.ui.layout.form.Form("F1",{
 				title: "SAPUI5 :: Supplier",
@@ -351,7 +351,8 @@
 		<div class="controls">
 			<ui5-label>Column Layout:</ui5-label>
 			<ui5-select id="selLayout">
-				<ui5-option selected value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option selected value="S1 M1 L2 XL3">S1 M1 L2 XL3</ui5-option>
 				<ui5-option value="S1 M2 L2 XL2">S1 M2 L2 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL2">S1 M2 L3 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL3">S1 M2 L3 XL3</ui5-option>

--- a/packages/main/test/pages/form/FormGroups6.html
+++ b/packages/main/test/pages/form/FormGroups6.html
@@ -18,9 +18,9 @@
 	<script>
         sap.ui.getCore().attachInit(function() {
 			var oLayout1 = new sap.ui.layout.form.ColumnLayout("L1", {
-				// columnsM: 2,
-				// columnsL: 3,
-				// columnsXL: 4,
+				columnsM: 1,
+				columnsL: 2,
+				columnsXL: 3,
 			});
 			var oForm1 = new sap.ui.layout.form.Form("F1",{
 				title: "SAPUI5 Form :: Supplier",
@@ -218,7 +218,8 @@
 		<div class="controls">
 			<ui5-label>Column Layout:</ui5-label>
 			<ui5-select id="selLayout">
-				<ui5-option selected value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option value="S1 M2 L2 XL2">S1 M1 L2 XL2</ui5-option>
+				<ui5-option selected value="S1 M1 L2 XL3">S1 M1 L2 XL3</ui5-option>
 				<ui5-option value="S1 M2 L2 XL2">S1 M2 L2 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL2">S1 M2 L3 XL2</ui5-option>
 				<ui5-option value="S1 M2 L3 XL3">S1 M2 L3 XL3</ui5-option>

--- a/packages/main/test/pages/form/FormHeaderWrapping.html
+++ b/packages/main/test/pages/form/FormHeaderWrapping.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+	<title>Form Header Text Wrapping</title>
+	<script src="../%VITE_BUNDLE_PATH%" type="module"></script>
+	<link rel="stylesheet" type="text/css" href="../styles/FormLayout.css">
+		
+	<script id='sap-ui-bootstrap'
+		src='https://openui5nightly.hana.ondemand.com/resources/sap-ui-core.js'
+		data-sap-ui-theme='sap_horizon'
+		data-sap-ui-libs='sap.m, sap.ui.core, sap.ui.layout'
+		data-sap-ui-preload="async"
+	></script>
+</head>
+
+<body class="bg">
+	<ui5-slider id="slider" min="1" max="100" value="100" class="slider"></ui5-slider>
+	
+	<section id="container">
+		<div class="banner"><div class="banner-inner"></div></div>
+
+		<section>
+			<ui5-form class="addressForm" header-text="Very Very Very Very  Very  Very  Very  Very  Very  Very long long long long long long long long text text text text text text text text text text text text text text text text text for a heading of a Form and it is wrapping">
+				<ui5-form-item>
+					<ui5-label slot="labelContent">Name:</ui5-label>
+					<span class="text">Red Point Stores</span>
+				</ui5-form-item>
+				
+				<ui5-form-item>
+					<ui5-label slot="labelContent">ZIP Code/City:</ui5-label>
+					<span class="text">411 Maintown</span>
+				</ui5-form-item>
+				
+				<ui5-form-item>
+					<ui5-label slot="labelContent">Street:</ui5-label>
+					<span class="text">Main St 1618</span>
+				</ui5-form-item>
+
+				<ui5-form-item>
+					<ui5-label slot="labelContent">Country:</ui5-label>
+					<span class="text">Germany</span>
+				</ui5-form-item>
+			</ui5-form>
+		</section>
+	</section>
+		
+	<script>
+		slider.addEventListener("ui5-input", function (event) {
+			container.style.width = event.target.value + '%';
+		});
+	</script>
+</body>
+</html>

--- a/packages/main/test/pages/form/FormMultipleColumns.html
+++ b/packages/main/test/pages/form/FormMultipleColumns.html
@@ -20,9 +20,9 @@
 	<div class="controls">
 		<ui5-label>Column Layout:</ui5-label>
 		<ui5-select id="selLayout">
-			<ui5-option selected value="S1 M3 L4 XL4">S1 M3 L4 XL4</ui5-option>
-			<ui5-option selected value="S2 M3 L5 XL5">S2 M3 L5 XL5</ui5-option>
-			<ui5-option selected value="S2 M3 L5 XL6">S2 M3 L5 XL6</ui5-option>
+			<ui5-option value="S1 M3 L4 XL4">S1 M3 L4 XL4</ui5-option>
+			<ui5-option value="S2 M3 L5 XL5">S2 M3 L5 XL5</ui5-option>
+			<ui5-option value="S2 M3 L5 XL6">S2 M3 L5 XL6</ui5-option>
 			<ui5-option selected value="S2 M4 L5 XL7">S2 M4 L5 XL7</ui5-option>
 			<ui5-option value="S2 M3 L6 XL8">S2 M3 L6 XL8</ui5-option>
 			<ui5-option value="S3 M4 L6 XL8">S3 M4 L6 XL8</ui5-option>

--- a/packages/website/docs/_components_pages/main/Form/Form.mdx
+++ b/packages/website/docs/_components_pages/main/Form/Form.mdx
@@ -10,6 +10,7 @@ import Layout from "../../../_samples/main/Form/Layout/Layout.md";
 import LabelSpan from "../../../_samples/main/Form/LabelSpan/LabelSpan.md";
 import LabelsOnTop from "../../../_samples/main/Form/LabelsOnTop/LabelsOnTop.md";
 import GroupColumnSpan from "../../../_samples/main/Form/GroupColumnSpan/GroupColumnSpan.md";
+import HeaderTextWrapping from "../../../_samples/main/Form/HeaderTextWrapping/HeaderTextWrapping.md";
 import ItemColumnSpan from "../../../_samples/main/Form/ItemColumnSpan/ItemColumnSpan.md";
 import FreeStyleForm from "../../../_samples/main/Form/FreeStyleForm/FreeStyleForm.md";
 import CustomHeader from "../../../_samples/main/Form/CustomHeader/CustomHeader.md";
@@ -26,6 +27,7 @@ import CustomHeader from "../../../_samples/main/Form/CustomHeader/CustomHeader.
 ### Layout
 Use the Form#**layout** property to define the number of columns to distribute the form content by breakpoint.
 
+- S1 M1 L2 XL3 - 1 cols in S, 1 cols in M, 2 cols in L and 3 cols in XL (default layout) 
 - S1 M2 L3 XL5 - 1 cols in S, 2 cols in M, 3 cols in L and 5 cols in XL
 - S1 M2 L4 XL6 -  1 cols in S, 2 cols in M, 4 cols in L and 6 cols in XL
 - S2 M3 L5 XL7 - 2 cols in S, 3 cols in M, 5 cols in L and 7 cols in XL
@@ -79,6 +81,12 @@ The FormItem#**columnSpan** defines to how many columns the form item should exp
 
 <ItemColumnSpan />
 
+
+### Header Text Wrapping
+
+The Form header text **is wrapping** when doesn't fit the available space.
+
+<HeaderTextWrapping />
 
 ### Custom Header
 

--- a/packages/website/docs/_samples/main/Form/CustomHeader/sample.html
+++ b/packages/website/docs/_samples/main/Form/CustomHeader/sample.html
@@ -12,7 +12,7 @@
 <body style="background-color: var(--sapBackgroundColor);height: 400px">
     <!-- playground-fold-end -->
 
-    <ui5-form layout="S1 M2 L2 XL2" item-spacing="Large" style="width: 600px;">
+    <ui5-form layout="S1 M2 L2 XL2" item-spacing="Large" style="width: 800px;">
 
             <ui5-bar design="Subheader" slot="header">
                 <ui5-title level="H4" slot="startContent">Address</ui5-title>

--- a/packages/website/docs/_samples/main/Form/HeaderTextWrapping/HeaderTextWrapping.md
+++ b/packages/website/docs/_samples/main/Form/HeaderTextWrapping/HeaderTextWrapping.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Form/HeaderTextWrapping/main.js
+++ b/packages/website/docs/_samples/main/Form/HeaderTextWrapping/main.js
@@ -1,0 +1,29 @@
+import "@ui5/webcomponents/dist/Form.js";
+import "@ui5/webcomponents/dist/FormItem.js";
+
+
+// The following code is required only for the sample
+import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
+import "@ui5/webcomponents/dist/Slider.js";
+
+const slider = document.getElementById("slider");
+const txtLayout = document.getElementById("txtLayout");
+const container = document.getElementById("container");
+
+slider.addEventListener("ui5-input", () => {
+	const width = (slider.value / 100 * 1500);
+	container.style.width = `${width}px`;
+	txtLayout.innerHTML = getLayoutByWidth(width);
+});
+
+const getLayoutByWidth = (width) => {
+	if (width > 599 && width <= 1023) {
+		return "M";
+	} else if (width >= 1024 && width <= 1439) {
+		return "L"
+	} else if (width >= 1440) {
+		return "XL"
+	}
+	return "S";
+};

--- a/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.html
@@ -14,8 +14,8 @@
     <!-- <ui5-label show-colon>Page Size</ui5-label><ui5-text id="txtLayout">L</ui5-text> -->
     <!-- <ui5-slider id="slider" value="85"></ui5-slider> -->
 
-    <div id="container" style="max-width: 1500px; width: 800px; overflow-x: auto">
-        <ui5-form class="addressForm" header-text="Very very very very  very  very  very  very  very  very long long long long long long long long text text text text text text text text text text text text text text text text text for a Form heading which is wrapping when does not fit the available space">
+    <div id="container" style="max-width: 1500px; width: 300px; overflow-x: auto">
+        <ui5-form class="addressForm" header-text="A very long header title for the form and more">
             <ui5-form-item>
                 <ui5-label slot="labelContent">Name:</ui5-label>
                 <ui5-text class="text">Red Point Stores</ui5-text>

--- a/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.html
+++ b/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.html
@@ -1,0 +1,47 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor)">
+    <!-- playground-fold-end -->
+    <!-- <ui5-label show-colon>Form Layout</ui5-label><ui5-text>S1 M1 L2 XL3</ui5-text></br> -->
+    <!-- <ui5-label show-colon>Page Size</ui5-label><ui5-text id="txtLayout">L</ui5-text> -->
+    <!-- <ui5-slider id="slider" value="85"></ui5-slider> -->
+
+    <div id="container" style="max-width: 1500px; width: 800px; overflow-x: auto">
+        <ui5-form class="addressForm" header-text="Very very very very  very  very  very  very  very  very long long long long long long long long text text text text text text text text text text text text text text text text text for a Form heading which is wrapping when does not fit the available space">
+            <ui5-form-item>
+                <ui5-label slot="labelContent">Name:</ui5-label>
+                <ui5-text class="text">Red Point Stores</ui5-text>
+            </ui5-form-item>
+            
+            <ui5-form-item>
+                <ui5-label slot="labelContent">ZIP Code/City:</ui5-label>
+                <ui5-text class="text">411 Maintown</ui5-text>
+            </ui5-form-item>
+            
+            <ui5-form-item>
+                <ui5-label slot="labelContent">Street:</ui5-label>
+                <ui5-text class="text">Main St 1618</ui5-text>
+            </ui5-form-item>
+
+            <ui5-form-item>
+                <ui5-label slot="labelContent">Country:</ui5-label>
+                <ui5-text class="text">Germany</ui5-text>
+            </ui5-form-item>
+        </ui5-form>
+    </div>
+   
+
+    <!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Form/Layout/sample.html
+++ b/packages/website/docs/_samples/main/Form/Layout/sample.html
@@ -18,6 +18,103 @@
 
     <div id="container" style="max-width: 1500px; width: 1035px; overflow-x: auto">
 
+        <ui5-form header-text="Form Layout: S1 M1 L2 XL3 (default)" label-span="S12 M12 L12 XL12">
+
+            <ui5-form-group header-text="Address">
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Name:</ui5-label>
+                    <ui5-text>Red Point Stores</ui5-text>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">ZIP Code/City:</ui5-label>
+                    <ui5-text>411 Maintown</ui5-text>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Street:</ui5-label>
+                    <ui5-text>Main St 1618</ui5-text>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Country:</ui5-label>
+                    <ui5-text>Germany</ui5-text>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">WebSite:</ui5-label>
+                    <ui5-link href="sap.com">sap.com</ui5-link>
+                </ui5-form-item>
+            </ui5-form-group>
+
+            <ui5-form-group header-text="Contact">
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Twitter:</ui5-label>
+                    <ui5-text>@sap</ui5-text>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Email:</ui5-label>
+                    <ui5-link>john.smith@sap.com</ui5-link>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Tel:</ui5-label>
+                    <ui5-link>+49 6227 747474</ui5-link>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">SMS:</ui5-label>
+                    <ui5-link>+49 6227 747474</ui5-link>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Mobile:</ui5-label>
+                    <ui5-link href="sap.com">+49 6227 747474</ui5-link>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Pager:</ui5-label>
+                    <ui5-link href="sap.com">+49 6227 747474</ui5-link>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Fax:</ui5-label>
+                    <ui5-link href="sap.com">+49 6227 747474</ui5-link>
+                </ui5-form-item>
+
+            </ui5-form-group>
+        
+            <ui5-form-group header-text="Other info">
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Name:</ui5-label>
+                    <ui5-text>Red Point Stores</ui5-text>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">ZIP Code/City:</ui5-label>
+                    <ui5-text>411 Maintown</ui5-text>
+                </ui5-form-item>
+                
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Street:</ui5-label>
+                    <ui5-text>Main St 1618</ui5-text>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">Country:</ui5-label>
+                    <ui5-text>Germany</ui5-text>
+                </ui5-form-item>
+
+                <ui5-form-item>
+                    <ui5-label slot="labelContent">WebSite:</ui5-label>
+                    <ui5-link href="sap.com">sap.com</ui5-link>
+                </ui5-form-item>
+            </ui5-form-group>
+        </ui5-form>
+
+        <br><br>
+
         <ui5-form header-text="Form Layout: S1 M2 L3 XL5" layout="S1 M2 L3 XL5" label-span="S12 M12 L12 XL12">
 
             <ui5-form-group header-text="Address">


### PR DESCRIPTION
Updates the Form web component to latest UX design

### 1. New default layout

Use 3 columns in XL by default (previously 2), e.g the layout property default is changed 
from `S1 M1 L2 XL2` to `S1 M1 L2 XL3`
 
<img width="1483" alt="Screenshot 2024-10-16 at 15 39 50" src="https://github.com/user-attachments/assets/3771199c-340c-48a1-8610-043b6a04cb43">


### 2.  Header text wrapping

<img width="549" alt="Screenshot 2024-10-16 at 15 42 12" src="https://github.com/user-attachments/assets/899be234-718b-4fc5-a229-1f16d1eeeb37">


Related to: https://github.com/SAP/ui5-webcomponents/issues/9963
