### PR TITLE
fix(ui5-table): wrong horiz. alignm. behavior and wrong texts

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -465,7 +465,7 @@ class Table extends UI5Element {
 
 	get styles() {
 		const headerStyleMap = this.headerRow?.[0]?.cells?.reduce((headerStyles, headerCell) => {
-			if (headerCell.horizontalAlign !== undefined) {
+			if (headerCell.horizontalAlign !== undefined && !headerCell._popin) {
 				headerStyles[`--horizontal-align-${headerCell._individualSlot}`] = headerCell.horizontalAlign;
 			}
 			return headerStyles;

--- a/packages/main/src/TableCellBase.ts
+++ b/packages/main/src/TableCellBase.ts
@@ -34,7 +34,7 @@ abstract class TableCellBase extends UI5Element {
 
 	/**
 	 * Determines the horizontal alignment of table cells.
-	 * Note: All values valid for justify-content can be used not just the ones inside the enum.
+	 * **Note:** All values valid for justify-content can be used, not just the ones inside the enumeration.
 	 * @default undefined
 	 * @public
 	 */

--- a/packages/main/test/pages/HAlignTable.html
+++ b/packages/main/test/pages/HAlignTable.html
@@ -10,7 +10,7 @@
 
 <body style="background-color: var(--sapBackgroundColor)">
     <div class="section">
-		<ui5-table id="table" overflow-mode="Popin">
+		<ui5-table id="table" overflow-mode="Popin" style="width: 1120px;">
 			<ui5-table-header-row slot="headerRow">
 				<ui5-table-header-cell id="productCol" width="300px"><span>Product</span></ui5-table-header-cell>
 				<ui5-table-header-cell id="supplierCol" horizontal-align="Center" width="200px">Supplier</ui5-table-header-cell>

--- a/packages/website/docs/_components_pages/main/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableCell.mdx
@@ -11,14 +11,14 @@ import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";
 
 ## Horizontal cell alignment
 
-Control the horizontal alignment of cells by utilizing the `horizontalAlign` property.
+Controls the horizontal alignment of cells by using the `horizontalAlign` property.
 
-Please note that the behaviour of `horizontalAlign` depends on where you set it:
-1. `horizontalAlign` is set on `TableHeaderCell` level<br />
-Changes the horizontal alignment of the `TableHeaderCell` and their corresponding `TableCells`.
-2. `horizontalAlign` is set on `TableCell` level only<br />
+Please note that the behavior of `horizontalAlign` depends on where you set it:
+- `horizontalAlign` is set on `TableHeaderCell` level<br />
+Changes the horizontal alignment of the `TableHeaderCell` and its corresponding `TableCell`.
+- `horizontalAlign` is set on `TableCell` level only<br />
 The horizontal alignment is only changed for this one `TableCell`
-3. `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
-Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCells` without a `horizontalAlign` property.
+- `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
+Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` without a `horizontalAlign` property.
 
 <HAlign />

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
@@ -21,14 +21,14 @@ import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";
 
 ## Horizontal cell alignment
 
-Control the horizontal alignment of cells by utilizing the `horizontalAlign` property.
+Controls the horizontal alignment of cells by using the `horizontalAlign` property.
 
-Please note that the behaviour of `horizontalAlign` depends on where you set it:
-1. `horizontalAlign` is set on `TableHeaderCell` level<br />
-Changes the horizontal alignment of the `TableHeaderCell` and their corresponding `TableCells`.
-2. `horizontalAlign` is set on `TableCell` level only<br />
+Please note that the behavior of `horizontalAlign` depends on where you set it:
+- `horizontalAlign` is set on `TableHeaderCell` level<br />
+Changes the horizontal alignment of the `TableHeaderCell` and its corresponding `TableCell`.
+- `horizontalAlign` is set on `TableCell` level only<br />
 The horizontal alignment is only changed for this one `TableCell`
-3. `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
-Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCells` without a `horizontalAlign` property.
+- `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
+Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` without a `horizontalAlign` property.
 
 <HAlign />


### PR DESCRIPTION
Fixed a problem where the horizontalAlign property would be applied to cells inside the popin area.
In addition I've changed some of the texts reviewed in the last PR (https://github.com/SAP/ui5-webcomponents/pull/9639).

fixes: https://github.com/SAP/ui5-webcomponents/issues/10017