### PR TITLE
fix: boot sequence

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1276,7 +1276,6 @@ abstract class UI5Element extends HTMLElement {
 			const result = await Promise.all([
 				this.fetchI18nBundles(),
 				this.fetchCLDR(),
-				boot(),
 				this.onDefine(),
 			]);
 			const [i18nBundles] = result;

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1272,9 +1272,9 @@ abstract class UI5Element extends HTMLElement {
 	 */
 	static define(): typeof UI5Element {
 		const defineSequence = async () => {
-			await boot();
+			await boot(); // boot must finish first, because it initializes configuration
 			const result = await Promise.all([
-				this.fetchI18nBundles(),
+				this.fetchI18nBundles(), // uses configuration
 				this.fetchCLDR(),
 				this.onDefine(),
 			]);

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1271,12 +1271,14 @@ abstract class UI5Element extends HTMLElement {
 	 * @public
 	 */
 	static define(): typeof UI5Element {
-		this.definePromise = Promise.all([
-			this.fetchI18nBundles(),
-			this.fetchCLDR(),
-			boot(),
-			this.onDefine(),
-		]).then(result => {
+		const defineSequence = async () => {
+			await boot();
+			const result = await Promise.all([
+				this.fetchI18nBundles(),
+				this.fetchCLDR(),
+				boot(),
+				this.onDefine(),
+			]);
 			const [i18nBundles] = result;
 			Object.entries(this.getMetadata().getI18n()).forEach((pair, index) => {
 				const propertyName = pair[0];
@@ -1284,7 +1286,8 @@ abstract class UI5Element extends HTMLElement {
 				(targetClass as Record<string, any>)[propertyName] = i18nBundles[index];
 			});
 			this.asyncFinished = true;
-		});
+		};
+		this.definePromise = defineSequence();
 
 		const tag = this.getMetadata().getTag();
 


### PR DESCRIPTION
`boot()` cannot be on the same level as `fetchI18nBundles` in a common `Promise.all` because if OpenUI5Support is enabled, `boot()` must have finished for the configuration to be available (and `fetchI18nBundles` needs the configuration).