### PR TITLE
fix(ui5-list): growing button loading layout fixed

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -99,6 +99,7 @@
 			{{#if loading}}
 				<ui5-busy-indicator
 					delay="{{loadingDelay}}"
+					class="ui5-list-growing-button-busy-indicator"
 					active>
 				</ui5-busy-indicator>
 			{{/if}}

--- a/packages/main/src/themes/GrowingButton.css
+++ b/packages/main/src/themes/GrowingButton.css
@@ -61,7 +61,11 @@
 	font-weight: bold;
 }
 
-:host([loading]) [growing-button-text]{
+:host([loading]) .ui5-list-growing-button-busy-indicator:not([_is-busy]) {
+	display: none;
+}
+
+:host([loading]) .ui5-list-growing-button-busy-indicator[_is-busy] + [growing-button-text]{
 	padding-left: 0.5rem;
 }
 


### PR DESCRIPTION
With #9977 change we started rendering the busy indicator next to the growing text.

This introduced an issue where we align the growing text slightly to the right of the busy indicator but before the busy indicator is actually shown.

This fix fixes the issue and the growing text is centered before showing the busy indicator.

Fixes: #10047
