### PR TITLE
fix(ui5-dynamic-page): align header area with title and content

### DIFF
--- a/packages/fiori/src/themes/base/DynamicPage-parameters.css
+++ b/packages/fiori/src/themes/base/DynamicPage-parameters.css
@@ -7,7 +7,7 @@
     --_ui5_dynamic_page_title_padding_XL: 0.5rem 3rem;
     --_ui5_dynamic_page_header_padding_S: 0.5rem 1rem 0.125rem;/* 1px padding-bottom added to ensue box-shadow is not overlapped */
     --_ui5_dynamic_page_header_padding_M: 1rem 2rem;
-    --_ui5_dynamic_page_header_padding_L: 1rem 3rem;
+    --_ui5_dynamic_page_header_padding_L: 1rem 2rem;
     --_ui5_dynamic_page_header_padding_XL: 1rem 3rem;
     --_ui5_dynamic_page_content_padding_S: 2rem 1rem 0;
     --_ui5_dynamic_page_content_padding_M: 2rem 2rem 0;


### PR DESCRIPTION
Problem:
In some screen ranges, the header area was misaligned with the title and content, leading to an inconsistent layout.

Solution:
Adjusted the padding of the header area to improve alignment between the title, header area, and content, ensuring a more consistent and visually cohesive layout across all screen sizes.

Fixes: [#10034](https://github.com/SAP/ui5-webcomponents/issues/10034)
