### PR TITLE
refactor(ui5-text): match enum and file names

### DIFF
--- a/packages/main/src/Text.ts
+++ b/packages/main/src/Text.ts
@@ -69,7 +69,7 @@ class Text extends UI5Element {
 	 * @public
 	 */
 	@property()
-	emptyIndicatorMode?: `${TextEmptyIndicatorMode}` = "Off";
+	emptyIndicatorMode: `${TextEmptyIndicatorMode}` = "Off";
 
 	/**
 	 * Defines the text of the component.

--- a/packages/main/src/Text.ts
+++ b/packages/main/src/Text.ts
@@ -7,7 +7,7 @@ import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsSco
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import willShowContent from "@ui5/webcomponents-base/dist/util/willShowContent.js";
-import EmptyIndicatorMode from "./types/TextEmptyIndicatorMode.js";
+import TextEmptyIndicatorMode from "./types/TextEmptyIndicatorMode.js";
 // Template
 import TextTemplate from "./generated/templates/TextTemplate.lit.js";
 
@@ -69,7 +69,7 @@ class Text extends UI5Element {
 	 * @public
 	 */
 	@property()
-	emptyIndicatorMode: `${EmptyIndicatorMode}` = "Off";
+	emptyIndicatorMode?: `${TextEmptyIndicatorMode}` = "Off";
 
 	/**
 	 * Defines the text of the component.
@@ -90,7 +90,7 @@ class Text extends UI5Element {
 	}
 
 	get _renderEmptyIndicator() {
-		return !this.hasText && this.emptyIndicatorMode === EmptyIndicatorMode.On;
+		return !this.hasText && this.emptyIndicatorMode === TextEmptyIndicatorMode.On;
 	}
 
 	get _emptyIndicatorAriaLabel() {

--- a/packages/main/src/types/TextEmptyIndicatorMode.ts
+++ b/packages/main/src/types/TextEmptyIndicatorMode.ts
@@ -2,7 +2,7 @@
  * Empty Indicator Mode.
  * @public
  */
-enum EmptyIndicatorMode {
+enum TextEmptyIndicatorMode {
 	/**
 	 * Empty indicator is never rendered.
 	 * @public
@@ -16,4 +16,4 @@ enum EmptyIndicatorMode {
 	On = "On",
 }
 
-export default EmptyIndicatorMode;
+export default TextEmptyIndicatorMode;


### PR DESCRIPTION
Match enum and file name - either use EmptyIndictaroMode for both, or TextEmptyIndictaroMode for both. As currently only the Text is known to have such mode - the change uses TextEmptyIndictaroMode for the enum and the file name.