### PR TITLE
fix(ui5-media-gallery): clear selected thumbnail on item removal

### DIFF
--- a/packages/fiori/src/MediaGallery.ts
+++ b/packages/fiori/src/MediaGallery.ts
@@ -246,6 +246,14 @@ class MediaGallery extends UI5Element {
 	}
 
 	_updateSelection() {
+		if (this.items.length === 0) {
+			this._selectedItem = undefined;
+			if (this._mainItem) {
+				const oldContent = this._mainItem.displayedContent;
+				oldContent?.remove();
+			}
+			return;
+		}
 		let itemToSelect = this.items.find(item => item.selected);
 		if (!itemToSelect || !this._isSelectableItem(itemToSelect)) {
 			itemToSelect = this._findSelectableItem();


### PR DESCRIPTION
Issue:
- When removing all of the media-gallery items, the thumbnail
  of the last selected item remains displayed
- The gallery fails to clear the displayed content even when there are
  no items left in the gallery

Solution:
- Added check for empty items array in _updateSelection method
- Clear selected item reference when no items exist
- Remove displayed content from main item when gallery is empty

Fixes: [#8642](https://github.com/SAP/ui5-webcomponents/issues/8642)