### PR TITLE
fix(dynamic-page) redundant  title hover removed

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -226,6 +226,7 @@ class DynamicPage extends UI5Element {
 			this.dynamicPageTitle.snapped = this._headerSnapped;
 			this.dynamicPageTitle.interactive = this.hasHeading;
 			this.dynamicPageTitle.hasSnappedTitleOnMobile = !!this.hasSnappedTitleOnMobile;
+			this.dynamicPageTitle.removeAttribute("hovered");
 		}
 	}
 


### PR DESCRIPTION
In order to not get redundant hover state, we should "clean" it on every rerender, since sometimes, when pressing the expand/collapse button, the change of the position of the mouse pointer is ignored according to viewport and the "hovered"
attribute remains in the title. 
I tried to cover the functionality with a test, but the specific mouse behaviour is hard to be mocked.

Fixes: #10019 