### PR TITLE
chore: replace event marking with focus-within

### DIFF
--- a/packages/compat/src/TableRow.ts
+++ b/packages/compat/src/TableRow.ts
@@ -16,7 +16,6 @@ import {
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import { getLastTabbableElement } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import CheckBox from "@ui5/webcomponents/dist/CheckBox.js";
 import type TableCell from "./TableCell.js";
 import type { ITableRow, TableColumnInfo } from "./Table.js";
@@ -295,7 +294,8 @@ class TableRow extends UI5Element implements ITableRow {
 		// If the user tab over a button on IOS device, the document.activeElement
 		// is the ui5-table-row. The check below ensure that, if a button within the row is pressed,
 		// the row will not be selected.
-		if (getEventMark(e) === "button") {
+
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -8,7 +8,6 @@ import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
 import Tag from "@ui5/webcomponents/dist/Tag.js";
@@ -492,8 +491,8 @@ class NotificationListItem extends NotificationListItemBase {
 	/**
 	 * Event handlers
 	 */
-	_onclick(e: MouseEvent) {
-		this.fireItemPress(e);
+	_onclick() {
+		this.fireItemPress();
 	}
 
 	_onShowMoreClick(e: MouseEvent) {
@@ -550,7 +549,7 @@ class NotificationListItem extends NotificationListItemBase {
 
 		const space = isSpace(e);
 
-		if (space && getEventMark(e) === "link") {
+		if (space && this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			this._onShowMoreClick(e as unknown as MouseEvent);
 			return;
 		}
@@ -592,8 +591,8 @@ class NotificationListItem extends NotificationListItemBase {
 	/**
 	 * Private
 	 */
-	fireItemPress(e: Event) {
-		if (getEventMark(e) === "button" || getEventMark(e) === "link") {
+	fireItemPress() {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -5,7 +5,6 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import { getTabbableElements } from "@ui5/webcomponents-base/dist/util/TabbableElements.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 
 // Texts
@@ -76,7 +75,7 @@ class NotificationListItemBase extends ListItemBase {
 	async _onkeydown(e: KeyboardEvent) {
 		super._onkeydown(e);
 
-		if (isSpace(e) && getEventMark(e) !== "button") {
+		if (isSpace(e) && this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			e.preventDefault();
 			return;
 		}

--- a/packages/fiori/src/Timeline.ts
+++ b/packages/fiori/src/Timeline.ts
@@ -13,7 +13,6 @@ import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNaviga
 import type ToggleButton from "@ui5/webcomponents/dist/ToggleButton.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { TIMELINE_ARIA_LABEL } from "./generated/i18n/i18n-defaults.js";
 import TimelineTemplate from "./generated/templates/TimelineTemplate.lit.js";
 import TimelineItem from "./TimelineItem.js";
@@ -171,7 +170,7 @@ class Timeline extends UI5Element {
 	_onkeydown(e: KeyboardEvent) {
 		const target = e.target as ITimelineItem;
 
-		if (target.nameClickable && getEventMark(e) !== "link") {
+		if (target.nameClickable && !target.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 

--- a/packages/main/src/Button.hbs
+++ b/packages/main/src/Button.hbs
@@ -5,10 +5,8 @@
 	data-sap-focus-ref
 	{{> ariaPressed}}
 	@focusout={{_onfocusout}}
-	@focusin={{_onfocusin}}
 	@click={{_onclick}}
 	@mousedown={{_onmousedown}}
-	@mouseup={{_onmouseup}}
 	@keydown={{_onkeydown}}
 	@keyup={{_onkeyup}}
 	@touchstart="{{_ontouchstart}}"

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -16,7 +16,6 @@ import type { AccessibilityAttributes, PassiveEventListenerObject } from "@ui5/w
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { markEvent } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { getIconAccessibleName } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 
 import {
@@ -338,9 +337,7 @@ class Button extends UI5Element implements IButton {
 			isGlobalHandlerAttached = true;
 		}
 
-		const handleTouchStartEvent = (e: TouchEvent) => {
-			markEvent(e, "button");
-
+		const handleTouchStartEvent = () => {
 			if (this.nonInteractive) {
 				return;
 			}
@@ -368,12 +365,11 @@ class Button extends UI5Element implements IButton {
 		this.buttonTitle = this.tooltip || await this.getDefaultTooltip();
 	}
 
-	_onclick(e: MouseEvent) {
+	_onclick() {
 		if (this.nonInteractive) {
 			return;
 		}
 
-		markEvent(e, "button");
 		if (this._isSubmit) {
 			submitForm(this);
 		}
@@ -387,12 +383,11 @@ class Button extends UI5Element implements IButton {
 		}
 	}
 
-	_onmousedown(e: MouseEvent) {
+	_onmousedown() {
 		if (this.nonInteractive) {
 			return;
 		}
 
-		markEvent(e, "button");
 		this._setActiveState(true);
 		activeButton = this; // eslint-disable-line
 	}
@@ -412,13 +407,8 @@ class Button extends UI5Element implements IButton {
 		}
 	}
 
-	_onmouseup(e: MouseEvent) {
-		markEvent(e, "button");
-	}
-
 	_onkeydown(e: KeyboardEvent) {
 		this._cancelAction = isShift(e) || isEscape(e);
-		markEvent(e, "button");
 
 		if (isSpace(e) || isEnter(e)) {
 			this._setActiveState(true);
@@ -430,10 +420,6 @@ class Button extends UI5Element implements IButton {
 	_onkeyup(e: KeyboardEvent) {
 		if (this._cancelAction) {
 			e.preventDefault();
-		}
-
-		if (isSpace(e)) {
-			markEvent(e, "button");
 		}
 
 		if (isSpace(e) || isEnter(e)) {
@@ -451,14 +437,6 @@ class Button extends UI5Element implements IButton {
 		if (this.active) {
 			this._setActiveState(false);
 		}
-	}
-
-	_onfocusin(e: FocusEvent) {
-		if (this.nonInteractive) {
-			return;
-		}
-
-		markEvent(e, "button");
 	}
 
 	_setActiveState(active: boolean) {

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -7,7 +7,6 @@ import ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 import type { IFormInputElement } from "@ui5/webcomponents-base/dist/features/InputElementsFormSupport.js";
 import {
@@ -272,7 +271,7 @@ class FileUploader extends UI5Element implements IFormInputElement {
 	}
 
 	_onclick(e: MouseEvent) {
-		if (getEventMark(e) === "button") {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			this._input.click();
 		}
 	}

--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -270,7 +270,7 @@ class FileUploader extends UI5Element implements IFormInputElement {
 		});
 	}
 
-	_onclick(e: MouseEvent) {
+	_onclick() {
 		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			this._input.click();
 		}

--- a/packages/main/src/Link.hbs
+++ b/packages/main/src/Link.hbs
@@ -12,7 +12,6 @@
 	aria-haspopup="{{_hasPopup}}"
 	aria-expanded="{{accessibilityAttributes.expanded}}"
 	aria-current="{{accessibilityAttributes.current}}"
-	@focusin={{_onfocusin}}
 	@click={{_onclick}}
 	@keydown={{_onkeydown}}
 	@keyup={{_onkeyup}}>

--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -10,7 +10,6 @@ import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type { I18nText } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
-import { markEvent } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import { getLocationHostname, getLocationPort, getLocationProtocol } from "@ui5/webcomponents-base/dist/Location.js";
 import LinkDesign from "./types/LinkDesign.js";
@@ -344,7 +343,6 @@ class Link extends UI5Element implements ITabbable {
 		} = e;
 
 		e.stopImmediatePropagation();
-		markEvent(e, "link");
 
 		const executeEvent = this.fireDecoratorEvent<LinkClickEventDetail>("click", {
 			altKey,
@@ -358,23 +356,16 @@ class Link extends UI5Element implements ITabbable {
 		}
 	}
 
-	_onfocusin(e: FocusEvent) {
-		markEvent(e, "link");
-	}
-
 	_onkeydown(e: KeyboardEvent) {
 		if (isEnter(e) && !this.href) {
 			this._onclick(e);
 		} else if (isSpace(e)) {
 			e.preventDefault();
 		}
-
-		markEvent(e, "link");
 	}
 
 	_onkeyup(e: KeyboardEvent) {
 		if (!isSpace(e)) {
-			markEvent(e, "link");
 			return;
 		}
 

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -800,7 +800,6 @@ class List extends UI5Element {
 	onSelectionRequested(e: CustomEvent<SelectionRequestEventDetail>) {
 		const previouslySelectedItems = this.getSelectedItems();
 		let selectionChange = false;
-		this._selectionRequested = true;
 
 		if (this.selectionMode !== ListSelectionMode.None && this[`handle${this.selectionMode}`]) {
 			selectionChange = this[`handle${this.selectionMode}`](e.detail.item, !!e.detail.selected);
@@ -1200,8 +1199,7 @@ class List extends UI5Element {
 			return;
 		}
 
-		if (!this._selectionRequested && this.selectionMode !== ListSelectionMode.Delete) {
-			this._selectionRequested = true;
+		if (this.selectionMode !== ListSelectionMode.Delete) {
 			const detail: SelectionRequestEventDetail = {
 				item: pressedItem,
 				selectionComponentPressed: false,
@@ -1211,8 +1209,6 @@ class List extends UI5Element {
 
 			this.onSelectionRequested({ detail } as CustomEvent<SelectionRequestEventDetail>);
 		}
-
-		this._selectionRequested = false;
 	}
 
 	// This is applicable to NotificationListItem

--- a/packages/main/src/ListItem.hbs
+++ b/packages/main/src/ListItem.hbs
@@ -92,7 +92,7 @@
 				id="{{_id}}-singleSelectionElement"
 				class="ui5-li-singlesel-radiobtn"
 				?checked="{{selected}}"
-				@click="{{onSingleSelectionComponentPress}}">
+				@ui5-change="{{onSingleSelectionComponentPress}}">
 		</ui5-radio-button>
 	{{/if}}
 
@@ -106,7 +106,7 @@
 				class="ui5-li-multisel-cb"
 				?checked="{{selected}}"
 				accessible-name="{{_accInfo.ariaLabel}}"
-				@click="{{onMultiSelectionComponentPress}}">
+				@ui5-change="{{onMultiSelectionComponentPress}}">
 		</ui5-checkbox>
 	{{/if}}
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -1,5 +1,4 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import {
 	isSpace, isEnter, isDelete, isF2,
 } from "@ui5/webcomponents-base/dist/Keys.js";
@@ -231,8 +230,8 @@ abstract class ListItem extends ListItemBase {
 			}
 		};
 
-		const handleTouchStartEvent = (e: TouchEvent) => {
-			this._onmousedown(e as unknown as MouseEvent);
+		const handleTouchStartEvent = () => {
+			this._onmousedown();
 		};
 
 		this._ontouchstart = {
@@ -298,22 +297,22 @@ abstract class ListItem extends ListItemBase {
 		}
 	}
 
-	_onmousedown(e: MouseEvent) {
-		if (getEventMark(e) === "button") {
+	_onmousedown() {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 		this.activate();
 	}
 
-	_onmouseup(e: MouseEvent) {
-		if (getEventMark(e) === "button") {
+	_onmouseup() {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 		this.deactivate();
 	}
 
-	_ontouchend(e: TouchEvent) {
-		this._onmouseup(e as unknown as MouseEvent);
+	_ontouchend() {
+		this._onmouseup();
 	}
 
 	_onfocusout() {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -14,7 +14,6 @@ import {
 	isTabPrevious,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 
 // Styles
 import styles from "./generated/themes/ListItemBase.css.js";
@@ -136,7 +135,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 			return this._handleTabPrevious(e);
 		}
 
-		if (getEventMark(e) === "button") {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 
@@ -150,7 +149,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 	}
 
 	_onkeyup(e: KeyboardEvent) {
-		if (getEventMark(e) === "button") {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 		if (isSpace(e)) {
@@ -159,9 +158,10 @@ class ListItemBase extends UI5Element implements ITabbable {
 	}
 
 	_onclick(e: MouseEvent) {
-		if (getEventMark(e) === "button") {
+		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
+
 		this.fireItemPress(e);
 	}
 

--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -19,7 +19,6 @@ import {
 import AriaHasPopup from "@ui5/webcomponents-base/dist/types/AriaHasPopup.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
-import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import litRender from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
 import "@ui5/webcomponents-icons/dist/slim-arrow-down.js";
 import type ButtonDesign from "./types/ButtonDesign.js";
@@ -234,7 +233,7 @@ class SplitButton extends UI5Element {
 	}
 
 	_onFocusOut(e: FocusEvent) {
-		if (this.disabled || getEventMark(e)) {
+		if (this.disabled || this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 
@@ -243,7 +242,7 @@ class SplitButton extends UI5Element {
 	}
 
 	_onFocusIn(e: FocusEvent) {
-		if (this.disabled || getEventMark(e)) {
+		if (this.disabled || this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
 		this._shiftOrEscapePressed = false;

--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -232,7 +232,7 @@ class SplitButton extends UI5Element {
 		this._fireClick(e);
 	}
 
-	_onFocusOut(e: FocusEvent) {
+	_onFocusOut() {
 		if (this.disabled || this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
@@ -241,7 +241,7 @@ class SplitButton extends UI5Element {
 		this._setTabIndexValue();
 	}
 
-	_onFocusIn(e: FocusEvent) {
+	_onFocusIn() {
 		if (this.disabled || this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -46,7 +46,7 @@ describe("List Tests", () => {
 		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "1", "selectionChange event has been fired.");
 
 		await secondItemRadio.click();
-		assert.strictEqual(await itemClickResultField.getProperty("value"), "2", "itemClick event has been fired second time");
+		assert.strictEqual(await itemClickResultField.getProperty("value"), "1", "itemClick event has been fired second time");
 		assert.strictEqual(await selectionChangeResultField.getProperty("value"), "2", "selectionChange event has been fired second time.");
 		assert.strictEqual(await selectionChangeResultFieldRadio.getProperty("value"), "true", "selectionChange event correct detail - selectionComponentPressed.");
 


### PR DESCRIPTION
Previously, event marking was used to identify the origin of an event from a specific component, preventing unintended interactions with other components. This approach prevented redundant event processing, particularly in cases of component composition.

Now, if a component receives focus, it will manage most events. The :has(:focus-within) selector checks if the current element (typically the root element) has a focusable child. If a child is focused, we assume it will handle user interactions.