### PR TITLE
ci: add issues commenting after release

### DIFF
--- a/.github/actions/commentOnFixedIssues.mjs
+++ b/.github/actions/commentOnFixedIssues.mjs
@@ -1,30 +1,18 @@
 import { promises as fs } from 'node:fs';
 import { success as issueCommenter } from '@semantic-release/github';
 
-const getRelease = async (version) => {
-	const releaseInfo = await github.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
-		owner: context.repo.owner,
-		repo: context.repo.repo,
-		tag: `v${version}`
-	});
-	const release = releaseInfo.data;
-	release.url = release.html_url;
+const getReleaseCommits = (releaseBody) => {
+	const commits = new Set();
 
-	return release;
-};
-
-const getReleaseCommits = (release) => {
-	const commits = [];
-
-	let result;
-	do {
-		result = /commit\/(?<sha>\w{40})/gm.exec(release.body);
-		if (result?.groups?.sha) {
-			commits.push({ hash: result.groups.sha });
+	const shaRegex = /commit\/(?<sha>\w{40})/g;
+	for (const match of releaseBody.matchAll(shaRegex)) {
+		if (match.groups?.sha) {
+			commits.add({ hash: match.groups.sha });
 		}
-	} while (result);
+	}
 
-	return commits;
+	// Converting Set back to an array to get unique commits as array
+	return Array.from(commits);
 };
 
 const getOctokitShim = (github) => {
@@ -37,23 +25,46 @@ const getOctokitShim = (github) => {
 
 /**
  * Publishes comments to issues that are fixed and released.
- * @param options.github
+ * @param options {object}
+ * @param options.github {import("@octokit/rest/dist-types/index.d.ts").Octokit}
  * @param options.context
- * @returns {Promise<void>}
  */
 export default async function run({ github, context }) {
-  const lerna = await fs.readFile(new URL('../../lerna.json', import.meta.url), 'utf8');
-  const { version } = JSON.parse(lerna);
-  const release = await getRelease(version);
-  const commits = getReleaseCommits(release);
-  const Octokit = getOctokitShim(github);
+	const lerna = await fs.readFile(new URL('../../lerna.json', import.meta.url), 'utf8');
+	const { version } = JSON.parse(lerna);
 
-  await issueCommenter({}, {
-    options: { repositoryUrl: `https://github.com/${context.repo.owner}/${context.repo.repo}`},
-    commits,
-    nextRelease: { version: `v${version}` },
-    releases: [release],
-    logger: console,
-    env: process.env
-  }, { Octokit });
+	const { owner, repo } = context.repo;
+	const releaseInfo = await github.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
+		owner,
+		repo,
+		tag: `v${version}`
+	});
+	const release = releaseInfo.data;
+	release.url = release.html_url;
+	
+
+	const commits = await getReleaseCommits(release.body);
+	
+	
+	try {
+		const semanticReleaseContext = {
+			options: { 
+				repositoryUrl: `https://github.com/${owner}/${repo}` 
+			},
+			commits,
+			nextRelease: { version: `v${version}` },
+			releases: [release],
+			logger: console,
+			env: process.env
+		};
+		const Octokit = getOctokitShim(github);
+
+		console.log('Commits:', commits.toString());
+		console.log('semanticReleaseContext:', semanticReleaseContext);
+
+		await issueCommenter({}, semanticReleaseContext, { Octokit });
+
+	} catch (error) {
+		console.error('Error in posting comment:', error);
+	}
 }

--- a/.github/workflows/issues-handling.yaml
+++ b/.github/workflows/issues-handling.yaml
@@ -5,6 +5,10 @@ on: workflow_dispatch
 jobs:
   test-issue-comment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -18,15 +22,14 @@ jobs:
     - name: Install
       run: yarn --frozen-lockfile
 
-    - name: Add release comments to issues and PRs
-      uses: actions/github-script@v6
+    - name: Publish Release Comments
+      uses: actions/github-script@v7
       env:
+          NODE_OPTIONS: '--max-old-space-size=12096'
           GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
       with:
+          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
           script: |
-            const { readFileSync } = require('fs');
-            const { URL } = require('url');
-            const { version } = require('./lerna.json');
-            console.log('Create issue comments for lerna version: ', version);
-            const script = require('./.github/actions/createIssueComments.cjs');
-            аwait script({ github: github.rest, context, core, version })
+            const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
+
+            await commentOnFixedIssues({ github , context });

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -16,6 +16,10 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -57,10 +61,11 @@ jobs:
     - name: Publish Release Comments
       uses: actions/github-script@v7
       env:
+          NODE_OPTIONS: '--max-old-space-size=12096'
           GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
       with:
           github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
           script: |
             const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
 
-            await commentOnFixedIssues({ github, context })
+            await commentOnFixedIssues({ github, context });


### PR DESCRIPTION
Create setup for commenting on issues that have been fixed and released.

For example
https://github.com/SAP/ui5-webcomponents/issues/9982#issuecomment-2444602555
https://github.com/SAP/ui5-webcomponents/issues/8544#issuecomment-2444602554