### PR TITLE
feat(ui5-date-picker): introduce open and close events

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -250,6 +250,18 @@ type DatePickerInputEventDetail = {
 	bubbles: true,
 	cancelable: true,
 })
+/**
+ * Fired after the value-help dialog of the component is opened.
+ * @since 2.4.0
+ * @public
+ */
+@event("open")
+/**
+ * Fired after the value-help dialog of the component is closed.
+ * @since 2.4.0
+ * @public
+ */
+@event("close")
 class DatePicker extends DateComponentBase implements IFormInputElement {
 	/**
 	 * Defines a formatted date value.
@@ -407,6 +419,12 @@ class DatePicker extends DateComponentBase implements IFormInputElement {
 		} else {
 			this._getInput()?.focus();
 		}
+
+		this.fireDecoratorEvent("close");
+	}
+
+	onResponsivePopoverAfterOpen() {
+		this.fireDecoratorEvent("open");
 	}
 
 	onResponsivePopoverBeforeOpen() {

--- a/packages/main/src/DatePickerPopover.hbs
+++ b/packages/main/src/DatePickerPopover.hbs
@@ -10,6 +10,7 @@
 	?_hide-header={{_shouldHideHeader}}
 	@keydown="{{_onkeydown}}"
 	@ui5-close="{{onResponsivePopoverAfterClose}}"
+	@ui5-open="{{onResponsivePopoverAfterOpen}}"
 	@ui5-before-open="{{onResponsivePopoverBeforeOpen}}"
 >
 	{{#if showHeader}}

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -223,6 +223,14 @@
 			e.preventDefault();
 	});
 
+	dpCalendarModeDays.addEventListener("ui5-open", function(e) {
+		console.log("Picker is opened");
+	});
+
+	dpCalendarModeDays.addEventListener("ui5-close", function(e) {
+		console.log("Picker is closed");
+	});
+
 	</script>
 </body>
 </html>


### PR DESCRIPTION
As we introduced a declaritive property `open` which controls wether the value-help dialog of the `<ui5-date-picker>` is open or not, we are now introducing `open` and `close` events fired after the value-help dialog is opened or closed.

