### PR TITLE
chore(ui5-li): correct active state

### DIFF
--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -298,9 +298,6 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	_onmousedown() {
-		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
-			return;
-		}
 		this.activate();
 	}
 
@@ -315,7 +312,19 @@ abstract class ListItem extends ListItemBase {
 		this._onmouseup();
 	}
 
-	_onfocusout() {
+	_onfocusin(e: FocusEvent) {
+		super._onfocusin(e);
+
+		if (e.target !== this.getFocusDomRef()) {
+			this.deactivate();
+		}
+	}
+
+	_onfocusout(e: FocusEvent) {
+		if (e.target !== this.getFocusDomRef()) {
+			return;
+		}
+
 		this.deactivate();
 	}
 


### PR DESCRIPTION
The `mousedown` event handler currently triggers before focus is applied, which can lead to false positives in the check.

With this PR, the handling of the active state for list items is updated as follows:

- On `mousedown`, the active state is always applied.
- When `focusin` is triggered:
  - If the target differs from the list item’s focus DOM reference: This indicates that a child element has gained focus, so the active state should be deactivated to display the correct state.
  - If the target matches the list item’s focus DOM reference: Do nothing, as the focus is still on the list item.
- When `focusout` is triggered:
  - If the target matches the list item’s focus DOM reference: Deactivate, as the list item may have had its active state set previously.
  - If the target differs from the list item’s focus DOM reference: Do nothing, as the focus might have moved from the child to the list item’s focus reference, which is handled in the first `focusin` condition above. 