### PR TITLE
docs: fix documentation of event bubbling

### DIFF
--- a/packages/tools/lib/cem/event.mjs
+++ b/packages/tools/lib/cem/event.mjs
@@ -104,7 +104,7 @@ function processEvent(ts, event, classNode, moduleDoc) {
 	result.description = description;
 	result._ui5Cancelable = eventCancelable !== undefined ? eventCancelable : false;
 	result._ui5allowPreventDefault = result._ui5Cancelable;
-	result._ui5Bubbles = eventBubbles !== undefined ? eventBubbles : true;
+	result._ui5Bubbles = eventBubbles !== undefined ? eventBubbles : false;
 
 	if (native) {
 		result.type = { text: "Event" };


### PR DESCRIPTION
At some point we switched the  defaults of the bubbles. When `bubbles` is not specified, it's false. And this is how the components behave. However, the change was not reflected in the documentation of the events - bubbles is considered `true`, when not present at all.

For example:


Currently, for the Select's close event
```ts
/**
 * Fired after the component's dropdown menu closes.
 * @public
 */
@event("close")
```

we get `bubbles: Yes`:

<img width="694" alt="Screenshot 2024-11-04 at 18 15 13" src="https://github.com/user-attachments/assets/9fb18d95-e6b4-487a-96a2-0fcad89aabb6">


but should be `bubbles: No`:

<img width="653" alt="Screenshot 2024-11-04 at 18 15 09" src="https://github.com/user-attachments/assets/a908d3b0-b8fb-46c3-a3c0-2e7c70fbd001">


