### PR TITLE
fix(ui5-select): add support for Vue.js v-model

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -199,6 +199,15 @@ type SelectLiveChangeEventDetail = {
 @event("selected-item-changed", {
 	bubbles: true,
 })
+
+/**
+ * Fired to make Vue.js two way data binding work properly.
+ * @private
+ */
+@event("input", {
+	bubbles: true,
+})
+
 class Select extends UI5Element implements IFormInputElement {
 	@i18n("@ui5/webcomponents")
 	static i18nBundle: I18nBundle;
@@ -748,6 +757,9 @@ class Select extends UI5Element implements IFormInputElement {
 
 		//  Angular two way data binding
 		this.fireDecoratorEvent("selected-item-changed");
+
+		// Fire input event for Vue.js two-way binding
+		this.fireDecoratorEvent("input");
 
 		if (changePrevented) {
 			this._select(this._selectedIndexBeforeOpen);


### PR DESCRIPTION
Enhances the `ui5-select` component to support Vue.js v-model directive by emitting an `input` event when the value changes.

Fixes: #9971
