### PR TITLE
fix(ui5-dynamic-page): move subheading slot outside the title wrapper

### DIFF
--- a/packages/fiori/src/DynamicPageTitle.hbs
+++ b/packages/fiori/src/DynamicPageTitle.hbs
@@ -28,7 +28,6 @@
       @ui5-_min-content-width-change={{onMinContentWidthChange}}>
       <div id="{{_id}}-heading" class="ui5-dynamic-page-title--heading">
         <slot name="{{headingSlotName}}"></slot>
-        <slot name="{{subheadingSlotName}}"></slot>
       </div>
 
       {{#if hasContent}}
@@ -49,7 +48,7 @@
         {{/unless}}
       </div>
     </div>
-
+    <slot name="{{subheadingSlotName}}"></slot>
   {{/if}}
   
   <span id="{{_id}}-toggle-description" class="ui5-hidden-text">{{_ariaDescribedbyText}}</span>

--- a/packages/fiori/test/pages/styles/DynamicPage.css
+++ b/packages/fiori/test/pages/styles/DynamicPage.css
@@ -63,6 +63,7 @@ html, body {
 }
 .snapped-title-heading [ui5-avatar] {
     position: absolute;
+    top: 0;
 }
 .snapped-title-heading [ui5-title] {
     font-family: var(--sapObjectHeader_Title_FontFamily);

--- a/packages/website/docs/_samples/fiori/DynamicPage/Basic/main.css
+++ b/packages/website/docs/_samples/fiori/DynamicPage/Basic/main.css
@@ -61,6 +61,7 @@
 }
 .snapped-title-heading [ui5-avatar] {
     position: absolute;
+    top: 0;
 }
 .snapped-title-heading [ui5-title] {
     font-family: var(--sapObjectHeader_Title_FontFamily);


### PR DESCRIPTION
Issue:
- The subheading width was not 100% and was constrained by the title wrapper’s flex layout.

Solution:
- Moved the subheading slot outside the title wrapper to allow it to take full width.

Additional change:
Aligned the avatar with the title heading and subheading.

Fixes: [#10161](https://github.com/SAP/ui5-webcomponents/issues/10161)