### PR TITLE
fix(ui5-table): content cut

### DIFF
--- a/packages/compat/src/themes/Table.css
+++ b/packages/compat/src/themes/Table.css
@@ -10,11 +10,15 @@
 	border-bottom: var(--ui5_table_bottom_border);
 }
 
-.ui5-table-root,
-.ui5-table-busy-indicator {
+.ui5-table-root {
 	width: 100%;
 	height: 100%;
+	display: flex;
 	box-sizing: border-box;
+}
+
+.ui5-table-busy-indicator {
+	flex-grow: 1;
 }
 
 table {


### PR DESCRIPTION
If the table has a fixed size and the text in its columns cannot wrap, the content will be cut off due to overflow when the total width of the columns exceeds the table's width.

![image](https://github.com/user-attachments/assets/d3a52eba-b944-4f07-ade6-e79b73903665)

This issue, caused by an incorrect size of the busy indicator, has been resolved with the current update.

Related to: #10168