### PR TITLE
fix(ui5-table): text cut due to column overflow

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@openui5/sap.ui.core": "1.120.17",
     "@ui5/webcomponents-tools": "1.24.13",
-    "chromedriver": "^129.0.0",
+    "chromedriver": "^131.0.0",
     "clean-css": "^5.2.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.3",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.24.13",
-    "chromedriver": "^129.0.0"
+    "chromedriver": "^131.0.0"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -35,7 +35,7 @@
     "@openui5/sap.ui.core": "1.120.17",
     "@ui5/webcomponents-tools": "1.24.13",
     "babel-plugin-amd-to-esm": "^2.0.3",
-    "chromedriver": "^129.0.0",
+    "chromedriver": "^131.0.0",
     "estree-walk": "^2.2.0",
     "mkdirp": "^1.0.4",
     "resolve": "^1.20.0"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "@ui5/webcomponents-tools": "1.24.13",
-    "chromedriver": "^129.0.0"
+    "chromedriver": "^131.0.0"
   }
 }

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -10,11 +10,15 @@
 	border-bottom: var(--ui5_table_bottom_border);
 }
 
-.ui5-table-root,
-.ui5-table-busy-indicator {
+.ui5-table-root {
 	width: 100%;
 	height: 100%;
+	display: flex;
 	box-sizing: border-box;
+}
+
+.ui5-table-busy-indicator {
+	flex-grow: 1;
 }
 
 table {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7658,10 +7658,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@^129.0.0:
-  version "129.0.4"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-129.0.4.tgz#64e598061b74f0f65fae605242327af84ebbfd28"
-  integrity sha512-j5I55cQwodFJUaYa1tWUmj2ss9KcPRBWmUa5Qonq3X8kqv2ASPyTboFYb4YB/YLztkYTUUw2E43txXw0wYzT/A==
+chromedriver@^131.0.0:
+  version "131.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-131.0.0.tgz#08bbc6d9fcd1c42abfe70ac7e3412fba96f44723"
+  integrity sha512-ukYmdCox2eRsjpCYUB4AOLV1fSfWQ1ZPfcUc0PIUWZKoyjyXKEl8i4DJ14bcNzNbEvaVx2Z2pnx/nLK2CM+ruQ==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.7.4"


### PR DESCRIPTION
If the table has a fixed size and the text in its columns cannot wrap, the content will be cut off due to overflow when the total width of the columns exceeds the table's width.

![image](https://github.com/user-attachments/assets/d3a52eba-b944-4f07-ade6-e79b73903665)

This issue, caused by an incorrect size of the busy indicator, has been resolved with the current update.

Fixes: #10168