### PR TITLE
fix(ui5-rating-indicator): outline border is visible when focus

### DIFF
--- a/packages/main/src/themes/RatingIndicator.css
+++ b/packages/main/src/themes/RatingIndicator.css
@@ -3,6 +3,7 @@
 	font-size: 24px;
 	margin: var(--_ui5_rating_indicator_component_spacing);
 	cursor: pointer;
+	padding: var(--_ui5_rating_indicator_component_padding);
 }
 
 :host([disabled]) {

--- a/packages/main/src/themes/RatingIndicator.css
+++ b/packages/main/src/themes/RatingIndicator.css
@@ -3,7 +3,6 @@
 	font-size: 24px;
 	margin: var(--_ui5_rating_indicator_component_spacing);
 	cursor: pointer;
-	padding: var(--_ui5_rating_indicator_component_padding);
 }
 
 :host([disabled]) {
@@ -41,6 +40,7 @@
 .ui5-rating-indicator-root {
 	outline: none;
 	position: relative;
+	padding: var(--_ui5_rating_indicator_component_padding);
 }
 
 .ui5-rating-indicator-list {

--- a/packages/main/src/themes/base/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/base/RatingIndicator-parameters.css
@@ -1,12 +1,13 @@
 :root {
-	--_ui5_rating_indicator_border_radius: 0px;
-	--_ui5_rating_indicator_outline_offset: 0px;
+	--_ui5_rating_indicator_border_radius: 0.5rem;
+	--_ui5_rating_indicator_outline_offset: -0.125rem;
 	--_ui5_rating_indicator_item_height: 1em;
 	--_ui5_rating_indicator_item_width: 1em;
 	--_ui5_rating_indicator_readonly_item_height: 1em;
 	--_ui5_rating_indicator_readonly_item_width: 1em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0px;
 	--_ui5_rating_indicator_component_spacing: 0.5rem 0px;
+	--_ui5_rating_indicator_component_padding: 0.25rem;
 }
 
 [data-ui5-compact-size],

--- a/packages/main/src/themes/sap_horizon/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon/RatingIndicator-parameters.css
@@ -1,8 +1,6 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	/* --_ui5_rating_indicator_border_radius: 0.25rem; */
-	--_ui5_rating_indicator_outline_offset: -0.125rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon/RatingIndicator-parameters.css
@@ -1,8 +1,8 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_border_radius: 0.25rem;
-	--_ui5_rating_indicator_outline_offset: 0.125rem;
+	/* --_ui5_rating_indicator_border_radius: 0.25rem; */
+	--_ui5_rating_indicator_outline_offset: -0.125rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_dark/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/RatingIndicator-parameters.css
@@ -1,8 +1,6 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_border_radius: 0.25rem;
-	--_ui5_rating_indicator_outline_offset: 0.125rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/RatingIndicator-parameters.css
@@ -1,7 +1,6 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_outline_offset: 0.0625rem;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/RatingIndicator-parameters.css
@@ -1,7 +1,6 @@
 @import "../base/RatingIndicator-parameters.css";
 
 :root {
-	--_ui5_rating_indicator_outline_offset: 0.0625rem;;
 	--_ui5_rating_indicator_readonly_item_height: 0.75em;
 	--_ui5_rating_indicator_readonly_item_width: 0.75em;
 	--_ui5_rating_indicator_readonly_item_spacing: 0.1875rem 0.1875rem;

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -17,7 +17,7 @@
 		}
 
 		body{
-			margin:0;
+			margin: 0;
 		}
 	</style>
 
@@ -127,13 +127,6 @@
 		<br>
 
 	</section>
-
-	<h3>RatingIndicator 0 margin - fixed</h3>
-	<ui5-rating-indicator id="0marginFixed"></ui5-rating-indicator>
-	<br>
-	<br>
-	<br>
-
 	<script>
 		var changeCount = 0;
 		var ratingIndicator4 = document.getElementById("rating-indicator4");

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -15,6 +15,10 @@
 			display: inline-block;
 			margin-right: 20px;
 		}
+
+		body{
+			margin:0;
+		}
 	</style>
 
 	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
@@ -123,6 +127,12 @@
 		<br>
 
 	</section>
+
+	<h3>RatingIndicator 0 margin - fixed</h3>
+	<ui5-rating-indicator id="0marginFixed"></ui5-rating-indicator>
+	<br>
+	<br>
+	<br>
 
 	<script>
 		var changeCount = 0;


### PR DESCRIPTION
FIXES: https://github.com/SAP/ui5-webcomponents/issues/10162

The solution:  made the "--_ui5_rating_indicator_outline_offset" parameter negative value, so now it can be seen when the rating indicator is focused. Added padding parameter, so the stars of the indicator are not touching the edges of the focus. Made the "--_ui5_rating_indicator_border_radius" parameter bigger. 