### PR TITLE
feat(ui5-list): add Home and End key handling for Load More button

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -16,6 +16,8 @@ import {
 	isEnter,
 	isTabPrevious,
 	isCtrl,
+	isEnd,
+	isHome,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import DragRegistry from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
 import { findClosestPosition, findClosestPositionsByKey } from "@ui5/webcomponents-base/dist/util/dragAndDrop/findClosestPosition.js";
@@ -952,6 +954,17 @@ class List extends UI5Element {
 	}
 
 	_onkeydown(e: KeyboardEvent) {
+		if (isEnd(e)) {
+			this._handleEnd();
+			e.preventDefault();
+			return;
+		}
+
+		if (isHome(e)) {
+			this._handleHome();
+			return;
+		}
+
 		if (isCtrl(e)) {
 			this._moveItem(e.target as ListItemBase, e);
 			return;
@@ -1082,6 +1095,22 @@ class List extends UI5Element {
 			e.stopImmediatePropagation();
 			e.preventDefault();
 		}
+	}
+
+	_handleHome() {
+		if (!this.growsWithButton) {
+			return;
+		}
+
+		this.focusFirstItem();
+	}
+
+	_handleEnd() {
+		if (!this.growsWithButton) {
+			return;
+		}
+
+		this._shouldFocusGrowingButton();
 	}
 
 	_onfocusin(e: FocusEvent) {
@@ -1312,6 +1341,16 @@ class List extends UI5Element {
 
 		if (growingBtn) {
 			growingBtn.focus();
+		}
+	}
+
+	_shouldFocusGrowingButton() {
+		const items = this.getItems();
+		const lastIndex = items.length - 1;
+		const currentIndex = items.indexOf(document.activeElement as ListItemBase);
+
+		if (currentIndex !== -1 && currentIndex === lastIndex) {
+			this.focusGrowingButton();
 		}
 	}
 


### PR DESCRIPTION
Improving the keyboard navigation for the ui5-list when the Load More button is present:

Home Key: 
- If the focus is on the Load More button and the Home key is pressed, the focus moves to the first item in the list.

End Key:
- When pressed once, the focus moves to the last item in the list.
- When pressed again while the focus is already on the last item, the focus moves to the Load More button.