### PR TITLE
chore: use fireDecoratorEvent over fireEvent

### DIFF
--- a/packages/main/src/SliderBase.ts
+++ b/packages/main/src/SliderBase.ts
@@ -343,12 +343,12 @@ abstract class SliderBase extends UI5Element {
 
 	_onInputChange() {
 		if (this._valueOnInteractionStart !== this.value) {
-			this.fireEvent("change");
+			this.fireDecoratorEvent("change");
 		}
 	}
 
 	_onInputInput() {
-		this.fireEvent("input");
+		this.fireDecoratorEvent("input");
 	}
 
 	_updateValueFromInput(e: Event) {


### PR DESCRIPTION
The fireEvent method is deprecated, we migrated the code base to use fireDecoratorEvent