### PR TITLE
fix(ui5-tokenizer): multiLine not properly displayed in Safari

### DIFF
--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -9,25 +9,25 @@
 
 :host([multi-line]) {
 	height: auto;
+}
 
-	.ui5-tokenizer--content {
-		display: flex;
-		align-content: baseline;
-		flex-wrap: wrap;
-		padding: .25rem;
-		box-sizing: border-box;
-		row-gap: .5rem;
-		column-gap: .25rem;
-		overflow-y: auto;
-		overflow-x: hidden;
-	}
+:host([multi-line]) .ui5-tokenizer--content {
+	display: flex;
+	align-content: baseline;
+	flex-wrap: wrap;
+	padding: .25rem;
+	box-sizing: border-box;
+	row-gap: .5rem;
+	column-gap: .25rem;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
 
-	::slotted(ui5-token) {
-		margin: 0;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		max-width: 100%;
-	}
+::slotted(ui5-token) {
+	margin: 0;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	max-width: 100%;
 }
 
 :host([disabled]) {

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -23,7 +23,7 @@
 	overflow-x: hidden;
 }
 
-:host([multi-line])::slotted(ui5-token) {
+:host([multi-line])::slotted([ui5-token]) {
 	margin: 0;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -23,7 +23,7 @@
 	overflow-x: hidden;
 }
 
-::slotted(ui5-token) {
+:host([multi-line])::slotted(ui5-token) {
 	margin: 0;
 	white-space: nowrap;
 	text-overflow: ellipsis;


### PR DESCRIPTION
MultiLine Tokenizer was not displayed properly in Safari because there seems to be a difference on how browsers inrerpret the css selectors when nested, therefore switched to a more "modular" approach.

Fixes: #10214