### PR TITLE
fix(ui5-tokenizer): adjust touch area for cozy and compact

### DIFF
--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -22,7 +22,7 @@
 	overflow-x: hidden;
 }
 
-:host([multi-line])::slotted(ui5-token) {
+:host([multi-line])::slotted([ui5-token]) {
 	margin: 0;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/packages/main/src/themes/Tokenizer.css
+++ b/packages/main/src/themes/Tokenizer.css
@@ -9,25 +9,24 @@
 
 :host([multi-line]) {
 	height: auto;
+}
 
-	.ui5-tokenizer--content {
-		display: flex;
-		align-content: baseline;
-		flex-wrap: wrap;
-		padding: .25rem;
-		box-sizing: border-box;
-		row-gap: .5rem;
-		column-gap: .25rem;
-		overflow-y: auto;
-		overflow-x: hidden;
-	}
+:host([multi-line]) .ui5-tokenizer--content {
+	display: flex;
+	align-content: baseline;
+	flex-wrap: wrap;
+	padding: .25rem;
+	box-sizing: border-box;
+	gap: var(--_ui5_tokenizer_gap);
+	overflow-y: auto;
+	overflow-x: hidden;
+}
 
-	::slotted(ui5-token) {
-		margin: 0;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		max-width: 100%;
-	}
+:host([multi-line])::slotted(ui5-token) {
+	margin: 0;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	max-width: 100%;
 }
 
 :host([disabled]) {

--- a/packages/main/src/themes/base/Tokenizer-parameters.css
+++ b/packages/main/src/themes/base/Tokenizer-parameters.css
@@ -1,5 +1,6 @@
 :root {
 	--_ui5_tokenizer_padding: 0.3125rem;
+	--_ui5_tokenizer_gap: 0.625rem 0.25rem;
 	--_ui5_tokenizer_n_more_text_color: var(--sapField_TextColor);
 	--_ui5_tokenizer-popover_offset: .3125rem;
 }
@@ -7,5 +8,6 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
+	--_ui5_tokenizer_gap: 0.375em 0.25rem;
 	--_ui5_tokenizer-popover_offset: .1875rem;
 }


### PR DESCRIPTION
Touch area in MultiLine mode is now according to specifiaction.

Fixes: #10216

MultiLine Tokenizer was not displayed properly in Safari because there seems to be a difference on how browsers inrerpret the css selectors when nested, therefore switched to a more "modular" approach.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10214