### PR TITLE
chore(ui5-toolbar): add targetRef to event data

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -528,7 +528,7 @@ class Toolbar extends UI5Element {
 			const abstractItem = this.getItemByID(refItemId);
 			const eventType = e.type;
 			const eventTypeNonPrefixed: string = e.type.replace("ui5-", "");
-			const prevented = !abstractItem?.fireEvent(eventTypeNonPrefixed, e.detail, true);
+			const prevented = !abstractItem?.fireDecoratorEvent(eventTypeNonPrefixed, { ...e.detail, targetRef: target });
 			const eventOptions = abstractItem?.subscribedEvents.get(eventType) || abstractItem?.subscribedEvents.get(eventTypeNonPrefixed);
 
 			if (prevented || abstractItem?.preventOverflowClosing || eventOptions?.preventClosing) {

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -45,7 +45,11 @@ type ToolbarButtonAccessibilityAttributes = ButtonAccessibilityAttributes;
  * property is set to `true`.
  * @public
  */
-@event("click")
+@event("click", {
+	bubbles: true,
+	cancelable: true,
+})
+
 class ToolbarButton extends ToolbarItem {
 	/**
 	 * Defines if the action is disabled.


### PR DESCRIPTION
This change adds a reference to the actual DOM element in the event data of toolbar-items related events.

Fixes: #9997
