### PR TITLE
fix(ui5-split-button): fix doubled click event when space is pressed

### DIFF
--- a/packages/main/src/SplitButton.ts
+++ b/packages/main/src/SplitButton.ts
@@ -409,10 +409,11 @@ class SplitButton extends UI5Element {
 			}
 		} else {
 			this._textButtonActive = true;
-			this._fireClick();
 			if (wasSpacePressed) {
 				this._spacePressed = true;
+				return;
 			}
+			this._fireClick();
 		}
 	}
 


### PR DESCRIPTION
During the work on another task I have found that when a default action of a `ui5-split-button` is activated by pressing of `Space` key, the `click` event is fired twice - on **keydown** and on **keyup**. It should be fired only once on **keyup** only if the `Space` is pressed and before the release `Escape` or `Shift` is not pressed (this is accessibility feature related to all buttons).

This PR fixes the issue.