### PR TITLE
docs(ui5-table-header-cell): describe minWidth specifics

### DIFF
--- a/packages/main/src/TableHeaderCell.ts
+++ b/packages/main/src/TableHeaderCell.ts
@@ -45,6 +45,8 @@ class TableHeaderCell extends TableCellBase {
 	 * If the table is in `Popin` mode, the column will move into the popin when
 	 * when the minimum width does not fit anymore.
 	 *
+	 * **Note:** If `minWidth` has value `auto`, the table ensures that the column cannot be smaller than `3rem`.
+	 *
 	 * @default "auto"
 	 * @public
 	 */


### PR DESCRIPTION
If `min-width="auto"`, the table ensures that the column cannot be smaller than 3rem. This was not mentioned in the documentation yet, which can lead to confusion (as auto behaves differently normally).
Therefore, enhance the documentation and explicitly mention this restriction.

Fixes #9679