### PR TITLE
fix(ui5-li): address additional text contrast issue

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -22,6 +22,10 @@
 	color: var(--sapList_Active_TextColor);
 }
 
+:host([active][actionable]) .ui5-li-additional-text {
+	text-shadow: none;
+}
+
 /* [ui5-li]: additionalTextState */
 :host([additional-text-state="Critical"]) .ui5-li-additional-text {
 	color: var(--sapCriticalTextColor);

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -27,11 +27,19 @@
 :host([selected]) {
 	background-color: var(--sapList_SelectionBackgroundColor);
 	border-bottom: var(--ui5-listitem-selected-border-bottom);
+
+	.ui5-li-additional-text {
+		text-shadow: var(--sapContent_TextShadow);
+	}
 }
 
 /* hovered */
 :host([actionable]:not([active]):not([selected]):not([ui5-li-group-header]):hover) {
     background-color: var(--sapList_Hover_Background);
+
+	.ui5-li-additional-text {
+		text-shadow: var(--sapContent_TextShadow);
+	}
 }
 
 /* selected and hovered */


### PR DESCRIPTION
The contrast of the additional text in the list item is not sufficient. This change addresses the issue by increasing the contrast of the additional text by adding a text shadow and aligning the component with the design guidelines.

Related: #9869
