### PR TITLE
fix(ui5-li): address additional text contrast issue

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -19,6 +19,10 @@
 /* hovered */
 :host([actionable]:not([active]):not([selected]):hover) {
 	background : var(--sapList_Hover_Background);
+
+	.ui5-li-additional-text {
+		text-shadow: var(--sapContent_TextShadow);
+	}
 }
 
 /* focused */
@@ -47,6 +51,10 @@
 :host([active][actionable]) .ui5-li-desc,
 :host([active][actionable]) .ui5-li-additional-text {
 	color: var(--sapList_Active_TextColor);
+}
+
+:host([active][actionable]) .ui5-li-additional-text {
+	text-shadow: none;
 }
 
 /* [ui5-li]: additionalTextState */

--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -12,6 +12,10 @@
 /* selected */
 :host([selected]) {
 	background: var(--sapList_SelectionBackgroundColor);
+
+	.ui5-li-additional-text {
+		text-shadow: var(--sapContent_TextShadow);
+	}
 }
 
 :host([has-border]) {


### PR DESCRIPTION
The contrast of the additional text in the list item is not sufficient. This change addresses the issue by increasing the contrast of the additional text by adding a text shadow and aligning the component with the design guidelines.

Fixes: #9869 
