### PR TITLE
refactor(ui5-list): remove unnecessary stopImmediatePropagation call

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1177,7 +1177,6 @@ class List extends UI5Element {
 			}
 
 			this.focusPreviouslyFocusedItem();
-			e.stopImmediatePropagation();
 		}
 
 		e.stopImmediatePropagation();


### PR DESCRIPTION
Removed unnecessary `stopImmediatePropagation()` from the if block that handles returning focus to the list within the _onfocusin function.