### PR TITLE
feat(ui5-tabcontainer): allow unselected tabcontainer

### DIFF
--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -314,6 +314,14 @@ class TabContainer extends UI5Element {
 	@property()
 	mediaRange?: string;
 
+	/**
+	 * Defines whether the first tab is selected by default if no tab is selected.
+	 * @default false
+	 * @public
+	 */
+	@property({ type: Boolean })
+	unselected = false;
+
 	@property({ type: Object })
 	_selectedTab?: Tab;
 
@@ -407,6 +415,8 @@ class TabContainer extends UI5Element {
 
 		if (selectedTab) {
 			this._selectedTab = selectedTab;
+		} else if (this.unselected) {
+			this._selectedTab = undefined;
 		} else {
 			this._selectedTab = this._itemsFlat[0] as Tab;
 		}

--- a/packages/main/test/pages/TabContainer.html
+++ b/packages/main/test/pages/TabContainer.html
@@ -885,6 +885,16 @@
 		</ui5-tabcontainer>
 	</section>
 
+	<section>
+		<h3>Unselected Tab Container</h3>
+		<ui5-tabcontainer id="unselectedTabContainer" unselected>
+			<ui5-tab text="One"></ui5-tab>
+			<ui5-tab text="Two"></ui5-tab>
+			<ui5-tab text="Three"></ui5-tab>
+			<ui5-tab text="Four"></ui5-tab>
+		</ui5-tabcontainer>
+	</section>
+
 	<script>
 		document.getElementById("tabContainer1").addEventListener("ui5-tab-select", async function (event) {
 			result.innerHTML = event.detail.tab.text;

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -417,6 +417,16 @@ describe("TabContainer general interaction", () => {
 
 		assert.ok(await listItem.getProperty("selected"), "tab is selected");
 	});
+
+	it("tests unselected tabcontainer", async () => {
+		const tabContainer = await browser.$("#unselectedTabContainer");
+		const tabs = await tabContainer.shadow$$(".ui5-tab-strip-item");
+		const SELECTION_CSS_CLASS = "ui5-tab-strip-item--selected";
+		for(let i = 0; i < tabs.length; i++) {
+            const tabHtml = await tabs[i].getHTML();
+            assert.notInclude(tabHtml, SELECTION_CSS_CLASS, `Tab at index ${i} should not have the CSS class ${SELECTION_CSS_CLASS}`);
+        }
+	});
 });
 
 describe("TabContainer keyboard handling", () => {


### PR DESCRIPTION
Problem Description
Currently, in a ui5-side-navigation scenario with a TabContainer component, the first tab is selected by default. However, in the specific use case where clicking on a ui5-side-navigation-item loads a corresponding view, the TabContainer should initially have no tab selected. This behaviour ensures that the view corresponds only to the side-navigation item, and that tabs are only activated when the user explicitly clicks on them.
<img width="1000" alt="Bildschirmfoto 2024-12-03 um 10 37 09" src="https://github.com/user-attachments/assets/a1312b66-d5b8-4596-87e2-7d454c076217">

Solution
This PR introduces a new property, _unselected_, for the TabContainer component. When this property is enabled:

- The TabContainer will render without any tab being pre-selected.

P.S. _since_ is missing in the jsdocs, but I don't know which version number