### PR TITLE
fix(ui5-view-settings-dialog): adjust dialog heading level

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.hbs
+++ b/packages/fiori/src/ViewSettingsDialog.hbs
@@ -20,7 +20,7 @@
 						@click="{{_navigateToFilters}}"
 					></ui5-button>
 				{{/if}}
-				<ui5-title wrapping-type="None" class="ui5-vsd-title" id="{{_id}}-label">{{_title}}</ui5-title>
+				<ui5-title wrapping-type="None" level="H1" class="ui5-vsd-title" id="{{_id}}-label">{{_title}}</ui5-title>
 			</div>
 			<div class="ui5-vsd-header-end">
 				<ui5-button


### PR DESCRIPTION
The dialog is considered as a separate context so it's heading should be `H1`.

Related to: https://github.com/SAP/ui5-webcomponents/discussions/10191