### PR TITLE
chore(ui5-table-growing): remove disabled property

### DIFF
--- a/packages/main/cypress/specs/TableGrowing.cy.ts
+++ b/packages/main/cypress/specs/TableGrowing.cy.ts
@@ -77,47 +77,6 @@ describe("TableGrowing - Button", () => {
 				.should("have.text", growingSubtext);
 		});
 
-		it("tests diabled state", () => {
-			cy.mount(html`
-				<ui5-table>
-					<ui5-table-growing slot="features" disabled></ui5-table-growing>
-					<ui5-table-header-row slot="headerRow">
-						<ui5-table-header-cell><span>ColumnA</span></ui5-table-header-cell>
-					</ui5-table-header-row>
-					<ui5-table-row>
-						<ui5-table-cell><ui5-label>Cell A</ui5-label></ui5-table-cell>
-					</ui5-table-row>
-				</ui5-table>
-			`);
-
-			cy.get("[ui5-table]")
-				.shadow()
-				.find("#growing-row")
-				.should("not.exist");
-
-			cy.get("[ui5-table-growing]")
-				.shadow()
-				.find("#growing-button")
-				.should("not.exist");
-		});
-
-		it("tests dynamically setting disabled state", () => {
-			mountTable();
-
-			cy.get("[ui5-table]")
-				.shadow()
-				.find("#growing-row")
-				.should("exist");
-
-			cy.get<TableGrowing>("[ui5-table-growing]")
-				.then(table => { table.get(0).disabled = true; });
-
-			cy.get("[ui5-table]")
-				.shadow()
-				.find("#growing-row")
-				.should("not.exist");
-		});
-
 		it("tests growing button not shown when no data", () => {
 			cy.mount(html`
 				<ui5-table>
@@ -255,23 +214,6 @@ describe("TableGrowing - Scroll", () => {
 				.find("#growing-row")
 				.should("exist");
 		});
-
-		it("tests button not shown when not scrollable and disabled", () => {
-			mountTable(1, true);
-
-			cy.get<TableGrowing>("[ui5-table-growing]")
-				.then(tableGrowing => { tableGrowing.get(0).disabled = true; });
-
-			cy.get("[ui5-table]")
-				.shadow()
-				.find("#growing-row")
-				.should("not.exist");
-
-			cy.get("[ui5-table-growing]")
-				.shadow()
-				.find("#growing-button")
-				.should("not.exist");
-		});
 	});
 
 	describe("Event", () => {
@@ -333,26 +275,6 @@ describe("TableGrowing - Scroll", () => {
 					.children("ui5-table-row")
 					.should("have.length", 1 + 10 * i);
 			}
-		});
-
-		it("tests load-more not fired when disabled", () => {
-			mountTable(11, true);
-
-			cy.get<TableGrowing>("[ui5-table-growing]")
-				.then(tableGrowing => {
-					tableGrowing.get(0).disabled = true;
-					tableGrowing.get(0).addEventListener("load-more", cy.stub().as("loadMore"));
-				});
-
-			cy.get("[ui5-table-row]:last-child")
-				.scrollIntoView();
-
-			cy.get("[ui5-table]")
-				.children("ui5-table-row")
-				.should("have.length", 11);
-
-			cy.get("@loadMore")
-				.should("not.have.been.called");
 		});
 	});
 });

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -116,15 +116,6 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	growingSubText?: string;
 
 	/**
-	 * Disables the growing feature.
-	 *
-	 * @default false
-	 * @public
-	 */
-	@property({ type: Boolean })
-	disabled = false;
-
-	/**
 	 * Defines the active state of the growing button.
 	 * Used for keyboard interaction.
 	 * @private
@@ -166,10 +157,6 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 			focusRow?.focus();
 		}
 
-		if (this.disabled) {
-			return;
-		}
-
 		if (this._renderContent !== this.hasGrowingComponent()) {
 			this._invalidate++;
 			return;
@@ -196,10 +183,6 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	}
 
 	hasGrowingComponent(): boolean {
-		if (this.disabled) {
-			return false;
-		}
-
 		if (this.type === TableGrowingMode.Scroll) {
 			return !!this._table && this._table._scrollContainer.clientHeight >= this._table._tableElement.scrollHeight;
 		}

--- a/packages/website/docs/_samples/main/Table/Growing/main.js
+++ b/packages/website/docs/_samples/main/Table/Growing/main.js
@@ -28,7 +28,7 @@ growing.addEventListener("load-more", () => {
 
 	counter++;
 	if (counter >= MAX_GROW) {
-		growing.disabled = true;
+		growing.remove();
 		return;
 	}
 });

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/main.js
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/main.js
@@ -28,7 +28,7 @@ growing.addEventListener("load-more", () => {
 
 	counter++;
 	if (counter >= MAX_GROW) {
-		growing.disabled = true;
+		growing.remove();
 		return;
 	}
 });


### PR DESCRIPTION
Remove the `disabled` property from TableGrowing, as it is not needed in major frameworks and is misleading in its functionality.