### PR TITLE
feat(ui5-user-menu): add title and manage button to pin header on phone

### DIFF
--- a/packages/fiori/cypress/specs/UserMenu.cy.ts
+++ b/packages/fiori/cypress/specs/UserMenu.cy.ts
@@ -343,3 +343,60 @@ describe("Events", () => {
 		cy.get("@clicked").should("have.been.calledOnce");
 	});
 });
+
+describe("Responsiveness", () => {
+	it("test basic structure on phone", () => {
+		cy.ui5SimulateDevice("phone");
+		cy.mount(html`<ui5-button id="openUserMenuBtn">Open User Menu</ui5-button>
+							<ui5-user-menu id="userMenuShellBar" open opener="openUserMenuBtn">
+								<ui5-user-menu-account slot="accounts"
+													   title-text="Alain Chevalier 1">
+								</ui5-user-menu-account>
+								<ui5-user-menu-item text="Setting1" data-id="setting1"></ui5-user-menu-item>
+							</ui5-user-menu>`);
+		cy.get("[ui5-user-menu]").as("userMenu");
+		cy.get("@userMenu").should("exist");
+		cy.get("@userMenu").shadow().find("[ui5-bar]").as("headerBar");
+		cy.get("@headerBar").should("have.class", "ui5-pm-phone-header");
+	});
+
+	it("tests scroll on phone", () => {
+		cy.ui5SimulateDevice("phone");
+		cy.mount(html`<ui5-button id="openUserMenuBtn">Open User Menu</ui5-button>
+							<ui5-user-menu id="userMenuShellBar" open opener="openUserMenuBtn"
+										   show-manage-account
+										   show-add-account>
+								<ui5-user-menu-account slot="accounts"
+													   title-text="Alain Chevalier 1">
+								</ui5-user-menu-account>
+								<ui5-user-menu-item text="Setting1" data-id="setting1"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting2" data-id="setting2"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting3" data-id="setting3"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting4" data-id="setting4"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting5" data-id="setting5"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting6" data-id="setting6"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting7" data-id="setting7"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting8" data-id="setting8"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting9" data-id="setting9"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting10" data-id="setting10"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting11" data-id="setting11"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting12" data-id="setting12"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting13" data-id="setting13"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting14" data-id="setting14"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting15" data-id="setting15"></ui5-user-menu-item>
+								<ui5-user-menu-item text="Setting16" data-id="setting16"></ui5-user-menu-item>
+							</ui5-user-menu>`);
+
+		cy.get("[ui5-user-menu]")
+			.shadow()
+			.find("[ui5-responsive-popover]")
+			.shadow()
+			.find("[ui5-dialog]")
+			.shadow()
+			.find(`div[part="content"]`)
+			.scrollTo("bottom");
+		cy.get("[ui5-user-menu]").shadow().find("[ui5-bar]").as("headerBar");
+		cy.get("@headerBar").find("[ui5-title]").contains("Alain Chevalier 1");
+		cy.get("@headerBar").find("[ui5-button]").should("have.length", 2);
+	});
+});

--- a/packages/fiori/src/UserMenu.hbs
+++ b/packages/fiori/src/UserMenu.hbs
@@ -1,5 +1,5 @@
 <ui5-responsive-popover
-		id="{{_id}}-user-menu-rp"
+		id="user-menu-rp"
 		class="ui5-pm-rp"
 		tabindex="-1"
 		placement="Bottom"
@@ -11,71 +11,72 @@
 		.open={{open}}
 		.opener={{opener}}
 >
-	<div class="ui5-pm-header" slot="header">
-		{{#if _isPhone}}
-			<ui5-button icon="decline" design="Transparent" class="ui5-pm-decline-btn" @click="{{_handleDeclineClick}}" tooltip="{{_declineButtonTooltip}}"></ui5-button>
-		{{/if}}
+	{{#if _isPhone}}
+		<ui5-bar class="ui5-pm-phone-header" slot="header">
+			{{#if _manageAccountVisibleInHeader}}
+				<ui5-button icon="user-settings" @click="{{_handleManageAccountClick}}" slot="startContent"></ui5-button>
+			{{/if}}
 
-		{{#if _selectedAccount}}
-			<div class="ui5-pm-selected-account" >
-				<ui5-avatar size="L" @click="{{_handleAvatarClick}}" .initials="{{_selectedAccount._initials}}" fallback-icon="person-placeholder" class="ui5-pm--selected-account-avatar">
-					{{#if _selectedAccount.avatarSrc}}
-						<img src={{_selectedAccount.avatarSrc}}/>
-					{{/if}}
-					<ui5-tag slot="badge" wrapping-type="None" design="Set1" color-scheme="5" title="{{_editAvatarTooltip}}">
-						<ui5-icon slot="icon" name="edit"></ui5-icon>
-					</ui5-tag>
-				</ui5-avatar>
-				{{#if _selectedAccount.titleText}}
-					<ui5-title class="ui5-pm-selected-account-title">{{_selectedAccount.titleText}}</ui5-title>
-				{{/if}}
-				{{#if _selectedAccount.subtitleText}}
-					<ui5-text class="ui5-pm-selected-account-subtitleText">{{_selectedAccount.subtitleText}}</ui5-text>
-				{{/if}}
-				{{#if _selectedAccount.description}}
-					<ui5-text class="ui5-pm-selected-account-description">{{_selectedAccount.description}}</ui5-text>
-				{{/if}}
-
-				{{#if showManageAccount}}
-					<ui5-button icon="user-settings" class="ui5-pm-manage-account-btn" @click="{{_handleManageAccountClick}}">{{_manageAccountButtonText}}</ui5-button>
-				{{/if}}
-			</div>
-		{{/if}}
-	</div>
+			{{#if _titleMovedToHeader}}
+				<ui5-title
+					level="H1"
+					wrapping-type="None"
+				>
+					{{this._selectedAccount.titleText}}
+				</ui5-title>
+			{{/if}}
+		
+			<ui5-button
+				icon="decline"
+				design="Transparent"
+				accessible-name="{{_closeDialogAriaLabel}}"
+				@click="{{_closeUserMenu}}"
+				slot="endContent"
+			>
+			</ui5-button>
+		</ui5-bar>
+		<div class="ui5-pm-header">
+			{{> headerContent}}
+		</div>
+	{{else}}
+		<div class="ui5-pm-header" slot="header">
+			{{> headerContent}}
+		</div>
+	{{/if}}
 
 	{{#if showOtherAccounts}}
 		<ui5-panel collapsed class="ui5-pm-other-accounts">
 			<div slot="header" class="ui5-user-menu-account-header">
 				<ui5-title slot="header" level="H4">{{_otherAccountsButtonText}} ({{_otherAccounts.length}})</ui5-title>
-			{{#if showAddAccount}}
-				<ui5-button slot="header" class="ui5-pm-add-account-btn" design="Transparent" icon="add-employee" @click="{{_handleAddAccountClick}}" tooltip="{{_addAccountTooltip}}"/>
-			{{/if}}
+				{{#if showAddAccount}}
+					<ui5-button slot="header" class="ui5-pm-add-account-btn" design="Transparent" icon="add-employee" @click="{{_handleAddAccountClick}}" tooltip="{{_addAccountTooltip}}"/>
+				{{/if}}
 			</div>
 			{{#if _otherAccounts.length}}
-			<ui5-list @ui5-item-click="{{_handleAccountSwitch}}">
-				{{#each _otherAccounts}}
-					<ui5-li-custom .associatedAccount="{{this}}">
-						<div class="ui5-pm-other-accounts-content">
-							<ui5-avatar slot="image" size="S" .initials="{{_initials}}" fallback-icon="person-placeholder">
-								{{#if avatarSrc}}
-									<img src={{avatarSrc}}/>
+				<ui5-list @ui5-item-click="{{_handleAccountSwitch}}">
+					{{#each _otherAccounts}}
+						<ui5-li-custom .associatedAccount="{{this}}">
+							<div class="ui5-pm-other-accounts-content">
+								<ui5-avatar slot="image" size="S" .initials="{{_initials}}" fallback-icon="person-placeholder">
+									{{#if avatarSrc}}
+										<img src={{avatarSrc}}/>
+									{{/if}}
+								</ui5-avatar>
+								<div>
+								{{#if titleText}}
+									<ui5-title>{{titleText}}</ui5-title>
 								{{/if}}
-							</ui5-avatar>
-							<div>
-							{{#if titleText}}
-								<ui5-title>{{titleText}}</ui5-title>
-							{{/if}}
-							{{#if subtitleText}}
-								<ui5-label>{{subtitleText}}</ui5-label>
-							{{/if}}
-							{{#if description}}
-								<ui5-label>{{description}}</ui5-label>
-							{{/if}}
+								{{#if subtitleText}}
+									<ui5-label>{{subtitleText}}</ui5-label>
+								{{/if}}
+								{{#if description}}
+									<ui5-label>{{description}}</ui5-label>
+								{{/if}}
+								</div>
 							</div>
-						</div>
-					</ui5-li-custom>
-				{{/each}}
-			</ui5-list>
+						</ui5-li-custom>
+					{{/each}}
+				</ui5-list>
 			{{/if}}
 		</ui5-panel>
 	{{/if}}
@@ -97,3 +98,32 @@
 		<ui5-button class="ui5-pm-sign-out-btn" design="Transparent" icon="log" @click="{{_handleSignOutClick}}">{{_signOutButtonText}}</ui5-button>
 	</div>
 </ui5-responsive-popover>
+
+{{#*inline "headerContent"}}
+	{{#if _selectedAccount}}
+		<div class="ui5-pm-selected-account">
+			<ui5-avatar size="L" @click="{{_handleAvatarClick}}" .initials="{{_selectedAccount._initials}}" fallback-icon="person-placeholder" class="ui5-pm--selected-account-avatar">
+				{{#if _selectedAccount.avatarSrc}}
+					<img src={{_selectedAccount.avatarSrc}}/>
+				{{/if}}
+				<ui5-tag slot="badge" wrapping-type="None" design="Set1" color-scheme="5" title="{{_editAvatarTooltip}}">
+					<ui5-icon slot="icon" name="edit"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
+			{{#if _selectedAccount.titleText}}
+				<ui5-title id="selected-account-title" class="ui5-pm-selected-account-title">{{_selectedAccount.titleText}}</ui5-title>
+			{{/if}}
+			
+			{{#if _selectedAccount.subtitleText}}
+				<ui5-text class="ui5-pm-selected-account-subtitleText">{{_selectedAccount.subtitleText}}</ui5-text>
+			{{/if}}
+			{{#if _selectedAccount.description}}
+				<ui5-text class="ui5-pm-selected-account-description">{{_selectedAccount.description}}</ui5-text>
+			{{/if}}
+
+			{{#if showManageAccount}}
+				<ui5-button id="selected-account-manage-btn" icon="user-settings" class="ui5-pm-manage-account-btn" @click="{{_handleManageAccountClick}}">{{_manageAccountButtonText}}</ui5-button>
+			{{/if}}
+		</div>
+	{{/if}}
+{{/inline}}

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -452,4 +452,6 @@ USER_MENU_ADD_ACCOUNT_TXT=Add account
 #XACT: ARIA information for the user menu popover
 USER_MENU_POPOVER_ACCESSIBLE_NAME=User menu for
 
+USER_MENU_CLOSE_DIALOG_BUTTON=Decline
+
 

--- a/packages/fiori/src/themes/UserMenu.css
+++ b/packages/fiori/src/themes/UserMenu.css
@@ -20,6 +20,20 @@
     flex-direction: column;
 }
 
+[on-phone] .ui5-pm-header {
+    padding-inline: 0;
+}
+
+.ui5-pm-phone-header::part(startContent),
+.ui5-pm-phone-header::part(endContent) {
+    padding: 0;
+}
+
+.ui5-pm-phone-header [ui5-button] {
+    margin-inline: 0.5rem;
+    font-family: var(--sapFontSemiboldFamily);
+}
+
 .ui5-pm-rp::part(content) {
     padding-top: 0;
     padding-bottom: 0.5rem;


### PR DESCRIPTION
On mobile phone, the header with selected account information should be scrollable and the title and manage account button should be moved to the header of the dialog when scrolled outside the visible view