### PR TITLE
fix(ui5-table): check for undefined in table type guard

### DIFF
--- a/packages/main/cypress/specs/TableUtils.cy.ts
+++ b/packages/main/cypress/specs/TableUtils.cy.ts
@@ -5,19 +5,22 @@ import TableRow from "../../src/TableRow.js";
 describe("#isInstanceOfTable", () => {
 	it("object is Table", () => {
 		const obj = new Table();
-		// eslint-disable-next-line no-unused-expressions
-		expect(isInstanceOfTable(obj)).to.be.true;
+		cy.wrap({ isInstanceOfTable })
+			.invoke("isInstanceOfTable", obj)
+			.should("be.true");
 	});
 
 	it("object is not Table", () => {
 		const obj = new TableRow();
-		// eslint-disable-next-line no-unused-expressions
-		expect(isInstanceOfTable(obj)).to.be.false;
+		cy.wrap({ isInstanceOfTable })
+			.invoke("isInstanceOfTable", obj)
+			.should("be.false");
 	});
 
 	it("object is undefined", () => {
 		const obj = undefined;
-		// eslint-disable-next-line no-unused-expressions
-		expect(isInstanceOfTable(obj)).to.be.false;
+		cy.wrap({ isInstanceOfTable })
+			.invoke("isInstanceOfTable", obj)
+			.should("be.false");
 	});
 });

--- a/packages/main/cypress/specs/TableUtils.cy.ts
+++ b/packages/main/cypress/specs/TableUtils.cy.ts
@@ -1,0 +1,23 @@
+import { isInstanceOfTable } from "../../src/TableUtils.js";
+import Table from "../../src/Table.js";
+import TableRow from "../../src/TableRow.js";
+
+describe("#isInstanceOfTable", () => {
+	it("object is Table", () => {
+		const obj = new Table();
+		// eslint-disable-next-line no-unused-expressions
+		expect(isInstanceOfTable(obj)).to.be.true;
+	});
+
+	it("object is not Table", () => {
+		const obj = new TableRow();
+		// eslint-disable-next-line no-unused-expressions
+		expect(isInstanceOfTable(obj)).to.be.false;
+	});
+
+	it("object is undefined", () => {
+		const obj = undefined;
+		// eslint-disable-next-line no-unused-expressions
+		expect(isInstanceOfTable(obj)).to.be.false;
+	});
+});

--- a/packages/main/src/TableUtils.ts
+++ b/packages/main/src/TableUtils.ts
@@ -2,7 +2,7 @@ import type Table from "./Table.js";
 import type TableRow from "./TableRow.js";
 
 const isInstanceOfTable = (obj: any): obj is Table => {
-	return "isTable" in obj && !!obj.isTable;
+	return !!obj && "isTable" in obj && !!obj.isTable;
 };
 
 const isSelectionCheckbox = (e: Event) => {


### PR DESCRIPTION
There are certain scenarios, where the row does not have the table as its parent (removed from the table). In these cases the type guard fails as `key in object` calls do not work with undefined values.
Therefore, introducing an additional check to avoid this issue.

Fixes #10340 