### PR TITLE
chore: remove StyleDataCSP and change StyleData / ThemeData to string

### DIFF
--- a/packages/base/cypress/specs/Boot.cy.ts
+++ b/packages/base/cypress/specs/Boot.cy.ts
@@ -9,11 +9,7 @@ describe("Framework boot", () => {
 
 		cy.wrap({ registerThemePropertiesLoader })
 			.invoke("registerThemePropertiesLoader", "@ui5/webcomponents-theming", "sap_horizon", () => {
-				return Promise.resolve({
-					content: `:root{ --customCol: #fff; --customBg: #000; }`,
-					packageName: "",
-					fileName: "",
-				});
+				return Promise.resolve(`:root{ --customCol: #fff; --customBg: #000; }`);
 			});
 
 		cy.wrap({ hasStyle })

--- a/packages/base/lib/generate-styles/index.js
+++ b/packages/base/lib/generate-styles/index.js
@@ -9,17 +9,7 @@ const generate = async () => {
 	const filesPromises = files.map(async file => {
 		let content = await fs.readFile(path.join("src/css/", file));
 		const res = new CleanCSS().minify(`${content}`);
-		content = `import type { StyleData } from "../../types.js";
-
-const styleData: StyleData = {
-	packageName: "@ui5/webcomponents-base",
-	fileName: "${file}",
-	content: \`${res.styles}\`,
-};
-
-export default styleData;
-`;
-
+		content = `export default \`${res.styles}\`;`;
 		return fs.writeFile(path.join("src/generated/css/", `${file}.ts`), content);
 	});
 

--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -1,4 +1,3 @@
-import type { StyleData, StyleDataCSP } from "./types.js";
 import { getCurrentRuntimeIndex, compareRuntimes } from "./Runtimes.js";
 
 const isSSR = typeof document === "undefined";
@@ -14,8 +13,7 @@ const shouldUpdate = (runtimeIndex: string | undefined) => {
 	return compareRuntimes(getCurrentRuntimeIndex(), parseInt(runtimeIndex)) === 1; // 1 means the current is newer, 0 means the same, -1 means the resource's runtime is newer
 };
 
-const createStyle = (data: StyleData, name: string, value = "", theme?: string) => {
-	const content = typeof data === "string" ? data : data.content;
+const createStyle = (content: string, name: string, value = "", theme?: string) => {
 	const currentRuntimeIndex = getCurrentRuntimeIndex();
 
 	const stylesheet = new CSSStyleSheet();
@@ -28,8 +26,7 @@ const createStyle = (data: StyleData, name: string, value = "", theme?: string) 
 	document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
 };
 
-const updateStyle = (data: StyleData, name: string, value = "", theme?: string) => {
-	const content = typeof data === "string" ? data : data.content;
+const updateStyle = (content: string, name: string, value = "", theme?: string) => {
 	const currentRuntimeIndex = getCurrentRuntimeIndex();
 
 	const stylesheet = document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));
@@ -62,30 +59,22 @@ const removeStyle = (name: string, value = "") => {
 	document.adoptedStyleSheets = document.adoptedStyleSheets.filter(sh => (sh as Record<string, any>)._ui5StyleId !== getStyleId(name, value));
 };
 
-const createOrUpdateStyle = (data: StyleData, name: string, value = "", theme?: string) => {
+const createOrUpdateStyle = (content: string, name: string, value = "", theme?: string) => {
 	if (hasStyle(name, value)) {
-		updateStyle(data, name, value, theme);
+		updateStyle(content, name, value, theme);
 	} else {
-		createStyle(data, name, value, theme);
+		createStyle(content, name, value, theme);
 	}
 };
 
-const mergeStyles = (style1?: StyleData, style2?: StyleData) => {
+const mergeStyles = (style1?: string, style2?: string) => {
 	if (style1 === undefined) {
 		return style2;
 	}
 	if (style2 === undefined) {
 		return style1;
 	}
-	const style2Content = typeof style2 === "string" ? style2 : style2.content;
-	if (typeof style1 === "string") {
-		return `${style1} ${style2Content}`;
-	}
-	return {
-		content: `${style1.content} ${style2Content}`,
-		packageName: style1.packageName,
-		fileName: style1.fileName,
-	};
+	return `${style1} ${style2}`;
 };
 
 export {
@@ -95,9 +84,4 @@ export {
 	removeStyle,
 	createOrUpdateStyle,
 	mergeStyles,
-};
-
-export type {
-	StyleData,
-	StyleDataCSP,
 };

--- a/packages/base/src/asset-registries/Themes.ts
+++ b/packages/base/src/asset-registries/Themes.ts
@@ -1,12 +1,11 @@
 import { DEFAULT_THEME } from "../generated/AssetParameters.js";
-import type { StyleData, StyleDataCSP } from "../ManagedStyles.js";
 import { mergeStyles } from "../ManagedStyles.js";
 import { fireThemeRegistered } from "../theming/ThemeRegistered.js";
 
-type ThemeData = {_: StyleDataCSP } | StyleDataCSP | string;
-type ThemeLoader = (themeName: string) => Promise<ThemeData>;
+type ThemeData = string;
+type ThemeLoader = (themeName: string) => Promise<string>;
 
-const themeStyles = new Map<string, StyleData>();
+const themeStyles = new Map<string, string>();
 const loaders = new Map<string, ThemeLoader>();
 const customLoaders = new Map<string, ThemeLoader>();
 const registeredPackages = new Set<string>();
@@ -68,8 +67,7 @@ const _getThemeProperties = async (packageName: string, themeName: string, forCu
 		return;
 	}
 
-	const themeProps = (data as {_: StyleDataCSP})._ || data; // Refactor: remove _ everywhere
-	return themeProps;
+	return data;
 };
 
 const getRegisteredPackages = () => {

--- a/packages/base/src/theming/getStylesString.ts
+++ b/packages/base/src/theming/getStylesString.ts
@@ -1,15 +1,13 @@
-import type { ComponentStylesData, StyleData } from "../types.js";
+import type { ComponentStylesData } from "../types.js";
 
 const MAX_DEPTH_INHERITED_CLASSES = 10; // TypeScript complains about Infinity and big numbers
 
 const getStylesString = (styles: ComponentStylesData) => {
 	if (Array.isArray(styles)) {
-		return (styles.filter(style => !!style).flat(MAX_DEPTH_INHERITED_CLASSES) as Array<StyleData>).map((style: StyleData) => {
-			return typeof style === "string" ? style : style.content;
-		}).join(" ");
+		return (styles.filter(style => !!style).flat(MAX_DEPTH_INHERITED_CLASSES) as Array<string>).join(" ");
 	}
 
-	return typeof styles === "string" ? styles : styles.content;
+	return styles;
 };
 
 export default getStylesString;

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -8,6 +8,8 @@ export type PromiseResolve = (value: void | PromiseLike<void>) => void;
 export type Timeout = ReturnType<typeof setTimeout>;
 export type Interval = ReturnType<typeof setInterval>;
 
+export type StyleData = string;
+
 export type ComponentStylesData = Array<ComponentStylesData> | string;
 export type ClassMapValue = Record<string, boolean>
 

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -8,15 +8,7 @@ export type PromiseResolve = (value: void | PromiseLike<void>) => void;
 export type Timeout = ReturnType<typeof setTimeout>;
 export type Interval = ReturnType<typeof setInterval>;
 
-export type StyleDataCSP = {
-	content: string,
-	packageName: string,
-	fileName: string,
-};
-
-export type StyleData = StyleDataCSP | string;
-
-export type ComponentStylesData = Array<ComponentStylesData> | Array<StyleData> | StyleData;
+export type ComponentStylesData = Array<ComponentStylesData> | string;
 export type ClassMapValue = Record<string, boolean>
 
 export type ClassMap = { [x: string] : ClassMapValue | ClassMap };

--- a/packages/base/test/assets/Themes.ts
+++ b/packages/base/test/assets/Themes.ts
@@ -1,34 +1,10 @@
 import { registerThemePropertiesLoader } from "../../src/asset-registries/Themes.js";
 
-const defaultTheme = {
-	content: `:root{ --var1: grey; }`,
-	packageName: "",
-	fileName: "",
-};
-
-const fiori3 = {
-	content: `:root{ --var1: red; }`,
-	packageName: "",
-	fileName: "",
-};
-
-const fiori3Dark = {
-	content: `:root{ --var1: green; }`,
-	packageName: "",
-	fileName: "",
-};
-
-const fiori3Hcb = {
-	content: `:root{ --var1: yellow; }`,
-	packageName: "",
-	fileName: "",
-};
-
-const fiori3Hcw = {
-	content: `:root{ --var1: yellow; }`,
-	packageName: "",
-	fileName: "",
-};
+const defaultTheme = `:root{ --var1: grey; }`;
+const fiori3 = `:root{ --var1: red; }`;
+const fiori3Dark = `:root{ --var1: green; }`;
+const fiori3Hcb = `:root{ --var1: yellow; }`;
+const fiori3Hcw = `:root{ --var1: yellow; }`;
 
 registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_horizon", async () => Promise.resolve(defaultTheme));
 registerThemePropertiesLoader("@ui5/webcomponents-base-test", "sap_fiori_3", async () => Promise.resolve(fiori3));

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -1,5 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import type { AccessibilityAttributes, StyleData } from "@ui5/webcomponents-base/dist/types.js";
+import type { AccessibilityAttributes } from "@ui5/webcomponents-base/dist/types.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
@@ -71,7 +71,7 @@ import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverComm
 
 type TabContainerPopoverOwner = "start-overflow" | "end-overflow" | TabInStrip;
 
-const tabStyles: Array<StyleData> = [];
+const tabStyles: Array<string> = [];
 const PAGE_UP_DOWN_SIZE = 5;
 
 type TabContainerStripInfo = {
@@ -354,7 +354,7 @@ class TabContainer extends UI5Element {
 	_handleResizeBound: () => void;
 	_setDraggedElement?: SetDraggedElementFunction;
 
-	static registerTabStyles(styles: StyleData) {
+	static registerTabStyles(styles: string) {
 		tabStyles.push(styles);
 	}
 

--- a/packages/tools/lib/css-processors/css-processor-components.mjs
+++ b/packages/tools/lib/css-processors/css-processor-components.mjs
@@ -28,7 +28,7 @@ let customPlugin = {
 
                 // JS/TS
                 const jsPath = f.path.replace(/dist[\/\\]css/, "src/generated/").replace(".css", extension);
-                const jsContent = getFileContent(tsMode, jsPath, packageJSON.name, "\`" + newText + "\`", true);
+                const jsContent = getFileContent(packageJSON.name, "\`" + newText + "\`", true);
                 writeFileIfChanged(jsPath, jsContent);
             });
         })

--- a/packages/tools/lib/css-processors/css-processor-themes.mjs
+++ b/packages/tools/lib/css-processors/css-processor-themes.mjs
@@ -42,16 +42,11 @@ let scopingPlugin = {
                 // JSON
                 const jsonPath = f.path.replace(/dist[\/\\]css/, "dist/generated/assets").replace(".css", ".css.json");
                 await mkdir(path.dirname(jsonPath), {recursive: true});
-                const data = {
-                    packageName: packageJSON.name,
-                    fileName: jsonPath.substr(jsonPath.lastIndexOf("themes")),
-                    content: newText,
-                };
-                writeFileIfChanged(jsonPath, JSON.stringify({_: data}));
+                writeFileIfChanged(jsonPath, JSON.stringify(newText));
 
                 // JS/TS
                 const jsPath = f.path.replace(/dist[\/\\]css/, "src/generated/").replace(".css", extension);
-                const jsContent = getFileContent(tsMode, jsPath, packageJSON.name, "\`" + newText + "\`");
+                const jsContent = getFileContent(packageJSON.name, "\`" + newText + "\`");
                 writeFileIfChanged(jsPath, jsContent);
             });
         })

--- a/packages/tools/lib/css-processors/shared.mjs
+++ b/packages/tools/lib/css-processors/shared.mjs
@@ -47,30 +47,10 @@ registerThemePropertiesLoader("${packageName}", "${DEFAULT_THEME}", async () => 
 `;
 };
 
-const getFileContent = (tsMode, targetFile, packageName, css, includeDefaultTheme) => {
-	if (tsMode) {
-		return getTSContent(targetFile, packageName, css, includeDefaultTheme);
-	}
-
-	return getJSContent(targetFile, packageName, css, includeDefaultTheme);
-}
-
-const getTSContent = (targetFile, packageName, css, includeDefaultTheme) => {
-	const typeImport = "import type { StyleData } from \"@ui5/webcomponents-base/dist/types.js\";"
+const getFileContent = (packageName, css, includeDefaultTheme) => {
 	const defaultTheme = includeDefaultTheme ? getDefaultThemeCode(packageName) : "";
-
-	// tabs are intentionally mixed to have proper identation in the produced file
-	return `${typeImport}
-${defaultTheme}
-const styleData: StyleData = {packageName:"${packageName}",fileName:"${targetFile.substr(targetFile.lastIndexOf("themes"))}",content:${css}};
-export default styleData;
-	`;
+	return `${defaultTheme}export default ${css.trim()}`
 }
 
-const getJSContent = (targetFile, packageName, css, includeDefaultTheme) => {
-	const defaultTheme = includeDefaultTheme ? getDefaultThemeCode(packageName) : "";
-
-	return `${defaultTheme}export default {packageName:"${packageName}",fileName:"${targetFile.substr(targetFile.lastIndexOf("themes"))}",content:${css}}`
-}
 
 export { writeFileIfChanged, stripThemingBaseContent, getFileContent}


### PR DESCRIPTION
The `StyleDataCSP` type has been removed and `StyleData` / `ThemeData` changed to `string`:

*Old:*

<img width="348" alt="image" src="https://github.com/user-attachments/assets/a4b71674-e546-4896-94d9-8095065ffee4" />

and

<img width="443" alt="image" src="https://github.com/user-attachments/assets/790d8e6e-6b83-4576-9467-d49d35f1adb0" />


*New:*

<img width="235" alt="image" src="https://github.com/user-attachments/assets/cb0493a4-ca07-46d5-b03b-75c5e7cb9537" />

and

<img width="183" alt="image" src="https://github.com/user-attachments/assets/11f5ec75-4543-488b-950c-5de5ed429eb4" />

A string is valid JSON, therefore it's not necessary to generate theme data with the `{"_": data}` syntax.

Also, the `StyleDataCSP` format (`packageName` + `fileName` + `content`) is now redundant as all modern browsers support adopted stylesheets.

All theme/component style-build scripts have been modified to export strings in`.js`, `.ts` and `.json` variations.

 - **Theme parameters**

*Old:*

<img width="377" alt="image" src="https://github.com/user-attachments/assets/d59b5099-fb2b-4acf-b80a-578b276befb7" />

*New:*

<img width="241" alt="image" src="https://github.com/user-attachments/assets/b655c1b1-2dd3-4aed-8060-c95733416f84" />

- **Component parameters**

*Old:*

<img width="723" alt="image" src="https://github.com/user-attachments/assets/763b61b9-c67d-4b13-8525-f94d197367ac" />

*New:*

<img width="292" alt="image" src="https://github.com/user-attachments/assets/5da99c86-27b5-4308-9f53-06cb1be61fed" />

