### PR TITLE
docs: upgrade examples to JSX

### DIFF
--- a/packages/website/src/components/Editor/examples/counter/main.js
+++ b/packages/website/src/components/Editor/examples/counter/main.js
@@ -1,21 +1,24 @@
 export default `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import jsxRender from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import { customElement, property } from "@ui5/webcomponents-base/dist/decorators.js";
 
 @customElement({
   tag: "my-counter",
-  renderer: litRender,
+  renderer: jsxRender,
 })
 export class MyCounter extends UI5Element {
   @property({ type: Number })
   count = 0;
 
   render() {
-    return html \`<div>
-    <slot></slot>
-    <button @click=\${() => {this.count += 2}}>
-        Count \${this.count}
-    </div>\`
+    return (
+      <div>
+        <slot></slot>
+        <button onClick={() => {this.count += 2}}>
+          Count {this.count}
+        </button>
+      </div>
+    );
   }
 
   static styles = \`button {

--- a/packages/website/src/components/Editor/examples/hello-world/main.js
+++ b/packages/website/src/components/Editor/examples/hello-world/main.js
@@ -1,20 +1,21 @@
 export default `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import { customElement, property } from "@ui5/webcomponents-base/dist/decorators.js";
 
 @customElement({
   tag: "my-element",
-  renderer: litRender,
+  renderer: jsxRenderer,
 })
 export class MyElement extends UI5Element {
   @property()
   name?: string;
 
   render() {
-    return html \`
+    return (
       <div>
-          Hello, \${this.name || "World"}!
-      </div>\`
+          Hello, {this.name || "World"}!
+      </div>
+    )
   }
 
   static styles = \`div {

--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -310,6 +310,7 @@ ${fixAssetPaths(_js)}`,
 
     // algolia search opens the search on key `/` because this custom element is the event target but has no `isContentEditable`
     Object.defineProperty(fileEditorRef.current, "isContentEditable", {
+        configurable: true,
         get() {
             return true;
         },

--- a/packages/website/src/pages/play.tsx
+++ b/packages/website/src/pages/play.tsx
@@ -21,22 +21,23 @@ const html = `<!-- playground-fold -->
 
 
 const ts = `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import litRender, { html } from "@ui5/webcomponents-base/dist/renderer/LitRenderer.js";
+import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import { customElement, property } from "@ui5/webcomponents-base/dist/decorators.js";
 
 @customElement({
   tag: "my-element",
-  renderer: litRender,
+  renderer: jsxRenderer,
 })
 export class MyElement extends UI5Element {
   @property()
   name?: string;
 
   render() {
-    return html \`
+    return (
       <div>
-          Hello, \${this.name || "World"}!
-      </div>\`
+          Hello, {this.name || "World"}!
+      </div>
+    )
   }
 
   static styles = \`div {
@@ -56,7 +57,7 @@ export default function () {
           html={html}
           js={ts}
           css={''}
-          mainFile={"main.ts"}
+          mainFile={"main.tsx"}
           canShare={true}
           mainFileSelected={true}
           standalone={true}


### PR DESCRIPTION
Update the playground page to work with JSX.

Type checking is broken locally and for nightly, since the local web server and the github pages hosting the `d.ts` files returns an incorrect mime type.

Also fixes the `isContentEditable` error.