### PR TITLE
 fix(framework): copy preact thirdparty files into `prod`

### DIFF
--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -45,7 +45,7 @@ const scripts = {
 	generateProd: {
 		"default": "nps generateProd.remove-dev-mode generateProd.copy-prod",
 		"remove-dev-mode": `node "${LIB}/remove-dev-mode/remove-dev-mode.mjs"`,
-		"copy-prod": `copy-and-watch "dist/sap/**/*" dist/prod/sap/`,
+		"copy-prod": `copy-and-watch "dist/sap/**/*" dist/prod/sap/ "dist/thirdparty/preact/**/*.js" dist/prod/thirdparty/preact/`,
 	},
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",

--- a/packages/base/package-scripts.cjs
+++ b/packages/base/package-scripts.cjs
@@ -45,7 +45,7 @@ const scripts = {
 	generateProd: {
 		"default": "nps generateProd.remove-dev-mode generateProd.copy-prod",
 		"remove-dev-mode": `node "${LIB}/remove-dev-mode/remove-dev-mode.mjs"`,
-		"copy-prod": `copy-and-watch "dist/sap/**/*" dist/prod/sap/ "dist/thirdparty/preact/**/*.js" dist/prod/thirdparty/preact/`,
+		"copy-prod": `copy-and-watch "dist/sap/**/*" dist/prod/sap/ && copy-and-watch "dist/thirdparty/preact/**/*.js" dist/prod/thirdparty/preact/`,
 	},
 	generateAPI: {
 		default: "nps generateAPI.generateCEM generateAPI.validateCEM",


### PR DESCRIPTION
When installing 2.6.0-rc.0 in an application, the app build fails to resolve the preact thirdparty files form the "prod" folder (otherwise available in `dist`, but missing in `dist/prod`). In this change, we extend the `generateProd` build step to to copy them as well.