### PR TITLE
fix(build): generation of custom-elements.json

### DIFF
--- a/packages/tools/lib/cem/event.mjs
+++ b/packages/tools/lib/cem/event.mjs
@@ -112,12 +112,16 @@ function processEvent(ts, event, classNode, moduleDoc) {
 			: sinceTag.name;
 	}
 
-	const eventDetailType = classNode.members?.find(member => member.name.text === "eventDetails")?.type;
+	const eventDetailType = classNode.members?.find(member => {
+		if (ts.isPropertyDeclaration(member)) {
+			return member.name.text === "eventDetails"
+		}
+
+		return false;
+	})?.type;
 	const eventDetailRef = eventDetailType?.members?.find(member => member.name.text === name) || eventDetailType?.types?.[eventDetailType?.types?.length - 1]?.members?.find(member => member.name.text === name);
 	const hasGeneric = !!event?.expression?.typeArguments
-	// if (name ==="value-state-change") {
-	// 	debugger
-	// }
+
 	if (commentParams.length) {
 		if (eventDetailRef && hasGeneric) {
 			logDocumentationError(moduleDoc.path, `Event details for event '${name}' has to be defined either with generic or with eventDetails.`)

--- a/packages/tools/lib/cem/event.mjs
+++ b/packages/tools/lib/cem/event.mjs
@@ -113,11 +113,7 @@ function processEvent(ts, event, classNode, moduleDoc) {
 	}
 
 	const eventDetailType = classNode.members?.find(member => {
-		if (ts.isPropertyDeclaration(member)) {
-			return member.name.text === "eventDetails"
-		}
-
-		return false;
+		return ts.isPropertyDeclaration(member) && member.name.text === "eventDetails"
 	})?.type;
 	const eventDetailRef = eventDetailType?.members?.find(member => member.name.text === name) || eventDetailType?.types?.[eventDetailType?.types?.length - 1]?.members?.find(member => member.name.text === name);
 	const hasGeneric = !!event?.expression?.typeArguments


### PR DESCRIPTION
The API generation was failing because event types are retrieved from a class member named `eventDetails`. To identify this, we needed to iterate through all class members and check their names. However, the constructor is also part of class members, but it is not treated as member by typescript because it doesn't have name.