### PR TITLE
fix(ui5-file-uploader): use optional chain in onclick check

### DIFF
--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -263,7 +263,7 @@ class FileUploader extends UI5Element implements IFormInputElement {
 	}
 
 	_onclick() {
-		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
+		if (this.getFocusDomRef()?.matches(":has(:focus-within)")) {
 			this._input.click();
 		}
 	}


### PR DESCRIPTION
Previously when there wasn't any slotted element in the `<ui5-file-uploader>` an error was thrown on click in the console.

The reason behind this is because of the `getFocusDomRef()`. 
The getter tries to access the first slotted element in the FileUploader resulting in `undefined` when such is missing, while in the `if ()` statement there was a non-nullish assertion (`!`)
                                      
```diff
- if (this.getFocusDomRef()!.matches(":has(:focus-within)"))
+ if (this.getFocusDomRef()?.matches(":has(:focus-within)"))
```

Fixes: #10329 