### PR TITLE
fix: custom theme detection

### DIFF
--- a/packages/base/src/theming/getThemeDesignerTheme.ts
+++ b/packages/base/src/theming/getThemeDesignerTheme.ts
@@ -69,7 +69,7 @@ const processThemeMetadata = (metadata: ThemeMetadata): ThemeDescriptor | undefi
 
 	try {
 		const pathParts = metadata.Path.split(".");
-		themeName = pathParts.length === 4 ? pathParts[2] : getComputedStyle(document.body).getPropertyValue('--sapSapThemeId');
+		themeName = pathParts.length === 4 ? pathParts[2] : getComputedStyle(document.body).getPropertyValue("--sapSapThemeId");
 		baseThemeName = metadata.Extends[0];
 	} catch (ex) {
 		if (!warnings.has("object")) {

--- a/packages/base/src/theming/getThemeDesignerTheme.ts
+++ b/packages/base/src/theming/getThemeDesignerTheme.ts
@@ -68,7 +68,7 @@ const processThemeMetadata = (metadata: ThemeMetadata): ThemeDescriptor | undefi
 	let baseThemeName;
 
 	try {
-		themeName = metadata.Path.match(/\.([^.]+)\.css_variables$/)![1];
+		themeName = metadata.Path.split(".")![2];
 		baseThemeName = metadata.Extends[0];
 	} catch (ex) {
 		if (!warnings.has("object")) {

--- a/packages/base/src/theming/getThemeDesignerTheme.ts
+++ b/packages/base/src/theming/getThemeDesignerTheme.ts
@@ -68,7 +68,8 @@ const processThemeMetadata = (metadata: ThemeMetadata): ThemeDescriptor | undefi
 	let baseThemeName;
 
 	try {
-		themeName = metadata.Path.split(".")![2];
+		const pathParts = metadata.Path.split(".");
+		themeName = pathParts.length === 4 ? pathParts[2] : getComputedStyle(document.body).getPropertyValue('--sapSapThemeId');
 		baseThemeName = metadata.Extends[0];
 	} catch (ex) {
 		if (!warnings.has("object")) {


### PR DESCRIPTION
We cannot rely on the `Path` field ending on `css_variables`, we have to follow the `<framework>.<lib>.<theme>.<field>` pattern, therefore the custom theme name is the third part of the value, split by `.`