### PR TITLE
fix(ui5-dynamic-page): correct z-index for dynamic page header

### DIFF
--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -2,7 +2,7 @@
     position: sticky;
     top: 0;
      /* We need the z-index to be higher than in the header actions, to avoid overlapping by snap on scroll */
-    z-index: 110;
+    z-index: 98;
 }
 
 :host {


### PR DESCRIPTION
Corrected the `z-index` of `.ui5-dynamic-page-title-header-wrapper` to ensure it does not overlap the busy indicator.

Fixes: [#10399](https://github.com/SAP/ui5-webcomponents/issues/10399)