### PR TITLE
fix(ui5-popover): revert rtl correction fix

### DIFF
--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -588,18 +588,12 @@ class Popover extends Popup {
 		const borderRadius = Number.parseInt(window.getComputedStyle(this).getPropertyValue("border-radius"));
 		const arrowPos = this.getArrowPosition(targetRect, popoverSize, left, top, isVertical, borderRadius);
 
-		this._left += this.getRTLCorrectionLeft();
-
 		return {
 			arrow: arrowPos,
 			top: this._top,
 			left: this._left,
 			placementType,
 		};
-	}
-
-	getRTLCorrectionLeft() {
-		return parseFloat(window.getComputedStyle(this).left) - this.getBoundingClientRect().left;
 	}
 
 	/**


### PR DESCRIPTION
reverted, because it breaks popover positioning, when the popover is inside an element with `transform` value

part of #9966
revert of #10316