### PR TITLE
fix(ui5-dynamic-page): update header sticky on manual snap

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -327,6 +327,11 @@ class DynamicPage extends UI5Element {
 		const headerHeight = this.dynamicPageHeader.getBoundingClientRect().height;
 		const lastHeaderSnapped = this._headerSnapped;
 
+		if (this._headerSnapped && scrollTop > headerHeight) {
+			this.showHeaderInStickArea = false;
+			return;
+		}
+
 		const shouldSnap = !this._headerSnapped && scrollTop > headerHeight + SCROLL_THRESHOLD;
 		const shouldExpand = this._headerSnapped && (scrollTop < headerHeight - SCROLL_THRESHOLD
 			|| (!scrollTop && !headerHeight));

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -329,7 +329,6 @@ class DynamicPage extends UI5Element {
 
 		if (this._headerSnapped && scrollTop > headerHeight) {
 			this.showHeaderInStickArea = false;
-			return;
 		}
 
 		const shouldSnap = !this._headerSnapped && scrollTop > headerHeight + SCROLL_THRESHOLD;


### PR DESCRIPTION
### Prevent header glitch when unsnapping after manual snap and scroll

When the header was manually snapped before scrolling, the sticky area
state wasn't properly updated, causing visual glitches during unsnap.

Fixes: [#10430](https://github.com/SAP/ui5-webcomponents/issues/10430)