### PR TITLE
fix(ui5-dynamic-page): prevent scroll position reset on unpinning the header

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -369,6 +369,9 @@ class DynamicPage extends UI5Element {
 
 	async onPinClick() {
 		this.headerPinned = !this.headerPinned;
+		if (this.headerPinned) {
+			this.showHeaderInStickArea = true;
+		}
 		this.fireDecoratorEvent("pin-button-toggle");
 		await renderFinished();
 		this.headerActions?.focusPinButton();


### PR DESCRIPTION
Issue:
- When header was pinned before scrolling, unpinning would reset scroll position due to incorrect sticky area state.

Solution:
- Set sticky area to true on pin to preserve scroll state.

Fixes: [#10440](https://github.com/SAP/ui5-webcomponents/issues/10440)