### PR TITLE
fix(ui5-dynamic-page): remove redundant padding

### DIFF
--- a/packages/fiori/src/themes/DynamicPageHeader.css
+++ b/packages/fiori/src/themes/DynamicPageHeader.css
@@ -6,6 +6,4 @@
 
 .ui5-dynamic-page-header-root {
     background: inherit;
-    padding-top: var(--_ui5_dynamic_page_header_padding_top);
-    padding-bottom: var(--_ui5_dynamic_page_header_padding_bottom);
 }

--- a/packages/fiori/src/themes/base/DynamicPageHeader-parameters.css
+++ b/packages/fiori/src/themes/base/DynamicPageHeader-parameters.css
@@ -1,7 +1,4 @@
 :root {
-	--_ui5_dynamic_page_header_padding_top: 1rem;
-    --_ui5_dynamic_page_header_padding_bottom: 1rem;
-
     --_ui5_dynamic_page_header_background_color: var(--sapObjectHeader_Background);
     --_ui5_dynamic_page_header-actions-box-shadow: var(--sapContent_Shadow0);
     --_ui5_dynamic_page_header-box-shadow: var(--sapContent_HeaderShadow);


### PR DESCRIPTION
Removed unnecessary padding-top and padding-bottom from `ui5-dynamic-page-header-root` to reduce spacing between the title and content.

Fixes: [#10413](https://github.com/SAP/ui5-webcomponents/issues/10413)