### PR TITLE
fix(framework): getComponentFeature can return undefined

### DIFF
--- a/packages/base/src/FeaturesRegistry.ts
+++ b/packages/base/src/FeaturesRegistry.ts
@@ -37,7 +37,7 @@ const registerComponentFeature = async (name: string, feature: typeof ComponentF
 	notifyForFeatureLoad(name);
 };
 
-const getComponentFeature = <T>(name: string): T => {
+const getComponentFeature = <T>(name: string): T | undefined => {
 	return componentFeatures.get(name) as T;
 };
 

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -207,8 +207,8 @@ class ColorPalette extends UI5Element {
 
 		if (this.showMoreColors) {
 			const ColorPaletteMoreColorsClass = getComponentFeature<typeof ColorPaletteMoreColors>("ColorPaletteMoreColors");
-			ColorPaletteMoreColorsClass.i18nBundle = ColorPalette.i18nBundle;
 			if (ColorPaletteMoreColorsClass) {
+				ColorPaletteMoreColorsClass.i18nBundle = ColorPalette.i18nBundle;
 				this.moreColorsFeature = new ColorPaletteMoreColorsClass();
 			}
 		}

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1263,8 +1263,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 		}
 
 		const Suggestions = getComponentFeature<typeof InputSuggestions>("InputSuggestions");
-		Suggestions.i18nBundle = Input.i18nBundle;
 		if (Suggestions) {
+			Suggestions.i18nBundle = Input.i18nBundle;
 			this.Suggestions = new Suggestions(this, "suggestionItems", true, false);
 		}
 	}


### PR DESCRIPTION
The fix: the `getComponentFeature` function returns either the requested feature, if imported, or `undefined`.

`ui5-input` and `ui5-color-palette` initialized the `i18nBundle` static members of their features without checking for undefined, leading to a runtime error if an app tried to use any of these components without the optional features.