### PR TITLE
test(ui5-popover): fix test page for popover arrow bounds

### DIFF
--- a/packages/main/test/pages/PopoverArrowBounds.html
+++ b/packages/main/test/pages/PopoverArrowBounds.html
@@ -18,12 +18,12 @@
 </head>
 
 <body class="sapUiSizeCompact">
-	<ui5-button id="myBtn1" data-placement="Start" class="myBtn">1</ui5-button>
+	<ui5-button id="myBtn1" data-placement="Start" data-vertical-align="Center" class="myBtn">1</ui5-button>
 	<ui5-button id="myBtn2" data-placement="Start" data-vertical-align="Top" class="myBtn">2</ui5-button>
-	<ui5-button id="myBtn3" data-placement="Bottom" class="myBtn">3</ui5-button>
-	<ui5-button id="myBtn4" data-placement="Top" class="myBtn">4</ui5-button>
-	<ui5-button id="myBtn5" data-placement="Start" class="myBtn">5</ui5-button>
-	<ui5-button id="myBtn6" data-placement="Start" class="myBtn">6</ui5-button>
+	<ui5-button id="myBtn3" data-placement="Bottom" data-vertical-align="Center" class="myBtn">3</ui5-button>
+	<ui5-button id="myBtn4" data-placement="Top" data-vertical-align="Center" class="myBtn">4</ui5-button>
+	<ui5-button id="myBtn5" data-placement="Start" data-vertical-align="Center" class="myBtn">5</ui5-button>
+	<ui5-button id="myBtn6" data-placement="Start" data-vertical-align="Center" class="myBtn">6</ui5-button>
 
 	<ui5-toggle-button id="customSizeBtn">Bigger Popover</ui5-toggle-button>
 


### PR DESCRIPTION
After https://github.com/SAP/ui5-webcomponents/pull/8846, fallback values are removed. This PR ensures that `verticalAlign` is not set to `undefined`.

Fixes https://github.com/SAP/ui5-webcomponents/issues/10309