### PR TITLE
fix(ui5-timeline-item): correct wrapping on long text

### DIFF
--- a/packages/fiori/src/TimelineItemTemplate.tsx
+++ b/packages/fiori/src/TimelineItemTemplate.tsx
@@ -58,7 +58,7 @@ function name(this: TimelineItem) {
 			{this.nameClickable ?
 				<Link
 					class="ui5-tli-title-name-clickable"
-					wrappingType="None"
+					wrappingType={this.layout === TimelineLayout.Horizontal ? "None" : "Normal"}
 					onClick={this.onNamePress}
 				>
 					{this.name}&nbsp;

--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -149,6 +149,7 @@
 	position: relative;
 	margin-left: .5rem;
 	padding: var(--_ui5_TimelineItem_bubble_content_padding);
+	word-break: break-word;
 }
 
 :host([layout="Horizontal"]) .ui5-tli-bubble {


### PR DESCRIPTION
Previously within our `ui5-timeline-item` component, when an exceptionally long text was provided in the `title-text`, `subtitle-text` or `name` properties, the content was being hidden due to missing properties for text wrapping.

With this change we now correctly wrap the words of the content, by leveraging the `word-break` CSS property, so now the whole content is being shown.

### Before

![2025-01-07_15-11-53](https://github.com/user-attachments/assets/b4571101-128b-43f1-a40b-97509926b24d)

### After
![2025-01-07_15-12-29](https://github.com/user-attachments/assets/ec2ad0b5-4fe3-4abb-9c86-80d0a02f0bb2)

Fixes: #10303