### PR TITLE
docs: update component badges in website

### DIFF
--- a/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPage.mdx
+++ b/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPage.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../DynamicPage
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../../_samples/fiori/DynamicPage/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPageHeader.mdx
+++ b/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPageHeader.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../DynamicPageHeader
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPageTitle.mdx
+++ b/packages/website/docs/_components_pages/fiori/DynamicPage/DynamicPageTitle.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../DynamicPageTitle
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/NavigationLayout.mdx
+++ b/packages/website/docs/_components_pages/fiori/NavigationLayout.mdx
@@ -2,7 +2,7 @@
 sidebar_class_name: newComponentBadge
 ---
 
-import Basic from "../../../_samples/fiori/NavigationLayout/Basic/Basic.md";
+import Basic from "../../_samples/fiori/NavigationLayout/Basic/Basic.md";
 
 <%COMPONENT_OVERVIEW%>
 

--- a/packages/website/docs/_components_pages/fiori/Timeline/TimelineGroupItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/Timeline/TimelineGroupItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../TimelineGroupItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Form/Form.mdx
+++ b/packages/website/docs/_components_pages/main/Form/Form.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../Form
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../../_samples/main/Form/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Form/FormGroup.mdx
+++ b/packages/website/docs/_components_pages/main/Form/FormGroup.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../FormGroup
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Form/FormItem.mdx
+++ b/packages/website/docs/_components_pages/main/Form/FormItem.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../FormItem
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/List/ListItemGroup.mdx
+++ b/packages/website/docs/_components_pages/main/List/ListItemGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../ListItemGroup
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Table/Table.mdx
+++ b/packages/website/docs/_components_pages/main/Table/Table.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../Table
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Basic from "../../../_samples/main/Table/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableCell.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableCell
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";

--- a/packages/website/docs/_components_pages/main/Table/TableGrowing.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableGrowing.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableGrowing
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Growing from "../../../_samples/main/Table/Growing/Growing.md";

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableHeaderCell
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Popin from "../../../_samples/main/Table/Popin/Popin.md";

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderRow.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderRow.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableHeaderRow
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import StickyHeader from "../../../_samples/main/Table/StickyHeader/StickyHeader.md";

--- a/packages/website/docs/_components_pages/main/Table/TableRow.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableRow.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableRow
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Interactive from "../../../_samples/main/Table/Interactive/Interactive.md";

--- a/packages/website/docs/_components_pages/main/Table/TableSelection.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableSelection.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableSelection
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Selection from "../../../_samples/main/Table/Selection/Selection.md";

--- a/packages/website/docs/_components_pages/main/Text.mdx
+++ b/packages/website/docs/_components_pages/main/Text.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../Text
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/main/Text/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Tokenizer.mdx
+++ b/packages/website/docs/_components_pages/main/Tokenizer.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../Tokenizer
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/main/Tokenizer/Basic/Basic.md";


### PR DESCRIPTION
There are a lot of components marked as new but available for 6 months+ => mark only the most recent as "new"