### PR TITLE
docs: fix jsdoc issues with native click

### DIFF
--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -90,18 +90,6 @@ type ButtonAccessibilityAttributes = Pick<AccessibilityAttributes, "expanded" | 
 	shadowRootOptions: { delegatesFocus: true },
 })
 /**
- * Fired when the component is activated either with a
- * mouse/tap or by using the Enter or Space key.
- *
- * **Note:** The event will not be fired if the `disabled`
- * property is set to `true`.
- * @public
- * @native
- */
-// @event("click", {
-// 	bubbles: true,
-// })
-/**
  * Fired whenever the active state of the component changes.
  * @private
  */
@@ -111,9 +99,9 @@ type ButtonAccessibilityAttributes = Pick<AccessibilityAttributes, "expanded" | 
 })
 class Button extends UI5Element implements IButton {
 	eventDetails!: {
-		"active-state-change": void
-		// click: void
-	}
+		"active-state-change": void,
+	};
+
 	/**
 	 * Defines the component design.
 	 * @default "Default"

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -130,6 +130,23 @@ function processClass(ts, classNode, moduleDoc) {
 	currClass.events = findAllDecorators(classNode, "event")
 		?.map(event => processEvent(ts, event, classNode, moduleDoc));
 
+	// TODO: remove after changing Button's click to custom event.
+	// Currently, the Button emits a native click that doesn't need and doesn't have an event decorator,
+	// so we add it manually to the events array.
+	if (currClass.tagName === "ui5-button") {
+		currClass.events.push({
+			"name": "click",
+			"_ui5privacy": "public",
+			"type": {
+				"text": "Event"
+			},
+			"description": "Fired when the component is activated either with a\nmouse/tap or by using the Enter or Space key.\n\n**Note:** The event will not be fired if the `disabled`\nproperty is set to `true`.",
+			"_ui5Cancelable": false,
+			"_ui5allowPreventDefault": false,
+			"_ui5Bubbles": true
+		});
+	}
+
 	const filename = classNode.getSourceFile().fileName;
 	const sourceFile = typeProgram.getSourceFile(filename);
 	const tsProgramClassNode = sourceFile.statements.find(statement => ts.isClassDeclaration(statement) && statement.name?.text === classNode.name?.text);


### PR DESCRIPTION
Currently, the Button emits a native click that doesn't need and doesn't have an event decorator, but at the same time event decorators are the source for displaying events in the website, moreover to include events in the custom elements manifest.

Until we find better way to describe native events, or change the event to custom (due to other considerations), we manually add the native click event entry to the custom elements manifest.