### PR TITLE
fix: fix incorrect module ref in custom-elements-manifest

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -26,7 +26,7 @@ import handleDragOver from "@ui5/webcomponents-base/dist/util/dragAndDrop/handle
 import handleDrop from "@ui5/webcomponents-base/dist/util/dragAndDrop/handleDrop.js";
 import Orientation from "@ui5/webcomponents-base/dist/types/Orientation.js";
 import DragRegistry from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
-import type { MoveEventDetail as ListMoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
+import type { MoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
 import { findClosestPosition, findClosestPositionsByKey } from "@ui5/webcomponents-base/dist/util/dragAndDrop/findClosestPosition.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
 import {
@@ -106,6 +106,8 @@ type ListItemToggleEventDetail = {
 type ListItemClickEventDetail = {
 	item: ListItemBase,
 }
+
+type ListMoveEventDetail = MoveEventDetail;
 
 /**
  * @class

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -10,7 +10,7 @@ import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delega
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
-import type { MoveEventDetail as TableMoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
+import type { MoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
 import TableTemplate from "./generated/templates/TableTemplate.lit.js";
 import TableStyles from "./generated/themes/Table.css.js";
 import TableRow from "./TableRow.js";
@@ -75,6 +75,8 @@ interface ITableGrowing extends ITableFeature {
 type TableRowClickEventDetail = {
 	row: TableRow,
 };
+
+type TableMoveEventDetail = MoveEventDetail;
 
 /**
  * @class
@@ -640,5 +642,5 @@ export type {
 	ITableFeature,
 	ITableGrowing,
 	TableRowClickEventDetail,
-	TableMoveEventDetail as TableTableMoveEventDetail,
+	TableMoveEventDetail,
 };


### PR DESCRIPTION
There is wrong data in the produced  custom-elements-manifest - TableMoveEventDetail and ListMoveEventDetail types are referenced with the wrong module. Instead being related to the List and Table classes, the types are related to the 
base class: "@ui5/webcomponents-basedist/util/dragAndDrop/DragRegistry.js"

Indeed the real type is in the DragRegistry base util class and the components are just re-exporting via casting:

```ts
import type { MoveEventDetail as ListMoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";

export type {
    ListMoveEventDetail,
};
```
And, the custom-elements-manifest analyzer can't deal with this.
Temporary fix will be to to create a local type and think of a convention or enhancing the analyzer:

```ts
type ListMoveEventDetail = MoveEventDetail;
export type {
    ListMoveEventDetail,
};
```