### PR TITLE
fix(ui5-popover): fix opener reference

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1080,6 +1080,10 @@ abstract class UI5Element extends HTMLElement {
 		return true;
 	}
 
+	get isUI5AbstractElement(): boolean {
+		return !(this.constructor as typeof UI5Element)._needsShadowDOM();
+	}
+
 	get classes(): ClassMap {
 		return {};
 	}

--- a/packages/main/src/Popover.ts
+++ b/packages/main/src/Popover.ts
@@ -1,3 +1,4 @@
+import { instanceOfUI5Element } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import type UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
@@ -7,7 +8,6 @@ import { getClosedPopupParent } from "@ui5/webcomponents-base/dist/util/PopupUti
 import clamp from "@ui5/webcomponents-base/dist/util/clamp.js";
 import getEffectiveScrollbarStyle from "@ui5/webcomponents-base/dist/util/getEffectiveScrollbarStyle.js";
 import DOMReferenceConverter from "@ui5/webcomponents-base/dist/converters/DOMReference.js";
-
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import Popup from "./Popup.js";
 import PopoverPlacement from "./types/PopoverPlacement.js";
@@ -300,7 +300,7 @@ class Popover extends Popup {
 		}
 
 		if (opener instanceof HTMLElement) {
-			return this._isUI5Element(opener) ? opener.getFocusDomRef() : opener;
+			return this._isUI5AbstractElement(opener) ? opener.getFocusDomRef() : opener;
 		}
 
 		let rootNode = this.getRootNode();
@@ -315,8 +315,8 @@ class Popover extends Popup {
 			openerHTMLElement = document.getElementById(opener);
 		}
 
-		if (openerHTMLElement && this._isUI5Element(openerHTMLElement)) {
-			return openerHTMLElement.getFocusDomRef() || openerHTMLElement;
+		if (openerHTMLElement) {
+			return this._isUI5AbstractElement(openerHTMLElement) ? openerHTMLElement.getFocusDomRef() : openerHTMLElement;
 		}
 
 		return openerHTMLElement;
@@ -379,7 +379,7 @@ class Popover extends Popup {
 
 		const opener = this.getOpenerHTMLElement(this.opener);
 
-		if (opener && this._isUI5Element(opener) && !opener.getDomRef()) {
+		if (opener && instanceOfUI5Element(opener) && !opener.getDomRef()) {
 			return;
 		}
 
@@ -487,8 +487,8 @@ class Popover extends Popup {
 		});
 	}
 
-	_isUI5Element(el: HTMLElement): el is UI5Element {
-		return "isUI5Element" in el;
+	_isUI5AbstractElement(el: HTMLElement): el is UI5Element {
+		return instanceOfUI5Element(el) && el.isUI5AbstractElement;
 	}
 
 	get arrowDOM() {


### PR DESCRIPTION
Previously the Popover's code assumed that if the opener is an UI5Element, then the DOM ref of the opener is the result of the `getFocusDomRef` method, which is not always the case.
There are also noticeable misalignments of the popover that are caused by this fact. For example here the popover is shifted as it's aligned with the inner input (the focus dom ref):

<img width="611" alt="Screenshot 2025-01-09 at 18 09 28" src="https://github.com/user-attachments/assets/448b7f0c-97ff-44df-b81b-1b263e94cfa9" />


 With this change, the popover will use the getFocusDomRef oof the opener, only if the opener is abstract UI5Element,
 with no effect on the rest of the cases.
 
<img width="483" alt="Screenshot 2025-01-09 at 18 10 35" src="https://github.com/user-attachments/assets/34573e7c-9687-45b8-84b1-3684483b253f" />

 