### PR TITLE
docs(ui5-form): remove exp flag

### DIFF
--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -26,10 +26,10 @@ const breakpoints = ["S", "M", "L", "Xl"];
 const MAX_FORM_ITEM_CELLS = 12;
 const DEFAULT_FORM_ITEM_LAYOUT = "4fr 8fr 0fr";
 const DEFAULT_FORM_ITEM_LAYOUT_S = "1fr";
+
 /**
  * Interface for components that can be slotted inside `ui5-form` as items.
  * @public
- * @experimental
  * @since 2.0.0
  */
 interface IFormItem extends UI5Element {
@@ -197,7 +197,6 @@ type ItemsInfo = {
  *
  * @public
  * @since 2.0.0
- * @experimental This component is availabe since 2.0 under an experimental flag and its API and behaviour are subject to change.
  * @extends UI5Element
  */
 @customElement({

--- a/packages/main/src/FormGroup.ts
+++ b/packages/main/src/FormGroup.ts
@@ -31,7 +31,6 @@ import type FormItemSpacing from "./types/FormItemSpacing.js";
  * @public
  * @implements {IFormItem}
  * @since 2.0.0
- * @experimental This component is availabe since 2.0 under an experimental flag and its API and behaviour are subject to change.
  * @extends UI5Element
  */
 @customElement({

--- a/packages/main/src/FormItem.ts
+++ b/packages/main/src/FormItem.ts
@@ -37,7 +37,6 @@ import type FormItemSpacing from "./types/FormItemSpacing.js";
  * @implements {IFormItem}
  * @public
  * @since 2.0.0
- * @experimental This component is availabe since 2.0 under an experimental flag and its API and behaviour are subject to change.
  * @extends UI5Element
  */
 @customElement({

--- a/packages/website/docs/_components_pages/main/Form/FormGroup.mdx
+++ b/packages/website/docs/_components_pages/main/Form/FormGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../FormGroup
-sidebar_class_name: expComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Form/FormItem.mdx
+++ b/packages/website/docs/_components_pages/main/Form/FormItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../FormItem
-sidebar_class_name: expComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>


### PR DESCRIPTION
Since the component is available for 6 months +  design has been finalised in the end of 2024 and we don't expect major design changes, we now remove the "experimental" flag.