### PR TITLE
fix(ui5-tree): improve keydown handling in content slot

### DIFF
--- a/packages/main/src/TreeItemCustom.ts
+++ b/packages/main/src/TreeItemCustom.ts
@@ -2,7 +2,12 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
-import { isTabNext, isTabPrevious, isF2 } from "@ui5/webcomponents-base/dist/Keys.js";
+import {
+	isTabNext,
+	isTabPrevious,
+	isF2,
+	isDown,
+} from "@ui5/webcomponents-base/dist/Keys.js";
 import TreeItemBase from "./TreeItemBase.js";
 
 // Template
@@ -53,6 +58,10 @@ class TreeItemCustom extends TreeItemBase {
 	content!: Array<HTMLElement>;
 
 	async _onkeydown(e: KeyboardEvent) {
+		if (isDown(e) && this.content?.some(el => el.contains(e.target as Node))) {
+			e.stopPropagation();
+			return;
+		}
 		const isTab = isTabNext(e) || isTabPrevious(e);
 		const isFocused = this.matches(":focus");
 


### PR DESCRIPTION
Stop propagation of arrow down events when interacting with elements in the content slot, enabling proper functionality of interactive elements while preserving tree navigation.

Fixes: [#10474](https://github.com/SAP/ui5-webcomponents/issues/10474)