### PR TITLE
fix: i18n decorator property definition

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -41,6 +41,7 @@ import { updateFormValue, setFormValue } from "./features/InputElementsFormSuppo
 import type { IFormInputElement } from "./features/InputElementsFormSupport.js";
 import { getComponentFeature, subscribeForFeatureLoad } from "./FeaturesRegistry.js";
 import { getI18nBundle } from "./i18nBundle.js";
+import type I18nBundle from "./i18nBundle.js";
 import { fetchCldr } from "./asset-registries/LocaleData.js";
 import getLocale from "./locale/getLocale.js";
 
@@ -1288,6 +1289,11 @@ abstract class UI5Element extends HTMLElement {
 
 	static asyncFinished: boolean;
 	static definePromise: Promise<void> | undefined;
+	static i18nBundleStorage: Record<string, I18nBundle> = {};
+
+	static get i18nBundles(): Record<string, I18nBundle> {
+		return this.i18nBundleStorage;
+	}
 
 	/**
 	 * Registers a UI5 Web Component in the browser window object
@@ -1304,8 +1310,7 @@ abstract class UI5Element extends HTMLElement {
 			const [i18nBundles] = result;
 			Object.entries(this.getMetadata().getI18n()).forEach((pair, index) => {
 				const propertyName = pair[0];
-				const targetClass = pair[1].target;
-				(targetClass as Record<string, any>)[propertyName] = i18nBundles[index];
+				this.i18nBundleStorage[propertyName] = i18nBundles[index];
 			});
 			this.asyncFinished = true;
 		};

--- a/packages/base/src/decorators/i18n.ts
+++ b/packages/base/src/decorators/i18n.ts
@@ -20,6 +20,13 @@ const i18n = (bundleName: string): i18nDecorator => {
 		if (!target.metadata.i18n) {
 			target.metadata.i18n = {};
 		}
+
+		Object.defineProperty(target, propertyName, {
+			get() {
+				return target.i18nBundles[propertyName];
+			},
+		});
+
 		target.metadata.i18n[propertyName] = {
 			bundleName,
 			target,

--- a/packages/base/src/decorators/i18n.ts
+++ b/packages/base/src/decorators/i18n.ts
@@ -25,6 +25,7 @@ const i18n = (bundleName: string): i18nDecorator => {
 			get() {
 				return target.i18nBundles[propertyName];
 			},
+			set() {},
 		});
 
 		target.metadata.i18n[propertyName] = {

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -185,10 +185,6 @@ class BarcodeScannerDialog extends UI5Element {
 		this._handleCaptureRegionBound = this._handleDrawCaptureRegion.bind(this);
 	}
 
-	static async onDefine() {
-		BarcodeScannerDialog.i18nBundle = await getI18nBundle("@ui5/webcomponents-fiori");
-	}
-
 	async onAfterRendering() {
 		if (!this._hasGetUserMedia()) {
 			this.fireDecoratorEvent("scan-error", { message: "getUserMedia() is not supported by your browser" });

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -7,7 +7,6 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
-import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { Result, Exception } from "@zxing/library";
 import type { Interval } from "@ui5/webcomponents-base/dist/types.js";
 // eslint-disable-next-line import/no-extraneous-dependencies


### PR DESCRIPTION
**Problem:**  
The i18n bundle is stored as a static property in the child class where the `i18n` decorator is last used. This creates an issue when trying to access the static property from a parent class if it is overridden in the child class. The result might be `undefined` because the bundle is only stored in the class where the decorator was last used.

This issue can be observed on the https://sap.github.io/ui5-webcomponents/nightly/components/Tree/
Note: The issue is reproducible only if the `ui5-tree` and `ui5-tree-item` components are loaded. For local testing, the defined components in the bundle should be limited to just these two.

**Example:**  
```typescript
abstract class ListItem extends ListItemBase {
	@i18n("@ui5/webcomponents")
	static i18nBundle: I18nBundle;

	get _accInfo(): AccInfo {
		return {
			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX) // This ListItem.i18nBundle is undefined because the bundle is only registered in TreeItemBase.
		};
	}
}

class TreeItemBase extends ListItem {
	@i18n("@ui5/webcomponents")
	static i18nBundle: I18nBundle;
}
```

**Solution:**  
The loaded bundle is now stored in a bundle storage variable. A getter is defined for each property that stores a bundle in every class where `i18n` decorator is used. This ensures access to the bundle storage for every class where the i18n decorator is used.