### PR TITLE
fix(ui5-toolbar): overflow behaviour

### DIFF
--- a/packages/main/src/themes/Toolbar.css
+++ b/packages/main/src/themes/Toolbar.css
@@ -20,7 +20,6 @@
 	display: inherit;
 	align-items: inherit;
 	justify-content: inherit;
-	gap: var(--_ui5-toolbar-items-gap);
 }
 
 .ui5-tb-items-full-width {
@@ -29,6 +28,19 @@
 
 .ui5-tb-item {
 	flex-shrink: 0;
+}
+
+.ui5-tb-item {
+	margin-inline-end: var(--_ui5-toolbar-item-margin-right);
+	margin-inline-start: var(--_ui5-toolbar-item-margin-left);
+}
+
+/* Last visible element should not have margins.
+Last element is: overflow button or tb-item when overflow button is hidden */
+.ui5-tb-overflow-btn,
+.ui5-tb-items:has(.ui5-tb-overflow-btn-hidden) .ui5-tb-item:nth-last-child(2) {
+	margin-inline-end: 0;
+	margin-inline-start: 0;
 }
 
 .ui5-tb-separator {

--- a/packages/main/src/themes/base/Toolbar-parameters.css
+++ b/packages/main/src/themes/base/Toolbar-parameters.css
@@ -1,5 +1,6 @@
 :root {
     --_ui5-toolbar-padding-left: 0.5rem;
 	--_ui5-toolbar-padding-right: 0.5rem;
-	--_ui5-toolbar-items-gap: 0.25rem;
+	--_ui5-toolbar-item-margin-left: 0;
+	--_ui5-toolbar-item-margin-right: 0.25rem;
 }


### PR DESCRIPTION
This PR fixes regression introduced with: https://github.com/SAP/ui5-webcomponents/pull/10405. Gap is not part of the overflow calculations and items overflow lately.

![image](https://github.com/user-attachments/assets/48fcfe22-7a38-4f33-8436-addb80f91913)
