### PR TITLE
chore(ui5-tokenizer): simplify popover items calculation

### DIFF
--- a/packages/main/src/Token.ts
+++ b/packages/main/src/Token.ts
@@ -135,13 +135,6 @@ class Token extends UI5Element implements IToken {
 	forcedTabIndex = "-1";
 
 	/**
-	 * Indicates whether the token is visible or not.
-	 * @private
-	 */
-	@property({ type: Boolean, noAttribute: true })
-	_isVisible = false
-
-	/**
 	 * Defines the close icon for the token. If nothing is provided to this slot, the default close icon will be used.
 	 * Accepts `ui5-icon`.
 	 * @public

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -570,7 +570,6 @@ class Tokenizer extends UI5Element {
 			this.open = false;
 		} else {
 			if (isPhone()) {
-				token._isVisible = false;
 				this._deletedDialogItems.push(token);
 			} else {
 				this.fireDecoratorEvent("token-delete", { tokens: [token] });
@@ -603,17 +602,6 @@ class Tokenizer extends UI5Element {
 	}
 
 	handleBeforeOpen() {
-		if (this.multiLine) {
-			this._resetTokensVisibility();
-
-			const focusedToken = this._tokens.find(token => token.focused);
-			focusedToken!._isVisible = true;
-		} else {
-			this._tokens.forEach(token => {
-				token._isVisible = true;
-			});
-		}
-
 		const list = this._getList();
 		const firstListItem = list.querySelectorAll("[ui5-li]")[0]! as ListItem;
 
@@ -626,10 +614,6 @@ class Tokenizer extends UI5Element {
 		this.open = false;
 		this._preventCollapse = false;
 		this._focusedElementBeforeOpen = null;
-
-		this._tokens.forEach(token => {
-			token._isVisible = true;
-		});
 	}
 
 	handleDialogButtonPress(e: MouseEvent) {
@@ -971,12 +955,6 @@ class Tokenizer extends UI5Element {
 				tokens: this._selectedTokens,
 			});
 		}
-	}
-
-	_resetTokensVisibility() {
-		this._tokens.forEach(token => {
-			token._isVisible = false;
-		});
 	}
 
 	get hasTokens() {

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -325,10 +325,6 @@ class Tokenizer extends UI5Element {
 		type: HTMLElement,
 		"default": true,
 		individualSlots: true,
-		invalidateOnChildChange: {
-			properties: ["_isVisible"],
-			slots: false,
-		},
 	})
 	tokens!: Array<Token>;
 

--- a/packages/main/src/TokenizerPopoverTemplate.tsx
+++ b/packages/main/src/TokenizerPopoverTemplate.tsx
@@ -42,7 +42,6 @@ export default function TokenizerPopoverTemplate(this: Tokenizer) {
 				onItemDelete={this.itemDelete}
 			>
 				{this._tokens
-					.filter(token => token._isVisible)
 					.map(token => <ListItemStandard key={String(token._id)} data-ui5-token-ref-id={token._id} wrappingType="Normal">{token.text}</ListItemStandard>)}
 			</List>
 


### PR DESCRIPTION
Tokenizer shows list item for each to token in the N-more popover. This means that _isVisible property is redundant and it has no value.