### PR TITLE
fix(popup): applying focus twice

### DIFF
--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -324,11 +324,6 @@ abstract class Popup extends UI5Element {
 		// initial focus, if focused element is statically created
 		await this.applyInitialFocus();
 
-		await renderFinished();
-
-		// initial focus, if focused element is dynamically created
-		await this.applyInitialFocus();
-
 		if (this.isConnected) {
 			this.fireDecoratorEvent("open");
 		}


### PR DESCRIPTION
Applying focus twice might result into an issue if navigation occurs before promise resolve.