### PR TITLE
fix(ui5-toast): fix template and remove additional text

### DIFF
--- a/packages/main/src/ToastTemplate.tsx
+++ b/packages/main/src/ToastTemplate.tsx
@@ -2,9 +2,11 @@ import type Toast from "./Toast.js";
 
 export default function ToastTemplate(this: Toast) {
 	return <>
-		this.open &&
-		<div class="ui5-toast-root" role="alert" tabindex={this._tabindex}>
-			<bdi><slot></slot></bdi>
-		</div>
-	</>;
+		{ 
+			this.open &&
+				<div class="ui5-toast-root" role="alert" tabindex={this._tabindex}>
+					<bdi><slot></slot></bdi>
+				</div>
+		}
+	</>
 }

--- a/packages/main/src/ToastTemplate.tsx
+++ b/packages/main/src/ToastTemplate.tsx
@@ -2,11 +2,11 @@ import type Toast from "./Toast.js";
 
 export default function ToastTemplate(this: Toast) {
 	return <>
-		{ 
+		{
 			this.open &&
 				<div class="ui5-toast-root" role="alert" tabindex={this._tabindex}>
 					<bdi><slot></slot></bdi>
 				</div>
 		}
-	</>
+	</>;
 }


### PR DESCRIPTION
Fix template - without brackets the condition is treated as string and appended to the DOM.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10558

<img width="220" alt="Screenshot 2025-01-14 at 18 07 34" src="https://github.com/user-attachments/assets/610d75d7-f770-48b8-8ac5-c0b2f5a1802a" />

<img width="252" alt="Screenshot 2025-01-14 at 18 07 25" src="https://github.com/user-attachments/assets/1680ae9e-4e60-4267-8177-a978edec0367" />

