### PR TITLE
fix(ui5-dynamic-page): prevent layout shift with container queries

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -7,9 +7,6 @@ import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
-import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import type { ResizeObserverCallback } from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
-import MediaRange from "@ui5/webcomponents-base/dist/MediaRange.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -203,8 +200,6 @@ class DynamicPage extends UI5Element {
 	@property({ type: Boolean })
 	_headerSnapped = false;
 
-	_updateMediaRange: ResizeObserverCallback;
-
 	@query(".ui5-dynamic-page-scroll-container")
 	scrollContainer?: HTMLElement;
 
@@ -213,26 +208,9 @@ class DynamicPage extends UI5Element {
 
 	constructor() {
 		super();
-
-		this._updateMediaRange = this.updateMediaRange.bind(this);
-	}
-
-	onEnterDOM() {
-		ResizeHandler.register(this, this._updateMediaRange);
-	}
-
-	onExitDOM() {
-		ResizeHandler.deregister(this, this._updateMediaRange);
 	}
 
 	onBeforeRendering() {
-		if (!this.mediaRange) {
-			this.mediaRange = MediaRange.getCurrentRange(
-				MediaRange.RANGESETS.RANGE_4STEPS,
-				window.innerWidth,
-			);
-		}
-
 		if (this.dynamicPageTitle) {
 			this.dynamicPageTitle.snapped = this._headerSnapped;
 			this.dynamicPageTitle.interactive = this.hasHeading;
@@ -437,10 +415,6 @@ class DynamicPage extends UI5Element {
 	async onExpandHoverOut() {
 		this.dynamicPageTitle?.removeAttribute("hovered");
 		await renderFinished();
-	}
-
-	updateMediaRange() {
-		this.mediaRange = MediaRange.getCurrentRange(MediaRange.RANGESETS.RANGE_4STEPS, this.getDomRef()!.offsetWidth);
 	}
 }
 

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -151,14 +151,6 @@ class DynamicPage extends UI5Element {
 	showFooter = false;
 
 	/**
-	 * Defines the current media query size.
-	 *
-	 * @private
-	 */
-	@property()
-	mediaRange?: string;
-
-	/**
 	 * Defines the content of the Dynamic Page.
 	 *
 	 * @public

--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -226,6 +226,13 @@ class DynamicPage extends UI5Element {
 	}
 
 	onBeforeRendering() {
+		if (!this.mediaRange) {
+			this.mediaRange = MediaRange.getCurrentRange(
+				MediaRange.RANGESETS.RANGE_4STEPS,
+				window.innerWidth,
+			);
+		}
+
 		if (this.dynamicPageTitle) {
 			this.dynamicPageTitle.snapped = this._headerSnapped;
 			this.dynamicPageTitle.interactive = this.hasHeading;

--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -12,6 +12,7 @@
 }
 
 .ui5-dynamic-page-root {
+    container-type: size;
     height: inherit;
     overflow-y: hidden;
 }
@@ -80,50 +81,54 @@
 
 /* Responsive paddings */
 
-:host([media-range="S"]) .ui5-dynamic-page-fit-content {
-    padding: var(--_ui5_dynamic_page_content_padding_S);
+/* S Size */
+@container (max-width: 599px) {
+    .ui5-dynamic-page-fit-content {
+        padding: var(--_ui5_dynamic_page_content_padding_S);
+    }
+    ::slotted([slot="titleArea"]) {
+        padding: var(--_ui5_dynamic_page_title_padding_S);
+    }
+    ::slotted([slot="headerArea"]) {
+        padding: var(--_ui5_dynamic_page_header_padding_S);
+    }
 }
 
-:host([media-range="S"]) ::slotted([slot="titleArea"]) {
-    padding: var(--_ui5_dynamic_page_title_padding_S);
+/* M Size */
+@container (min-width: 600px) and (max-width: 1023px) {
+    .ui5-dynamic-page-fit-content {
+        padding: var(--_ui5_dynamic_page_content_padding_M);
+    }
+    ::slotted([slot="titleArea"]) {
+        padding: var(--_ui5_dynamic_page_title_padding_M);
+    }
+    ::slotted([slot="headerArea"]) {
+        padding: var(--_ui5_dynamic_page_header_padding_M);
+    }
 }
 
-:host([media-range="S"]) ::slotted([slot="headerArea"]) {
-    padding: var(--_ui5_dynamic_page_header_padding_S);
+/* L Size */
+@container (min-width: 1024px) and (max-width: 1439px) {
+    .ui5-dynamic-page-fit-content {
+        padding: var(--_ui5_dynamic_page_content_padding_L);
+    }
+    ::slotted([slot="titleArea"]) {
+        padding: var(--_ui5_dynamic_page_title_padding_L);
+    }
+    ::slotted([slot="headerArea"]) {
+        padding: var(--_ui5_dynamic_page_header_padding_L);
+    }
 }
 
-:host([media-range="M"]) .ui5-dynamic-page-fit-content {
-    padding: var(--_ui5_dynamic_page_content_padding_M);
-}
-
-:host([media-range="M"]) ::slotted([slot="titleArea"]) {
-    padding: var(--_ui5_dynamic_page_title_padding_M);
-}
-
-:host([media-range="M"]) ::slotted([slot="headerArea"]) {
-    padding: var(--_ui5_dynamic_page_header_padding_M);
-}
-
-:host([media-range="L"]) .ui5-dynamic-page-fit-content {
-    padding: var(--_ui5_dynamic_page_content_padding_L);
-}
-
-:host([media-range="L"]) ::slotted([slot="titleArea"]) {
-    padding: var(--_ui5_dynamic_page_title_padding_L);
-}
-
-:host([media-range="L"]) ::slotted([slot="headerArea"]) {
-    padding: var(--_ui5_dynamic_page_header_padding_L);
-}
-
-:host([media-range="XL"]) .ui5-dynamic-page-fit-content {
-    padding: var(--_ui5_dynamic_page_content_padding_XL);
-}
-
-:host([media-range="XL"]) ::slotted([slot="titleArea"]) {
-    padding: var(--_ui5_dynamic_page_title_padding_XL);
-}
-
-:host([media-range="XL"]) ::slotted([slot="headerArea"]) {
-    padding: var(--_ui5_dynamic_page_header_padding_XL);
+/* XL Size */
+@container (min-width: 1440px) {
+    .ui5-dynamic-page-fit-content {
+        padding: var(--_ui5_dynamic_page_content_padding_XL);
+    }
+    ::slotted([slot="titleArea"]) {
+        padding: var(--_ui5_dynamic_page_title_padding_XL);
+    }
+    ::slotted([slot="headerArea"]) {
+        padding: var(--_ui5_dynamic_page_header_padding_XL);
+    }
 }


### PR DESCRIPTION
- Replace media-range attributes with container queries for responsive paddings

Fixes: [#10564](https://github.com/SAP/ui5-webcomponents/issues/10564)
