### PR TITLE
fix(ui5-switch): apply focus only on root element click

### DIFF
--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -3,6 +3,7 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
+	pointer-events: none;
 }
 
 .ui5-switch-root {
@@ -15,6 +16,7 @@
 	cursor: pointer;
 	outline: none;
 	border-radius: var(--_ui5-switch-root-border-radius);
+	pointer-events: all;
 }
 
 .ui5-switch-root:not(.ui5-switch--no-label):not(.ui5-switch--semantic) {


### PR DESCRIPTION
Previously on our `ui5-switch` component, focus was being applied even if the root element was not clicked. 

With this change, focus is applied only when the `ui5-switch`'s touch area is clicked.

### Before
![2025-01-20_09-03-48](https://github.com/user-attachments/assets/1edaed7c-6d01-4117-8b41-e6360ff68204)

### After
![2025-01-20_09-04-12](https://github.com/user-attachments/assets/e4045f60-2aa8-4331-aa3e-0b429ebdd4d6)

Fixes: #10567
