### PR TITLE
feat(ui5-shellbar): introduce content slot

### DIFF
--- a/packages/fiori/src/ShellBar.hbs
+++ b/packages/fiori/src/ShellBar.hbs
@@ -76,7 +76,7 @@
 		</div>
 	{{/if}}
 		<div class="ui5-shellbar-overflow-container ui5-shellbar-overflow-container-right">
-			{{#if showAdditionalContext}}
+			{{#if hasAdditionalContext}}
 				<div
 					style="{{styles.additionalContext.start.separator}}"
 					class="ui5-shellbar-separator ui5-shellbar-separator-start">

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -475,24 +475,14 @@ class ShellBar extends UI5Element {
 	midContent!: Array<HTMLElement>;
 
 	/**
-	 * Define the items displayed in the start of the additional content area.
-	 * **Note:** The `startContent` slot is in an experimental state and is a subject to change.
+	 * Define the items displayed in the additional content area.
+	 * **Note:** The `content` slot is in an experimental state and is a subject to change.
 	 *
 	 * @public
 	 * @since 2.7.0
 	 */
 	@slot({ type: HTMLElement, individualSlots: true })
-	startContent!: Array<HTMLElement>;
-
-	/**
-	 * Define the items displayed in the end of the additional content area.
- 	 * **Note:** The `endContent` slot is in an experimental state and is a subject to change.
-	 *
-	 * @public
-	 * @since 2.7.0
-	 */
-	@slot({ type: HTMLElement, individualSlots: true })
-	endContent!: Array<HTMLElement>;
+	content!: Array<HTMLElement>;
 
 	@i18n("@ui5/webcomponents-fiori")
 	static i18nBundle: I18nBundle;
@@ -648,8 +638,7 @@ class ShellBar extends UI5Element {
 			...this.shadowRoot!.querySelectorAll(".ui5-shellbar-logo"),
 			...this.shadowRoot!.querySelectorAll(".ui5-shellbar-logo-area"),
 			...this.shadowRoot!.querySelectorAll(".ui5-shellbar-menu-button"),
-			...this.startContent,
-			...this.endContent,
+			...this.additionalContext,
 			...this._getRightChildItems(),
 		] as HTMLElement[];
 	}
@@ -1430,6 +1419,35 @@ class ShellBar extends UI5Element {
 		return [...this.startContent, ...this.endContent];
 	}
 
+	get startContent() {
+		// return all items before the ui5-shellbar-spacer
+		const startContent = [];
+		for (let i = 0; i < this.content.length; i++) {
+			const child = this.content[i];
+			if (child.hasAttribute("ui5-shellbar-spacer")) {
+				break;
+			}
+			startContent.push(child);
+		}
+		return startContent;
+	}
+
+	get endContent() {
+		// return all items after the ui5-shellbar-spacer
+		const endContent = [];
+		let spacerFound = false;
+		for (let i = 0; i < this.content.length; i++) {
+			const child = this.content[i];
+			if (spacerFound) {
+				endContent.push(child);
+			}
+			if (child.hasAttribute("ui5-shellbar-spacer")) {
+				spacerFound = true;
+			}
+		}
+		return endContent;
+	}
+
 	get _rightChildRole() {
 		const items = this._getRightChildItems();
 		const visibleItems = items.filter(item => {
@@ -1487,11 +1505,7 @@ class ShellBar extends UI5Element {
 	}
 
 	get hasAdditionalContext() {
-		return this.startContent.length > 0 || this.endContent.length > 0;
-	}
-
-	get showAdditionalContext() {
-		return this.hasAdditionalContext;
+		return this.additionalContext.length > 0;
 	}
 
 	get _hasVisibleStartContent() {

--- a/packages/fiori/src/ShellBarSpacer.ts
+++ b/packages/fiori/src/ShellBarSpacer.ts
@@ -20,10 +20,6 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 class ShellBarSpacer extends UI5Element {
 	@property({ type: Boolean })
 	visible = false;
-
-	get isSpacer() {
-		return true;
-	}
 }
 
 ShellBarSpacer.define();

--- a/packages/fiori/src/ShellBarSpacer.ts
+++ b/packages/fiori/src/ShellBarSpacer.ts
@@ -7,6 +7,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
  *
  * ### Overview
  * The `ui5-shellbar-spacer` is an element, used for visual separation between the two content parts of the `ui5-shellbar`.
+ * **Note:** The `ui5-shellbar-spacer` component is in an experimental state and is a subject to change.
  * @constructor
  * @extends UI5Element
  * @since 2.7.0

--- a/packages/fiori/src/ShellBarSpacer.ts
+++ b/packages/fiori/src/ShellBarSpacer.ts
@@ -1,0 +1,31 @@
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+
+/**
+ * @class
+ *
+ * ### Overview
+ * The `ui5-shellbar-spacer` is an element, used for visual separation between the two content parts of the `ui5-shellbar`.
+ * @constructor
+ * @extends UI5Element
+ * @since 2.7.0
+ * @abstract
+ * @public
+ */
+@customElement({
+	tag: "ui5-shellbar-spacer",
+})
+
+class ShellBarSpacer extends UI5Element {
+	@property({ type: Boolean })
+	visible = false;
+
+	get isSpacer() {
+		return true;
+	}
+}
+
+ShellBarSpacer.define();
+
+export default ShellBarSpacer;

--- a/packages/fiori/src/bundle.esm.ts
+++ b/packages/fiori/src/bundle.esm.ts
@@ -28,6 +28,7 @@ import Page from "./Page.js";
 import ProductSwitch from "./ProductSwitch.js";
 import ProductSwitchItem from "./ProductSwitchItem.js";
 import ShellBar from "./ShellBar.js";
+import ShellBarSpacer from "./ShellBarSpacer.js";
 import ShellBarItem from "./ShellBarItem.js";
 import SideNavigation from "./SideNavigation.js";
 import SideNavigationItem from "./SideNavigationItem.js";

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -329,14 +329,6 @@ slot[name="profile"] {
 }
 
 .ui5-shellbar-overflow-container-right {
-	/* display: flex;
-	overflow: hidden;
-	position: relative;
-	box-sizing: border-box;
-	white-space: nowrap;
-	justify-content: flex-end;
-	flex-grow: 1;
-	overflow: hidden; */
 	flex-grow: 1;
 	justify-content: flex-end;
 }
@@ -362,7 +354,6 @@ slot[name="profile"] {
 	flex-shrink: 1;
 }
 
-::slotted(.ui5-shellbar-separator),
 .ui5-shellbar-separator {
 	flex-grow: 0;
 	flex-shrink: 0;
@@ -395,20 +386,13 @@ slot[name="profile"] {
 	position: absolute;
 }
 
-::slotted([slot^="startContent"]),
-::slotted([slot^="endContent"]) {
- 	margin-inline-start: var(--_ui5-shellbar-content-margin-start);
-}
-
-::slotted([slot^="startContent"][slot$="-1"]),
-::slotted([slot^="endContent"][slot$="-1"]) {
-	margin-inline-start: 0;
-}
-
 .ui5-shellbar-additional-content-item {
 	flex-shrink: 0;
-	margin: 0;
-	padding: 0;
+ 	padding-inline-start: var(--_ui5-shellbar-content-margin-start);
+}
+
+.ui5-shellbar-additional-content-item:first-child {
+	padding-inline-start: 0;
 }
 
 :host(:not([notifications-count])) .ui5-shellbar-bell-button {

--- a/packages/fiori/test/pages/ShellBar.html
+++ b/packages/fiori/test/pages/ShellBar.html
@@ -140,8 +140,8 @@
 		show-product-switch
 		show-search-field
 	>
-		<ui5-button slot="startContent">Button 1</ui5-button>
-		<ui5-button slot="startContent">Button 2</ui5-button>
+		<ui5-button slot="content">Button 1</ui5-button>
+		<ui5-button slot="content">Button 2</ui5-button>
  		<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
 
 		<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg"/>

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -57,29 +57,30 @@
 		slot="header"
 	>
 		<ui5-button icon="menu2" slot="startButton" id="btnOpenStart"></ui5-button>
-		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="startContent" data-hide-order="10">PR10</ui5-button>
+		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="content" data-hide-order="10">PR10</ui5-button>
 
-		<ui5-tag color-scheme="7" slot="startContent" data-hide-order="4">PR 4</ui5-tag>
-		<ui5-text slot="startContent" data-hide-order="3">PR3</ui5-text>
+		<ui5-tag color-scheme="7" slot="content" data-hide-order="4">PR 4</ui5-tag>
+		<ui5-text slot="content" data-hide-order="3">PR3</ui5-text>
 
-		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="startContent"></ui5-switch>
+		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="content"></ui5-switch>
 
+		<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+		<ui5-toggle-button  slot="content" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
 
 		<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
 			<div slot="valueStateMessage">Instructions</div>
 		</ui5-input>
-		<ui5-toggle-button  slot="endContent" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
-
 
 		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
 		<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
@@ -101,29 +102,30 @@
 		slot="header"
 	>
 		<ui5-button icon="menu2" slot="startButton" id="btnOpenStart"></ui5-button>
-		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="startContent" data-hide-order="10">PR10</ui5-button>
+		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="content" data-hide-order="10">PR10</ui5-button>
 
-		<ui5-tag color-scheme="7" slot="startContent" data-hide-order="4">PR 4</ui5-tag>
-		<ui5-text slot="startContent" data-hide-order="3">PR3</ui5-text>
+		<ui5-tag color-scheme="7" slot="content" data-hide-order="4">PR 4</ui5-tag>
+		<ui5-text slot="content" data-hide-order="3">PR3</ui5-text>
 
-		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="startContent"></ui5-switch>
+		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="content"></ui5-switch>
 
+		<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+		<ui5-toggle-button  slot="content" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
+
+		<ui5-toggle-button  slot="content" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
 
 		<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
 			<div slot="valueStateMessage">Instructions</div>
 		</ui5-input>
-		<ui5-toggle-button  slot="endContent" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="endContent" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
-
 
 		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
 		<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -52,6 +52,7 @@ describe("Component Behavior", () => {
 
 	describe("ui5-shellbar menu", () => {
 		it("tests prevents close on content click", async () => {
+			await browser.setWindowSize(1920, 1680);
 			const primaryTitle = await browser.$("#shellbar").shadow$(".ui5-shellbar-menu-button");
 			const menuPopover = await browser.$(`#shellbar`).shadow$(".ui5-shellbar-menu-popover");
 			const firstMenuItem = await menuPopover.$("ui5-list > ui5-li");
@@ -392,6 +393,7 @@ describe("Component Behavior", () => {
 		describe("Small screen", () => {
 			beforeEach(async () => {
 				await browser.setWindowSize(510, 1680);
+				await browser.$("#shellbar").setProperty("showSearchField", false);
 			});
 
 			it("tests logoClick event", async () => {

--- a/packages/fiori/test/ssr/component-imports.js
+++ b/packages/fiori/test/ssr/component-imports.js
@@ -12,6 +12,7 @@ import Page from "../../dist/Page.js";
 import ProductSwitch from "../../dist/ProductSwitch.js";
 import ProductSwitchItem from "../../dist/ProductSwitchItem.js";
 import ShellBar from "../../dist/ShellBar.js";
+import ShellBarSpacer from "../../dist/ShellBarSpacer.js"
 import ShellBarItem from "../../dist/ShellBarItem.js";
 import SideNavigation from "../../dist/SideNavigation.js";
 import SideNavigationItem from "../../dist/SideNavigationItem.js";


### PR DESCRIPTION
This pull request introduces changes to the ShellBar component to improve content management and introduces a new `ui5-shellbar-spacer` element for better layout separation. Below are the 

## Key updates:
**Refactored Slots:**
- Replaced `startContent` and `endContent` slots with a unified `content` slot.
Added new computed properties (startContent and endContent) to dynamically calculate items before and after the `ui5-shellbar-spacer`. This is usefull in order to keep the current implementaion around the additional items slots, like resposnsive design, overflow, etc.  

**Addapted tests:**
- some tests were previously working correctly based on a side effect where a shellbar cofngured with `show-search-field` was initially loaded with closed input.

## New Component: `ui5-shellbar-spacer`

- Serves as a visual separator between the start and end content of the ShellBar.
- Abstract component with minimal overhead.
- Shellbar enhances its styles
