### PR TITLE
chore: make color palette more colors declarative

### DIFF
--- a/packages/main/cypress/support/commands/ColorPalette.commands.ts
+++ b/packages/main/cypress/support/commands/ColorPalette.commands.ts
@@ -43,6 +43,7 @@ Cypress.Commands.add("ui5ColorPaletteCheckSelectedColor", { prevSubject: true },
 		.shadow()
 		.find("ui5-dialog")
 		.find("ui5-button")
+		.should("have.attr", "design", "Emphasized") // The OK button is Emphasized (the Cancel button is Transparent)
 		.as("okButton");
 
 	cy.get("@redColor")
@@ -59,4 +60,9 @@ Cypress.Commands.add("ui5ColorPaletteCheckSelectedColor", { prevSubject: true },
 
 	cy.get("@okButton")
 		.realClick();
+
+	cy.get("@colorPalette")
+		.shadow()
+		.find("ui5-dialog")
+		.should("not.be.visible"); // Make sure the dialog is closed at the end of the command (otherwise the next command will sometimes assert against the old dialog values)
 });

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -150,6 +150,18 @@ class ColorPalette extends UI5Element {
 	onPhone = false;
 
 	/**
+	 * @private
+	 */
+	@property({ type: Boolean })
+	dialogOpen = false;
+
+	/**
+	 * @private
+	 */
+	@property()
+	colorPickerValue = "rgba(255,255,255,1)";
+
+	/**
 	 * Defines the `ui5-color-palette-item` elements.
 	 * @public
 	 */
@@ -471,9 +483,12 @@ class ColorPalette extends UI5Element {
 		return this.colorPaletteNavigationElements[0];
 	}
 
+	onColorPickerChange(e: Event) {
+		this.colorPickerValue = (e.target as ColorPicker).value;
+	}
+
 	_chooseCustomColor() {
-		const colorPicker = this.getColorPicker();
-		this._setColor(colorPicker.value);
+		this._setColor(this.colorPickerValue);
 		this._closeDialog();
 		this._shouldFocusRecentColors = true;
 	}
@@ -488,19 +503,16 @@ class ColorPalette extends UI5Element {
 	}
 
 	_closeDialog() {
-		const dialog = this._getDialog();
-		dialog.open = false;
+		this.dialogOpen = false;
 	}
 
 	_openMoreColorsDialog() {
-		const dialog = this._getDialog();
-		const colorPicker = this.getColorPicker();
 		const value = this._currentlySelected ? this._currentlySelected.value : undefined;
 
 		if (value) {
-			colorPicker.value = value;
+			this.colorPickerValue = value;
 		}
-		dialog.open = true;
+		this.dialogOpen = true;
 	}
 
 	_onDefaultColorClick() {
@@ -628,15 +640,6 @@ class ColorPalette extends UI5Element {
 				"ui5-cp-root-phone": isPhone(),
 			},
 		};
-	}
-
-	_getDialog() {
-		return this.shadowRoot!.querySelector<Dialog>("[ui5-dialog]")!;
-	}
-
-	getColorPicker() {
-		const dialog = this._getDialog();
-		return dialog.content[0].querySelector<ColorPicker>("[ui5-color-picker]")!;
 	}
 }
 

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -21,7 +21,6 @@ import { getComponentFeature } from "@ui5/webcomponents-base/dist/FeaturesRegist
 import ColorPaletteTemplate from "./ColorPaletteTemplate.js";
 import type ColorPaletteItem from "./ColorPaletteItem.js";
 import type Button from "./Button.js";
-import type Dialog from "./Dialog.js";
 import type ColorPaletteMoreColors from "./features/ColorPaletteMoreColors.js";
 import type ColorPicker from "./ColorPicker.js";
 import "./ColorPaletteItem.js";

--- a/packages/main/src/features/ColorPaletteMoreColorsTemplate.tsx
+++ b/packages/main/src/features/ColorPaletteMoreColorsTemplate.tsx
@@ -5,9 +5,9 @@ import ColorPicker from "../ColorPicker.js";
 
 export default function ColorPaletteMoreColorsTemplate(this: ColorPalette) {
 	return (
-		<Dialog headerText={this.colorPaletteDialogTitle}>
+		<Dialog open={this.dialogOpen} headerText={this.colorPaletteDialogTitle} onClose={this._closeDialog}>
 			<div class="ui5-cp-dialog-content">
-				<ColorPicker />
+				<ColorPicker value={this.colorPickerValue} onChange={this.onColorPickerChange} />
 			</div>
 
 			<div slot="footer" class="ui5-cp-dialog-footer">

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -78,8 +78,6 @@ describe("ColorPalette interactions", () => {
 
 		assert.ok(colorPicker, "Color picker is rendered");
 
-		await colorPicker.setProperty("value", "#fafafa");
-
 		// The initial focus is on the first slider
 		await browser.keys("Tab"); // Slider 2
 		await browser.keys("Tab"); // Hex field

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -80,9 +80,13 @@ describe("ColorPalette interactions", () => {
 
 		await colorPicker.setProperty("value", "#fafafa");
 
-		// The initial focus is on the HEX input
-		await browser.keys("Tab"); // Slider 1
+		// The initial focus is on the first slider
 		await browser.keys("Tab"); // Slider 2
+		await browser.keys("Tab"); // Hex field
+
+		// Now the focus is on the hex field
+		await browser.keys("fafafa"); // type the new value in the hex field (this is the same as rgba(250, 250, 250, 1))
+
 		await browser.keys("Tab"); // Red
 		await browser.keys("Tab"); // Green
 		await browser.keys("Tab"); // Blue
@@ -92,7 +96,7 @@ describe("ColorPalette interactions", () => {
 
 		await browser.keys("Enter"); // Close the dialog & change the value of the color palette
 
-		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "#fafafa", "Custom color is selected from the color picker");
+		assert.strictEqual(await colorPalette.getProperty("selectedColor"), "rgba(250, 250, 250, 1)", "Custom color is selected from the color picker");
 	})
 
 	it("Tests show-recent-colors functionality", async () => {


### PR DESCRIPTION
Changes:
 - Querying the shadow DOM and manually modifying the composed components' state is an anti-pattern. The component was reworked to use state so that the changes to the composed elements are done via bindings.

**Important:** this will enable the rework to component features (they will become dynamic imports) - the feature template will be loaded dynamically and executed at a later stage, therefore _there can't be any functionality that directly queries elements in the shadow DOM_ (they won't be there until the feature template has been dynamically loaded and executed) 

 - two improvements to the Cypress test: the OK button selector is improved (very minor) and more importantly, the command **waits till the dialog has closed** - this ensures that the next command won't run until the full flow of the previous command has finished (and avoids the "test clicking too fast" situations)

 - the WDIO more colors feature test was fixed - it used to query the color picker in the shadow root and set its properties, which is *not allowed* for a test. This was necessary to make the test work regardless of the underlying implementation (until now it only worked with the old implementation which used to do exactly the same as the test - get a reference to the color picker and directly set its value). 

**Important: all tests should only do what the user can do**. The user cannot change the value of some property of a component in the shadow root. They can only click with the mouse, type with the keyboard, etc.
