### PR TITLE
fix(ui5-side-navigation): corrects playground sample 

### DIFF
--- a/packages/website/docs/_samples/fiori/SideNavigation/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/SideNavigation/Basic/main.js
@@ -1,6 +1,7 @@
 import "@ui5/webcomponents-fiori/dist/SideNavigation.js";
 import "@ui5/webcomponents-fiori/dist/SideNavigationItem.js";
 import "@ui5/webcomponents-fiori/dist/SideNavigationSubItem.js";
+import "@ui5/webcomponents-fiori/dist/SideNavigationGroup.js";
 
 import "@ui5/webcomponents-icons/dist/home.js";
 import "@ui5/webcomponents-icons/dist/chain-link.js";


### PR DESCRIPTION
Missing import resulted in side navigation sample not loading in the playground

Fixes: #10592