### PR TITLE
docs(ui5-table-growing): add note for scroll type

### DIFF
--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -48,6 +48,10 @@ import {
  * </ui5-table>
  * ```
  *
+ * **Notes**:
+ * * When the `ui5-table-growing` component is used with the `Scroll` type and the table is currently not scrollable,
+ * the component will render a growing button instead to ensure growing capabilities until the table becomes scrollable.
+ *
  * ### ES6 Module Import
  *
  * `import "@ui5/webcomponents/dist/TableGrowing.js";`
@@ -85,7 +89,8 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	 *
 	 * Button - Shows a More button at the bottom of the table, pressing it will load more rows.
 	 *
-	 * Scroll - The rows are loaded automatically by scrolling to the bottom of the table. If the table is not scrollable, this option is the same as the Button.
+	 * Scroll - The rows are loaded automatically by scrolling to the bottom of the table. If the table is not scrollable,
+	 * a growing button will be rendered instead to ensure growing functionality.
 	 * @default "Button"
 	 * @public
 	 */

--- a/packages/main/src/types/TableGrowingMode.ts
+++ b/packages/main/src/types/TableGrowingMode.ts
@@ -12,6 +12,8 @@ enum TableGrowingMode {
 
 	/**
 	 * Scroll to load more data.
+	 *
+	 * **Note:** If the table is not scrollable, a growing button will be rendered instead to ensure growing functionality.
 	 * @public
 	 */
 	Scroll = "Scroll",


### PR DESCRIPTION
Add special note regarding Scrolling in TableGrowing description to ensure its availability in the React Wrapper.

If the type is set to `Scroll`, but the Table is not scrollable yet (not enough items, etc.), the table will render a growing button. This will ensure that growing can always be triggered.

Fixes #10481