### PR TITLE
fix(ui5-side-navigation): don't toggle expanded state of items in popover

### DIFF
--- a/packages/fiori/cypress/specs/SideNavigation.cy.ts
+++ b/packages/fiori/cypress/specs/SideNavigation.cy.ts
@@ -124,6 +124,37 @@ describe("Side Navigation interaction", () => {
 		cy.get("#unselectableItem").should("not.have.attr", "expanded");
 	});
 
+	it("Tests expanding and collapsing of unselectable parent item when SideNavigation is collapsed", () => {
+		cy.mount(html`
+			<ui5-side-navigation id="sideNav" collapsed>
+				<ui5-side-navigation-item id="item1" text="1" unselectable>
+					<ui5-side-navigation-sub-item text="1.1"></ui5-side-navigation-sub-item>
+				</ui5-side-navigation-item>
+			</ui5-side-navigation>
+		`);
+
+		// act
+		cy.get("#item1").realClick();
+
+		// assert
+		cy.get("#sideNav")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-side-navigation-item][text='1']")
+			.should("have.attr", "expanded");
+
+		// assert
+		cy.get("#sideNav")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-side-navigation-item][text='1']")
+			.realClick();
+
+		// assert
+		cy.get("#sideNav")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-side-navigation-item][text='1']")
+			.should("have.attr", "expanded");
+	});
+
 	it("Tests isSelectable", () => {
 		cy.mount(`
 			<ui5-side-navigation>

--- a/packages/fiori/src/SideNavigationItem.ts
+++ b/packages/fiori/src/SideNavigationItem.ts
@@ -191,7 +191,7 @@ class SideNavigationItem extends SideNavigationSelectableItemBase {
 	}
 
 	_onclick(e: MouseEvent) {
-		if (this.unselectable) {
+		if (!this.inPopover && this.unselectable) {
 			this._toggle();
 		}
 


### PR DESCRIPTION
BGSOFUIRODOPI-3344