### PR TITLE
chore: address ai regenerate pattern feedback

### DIFF
--- a/packages/website/docs/_samples/patterns/AIRegenerate/Basic/main.js
+++ b/packages/website/docs/_samples/patterns/AIRegenerate/Basic/main.js
@@ -14,6 +14,7 @@ import "@ui5/webcomponents/dist/CheckBox.js";
 
 let response = null;
 let texts = null;
+let skipDialog = false;
 
 if (!response) {
 	response = await fetch("../assets/data/predefinedTexts.json");
@@ -30,12 +31,23 @@ const toggleDialog = (dialog, isOpen) => {
 dialogCloser.addEventListener("click", () => toggleDialog(dialog, false));
 
 myAiButton.addEventListener("click", () => {
-	if (myAiButton.state !== "generating") {
+	if (myAiButton.state === "generating") {
+		myAiButton.state = "regenerate";
+		stopTextGeneration();
+		return;
+	}
+
+	if (skipDialog) {
+		startGenerationHandler();
+	} else {
 		toggleDialog(dialog, true);
 	}
 });
 
 document.getElementById("dialogProceed").addEventListener("click", () => {
+	if (checkbox.checked) {
+		skipDialog = true;
+	}
 	toggleDialog(dialog, false);
 	startGenerationHandler();
 });
@@ -131,10 +143,3 @@ const typeText = (text, output) => {
 		generationIntervals.push(interval);
 	});
 };
-
-myAiButton.addEventListener("click", () => {
-	if (myAiButton.state === "generating") {
-		myAiButton.state = "regenerate";
-		stopTextGeneration();
-	}
-});

--- a/packages/website/docs/_samples/patterns/AIRegenerate/Basic/sample.html
+++ b/packages/website/docs/_samples/patterns/AIRegenerate/Basic/sample.html
@@ -68,7 +68,7 @@
 			Regenerating will overwrite all fields with AI-generated content.<br>
 			Do you wish to proceed?
 		</ui5-text>
-		<ui5-checkbox style="margin-inline-start: -0.625rem;" text="Don't show this message again"></ui5-checkbox>
+		<ui5-checkbox id="checkbox" style="margin-inline-start: -0.625rem;" text="Don't show this message again"></ui5-checkbox>
 		<div slot="footer" class="dialog-footer">
 			<ui5-button design="Emphasized" id="dialogProceed">Proceed</ui5-button>
 			<ui5-button id="dialogCloser">Cancel</ui5-button>


### PR DESCRIPTION
Previously, in our AI Regenerate pattern sample, the dialog notifying users that fields would be regenerated with AI-generated content continued to appear every time someone clicked the "Regenerate" button—even when the corresponding checkbox was selected.

With this change, the checkbox selection is being taken into account and no longer displays the dialog repeatedly.

### Before
![2025-01-29_09-39-49](https://github.com/user-attachments/assets/89e2c095-1257-4905-b27c-df794e1de717)

### After
![2025-01-29_09-40-07](https://github.com/user-attachments/assets/6fd3c116-8e54-49e3-bc5a-10d7bc404d85)


