### PR TITLE
fix(ui5-file-uploder): match focus correctly with screen readers

### DIFF
--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -257,7 +257,7 @@ class FileUploader extends UI5Element implements IFormInputElement {
 	}
 
 	_onclick() {
-		if (this.getFocusDomRef()?.matches(":has(:focus-within)")) {
+		if (this.getFocusDomRef()?.matches(":focus-within")) {
 			this._input.click();
 		}
 	}


### PR DESCRIPTION
Previously, when using screen reader with `ui5-file-uploader` with attribute `hide-input` set to `true`, the check 
`this.getFocusDomRef().matches(":has(:focus-within)")` on our `_onclick()` event handler was falsy when the component was being focused with screen reader ON, preventing the `click` event from happening.

The reason may be that with the screen reader on, focus is **most likely** landing on the parent element itself (not on a child), which breaks the `:has(:focus-within)` check.

The `:has(:focus-within)` checks - "does this element contain at least one child that is `:focus-within`", which excludes the parent itself causing the check to be falsy in those scenarios.

With this change, the `element.matches(":focus-within")` checks -"Is this element or any of its children focused?" which fixes the problem, and checks correctly which is the focused item, triggering the `click` event as expected even with screen reader ON.

Tested with JAWS.

Fixes: #10656