### PR TITLE
docs(ui5-ai-button): change split mode label in the sample

### DIFF
--- a/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/main.js
+++ b/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/main.js
@@ -11,7 +11,7 @@ function startGeneration(button) {
 	console.warn("startGeneration");
 	generationId = setTimeout(function() {
 		console.warn("Generation completed");
-		button.state = "revise";
+		button.state = "regenerate";
 	}, 3000);
 }
 
@@ -34,9 +34,9 @@ function aiButtonClickHandler(evt) {
 			button.state = prevTriggerState;
 			stopGeneration();
 			break;
-		case "revise":
+		case "regenerate":
 			menu.open = false;
-			prevTriggerState = "revise";
+			prevTriggerState = "regenerate";
 			button.state = "generating";
 			startGeneration(button);
 			break;
@@ -53,7 +53,7 @@ function aiButtonArrowClickHandler(evt) {
 function menuItemClickHandler(evt) {
 	var button = menu.opener;
 
-	prevTriggerState = "revise";
+	prevTriggerState = "regenerate";
 	button.state = "generating";
 	startGeneration(button);
 }

--- a/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/sample.html
+++ b/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/sample.html
@@ -14,7 +14,7 @@
 		<ui5-ai-button id="myAiButton" state="generate">
 			<ui5-ai-button-state name="generate" text="Generate" icon="ai"></ui5-ai-button-state>
 			<ui5-ai-button-state name="generating" text="Stop Generating" icon="stop"></ui5-ai-button-state>
-			<ui5-ai-button-state name="revise" text="Revise" icon="ai" show-arrow-button></ui5-ai-button-state>
+			<ui5-ai-button-state name="regenerate" text="Regenerate" icon="ai" show-arrow-button></ui5-ai-button-state>
 		</ui5-ai-button>
 
 		<ui5-menu id="menu">


### PR DESCRIPTION
There is a recommendation from AI topics design team to change the label of one state of AI button in split button mode sample from 'Revise' to 'Regenerate'.

![image](https://github.com/user-attachments/assets/7734a4ee-c9e8-4b46-b32f-aeb704490984)
