### PR TITLE
chore(ui5-side-navigation): skip unstable test

### DIFF
--- a/packages/fiori/cypress/specs/SideNavigation.cy.ts
+++ b/packages/fiori/cypress/specs/SideNavigation.cy.ts
@@ -125,7 +125,7 @@ describe("Side Navigation interaction", () => {
 		cy.get("#item1").should("not.have.attr", "expanded");
 	});
 
-	it("Tests expanding and collapsing of unselectable items with Space and Enter", () => {
+	it.skip("Tests expanding and collapsing of unselectable items with Space and Enter", () => {
 		cy.mount(html`
 			<ui5-side-navigation>
 				<ui5-side-navigation-item id="focusStart" text="focus start"></ui5-side-navigation-item>


### PR DESCRIPTION
This test failed many times today in different PRs.

Skipping temporarily.

<img width="919" alt="image" src="https://github.com/user-attachments/assets/3192b3fe-e178-49f4-b687-2f3339d93f05" />
