### PR TITLE
docs: fix theme switch in website

### DIFF
--- a/packages/website/src/components/Editor/playground-support.js
+++ b/packages/website/src/components/Editor/playground-support.js
@@ -26,11 +26,11 @@ const loadThemeProperties = async (themeName) => {
 };
 const loadAndCheck = async (themeName) => {
     const data = await loadThemeProperties(themeName);
+    debugger;
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }
-    const result = {_:data}
-    return result;
+    return data;
 };
 
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
@@ -54,8 +54,7 @@ const loadAndCheckFiori = async (themeName) => {
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }
-    const result = {_:data}
-    return result;
+    return data;
 };
 
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
@@ -80,8 +79,7 @@ const loadAndCheckCompat = async (themeName) => {
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }
-    const result = {_:data}
-    return result;
+    return data;
 };
 
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
@@ -108,8 +106,7 @@ const loadAndCheckAI = async (themeName) => {
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }
-    const result = {_:data}
-    return result;
+    return data;
 };
 
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
@@ -134,7 +131,7 @@ const loadAndCheck2 = async (themeName) => {
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }
-    return {_:data};
+    return data;
 };
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
     .forEach(themeName => registerThemePropertiesLoader("@ui5/webcomponents-theming", themeName, loadAndCheck2));

--- a/packages/website/src/components/Editor/playground-support.js
+++ b/packages/website/src/components/Editor/playground-support.js
@@ -26,7 +26,7 @@ const loadThemeProperties = async (themeName) => {
 };
 const loadAndCheck = async (themeName) => {
     const data = await loadThemeProperties(themeName);
-    debugger;
+    
     if (typeof data === "string" && data.endsWith(".json")) {
         throw new Error("error");
     }


### PR DESCRIPTION
Documentation samples don't display correctly in any theme other than Horizon light. Upon loading via getThemeProperties, the website loaders used to respond with the old format {_: stylesData } (removed with https://github.com/SAP/ui5-webcomponents/pull/10368), which led to wrong creation of the adopted stylesheets

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10607