### PR TITLE
docs: remove new default main file if shared/save project has an old default main file

### DIFF
--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -270,8 +270,10 @@ ${fixAssetPaths(_js)}`,
         try {
           const savedConfig = JSON.parse(savedProject);
           savedConfig["index.html"].content = addHeadContent(fixAssetPaths(savedConfig["index.html"].content));
-          if (savedConfig["main.js"] && newConfig.files["main.ts"]) {
-            delete newConfig.files["main.ts"];
+          const oldMainFile = savedConfig["main.js"] || savedConfig["main.ts"];
+          if (oldMainFile && newConfig.files["main.tsx"]) {
+            // if the saved project has a main from an old default, and the default project has a main.tsx file, restore the saved one
+            delete newConfig.files["main.tsx"];
           }
           newConfig.files = {...newConfig.files, ...savedConfig};
         } catch (e) {
@@ -285,8 +287,10 @@ ${fixAssetPaths(_js)}`,
       try {
         const sharedConfig = JSON.parse(decodeFromBase64(location.hash.replace("#", "")));
         sharedConfig["index.html"].content = addHeadContent(fixAssetPaths(sharedConfig["index.html"].content));
-        if (sharedConfig["main.js"] && newConfig.files["main.ts"]) {
-          delete newConfig.files["main.ts"];
+        const oldMainFile = sharedConfig["main.js"] || sharedConfig["main.ts"];
+        if (oldMainFile && newConfig.files["main.tsx"]) {
+            // if the shared project has a main from an old default, and the default project has a main.tsx file, restore the saved one
+          delete newConfig.files["main.tsx"];
         }
         newConfig.files = {...newConfig.files, ...sharedConfig};
       } catch (e) {


### PR DESCRIPTION
opening the playground for the first time loads a project with a `main.tsx` file and stores it in localStorage

## Issue 1 - localStorage
if the playground is opened and there was an old `main.js` or `main.ts` file stored from the old template default, then the new one has to be removed, otherwise two files show up

## Issue 2 - share link
if the playground is opened via a share link (from the samples for example), then both `main.ts` and `main.tsx` exist and the sample is broken until `main.tsx` is removed.

this change fixes the both issues.