### PR TITLE
fix(ui5-select): improved custom value state click behavior

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -400,6 +400,10 @@ class Select extends UI5Element implements IFormInputElement {
 		}
 	}
 
+	_applyFocus() {
+		this.focus();
+	}
+
 	_onfocusin() {
 		this.focused = true;
 	}

--- a/packages/main/src/SelectPopoverTemplate.tsx
+++ b/packages/main/src/SelectPopoverTemplate.tsx
@@ -99,7 +99,7 @@ function valueStateMessage(this: Select) {
 		<>
 			{this.shouldDisplayDefaultValueStateMessage
 				? this.valueStateText
-				: <slot name="valueStateMessage"></slot>
+				: <slot onClick={this._applyFocus} name="valueStateMessage"></slot>
 			}
 		</>
 	);


### PR DESCRIPTION
We can now navigate through Select's options with arrow keys after clicking custom value state message slot.

Fixes: #10661
