### PR TITLE
fix(framework): improve check for native popovers

### DIFF
--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -26,11 +26,22 @@ const closeNativePopover = (domRef: HTMLElement) => {
 	}
 };
 
+const isNativePopoverOpen = (root: Document | ShadowRoot = document): boolean => {
+	if (root.querySelector(":popover-open")) {
+		return true;
+	}
+
+	return Array.from(root.querySelectorAll("*")).some(element => {
+		const shadowRoot = element.shadowRoot;
+		return shadowRoot && isNativePopoverOpen(shadowRoot);
+	});
+};
+
 const patchOpen = (Popup: OpenUI5Popup) => {
 	const origOpen = Popup.prototype.open;
 	Popup.prototype.open = function open(...args: any[]) {
 		origOpen.apply(this, args); // call open first to initiate opening
-		const topLayerAlreadyInUse = !!document.body.querySelector(":popover-open"); // check if there is already something in the top layer
+		const topLayerAlreadyInUse = isNativePopoverOpen();
 		const openingInitiated = ["OPENING", "OPEN"].includes(this.getOpenState());
 		if (openingInitiated && topLayerAlreadyInUse) {
 			const element = this.getContent();


### PR DESCRIPTION
Currently, `patchPopup.ts` checks for open native popovers in the body only, which is incorrect. It should check inside shadow roots as well.

closes: https://github.com/SAP/ui5-webcomponents/issues/10740