### PR TITLE
 chore: mount JSX only once in tests

### DIFF
--- a/packages/tools/components-package/cypress/support/component.d.ts
+++ b/packages/tools/components-package/cypress/support/component.d.ts
@@ -6,7 +6,7 @@ export interface MountUI5Options extends MountLitTemplateOptions {
 	ui5Configuration: object;
 }
 export type MountOptions = Partial<MountUI5Options>;
-export declare function mount<T extends keyof HTMLElementTagNameMap = any>(component: JSX.Element, options?: MountOptions): Cypress.Chainable<JQuery<HTMLElementTagNameMap[T]>>;
+export declare function mount(component: JSX.Element, options?: MountOptions): CypressChainable<JQuery<HTMLElement>>;
 declare global {
 	namespace Cypress {
 		interface Chainable {

--- a/packages/tools/components-package/cypress/support/component.js
+++ b/packages/tools/components-package/cypress/support/component.js
@@ -22,23 +22,24 @@ function mount(component, options = {}) {
 	applyConfiguration(options);
 
 	// Mount JSX Element
-	return cy.wrap({ preactMount })
-		.invoke("preactMount", component, container)
-		.then(() => {
-			cy.get(container)
-				.find("*")
-				.should($el => {
-					const shadowrootsExist = [...$el].every(el => {
-						if (el.tagName.includes("-") && el.shadowRoot) {
-							return el.shadowRoot.hasChildNodes();
-						}
+	preactMount(null, container); // clean content in order to prevent preact from just updating it.
+	preactMount(component, container);
 
-						return true;
-					})
+	cy.get(container)
+	.find("*")
+	.should($el => {
+		const shadowrootsExist = [...$el].every(el => {
+			if (el.tagName.includes("-") && el.shadowRoot) {
+				return el.shadowRoot.hasChildNodes();
+			}
 
-					expect(shadowrootsExist, "Custom elements with shadow DOM have content in their shadow DOM").to.be.true;
-				})
-		});
+			return true;
+		})
+
+		expect(shadowrootsExist, "Custom elements with shadow DOM have content in their shadow DOM").to.be.true;
+	})
+
+	return cy.get(container);
 }
 
 setupHooks(cleanup);

--- a/packages/tools/components-package/cypress/support/component.js
+++ b/packages/tools/components-package/cypress/support/component.js
@@ -22,7 +22,6 @@ function mount(component, options = {}) {
 	applyConfiguration(options);
 
 	// Mount JSX Element
-	preactMount(null, container); // clean content in order to prevent preact from just updating it.
 	preactMount(component, container);
 
 	cy.get(container)


### PR DESCRIPTION
In the previous solution, the mount function was executed twice because the invoke function runs once for each chainer it contains.