### PR TITLE
fix(ui5-button): remove tap highlight on safari

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -21,6 +21,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	-webkit-tap-highlight-color: transparent;
 }
 
 .ui5-button-root {


### PR DESCRIPTION
Before:
When you click on button on mobile in safari, there was a gray rectangle appearing on touch end.


https://github.com/user-attachments/assets/40450726-eb4d-4122-9a70-7c3355dbc08f

After:

https://github.com/user-attachments/assets/0385a6a9-0b28-450a-80d5-8dcbfd78b7c8


fixes: https://github.com/SAP/ui5-webcomponents/issues/10777
