### PR TITLE
fix(ui5-flexible-column-layout): correct focus outline styles

### DIFF
--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -45,11 +45,12 @@
 	border-inline-end: var(--_ui5_fcl_column_border);
 	position: relative;
 	box-sizing: border-box;
+	z-index: 1;
 }
 
-.ui5-fcl-separator:focus {
-	border:var(--_ui5_fcl_separator_focus_border);
-	outline: none;
+.ui5-fcl-separator:focus { 
+	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+	outline-offset: calc(-1 * var(--sapContent_FocusWidth));
 }
 
 .ui5-fcl-grip {

--- a/packages/fiori/src/themes/base/FlexibleColumnLayout-parameters.css
+++ b/packages/fiori/src/themes/base/FlexibleColumnLayout-parameters.css
@@ -3,5 +3,4 @@
 	--_ui5_fcl_column_border: none;
 	--_ui5_fcl_decoration_top: linear-gradient(to top, var(--sapHighlightColor), transparent);
 	--_ui5_fcl_decoration_bottom: linear-gradient(to bottom, var(--sapHighlightColor), transparent);
-	--_ui5_fcl_separator_focus_border: 0.125rem solid var(--sapContent_FocusColor); 
 }


### PR DESCRIPTION
 - Problem:
. High Contrast Black/White themes had missing focus indicators
. The CSS parameter --_ui5_fcl_separator_focus_border was undefined when switching to High Contrast themes (HCB/HCW)

 - Solution:
 . Replaced border-based focus with outline and adjusted offset to ensure proper focus visualization across all themes
 
Fixes: [#10670](https://github.com/SAP/ui5-webcomponents/issues/10670)