### PR TITLE
chore(ui5-select): remove unused css vars

### DIFF
--- a/packages/main/src/themes/base/Select-parameters.css
+++ b/packages/main/src/themes/base/Select-parameters.css
@@ -1,9 +1,4 @@
 :root {
-	--_ui5_select_disabled_background: var(--sapField_Background);
-	--_ui5_select_disabled_border_color: var(--sapField_BorderColor);
-	--_ui5_select_state_error_warning_border_style: solid;
-	--_ui5_select_state_error_warning_border_width: 0.125rem;
 	--_ui5_select_hover_icon_left_border: 1px solid transparent;
-	--_ui5_select_focus_width: 1px;
 	--_ui5_select_label_color: var(--sapField_TextColor);
 }

--- a/packages/main/src/themes/sap_fiori_3_hcb/Select-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Select-parameters.css
@@ -1,10 +1,5 @@
 @import "../base/Select-parameters.css";
 
 :root {
-	--_ui5_select_disabled_background: var(--sapHC_ReducedBackground);
-	--_ui5_select_disabled_border_color: var(--sapHC_ReducedForeground);
-	--_ui5_select_state_error_warning_border_style: dashed;
-	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/Select-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Select-parameters.css
@@ -1,10 +1,5 @@
 @import "../base/Select-parameters.css";
 
 :root {
-	--_ui5_select_disabled_background: var(--sapHC_ReducedBackground);
-	--_ui5_select_disabled_border_color: var(--sapHC_ReducedForeground);
-	--_ui5_select_state_error_warning_border_style: dashed;
-	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Select-parameters.css
@@ -1,10 +1,5 @@
 @import "../base/Select-parameters.css";
 
 :root {
-	--_ui5_select_disabled_background: var(--sapHC_ReducedBackground);
-	--_ui5_select_disabled_border_color: var(--sapHC_ReducedForeground);
-	--_ui5_select_state_error_warning_border_style: dashed;
-	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_focus_width: 0.125rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Select-parameters.css
@@ -1,10 +1,5 @@
 @import "../base/Select-parameters.css";
 
 :root {
-	--_ui5_select_disabled_background: var(--sapHC_ReducedBackground);
-	--_ui5_select_disabled_border_color: var(--sapHC_ReducedForeground);
-	--_ui5_select_state_error_warning_border_style: dashed;
-	--_ui5_select_state_error_warning_border_width: 1px;
 	--_ui5_select_hover_icon_left_border: 0.0625rem solid var(--sapField_Hover_BorderColor);
-	--_ui5_select_focus_width: 0.125rem;
 }


### PR DESCRIPTION
The Select component is reusing the input styles, there were still some vars which were not removed.