### PR TITLE
fix(ui5-switch): remove delegate focus of switch

### DIFF
--- a/packages/main/src/Switch.ts
+++ b/packages/main/src/Switch.ts
@@ -55,7 +55,7 @@ import switchCss from "./generated/themes/Switch.css.js";
 	styles: switchCss,
 	renderer: jsxRenderer,
 	template: SwitchTemplate,
-	shadowRootOptions: { delegatesFocus: true },
+	// shadowRootOptions: { delegatesFocus: true },
 })
 /**
  * Fired when the component checked state changes.

--- a/packages/main/src/themes/Switch.css
+++ b/packages/main/src/themes/Switch.css
@@ -3,7 +3,6 @@
 
 :host(:not([hidden])) {
 	display: inline-block;
-	pointer-events: none;
 }
 
 .ui5-switch-root {
@@ -16,7 +15,6 @@
 	cursor: pointer;
 	outline: none;
 	border-radius: var(--_ui5-switch-root-border-radius);
-	pointer-events: all;
 }
 
 .ui5-switch-root:not(.ui5-switch--no-label):not(.ui5-switch--semantic) {


### PR DESCRIPTION
With change #10588 we addressed an issue, where the focus was being applied even if the root of the element (the touch area) was not clicked/touched, by removing the pointer events on host level.

However this would've caused issues within cypress testing.

To address the issue without breaking the cypress tests, we now remove the `delegateFocus` option, from the `shadowRootOptions`. By removing focus delegation, we stopped the automatic forwarding of focus. Now, only an explicit click on the focusable inner element results in it receiving focus. This change aligns the component’s behavior with your intent: the switch is only focused when its interactive area is clicked, not merely because the host received a focus event.

Fixes: #10773