### PR TITLE
fix(ui5-button): remove tap highlight on safari

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -21,6 +21,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	-webkit-tap-highlight-color: transparent;
 }
 
 .ui5-button-root {


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-webcomponents/issues/10777

downport of: https://github.com/SAP/ui5-webcomponents/pull/10786