### PR TITLE
[V1] feat: Export `BarDesign` enum

### DIFF
--- a/packages/main/src/types/BarDesign.ts
+++ b/packages/main/src/types/BarDesign.ts
@@ -1,0 +1,31 @@
+/**
+ * Different types of Bar design
+ * @public
+ */
+enum BarDesign {
+	/**
+	 * Default type
+	 * @public
+	 */
+	Header = "Header",
+
+	/**
+	 * Subheader type
+	 * @public
+	 */
+	Subheader = "Subheader",
+
+	/**
+	 * Footer type
+	 * @public
+	 */
+	Footer = "Footer",
+
+	/**
+	 * Floating Footer type - there is visible border on all sides
+	 * @public
+	 */
+	FloatingFooter = "FloatingFooter",
+}
+
+export default BarDesign;


### PR DESCRIPTION
In V2, the `BarDesign` enum is exported. In V1, it isn't. To better prepare for the update, it would help us a lot if it was so we can migrate our imports from UI5WC4R to UI5WC.

FYI: Your PR message placeholder contains a dead link:

- [ ] Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

Thanks!
