### PR TITLE
chore: create and connect all main components to test jsdom support

### DIFF
--- a/packages/main/src/bundle.esm.ts
+++ b/packages/main/src/bundle.esm.ts
@@ -18,6 +18,7 @@ import icon3d from "@ui5/webcomponents-icons-business-suite/dist/3d.js";
 import icon3dv1 from "@ui5/webcomponents-icons-business-suite/dist/v1/3d.js";
 import icon3dv2 from "@ui5/webcomponents-icons-business-suite/dist/v2/3d.js";
 import generateHighlightedMarkup from "@ui5/webcomponents-base/dist/util/generateHighlightedMarkup.js";
+import { getAllRegisteredTags } from "@ui5/webcomponents-base/dist/CustomElementsRegistry.js";
 
 // The SAP Icons V4 icon collection is set by default in sap_fiori_3,
 // but it's configurable:
@@ -125,6 +126,7 @@ const testAssets = {
 	getAcceptIconPathData: getPathData,
 	generateHighlightedMarkup,
 	getExportedIconsValues: () => icons,
+	getAllRegisteredTags,
 };
 
 registerIconLoader("my-icons", () => {

--- a/packages/main/test/unit/vitest.test.js
+++ b/packages/main/test/unit/vitest.test.js
@@ -7,7 +7,7 @@ import testAssets from "@ui5/webcomponents/dist/bundle.esm.js";
 
 test('ui5-button should be a real web component instance', () => {
   const button = document.createElement("ui5-button");
-  // document.body.appendChild(button);
+  document.body.appendChild(button);
   expect(button).toBeTruthy();
   expect(button.constructor.getMetadata().getTag()).toBe("ui5-button");
 

--- a/packages/main/test/unit/vitest.test.js
+++ b/packages/main/test/unit/vitest.test.js
@@ -3,14 +3,26 @@
 import { expect, test } from 'vitest'
 import "@ui5/webcomponents/dist/Button.js";
 import "@ui5/webcomponents/dist/Dialog.js";
+import testAssets from "@ui5/webcomponents/dist/bundle.esm.js";
 
 test('ui5-button should be a real web component instance', () => {
   const button = document.createElement("ui5-button");
+  // document.body.appendChild(button);
   expect(button).toBeTruthy();
   expect(button.constructor.getMetadata().getTag()).toBe("ui5-button");
 
+});
+test('ui5-dialog can be opened (popover works)', () => {
   const dialog = document.createElement("ui5-dialog");
   document.body.appendChild(dialog);
   dialog.open = true;
   expect(dialog).toBeTruthy();
+});
+
+test('all registered tags from `main` should be created and appended in document ', () => {
+  testAssets.getAllRegisteredTags().forEach(tag => {
+    const el = document.createElement(tag);
+    document.body.appendChild(el);
+    expect(el).toBeTruthy();
+  })
 })


### PR DESCRIPTION
Basic jsdom support was added with https://github.com/SAP/ui5-webcomponents/pull/10606

Later, a bug was found in the `ui5-button` which was using some non-existent functionality (fixed with https://github.com/SAP/ui5-webcomponents/pull/10782)

This change adds a smoke test that will run for all components from the `main` package by doing the following for each registered tag in the bundle:
```ts
// step 1 - it should be possible to create every element
const el = document.createElement(tag);
// step 2 - adding it in the document should not fail (connectedCallback and render)
document.body.appendChild(el)
```