### PR TITLE
docs: fix TimelineGrowingMode enum docs

### DIFF
--- a/packages/fiori/src/types/TimelineGrowingMode.ts
+++ b/packages/fiori/src/types/TimelineGrowingMode.ts
@@ -1,3 +1,8 @@
+/**
+ * Timeline growing modes.
+ * @public
+ * @since 2.7.0
+ */
 enum TimelineGrowingMode {
 	/**
 	 * Event `load-more` is fired


### PR DESCRIPTION
The TimelineGrowingMode enum was lacking the public tag and some data in the custom-element manifest was missing.
The UI5 Web Components for Angular tooling is using it and depends on it to generate properly the UI5 Web Components wrappers.