### PR TITLE
chore(ui5-multi-cbx): apply icon pressed styles

### DIFF
--- a/packages/main/src/MultiComboBoxTemplate.tsx
+++ b/packages/main/src/MultiComboBoxTemplate.tsx
@@ -101,7 +101,10 @@ export default function MultiComboBoxTemplate(this: MultiComboBox) {
 
 			{!this.readonly &&
 				<Icon name="slim-arrow-down"
-					class="inputIcon"
+					class={{
+						"inputIcon": true,
+						"inputIcon--pressed": this._iconPressed,
+					}}
 					slot="icon"
 					tabIndex={-1}
 					onClick={this.togglePopoverByDropdownIcon}


### PR DESCRIPTION
This is the Combo
<img width="558" alt="Screenshot 2025-02-11 at 11 59 50" src="https://github.com/user-attachments/assets/ff564721-6c3e-430c-b7f1-dafb159a91c6" />

This is the Select
<img width="305" alt="Screenshot 2025-02-11 at 11 59 56" src="https://github.com/user-attachments/assets/7eeb26c8-179e-4156-817d-67302d8097b7" />

And this is the Multi prior the current change:
<img width="696" alt="Screenshot 2025-02-11 at 12 00 15" src="https://github.com/user-attachments/assets/7373da5e-862c-415c-8a67-0fb40ece987f" />

Although the Select and the Combo are also behind the latest specs (see this [issue](https://github.com/SAP/ui5-webcomponents/issues/10819)) and the icon pressed state seems to be changed, still the Multi does not get any icon styling and this is now corrected. Once the shared InputIcon styles is updated, all components with input and icon will get it - including the MultiComboBox.


For now, this is the Multi with the change (its icon pressed state looks like the Combo and the Select):
<img width="616" alt="Screenshot 2025-02-11 at 12 03 32" src="https://github.com/user-attachments/assets/cddee25a-86c1-4bdb-94d1-21eb09055735" />
