### PR TITLE
chore: correct generation of events in cem

### DIFF
--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -127,7 +127,7 @@ function processClass(ts, classNode, moduleDoc) {
 	}
 
 	// Events
-	currClass.events = findAllDecorators(classNode, "event")
+	currClass.events = findAllDecorators(classNode, ["event", "eventStrict"])
 		?.map(event => processEvent(ts, event, classNode, moduleDoc));
 
 	// TODO: remove after changing Button's click to custom event.

--- a/packages/tools/lib/cem/utils.mjs
+++ b/packages/tools/lib/cem/utils.mjs
@@ -263,12 +263,22 @@ const findDecorator = (node, decoratorName) => {
 };
 
 const findAllDecorators = (node, decoratorName) => {
-    return (
-        node?.decorators?.filter(
-            (decorator) =>
-                decorator?.expression?.expression?.text === decoratorName
-        ) || []
-    );
+    if (typeof decoratorName === "string") {
+        return node?.decorators?.filter(decorator => decorator?.expression?.expression?.text === decoratorName ) || [];
+    }
+
+    if (Array.isArray(decoratorName)) {
+        return node?.decorators?.filter(decorator => {
+                if (decorator?.expression?.expression?.text) {
+                    return decoratorName.includes(decorator.expression.expression.text);
+                }
+
+                return false;
+            }
+        ) || [];
+    }
+
+    return [];
 };
 
 const hasTag = (jsDoc, tagName) => {


### PR DESCRIPTION
TypeScript decorators can be imported in two ways:  
- **Default import** from `@ui5/webcomponents-base/dist/decorators/{decoratorName}.js`  
- **Named import** from `@ui5/webcomponents-base/dist/decorators.js`  

Recently, the `event.js` decorator was deprecated and replaced with `event-strict.js`. When using the default import, the decorator could retain its old name, and the custom element analyzer would still process it correctly. However, when using the named import, the `@eventStrict` decorator was not processed, leading to missing parts of the component's API.  

This PR adjusts the custom element analyzer to correctly process both `@event` and `@eventStrict` decorators.  