### PR TITLE
refactor(ui5-select): stop  bubbling of the `open` event

### DIFF
--- a/packages/main/cypress/specs/base/Events.cy.tsx
+++ b/packages/main/cypress/specs/base/Events.cy.tsx
@@ -222,7 +222,7 @@ describe("Event bubbling", () => {
 
 		// assert - the open event of the MultiComboBox do not bubble
 		cy.get("@mcbOpened").should("have.been.calledOnce");
-		cy.get("@dialogOpened").should("have.been.calledTwice");
+		cy.get("@dialogOpened").should("have.been.calledOnce");
 
 		cy.get("@multiComboboxIcon")
 			.realClick();

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -168,9 +168,7 @@ type SelectLiveChangeEventDetail = {
  * Fired after the component's dropdown menu opens.
  * @public
  */
-@event("open", {
-	bubbles: true,
-})
+@event("open")
 
 /**
  * Fired after the component's dropdown menu closes.


### PR DESCRIPTION
Stop bubbling of the open event as it causes issues when the Select is used inside Dialog.
It's likely for consumers to listen for the Select's open on the Select level, not on a parent of the Select.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10422