### PR TITLE
chore(ui5-input): fix failing tests

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1234,7 +1234,6 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	_handlePickerAfterOpen() {
-		this.Suggestions?._onOpen();
 		this.fireDecoratorEvent("open");
 	}
 

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -268,18 +268,8 @@ class Suggestions {
 		this.onItemSelected(pressedItem as SuggestionItem, false /* keyboardUsed */);
 	}
 
-	_onOpen() {
-		this._applyFocus();
-	}
-
 	_onClose() {
 		this._handledPress = false;
-	}
-
-	_applyFocus() {
-		if (this.selectedItemIndex) {
-			this._getItems()[this.selectedItemIndex]?.focus();
-		}
 	}
 
 	_isItemOnTarget() {


### PR DESCRIPTION
There was some legacy code mistakenly left in the Input Suggestions, which previously caused items to receive focus (as was the case with non-physical items). This should no longer happen, and only a fake focus should now be applied to the Input Suggestions.

FIXES: #10830