### PR TITLE
fix(ui5-avatar): fix acc-name announcement

### DIFF
--- a/packages/main/cypress/specs/Avatar.cy.tsx
+++ b/packages/main/cypress/specs/Avatar.cy.tsx
@@ -1,4 +1,5 @@
 import Avatar from "../../src/Avatar.js";
+import "@ui5/webcomponents-icons/dist/supplier.js";
 
 describe("Accessibility", () => {
 	it("checks if initials of avatar are correctly announced", () => {
@@ -14,5 +15,19 @@ describe("Accessibility", () => {
 			.shadow()
 			.find(".ui5-avatar-root")
 			.should("have.attr", "aria-label", expectedLabel);
+	});
+
+	it("checks if accessible-name is correctly passed to the icon", () => {
+		const ACCESSIBLE_NAME = "Supplier Icon";
+		const ICON_NAME = "supplier";
+
+		cy.mount(<Avatar id="avatar-with-icon" icon={ICON_NAME} accessible-name={ACCESSIBLE_NAME}></Avatar>);
+
+		cy.get("#avatar-with-icon")
+			.shadow()
+			.find("ui5-icon")
+			.shadow()
+			.find("svg")
+			.should("have.attr", "aria-label", ACCESSIBLE_NAME);
 	});
 });

--- a/packages/main/src/AvatarTemplate.tsx
+++ b/packages/main/src/AvatarTemplate.tsx
@@ -18,7 +18,7 @@ export default function AvatarTemplate(this: Avatar) {
 				<slot></slot>
 				:
 				<>
-					{ this.icon && <Icon class="ui5-avatar-icon" name={this.icon}></Icon> }
+					{ this.icon && <Icon class="ui5-avatar-icon" name={this.icon} accessibleName={this.accessibleName}></Icon> }
 
 					{ this.initials &&
 					<>


### PR DESCRIPTION
Now, when the `ui5-avatar` is used with an icon, its accessible-name is correctly set at the SVG level, ensuring proper announcement.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10461