### PR TITLE
fix(framework): allow usage of events with any name not only kebab-case

### DIFF
--- a/packages/base/cypress/specs/Events.cy.tsx
+++ b/packages/base/cypress/specs/Events.cy.tsx
@@ -1,0 +1,28 @@
+import EventsConsumer from "../../test/test-elements/Events.js";
+import type { Events } from "../../test/test-elements/Events.js";
+
+describe("Event provider attaches and detaches listeners properly", () => {
+	it("Tests that attaching camelCase and kebab-case events in templates works", () => {
+		cy.mount(<EventsConsumer></EventsConsumer>);
+		cy.get<EventsConsumer>("[ui5-test-events-consumer]")
+			.as("eventsConsumer");
+
+		cy.get("@eventsConsumer")
+			.shadow()
+			.find("[ui5-test-events]")
+			.then(elements => {
+				(elements[0] as Events).fireKebaCaseEvent();
+			});
+		cy.get("@eventsConsumer")
+			.should("have.prop", "kebabCaseFired", true);
+
+		cy.get("@eventsConsumer")
+			.shadow()
+			.find("[ui5-test-events]")
+			.then(elements => {
+				(elements[0] as Events).fireCamelCaseEvent();
+			});
+		cy.get("@eventsConsumer")
+			.should("have.prop", "camelCaseFired", true);
+	});
+});

--- a/packages/base/src/jsx-utils.ts
+++ b/packages/base/src/jsx-utils.ts
@@ -10,11 +10,19 @@ function convertEventScoping(type: typeof UI5Element, props: Record<string, any>
 			// Exteract the kebab-case event: onChange - change, onSelectionChange - selection-change, etc.
 			const pascalEvent = prop.slice("on".length);
 			const kebabCaseEvent = pascalToKebabCase(pascalEvent);
+			// Also support camelCase events
+			const camelCaseEvent = pascalEvent.charAt(0).toLowerCase() + pascalEvent.slice(1);
 
-			// Attach for the "ui5-" preffixed event
+			let origEvent: string | undefined;
 			if (kebabCaseEvent in events) {
+				origEvent = kebabCaseEvent;
+			} else if (camelCaseEvent in events) {
+				origEvent = camelCaseEvent;
+			}
+			// Attach for the "ui5-" preffixed event
+			if (origEvent) {
 				if ((prop !== "onClick")) {
-					props[`onui5-${kebabCaseEvent}`] = props[prop];
+					props[`onui5-${origEvent}`] = props[prop];
 					// TODO keep native events for now, find a way to mark them for runtime
 					delete props[prop];
 				}

--- a/packages/base/test/test-elements/Events.tsx
+++ b/packages/base/test/test-elements/Events.tsx
@@ -1,0 +1,60 @@
+import UI5Element from "../../src/UI5Element.js";
+import customElement from "../../src/decorators/customElement.js";
+import property from "../../src/decorators/property.js";
+import event from "../../src/decorators/event-strict.js";
+import jsxRenderer from "../../src/renderer/JsxRenderer.js";
+
+@customElement({
+	tag: "ui5-test-events",
+	renderer: jsxRenderer,
+})
+@event("kebab-case")
+@event("camelCase")
+export class Events extends UI5Element {
+	declare eventDetails: {
+		"kebab-case": void
+		"camelCase": void
+	}
+
+	fireKebaCaseEvent() {
+		this.fireDecoratorEvent("kebab-case");
+	}
+
+	fireCamelCaseEvent() {
+		this.fireDecoratorEvent("camelCase");
+	}
+
+	static get template() {
+		return () => {
+			return <div></div>;
+		};
+	}
+}
+
+Events.define();
+
+@customElement({
+	tag: "ui5-test-events-consumer",
+	renderer: jsxRenderer,
+})
+class EventsConsumer extends UI5Element {
+	@property()
+	kebabCaseFired = false;
+	@property()
+	camelCaseFired = false;
+
+	static get template() {
+		return function (this: EventsConsumer){
+			return (
+				<Events
+					onKebabCase={() => this.kebabCaseFired = true}
+					onCamelCase={() => this.camelCaseFired = true}
+				>
+				</Events>
+			);
+		};
+	}
+}
+EventsConsumer.define();
+
+export default EventsConsumer;


### PR DESCRIPTION
There are some assumptions in the code base that event names are `kebab-case`. This change adds support for `camelCase` event names

Event name: `token-delete` (kebap-case)
   fired events    |   TSX usage:    | subscribed event:
------------------ | --------------- | ------------------
`token-delete`     |                 |
`ui5-token-delete` | `onTokenDelete` | `ui5-token-delete`
`TokenDelete`      |                 |
`ui5-TokenDelete`  |                 |

In the table above, the subscribed event matches the declared event and is subscribed with the prefix so noConflict works

Event name: `tokenDelete` (camelCase)
|   fired events    |   TSX usage:    | subscribed event: |            |
| ----------------- | --------------- | ----------------- | ---------- |
| `tokenDelete`     |                 |                   |            |
| `ui5-tokenDelete` |                 |                   |            |
| `Tokendelete`***  |                 |                   |            |
| `ui5-Tokendelete` |                 |                   |            |
|                   | `onTokenDelete` | `TokenDelete`***  | Before Fix |
|                   | `onTokenDelete` | `ui5-tokenDelete` | After Fix  |

When JSX is processing events to add the event prefix, it needs to find the event in the metadata. In the above case, `onTokenDelete` becomes `token-delete` which does not match the event in the metadata `tokenDelete`

This makes the subscribed event `TokenDelete` instead of `ui5-tokenDelete` - no prefix
In addition, the fireted event `Tokendelete` does not match the subscribed event, so it doesn't even work without a suffix.

This change makes the event lookup from property name `onXXX` to event metadata try both kebab-case and camelCase conversions, so "After Fix" correctly finds `tokenDelete` and subscribes to it with the suffix `ui5-tokenDelete`

FIXES: #10866
