### PR TITLE
chore: add deprecation message in component pages

### DIFF
--- a/packages/main/src/TableHeaderCellActionAI.ts
+++ b/packages/main/src/TableHeaderCellActionAI.ts
@@ -19,6 +19,7 @@ import "@ui5/webcomponents-icons/dist/ai.js";
  * @extends TableHeaderCellActionBase
  * @since 2.8.0
  * @public
+ * @experimental
  */
 @customElement({ tag: "ui5-table-header-cell-action-ai" })
 

--- a/packages/main/src/TableRowAction.ts
+++ b/packages/main/src/TableRowAction.ts
@@ -9,6 +9,7 @@ import TableRowActionBase from "./TableRowActionBase.js";
  * @extends TableRowActionBase
  * @since 2.7.0
  * @public
+ * @experimental
  */
 @customElement({ tag: "ui5-table-row-action" })
 

--- a/packages/main/src/TableRowActionNavigation.ts
+++ b/packages/main/src/TableRowActionNavigation.ts
@@ -19,6 +19,7 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
  * @extends TableRowActionBase
  * @since 2.7.0
  * @public
+ * @experimental
  */
 @customElement({ tag: "ui5-table-row-action-navigation" })
 

--- a/packages/main/src/types/TableCellHorizontalAlign.ts
+++ b/packages/main/src/types/TableCellHorizontalAlign.ts
@@ -2,6 +2,7 @@
  * Alignment of the &lt;ui5-table-cell&gt; component.
  *
  * @public
+ * @experimental
  */
 enum TableCellHorizontalAlign {
     /**

--- a/packages/main/src/types/TableGrowingMode.ts
+++ b/packages/main/src/types/TableGrowingMode.ts
@@ -2,6 +2,7 @@
  * Growing mode of the &lt;ui5-table&gt; component.
  *
  * @public
+ * @experimental
  */
 enum TableGrowingMode {
 	/**

--- a/packages/main/src/types/TableOverflowMode.ts
+++ b/packages/main/src/types/TableOverflowMode.ts
@@ -2,6 +2,7 @@
  * Column mode of the &lt;ui5-table&gt; component.
  *
  * @public
+ * @experimental
  */
 enum TableOverflowMode {
 	/**

--- a/packages/main/src/types/TableSelectionMode.ts
+++ b/packages/main/src/types/TableSelectionMode.ts
@@ -2,6 +2,7 @@
  * Selection modes of the &lt;ui5-table&gt; component.
  *
  * @public
+ * @experimental
  */
 enum TableSelectionMode {
 	/**

--- a/packages/tools/lib/cem/utils.mjs
+++ b/packages/tools/lib/cem/utils.mjs
@@ -241,7 +241,7 @@ const allowedTags = {
     eventParam: [...commonTags],
     method: [...commonTags, "param", "returns", "override"],
     class: [...commonTags, "constructor", "class", "abstract", "experimental", "implements", "extends", "slot", "csspart"],
-    enum: [...commonTags],
+    enum: [...commonTags, "experimental",],
     enumMember: [...commonTags, "experimental",],
     interface: [...commonTags, "experimental",],
 };
@@ -264,17 +264,17 @@ const findDecorator = (node, decoratorName) => {
 
 const findAllDecorators = (node, decoratorName) => {
     if (typeof decoratorName === "string") {
-        return node?.decorators?.filter(decorator => decorator?.expression?.expression?.text === decoratorName ) || [];
+        return node?.decorators?.filter(decorator => decorator?.expression?.expression?.text === decoratorName) || [];
     }
 
     if (Array.isArray(decoratorName)) {
         return node?.decorators?.filter(decorator => {
-                if (decorator?.expression?.expression?.text) {
-                    return decoratorName.includes(decorator.expression.expression.text);
-                }
-
-                return false;
+            if (decorator?.expression?.expression?.text) {
+                return decoratorName.includes(decorator.expression.expression.text);
             }
+
+            return false;
+        }
         ) || [];
     }
 

--- a/packages/website/build-scripts/api-reference-generation/component-file.mjs
+++ b/packages/website/build-scripts/api-reference-generation/component-file.mjs
@@ -263,7 +263,11 @@ const parseDeclaration = (declaration, packageName) => {
 
     let sections = [];
 
-    if (declaration._ui5experimental) {
+    if (declaration.deprecated) {
+        sections.push(`:::warning
+${deprecatedText(declaration)}
+:::`)
+    } else if (declaration._ui5experimental) {
         sections.push(`:::info
 ${experimentalText(declaration)}
 :::`)
@@ -296,7 +300,10 @@ ${declaration._implementations.map(_implementation => `| ${_implementation.split
 
     let fileContent = sections.join("\n\n");
 
-    if (declaration._ui5experimental) {
+
+    if (declaration.deprecated) {
+        fileContent = addDeprecatedClassName(fileContent, declaration);
+    } else if (declaration._ui5experimental) {
         fileContent = addExperimentalClassName(fileContent, declaration);
     }
 
@@ -304,12 +311,16 @@ ${declaration._implementations.map(_implementation => `| ${_implementation.split
     return fileContent;
 }
 
-
-
 const experimentalText = declaration => {
-    return typeof declaration._ui5experimental === "boolean" ? 
+    return typeof declaration._ui5experimental === "boolean" ?
         "The following entity is available under an experimental flag and its API and behavior are subject to change."
         : declaration._ui5experimental;
+}
+
+const deprecatedText = declaration => {
+    return typeof declaration.deprecated === "boolean" ?
+        "The following entity is deprecated and will be removed in the next major version."
+        : declaration.deprecated;
 }
 
 
@@ -326,7 +337,15 @@ const parseComponentDeclaration = (declaration, fileContent) => {
         fileContent = enhanceFrontMatter(fileContent, "ui5_since", `${declaration._ui5since}`)
     }
 
-    if (declaration._ui5experimental) {
+    if (declaration.deprecated) {
+        fileContent = addDeprecatedClassName(fileContent, declaration);
+
+        fileContent = fileContent.replace("<%COMPONENT_OVERVIEW%>", `:::warning
+${deprecatedText(declaration)}
+:::
+
+${parseDeclarationDescription(declaration.description)}`)
+    } else if (declaration._ui5experimental) {
         fileContent = addExperimentalClassName(fileContent, declaration);
 
         fileContent = fileContent.replace("<%COMPONENT_OVERVIEW%>", `:::info
@@ -352,6 +371,25 @@ ${parseDeclarationDescription(declaration.description)}`)
 }
 
 const experimentalCssClass = "expComponentBadge";
+const deprecatedCssClass = "deprComponentBadge";
+
+const addDeprecatedClassName = (fileContent, declaration) => {
+    if (!declaration.deprecated) {
+        return fileContent;
+    }
+
+    const frontMatter = fileContent.match(/^---\n(?:.+\n)*---/);
+
+    if (!frontMatter) {
+        return `---
+sidebar_class_name: ${deprecatedCssClass}
+---
+
+${fileContent}`
+    }
+
+    return enhanceFrontMatter(fileContent, "sidebar_class_name", deprecatedCssClass)
+}
 
 const addExperimentalClassName = (fileContent, declaration) => {
     if (!declaration._ui5experimental) {
@@ -390,7 +428,7 @@ ${fileContent}`
     if (classLine && !hasExperimentalClass) {
         frontMatterLines[classLineIndex] = `${classLine} ${value}`;
     } else if (!classLine) {
-       frontMatterLines.splice(frontMatterLines.length - 1, 0, `${front_matter_name}: ${value}`);
+        frontMatterLines.splice(frontMatterLines.length - 1, 0, `${front_matter_name}: ${value}`);
     }
 
     return fileContent.replace(frontMatter[0], frontMatterLines.join("\n"));

--- a/packages/website/docs/_components_pages/ai/Button/Button.mdx
+++ b/packages/website/docs/_components_pages/ai/Button/Button.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../Button
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import ButtonMenu from "../../../_samples/ai/Button/ButtonMenu/ButtonMenu.md";

--- a/packages/website/docs/_components_pages/ai/Button/ButtonState.mdx
+++ b/packages/website/docs/_components_pages/ai/Button/ButtonState.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../ButtonState
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/ai/PromptInput.mdx
+++ b/packages/website/docs/_components_pages/ai/PromptInput.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/ai/PromptInput/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Table/Table.mdx
+++ b/packages/website/docs/_components_pages/main/Table/Table.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../Table
-sidebar_class_name: expComponentBadge
 ---
 
 import Basic from "../../../_samples/main/Table/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableCell.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableCell
-sidebar_class_name: expComponentBadge
 ---
 
 import HAlign from "../../../_samples/main/Table/HAlign/HAlign.md";

--- a/packages/website/docs/_components_pages/main/Table/TableGrowing.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableGrowing.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableGrowing
-sidebar_class_name: expComponentBadge
 ---
 
 import Growing from "../../../_samples/main/Table/Growing/Growing.md";

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableHeaderCell
-sidebar_class_name: expComponentBadge
 ---
 
 import Popin from "../../../_samples/main/Table/Popin/Popin.md";

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCellActionAI.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCellActionAI.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableHeaderCellActionAI
-sidebar_class_name: expComponentBadge
 ---
 
 import HeaderCellActionAI from "../../../_samples/main/Table/HeaderCellActionAI/HeaderCellActionAI.md";

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderRow.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderRow.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableHeaderRow
-sidebar_class_name: expComponentBadge
 ---
 
 import StickyHeader from "../../../_samples/main/Table/StickyHeader/StickyHeader.md";

--- a/packages/website/docs/_components_pages/main/Table/TableRow.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableRow.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableRow
-sidebar_class_name: expComponentBadge
 ---
 
 import Interactive from "../../../_samples/main/Table/Interactive/Interactive.md";

--- a/packages/website/docs/_components_pages/main/Table/TableRowAction.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableRowAction.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableRowAction
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import RowAction from "../../../_samples/main/Table/RowAction/RowAction.md";

--- a/packages/website/docs/_components_pages/main/Table/TableRowActionNavigation.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableRowActionNavigation.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableRowActionNavigation
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import RowActionNavigation from "../../../_samples/main/Table/RowActionNavigation/RowActionNavigation.md";

--- a/packages/website/docs/_components_pages/main/Table/TableSelection.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableSelection.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../TableSelection
-sidebar_class_name: expComponentBadge
 ---
 
 import Selection from "../../../_samples/main/Table/Selection/Selection.md";

--- a/packages/website/docs/_components_pages/main/Table/TableVirtualizer.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableVirtualizer.mdx
@@ -1,6 +1,6 @@
 ---
 slug: ../../TableVirtualizer
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Virtualizer from "../../../_samples/main/Table/Virtualizer/Virtualizer.md";

--- a/packages/website/docs/components/patterns/AI Acknowledgement.mdx
+++ b/packages/website/docs/components/patterns/AI Acknowledgement.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/patterns/AIAcknowledgement/Basic/Basic.md";

--- a/packages/website/docs/components/patterns/AI CustomPrompt/AI CustomPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/AI CustomPrompt.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 :::info

--- a/packages/website/docs/components/patterns/AI GuidedPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI GuidedPrompt.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Popover from "../../_samples/patterns/AIGuidedPrompt/Popover/Popover.md";

--- a/packages/website/docs/components/patterns/AI QuickPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI QuickPrompt.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/patterns/AIQuickPrompt/Basic.md";

--- a/packages/website/docs/components/patterns/AI Regenerate.mdx
+++ b/packages/website/docs/components/patterns/AI Regenerate.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/patterns/AIRegenerate/Basic/Basic.md";

--- a/packages/website/docs/components/patterns/SelectionAssistant/Selection Assistant.mdx
+++ b/packages/website/docs/components/patterns/SelectionAssistant/Selection Assistant.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: newComponentBadge
 ---
 
 import Input from "../../../components/patterns/SelectionAssistant/InputSelectionAssistant/Basic/Basic.md";

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -209,7 +209,8 @@ code {
 }
 
 .newComponentBadge,
-.expComponentBadge {
+.expComponentBadge,
+.deprComponentBadge {
   position: relative;
 }
 
@@ -227,7 +228,27 @@ code {
   pointer-events: none;
 }
 
-.newComponentBadge.expComponentBadge:before {
+.deprComponentBadge:before {
+  color: #fff;
+  position: absolute;
+  top: 0.25rem;
+  inset-inline-end: 1rem;
+  border-radius: 0.5rem;
+  padding: 0.125rem 0.25rem;
+  box-sizing: border-box;
+  font-size: 0.75rem;
+  content: "depr";
+  background: #ffb700e0;
+  pointer-events: none;
+}
+
+.deprComponentBadge.expComponentBadge:before {
+	display: none;
+}
+
+
+.newComponentBadge.expComponentBadge:before,
+.newComponentBadge.deprComponentBadge:before {
   inset-inline-end: 3.25rem;
 }
 
@@ -246,11 +267,13 @@ code {
 }
 
 .theme-doc-sidebar-item-category.newComponentBadge:after,
-.theme-doc-sidebar-item-category.expComponentBadge:before {
+.theme-doc-sidebar-item-category.expComponentBadge:before,
+.theme-doc-sidebar-item-category.deprComponentBadge:before {
     inset-inline-end: 2.25rem;
 }
 
-.theme-doc-sidebar-item-category.newComponentBadge.expComponentBadge:before {
+.theme-doc-sidebar-item-category.newComponentBadge.expComponentBadge:before,
+.theme-doc-sidebar-item-category.newComponentBadge.deprComponentBadge:before {
     inset-inline-end: 4.5rem;
 }
 


### PR DESCRIPTION
A visual indication for component deprecation has been added to the playground. Previously, a message was automatically displayed for components in an experimental state. Now, if a component is deprecated, the deprecation message will override the experimental message and be displayed instead.  

In addition:
- Enabled the experimental tag for enums.  
- Removed unnecessary experimental CSS classes from component pages (these are added automatically).  
- Unmarked patterns as experimental since they are examples and do not have compatibility concerns.

### Side navigation appearing
![Screenshot 2025-02-19 at 15 41 33](https://github.com/user-attachments/assets/595e48bb-2382-47c6-b3c0-ea474c53c935)


### Component page appearing
![Screenshot 2025-02-19 at 15 42 01](https://github.com/user-attachments/assets/7401c991-5eb9-43dc-94b8-5ecc6ae19b0a)
