### PR TITLE
test: fix single test run command

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -27,7 +27,7 @@
     "bundle": "nps build.bundle",
     "test": "nps test-cy-ci",
     "test:cypress": "nps test-cy-ci",
-    "test:cypress:single": "nps test-cy-single",
+    "test:cypress:single": "npx cypress run --component --browser chrome --spec",
     "test:cypress:open": "nps test-cy-open",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "create-ui5-element": "wc-create-ui5-element",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -43,7 +43,7 @@
     "test": "wc-dev test",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "test:cypress": "nps test-cy-ci",
-    "test:cypress:single": "nps test-cy-single",
+    "test:cypress:single": "npx cypress run --component --browser chrome --spec",
     "test:cypress:open": "nps test-cy-open",
     "create-ui5-element": "wc-create-ui5-element",
     "prepublishOnly": "tsc -b"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -32,7 +32,7 @@
     "test:cypress:suite-1": "nps test-cy-ci-suite-1",
     "test:cypress:suite-2": "nps test-cy-ci-suite-2",
     "test:cypress:open": "nps test-cy-open",
-    "test:cypress:single": "nps test-cy-single",
+    "test:cypress:single": "npx cypress run --component --browser chrome --spec",
     "test:vitest": "yarn vitest run",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",
     "create-ui5-element": "wc-create-ui5-element",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -126,7 +126,6 @@ const getScripts = (options) => {
 		"test-cy-ci-suite-1": `cross-env CYPRESS_COVERAGE=true TEST_SUITE=SUITE1 yarn cypress run --component --browser chrome`,
 		"test-cy-ci-suite-2": `cross-env CYPRESS_COVERAGE=true TEST_SUITE=SUITE2 yarn cypress run --component --browser chrome`,
 		"test-cy-open": `cross-env CYPRESS_COVERAGE=true yarn cypress open --component --browser chrome`,
-		"test-cy-single": `cross-env yarn cypress run --component --browser chrome --spec ${process.argv[3]}`,
 		"test-suite-1": `node "${LIB}/test-runner/test-runner.js" --suite suite1`,
 		"test-suite-2": `node "${LIB}/test-runner/test-runner.js" --suite suite2`,
 		startWithScope: "nps scope.prepare scope.watchWithBundle",


### PR DESCRIPTION
Rework the `test:cypress:single` to run without `nps`, as with nps the command was unexpectedly starting additional tasks after finishing with the test run. The additional task is always the first available script in nps.js and it happens to be the clean command, which removes generated resources and sequential test run is not possible without rebuilding these resources, which is not convenient at all.

To run a single Cypress test:

`cd packages/main|fiori|ai`
`yarn test:cypress:single -- ./cypress/specs/Avatar.cy.tsx`