### PR TITLE
fix(ui5-shellbar): adjust focus style of startButton

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -268,9 +268,13 @@ slot[name="profile"] {
 }
 
 .ui5-shellbar-button {
-	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 	width: 2.5rem;
 	box-sizing: border-box;
+}
+
+.ui5-shellbar-button,
+::slotted([ui5-button][slot="startButton"]) {
+	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 }
 
 .ui5-shellbar-search-button {
@@ -522,7 +526,6 @@ slot[name="profile"] {
 	margin-inline: 0 0.5rem;
 	justify-content: center;
 	align-items: center;
-	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 }
 
 ::slotted([ui5-button][data-profile-btn]) {

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -522,6 +522,7 @@ slot[name="profile"] {
 	margin-inline: 0 0.5rem;
 	justify-content: center;
 	align-items: center;
+	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 }
 
 ::slotted([ui5-button][data-profile-btn]) {


### PR DESCRIPTION
- Override button's default focus border to match shellbar's focus styling

Fixes: [#10598](https://github.com/SAP/ui5-webcomponents/issues/10598)