### PR TITLE
fix(ui5-toolbar-button): add hidden property

### DIFF
--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -158,7 +158,7 @@ class ToolbarButton extends ToolbarItem {
 
 	/**
      * Defines if the toolbar button is hidden.
-     * @public
+     * @private
      * @default false
      */
 	@property({ type: Boolean })

--- a/packages/main/src/ToolbarButton.ts
+++ b/packages/main/src/ToolbarButton.ts
@@ -156,6 +156,14 @@ class ToolbarButton extends ToolbarItem {
 	@property()
 	width?: string;
 
+	/**
+     * Defines if the toolbar button is hidden.
+     * @public
+     * @default false
+     */
+	@property({ type: Boolean })
+	hidden = false;
+
 	get styles() {
 		return {
 			width: this.width,


### PR DESCRIPTION
- The ToolbarButton component had no hidden property implemented, which meant that buttons could not be dynamically shown or hidden after the initial render.

Fixes: [#10585](https://github.com/SAP/ui5-webcomponents/issues/10585)