### PR TITLE
fix(ui5-menu): prevent global line-height inheritance

### DIFF
--- a/packages/main/src/themes/Menu.css
+++ b/packages/main/src/themes/Menu.css
@@ -1,3 +1,10 @@
+:host {
+	line-height: initial;
+}
+
+::slotted([ui5-menu-item]) {
+	line-height: inherit;
+  }
 
 .ui5-menu-rp[ui5-responsive-popover]::part(header),
 .ui5-menu-rp[ui5-responsive-popover]::part(content),


### PR DESCRIPTION
Previously setting a `line-height` property on global level e.g `body { line-height: 0.5rem }` was being inherited by the `ui5-menu` and its `ui5-menu-item`'s which was not convenient.

With this chnange we now prevent the global inheritance of the `line-height` with the following priority:

`ui5-menu-item` > `ui5-menu` > `global (globally no longer takes effect)`, which means if a `line-height` is set to the `ui5-menu`, all of its children (ui5-menu-items) would receive the effect, but if a specific `ui5-menu-item` receives the property, it would take over.

For example, here all children, except the first one (which has explicitly set `style="line-height: 0.5rem;"`) would have `line-height` of `1rem`
```ts
	<ui5-menu style="line-height: 1rem;" header-text="Basic Menu with Items" id="menuBasic" opener="btnOpenBasic">
		<ui5-menu-item style="line-height: 0.5rem;" text="New File" icon="add-document"></ui5-menu-item>
		<ui5-menu-item text="New Folder" icon="add-folder" disabled></ui5-menu-item>
		<ui5-menu-item text="Save" icon="add-folder" disabled></ui5-menu-item>
	</ui5-menu>
```

### Before
![2025-02-20_16-11-36](https://github.com/user-attachments/assets/44c6f81a-32ed-41ee-8b58-21440386493b)

### After
![2025-02-20_16-11-50](https://github.com/user-attachments/assets/cc4a3571-78eb-437c-b74a-ff20998b3960)


Fixes: #10754 