### PR TITLE
fix: i18n bundle storage

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1312,8 +1312,8 @@ abstract class UI5Element extends HTMLElement {
 			]);
 			const [i18nBundles] = result;
 			Object.entries(this.getMetadata().getI18n()).forEach((pair, index) => {
-				const propertyName = pair[0];
-				this.i18nBundleStorage[propertyName] = i18nBundles[index];
+				const bundleName = pair[1].bundleName;
+				this.i18nBundleStorage[bundleName] = i18nBundles[index];
 			});
 			this.asyncFinished = true;
 		};

--- a/packages/base/src/decorators/i18n.ts
+++ b/packages/base/src/decorators/i18n.ts
@@ -23,7 +23,7 @@ const i18n = (bundleName: string): i18nDecorator => {
 
 		Object.defineProperty(target, propertyName, {
 			get() {
-				return target.i18nBundles[propertyName];
+				return target.i18nBundles[bundleName];
 			},
 			set() {},
 		});


### PR DESCRIPTION
With the introduction of i18n storage, all loaded bundles are now stored within `UI5Element` ([PR #10521](https://github.com/SAP/ui5-webcomponents/pull/10521)). This storage mechanism allows child components of a `UI5Element` to share localization data, but the final stored bundle depends on which component loads its bundle last.  

### Example:  

```
class Example extends UI5Element {
  @i18n("@ui5/webcomponents")
  static i18nBundle: I18nBundle;
}

class Example2 extends UI5Element {
  @i18n("@ui5/webcomponents-fiori")
  static i18nBundle: I18nBundle;
}
```

Previously, when accessing `i18nBundle`, the storage would always return `@ui5/webcomponents-fiori`, since bundles were stored under a shared key, leading to overwrites.  

With this change, bundles are now stored with their bundle names. As a result:  
- `Example2.i18nBundle` will correctly access the `@ui5/webcomponents-fiori` bundle.  
- `Example.i18nBundle` will correctly access the `@ui5/webcomponents` bundle.  

This ensures that each component retrieves the correct localization data.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10808