### PR TITLE
docs(ui5-avatar): add missing CSS example

### DIFF
--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -213,7 +213,7 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	/**
 	 * Receives the desired `<img>` tag
 	 *
-	 * **Note:** If you experience flickering of the provided image, you can hide the component until it is being defined with the following CSS:<br/>
+	 * **Note:** If you experience flickering of the provided image, you can hide the component until it is defined with the following CSS:<br/>
 	 * `ui5-avatar:not(:defined) {`<br/>
 	 * &nbsp;&nbsp;&nbsp;&nbsp;`visibility: hidden;`<br/>
 	 * `}`

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -213,7 +213,10 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	/**
 	 * Receives the desired `<img>` tag
 	 *
-	 * **Note:** If you experience flickering of the provided image, you can hide the component until it is being defined with the following CSS:
+	 * **Note:** If you experience flickering of the provided image, you can hide the component until it is being defined with the following CSS:<br/>
+	 * `ui5-avatar:not(:defined) {`<br/>
+	 * &nbsp;&nbsp;&nbsp;&nbsp;`visibility: hidden;`<br/>
+	 * `}`
 	 * @public
 	 * @since 1.0.0-rc.15
 	 */


### PR DESCRIPTION
Fixes: #10583 