### PR TITLE
fix(ui5-list): ensure no data text wraps instead of truncating

### DIFF
--- a/packages/main/src/themes/List.css
+++ b/packages/main/src/themes/List.css
@@ -87,7 +87,7 @@
 	border-bottom: 1px solid var(--sapList_BorderColor);
 	padding: 0 1rem !important;
 	outline: none;
-	height: var(--_ui5_list_no_data_height);
+    min-height: var(--_ui5_list_no_data_height);
 	font-size: var(--_ui5_list_no_data_font_size);
 	font-family: "72override", var(--sapFontFamily);
 	position: relative;
@@ -104,7 +104,8 @@
 .ui5-list-nodata-text {
 	overflow: hidden;
 	text-overflow: ellipsis;
-	white-space: nowrap;
+	white-space: normal;
+    margin: var(--_ui5_list_item_content_vertical_offset) 0;
 }
 
 :host([growing="Scroll"]) .ui5-list-end-marker {


### PR DESCRIPTION
- Added min-height to .ui5-list-nodata to maintain proper spacing.
- Set white-space: normal to .ui5-list-nodata-text to allow text wrapping and applied margin for better vertical alignment.

Fixes: [#10346](https://github.com/SAP/ui5-webcomponents/issues/10346)
