### PR TITLE
feat(ui5-select): introduced tooltip property

### DIFF
--- a/packages/main/cypress/specs/Select.cy.tsx
+++ b/packages/main/cypress/specs/Select.cy.tsx
@@ -35,6 +35,21 @@ describe("Select - Accessibility", () => {
 			.find("li.ui5-li-root")
 			.should("have.attr", "title", EXPECTED_TOOLTIP);
 	});
+
+	it("setting tooltip on the host is reflected on the select's shadow dom root", () => {
+		cy.mount(<Select tooltip="Go home">
+			<Option value="1">Option 1</Option>
+			<OptionCustom value="2">Option 2</OptionCustom>
+		</Select>);
+
+		cy.get("[ui5-select]")
+			.shadow()
+			.find(".ui5-select-root")
+			.as("select");
+
+		cy.get("@select")
+			.should("have.attr", "title", "Go home");
+	});
 });
 
 describe("Select - Popover", () => {

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -272,6 +272,15 @@ class Select extends UI5Element implements IFormInputElement {
 	accessibleNameRef?: string;
 
 	/**
+	 * Defines the tooltip of the select.
+	 * @default undefined
+	 * @public
+	 * @since 2.8.0
+	 */
+	@property()
+	tooltip?: string;
+
+	/**
 	 * @private
 	 */
 	@property({ type: Boolean, noAttribute: true })

--- a/packages/main/src/SelectTemplate.tsx
+++ b/packages/main/src/SelectTemplate.tsx
@@ -13,6 +13,7 @@ export default function SelectTemplate(this: Select) {
 				}}
 				id={`${this._id}-select`}
 				onClick={this._onclick}
+				title={this.tooltip}
 			>
 				{this.selectedOptionIcon &&
 					<Icon


### PR DESCRIPTION
New "tooltip" property is introduced to the Select component.

When the property is set to a string, it is shown as tooltip when we hover over the component.

Implements: #10855
