### PR TITLE
fix(ui5-popover): ensure that popover is closed when mousedown propagation is stopped

### DIFF
--- a/packages/main/cypress/specs/Popover.cy.tsx
+++ b/packages/main/cypress/specs/Popover.cy.tsx
@@ -157,8 +157,8 @@ describe("Popover interaction", () => {
 			cy.mount(
 				<>
 					<button id="opener">Open</button>
-					<Popover id="pop" open={true} opener="opener">
-						<Button id="btnClosePopover">Close</Button>
+					<Popover id="pop" open={true} opener="opener" placement="Bottom">
+						<span>popover content</span>
 					</Popover>
 					<button id="btn">Stops mousedown propagation</button>
 				</>

--- a/packages/main/cypress/specs/Popover.cy.tsx
+++ b/packages/main/cypress/specs/Popover.cy.tsx
@@ -153,6 +153,31 @@ describe("Popover interaction", () => {
 			cy.get("#openerShadowRooTest").shadow().find("[ui5-popover]").should("be.visible");
 		});
 	});
+
+	it("tests clicking outside the popover when 'mousedown' event propagation is stopped", () => {
+		cy.mount(
+			<>
+				<button id="opener">Open</button>
+				<Popover id="pop" open={true} opener="opener">
+					<Button id="btnClosePopover">Close</Button>
+				</Popover>
+				<button id="btn">Stops mousedown propagation</button>
+			</>
+		);
+
+		cy.get("#pop").should("be.visible");
+		cy.get("#btn").then(btn => {
+			btn.get(0).addEventListener("mousedown", event => {
+				event.stopPropagation();
+			});
+		});
+
+		// act
+		cy.get("#btn").realClick();
+
+		// assert
+		cy.get("#pop").should("not.be.visible");
+	});
 });
 
 describe("Focusing", () => {

--- a/packages/main/cypress/specs/Popover.cy.tsx
+++ b/packages/main/cypress/specs/Popover.cy.tsx
@@ -152,31 +152,31 @@ describe("Popover interaction", () => {
 			// assert
 			cy.get("#openerShadowRooTest").shadow().find("[ui5-popover]").should("be.visible");
 		});
-	});
 
-	it("tests clicking outside the popover when 'mousedown' event propagation is stopped", () => {
-		cy.mount(
-			<>
-				<button id="opener">Open</button>
-				<Popover id="pop" open={true} opener="opener">
-					<Button id="btnClosePopover">Close</Button>
-				</Popover>
-				<button id="btn">Stops mousedown propagation</button>
-			</>
-		);
+		it("tests clicking outside the popover when 'mousedown' event propagation is stopped", () => {
+			cy.mount(
+				<>
+					<button id="opener">Open</button>
+					<Popover id="pop" open={true} opener="opener">
+						<Button id="btnClosePopover">Close</Button>
+					</Popover>
+					<button id="btn">Stops mousedown propagation</button>
+				</>
+			);
 
-		cy.get("#pop").should("be.visible");
-		cy.get("#btn").then(btn => {
-			btn.get(0).addEventListener("mousedown", event => {
-				event.stopPropagation();
+			cy.get("#pop").should("be.visible");
+			cy.get("#btn").then(btn => {
+				btn.get(0).addEventListener("mousedown", event => {
+					event.stopPropagation();
+				});
 			});
+
+			// act
+			cy.get("#btn").realMouseDown();
+
+			// assert
+			cy.get("#pop").should("not.be.visible");
 		});
-
-		// act
-		cy.get("#btn").realClick();
-
-		// assert
-		cy.get("#pop").should("not.be.visible");
 	});
 });
 

--- a/packages/main/src/popup-utils/PopoverRegistry.ts
+++ b/packages/main/src/popup-utils/PopoverRegistry.ts
@@ -59,7 +59,7 @@ const attachGlobalClickHandler = () => {
 };
 
 const detachGlobalClickHandler = () => {
-	document.removeEventListener("mousedown", clickHandler);
+	document.removeEventListener("mousedown", clickHandler, { capture: true });
 };
 
 const clickHandler = (event: MouseEvent) => {

--- a/packages/main/src/popup-utils/PopoverRegistry.ts
+++ b/packages/main/src/popup-utils/PopoverRegistry.ts
@@ -55,7 +55,7 @@ const detachScrollHandler = (popover: Popover) => {
 };
 
 const attachGlobalClickHandler = () => {
-	document.addEventListener("mousedown", clickHandler);
+	document.addEventListener("mousedown", clickHandler, { capture: true });
 };
 
 const detachGlobalClickHandler = () => {


### PR DESCRIPTION
Fixes https://github.com/SAP/ui5-webcomponents/issues/10237