### PR TITLE
Switch touch area fix

### DIFF
--- a/packages/main/src/themes/sap_horizon/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Switch-parameters.css
@@ -130,16 +130,16 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--_ui5_switch_width: 3rem;
+	--_ui5_switch_width: 2.75rem;
 	--_ui5_switch_min_width: none;
-	--_ui5_switch_with_label_width: 3.75rem;
+	--_ui5_switch_with_label_width: 2.75rem;
 	--_ui5_switch_root_outline_top: 0.25rem;
 	--_ui5_switch_root_outline_bottom: 0.25rem;
 	--_ui5_switch_transform: translateX(100%) translateX(-1.375rem);
 	--_ui5_switch_transform_with_label: translateX(100%) translateX(-1.875rem);
 	--_ui5_switch_rtl_transform: translateX(1.375rem) translateX(-100%);
 	--_ui5_switch_rtl_transform_with_label: translateX(1.875rem) translateX(-100%);
-	--_ui5_switch_track_width: 2rem;
+	--_ui5_switch_track_width: 2.75rem;
 	--_ui5_switch_track_height: 1.25rem;
 	--_ui5_switch_track_with_label_width: 2.75rem;
 	--_ui5_switch_track_with_label_height: 1.25rem;

--- a/packages/main/src/themes/sap_horizon/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Switch-parameters.css
@@ -1,10 +1,10 @@
 @import "../base/Switch-parameters.css";
 :root {
 	/* Switch */
-	--_ui5_switch_width: 3.5rem;
+	--_ui5_switch_width: 2.5rem;
 	--_ui5_switch_min_width: none;
 
-	--_ui5_switch_with_label_width: 3.875rem;
+	--_ui5_switch_with_label_width: 2.875rem;
 
 	--_ui5_switch_focus_outline: none;
 	--_ui5_switch_root_after_outline: 0.125rem solid var(--sapContent_FocusColor);
@@ -14,8 +14,8 @@
 
 	--_ui5_switch_root_outline_top: 0.5rem;
 	--_ui5_switch_root_outline_bottom: 0.5rem;
-	--_ui5_switch_root_outline_left: 0.375rem;
-	--_ui5_switch_root_outline_right: 0.375rem;
+	--_ui5_switch_root_outline_left: -0.125rem;
+	--_ui5_switch_root_outline_right: -0.125rem;
 
 
 	--_ui5_switch_disabled_opacity: var(--sapContent_DisabledOpacity);

--- a/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
@@ -128,16 +128,16 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--_ui5_switch_width: 3rem;
+	--_ui5_switch_width: 2.75rem;
 	--_ui5_switch_min_width: none;
-	--_ui5_switch_with_label_width: 3.75rem;
+	--_ui5_switch_with_label_width: 2.75rem;
 	--_ui5_switch_root_outline_top: 0.25rem;
 	--_ui5_switch_root_outline_bottom: 0.25rem;
 	--_ui5_switch_transform: translateX(100%) translateX(-1.375rem);
 	--_ui5_switch_transform_with_label: translateX(100%) translateX(-1.875rem);
 	--_ui5_switch_rtl_transform: translateX(1.375rem) translateX(-100%);
 	--_ui5_switch_rtl_transform_with_label: translateX(1.875rem) translateX(-100%);
-	--_ui5_switch_track_width: 2rem;
+	--_ui5_switch_track_width: 2.75rem;
 	--_ui5_switch_track_height: 1.25rem;
 	--_ui5_switch_track_with_label_width: 2.75rem;
 	--_ui5_switch_track_with_label_height: 1.25rem;

--- a/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Switch-parameters.css
@@ -1,10 +1,10 @@
 @import "../base/Switch-parameters.css";
 :root {
 	/* Switch */
-	--_ui5_switch_width: 3.5rem;
+	--_ui5_switch_width: 2.5rem;
 	--_ui5_switch_min_width: none;
 
-	--_ui5_switch_with_label_width: 3.875rem;
+	--_ui5_switch_with_label_width: 2.875rem;
 
 	--_ui5_switch_focus_outline: none;
 	--_ui5_switch_root_after_outline: 0.125rem solid var(--sapContent_FocusColor);
@@ -14,8 +14,8 @@
 
 	--_ui5_switch_root_outline_top: 0.5rem;
 	--_ui5_switch_root_outline_bottom: 0.5rem;
-	--_ui5_switch_root_outline_left: 0.375rem;
-	--_ui5_switch_root_outline_right: 0.375rem;
+	--_ui5_switch_root_outline_left: -0.125rem;
+	--_ui5_switch_root_outline_right: -0.125rem;
 
 	--_ui5_switch_disabled_opacity: var(--sapContent_DisabledOpacity);
 

--- a/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
@@ -2,12 +2,11 @@
 :root {
 	/* Switch */
 	--_ui5_switch_width: 2.5rem;
-	--_ui5_switch_compact_width: 3rem;
 	--_ui5_switch_min_width: none;
 	--_ui5_switch_compact_min_width: none;
 
 	--_ui5_switch_with_label_width: 2.875rem;
-	--_ui5_switch_compact_with_label_width: 3.75rem;
+	--_ui5_switch_compact_with_label_width: 2.75rem;
 
 	--_ui5_switch_focus_outline: none;
 	--_ui5_switch_root_after_outline: 0.125rem solid var(--sapContent_FocusColor);
@@ -37,7 +36,7 @@
 
 	/* track */
 	--_ui5_switch_track_width: 2.5rem;
-	--_ui5_switch_track_compact_width: 2rem;
+	--_ui5_switch_track_compact_width: 2.75rem;
 	--_ui5_switch_track_height: 1.5rem;
 	--_ui5_switch_track_compact_height: 1.25rem;
 
@@ -148,16 +147,16 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--_ui5_switch_width: 3rem;
+	--_ui5_switch_width: 2.75rem;
 	--_ui5_switch_min_width: none;
-	--_ui5_switch_with_label_width: 3.75rem;
+	--_ui5_switch_with_label_width: 2.75rem;
 	--_ui5_switch_root_outline_top: 0.25rem;
 	--_ui5_switch_root_outline_bottom: 0.25rem;
 	--_ui5_switch_transform: translateX(100%) translateX(-1.375rem);
 	--_ui5_switch_transform_with_label: translateX(100%) translateX(-1.875rem);
 	--_ui5_switch_rtl_transform: translateX(1.375rem) translateX(-100%);
 	--_ui5_switch_rtl_transform_with_label: translateX(1.875rem) translateX(-100%);
-	--_ui5_switch_track_width: 2rem;
+	--_ui5_switch_track_width: 2.75rem;
 	--_ui5_switch_track_height: 1.25rem;
 	--_ui5_switch_track_with_label_width: 2.75rem;
 	--_ui5_switch_track_with_label_height: 1.25rem;

--- a/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
@@ -1,12 +1,12 @@
 @import "../base/Switch-parameters.css";
 :root {
 	/* Switch */
-	--_ui5_switch_width: 3.5rem;
+	--_ui5_switch_width: 2.5rem;
 	--_ui5_switch_compact_width: 3rem;
 	--_ui5_switch_min_width: none;
 	--_ui5_switch_compact_min_width: none;
 
-	--_ui5_switch_with_label_width: 3.875rem;
+	--_ui5_switch_with_label_width: 2.875rem;
 	--_ui5_switch_compact_with_label_width: 3.75rem;
 
 	--_ui5_switch_focus_outline: none;
@@ -17,8 +17,8 @@
 
 	--_ui5_switch_root_outline_top: 0.5rem;
 	--_ui5_switch_root_outline_bottom: 0.5rem;
-	--_ui5_switch_root_outline_left: 0.375rem;
-	--_ui5_switch_root_outline_right: 0.375rem;
+	--_ui5_switch_root_outline_left: -0.125rem;
+	--_ui5_switch_root_outline_right: -0.125rem;
 
 	--_ui5_switch_root_compact_outline_top: 0.25rem;
 	--_ui5_switch_root_compact_outline_bottom: 0.25rem;

--- a/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Switch-parameters.css
@@ -3,10 +3,8 @@
 	/* Switch */
 	--_ui5_switch_width: 2.5rem;
 	--_ui5_switch_min_width: none;
-	--_ui5_switch_compact_min_width: none;
 
 	--_ui5_switch_with_label_width: 2.875rem;
-	--_ui5_switch_compact_with_label_width: 2.75rem;
 
 	--_ui5_switch_focus_outline: none;
 	--_ui5_switch_root_after_outline: 0.125rem solid var(--sapContent_FocusColor);
@@ -19,31 +17,20 @@
 	--_ui5_switch_root_outline_left: -0.125rem;
 	--_ui5_switch_root_outline_right: -0.125rem;
 
-	--_ui5_switch_root_compact_outline_top: 0.25rem;
-	--_ui5_switch_root_compact_outline_bottom: 0.25rem;
-
 	--_ui5_switch_disabled_opacity: var(--sapContent_DisabledOpacity);
 
 	--_ui5_switch_transform: translateX(100%) translateX(-1.625rem);
-	--_ui5_switch_compact_transform: translateX(100%) translateX(-1.375rem);
 	--_ui5_switch_transform_with_label: translateX(100%) translateX(-1.875rem);
-	--_ui5_switch_compact_transform_with_label: translateX(100%) translateX(-1.875rem);
 
 	--_ui5_switch_rtl_transform: translateX(-100%) translateX(1.625rem);
-	--_ui5_switch_compact_rtl_transform: translateX(1.375rem) translateX(-100%);
 	--_ui5_switch_rtl_transform_with_label: translateX(-100%) translateX(1.875rem);
-	--_ui5_switch_compact_rtl_transform_with_label: translateX(1.875rem) translateX(-100%);
 
 	/* track */
 	--_ui5_switch_track_width: 2.5rem;
-	--_ui5_switch_track_compact_width: 2.75rem;
 	--_ui5_switch_track_height: 1.5rem;
-	--_ui5_switch_track_compact_height: 1.25rem;
 
 	--_ui5_switch_track_with_label_width: 2.875rem;
-	--_ui5_switch_track_with_label_compact_width: 2.75rem;
 	--_ui5_switch_track_with_label_height: 1.5rem;
-	--_ui5_switch_track_with_label_compact_height: 1.25rem;
 
 	--_ui5_switch_track_active_background_color: var(--sapButton_Track_Selected_Background);
 	--_ui5_switch_track_inactive_background_color: var(--sapButton_Track_Background);
@@ -69,16 +56,12 @@
 
 	/* handle */
 	--_ui5_switch_handle_width: 1.5rem;
-	--_ui5_switch_handle_compact_width: 1.25rem;
 
 	--_ui5_switch_handle_height: 1.25rem;
-	--_ui5_switch_handle_compact_height: 1rem;
 
 	--_ui5_switch_handle_with_label_width: 1.75rem;
-	--_ui5_switch_handle_with_label_compact_width: 1.75rem;
 
 	--_ui5_switch_handle_with_label_height: 1.25rem;
-	--_ui5_switch_handle_with_label_compact_height: 1rem;
 
 	--_ui5_switch_handle_border: var(--_ui5_switch_handle_border_width) solid var(--sapButton_Handle_BorderColor);
 	--_ui5_switch_handle_border_width: 0.125rem;
@@ -113,9 +96,7 @@
 	/* switch text */
 	--_ui5_switch_text_font_family: var(--sapContent_IconFontFamily);
 	--_ui5_switch_text_font_size: var(--sapFontLargeSize);
-	--_ui5_switch_text_compact_font_size: var(--sapFontSize);
 	--_ui5_switch_text_width: 1.25rem;
-	--_ui5_switch_text_compact_width: 1rem;
 
 	--_ui5_switch_text_with_label_font_family: "72-Condensed-Bold" , "72" , "72full" , Arial, Helvetica, sans-serif;
 	--_ui5_switch_text_with_label_font_size: var(--sapFontSmallSize);
@@ -126,7 +107,6 @@
 	--_ui5_switch_text_inactive_right: auto;
 	--_ui5_switch_text_active_left: 0.1875rem;
 	--_ui5_switch_text_active_left_alternate: 0.0625rem;
-	--_ui5_switch_text_compact_active_left: 0.1875rem;
 	--_ui5_switch_text_active_right: auto;
 
 	--_ui5_switch_text_active_color: var(--sapButton_Handle_Selected_TextColor);

--- a/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
@@ -1,10 +1,10 @@
 @import "../base/Switch-parameters.css";
 :root {
 	/* Switch */
-	--_ui5_switch_width: 3.5rem;
+	--_ui5_switch_width: 2.5rem;
 	--_ui5_switch_min_width: none;
 
-	--_ui5_switch_with_label_width: 3.875rem;
+	--_ui5_switch_with_label_width: 2.875rem;
 
 	--_ui5_switch_focus_outline: none;
 	--_ui5_switch_root_after_outline: 0.125rem solid var(--sapContent_FocusColor);
@@ -14,8 +14,8 @@
 
 	--_ui5_switch_root_outline_top: 0.5rem;
 	--_ui5_switch_root_outline_bottom: 0.5rem;
-	--_ui5_switch_root_outline_left: 0.375rem;
-	--_ui5_switch_root_outline_right: 0.375rem;
+	--_ui5_switch_root_outline_left: -0.125rem;
+	--_ui5_switch_root_outline_right: -0.125rem;
 
 
 	--_ui5_switch_disabled_opacity: var(--sapContent_DisabledOpacity);

--- a/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Switch-parameters.css
@@ -128,16 +128,16 @@
 [data-ui5-compact-size],
 .ui5-content-density-compact,
 .sapUiSizeCompact {
-	--_ui5_switch_width: 3rem;
+	--_ui5_switch_width: 2.75rem;
 	--_ui5_switch_min_width: none;
-	--_ui5_switch_with_label_width: 3.75rem;
+	--_ui5_switch_with_label_width: 2.75rem;
 	--_ui5_switch_root_outline_top: 0.25rem;
 	--_ui5_switch_root_outline_bottom: 0.25rem;
 	--_ui5_switch_transform: translateX(100%) translateX(-1.375rem);
 	--_ui5_switch_transform_with_label: translateX(100%) translateX(-1.875rem);
 	--_ui5_switch_rtl_transform: translateX(1.375rem) translateX(-100%);
 	--_ui5_switch_rtl_transform_with_label: translateX(1.875rem) translateX(-100%);
-	--_ui5_switch_track_width: 2rem;
+	--_ui5_switch_track_width: 2.75rem;
 	--_ui5_switch_track_height: 1.25rem;
 	--_ui5_switch_track_with_label_width: 2.75rem;
 	--_ui5_switch_track_with_label_height: 1.25rem;


### PR DESCRIPTION
Previously our `ui5-switch`'s touch area was not according to visual specification, and was a little bit wider.

With this change we apply the correct `width` to our `ui5-switch` component, and clear some unused variables.

### Before
![image](https://github.com/user-attachments/assets/eba5a172-3811-4159-a359-2e1a1a358839)


### After

![image](https://github.com/user-attachments/assets/8441bf1c-a4e8-4c3b-8df9-ac9e2aeca612)

Fixes: #10219 
