### PR TITLE
chore(ui5-timeline): add missing import in sample

### DIFF
--- a/packages/website/docs/_samples/fiori/Timeline/WithState/main.js
+++ b/packages/website/docs/_samples/fiori/Timeline/WithState/main.js
@@ -1,6 +1,7 @@
 import "@ui5/webcomponents/dist/Label.js";
 
 import "@ui5/webcomponents-fiori/dist/Timeline.js";
+import "@ui5/webcomponents-fiori/dist/TimelineGroupItem.js"
 import "@ui5/webcomponents-fiori/dist/TimelineItem.js";
 
 import "@ui5/webcomponents-icons/dist/message-information.js";


### PR DESCRIPTION
There was a missing import in the `Timeline`'s sample, leading to missing sample. With this import, we fix the issue.

### Before
![image](https://github.com/user-attachments/assets/be909a77-622f-4e47-bcc1-041cc190158b)

### After
![image](https://github.com/user-attachments/assets/ed26b62c-d389-4081-bdb0-694a0e99ab54)
