### PR TITLE
feat(framework): add `.currentTarget` to the type of event handler in TSX and UI5CustomEvent

### DIFF
--- a/docs/4-development/08-templates.md
+++ b/docs/4-development/08-templates.md
@@ -276,6 +276,52 @@ class MyCompponent {
 
 For native browser events, the most common way is to simply specify `KeyboardEvent` or `MouseEvent`
 
+### Event handler `.currentTarget`
+
+When writing an inline event handler, `e.currentTarget` will be set to the element on which the handler is attached, and it will have the correct type. This removes the necessity to use type assertions which also might be wrong in case the same event handler is attached to a different element.
+
+```tsx
+// Before
+<Input onClick={(e => (e.target as Input))} />
+                     // ^^^^^^^^^^^^^^^^
+                     // Casting the event target to input might be wrong and is not checked
+
+// After
+<Input onClick={(e => e.currentTarget)} />
+                     // ^^^^^^^^^^^^^
+                     // instance of `Input` class
+```
+
+The same typing information is also available via the `UI5CustomEvent` type helper
+
+```ts
+// Before
+handleInput(e: CustomEvent) {
+    console.log(e.target as Input);
+    //          ^^^^^^^^^^^^^^^^^
+    //          this is of type Input, but TypeScript will not check in case the handler is attached to a Slider
+}
+
+// After
+handleInput(e: UI5CustomEvent<Input, "input">) {
+    console.log(e.currentTarget);
+    //          ^^^^^^^^^^^^^^^
+    //          this is of type Input and checked
+}
+```
+
+Typescript will check that the `handleInput` handler can only be attached on an Input element. If the same handler is attached on a Slider, you you will have to add it in the parameters
+```tsx
+handleInput(e: UI5CustomEvent<Input, "input"> | UI5CustomEvent<Slider, "input">) {
+    console.log(e.currentTarget);
+    //          ^^^^^^^^^^^^^^^
+    //          Input | Slider
+    console.log(e.currentTarget.value);
+    //          ^^^^^^^^^^^^^^^^^^^^^
+    //          string | number
+}
+```
+
 ### Event handlers and `this`
 
 UI5 Web Components are authored as classes and event handlers are methods, they usually access the component state via `this.prop`. In order for this to work when event handlers are attached to the DOM, the framework automatically binds all event handlers to the instance that is being rendered, so accessing `this` from the event handlers works as expected without any additional work.

--- a/packages/ai/src/PromptInput.ts
+++ b/packages/ai/src/PromptInput.ts
@@ -21,6 +21,7 @@ import PromptInputTemplate from "./PromptInputTemplate.js";
 
 // Styles
 import PromptInputCss from "./generated/themes/PromptInput.css.js";
+import type { UI5CustomEvent } from "@ui5/webcomponents-base/dist/index.js";
 
 /**
  * @class
@@ -229,8 +230,8 @@ class PromptInput extends UI5Element {
 		}
 	}
 
-	_onInnerInput(e: CustomEvent<InputEventDetail>) {
-		this.value = (e.target as Input).value;
+	_onInnerInput(e: UI5CustomEvent<Input, "input">) {
+		this.value = e.currentTarget.value;
 
 		this.fireDecoratorEvent("input");
 	}
@@ -243,8 +244,8 @@ class PromptInput extends UI5Element {
 		this.fireDecoratorEvent("submit");
 	}
 
-	_onTypeAhead(e: CustomEvent): void {
-		this.value = (e.target as Input).value;
+	_onTypeAhead(e: UI5CustomEvent<Input, "type-ahead">): void {
+		this.value = e.currentTarget.value;
 	}
 
 	get _exceededText() {

--- a/packages/ai/src/PromptInput.ts
+++ b/packages/ai/src/PromptInput.ts
@@ -7,7 +7,7 @@ import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type ValueState from "@ui5/webcomponents-base/dist/types/ValueState.js";
-import type { IInputSuggestionItem, InputEventDetail } from "@ui5/webcomponents/dist/Input.js";
+import type { IInputSuggestionItem } from "@ui5/webcomponents/dist/Input.js";
 import type Input from "@ui5/webcomponents/dist/Input.js";
 import {
 	isEnter,

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -151,7 +151,13 @@ type KebabToPascal<T extends string> = Capitalize<KebabToCamel<T>>;
 
 type GlobalHTMLAttributeNames = "accesskey" | "autocapitalize" | "autofocus" | "autocomplete" | "contenteditable" | "contextmenu" | "class" | "dir" | "draggable" | "enterkeyhint" | "hidden" | "id" | "inputmode" | "lang" | "nonce" | "part" | "exportparts" | "pattern" | "slot" | "spellcheck" | "style" | "tabIndex" | "tabindex" | "title" | "translate" | "ref" | "inert";
 type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
-type Convert<T> = { [Property in keyof T as `on${KebabToPascal<string & Property>}` ]: IsAny<T[Property], any, (e: CustomEvent<T[Property]>) => void> }
+type TargetedCustomEvent<D, T> = Omit<CustomEvent<D>, "currentTarget"> & { currentTarget: T };
+// define as method and extract the function signature from the method to make it bivariant so that inheritance of event handlers is not checked via strictFunctionTypes
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#strict-function-types
+type TargetedEventHandler<D, T> = {
+	asMethod(e: TargetedCustomEvent<D, T>): void
+}["asMethod"];
+type Convert<T, K extends UI5Element> = { [Property in keyof T as `on${KebabToPascal<string & Property>}` ]: IsAny<T[Property], any, TargetedEventHandler<T[Property], K>> }
 
 /**
  * @class
@@ -164,7 +170,7 @@ abstract class UI5Element extends HTMLElement {
 	eventDetails!: NotEqual<this, UI5Element> extends true ? object : {
 		[k: string]: any
 	};
-	_jsxEvents!: Omit<JSX.DOMAttributes<this>, keyof Convert<this["eventDetails"]> | "onClose" | "onToggle" | "onChange" | "onSelect" | "onInput"> & Convert<this["eventDetails"]>
+	_jsxEvents!: Omit<JSX.DOMAttributes<this>, keyof Convert<this["eventDetails"], this> | "onClose" | "onToggle" | "onChange" | "onSelect" | "onInput"> & Convert<this["eventDetails"], this>
 	_jsxProps!: Pick<JSX.AllHTMLAttributes<HTMLElement>, GlobalHTMLAttributeNames> & ElementProps<this> & Partial<this["_jsxEvents"]> & { key?: any };
 	__id?: string;
 	_suppressInvalidation: boolean;

--- a/packages/base/src/index.d.ts
+++ b/packages/base/src/index.d.ts
@@ -1,6 +1,10 @@
 import type { JSX } from "./jsx-runtime.d.ts";
 
-export type UI5CustomEvent<T extends UI5Element, N extends keyof T["eventDetails"]> = CustomEvent<T["eventDetails"][N]>;
+// type b = Parameters<JSX.IntrinsicElements["li"]["onClick"]>[0];
+
+type TargetedCustomEvent<D, T> = Omit<CustomEvent<D>, "currentTarget"> & { currentTarget: T };
+// export type UI5NativeEvent<T extends keyof HTMLElementTagNameMap, N> = Parameters<JSX.IntrinsicElements[T][N]>[0];
+export type UI5CustomEvent<T extends UI5Element, N extends keyof T["eventDetails"]> = TargetedCustomEvent<T["eventDetails"][N], T>;
 export type JsxTemplateResult = JSX.Element | void;
 export type JsxTemplate = () => JsxTemplateResult;
 

--- a/packages/fiori/src/NotificationListInternal.ts
+++ b/packages/fiori/src/NotificationListInternal.ts
@@ -42,7 +42,6 @@ class NotificationListInternal extends List {
 
 			if (item instanceof NotificationListGroupItem && !item.collapsed && !item.loading) {
 				item.items.forEach(subItem => {
-					// @ts-expect-error strictEvents
 					items.push(subItem);
 					allNavigationItems.push(subItem);
 				});

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -546,7 +546,6 @@ class NotificationListItem extends NotificationListItemBase {
 		// NotificationListItem will never be assigned to a variable of type ListItemBase
 		// typescipt complains here, if that is the case, the parameter to the _press event handler could be a ListItemBase item,
 		// but this is never the case, all components are used by their class and never assigned to a variable with a type of ListItemBase
-		// @ts-expect-error
 		this.fireDecoratorEvent("_press", { item: this });
 	}
 

--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -39,6 +39,7 @@ import {
 
 // Styles
 import ColorPickerCss from "./generated/themes/ColorPicker.css.js";
+import type { UI5CustomEvent } from "@ui5/webcomponents-base/dist/index.js";
 
 const PICKER_POINTER_WIDTH = 6.5;
 
@@ -298,8 +299,8 @@ class ColorPicker extends UI5Element implements IFormInputElement {
 		this._changeSelectedColor(e.offsetX, e.offsetY);
 	}
 
-	_handleAlphaInput(e: CustomEvent) {
-		const aphaInputValue: string = (e.target as Input).value;
+	_handleAlphaInput(e: UI5CustomEvent<Input, "input"> | UI5CustomEvent<Slider, "input">) {
+		const aphaInputValue = String(e.currentTarget.value);
 		this._alpha = parseFloat(aphaInputValue);
 		if (Number.isNaN(this._alpha)) {
 			this._alpha = 1;


### PR DESCRIPTION
The generated event handlers for events described in `eventDetails` now have the correct type for the `e.currentTarget` parameter

```tsx
<Input onClick={(e => e.currentTarget)} />
                     // ^^^^^^^^^^^^^
                     // `ui5-input` element now, was `EventTarget` before
```

Additionally, the `UI5CustomEvent` helper also adds the correct type to the event parameter `e.currentTarget`

## An event handler no longer has to use type assertions
Before:
```ts
onInput(e: CustomEvent) {
  const value: string = (e.target as Input).value;
```

This works, but the same event handler is also attached to a ui5-slider and the `e.target.value` is a number in that case which goes unnoticed because of the `as Input` type assertion.

After
```ts
onInput(e: UI5CustomEvent<Input, "input">) {
  const value: string = e.currentTarget.value;
//                        ^^^^^^^^^^^^^^^^^^^
//                        this is checked now, adding the same handler to a slider will result in an error
```

## Implementation note
Event handlers are contravariant (an event handler that takes a subclass as a parameter cannot be assigned to a property in the base class that takes the base class as a parameter).

To circumvent this, the generated event handlers are using the method notation so that typescript handles them as bivariant

More info in the `strictFunctionTypes` compiler option here:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#strict-function-types