### PR TITLE
fix(ui5-icon): revert default mode to decorative

### DIFF
--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -178,12 +178,12 @@ class Icon extends UI5Element implements IIcon {
 
 	/**
 	 * Defines the mode of the component.
-	 * @default "Image"
+	 * @default "Decorative"
 	 * @public
 	 * @since 2.0.0
 	 */
 	@property()
-	mode: `${IconMode}` = "Image";
+	mode: `${IconMode}` = "Decorative";
 
 	/**
 	 * @private

--- a/packages/main/test/specs/Icon.spec.js
+++ b/packages/main/test/specs/Icon.spec.js
@@ -120,8 +120,9 @@ describe("Icon general interaction", () => {
 		const imageMode = "Image";
 		const decorativeMode = "Decorative";
 
-		assert.equal(await mode, imageMode, "Image mode is correctly set by default.");
-		assert.equal(await iconSVG.getAttribute("role"), "img", "The SVG for the image icon has the correct role.");
+		assert.equal(await mode, decorativeMode, "Decorative mode is correctly set by default.");
+		assert.equal(await iconSVG.getAttribute("role"), "presentation", "The SVG for the decorative icon has the correct role.");
+		assert.equal(await iconSVG.getAttribute("aria-hidden"), "true", "The SVG for the decorative icon includes aria-hidden=true as expected");
 
 		await icon.setProperty("mode", intercativeMode)
 		mode = await icon.getProperty("mode");
@@ -129,12 +130,9 @@ describe("Icon general interaction", () => {
 		assert.equal(await mode, intercativeMode, "Interactive mode is correctly set.");
 		assert.equal(await iconSVG.getAttribute("role"), "button", "The SVG for the interactive icon has the correct role.");
 
-		await icon.setProperty("mode", decorativeMode)
+		await icon.setProperty("mode", imageMode)
 		mode = await icon.getProperty("mode");
 
-		assert.equal(await mode, decorativeMode, "Decorative mode is correctly set.");
-		assert.equal(await iconSVG.getAttribute("role"), "presentation", "The SVG for the decorative icon has the correct role.");
-		assert.equal(await iconSVG.getAttribute("aria-hidden"), "true", "The SVG for the decorative icon includes aria-hidden=true as expected");
-
+		assert.equal(await iconSVG.getAttribute("role"), "img", "The SVG for the image icon has the correct role.");
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/10835

With v2 the default mode was changed to "Image" unintentionally, which results in many app reports for icons with no labels.