### PR TITLE
fix(ui5-avatar-group): fixed unnecessary rendering of overflow button

### DIFF
--- a/packages/main/cypress/specs/AvatarGroup.cy.tsx
+++ b/packages/main/cypress/specs/AvatarGroup.cy.tsx
@@ -1,0 +1,36 @@
+import Avatar from "../../src/Avatar.js";
+import AvatarGroup from "../../src/AvatarGroup.js";
+
+describe("Overflow", () => {
+	it("checks if overflow button is hiding properly", () => {
+		cy.mount(<AvatarGroup id="ag" style="width: 100px;">
+			<Avatar initials="II"></Avatar>
+			<Avatar initials="II"></Avatar>
+			<Avatar initials="II"></Avatar>
+		</AvatarGroup>);
+
+		// Store the expected hidden items to compare against
+		const expectedHiddenItems = 0;
+
+		// Check if the aria-label is correctly set
+		cy.get("#ag")
+			.as("ag")
+			.then($el => {
+				$el.get(0).innerHTML = "";
+				return $el;
+			});
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(200);
+
+		cy.get("@ag")
+			.then($el => {
+				const avatar = document.createElement("ui5-avatar");
+				avatar.setAttribute("initials", "II");
+				$el.get(0).appendChild(avatar);
+				const ag = document.querySelector("#ag") as AvatarGroup;
+				return ag._hiddenItems;
+			})
+			.should("equal", expectedHiddenItems);
+	});
+});

--- a/packages/main/src/AvatarGroup.ts
+++ b/packages/main/src/AvatarGroup.ts
@@ -504,6 +504,7 @@ class AvatarGroup extends UI5Element {
 	_overflowItems() {
 		if (this.items.length < 2) {
 			// no need to overflow avatars
+			this._setHiddenItems(0);
 			return;
 		}
 


### PR DESCRIPTION
In some cases overflow button is rendered even though there is only one item in the group.

This change fixes the issue.

Fixes: #10948
