### PR TITLE
fix(ui5-li): safari issue duo to nested css selectors

### DIFF
--- a/packages/main/src/themes/ListItemBase.css
+++ b/packages/main/src/themes/ListItemBase.css
@@ -27,19 +27,19 @@
 :host([selected]) {
 	background-color: var(--sapList_SelectionBackgroundColor);
 	border-bottom: var(--ui5-listitem-selected-border-bottom);
+}
 
-	.ui5-li-additional-text {
-		text-shadow: var(--sapContent_TextShadow);
-	}
+:host([selected]) .ui5-li-additional-text {
+	text-shadow: var(--sapContent_TextShadow);
 }
 
 /* hovered */
 :host([actionable]:not([active]):not([selected]):not([ui5-li-group-header]):hover) {
     background-color: var(--sapList_Hover_Background);
+}
 
-	.ui5-li-additional-text {
-		text-shadow: var(--sapContent_TextShadow);
-	}
+:host([actionable]:not([active]):not([selected]):not([ui5-li-group-header]):hover) .ui5-li-additional-text {
+	text-shadow: var(--sapContent_TextShadow);
 }
 
 /* selected and hovered */


### PR DESCRIPTION
Fixes: #10872 

An webkit issue causes safari to crash while processing [nested css selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector).

```css
.parent-rule {
  /* parent rule properties */
  .child-rule {
    /* child rule properties */
  }
}
```

https://bugs.webkit.org/show_bug.cgi?id=276942

This change converts the nested selector to a standard parent-child selector
```css
.parent-rule child-rule {
  /* child rule properties */
}