### PR TITLE
fix(ui5-avatar-group): fixed focus outline

### DIFF
--- a/packages/main/cypress/specs/AvatarGroup.cy.tsx
+++ b/packages/main/cypress/specs/AvatarGroup.cy.tsx
@@ -34,3 +34,18 @@ describe("Overflow", () => {
 			.should("equal", expectedHiddenItems);
 	});
 });
+
+describe("Avatars arrangement", () => {
+	it("checks if no unnecessary margin is applied of only one Avatar is available", () => {
+		cy.mount(<AvatarGroup id="ag2" type="Group">
+			<Avatar id="av1" initials="II"></Avatar>
+			<Avatar id="av2" initials="II"></Avatar>
+		</AvatarGroup>);
+
+		cy.get("#av2").invoke("remove");
+
+		cy.get("#av1")
+			.invoke("attr", "style")
+			.should("equal", "");
+	});
+});

--- a/packages/main/src/AvatarGroup.ts
+++ b/packages/main/src/AvatarGroup.ts
@@ -463,6 +463,8 @@ class AvatarGroup extends UI5Element {
 			if (index !== this._itemsCount - 1 || this._customOverflowButton) {
 				// based on RTL the browser automatically sets left or right margin to avatars
 				avatar.style.marginInlineEnd = offsets[avatar.effectiveSize][this.type];
+			} else {
+				avatar.style.marginInlineEnd = "";
 			}
 		});
 	}


### PR DESCRIPTION
Problem: In some cases there the focus outline of the AvatarGroup is incorrect.

Root cause: There is unnecessary inline margin left when dynamically removing Avatars from the AvatarGroup.

Solution: We make sure to always remove the margin when we no longer need it.

Fixes: #10963
