### PR TITLE
fix(ui5-li-notification): footer no longer overflows

### DIFF
--- a/packages/fiori/src/themes/NotificationListItem.css
+++ b/packages/fiori/src/themes/NotificationListItem.css
@@ -156,7 +156,6 @@
 	font-size: var(--sapFontSize);
 	margin-top: var(--_ui5-notification_item-footer-margin-top);
 	box-sizing: border-box;
-	flex-wrap: wrap;
 	align-items: center;
 }
 
@@ -168,6 +167,7 @@
 
 .ui5-nli-footnotes {
 	display: flex;
+	min-width: 0; /* prevents overflowing footnotes */
 }
 
 .ui5-nli-footer-showMore {

--- a/packages/fiori/test/pages/NotificationListItem.html
+++ b/packages/fiori/test/pages/NotificationListItem.html
@@ -104,6 +104,35 @@
 			<span slot="footnotes">John Doe</span>
 			<span slot="footnotes">2 Days</span>
 			<span slot="footnotes">Other stuff</span>
+			<span slot="footnotes">
+				Very long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long 
+				long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+				long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long text
+			</span>
+		</ui5-li-notification>
+
+		<ui5-li-notification
+			show-close
+			state="Negative"
+			title-text="Very long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long 
+			long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+			long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+			long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+			long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long title"
+		>Notification with no actions
+
+			<ui5-avatar size="XS" slot="avatar">
+				<img src="./img/man_avatar_1.png" />
+			</ui5-avatar>
+
+			<span slot="footnotes">John Doe</span>
+			<span slot="footnotes">2 Days</span>
+			<span slot="footnotes">Other stuff</span>
+			<span slot="footnotes">
+				Very long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long 
+				long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+				long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long text
+			</span>
 		</ui5-li-notification>
 	</ui5-notification-list>
 


### PR DESCRIPTION
The footer of the NotificationListItem no longer overflows when its content is too long.

Fixes https://github.com/SAP/ui5-webcomponents/issues/10882