### PR TITLE
fix(ui5-shellbar): sap home no longer hard coded in title readings

### DIFF
--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -153,7 +153,7 @@ SHELLBAR_LABEL = Shell Bar
 SHELLBAR_LOGO = Logo
 
 #XACT: ARIA announcement for the logo area
-SHELLBAR_LOGO_AREA = SAP {0} {1} Home
+SHELLBAR_LOGO_AREA = {0} {1}
 
 #XACT: ARIA announcement for the main navigation button
 SHELLBAR_ADDITIONAL_CONTEXT = Additional Info


### PR DESCRIPTION
Fixes: #10970
