### PR TITLE
docs(ui5-menu-item): update accessibilityAttributes documentation

### DIFF
--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -209,7 +209,7 @@ class MenuItem extends ListItem implements IMenuItem {
 	 * @default {}
 	 */
 	@property({ type: Object })
-	accessibilityAttributes: MenuItemAccessibilityAttributes = {};
+	declare accessibilityAttributes: MenuItemAccessibilityAttributes;
 
 	/**
 	 * Indicates whether any of the element siblings have icon.


### PR DESCRIPTION
related to: https://github.com/SAP/ui5-webcomponents/issues/10981

After we merge this we will have to wait for [this](https://github.com/SAP/ui5-webcomponents/issues/11041) so it can take effect, because currently declare only applies the JSDoc override, but not the type itself.