### PR TITLE
refactor(ui5-navigation-menu-item): remove usage of ineffective `listItemPostContent` hook 

### DIFF
--- a/packages/fiori/cypress/specs/SideNavigation.cy.tsx
+++ b/packages/fiori/cypress/specs/SideNavigation.cy.tsx
@@ -2,6 +2,7 @@ import SideNavigation from "../../src/SideNavigation.js";
 import SideNavigationItem from "../../src/SideNavigationItem.js";
 import SideNavigationSubItem from "../../src/SideNavigationSubItem.js";
 import group from "@ui5/webcomponents-icons/dist/group.js";
+import { NAVIGATION_MENU_POPOVER_HIDDEN_TEXT } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Side Navigation Rendering", () => {
 	it("Tests rendering in collapsed mode", () => {
@@ -714,6 +715,45 @@ describe("Side Navigation Accessibility", () => {
 			.shadow()
 			.find(".ui5-sn-item")
 			.should("not.have.attr", "aria-checked");
+	});
+
+	it("Tests accessible-name of overflow menu and sub menu", () => {
+		cy.mount(
+			<SideNavigation id="sideNav" collapsed={true}>
+				<SideNavigationItem text="dummy item"></SideNavigationItem>
+				<SideNavigationItem text="1">
+					<SideNavigationSubItem text="1.1" />
+				</SideNavigationItem>
+			</SideNavigation>
+		);
+
+		cy.get("#sideNav")
+			.invoke("attr", "style", "height: 100px");
+
+		cy.get("#sideNav")
+			.shadow()
+			.find(".ui5-sn-item-overflow")
+			.realClick();
+
+		cy.get("#sideNav")
+			.shadow()
+			.find(".ui5-side-navigation-overflow-menu")
+			.shadow()
+			.find(".ui5-menu-rp")
+			.invoke("attr", "accessible-name-ref")
+			.should("match", /navigationMenuPopoverText$/);
+
+		cy.get("#sideNav")
+			.shadow()
+			.find(".ui5-side-navigation-overflow-menu [ui5-navigation-menu-item][text='1']")
+			.realClick();
+
+		cy.get("#sideNav")
+			.shadow()
+			.find(".ui5-side-navigation-overflow-menu [ui5-navigation-menu-item][text='1']")
+			.shadow()
+			.find(".ui5-menu-rp")
+			.should("have.attr", "accessible-name", NAVIGATION_MENU_POPOVER_HIDDEN_TEXT.defaultText);
 	});
 });
 

--- a/packages/fiori/src/NavigationMenuItem.ts
+++ b/packages/fiori/src/NavigationMenuItem.ts
@@ -107,7 +107,7 @@ class NavigationMenuItem extends MenuItem {
 		return result;
 	}
 
-	get accSideNavigationPopoverHiddenText() {
+	get acessibleNameText() {
 		return NavigationMenu.i18nBundle.getText(NAVIGATION_MENU_POPOVER_HIDDEN_TEXT);
 	}
 }

--- a/packages/fiori/src/NavigationMenuItemTemplate.tsx
+++ b/packages/fiori/src/NavigationMenuItemTemplate.tsx
@@ -1,24 +1,17 @@
 import type NavigationMenuItem from "./NavigationMenuItem.js";
 import MenuItemTemplate from "@ui5/webcomponents/dist/MenuItemTemplate.js";
-import type { MenuItemHooks } from "@ui5/webcomponents/dist/MenuItemTemplate.js";
 import Icon from "@ui5/webcomponents/dist/Icon.js";
 import slimArrowRightIcon from "@ui5/webcomponents-icons/dist/slim-arrow-right.js";
 import arrowRightIcon from "@ui5/webcomponents-icons/dist/arrow-right.js";
-import declineIcon from "@ui5/webcomponents-icons/dist/decline.js";
-import navBackIcon from "@ui5/webcomponents-icons/dist/nav-back.js";
-import ResponsivePopover from "@ui5/webcomponents/dist/ResponsivePopover.js";
-import Button from "@ui5/webcomponents/dist/Button.js";
-import List from "@ui5/webcomponents/dist/List.js";
-import BusyIndicator from "@ui5/webcomponents/dist/BusyIndicator.js";
+import type { ListItemHooks } from "@ui5/webcomponents/dist/ListItemTemplate.js";
 
-const predefinedHooks: Partial<MenuItemHooks> = {
+const predefinedHooks: Partial<ListItemHooks> = {
 	listItemContent,
 	iconBegin,
 	iconEnd,
-	listItemPostContent: () => { },
 };
 
-export default function NavigationMenuItemTemplate(this: NavigationMenuItem, hooks?: Partial<MenuItemHooks>) {
+export default function NavigationMenuItemTemplate(this: NavigationMenuItem, hooks?: Partial<ListItemHooks>) {
 	const currentHooks = { ...predefinedHooks, ...hooks, };
 
 	return <>
@@ -33,8 +26,6 @@ export default function NavigationMenuItemTemplate(this: NavigationMenuItem, hoo
 				</a>
 			) : MenuItemTemplate.call(this, currentHooks)
 		}
-
-		{listItemPostContent.call(this)}
 	</>;
 }
 
@@ -70,75 +61,4 @@ function iconEnd(this: NavigationMenuItem) {
 			name={arrowRightIcon}
 		/>;
 	}
-}
-
-function listItemPostContent(this: NavigationMenuItem) {
-	return this.hasSubmenu && <ResponsivePopover
-		id={`${this._id}-navigation-menu-rp`}
-		class="ui5-menu-rp ui5-navigation-menu ui5-menu-rp-sub-menu"
-		verticalAlign="Center"
-		preventInitialFocus
-		preventFocusRestore
-		accessibleNameRef={`${this._id}-navigationMenuPopoverText`}
-		onBeforeOpen={this._beforePopoverOpen}
-		onOpen={this._afterPopoverOpen}
-		onBeforeClose={this._beforePopoverClose}
-		onClose={this._afterPopoverClose}
-	>
-		<span id={`${this._id}-navigationMenuPopoverText`} class="ui5-hidden-text">{this.accSideNavigationPopoverHiddenText}</span>
-
-		{this.isPhone && (
-			<div slot="header" class="ui5-menu-dialog-header">
-				{this.isSubMenuOpen && (
-					<Button
-						icon={navBackIcon}
-						class="ui5-menu-back-button"
-						design="Transparent"
-						aria-label={this.labelBack}
-						onClick={this._close}
-					/>
-				)}
-
-				<div class="ui5-menu-dialog-title">
-					<div>
-						{this.menuHeaderTextPhone}
-					</div>
-				</div>
-
-				<Button
-					icon={declineIcon}
-					design="Transparent"
-					aria-label={this.labelClose}
-					onClick={this._closeAll}
-				/>
-			</div>
-		)}
-
-		<div id={`${this._id}-menu-main`} class="ui5-navigation-menu-main">
-			{this.items.length ? (
-				<List
-					accessibleRole="Tree"
-					id={`${this.id}-menu-list`}
-					selectionMode="None"
-					loading={this.loading}
-					loadingDelay={this.loadingDelay}
-					separators="None"
-					// handles event from slotted children
-					onui5-close-menu={this._close}
-				>
-					<slot></slot>
-				</List>
-			) : (
-				this.loading && (
-					<BusyIndicator
-						id={`${this._id}-menu-busy-indicator`}
-						delay={this.loadingDelay}
-						class="ui5-menu-busy-indicator"
-						active={true}
-					/>
-				)
-			)}
-		</div>
-
-	</ResponsivePopover >;
 }

--- a/packages/main/src/MenuItemTemplate.tsx
+++ b/packages/main/src/MenuItemTemplate.tsx
@@ -1,4 +1,3 @@
-import type { JsxTemplate } from "@ui5/webcomponents-base";
 import type MenuItem from "./MenuItem.js";
 import ResponsivePopover from "./ResponsivePopover.js";
 import Button from "./Button.js";
@@ -11,16 +10,12 @@ import Icon from "./Icon.js";
 import ListItemTemplate from "./ListItemTemplate.js";
 import type { ListItemHooks } from "./ListItemTemplate.js";
 
-export type MenuItemHooks = ListItemHooks & {
-	listItemPostContent: JsxTemplate,
-}
-
-const predefinedHooks: Partial<MenuItemHooks> = {
+const predefinedHooks: Partial<ListItemHooks> = {
 	listItemContent,
 	iconBegin,
 };
 
-export default function MenuItemTemplate(this: MenuItem, hooks?: Partial<MenuItemHooks>) {
+export default function MenuItemTemplate(this: MenuItem, hooks?: Partial<ListItemHooks>) {
 	const currentHooks = { ...predefinedHooks, ...hooks };
 
 	return <>


### PR DESCRIPTION
1. Removed obsolete and ineffective `listItemPostContent` hook from MenuItemTemplate
2. Implemented alternative solution for `accessible-name` of NavigationMenuItem's popover