### PR TITLE
fix(ui5-combobox): prevent 'change' event from being fired if the value is set programmatically

### DIFF
--- a/packages/main/cypress/specs/ComboBox.cy.tsx
+++ b/packages/main/cypress/specs/ComboBox.cy.tsx
@@ -19,3 +19,22 @@ describe("Security", () => {
 			.should("have.text", "Albania<button onClick='alert(1)'>alert</button>");
 	});
 });
+
+describe("General interactions", () => {
+	it("should not fire 'change' event on focusout if initial value is not changed", () => {
+		cy.mount(
+			<>
+				<ComboBox id="cb" value = "ComboBox item text"></ComboBox>
+				<ComboBox id="another-cb"></ComboBox>
+			</>
+		);
+
+		cy.get("#cb").then($cb => {
+			$cb[0].addEventListener("ui5-change", cy.stub().as("changeStub"));
+		});
+
+		cy.get("#cb").shadow().find("input").click();
+		cy.get("#another-cb").shadow().find("input").click();
+		cy.get("@changeStub").should("not.have.been.called");
+	});
+});

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -489,6 +489,7 @@ class ComboBox extends UI5Element implements IFormInputElement {
 	_focusin(e: FocusEvent) {
 		this.focused = true;
 		this._autocomplete = false;
+		this._lastValue = this.value;
 
 		!isPhone() && (e.target as HTMLInputElement).setSelectionRange(0, this.value.length);
 	}


### PR DESCRIPTION
fixes: #10959
