### PR TITLE
fix(ui5-select-menu): handle late component definition

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -937,7 +937,7 @@ class Select extends UI5Element implements IFormElement {
 	get selectOptions(): Array<IOption> {
 		const menu = this._getSelectMenu();
 		if (menu) {
-			return menu.options;
+			return Array.from(menu.children) as Array<IOption>;
 		}
 		return this._filteredItems;
 	}


### PR DESCRIPTION
In some cases the SelectMenu is discovered by id or reference, but its definition is not completed, and some accessors are not yet available but called from the Select, leading to a JS error in `this.selectOptions.find(..)` (this.selectOptions returns undefined, because menu.options is undefined)

<img width="659" alt="Screenshot 2025-03-10 at 19 37 48" src="https://github.com/user-attachments/assets/4fa5ef3a-3be5-4291-ae5c-76f9f637a13c" />

Fixes: https://github.com/SAP/ui5-webcomponents/issues/11019