### PR TITLE
fix(ui5-shellbar): fix separators visibility when items are hidden

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -1,5 +1,6 @@
 import ShellBar from "../../src/ShellBar.js";
 import ShellBarItem from "../../src/ShellBarItem.js";
+import ShellBarSpacer from "@ui5/webcomponents-fiori/dist/ShellBarSpacer.js";
 import activities from "@ui5/webcomponents-icons/dist/activities.js";
 import navBack from "@ui5/webcomponents-icons/dist/nav-back.js";
 import sysHelp from "@ui5/webcomponents-icons/dist/sys-help.js";
@@ -30,7 +31,7 @@ describe("Responsiveness", () => {
 				<img src="https://sdk.openui5.org/test-resources/sap/f/images/Woman_avatar_01.png" />
 			</Avatar>
 
-			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg"/>
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
 
 			<Button icon={navBack} slot="startButton" id="start-button"></Button>
 
@@ -66,7 +67,7 @@ describe("Responsiveness", () => {
 				<img src="https://sdk.openui5.org/test-resources/sap/f/images/Woman_avatar_01.png" />
 			</Avatar>
 
-			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg"/>
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
 
 			<Button icon={navBack} slot="startButton" id="start-button"></Button>
 
@@ -88,7 +89,7 @@ describe("Responsiveness", () => {
 			showNotifications={true}
 			showProductSwitch={true}
 		>
-			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg"/>
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
 		</ShellBar>;
 	}
 	beforeEach(() => {
@@ -294,5 +295,77 @@ describe("Responsiveness", () => {
 			.shadow()
 			.find(".ui5-shellbar-overflow-button")
 			.should("be.hidden");
+	});
+});
+
+describe("Slots", () => {
+	describe("Content slot", () => {
+		it("Test separators visibility", () => {
+			function assertStartSeparatorVisibility(expectedExist: boolean) {
+				cy.get("#shellbar")
+					.shadow()
+					.find(".ui5-shellbar-overflow-container-right-inner > .ui5-shellbar-separator-start")
+					.should(expectedExist ? "exist" : "not.exist");
+			}
+			function assertEndSeparatorVisibility(expectedExist: boolean) {
+				cy.get("#shellbar")
+					.shadow()
+					.find(".ui5-shellbar-overflow-container-right-inner > .ui5-shellbar-separator-end")
+					.should(expectedExist ? "exist" : "not.exist");
+			}
+
+			cy.mount(
+				<ShellBar id="shellbar" primaryTitle="Product Title" showNotifications={true} showProductSwitch={true}>
+					<Button icon={navBack} slot="startButton"></Button>
+					<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+					<Button slot="content">Start Button 1</Button>
+					<Button slot="content" data-hide-order="1">Start Button 2</Button>
+					<ShellBarSpacer slot="content" />
+					<Button slot="content">End Button 1</Button>
+					<Button slot="content" data-hide-order="1">End Button 2</Button>
+				</ShellBar>
+			);
+
+			// both separators should be visible
+			assertStartSeparatorVisibility(true);
+			assertEndSeparatorVisibility(true);
+
+			cy.viewport(420, 1080);
+			// only end separator should be hidden
+			assertStartSeparatorVisibility(true);
+			assertEndSeparatorVisibility(false);
+
+			cy.viewport(320, 1080);
+			// both separators should be hidden
+			assertStartSeparatorVisibility(false);
+			assertEndSeparatorVisibility(false);
+
+			// once items are hidden, both separators should be rendered with the last visible item
+			cy.get("#shellbar")
+				.shadow()
+				.find("div[id='content-2'] > .ui5-shellbar-separator-start")
+				.should("exist");
+
+			cy.get("#shellbar")
+				.shadow()
+				.find("div[id='content-5'] > .ui5-shellbar-separator-end")
+				.should("exist");
+
+			cy.viewport(1920, 1080);
+			// both separators should be visible
+			assertStartSeparatorVisibility(true);
+			assertEndSeparatorVisibility(true);
+
+			// once items are shown, both separators shouldn't be rendered with the last visible item
+			cy.get("#shellbar")
+				.shadow()
+				.find("div[id='content-2'] > .ui5-shellbar-separator-start")
+				.should("not.exist");
+
+			cy.get("#shellbar")
+				.shadow()
+				.find("div[id='content-5'] > .ui5-shellbar-separator-end")
+				.should("not.exist");
+		});
 	});
 });

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -320,9 +320,11 @@ describe("Slots", () => {
 					<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
 					<Button slot="content">Start Button 1</Button>
 					<Button slot="content" data-hide-order="1">Start Button 2</Button>
+					<Button slot="content">Start Button 3</Button>
 					<ShellBarSpacer slot="content" />
 					<Button slot="content">End Button 1</Button>
 					<Button slot="content" data-hide-order="1">End Button 2</Button>
+					<Button slot="content">End Button 3</Button>
 				</ShellBar>
 			);
 
@@ -348,7 +350,7 @@ describe("Slots", () => {
 
 			cy.get("#shellbar")
 				.shadow()
-				.find("div[id='content-5'] > .ui5-shellbar-separator-end")
+				.find("div[id='content-6'] > .ui5-shellbar-separator-end")
 				.should("exist");
 
 			cy.viewport(1920, 1080);
@@ -364,7 +366,7 @@ describe("Slots", () => {
 
 			cy.get("#shellbar")
 				.shadow()
-				.find("div[id='content-5'] > .ui5-shellbar-separator-end")
+				.find("div[id='content-6'] > .ui5-shellbar-separator-end")
 				.should("not.exist");
 		});
 	});

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1227,7 +1227,7 @@ class ShellBar extends UI5Element {
 		if (!itemInfo) {
 			return false;
 		}
-		const lastVisibleItem = contentInfo.at(1);
+		const lastVisibleItem = contentInfo.at(-1);
 		return lastVisibleItem?.id === itemInfo.id && itemInfo.classes.indexOf("ui5-shellbar-hidden-button") > -1;
 	}
 

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1358,12 +1358,18 @@ class ShellBar extends UI5Element {
 	get startContent() {
 		// all items before the first spacer
 		const spacerIndex = this.content.findIndex(child => child.hasAttribute("ui5-shellbar-spacer"));
+		if (spacerIndex === -1) {
+			return this.content;
+		}
 		return this.content.slice(0, spacerIndex);
 	}
 
 	get endContent() {
 		// all items after the first spacer
 		const spacerIndex = this.content.findIndex(child => child.hasAttribute("ui5-shellbar-spacer"));
+		if (spacerIndex === -1) {
+			return [];
+		}
 		return this.content.slice(spacerIndex + 1);
 	}
 

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1201,32 +1201,34 @@ class ShellBar extends UI5Element {
 		return (this.showSearchField || this._autoRestoreSearchField) && !onFocus && isEmpty;
 	}
 
-	get showStartSeparatorInWrapper(): boolean {
-		// show separator at the beginning of content if more than one
-		// item is visible, otherwise, the separator is packed with the
-		// first visible item to be calculated with the next overflow action
-		const starContent = this.startContent;
-		const hiddenStartContentItems = this._contentInfo.filter(item => {
-			const isHidden = item.classes.indexOf("ui5-shellbar-hidden-button") !== -1;
-			const isInContent = starContent.find(contentItem => contentItem.slot === item.id);
-			return isHidden && isInContent;
-		}).map(item => item.id);
-
-		return (starContent.length - hiddenStartContentItems.length) > 0;
+	get startContentInfoSorted() {
+		return this._contentInfo
+			.filter(item => this.startContent.find(contentItem => contentItem.slot === item.id))
+			.sort((a, b) => a.hideOrder - b.hideOrder);
 	}
 
-	get showEndSeparatorInWrapper(): boolean {
-		// show separator at the end of content if more than one
-		// item is visible, otherwise, the separator is packed with the
-		// last visible item to be calculated with the next overflow
-		const endContent = this.endContent;
-		const hiddenEndContentItems = this._contentInfo.filter(item => {
-			const isHidden = item.classes.indexOf("ui5-shellbar-hidden-button") !== -1;
-			const isInContent = endContent.find(contentItem => contentItem.slot === item.id);
-			return isHidden && isInContent;
-		}).map(item => item.id);
+	get endContentInfoSorted() {
+		return this._contentInfo
+			.filter(item => this.endContent.find(contentItem => contentItem.slot === item.id))
+			.sort((a, b) => a.hideOrder - b.hideOrder);
+	}
 
-		return (endContent.length - hiddenEndContentItems.length) > 0;
+	get showStartSeparator(): boolean {
+		return this.startContentInfoSorted.some(item => !item.classes.includes("ui5-shellbar-hidden-button"));
+	}
+
+	get showEndSeparator(): boolean {
+		return this.endContentInfoSorted.some(item => !item.classes.includes("ui5-shellbar-hidden-button"));
+	}
+
+	shouldIncludeSeparator(itemInfo: IShellBarContentItem | undefined, contentInfo: IShellBarContentItem[]) {
+		// once the last item from the start/end content was hidden, the
+		// separator is "packed" with it in order to account for any next measurements
+		if (!itemInfo) {
+			return false;
+		}
+		const lastVisibleItem = contentInfo.at(1);
+		return lastVisibleItem?.id === itemInfo.id && itemInfo.classes.indexOf("ui5-shellbar-hidden-button") > -1;
 	}
 
 	get classes(): ClassMap {

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -76,17 +76,18 @@ export default function ShellBarTemplate(this: ShellBar) {
 					<div class="ui5-shellbar-overflow-container-right-inner">
 						{this.hasContentItems && (
 							<>
-								{this.showStartSeparatorInWrapper && (
+								{this.showStartSeparator && (
 									<div class={{
 										"ui5-shellbar-separator": true,
 										"ui5-shellbar-separator-start": true,
 									}}></div>
 								)}
-								{this.startContent.map((item, index) => {
+								{this.startContent.map(item => {
 									const itemInfo = this._contentInfo.find(info => info.id === item._individualSlot);
 									return (
 										<div key={item._individualSlot} id={item._individualSlot} class={itemInfo?.classes}>
-											{!this.showStartSeparatorInWrapper && index === 0 && (
+											{this.shouldIncludeSeparator(itemInfo, this.startContentInfoSorted) && (
+												// never displayed, only "packed" with last item that was hidden, used for measurement purposes
 												<div class={{
 													"ui5-shellbar-separator": true,
 													"ui5-shellbar-separator-start": true,
@@ -97,12 +98,13 @@ export default function ShellBarTemplate(this: ShellBar) {
 									);
 								})}
 								<div class="ui5-shellbar-spacer"></div>
-								{this.endContent.map((item, index) => {
+								{this.endContent.map(item => {
 									const itemInfo = this._contentInfo.find(info => info.id === item._individualSlot);
 									return (
 										<div key={item._individualSlot} id={item._individualSlot} class={itemInfo?.classes}>
 											<slot name={item._individualSlot}></slot>
-											{!this.showEndSeparatorInWrapper && index === this.endContent.length - 1 && (
+											{this.shouldIncludeSeparator(itemInfo, this.endContentInfoSorted) && (
+												// never displayed, only "packed" with last item that was hidden, used for measurement purposes
 												<div class={{
 													"ui5-shellbar-separator": true,
 													"ui5-shellbar-separator-end": true,
@@ -111,7 +113,7 @@ export default function ShellBarTemplate(this: ShellBar) {
 										</div>
 									);
 								})}
-								{this.showEndSeparatorInWrapper && (
+								{this.showEndSeparator && (
 									<div class={{
 										"ui5-shellbar-separator": true,
 										"ui5-shellbar-separator-end": true,


### PR DESCRIPTION
When items are being hidden, the disappearing separators were messing up the math for calculating available space. 

This commit fixes the issue by rendering the hidden separators with the last visible item. This way the space is still resevered and taken into account when calculating the available space. 

The tests are also extended to cover this case.