### PR TITLE
chore: correct typescript configuration for cypress mount

### DIFF
--- a/packages/cypress-ct-ui5-webc/tsconfig.definition.json
+++ b/packages/cypress-ct-ui5-webc/tsconfig.definition.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-	"outDir": "dist",
-	"rootDir": "src",
+    "outDir": "dist",
     "target": "ES2015",
     "module": "CommonJS",
     "moduleResolution": "node",
@@ -12,4 +11,5 @@
     "types": ["cypress"],
     "skipLibCheck": true
   },
+  "include": ["./src/definition.ts"]
 }

--- a/packages/cypress-ct-ui5-webc/tsconfig.mount.json
+++ b/packages/cypress-ct-ui5-webc/tsconfig.mount.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-	"outDir": "dist",
-	"rootDir": "src",
+    "outDir": "dist",
     "target": "ES6",
     "module": "ES6",
     "moduleResolution": "node",
@@ -11,4 +10,5 @@
     "strict": true,
     "types": ["cypress"]
   },
+  "include": ["./src/index.ts"]
 }


### PR DESCRIPTION
Both TypeScript configurations were configured to process all files in `src` file. With that modules were not in the correct in the correct format that `cypress` expects.

- `definition.js` should be resolved in CommonJS
- `index.js` should be resolved in ESM