### PR TITLE
chore(ui5-icon): remove 'no name' warning

### DIFF
--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -269,8 +269,7 @@ class Icon extends UI5Element implements IIcon {
 	async onBeforeRendering() {
 		const name = this.name;
 		if (!name) {
-			/* eslint-disable-next-line */
-			return console.warn("Icon name property is required", this);
+			return;
 		}
 
 		let iconData: typeof ICON_NOT_FOUND | IconData | undefined = getIconDataSync(name);


### PR DESCRIPTION
In some frameworks, even if the name is part of the template and added on the ui5-icon, it is sometimes set on a second step and the warning is confusing. Also, not very useful in general, because using the component without an icon name is not something that people will easily miss and even if they miss it - they will quickly get it because nothing will be displayed.