### PR TITLE
fix: keep export paths in base in sync

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -35,7 +35,11 @@
     },
     "./package.json": "./package.json",
     "./bundle.esm.js": "./bundle.esm.js",
-    "./*": "./dist/*"
+    "./*": {
+      "production": "./dist/prod/*",
+      "development": "./dist/*",
+      "default": "./dist/*"
+    }
   },
   "types": "./dist",
   "scripts": {


### PR DESCRIPTION
The current base export paths could lead to corrupted production builds if you e.g. import the `setTheme` from  `'@ui5/webcomponents-base/config/Theme.js'` instead of `'@ui5/webcomponents-base/dist/config/Theme.js'`

Due to the not existing `production` case, we were actually running in two different bundles of UI5 Web Components in our production build.