### PR TITLE
chore: integrate `cypress-axe` for accessibility testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ dist
 coverage
 .nyc_output
 
+# Cypress internal logs
+cypress-logs
+
 # scoping feature generated entry points for vite consumption
 packages/compat/test/pages/scoped
 packages/main/test/pages/scoped

--- a/packages/cypress-internal/package.json
+++ b/packages/cypress-internal/package.json
@@ -13,14 +13,14 @@
   },
   "type": "module",
   "dependencies": {
+    "eslint-plugin-cypress": "^3.4.0",
     "@ui5/cypress-ct-ui5-webc": "0.0.2",
+    "cypress": "^13.11.0",
+    "typescript": "^5.6.2",
     "rimraf": "^3.0.2",
+    "cypress-real-events": "^1.12.0",
     "@cypress/code-coverage": "^3.13.11",
     "axe-core": "^4.10.2",
-    "cypress": "^13.11.0",
-    "cypress-axe": "^1.6.0",
-    "cypress-real-events": "^1.12.0",
-    "eslint-plugin-cypress": "^3.4.0",
-    "typescript": "^5.6.2"
+    "cypress-axe": "^1.6.0"
   }
 }

--- a/packages/cypress-internal/package.json
+++ b/packages/cypress-internal/package.json
@@ -13,12 +13,14 @@
   },
   "type": "module",
   "dependencies": {
-    "eslint-plugin-cypress": "^3.4.0",
     "@ui5/cypress-ct-ui5-webc": "0.0.2",
-    "cypress": "^13.11.0",
-    "typescript": "^5.6.2",
     "rimraf": "^3.0.2",
+    "@cypress/code-coverage": "^3.13.11",
+    "axe-core": "^4.10.2",
+    "cypress": "^13.11.0",
+    "cypress-axe": "^1.6.0",
     "cypress-real-events": "^1.12.0",
-    "@cypress/code-coverage": "^3.13.11"
+    "eslint-plugin-cypress": "^3.4.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/packages/cypress-internal/src/acc_report/index
+++ b/packages/cypress-internal/src/acc_report/index
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cypress Test Report</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        ul {
+            list-style-type: none;
+            padding-left: 20px;
+        }
+
+        .violations ul li:not(:last-child) {
+            border-bottom: 1px solid black;
+        }
+
+        details {
+            margin-bottom: 10px;
+        }
+
+        summary {
+            cursor: pointer;
+        }
+
+        details>ul {
+            margin-top: 5px;
+        }
+    </style>
+</head>
+
+<body>
+
+    <h1>Cypress Test Report</h1>
+
+    <div>
+        <ul id="test-report">
+        </ul>
+    </div>
+
+    <script type="module">
+        const response = await fetch("./acc_logs.json")
+        const reportData = await response.json();
+
+        const printError = (error) => {
+            return `
+            <li>
+                <details class="violations">
+                    <summary>[FAILED] ${error.testTitlePath.join(" > ")}</summary>
+                    <ul>
+                    ${error.violations.map(printViolation).join("")}
+                    </ul>
+                </details>
+            </li>`
+        };
+
+        const printViolation = (violation) => {
+            return `
+            <li>
+                <b>id:</b> ${violation.id}<br />
+                <b>impact:</b> ${violation.impact}<br />
+                <b>description:</b> ${violation.description}
+            </li>`;
+        };
+
+        const printFileLog = () => {
+            const testReport = document.querySelector("#test-report");
+
+            testReport.innerHTML = reportData.map(fileLog => {
+                return `
+                <li>
+                    <details open>
+                    <summary>Test file: ${fileLog.testFile}</summary>
+                    <ul>
+                        ${fileLog.errors.map(printError).join("")}
+                    </ul>
+                    </details>
+                </li>`;
+            }).join("");
+        }
+
+        printFileLog();
+    </script>
+
+
+</body>
+
+</html>

--- a/packages/cypress-internal/src/acc_report/support.ts
+++ b/packages/cypress-internal/src/acc_report/support.ts
@@ -9,14 +9,14 @@ type Vialotation = {
     nodes: number,
 }
 
-type TestFails = {
+type TestVialotation = {
     testTitlePath: string[],
     violations: Vialotation[]
 }
 
 type TestReport = {
     testFile: string,
-    errors: TestFails[]
+    errors: TestVialotation[]
 }
 
 function checkA11TerminalLog(violations: typeof AxeResults.violations) {

--- a/packages/cypress-internal/src/acc_report/support.ts
+++ b/packages/cypress-internal/src/acc_report/support.ts
@@ -1,0 +1,63 @@
+import 'cypress-axe'
+import type { AxeResults, ImpactValue } from "axe-core";
+import { Options } from "cypress-axe";
+
+type Vialotation = {
+    id: string,
+    impact: ImpactValue | undefined,
+    description: string
+    nodes: number,
+}
+
+type TestFails = {
+    testTitlePath: string[],
+    violations: Vialotation[]
+}
+
+type TestReport = {
+    testFile: string,
+    errors: TestFails[]
+}
+
+function checkA11TerminalLog(violations: typeof AxeResults.violations) {
+    const violationData = violations.map<Vialotation>(
+        ({ id, impact, description, nodes }) => ({
+            id,
+            impact,
+            description,
+            nodes: nodes.length
+        })
+    )
+
+    const report: TestReport = {
+        testFile: Cypress.spec.relative,
+        errors: [{
+            testTitlePath: Cypress.currentTest.titlePath,
+            violations: violationData,
+        }]
+    }
+
+    cy.task('ui5ReportA11y', report)
+}
+
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            ui5CheckA11y(context?: string | Node | undefined, options?: Options | undefined): Cypress.Chainable<void>;
+        }
+    }
+}
+
+Cypress.Commands.add("ui5CheckA11y", (context?: string | Node | undefined, options?: Options | undefined) => {
+    return cy.checkA11y(context || "[data-cy-root]", options, checkA11TerminalLog, false)
+})
+
+if (Cypress.env('ui5AccTasksRegistered') === true) {
+    before(() => {
+        cy.task('ui5ReportA11yReset', Cypress.spec.relative);
+    })
+}
+
+export type {
+    TestReport,
+}

--- a/packages/cypress-internal/src/acc_report/task.ts
+++ b/packages/cypress-internal/src/acc_report/task.ts
@@ -1,0 +1,94 @@
+import { TestReport } from "./support.js";
+// @ts-ignore
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+// @ts-ignore
+import * as path from "path";
+
+const outputPath = path.resolve("./cypress-logs/acc_log.json");
+
+const findExistingReport = (fileData: TestReport[], testFile: string) => fileData.find(report => report.testFile === testFile);
+
+const log = (currentReport: TestReport) => {
+	let fileData: TestReport[] = [];
+
+	try {
+		fileData = JSON.parse(readFileSync(outputPath, { encoding: "utf-8" })) as TestReport[];
+	} catch (e) { }
+
+	const existingReport = findExistingReport(fileData, currentReport.testFile);
+
+	if (existingReport) {
+		existingReport.errors.push(...currentReport.errors)
+	} else {
+		fileData.push(currentReport);
+	}
+
+	fileData.forEach(file => {
+		const paths = file.errors.map(error => error.testTitlePath.join(" "));
+		file.errors = file.errors.filter((error, index) => paths.indexOf(error.testTitlePath.join(" ")) === index);
+	})
+
+	saveReportFile(fileData);
+}
+
+const saveReportFile = (fileData: TestReport[]) => {
+	mkdirSync(path.dirname(outputPath), { recursive: true });
+
+	writeFileSync(outputPath, JSON.stringify(fileData, undefined, 4));
+};
+
+const reset = (testFile: string) => {
+	try {
+		let fileData = JSON.parse(readFileSync(outputPath, { encoding: "utf-8" })) as TestReport[];
+		const existingReport = findExistingReport(fileData, testFile);
+
+		if (existingReport) {
+			fileData.splice(fileData.indexOf(existingReport), 1)
+
+			saveReportFile(fileData);
+		}
+	} catch (e) { }
+}
+
+function accTask(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
+	if (config.env.UI5_ACC === true) {
+		on('before:run', () => {
+			// Reset the report file when tests are run with the `cypress run` command.
+			// This event is triggered when running tests with the `cypress open` command (behind an experimental flag).
+			// `config.isInteractive` helps us determine whether the tests are running in interactive mode (`cypress open`) or non-interactive mode (`cypress run`).
+			if (!config.isInteractive) {
+				saveReportFile([]);
+			}
+		});
+
+		on('before:browser:launch', () => {
+			// Reset the report file when tests are run with the `cypress open` command.
+			// `config.isInteractive` helps us determine whether the tests are running in interactive mode (`cypress open`) or non-interactive mode (`cypress run`).
+			if (config.isInteractive) {
+				saveReportFile([]);
+			}
+		});
+
+		on('task', {
+			// Adds the accessibility report for the current test to the spec file logs
+			ui5ReportA11y(report: TestReport) {
+				log(report);
+
+				return null;
+			},
+
+			// Removes all existing logs for the current test file when the spec file is loaded
+			ui5ReportA11yReset(testFile: string) {
+				reset(testFile);
+
+				return null;
+			}
+		})
+
+		config.env.ui5AccTasksRegistered = true
+	}
+
+	return config
+}
+
+export default accTask;

--- a/packages/cypress-internal/src/acc_report/task.ts
+++ b/packages/cypress-internal/src/acc_report/task.ts
@@ -1,10 +1,17 @@
 import { TestReport } from "./support.js";
-// @ts-ignore
+// @ts-expect-error
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
-// @ts-ignore
+// @ts-expect-error
 import * as path from "path";
+// @ts-expect-error
+import { fileURLToPath } from 'node:url';
 
-const outputPath = path.resolve("./cypress-logs/acc_log.json");
+// @ts-expect-error
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const outputPath = path.resolve("./cypress-logs/acc_logs.json");
+const outputPathIndex = path.resolve("./cypress-logs/index.html");
 
 const findExistingReport = (reportData: TestReport[], testFile: string) => reportData.find(report => report.testFile === testFile);
 
@@ -52,6 +59,14 @@ const reset = (testFile: string) => {
 	}
 }
 
+const prepare = () => {
+	const indexTemplate = readFileSync(path.join(__dirname, "index"), { encoding: "utf-8" });
+	writeFileSync(outputPathIndex, indexTemplate);
+
+	saveReportFile([]);
+
+}
+
 function accTask(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
 	if (config.env.UI5_ACC === true) {
 		on('before:run', () => {
@@ -59,7 +74,7 @@ function accTask(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) 
 			// This event is triggered when running tests with the `cypress open` command (behind an experimental flag).
 			// `config.isInteractive` helps us determine whether the tests are running in interactive mode (`cypress open`) or non-interactive mode (`cypress run`).
 			if (!config.isInteractive) {
-				saveReportFile([]);
+				prepare();
 			}
 		});
 
@@ -67,7 +82,7 @@ function accTask(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) 
 			// Reset the report file when tests are run with the `cypress open` command.
 			// `config.isInteractive` helps us determine whether the tests are running in interactive mode (`cypress open`) or non-interactive mode (`cypress run`).
 			if (config.isInteractive) {
-				saveReportFile([]);
+				prepare();
 			}
 		});
 

--- a/packages/cypress-internal/src/commands.ts
+++ b/packages/cypress-internal/src/commands.ts
@@ -1,5 +1,7 @@
 import "cypress-real-events";
 import '@cypress/code-coverage/support'
+import "./acc_report/support.js";
+import "./helpers.js"
 
 const realEventCmdCallback = (originalFn: any, element: any, ...args: any) => {
 	cy.get(element)

--- a/packages/cypress-internal/src/copy.js
+++ b/packages/cypress-internal/src/copy.js
@@ -3,7 +3,11 @@ import path from "path";
 
 const dirname = import.meta.dirname;
 
-await copyFile(path.join(dirname, "./eslint.cjs"), path.join(dirname, "../dist/eslint.cjs"))
-await copyFile(path.join(dirname, "./acc_report/index"), path.join(dirname, "../dist/acc_report/index"))
+const files = [
 
+];
+
+await copyFile(path.join(dirname, "./eslint.cjs"), path.join(dirname, "../dist/eslint.cjs"))
 console.log("eslint.cjs copied successfully")
+await copyFile(path.join(dirname, "./acc_report/index"), path.join(dirname, "../dist/acc_report/index"))
+console.log("acc_report/index copied successfully")

--- a/packages/cypress-internal/src/copy.js
+++ b/packages/cypress-internal/src/copy.js
@@ -4,5 +4,6 @@ import path from "path";
 const dirname = import.meta.dirname;
 
 await copyFile(path.join(dirname, "./eslint.cjs"), path.join(dirname, "../dist/eslint.cjs"))
+await copyFile(path.join(dirname, "./acc_report/index"), path.join(dirname, "../dist/acc_report/index"))
 
 console.log("eslint.cjs copied successfully")

--- a/packages/cypress-internal/src/cypress.config.ts
+++ b/packages/cypress-internal/src/cypress.config.ts
@@ -2,11 +2,14 @@ import { defineConfig } from "cypress";
 // @ts-ignore
 import viteConfig from "../../../vite.config.js";
 import coverageTask from "@cypress/code-coverage/task.js";
+import accTask from "./acc_report/task.js";
+
 
 export default defineConfig({
 	component: {
 		setupNodeEvents(on, config) {
 			coverageTask(on, config);
+			accTask(on, config)
 
 			return config
 		},

--- a/packages/cypress-internal/src/helpers.ts
+++ b/packages/cypress-internal/src/helpers.ts
@@ -1,0 +1,16 @@
+declare global {
+    function ui5AccDescribe(title: string, fn: (this: Mocha.Suite) => void): Mocha.Suite | void;
+}
+
+globalThis.ui5AccDescribe = (title: string, fn: (this: Mocha.Suite) => void): Mocha.Suite | void => {
+    if (Cypress.env('ui5AccTasksRegistered') === true) {
+        return describe.only(`[UI5-ACC-TESTS] ${title}`, function (this: Mocha.Suite) {
+            before(() => {
+                cy.injectAxe({ axeCorePath: "../../node_modules/axe-core/axe.min.js" });
+            });
+            fn.call(this);
+        });
+    }
+};
+
+export { }

--- a/packages/cypress-internal/src/helpers.ts
+++ b/packages/cypress-internal/src/helpers.ts
@@ -4,7 +4,7 @@ declare global {
 
 globalThis.ui5AccDescribe = (title: string, fn: (this: Mocha.Suite) => void): Mocha.Suite | void => {
     if (Cypress.env('ui5AccTasksRegistered') === true) {
-        return describe.only(`[UI5-ACC-TESTS] ${title}`, function (this: Mocha.Suite) {
+        return describe.only(`${title}`, function (this: Mocha.Suite) {
             before(() => {
                 cy.injectAxe({ axeCorePath: "../../node_modules/axe-core/axe.min.js" });
             });

--- a/packages/cypress-internal/tsconfig.json
+++ b/packages/cypress-internal/tsconfig.json
@@ -14,7 +14,8 @@
 		"esModuleInterop": true,
 		"strict": true,
 		"types": [
-			"cypress"
+			"cypress",
+			"cypress-axe",
 		]
 	},
 }

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -395,5 +395,4 @@ ui5AccDescribe("Automated accessibility tests", () => {
 
 		cy.ui5CheckA11y();
 	})
-	})
 });

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -41,6 +41,7 @@ describe("Button general interaction", () => {
 			.find(".ui5-button-icon")
 			.should("not.exist", "icon is not present");
 	});
+
 	it("tests button's endIon rendering", () => {
 		cy.mount(<Button>Action Bar Button</Button>);
 
@@ -386,4 +387,19 @@ describe("Accessibility", () => {
 		cy.get("@tag")
 			.should("have.text", "999+");
 	});
+});
+
+ui5AccDescribe("Automated accessibility tests", () => {
+	it("1", () => {
+		cy.wait(5000);
+		cy.mount(<Button icon="message-information"></Button>);
+
+		cy.ui5CheckA11y();
+	})
+
+	it("2", () => {
+		cy.mount(<Button icon="message-information"></Button>);
+
+		cy.ui5CheckA11y();
+	})
 });

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -390,16 +390,11 @@ describe("Accessibility", () => {
 });
 
 ui5AccDescribe("Automated accessibility tests", () => {
-	it("1", () => {
+	it("Icon only", () => {
 		cy.wait(5000);
 		cy.mount(<Button icon="message-information"></Button>);
 
 		cy.ui5CheckA11y();
 	})
-
-	it("2", () => {
-		cy.mount(<Button icon="message-information"></Button>);
-
-		cy.ui5CheckA11y();
 	})
 });

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -391,7 +391,6 @@ describe("Accessibility", () => {
 
 ui5AccDescribe("Automated accessibility tests", () => {
 	it("Icon only", () => {
-		cy.wait(5000);
 		cy.mount(<Button icon="message-information"></Button>);
 
 		cy.ui5CheckA11y();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6223,6 +6223,11 @@ axe-core@4.2.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
   integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
 
+axe-core@^4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
+  integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
 axios@^1.0.0, axios@^1.7.4:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.3.tgz#9ebccd71c98651d547162a018a1a95a4b4ed4de8"
@@ -8075,6 +8080,11 @@ custom-elements-manifest@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz#b35c2129076a1dc9f95d720c6f7b5b71a857274b"
   integrity sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==
+
+cypress-axe@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.6.0.tgz#2d70475e15356dd243ebcbfefd5719526f7ca9bc"
+  integrity sha512-C/ij50G8eebBrl/WsGT7E+T/SFyIsRZ3Epx9cRTLrPL9Y1GcxlQGFoAVdtSFWRrHSCWXq9HC6iJQMaI89O9yvQ==
 
 cypress-real-events@^1.12.0:
   version "1.12.0"


### PR DESCRIPTION
**Note: These changes are intended for use within the monorepo only**

These changes are integrating the `cypress-axe` plugin to enable accessibility testing within the UI5 webcomponents project. As part of the integration, a new `CYPRESS_UI5_ACC` environment  has been added to control the execution of accessibility tests. When set to `true`, it allows generating an accessibility report otherwise, the tests are skipped.  

Additionally, a new global function, `ui5AccDescribe`, has been introduced for test files. This function acts as a wrapper around the standard `describe` function, accepting the same parameters. Internally, it determines whether to run or skip tests based on the `CYPRESS_UI5_ACC` value. The wrapper also injects the necessary `axe-core` tool and includes the `ui5CheckA11y` command, which is used for accessibility validation.  

**Note: If `CYPRESS_UI5_ACC` is set, only accessibility tests will run**

Furthermore, the `ui5CheckA11y` command has been added to execute `axe` on mounted content.  

Related to: https://github.com/SAP/ui5-webcomponents/pull/11128
