### PR TITLE
feat(ui5-bar): allow role change

### DIFF
--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -68,10 +68,17 @@ class Bar extends UI5Element {
 	design: `${BarDesign}` = "Header";
 
 	/**
-	 * Used to define the role of the bar.
-	 * @private
+	 * Specifies the ARIA role applied to the component for accessibility purposes.
+	 * 
+	 * **Note:**
+	 * 
+	 * - Set accessibleRole to "toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
+	 * 
+	 * - If there is only one or no active element, it is recommended to avoid using the toolbar role, as it implies a grouping of multiple interactive controls.
+	 * 
+	 * @public
 	 * @default "Toolbar"
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 *
 	 */
 	@property()

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -74,7 +74,7 @@ class Bar extends UI5Element {
 	 *
 	 * - Set accessibleRole to "toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
 	 *
-	 * - If there is only one or no active element, it is recommended to avoid using the toolbar role, as it implies a grouping of multiple interactive controls.
+	 * - If there is only one or no active element, it is recommended to avoid using the "toolbar" role, as it implies a grouping of multiple interactive controls.
 	 *
 	 * @public
 	 * @default "Toolbar"

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -69,13 +69,13 @@ class Bar extends UI5Element {
 
 	/**
 	 * Specifies the ARIA role applied to the component for accessibility purposes.
-	 * 
+	 *
 	 * **Note:**
-	 * 
+	 *
 	 * - Set accessibleRole to "toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
-	 * 
+	 *
 	 * - If there is only one or no active element, it is recommended to avoid using the toolbar role, as it implies a grouping of multiple interactive controls.
-	 * 
+	 *
 	 * @public
 	 * @default "Toolbar"
 	 * @since 2.10.0

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -5,12 +5,14 @@ import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import type BarDesign from "./types/BarDesign.js";
+import type BarAccessibleRole from "./types/BarAccessibleRole.js";
 
 // Template
 import BarTemplate from "./BarTemplate.js";
 
 // Styles
 import BarCss from "./generated/themes/Bar.css.js";
+import type { AriaRole } from "@ui5/webcomponents-base/dist/types.js";
 
 /**
  * @class
@@ -66,6 +68,16 @@ class Bar extends UI5Element {
 	design: `${BarDesign}` = "Header";
 
 	/**
+	 * Used to define the role of the bar.
+	 * @private
+	 * @default "Toolbar"
+	 * @since 2.9.0
+	 *
+	 */
+	@property()
+	accessibleRole: `${BarAccessibleRole}` = "Toolbar";
+
+	/**
 	* Defines the content at the start of the bar.
 	* @public
 	*/
@@ -91,6 +103,7 @@ class Bar extends UI5Element {
 	get accInfo() {
 		return {
 			"label": this.design,
+			"role": this.effectiveRole,
 		};
 	}
 
@@ -124,6 +137,10 @@ class Bar extends UI5Element {
 		this.getDomRef()!.querySelectorAll(".ui5-bar-content-container").forEach(child => {
 			ResizeHandler.deregister(child as HTMLElement, this._handleResizeBound);
 		}, this);
+	 }
+
+	 get effectiveRole() {
+		return this.accessibleRole.toLowerCase() as AriaRole;
 	 }
 }
 

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -140,7 +140,7 @@ class Bar extends UI5Element {
 	 }
 
 	 get effectiveRole() {
-		return this.accessibleRole.toLowerCase() as AriaRole;
+		return this.accessibleRole.toLowerCase() === "toolbar" ? "toolbar" as AriaRole : undefined;
 	 }
 }
 

--- a/packages/main/src/BarTemplate.tsx
+++ b/packages/main/src/BarTemplate.tsx
@@ -5,7 +5,7 @@ export default function BarTemplate(this: Bar) {
 		<div
 			class="ui5-bar-root"
 			aria-label={this.accInfo.label}
-			role="toolbar"
+			role={this.accInfo.role}
 			part="bar"
 		>
 			<div class="ui5-bar-content-container ui5-bar-startcontent-container" part="startContent">

--- a/packages/main/src/BarTemplate.tsx
+++ b/packages/main/src/BarTemplate.tsx
@@ -4,7 +4,7 @@ export default function BarTemplate(this: Bar) {
 	return (
 		<div
 			class="ui5-bar-root"
-			aria-label={this.accInfo.label}
+			aria-label={this.accInfo.role && this.accInfo.label}
 			role={this.accInfo.role}
 			part="bar"
 		>

--- a/packages/main/src/types/BarAccessibleRole.ts
+++ b/packages/main/src/types/BarAccessibleRole.ts
@@ -1,0 +1,22 @@
+/**
+ * ListItem accessible roles.
+ * @public
+ * @since 2.9.0
+ */
+enum BarAccessibleRole {
+
+	/**
+	 * Represents the ARIA role "toolbar".
+	 * @public
+	 */
+	Toolbar = "Toolbar",
+
+	/**
+	 * Represents the ARIA role "none".
+	 * @public
+	 */
+	None = "None"
+
+}
+
+export default BarAccessibleRole;

--- a/packages/main/test/pages/Bar.html
+++ b/packages/main/test/pages/Bar.html
@@ -16,10 +16,10 @@
 
 <body class="bar1auto">
 	<section>
-		<ui5-bar design="Header">
-		<ui5-title id="titleElement" slot="startContent">Title</ui5-title>
-		<ui5-label>Title</ui5-label>
-		<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
+		<ui5-bar design="Header" accessible-role="None">
+			<ui5-title id="titleElement" slot="startContent">Title</ui5-title>
+			<ui5-label>Title</ui5-label>
+			<ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
 		</ui5-bar>
 		<ui5-bar design="Subheader">
 			<ui5-title id="titleElement" slot="startContent">Title</ui5-title>

--- a/packages/website/docs/_components_pages/main/Bar.mdx
+++ b/packages/website/docs/_components_pages/main/Bar.mdx
@@ -1,4 +1,5 @@
 import Basic from "../../_samples/main/Bar/Basic/Basic.md";
+import AccessibleRole from "../../_samples/main/Bar/AccessibleRole/AccessibleRole.md";
 
 <%COMPONENT_OVERVIEW%>
 
@@ -6,3 +7,6 @@ import Basic from "../../_samples/main/Bar/Basic/Basic.md";
 <Basic />
 
 <%COMPONENT_METADATA%>
+
+## Bar with accessible role
+<AccessibleRole />

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/AccessibleRole.md
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/AccessibleRole.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/main.js
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/main.js
@@ -1,0 +1,5 @@
+import "@ui5/webcomponents/dist/Button.js";
+import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Bar.js";
+import "@ui5/webcomponents-icons/dist/home.js"
+import "@ui5/webcomponents-icons/dist/action-settings.js"

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.html
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.html
@@ -1,0 +1,27 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+<body style="background-color: var(--sapBackgroundColor)">
+<!-- playground-fold-end -->
+    <ui5-label>Bar with two or more active items:</ui5-label>
+    <ui5-bar design="Header" accessible-role="Toolbar">
+        <ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
+        <ui5-label id="basic-label">Content</ui5-label>
+        <ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
+    </ui5-bar>
+    <br>
+    <ui5-label>Bar with less than two active items:</ui5-label>
+    <ui5-bar design="Header">
+        <ui5-label id="basic-label">Storybook title</ui5-label>
+    </ui5-bar>
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+</html>
+<!-- playground-fold-end -->
+


### PR DESCRIPTION
Introduces a new `accessibleRole` property to the `ui5-bar` component, allowing developers to customize the ARIA role of the bar for accessibility purposes.

By default, the role is set to "toolbar", but now it can be explicitly changed by the application.

fixes: https://github.com/SAP/ui5-webcomponents/issues/10990
