### PR TITLE
fix(ui5-select): add listbox role to meet ARIA parent-child requirements

### DIFF
--- a/packages/main/src/SelectPopoverTemplate.tsx
+++ b/packages/main/src/SelectPopoverTemplate.tsx
@@ -64,6 +64,7 @@ export default function SelectPopoverTemplate(this: Select) {
 						separators="None"
 						onMouseDown={this._itemMousedown}
 						onItemClick={this._handleItemPress}
+						accessibleRole="ListBox"
 					>
 						<slot></slot>
 					</List>


### PR DESCRIPTION
Problem:
- List items with role="option" lack required parent with role="listbox".

Solution:
- Set accessibleRole="ListBox" on List component to establish proper ARIA hierarchy.

Fixes: [#11151](https://github.com/SAP/ui5-webcomponents/issues/11151)
Fixes: [#11152](https://github.com/SAP/ui5-webcomponents/issues/11152)