### PR TITLE
chore: fix internal test setup preparation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "scopeStart:all": "npm-run-all --parallel watch:base scopeWatch:main scopeWatch:compat scopeWatch:ai scopeWatch:fiori dev",
     "start:website": "yarn ci:releasebuild && yarn workspace @ui5/webcomponents-website start",
 
-    "start": "npm-run-all --sequential generate start:all ci:test:prepare",
+    "start": "npm-run-all --sequential generate ci:test:prepare start:all",
     "build": "yarn ci:releasebuild && yarn ci:test:prepare",
     "test": "yarn wsrun --exclude-missing test",
     "test:prepare": "yarn ci:test:prepare && yarn generate",


### PR DESCRIPTION
The `ci:test:prepare` script was placed after `start:all`, causing it to never execute. As a result, required test files were missing when running tests locally.