### PR TITLE
fix(ui5-shellbar): improve accessibility for shellbar item count announcement

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -132,6 +132,7 @@ interface IShelBarItemInfo extends IShellBarHidableItem {
 	profile?: boolean,
 	tooltip?: string,
 	accessibilityAttributes?: ShellBarItemAccessibilityAttributes,
+	accessibleName?: string,
 }
 
 interface IShellBarContentItem extends IShellBarHidableItem {
@@ -1063,6 +1064,7 @@ class ShellBar extends UI5Element {
 					stableDomRef: item.stableDomRef,
 					tooltip: item.title || item.text,
 					accessibilityAttributes: item.accessibilityAttributes,
+					accessibleName: item.count ? `${item.title || item.text}, ${item.count}` : (item.title || item.text),
 				};
 			}),
 			{

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -197,6 +197,7 @@ export default function ShellBarTemplate(this: ShellBar) {
 									data-ui5-stable={item.stableDomRef}
 									onClick={item.press}
 									accessibilityAttributes={item.accessibilityAttributes}
+									accessibleName={item.accessibleName}
 								/>
 							))}
 						</div>


### PR DESCRIPTION
- Added accessible name that announces item title and text with count from data-count.

Fixes: [#11198](https://github.com/SAP/ui5-webcomponents/issues/11198)