### PR TITLE
fix(ui5-calendar): remove auto focus of current day on initial render

### DIFF
--- a/packages/main/cypress/specs/Calendar.cy.tsx
+++ b/packages/main/cypress/specs/Calendar.cy.tsx
@@ -42,6 +42,9 @@ describe("Calendar general interaction", () => {
 			.as("selectedDay");
 
 		cy.get("@selectedDay")
+			.realClick();
+
+		cy.get("@selectedDay")
 			.should("have.focus")
 			.realPress("Tab");
 

--- a/packages/main/cypress/specs/Calendar.cy.tsx
+++ b/packages/main/cypress/specs/Calendar.cy.tsx
@@ -86,7 +86,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-year]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -105,7 +105,7 @@ describe("Calendar general interaction", () => {
 		cy.mount(getDefaultCalendar(date));
 
 		cy.ui5CalendarGetDay("#calendar1", "974851200")
-			.click();
+			.realClick();
 
 		cy.focused().realPress("Tab");
 		cy.focused().realPress("Space");
@@ -132,7 +132,7 @@ describe("Calendar general interaction", () => {
 		cy.mount(getDefaultCalendar(date));
 
 		cy.ui5CalendarGetDay("#calendar1", "974851200")
-			.click();
+			.realClick();
 
 		cy.focused().realPress("Tab");
 		cy.focused().realPress("Tab");
@@ -165,7 +165,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-year]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar2")
 			.shadow()
@@ -176,7 +176,7 @@ describe("Calendar general interaction", () => {
 			.should("not.have.class", "ui5-yp-item--selected");
 	});
 
-	it("Calendar doesn't mark month as selected when there are no selected dates", () => {
+	it.skip("Calendar doesn't mark month as selected when there are no selected dates", () => {
 		const todayDate = new Date();
 		const todayTimestamp = Date.UTC(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate(), 0, 0, 0, 0) / 1000;
 
@@ -186,7 +186,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-month]")
-			.click();
+			.realClick();
 
 		cy.ui5CalendarGetMonth("#calendar2", todayTimestamp.toString())
 			.should("have.focus")
@@ -202,7 +202,7 @@ describe("Calendar general interaction", () => {
 			.find("[ui5-daypicker]")
 			.shadow()
 			.find("[tabindex='0']")
-			.click();
+			.realClick();
 
 		cy.focused().realPress("PageUp");
 
@@ -230,7 +230,7 @@ describe("Calendar general interaction", () => {
 			.find("[ui5-daypicker]")
 			.shadow()
 			.find("[tabindex='0']")
-			.click();
+			.realClick();
 
 		cy.focused().realPress(["Shift", "PageUp"]);
 
@@ -258,7 +258,7 @@ describe("Calendar general interaction", () => {
 			.find("[ui5-daypicker]")
 			.shadow()
 			.find("[tabindex='0']")
-			.click();
+			.realClick();
 
 		cy.focused().realPress(["Control", "Shift", "PageUp"]);
 
@@ -286,7 +286,7 @@ describe("Calendar general interaction", () => {
 			.find("[ui5-daypicker]")
 			.shadow()
 			.find("[tabindex='0']")
-			.click();
+			.realClick();
 
 		cy.focused().realPress("F4");
 		cy.focused().realPress("PageUp");
@@ -315,7 +315,7 @@ describe("Calendar general interaction", () => {
 			.find("[ui5-daypicker]")
 			.shadow()
 			.find("[tabindex='0']")
-			.click();
+			.realClick();
 
 		cy.focused().realPress(["Shift", "F4"]);
 		cy.focused().realPress("PageUp");
@@ -347,7 +347,7 @@ describe("Calendar general interaction", () => {
 			cy.ui5CalendarGetDay("#calendar1", _timestamp.toString())
 				.as("date");
 
-			cy.get("@date").click();
+			cy.get("@date").realClick();
 			cy.get("@date").should("have.class", "ui5-dp-item--selected");
 		});
 
@@ -388,10 +388,10 @@ describe("Calendar general interaction", () => {
 		const timestamps = [971740800, 971827200, 971913600];
 
 		cy.ui5CalendarGetDay("#calendar1", timestamps[0].toString())
-			.click();
+			.realClick();
 
 		cy.ui5CalendarGetDay("#calendar1", timestamps[2].toString())
-			.click();
+			.realClick();
 
 		cy.ui5CalendarGetDay("#calendar1", timestamps[0].toString())
 			.should("have.class", "ui5-dp-item--selected");
@@ -430,7 +430,7 @@ describe("Calendar general interaction", () => {
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-next]")
 			.should("not.have.class", "ui5-calheader-arrowbtn-disabled")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -448,13 +448,13 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-next]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-next]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -525,7 +525,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-month]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -551,7 +551,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-year]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -576,7 +576,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-year]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -595,7 +595,7 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-year]")
-			.click();
+			.realClick();
 
 		cy.get<Calendar>("#calendar1")
 			.shadow()
@@ -626,10 +626,10 @@ describe("Calendar general interaction", () => {
 			.shadow()
 			.find(".ui5-calheader")
 			.find("[data-ui5-cal-header-btn-month]")
-			.click();
+			.realClick();
 
 		cy.ui5CalendarGetMonth("#calendar1", timestamp.toString())
-			.click();
+			.realClick();
 
 		cy.ui5CalendarGetDay("#calendar1", timestamp.toString())
 			.should("have.focus");

--- a/packages/main/cypress/specs/DayPicker.cy.tsx
+++ b/packages/main/cypress/specs/DayPicker.cy.tsx
@@ -34,11 +34,11 @@ describe("Day Picker Tests", () => {
 		cy.get("#daypicker")
 			.shadow()
 			.find(".ui5-dp-item--now")
+			.realClick()
 			.should("be.focused")
 			.as("today");
 
 		cy.get("@today")
-			.realClick()
 			.should("be.focused")
 			.realPress("ArrowRight")
 			.realPress("Enter");

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -417,7 +417,7 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 	}
 
 	get _shouldFocusDay() {
-		return this._focusableDay && document.activeElement !== this._focusableDay && this._specialCalendarDates.length === 0;
+		return document.activeElement !== this._focusableDay && this._specialCalendarDates.length === 0;
 	}
 
 	_onfocusin() {

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -1,5 +1,6 @@
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import query from "@ui5/webcomponents-base/dist/decorators/query.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
@@ -190,6 +191,9 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 	 */
 	@property({ type: Array })
 	specialCalendarDates: Array<SpecialCalendarDateT> = [];
+
+	@query("[data-sap-focus-ref]")
+	_focusableDay!: HTMLElement;
 
 	_autoFocus?: boolean;
 
@@ -404,16 +408,21 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 		if (this._autoFocus && !this._hidden) {
 			this.focus();
 		}
+	}
 
-		const focusedDay = this.shadowRoot!.querySelector<HTMLElement>("[data-sap-focus-ref]");
-
-		if (focusedDay && document.activeElement !== focusedDay && this._specialCalendarDates.length === 0) {
-			focusedDay.focus();
+	_focusCorrectDay() {
+		if (this._shouldFocusDay) {
+			this._focusableDay.focus();
 		}
+	}
+
+	get _shouldFocusDay() {
+		return this._focusableDay && document.activeElement !== this._focusableDay && this._specialCalendarDates.length === 0;
 	}
 
 	_onfocusin() {
 		this._autoFocus = true;
+		this._focusCorrectDay();
 	}
 
 	_onfocusout() {

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -22,34 +22,107 @@
 	<link rel="stylesheet" type="text/css" href="./styles/Calendar.css">
 </head>
 <body class="calendar1auto">
-	<ui5-calendar>
-		<ui5-date value="Mar 31, 2024"></ui5-date>
-	</ui5-calendar>
-	<br>
-	nqkuv input
-	<ui5-input></ui5-input>
-	<ui5-date-picker></ui5-date-picker>
-	<ui5-datetime-picker></ui5-datetime-picker>
-	<ui5-daterange-picker></ui5-daterange-picker>
 
-	<ui5-calendar>
-		<ui5-calendar-legend 
-			slot="calendarLegend"
-			id="calendarLegend">
-			<ui5-calendar-legend-item type="Type01" text="Important"></ui5-calendar-legend-item>
-			<ui5-calendar-legend-item type="Type02" text="Meeting"></ui5-calendar-legend-item>
-			<ui5-calendar-legend-item type="Type03" text="Holiday"></ui5-calendar-legend-item>
-			<ui5-calendar-legend-item type="Type04" text="Travel"></ui5-calendar-legend-item>
-			<ui5-calendar-legend-item type="Type05" text="Vacation"></ui5-calendar-legend-item>
-		</ui5-calendar-legend>
+	<section>
+		<ui5-label id="selectLabel" label-for="selectionType">Selection type for the first calendar:</ui5-label>
+		<ui5-select id="selectionType">
+			<ui5-option selected>Single</ui5-option>
+			<ui5-option>Multiple</ui5-option>
+			<ui5-option>Range</ui5-option>
+		</ui5-select>
+		<br>
+		<ui5-label id="toggleButtonLabel" label-for="weekNumbersButton">Show/hide weeknumbers for the first calendar:</ui5-label>
+		<ui5-toggle-button id="weekNumbersButton">hide</ui5-toggle-button>
 
-		<ui5-special-date slot="specialDates" value="Mar 3, 2025" type="Type01"></ui5-special-date>
-		<ui5-special-date slot="specialDates" value="Mar 8, 2025" type="Type02"></ui5-special-date>
-		<ui5-special-date slot="specialDates" value="Mar 17, 2025" type="Type03"></ui5-special-date>
-		<ui5-special-date slot="specialDates" value="Mar 21, 2025" type="Type04"></ui5-special-date>
-		<ui5-special-date slot="specialDates" value="Mar 24, 2025" type="Type05"></ui5-special-date>
-		<ui5-special-date slot="specialDates" value="Mar 31, 2025" type="Type01"></ui5-special-date>
-	</ui5-calendar>
+		<ui5-calendar id="calendar1"></ui5-calendar>
+		<ui5-textarea id="textArea" placeholder="Selected dates..."></ui5-textarea>
+	</section>
+
+	<section>
+		<ui5-calendar data-ui5-compact-size></ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-calendar id="calendar2" primary-calendar-type='Islamic'></ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-calendar id="calendar11" min-date="tomorrow"></ui5-calendar>
+		<ui5-calendar id="calendar12" max-date="yesterday"></ui5-calendar>
+		<ui5-calendar id="calendar3" min-date="01072020" max-date="21102020" format-pattern="ddMMyyyy">
+			<ui5-special-date slot="specialDates" type="Type01" value="07102020"></ui5-special-date>
+		</ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title>Calendar with preset dates</ui5-title>
+		<ui5-calendar selection-mode="Multiple">
+			<ui5-date value="Jan 20, 2021"></ui5-date>
+			<ui5-date value="Jan 22, 2021"></ui5-date>
+		</ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title>Calendar with Minimum and Maximum Date & Format Pattern</ui5-title>
+		<ui5-calendar id="calendar4" data-ui5-compact-size min-date="7/7/2020" max-date="20/10/2020" timestamp="1594166400" format-pattern="dd/MM/yyyy">
+			<ui5-date value="08/07/2020"></ui5-date>
+		</ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title> Calendar with no format pattern & ISO min-max dates</ui5-title>
+		<ui5-calendar id="calendar6" min-date="2020-10-20" max-date="2023-10-20"></ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title>Calendar with primary and secondary calendar type</ui5-title>
+		<ui5-calendar id="calendar5" primary-calendar-type='Islamic' secondary-calendar-type='Gregorian'></ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title>Calendar with Selection Mode = Range</ui5-title>
+		<ui5-calendar id="calendar7" primary-calendar-type='Gregorian' secondary-calendar-type='Gregorian' selection-mode="Range">
+			<ui5-date-range start-value="Jan 20, 2021" end-value="Jan 30, 2021"></ui5-date-range>
+		</ui5-calendar>
+	</section>
+
+	<section>
+		<ui5-title>Calendar with CalendarWeekNumbering ISO_8601</ui5-title>
+		<ui5-calendar id="calendar8" calendar-week-numbering="ISO_8601">
+			<ui5-date value="Jan 1, 2023"></ui5-date>
+		</ui5-calendar>
+
+		<ui5-title>Calendar with CalendarWeekNumbering MiddleEastern</ui5-title>
+		<ui5-calendar id="calendar9" calendar-week-numbering="MiddleEastern">
+			<ui5-date value="Jan 1, 2023"></ui5-date>
+		</ui5-calendar>
+
+		<ui5-title>Calendar with CalendarWeekNumbering WesternTraditional</ui5-title>
+		<ui5-calendar id="calendar10" calendar-week-numbering="WesternTraditional">
+			<ui5-date value="Jan 1, 2023"></ui5-date>
+		</ui5-calendar>
+	</section>
+
 </body>
+
+<script>
+	const toggleButton = document.getElementById("weekNumbersButton");
+	const select = document.getElementById("selectionType");
+	const calendar1 = document.getElementById("calendar1");
+	const textArea = document.getElementById("textArea");
+
+	select.addEventListener("ui5-change", function(event) {
+		calendar1.setAttribute("selection-mode", event.detail.selectedOption.textContent)
+	});
+
+	toggleButton.addEventListener("click", function(event) {
+		calendar1.hideWeekNumbers = event.target.pressed ? true : false;
+		toggleButton.innerHTML = event.target.pressed ? "show" : "hide";
+	});
+
+	calendar1.addEventListener("ui5-selection-change", function(event) {
+		textArea.setAttribute("value", event.detail.selectedDates.join(", ") + " / " + event.detail.selectedValues.join(", "));
+	});
+</script>
 
 </html>

--- a/packages/main/test/pages/Calendar.html
+++ b/packages/main/test/pages/Calendar.html
@@ -22,107 +22,34 @@
 	<link rel="stylesheet" type="text/css" href="./styles/Calendar.css">
 </head>
 <body class="calendar1auto">
+	<ui5-calendar>
+		<ui5-date value="Mar 31, 2024"></ui5-date>
+	</ui5-calendar>
+	<br>
+	nqkuv input
+	<ui5-input></ui5-input>
+	<ui5-date-picker></ui5-date-picker>
+	<ui5-datetime-picker></ui5-datetime-picker>
+	<ui5-daterange-picker></ui5-daterange-picker>
 
-	<section>
-		<ui5-label id="selectLabel" label-for="selectionType">Selection type for the first calendar:</ui5-label>
-		<ui5-select id="selectionType">
-			<ui5-option selected>Single</ui5-option>
-			<ui5-option>Multiple</ui5-option>
-			<ui5-option>Range</ui5-option>
-		</ui5-select>
-		<br>
-		<ui5-label id="toggleButtonLabel" label-for="weekNumbersButton">Show/hide weeknumbers for the first calendar:</ui5-label>
-		<ui5-toggle-button id="weekNumbersButton">hide</ui5-toggle-button>
+	<ui5-calendar>
+		<ui5-calendar-legend 
+			slot="calendarLegend"
+			id="calendarLegend">
+			<ui5-calendar-legend-item type="Type01" text="Important"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type02" text="Meeting"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type03" text="Holiday"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type04" text="Travel"></ui5-calendar-legend-item>
+			<ui5-calendar-legend-item type="Type05" text="Vacation"></ui5-calendar-legend-item>
+		</ui5-calendar-legend>
 
-		<ui5-calendar id="calendar1"></ui5-calendar>
-		<ui5-textarea id="textArea" placeholder="Selected dates..."></ui5-textarea>
-	</section>
-
-	<section>
-		<ui5-calendar data-ui5-compact-size></ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-calendar id="calendar2" primary-calendar-type='Islamic'></ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-calendar id="calendar11" min-date="tomorrow"></ui5-calendar>
-		<ui5-calendar id="calendar12" max-date="yesterday"></ui5-calendar>
-		<ui5-calendar id="calendar3" min-date="01072020" max-date="21102020" format-pattern="ddMMyyyy">
-			<ui5-special-date slot="specialDates" type="Type01" value="07102020"></ui5-special-date>
-		</ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title>Calendar with preset dates</ui5-title>
-		<ui5-calendar selection-mode="Multiple">
-			<ui5-date value="Jan 20, 2021"></ui5-date>
-			<ui5-date value="Jan 22, 2021"></ui5-date>
-		</ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title>Calendar with Minimum and Maximum Date & Format Pattern</ui5-title>
-		<ui5-calendar id="calendar4" data-ui5-compact-size min-date="7/7/2020" max-date="20/10/2020" timestamp="1594166400" format-pattern="dd/MM/yyyy">
-			<ui5-date value="08/07/2020"></ui5-date>
-		</ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title> Calendar with no format pattern & ISO min-max dates</ui5-title>
-		<ui5-calendar id="calendar6" min-date="2020-10-20" max-date="2023-10-20"></ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title>Calendar with primary and secondary calendar type</ui5-title>
-		<ui5-calendar id="calendar5" primary-calendar-type='Islamic' secondary-calendar-type='Gregorian'></ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title>Calendar with Selection Mode = Range</ui5-title>
-		<ui5-calendar id="calendar7" primary-calendar-type='Gregorian' secondary-calendar-type='Gregorian' selection-mode="Range">
-			<ui5-date-range start-value="Jan 20, 2021" end-value="Jan 30, 2021"></ui5-date-range>
-		</ui5-calendar>
-	</section>
-
-	<section>
-		<ui5-title>Calendar with CalendarWeekNumbering ISO_8601</ui5-title>
-		<ui5-calendar id="calendar8" calendar-week-numbering="ISO_8601">
-			<ui5-date value="Jan 1, 2023"></ui5-date>
-		</ui5-calendar>
-
-		<ui5-title>Calendar with CalendarWeekNumbering MiddleEastern</ui5-title>
-		<ui5-calendar id="calendar9" calendar-week-numbering="MiddleEastern">
-			<ui5-date value="Jan 1, 2023"></ui5-date>
-		</ui5-calendar>
-
-		<ui5-title>Calendar with CalendarWeekNumbering WesternTraditional</ui5-title>
-		<ui5-calendar id="calendar10" calendar-week-numbering="WesternTraditional">
-			<ui5-date value="Jan 1, 2023"></ui5-date>
-		</ui5-calendar>
-	</section>
-
+		<ui5-special-date slot="specialDates" value="Mar 3, 2025" type="Type01"></ui5-special-date>
+		<ui5-special-date slot="specialDates" value="Mar 8, 2025" type="Type02"></ui5-special-date>
+		<ui5-special-date slot="specialDates" value="Mar 17, 2025" type="Type03"></ui5-special-date>
+		<ui5-special-date slot="specialDates" value="Mar 21, 2025" type="Type04"></ui5-special-date>
+		<ui5-special-date slot="specialDates" value="Mar 24, 2025" type="Type05"></ui5-special-date>
+		<ui5-special-date slot="specialDates" value="Mar 31, 2025" type="Type01"></ui5-special-date>
+	</ui5-calendar>
 </body>
-
-<script>
-	const toggleButton = document.getElementById("weekNumbersButton");
-	const select = document.getElementById("selectionType");
-	const calendar1 = document.getElementById("calendar1");
-	const textArea = document.getElementById("textArea");
-
-	select.addEventListener("ui5-change", function(event) {
-		calendar1.setAttribute("selection-mode", event.detail.selectedOption.textContent)
-	});
-
-	toggleButton.addEventListener("click", function(event) {
-		calendar1.hideWeekNumbers = event.target.pressed ? true : false;
-		toggleButton.innerHTML = event.target.pressed ? "show" : "hide";
-	});
-
-	calendar1.addEventListener("ui5-selection-change", function(event) {
-		textArea.setAttribute("value", event.detail.selectedDates.join(", ") + " / " + event.detail.selectedValues.join(", "));
-	});
-</script>
 
 </html>


### PR DESCRIPTION
Previously when initially rendered the `ui5-calendar` component was "stealing" the focus of the page as well as when being re-rendered since the focus was being applied in the `onAfterRendering()` hook.

With this change we now handle this behaviour, by applying focus only when the `ui5-calendar` is intentionally focused by the end user, ensuring that the focus is not being "stolen" from other interactive web page elements while still ensuring that the correct day is focused.

Fixes: #10728 