### PR TITLE
feat(ui5-button): provide focus support for mobile

### DIFF
--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -134,15 +134,15 @@ describe("Wizard general interaction", () => {
 		assert.strictEqual(await step1InHeader.getAttribute("disabled"), null,
 			"First step in header is enabled.");
 
-		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.matches(":focus"), "The First focusable element in the step content is focused.");
 
 		await step1InHeader.keys(["Shift", "Tab"]);
 		await step2InHeader.keys("Space");
-		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.matches(":focus"), "The First focusable element in the step content is focused.");
 
 		await step1InHeader.keys(["Shift", "Tab"]);
 		await step2InHeader.keys("Enter");
-		assert.ok(await firstFocusableElement.getProperty("focused"), "The First focusable element in the step content is focused.");
+		assert.ok(await firstFocusableElement.matches(":focus"), "The First focusable element in the step content is focused.");
 
 		// assert - that second step in the content and in the header are not selected
 		assert.strictEqual(await step2.getAttribute("selected"), null,

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -21,9 +21,6 @@ import { markEvent } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import { getIconAccessibleName } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 
 import {
-	isPhone,
-	isTablet,
-	isCombi,
 	isDesktop,
 	isSafari,
 } from "@ui5/webcomponents-base/dist/Device.js";
@@ -259,13 +256,6 @@ class Button extends UI5Element implements IFormElement, IButton {
 	iconOnly!: boolean;
 
 	/**
-	 * Indicates if the elements is on focus
-	 * @private
-	 */
-	@property({ type: Boolean })
-	focused!: boolean;
-
-	/**
 	 * Indicates if the elements has a slotted icon
 	 * @private
 	 */
@@ -273,7 +263,7 @@ class Button extends UI5Element implements IFormElement, IButton {
 	hasIcon!: boolean;
 
 	/**
-	 * Indicates if the element if focusable
+	 * Indicates if the element is focusable
 	 * @private
 	 */
 	@property({ type: Boolean })
@@ -356,7 +346,9 @@ class Button extends UI5Element implements IFormElement, IButton {
 	}
 
 	onEnterDOM() {
-		this._isTouch = (isPhone() || isTablet()) && !isCombi();
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
+		}
 	}
 
 	async onBeforeRendering() {
@@ -394,7 +386,7 @@ class Button extends UI5Element implements IFormElement, IButton {
 	}
 
 	_onmousedown(e: MouseEvent) {
-		if (this.nonInteractive || this._isTouch) {
+		if (this.nonInteractive) {
 			return;
 		}
 
@@ -453,10 +445,6 @@ class Button extends UI5Element implements IFormElement, IButton {
 		if (this.active) {
 			this._setActiveState(false);
 		}
-
-		if (isDesktop()) {
-			this.focused = false;
-		}
 	}
 
 	_onfocusin(e: FocusEvent) {
@@ -465,9 +453,6 @@ class Button extends UI5Element implements IFormElement, IButton {
 		}
 
 		markEvent(e, "button");
-		if (isDesktop()) {
-			this.focused = true;
-		}
 	}
 
 	_setActiveState(active: boolean) {

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -232,7 +232,6 @@ class SegmentedButton extends UI5Element {
 		}
 
 		if (isTargetSegmentedButtonItem) {
-			eventTarget.focus();
 			this._itemNavigation.setCurrentItem(eventTarget);
 			this.hasPreviouslyFocusedItem = true;
 		}

--- a/packages/main/src/SplitButton.hbs
+++ b/packages/main/src/SplitButton.hbs
@@ -20,29 +20,29 @@
 		@touchstart={{_textButtonPress}}
 		@mousedown={{_textButtonPress}}
 		@mouseup={{_textButtonRelease}}
-		@focusin={{_textButtonFocusIn}}
+		@focusin={{_onInnerButtonFocusIn}}
 		@focusout={{_onFocusOut}}
 	>
 		{{#if isTextButton}}
 			<slot></slot>
 		{{/if}}
 	</ui5-button>
-		<ui5-button
-			class="ui5-split-arrow-button"
-			design="{{design}}"
-			icon="slim-arrow-down"
-			tabindex="-1"
-			?disabled="{{disabled}}"
-			?active="{{effectiveActiveArrowButton}}"
-			tooltip="{{accInfo.arrowButton.title}}"
-			.accessibilityAttributes={{accInfo.arrowButton.accessibilityAttributes}}
-			@click="{{_handleArrowButtonAction}}"
-			@mousedown={{_arrowButtonPress}}
-			@mouseup={{_arrowButtonRelease}}
-			@focusin={{_setTabIndexValue}}
-			@ui5-_active-state-change={{_onArrowButtonActiveStateChange}}
-		>
-		</ui5-button>
+	<ui5-button
+		class="ui5-split-arrow-button"
+		design="{{design}}"
+		icon="slim-arrow-down"
+		tabindex="-1"
+		?disabled="{{disabled}}"
+		?active="{{effectiveActiveArrowButton}}"
+		tooltip="{{accInfo.arrowButton.title}}"
+		.accessibilityAttributes={{accInfo.arrowButton.accessibilityAttributes}}
+		@click="{{_handleArrowButtonAction}}"
+		@mousedown={{_arrowButtonPress}}
+		@mouseup={{_arrowButtonRelease}}
+		@focusin={{_onInnerButtonFocusIn}}
+		@ui5-_active-state-change={{_onArrowButtonActiveStateChange}}
+	>
+	</ui5-button>
 	<span id="{{_id}}-invisibleText" class="ui5-hidden-text">{{accInfo.root.description}} {{accInfo.root.keyboardHint}} {{accessibleName}}</span>
 	<span id="{{_id}}-invisibleTextDefault" class="ui5-hidden-text">{{textButtonAccText}}</span>
 

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -111,9 +111,12 @@
 	pointer-events: none;
 }
 
-:host([focused]:not([active])) .ui5-button-root:after,
-:host([focused][active][design="Emphasized"]) .ui5-button-root:after,
-:host([focused][active]) .ui5-button-root:before {
+:host([desktop]:not([active])) .ui5-button-root:focus-within:after,
+:host(:not([active])) .ui5-button-root:focus-visible:after,
+:host([desktop][active][design="Emphasized"]) .ui5-button-root:focus-within:after,
+:host([active][design="Emphasized"]) .ui5-button-root:focus-visible:after,
+:host([desktop][active]) .ui5-button-root:focus-within:before,
+:host([active]) .ui5-button-root:focus-visible:before {
 	content: "";
 	position: absolute;
 	box-sizing: border-box;
@@ -125,15 +128,18 @@
 	border-radius: var(--_ui5_button_focused_border_radius);
 }
 
-:host([focused][active]) .ui5-button-root:before {
+:host([desktop][active]) .ui5-button-root:focus-within:before,
+:host([active]) .ui5-button-root:focus-visible:before {
 	border-color: var(--_ui5_button_pressed_focused_border_color);
 }
 
-:host([design="Emphasized"][focused]) .ui5-button-root:after {
+:host([design="Emphasized"][desktop]) .ui5-button-root:focus-within:after,
+:host([design="Emphasized"]) .ui5-button-root:focus-visible:after {
 	border-color: var(--_ui5_button_emphasized_focused_border_color);
 }
 
-:host([design="Emphasized"][focused]) .ui5-button-root:before {
+:host([design="Emphasized"][desktop]) .ui5-button-root:focus-within:before,
+:host([design="Emphasized"]) .ui5-button-root:focus-visible:before  {
 	content: "";
 	position: absolute;
 	box-sizing: border-box;
@@ -246,13 +252,15 @@ bdi {
 	color: var(--sapButton_Emphasized_Active_TextColor);
 }
 
-:host([design="Emphasized"][focused]) .ui5-button-root:after {
+:host([design="Emphasized"][desktop]) .ui5-button-root:focus-within:after,
+:host([design="Emphasized"]) .ui5-button-root:focus-visible:after {
 	border-color: var(--_ui5_button_emphasized_focused_border_color);
 	outline: none;
 }
 
 /* Belize related */
-:host([design="Emphasized"][focused][active]:not([non-interactive])) .ui5-button-root:after {
+:host([design="Emphasized"][desktop][active]:not([non-interactive])) .ui5-button-root:focus-within:after,
+:host([design="Emphasized"][active]:not([non-interactive])) .ui5-button-root:focus-visible:after  {
 	border-color: var(--_ui5_button_emphasized_focused_active_border_color);
 }
 
@@ -277,18 +285,22 @@ bdi {
 }
 
 /* SegmentedButton and ToggleButton */
-:host([ui5-segmented-button-item][active][focused]) .ui5-button-root:after,
-:host([pressed][focused]) .ui5-button-root:after {
+:host([ui5-segmented-button-item][active][desktop]) .ui5-button-root:focus-within:after,
+:host([ui5-segmented-button-item][active]) .ui5-button-root:focus-visible:after,
+:host([pressed][desktop]) .ui5-button-root:focus-within:after,
+:host([pressed]) .ui5-button-root:focus-visible:after  {
 	border-color: var(--_ui5_button_pressed_focused_border_color);
 	outline: none;
 }
 
-:host([ui5-segmented-button-item][focused]:not(:last-child)) .ui5-button-root:after {
+:host([ui5-segmented-button-item][desktop]:not(:last-child)) .ui5-button-root:focus-within:after,
+:host([ui5-segmented-button-item]:not(:last-child)) .ui5-button-root:focus-visible:after {
 	border-top-right-radius: var(--_ui5_button_focused_inner_border_radius);
 	border-bottom-right-radius: var(--_ui5_button_focused_inner_border_radius);
 }
 
-:host([ui5-segmented-button-item][focused]:not(:first-child)) .ui5-button-root:after {
+:host([ui5-segmented-button-item][desktop]:not(:first-child)) .ui5-button-root:focus-within:after,
+:host([ui5-segmented-button-item]:not(:first-child)) .ui5-button-root:focus-visible:after {
 	border-top-left-radius: var(--_ui5_button_focused_inner_border_radius);
 	border-bottom-left-radius: var(--_ui5_button_focused_inner_border_radius);
 }

--- a/packages/main/src/themes/SplitButton.css
+++ b/packages/main/src/themes/SplitButton.css
@@ -90,11 +90,13 @@
 	color: var(--_ui5_split_button_transparent_hover_color);
 }
 
-:host([focused]) .ui5-split-button-root {
+:host([desktop]) .ui5-split-button-root:focus-within,
+.ui5-split-button-root:focus-visible{
 	outline: 0;
 }
 
-:host([focused]) .ui5-split-button-root:after {
+:host([desktop]) .ui5-split-button-root:focus-within:after,
+.ui5-split-button-root:focus-visible:after {
 	content: "";
 	position: absolute;
 	box-sizing: border-box;
@@ -104,7 +106,8 @@
 	border-radius: var(--_ui5_split_button_focused_border_radius);
 }
 
-:host([design="Emphasized"][focused]) .ui5-split-button-root:after {
+:host([design="Emphasized"][desktop]) .ui5-split-button-root:focus-within:after,
+:host([design="Emphasized"]) .ui5-split-button-root:focus-visible:after {
 	border-color: var(--sapContent_ContrastFocusColor);
 }
 
@@ -305,12 +308,14 @@
 
 
 
-.ui5-split-arrow-button[focused]::part(button)::after {
+.ui5-split-arrow-button[desktop]::part(button):focus-within::after,
+.ui5-split-arrow-button::part(button):focus-visible::after {
 	border-start-start-radius: var(--_ui5_split_button_inner_focused_border_radius_inner);
 	border-end-start-radius: var(--_ui5_split_button_inner_focused_border_radius_inner);
 }
 
-.ui5-split-text-button[focused]::part(button)::after {
+.ui5-split-arrow-button[desktop]::part(button):focus-within::after,
+.ui5-split-text-button::part(button):focus-visible::after  {
 	border-start-end-radius: var(--_ui5_split_button_inner_focused_border_radius_inner);
 	border-end-end-radius: var(--_ui5_split_button_inner_focused_border_radius_inner);
 }

--- a/packages/main/src/themes/ToggleButton.css
+++ b/packages/main/src/themes/ToggleButton.css
@@ -29,10 +29,10 @@
 	color: var(--sapButton_Selected_TextColor);
 }
 
-:host([active][focused]),
-:host([design="Default"][active][focused]),
-:host([design="Transparent"][active][focused]),
-:host([design="Emphasized"][active][focused]) {
+:host([active]:not([disabled])),
+:host([design="Default"][active]:not([disabled])),
+:host([design="Transparent"][active]:not([disabled])),
+:host([design="Emphasized"][active]:not([disabled])) {
 	background: var(--sapButton_Active_Background);
 	border-color: var(--sapButton_Active_BorderColor);
 	color: var(--sapButton_Selected_TextColor);
@@ -53,7 +53,7 @@
 	color: var(--sapButton_Reject_Selected_TextColor);
 }
 
-:host([design="Negative"][active][focused]) {
+:host([design="Negative"][active]:not([disabled])){
 	background: var(--sapButton_Reject_Active_Background);
 	border-color: var(--sapButton_Reject_Active_BorderColor);
 	color: var(--sapButton_Reject_Active_TextColor);
@@ -78,7 +78,7 @@
 	color: var(--sapButton_Accept_Selected_TextColor);
 }
 
-:host([design="Positive"][active][focused]) {
+:host([design="Positive"][active]:not([disabled])) {
 	background: var(--sapButton_Accept_Active_Background);
 	border-color: var(--sapButton_Accept_Active_BorderColor);
 	color: var(--sapButton_Accept_Selected_TextColor);
@@ -103,7 +103,7 @@
 	color: var(--sapButton_Attention_Selected_TextColor);
 }
 
-:host([design="Attention"][active][focused]) {
+:host([design="Attention"][active]:not([disabled])){
 	background: var(--sapButton_Attention_Active_Background);
 	border-color: var(--sapButton_Attention_Active_BorderColor);
 	color: var(--sapButton_Attention_Active_TextColor);

--- a/packages/main/test/pages/ToggleButton.html
+++ b/packages/main/test/pages/ToggleButton.html
@@ -35,7 +35,7 @@
 	<div class="samples">
 		<h2>ToggleButton states</h2>
 		<div class="sample" id="main-sample">
-			<ui5-toggle-button class="toggleButton" id="toggle-button" pressed>ToggleButton</ui5-toggle-button>
+			<ui5-toggle-button class="toggleButton" id="toggle-button">ToggleButton</ui5-toggle-button>
 			<ui5-toggle-button class="toggleButton" pressed>Pressed ToggleButton</ui5-toggle-button>
 			<ui5-toggle-button class="toggleButton" disabled id="disabled-toggle-button">Disabled ToggleButton</ui5-toggle-button>
 			<ui5-toggle-button class="toggleButton" disabled pressed>Disabled ToggleButton</ui5-toggle-button>

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -17,7 +17,7 @@ describe("ColorPalette interactions", () => {
 		const defaultButton = await colorPalette.shadow$(".ui5-cp-default-color-button");
 
 		// assert - default btn is focused
-		assert.ok(await defaultButton.getProperty("focused"),  "The first element is focused");
+		assert.ok(await defaultButton.matches(":focus"),  "The first element is focused");
 
 		// act - close popover
 		await defaultButton.click();
@@ -67,7 +67,7 @@ describe("ColorPalette interactions", () => {
 
 		// act - open color palette popover
 		await colorPaletteButton.click();
-	
+
 		const colorPalettePopover = await browser.$("#colorPalettePopoverTest4");
 		const colorPalette = await colorPalettePopover.shadow$("[ui5-responsive-popover]").$("[ui5-color-palette]");
 		const moreColorsButton = await colorPalette.shadow$(".ui5-cp-more-colors");
@@ -76,7 +76,7 @@ describe("ColorPalette interactions", () => {
 		await defaultButton.keys("ArrowUp");
 
 		// assert - MoreColors button is focused
-		assert.ok(await moreColorsButton.getProperty("focused"),  "Button 'MoreColors' is focused");
+		assert.ok(await moreColorsButton.matches(":focus"),  "Button 'MoreColors' is focused");
 
 		// act - close popover
 		await defaultButton.click();
@@ -84,7 +84,7 @@ describe("ColorPalette interactions", () => {
 
 	it("Tests navigation with recent colors", async () => {
 		const colorPaletteButton = await browser.$("#colorPaletteBtnTest5");
-	
+
 		// act - open color palette popover
 		await colorPaletteButton.click();
 
@@ -103,7 +103,7 @@ describe("ColorPalette interactions", () => {
 		await firstRecentColorsElement.keys("ArrowUp");
 
 		// assert - MoreColors is focused
-		assert.ok(await moreColorsButton.getProperty("focused"),  "Check if more colors button is focused");
+		assert.ok(await moreColorsButton.matches(":focus"),  "Check if more colors button is focused");
 
 		// act - close popover
 		await defaultButton.click();
@@ -149,5 +149,5 @@ describe("ColorPalette interactions", () => {
 		assert.ok(await colorPalette.getProperty("showRecentColors"), "Check if recent colors is on");
 		assert.ok(await colorPalette.getProperty("showMoreColors"), "Check if more colors is on");
 	})
-	
+
 });

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -220,7 +220,7 @@ describe("Popover general interaction", () => {
 
 		await btnOpenPopover.click();
 
-		assert.ok(await focusedButton.getProperty("focused"), "The button is focused.");
+		assert.ok(await focusedButton.matches(":focus"), "The button is focused.");
 
 		await browser.keys("Escape");
 	});
@@ -231,17 +231,17 @@ describe("Popover general interaction", () => {
 
 		await btn.click();
 
-		assert.ok(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.ok(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		// list
 		await browser.keys("Tab");
 
-		assert.notOk(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.notOk(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		// button
 		await browser.keys("Tab");
 
-		assert.notOk(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.notOk(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		// select
 		await browser.keys("Tab");
@@ -252,7 +252,7 @@ describe("Popover general interaction", () => {
 		// goes to first focusable again
 		await browser.keys("Tab");
 
-		assert.ok(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.ok(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		await browser.keys("Escape");
 	});
@@ -263,7 +263,7 @@ describe("Popover general interaction", () => {
 
 		await btn.click();
 
-		assert.ok(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.ok(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		// footer button
 		await browser.keys(["Shift", "Tab"]);
@@ -280,7 +280,7 @@ describe("Popover general interaction", () => {
 		// header button
 		await browser.keys(["Shift", "Tab"]);
 
-		assert.ok(await ff.getProperty("focused"), "The first focusable element is focused.");
+		assert.ok(await ff.matches(":focus"), "The first focusable element is focused.");
 
 		await browser.keys("Escape");
 	});

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -148,10 +148,10 @@ describe("Table general interaction", () => {
 				await browser.keys("Tab");
 				await browser.keys("Tab");
 
-				assert.equal(await link.getProperty("focused"), true, "Link is focused")
+				assert.equal(await link.matches(":focus"), true, "Link is focused")
 
 				await browser.keys("Tab");
-				assert.equal(await afterBtn.getProperty("focused"), true, "Button is focused")
+				assert.equal(await afterBtn.matches(":focus"), true, "Button is focused")
 			});
 
 			it("Should have correct focus handling when having popin rows", async () => {
@@ -162,10 +162,10 @@ describe("Table general interaction", () => {
 				await input.click();
 				await browser.keys("Tab");
 
-				assert.equal(await btn.getProperty("focused"), true, "Button is focused")
+				assert.equal(await btn.matches(":focus"), true, "Button is focused")
 
 				await browser.keys("Tab");
-				assert.equal(await secondInput.getProperty("focused"), true, "Input is focused")
+				assert.equal(await secondInput.matches(":focus"), true, "Input is focused")
 			});
 
 			after(async () => {

--- a/packages/main/test/specs/ToggleButton.spec.js
+++ b/packages/main/test/specs/ToggleButton.spec.js
@@ -10,20 +10,20 @@ describe("ToggleButton general interaction", () => {
 		const result = await browser.$("#click-result");
 
 		await toggleButton.click();
-		assert.strictEqual(await result.getText(), "ToggleButton: false", "click event changed pressed state");
+		assert.strictEqual(await result.getText(), "ToggleButton: true", "click event changed pressed state");
 
 		await toggleButton.keys("Space");
-		assert.strictEqual(await result.getText(), "ToggleButton: true", "Space triggered click and changed pressed state");
+		assert.strictEqual(await result.getText(), "ToggleButton: false", "Space triggered click and changed pressed state");
 
 		await toggleButton.keys("Enter");
-		assert.strictEqual(await result.getText(), "ToggleButton: false", "Enter triggered click and changed pressed state");
+		assert.strictEqual(await result.getText(), "ToggleButton: true", "Enter triggered click and changed pressed state");
 	});
 
 	it("should not fire click event on a disabled togglebutton", async () => {
 		const toggleButton = await browser.$("#disabled-toggle-button").shadow$("button");
 		const result = await browser.$("#click-result");
 
-		assert.strictEqual(await result.getText(), "ToggleButton: false", "toggle state should not change");
+		assert.strictEqual(await result.getText(), "ToggleButton: true", "toggle state should not change");
 
 		// don't test space and enter, as wdio always fires a click but the browser not.
 

--- a/packages/tools/components-package/wdio.js
+++ b/packages/tools/components-package/wdio.js
@@ -236,6 +236,12 @@ exports.config = {
 			}, this, attrName);
 		}, true);
 
+		await browser.addCommand("matches", async function(selector) {
+			return browser.executeAsync((elem, selector, done) => {
+				done(elem.matches(selector));
+			}, this, selector);
+		}, true);
+
 		await browser.addCommand("getStaticAreaItemClassName", async function(selector) {
 			return browser.executeAsync(async (selector, done) => {
 				const staticAreaItem = await document.querySelector(selector).getStaticAreaItemDomRef();


### PR DESCRIPTION
Button elements can now receive focus when using keyboards on mobile devices. Focus outline is now displayed via CSS pseudo-classes and no longer relies on using the[focused] attribute.

The following components were updated:
* ui5-button
* ui5-toggle-button
* ui5-segmented-button
* ui5-split-button

Fixes: #11024

Downport of: https://github.com/SAP/ui5-webcomponents/pull/8414