### PR TITLE
fix(ui5-table-growing): add rootMargin to observer

### DIFF
--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -14,6 +14,7 @@ import {
 	TABLE_MORE,
 	TABLE_MORE_DESCRIPTION,
 } from "./generated/i18n/i18n-defaults.js";
+import { findVerticalScrollContainer } from "./TableUtils.js";
 
 // The documentation should be similar to the Table.ts class documentation!
 // Please only use that style where it uses markdown and the documentation is more readable.
@@ -225,7 +226,10 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	 */
 	_getIntersectionObserver(): IntersectionObserver {
 		if (!this._observer) {
-			this._observer = new IntersectionObserver(this._onIntersection.bind(this), { root: document });
+			this._observer = new IntersectionObserver(this._onIntersection.bind(this), {
+				root: findVerticalScrollContainer(this._table?._endRow ?? document.body),
+				rootMargin: "5px",
+			});
 		}
 		return this._observer;
 	}

--- a/packages/main/src/TableUtils.ts
+++ b/packages/main/src/TableUtils.ts
@@ -20,7 +20,11 @@ const findRowInPath = (composedPath: Array<EventTarget>) => {
 const findVerticalScrollContainer = (element: HTMLElement): HTMLElement => {
 	while (element) {
 		const { overflowY } = window.getComputedStyle(element);
-		if (overflowY === "auto" || overflowY === "scroll") {
+		if (overflowY === "auto") {
+			if (element.scrollHeight > element.clientHeight) {
+				return element;
+			}
+		} else if (overflowY === "scroll") {
 			return element;
 		}
 


### PR DESCRIPTION
There is an issue with subpixel rendering introducing rounding errors. The growing sample in the playground is not working with zoom lower than 100%.

If the table is inside a scroll container, which is inside of an IFrame taken a fraction of the available width, rounding errors lead to the IntersectionObserver not calling the callback, as it does not detect the end-row scrolling into viewport.

Added a rootMargin of 5px to try to circumvent the rounding issue by increasing the intersection area. Additionally, the root should be the scrollContainer instead of the document.

Fixes #11071