### PR TITLE
refactor(ui5-side-navigation): add box-shadow by default

### DIFF
--- a/packages/fiori/src/themes/NavigationLayout.css
+++ b/packages/fiori/src/themes/NavigationLayout.css
@@ -40,10 +40,6 @@
 	width: 100%;
 }
 
-:host(:not([is-phone])) ::slotted([ui5-side-navigation][slot="sideContent"]) {
-	box-shadow: var(--_ui5_nl_side_navigation_box_shadow);
-}
-
 :host([is-phone]) ::slotted([ui5-side-navigation][slot="sideContent"]) {
 	width: 100%;
 	box-shadow: none;

--- a/packages/fiori/src/themes/SideNavigation.css
+++ b/packages/fiori/src/themes/SideNavigation.css
@@ -10,6 +10,8 @@
 	font-family: "72override", var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	background: var(--sapList_Background);
+	box-shadow: var(--_ui5_side_navigation_box_shadow);
+	border-inline-end: var(--_ui5_side_navigation_border_right);
 }
 
 :host([collapsed]) {
@@ -27,7 +29,6 @@
 	flex-direction: column;
 	box-sizing: border-box;
 	border-radius: inherit;
-	border-inline-end: var(--_ui5_side_navigation_border_right);
 }
 
 .ui5-sn-flexible {

--- a/packages/fiori/src/themes/SideNavigation.css
+++ b/packages/fiori/src/themes/SideNavigation.css
@@ -12,6 +12,7 @@
 	background: var(--sapList_Background);
 	box-shadow: var(--_ui5_side_navigation_box_shadow);
 	border-inline-end: var(--_ui5_side_navigation_border_right);
+	box-sizing: border-box;
 }
 
 :host([collapsed]) {
@@ -27,7 +28,7 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	box-sizing: border-box;
+	box-sizing: inherit;
 	border-radius: inherit;
 }
 

--- a/packages/fiori/src/themes/base/NavigationLayout-parameters.css
+++ b/packages/fiori/src/themes/base/NavigationLayout-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_nl_side_navigation_box_shadow: none;
-}

--- a/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
@@ -7,7 +7,6 @@
 @import "../base/ProductSwitchItem-parameters.css";
 @import "./ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
-@import "../base/NavigationLayout-parameters.css";
 @import "../base/TimelineItem-parameters.css";
 @import "../base/UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -7,7 +7,6 @@
 @import "../base/ProductSwitchItem-parameters.css";
 @import "./ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
-@import "../base/NavigationLayout-parameters.css";
 @import "../base/TimelineItem-parameters.css";
 @import "../base/UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -7,7 +7,6 @@
 @import "./ProductSwitchItem-parameters.css";
 @import "../base/ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
-@import "../base/NavigationLayout-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -7,7 +7,6 @@
 @import "./ProductSwitchItem-parameters.css";
 @import "../base/ShellBar-parameters.css";
 @import "../base/SideNavigation-parameters.css";
-@import "../base/NavigationLayout-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon/NavigationLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/NavigationLayout-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_nl_side_navigation_box_shadow: var(--sapContent_Shadow0);
-}

--- a/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
@@ -10,7 +10,6 @@
 @import "./ShellBar-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./SideNavigation-parameters.css";
-@import "./NavigationLayout-parameters.css";
 @import "./UploadCollection-parameters.css";
 @import "./Wizard-parameters.css";
 @import "./WizardTab-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_dark/NavigationLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/NavigationLayout-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_nl_side_navigation_box_shadow: var(--sapContent_Shadow0);
-}

--- a/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -11,7 +11,7 @@
 @import "../base/SearchField-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./SideNavigation-parameters.css";
-@import "./NavigationLayout-parameters.css";
+
 @import "./UploadCollection-parameters.css";
 @import "./Wizard-parameters.css";
 @import "./WizardTab-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_hcb/NavigationLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/NavigationLayout-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_nl_side_navigation_box_shadow: var(--sapContent_Shadow0);
-}

--- a/packages/fiori/src/themes/sap_horizon_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/parameters-bundle.css
@@ -8,7 +8,7 @@
 @import "../base/ShellBar-parameters.css";
 @import "./ShellBar-parameters.css";
 @import "./SideNavigation-parameters.css";
-@import "./NavigationLayout-parameters.css";
+
 @import "./TimelineItem-parameters.css";
 @import "./UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_hcw/NavigationLayout-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/NavigationLayout-parameters.css
@@ -1,3 +1,0 @@
-:root {
-	--_ui5_nl_side_navigation_box_shadow: var(--sapContent_Shadow0);
-}

--- a/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -7,7 +7,6 @@
 @import "./ProductSwitchItem-parameters.css";
 @import "../sap_horizon_hcb/ShellBar-parameters.css";
 @import "./SideNavigation-parameters.css";
-@import "./NavigationLayout-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./UploadCollection-parameters.css";
 @import "../base/ViewSettingsDialog-parameters.css";

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
@@ -18,4 +18,6 @@
 
 #sideNavigation {
 	width: 18rem;
+	box-shadow: none;
+	border: none;
 }

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
@@ -19,4 +19,5 @@
 #sideNavigation {
 	width: 18rem;
 	box-shadow: none;
+	border-inline-end: none;
 }

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.css
@@ -19,5 +19,4 @@
 #sideNavigation {
 	width: 18rem;
 	box-shadow: none;
-	border: none;
 }


### PR DESCRIPTION
The change
- brings the `box-shadow` by default back as the Side Navigation can be used in different layouts and use-cases with or without NavigationLayout and the box-shadow is by spec
- In case the box-shadow is not necessary (f.e. when the SideNavigation is used in popover), 
it can be removed by single line of css, as it is set on the host and this is what we will suggest now. This will give us time to decide to provide css class or API in future.