### PR TITLE
docs(ui5-daterange-picker): correct jsdoc

### DIFF
--- a/packages/main/src/DateRangePicker.ts
+++ b/packages/main/src/DateRangePicker.ts
@@ -226,7 +226,9 @@ class DateRangePicker extends DatePicker implements IFormInputElement {
 	}
 
 	/**
-	 * @override
+	 * Checks if a value is valid against the current date format of the DatePicker.
+	 * @public
+	 * @param value A value to be tested against the current date format
 	 */
 	isValid(value: string): boolean {
 		const parts = this._splitValueByDelimiter(value);
@@ -234,7 +236,9 @@ class DateRangePicker extends DatePicker implements IFormInputElement {
 	}
 
 	/**
-	 * @override
+	 * Checks if a date is between the minimum and maximum date.
+	 * @public
+	 * @param value A value to be checked
 	 */
 	isInValidRange(value: string): boolean {
 		return this._splitValueByDelimiter(value).every(dateString => super.isInValidRange(dateString));


### PR DESCRIPTION
With https://github.com/SAP/ui5-webcomponents/pull/11162, the override still appears and is only partially applied, leading to incorrect CEM information. This PR adds explicit JSDoc for the `isValid` and `isValidInRange` methods.