### PR TITLE
ci: reopen GitHub issues via commenting

### DIFF
--- a/.github/workflows/issue-comment-on-close.yaml
+++ b/.github/workflows/issue-comment-on-close.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Comment that the issue can be reopened
+      - name: Comment on closed issue
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/issue-comment-on-close.yaml
+++ b/.github/workflows/issue-comment-on-close.yaml
@@ -1,0 +1,21 @@
+name: Comment on Closing Issue
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  comment-on-close:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment that the issue can be reopened
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "This issue has been closed. To reopen, just leave a comment!"
+            })

--- a/.github/workflows/issue-reopen-on-comment.yaml
+++ b/.github/workflows/issue-reopen-on-comment.yaml
@@ -1,0 +1,35 @@
+name: Reopen Issue on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  reopen-issue:
+    if: github.event.issue.state == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Commenter
+        id: check_user
+        run: |
+          COMMENTER="${{ github.event.comment.user.login }}"
+          ALLOWED_USER="ui5-webcomponents-bot"
+
+          if [ "$COMMENTER" != "ui5-webcomponents-bot" ] && [ "$COMMENTER" != "github-actions[bot]" ]; then
+            echo "systemUser=false" >> $GITHUB_OUTPUT
+          else
+            echo "systemUser=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Reopen Issue
+        if: steps.check_user.outputs.systemUser == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'open'
+            })


### PR DESCRIPTION
Sometimes users are commenting on closed issues and they got overlooked, not f followed or response is delayed as considered already resolved. To address this, we add two new actions:
- the first leaving a comment after closing an issue: "This issue has been closed. To reopen, just leave a comment!"
- the second - reopens a GitHub issue when someone comments on a closed issue