### PR TITLE
fix(ui5-side-navigation): remove separator line

### DIFF
--- a/packages/fiori/src/themes/SideNavigationItemBase.css
+++ b/packages/fiori/src/themes/SideNavigationItemBase.css
@@ -197,8 +197,6 @@ and there is an additional border that appears on hover. */
 	min-width: 3rem;
 }
 
-:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover .ui5-sn-item-toggle-icon,
-:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus .ui5-sn-item-toggle-icon,
 :host(:not([side-nav-collapsed])) .ui5-sn-item-toggle-icon {
 	min-width: var(--_ui5_side_navigation_expand_icon_width);
 	padding-inline: 0.25rem 0.375rem;
@@ -209,9 +207,14 @@ and there is an additional border that appears on hover. */
 
 :host([unselectable]:not([side-nav-collapsed])) .ui5-sn-item-toggle-icon,
 :host(:not([side-nav-collapsed])) .ui5-sn-item-group .ui5-sn-item-toggle-icon,
-:host([unselectable][side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover .ui5-sn-item-toggle-icon,
-:host([unselectable][side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus .ui5-sn-item-toggle-icon {
+:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover .ui5-sn-item-toggle-icon,
+:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus .ui5-sn-item-toggle-icon {
 	border-inline-start: none;
+}
+
+:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover .ui5-sn-item-toggle-icon,
+:host([side-nav-collapsed]) .ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus .ui5-sn-item-toggle-icon {
+	min-width: 3rem;
 }
 
 :host([in-popover]) .ui5-sn-item-toggle-icon {
@@ -254,17 +257,12 @@ and there is an additional border that appears on hover. */
 	width: var(--_ui5_side_navigation_item_collapsed_hover_focus_width);
 	box-shadow: var(--_ui5_side_navigation_box_shadow);
 	z-index: 2;
-	padding-inline-end: var(--_ui5_side_navigation_item_collapsed_padding_right);
+	padding-inline-end: var(--_ui5_side_navigation_item_collapsed_padding);
 }
 
 :host([side-nav-collapsed]) a.ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover:not(.ui5-sn-item-with-expander),
 :host([side-nav-collapsed]) a.ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus:not(.ui5-sn-item-with-expander) {
 	padding-inline-end: 0;
-}
-
-:host([unselectable][side-nav-collapsed]) .ui5-sn-item.ui5-sn-item.ui5-sn-item-with-expander:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):hover,
-:host([unselectable][side-nav-collapsed]) .ui5-sn-item.ui5-sn-item.ui5-sn-item-with-expander:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):focus {
-	padding-inline-end: var(--_ui5_side_navigation_item_collapsed_unselectable_padding);
 }
 
 :host([unselectable][side-nav-collapsed]) div.ui5-sn-item:not(.ui5-sn-item-active):not(.ui5-sn-item-no-hover-effect):not(.ui5-sn-item-with-expander):hover,

--- a/packages/fiori/src/themes/base/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/base/SideNavigation-parameters.css
@@ -59,9 +59,8 @@
 	--_ui5_side_navigation_item_collapsed_hover_focus_width: auto;
 	--_ui5_side_navigation_item_collapsed_hover_focus_display: none;
 	--_ui5_side_navigation_item_collapsed_hover_focus_padding_right: 0;
-	--_ui5_side_navigation_item_collapsed_padding_right: 0;
 	--_ui5_side_navigation_action_item_collapsed_padding: 0;
-	--_ui5_side_navigation_item_collapsed_unselectable_padding: 0;
+	--_ui5_side_navigation_item_collapsed_padding: 0;
 	--_ui5_side_navigation_action_item_border_hover: var(--sapButton_BorderWidth) solid var(--sapButton_Hover_BorderColor);
 	--_ui5_side_navigation_action_item_border_active: var(--sapButton_BorderWidth) solid var(--sapButton_Active_BorderColor);
 

--- a/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
@@ -46,9 +46,8 @@
 	--_ui5_side_navigation_item_collapsed_hover_focus_width: fit-content;
 	--_ui5_side_navigation_item_collapsed_hover_focus_display: block;
 	--_ui5_side_navigation_item_collapsed_hover_focus_padding_right: 1rem;
-	--_ui5_side_navigation_item_collapsed_padding_right: 3.9375rem;
 	--_ui5_side_navigation_action_item_collapsed_padding: 1rem;
-	--_ui5_side_navigation_item_collapsed_unselectable_padding: 3rem;
+	--_ui5_side_navigation_item_collapsed_padding: 3rem;
 }
 
 [data-ui5-compact-size],

--- a/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
@@ -46,9 +46,8 @@
 	--_ui5_side_navigation_item_collapsed_hover_focus_width: fit-content;
 	--_ui5_side_navigation_item_collapsed_hover_focus_display: block;
 	--_ui5_side_navigation_item_collapsed_hover_focus_padding_right: 1rem;
-	--_ui5_side_navigation_item_collapsed_padding_right: 3.9375rem;
 	--_ui5_side_navigation_action_item_collapsed_padding: 1rem;
-	--_ui5_side_navigation_item_collapsed_unselectable_padding: 3rem;
+	--_ui5_side_navigation_item_collapsed_padding: 3rem;
 }
 
 [data-ui5-compact-size],

--- a/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
@@ -43,9 +43,8 @@
 	--_ui5_side_navigation_item_collapsed_hover_focus_width: fit-content;
 	--_ui5_side_navigation_item_collapsed_hover_focus_display: block;
 	--_ui5_side_navigation_item_collapsed_hover_focus_padding_right: 1rem;
-	--_ui5_side_navigation_item_collapsed_padding_right: 3.9375rem;
 	--_ui5_side_navigation_action_item_collapsed_padding: 1rem;
-	--_ui5_side_navigation_item_collapsed_unselectable_padding: 3rem;
+	--_ui5_side_navigation_item_collapsed_padding: 3rem;
 }
 
 [data-ui5-compact-size],

--- a/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
@@ -43,9 +43,8 @@
 	--_ui5_side_navigation_item_collapsed_hover_focus_width: fit-content;
 	--_ui5_side_navigation_item_collapsed_hover_focus_display: block;
 	--_ui5_side_navigation_item_collapsed_hover_focus_padding_right: 1rem;
-	--_ui5_side_navigation_item_collapsed_padding_right: 3.9375rem;
 	--_ui5_side_navigation_action_item_collapsed_padding: 1rem;
-	--_ui5_side_navigation_item_collapsed_unselectable_padding: 3rem;
+	--_ui5_side_navigation_item_collapsed_padding: 3rem;
 }
 
 [data-ui5-compact-size],


### PR DESCRIPTION
Separator line from the hovered two-click item in collapsed Side Navigation
is removed since there are no two click areas in this case.

JIRA: BGSOFUIRODOPI-3443
