### PR TITLE
feat(ui5-menu): introduce HorizontalAlign property

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -24,6 +24,7 @@ import type { Timeout } from "@ui5/webcomponents-base/dist/types.js";
 import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import DOMReferenceConverter from "@ui5/webcomponents-base/dist/converters/DOMReference.js";
 import type ResponsivePopover from "./ResponsivePopover.js";
+import type PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 import type MenuItem from "./MenuItem.js";
 import "./MenuItem.js";
 import "./MenuSeparator.js";
@@ -184,13 +185,21 @@ class Menu extends UI5Element {
 	headerText?: string;
 
 	/**
-	 * Indicates if the menu is open
+	 * Indicates if the menu is open.
 	 * @public
 	 * @default false
 	 * @since 1.10.0
 	 */
 	@property({ type: Boolean })
 	open = false;
+
+	/**
+	 * Determines the horizontal alignment of the menu relative to its opener control.
+	 * @default "Start"
+	 * @public
+	 */
+	@property()
+	horizontalAlign: `${PopoverHorizontalAlign}` = "Start";
 
 	/**
 	 * Defines if a loading indicator would be displayed inside the corresponding ui5-menu popover.
@@ -202,7 +211,7 @@ class Menu extends UI5Element {
 	loading = false;
 
 	/**
-	 * Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover..
+	 * Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
 	 * @default 1000
 	 * @public
 	 * @since 1.13.0

--- a/packages/main/src/MenuTemplate.tsx
+++ b/packages/main/src/MenuTemplate.tsx
@@ -12,6 +12,7 @@ export default function MenuTemplate(this: Menu) {
 			class="ui5-menu-rp"
 			placement="Bottom"
 			verticalAlign="Bottom"
+			horizontalAlign={this.horizontalAlign}
 			opener={this.opener}
 			open={this.open}
 			preventInitialFocus={true}

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -13,7 +13,7 @@
 </head>
 
 <style>
-	.centeredbutton {
+	.center-content {
 		display: flex;
 		justify-content: center;
 		align-items: center;
@@ -128,7 +128,7 @@
 
 	<ui5-title level="H5" class="header-title">Menu with right alignment</ui5-title>
 
-	<div class="centeredbutton">
+	<div class="center-content">
 		<ui5-button id="btnOpenRight">Open Menu</ui5-button> <br/>
 	</div>
 

--- a/packages/main/test/pages/Menu.html
+++ b/packages/main/test/pages/Menu.html
@@ -12,6 +12,14 @@
 	<link rel="stylesheet" type="text/css" href="./styles/Menu.css">
 </head>
 
+<style>
+	.centeredbutton {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+</style>
+
 <body class="bg">
 	<ui5-button id="btnOpen">Open Menu</ui5-button> <br/>
 	<ui5-menu id="menu" header-text="My ui5-menu">
@@ -116,7 +124,19 @@
 	</ui5-popover>
 
 
-	<ui5-button id="btnAddOpenerDelay">Delayed</ui5-button>
+	<ui5-button id="btnAddOpenerDelay">Delayed</ui5-button> <br/><br/>
+
+	<ui5-title level="H5" class="header-title">Menu with right alignment</ui5-title>
+
+	<div class="centeredbutton">
+		<ui5-button id="btnOpenRight">Open Menu</ui5-button> <br/>
+	</div>
+
+	<ui5-menu id="menuRight" header-text="Menu" horizontal-align="End">
+		<ui5-menu-item text="Open" icon="open-folder"></ui5-menu-item>
+		<ui5-menu-separator></ui5-menu-separator>
+		<ui5-menu-item text="Close" additional-text="Ctrl+W" ></ui5-menu-item>
+	</ui5-menu>
 
 	<script>
 		btnOpen.accessibilityAttributes = {
@@ -131,6 +151,11 @@
 		btnOpenEndContent.addEventListener("click", function() {
 			menuEndContent.opener = "btnOpenEndContent";
 			menuEndContent.open = !menu.open;
+		});
+
+		btnOpenRight.addEventListener ("click", function() {
+			menuRight.opener = "btnOpenRight";
+			menuRight.open = !menuRight.open;
 		});
 
 		btnAddOpener.addEventListener("click", function() {

--- a/packages/website/docs/_samples/patterns/AIQuickPrompt/sample.html
+++ b/packages/website/docs/_samples/patterns/AIQuickPrompt/sample.html
@@ -39,7 +39,7 @@
 		<ui5-toast placement="MiddleCenter" id="quickPromptToast" duration="3000">Your message was sent successfully!</ui5-toast>
 	</ui5-card>
 
-	<ui5-menu id="menu1">
+	<ui5-menu id="menu1" horizontal-align="End">
 		<ui5-menu-item text="Regenerate"></ui5-menu-item>
 		<ui5-menu-separator></ui5-menu-separator>
 		<ui5-menu-item text="Fix Spelling and Grammar"></ui5-menu-item>


### PR DESCRIPTION
This change introduces a new `horizontalAlign` property to `ui5-menu`, similar to what's available in `ui5-popover`. It allows users to control the menu's horizontal alignment. 

The default value is `start`, but it can also be set to `end`, `center`, or `stretch`.

## Usage:

Setting the property to `end` as follows will align the menu to the end of the opener button:
```html
<ui5-menu horizontal-align="End">
    <ui5-menu-item ...
</ui5-menu>
```
The menu will look as follows:

<img width="250" src="https://github.com/user-attachments/assets/37a27583-d53e-478a-b0c0-d56558e9b9fb" />

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10765
