### PR TITLE
fix(ui5-shellbar): fixed avatar font-size

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -111,6 +111,8 @@ slot[name="profile"] {
 	min-width: 0;
 	min-height: 2rem;
 	pointer-events: none;
+	font-size: var(--_ui5-v2-9-0-rc-2_avatar_fontsize_XS);
+	font-weight: normal;
 }
 
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive::-moz-focus-inner {

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -20,7 +20,7 @@
 
 <body class="shellbar1auto">
 
-<ui5-navigation-layout side-collapsed>
+<ui5-navigation-layout mode="Collapsed">
 
 	<ui5-menu id="menuSubsDynamic" opener="btnOpenBasicDynamic">
 		<ui5-menu-item text="New File" icon="add-document"></ui5-menu-item>

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -20,7 +20,7 @@
 
 <body class="shellbar1auto">
 
-<ui5-navigation-layout mode="Collapsed">
+<ui5-navigation-layout side-collapsed>
 
 	<ui5-menu id="menuSubsDynamic" opener="btnOpenBasicDynamic">
 		<ui5-menu-item text="New File" icon="add-document"></ui5-menu-item>
@@ -72,8 +72,7 @@
 		</ui5-input>
 
 		<ui5-toggle-button id="assistantDynamic" icon="sap-icon://da" slot="assistant" text="Assitant" title="Assitant"></ui5-toggle-button>
-		<ui5-avatar slot="profile">
-			<img src="./img/John_Miller.png" alt="John Miller">
+		<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
 		</ui5-avatar>
 	</ui5-shellbar>
 


### PR DESCRIPTION
Avatar font-size was inheriting style for size "S", while it has hardcoded size, which is smaller than "S" and a little bit larger than "XS", so font-size for XS looks more suitable.