### PR TITLE
fix(ui5-dynamic-page): change the container-type

### DIFF
--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -12,7 +12,7 @@
 }
 
 .ui5-dynamic-page-root {
-    container-type: size;
+    container-type: inline-size;
     height: inherit;
     overflow-y: hidden;
 }


### PR DESCRIPTION
Problem:
- The current implementation uses 'container-type: size' which applies containment 
to both width and height dimensions. This creates a problem when combined with 
'height: inherit' as it disrupts the height inheritance chain, causing inner 
components to collapse to zero height while width continues to work correctly.

Solution:
- By changing to 'container-type: inline-size', we maintain containment only for
the inline (width) dimension while allowing height to behave normally. This 
preserves all width-based container queries used for responsive design while
fixing the height inheritance issue.

Related to: [#11309](https://github.com/SAP/ui5-webcomponents/issues/11309)