### PR TITLE
chore: correct file path of template files

### DIFF
--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -18,7 +18,7 @@ const VERSION = JSON.parse(
 
 // Constants
 const SUPPORTED_TEST_SETUPS = ["cypress", "manual"];
-const SRC_DIR = "template";
+const SRC_DIR = path.join(__dirname, "template");
 const FILES_TO_RENAME = {
 	"npmrc": ".npmrc",
 	"gitignore": ".gitignore",


### PR DESCRIPTION
Globby isn't finding any files because the script is being executed from the `bin` folder. Update the file path to explicitly point to the location of the `create-package.js` module and search for template files relative to that path.