### PR TITLE
fix(ui5-table-growing): remember correct last row with Enter

### DIFF
--- a/packages/main/cypress/specs/TableGrowing.cy.tsx
+++ b/packages/main/cypress/specs/TableGrowing.cy.tsx
@@ -151,7 +151,7 @@ describe("TableGrowing - Button", () => {
 				.should("have.been.calledTwice");
 		});
 
-		it("tests focus is set to first newly added row", () => {
+		it("tests focus is set to first newly added row - click", () => {
 			cy.mount(<TableSample></TableSample>);
 
 			cy.get<TableGrowing>("[ui5-table-growing]")
@@ -165,6 +165,30 @@ describe("TableGrowing - Button", () => {
 					});
 				})
 				.realClick();
+
+			cy.get("[ui5-table]")
+				.children("ui5-table-row")
+				.should("have.length", 2);
+
+			cy.get("#new-row")
+				.should("exist")
+				.should("have.focus");
+		});
+
+		it("tests focus is set to first newly added row - ENTER", () => {
+			cy.mount(<TableSample></TableSample>);
+
+			cy.get<TableGrowing>("[ui5-table-growing]")
+				.then(tableGrowing => {
+					tableGrowing.get(0).addEventListener("load-more", () => {
+						const table = document.getElementById("table");
+						const row = document.createElement("ui5-table-row");
+						row.id = "new-row";
+						row.innerHTML = "<ui5-table-cell><ui5-label>Cell B</ui5-label></ui5-table-cell>";
+						table!.appendChild(row);
+					});
+				})
+				.trigger("keydown", { key: "Enter", code: "Enter", which: 13 });
 
 			cy.get("[ui5-table]")
 				.children("ui5-table-row")

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -176,7 +176,6 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	onBeforeRendering(): void {
 		this._observer?.disconnect();
 		this._observer = undefined;
-		this._currentLastRow = undefined;
 		this._renderContent = this.hasGrowingComponent();
 		this._invalidateTable();
 	}


### PR DESCRIPTION
When pressing the Growing button with "Enter" instead of clicking it, the growing button stays focused, although
the last remembered row should be focused now.
Removed reset of _currentLastRow in onBeforeRendering to avoid this issue

Fixes #10978 