### PR TITLE
fix(ui5-breadcrumbs): dropdown arrow focused color fixed

### DIFF
--- a/packages/main/src/themes/Breadcrumbs.css
+++ b/packages/main/src/themes/Breadcrumbs.css
@@ -47,7 +47,7 @@
     color: var(--sapLinkColor);
 }
 
-.ui5-breadcrumbs-dropdown-arrow-link-wrapper [ui5-link][focused] [ui5-icon] {
+.ui5-breadcrumbs-dropdown-arrow-link-wrapper:focus-within [ui5-link] [ui5-icon] {
     color: var(--_ui5_link_focus_color);
 }
 


### PR DESCRIPTION
Bug description: When we have dropdown arrow (when there is not enough space for all the links) and we focus it, the color of the arrow and triple dots remains bluish. It should become white.

This change fixes the issue by improving the CSS selector for making the focused color to be bright.

Fixes: #11336 
