### PR TITLE
fix(ui5-tree): add event validation to selection handler

### DIFF
--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -440,6 +440,10 @@ class Tree extends UI5Element {
 	}
 
 	_onListSelectionChange(e: CustomEvent<ListSelectionChangeEventDetail>) {
+		if (!e.detail || !e.detail.previouslySelectedItems || !e.detail.selectedItems) {
+			return;
+		}
+
 		const previouslySelectedItems = e.detail.previouslySelectedItems as Array<TreeItemBase>;
 		const selectedItems = e.detail.selectedItems as Array<TreeItemBase>;
 		const targetItem = e.detail.targetItem as TreeItemBase;


### PR DESCRIPTION
- Problem:
     - The issue occurs because the selection-change event from the MultiComboBox bubbles up to the Tree component, which tries to process it as a Tree selection event but the event  doesn't have the expected properties.

- Solution:
   - Added validation checks in the _onListSelectionChange method to verify that the expected properties exist before attempting to access them.

Fixes: [#11352](https://github.com/SAP/ui5-webcomponents/issues/11352)