### PR TITLE
chore: stabilize `ui5-datetime-picker` tests

### DIFF
--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -366,14 +366,14 @@ describe("DateTimePicker general interaction", () => {
 		// act: confirm selection
 		cy.get("@dtp")
 			.shadow()
-			.find("ui5-responsive-popover #ok")
+			.find("[ui5-responsive-popover] #ok")
 			.realClick();
 
 		// assert: the picker is closed
 		cy.get("@dtp")
 			.shadow()
-			.find("ui5-responsive-popover")
-			.should("exist").and("not.be.visible");
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverClosed();
 
 		// assert: the value is not changed
 		cy.get("@input")

--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -31,60 +31,66 @@ describe("DateTimePicker general interaction", () => {
 		const PREVIOUS_VALUE = "13/04/2020, 03:16:16 AM";
 
 		cy.mount(<DateTimePicker id="dtSeconds" formatPattern="dd/MM/yyyy, hh:mm:ss a" value={PREVIOUS_VALUE} />);
-		cy.ui5DateTimePickerOpen("#dtSeconds");
 
-		cy.get("#dtSeconds")
+		cy.get<DateTimePicker>("#dtSeconds")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
+
+		cy.get("@dtp")
 			.shadow()
 			.find("ui5-datetime-input")
 			.should("have.value", PREVIOUS_VALUE);
 
-		cy.ui5DateTimePickerGetPopover("#dtSeconds").within(() => {
-			// Adjust hours:
-			cy.get("ui5-time-selection-clocks")
-				.shadow()
-				.as("clocks");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				// Adjust hours:
+				cy.get("ui5-time-selection-clocks")
+					.shadow()
+					.as("clocks");
 
-			cy.get("@clocks")
-				.find(`ui5-toggle-spin-button[data-ui5-clock="hours"]`)
-				.realClick()
-				.should("be.focused");
+				cy.get("@clocks")
+					.find(`ui5-toggle-spin-button[data-ui5-clock="hours"]`)
+					.realClick()
+					.should("be.focused");
 
-			cy.realPress("ArrowDown");
-			cy.realPress("Space");
+				cy.realPress("ArrowDown");
+				cy.realPress("Space");
 
-			// Adjust minutes.
-			cy.get("@clocks")
-				.find(`ui5-toggle-spin-button[data-ui5-clock="minutes"]`)
-				.realClick()
-				.should("be.focused");
+				// Adjust minutes.
+				cy.get("@clocks")
+					.find(`ui5-toggle-spin-button[data-ui5-clock="minutes"]`)
+					.realClick()
+					.should("be.focused");
 
-			cy.realPress("ArrowDown");
-			cy.realPress("ArrowDown");
-			cy.realPress("Space");
+				cy.realPress("ArrowDown");
+				cy.realPress("ArrowDown");
+				cy.realPress("Space");
 
-			// Adjust seconds.
-			cy.get("@clocks")
-				.find(`ui5-toggle-spin-button[data-ui5-clock="seconds"]`)
-				.realClick()
-				.should("be.focused");
+				// Adjust seconds.
+				cy.get("@clocks")
+					.find(`ui5-toggle-spin-button[data-ui5-clock="seconds"]`)
+					.realClick()
+					.should("be.focused");
 
-			cy.realPress("ArrowUp");
-			cy.realPress("ArrowUp");
-			cy.realPress("ArrowUp");
-			cy.realType("p");
+				cy.realPress("ArrowUp");
+				cy.realPress("ArrowUp");
+				cy.realPress("ArrowUp");
+				cy.realType("p");
 
-			// Confirm.
-			cy.get("#ok").realClick();
-		});
+				// Confirm.
+				cy.get("#ok").realClick();
+			});
 
 		// Only the time parts have been updated.
-		cy.get("#dtSeconds")
+		cy.get<DateTimePicker>("@dtp")
 			.shadow()
 			.find("ui5-datetime-input")
 			.should("be.focused")
 			.should("have.attr", "value", "13/04/2020, 02:14:19 PM");
 
-		cy.ui5DateTimePickerIsOpen("#dtSeconds").should("equal", false);
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(false);
 
 		setAnimationMode(AnimationMode.Full);
 	});
@@ -92,58 +98,74 @@ describe("DateTimePicker general interaction", () => {
 	it("tests picker opens/closes programmatically", () => {
 		cy.mount(<DefaultDateTimePicker />);
 
-		cy.ui5DateTimePickerOpen("#dt");
-		cy.ui5DateTimePickerIsOpen("#dt").should("equal", true);
-		cy.ui5DateTimePickerClose("#dt");
-		cy.ui5DateTimePickerIsOpen("#dt").should("equal", false);
+		cy.get<DateTimePicker>("#dt")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(true);
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerClose();
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(false);
 	});
 
 	// Unstable but valid test, needs to be individually observed
-	it.skip("tests selection of new date", () => {
+	it("tests selection of new date", () => {
 		setAnimationMode(AnimationMode.None);
 		const PREVIOUS_VALUE = "13/04/2020, 03:16:16 AM";
 
 		cy.mount(<DateTimePicker id="dtSeconds" formatPattern="dd/MM/yyyy, hh:mm:ss a" value={PREVIOUS_VALUE} />);
-		cy.ui5DateTimePickerOpen("#dtSeconds");
+
+		cy.get<DateTimePicker>("#dtSeconds")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
 
 		cy.get("#dtSeconds")
 			.shadow()
 			.as("DateTimePicker");
 
-		cy.get("@DateTimePicker")
+		cy.get("@dtp")
+			.shadow()
 			.find("ui5-datetime-input")
 			.should("have.value", PREVIOUS_VALUE);
 
-		cy.ui5DateTimePickerGetPopover("#dtSeconds").within(() => {
-			// Click the currently selected day and then move to the next day.
-			cy.get("ui5-calendar")
-				.shadow()
-				.as("calendar");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				// Click the currently selected day and then move to the next day.
+				cy.get("ui5-calendar")
+					.shadow()
+					.as("calendar");
 
-			cy.get("@calendar")
-				.find("ui5-daypicker")
-				.shadow()
-				.as("daypicker")
+				cy.get("@calendar")
+					.find("ui5-daypicker")
+					.shadow()
+					.as("daypicker")
 
-			cy.get("@daypicker")
-				.find(".ui5-dp-item--selected")
-				.realClick()
-				.should("be.focused");
+				cy.get("@daypicker")
+					.find(".ui5-dp-item--selected")
+					.realClick()
+					.should("be.focused");
 
-			cy.realPress("ArrowRight");
-			cy.realPress("Space");
+				cy.realPress("ArrowRight");
+				cy.realPress("Space");
 
-			// Confirm the change.
-			cy.get("#ok").realClick();
-		});
+				// Confirm the change.
+				cy.get("#ok").realClick();
+			});
 
 		// Only the date has changed; the time remains the same.
-		cy.get("@DateTimePicker")
+		cy.get("@dtp")
+			.shadow()
 			.find("ui5-datetime-input")
 			.should("be.focused")
 			.should("have.attr", "value", "14/04/2020, 03:16:16 AM");
 
-		cy.ui5DateTimePickerIsOpen("#dtSeconds").should("equal", false);
+		cy.get<DateTimePicker>("@dtp").ui5DateTimePickerCheckOpen(false);
+
 		setAnimationMode(AnimationMode.Full);
 	});
 
@@ -152,57 +174,81 @@ describe("DateTimePicker general interaction", () => {
 		setAnimationMode(AnimationMode.None);
 
 		const PREVIOUS_VALUE = "14/04/2020, 02:14:19 PM";
-		cy.mount(<DateTimePickerWithSeconds initialValue={PREVIOUS_VALUE} />);
+		cy.mount(<>
+			<button>before</button>
+			<DateTimePickerWithSeconds initialValue={PREVIOUS_VALUE} />
+		</>);
 
 		cy.get("#dtSeconds")
+			.as("dtp")
 			.shadow()
-			.find("ui5-datetime-input")
+			.find("[ui5-datetime-input]")
 			.should("have.value", PREVIOUS_VALUE);
 
-		// Simulate keyboard interactions
-		cy.realPress("Tab");
-		cy.realPress(["Shift", "Tab"]);
-		cy.realPress("Backspace");
-		cy.get("#dtSeconds")
-			.shadow()
-			.find("ui5-datetime-input")
-			.realClick()
+		cy.get("button")
+			.contains("before")
+			.realClick();
+
+		cy.get("button")
+			.contains("before")
 			.should("be.focused");
+
+		cy.realPress("Tab");
+
+		// Simulate keyboard interactions
+		cy.get("@dtp")
+			.shadow()
+			.find("[ui5-datetime-input]")
+			.should("be.focused");
+
+		cy.realPress("Backspace");
 		cy.realType("wrongtext");
 		cy.realPress("Tab");
 
-		cy.ui5DateTimePickerOpen("#dtSeconds");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
 
-		// Act
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(true);
+
 		let selectedDate = "";
-		cy.ui5DateTimePickerGetPopover("#dtSeconds").within(() => {
-			cy.get("ui5-calendar")
-				.shadow()
-				.as("calendar");
 
-			cy.get("@calendar")
-				.find("ui5-daypicker")
-				.shadow()
-				.as("daypicker");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				cy.get("ui5-calendar")
+					.shadow()
+					.as("calendar");
 
-			cy.get("@daypicker")
-				.find(".ui5-dp-item--now")
-				.should("be.focused")
-				.then($el => {
-					const timestamp = $el.attr("data-sap-timestamp") || "";
-					const date = new Date(parseInt(timestamp) * 1000);
-					selectedDate = `${String(date.getDate()).padStart(2, "0")}/${String(date.getMonth() + 1).padStart(2, "0")}/${date.getFullYear()}`;
-				})
-				.realClick();
+				cy.get("@calendar")
+					.find("ui5-daypicker")
+					.shadow()
+					.as("daypicker");
 
-			cy.get("#ok").realClick();
-		});
+				cy.get("@daypicker")
+					.find(".ui5-dp-item--now")
+					.realClick();
 
-		cy.get("#dtSeconds")
-			.shadow()
-			.find("ui5-datetime-input")
-			.should("be.focused")
-			.should("have.attr", "value", selectedDate + ", 02:14:19 PM");
+				cy.get("@daypicker")
+					.find(".ui5-dp-item--now")
+					.should("be.focused")
+					.then($el => {
+						const timestamp = $el.attr("data-sap-timestamp") || "";
+						const date = new Date(parseInt(timestamp) * 1000);
+						selectedDate = `${String(date.getDate()).padStart(2, "0")}/${String(date.getMonth() + 1).padStart(2, "0")}/${date.getFullYear()}`;
+					})
+			})
+			.then(() => {
+				cy.get<DateTimePicker>("@dtp")
+					.ui5DateTimePickerGetSubmitButton()
+					.realClick();
+
+				cy.get("#dtSeconds")
+					.shadow()
+					.find("ui5-datetime-input")
+					.should("be.focused")
+					.and("have.attr", "value", selectedDate + ", 02:14:19 PM");
+			});
 
 		setAnimationMode(AnimationMode.Full);
 	});
@@ -213,19 +259,21 @@ describe("DateTimePicker general interaction", () => {
 
 		cy.mount(<DateTimePickerWithSeconds />);
 
-		cy.ui5DateTimePickerOpen("#dtSeconds");
+		cy.get<DateTimePicker>("#dtSeconds")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
 
-		cy.ui5DateTimePickerTimeSelectionClocksCount("#dtSeconds").then(clocksCount => {
-			expect(clocksCount).to.equal(expectedClocksCount,
-				"The picker should display 3 clocks for hours, minutes and seconds.");
-		});
 
-		cy.ui5DateTimePickerPeriodSegmentedButtonCount("#dtSeconds").then(periodCount => {
-			expect(periodCount).to.equal(expectedPeriodCount,
-				"The picker should display 1 period selector.");
-		});
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerTimeSelectionClocksCount()
+			.should("be.equal", expectedClocksCount)
 
-		cy.ui5DateTimePickerClose("#dtSeconds");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerPeriodSegmentedButtonCount()
+			.should("be.equal", expectedPeriodCount)
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerClose();
 	});
 
 	it("tests time controls for dtMinutes picker", () => {
@@ -234,49 +282,64 @@ describe("DateTimePicker general interaction", () => {
 
 		cy.mount(<DateTimePickerWithMinutes />);
 
-		cy.ui5DateTimePickerOpen("#dtMinutes");
+		cy.get<DateTimePicker>("#dtMinutes")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
 
-		cy.ui5DateTimePickerTimeSelectionClocksCount("#dtMinutes").then(clocksCount => {
-			expect(clocksCount).to.equal(expectedClocksCount,
-				"The picker should display 2 clocks for hours and minutes.");
-		});
 
-		cy.ui5DateTimePickerPeriodSegmentedButtonCount("#dtMinutes").then(periodCount => {
-			expect(periodCount).to.equal(expectedPeriodCount,
-				"The picker should display 1 period selector.");
-		});
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerTimeSelectionClocksCount()
+			.should("be.equal", expectedClocksCount)
 
-		cy.ui5DateTimePickerClose("#dtMinutes");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerPeriodSegmentedButtonCount()
+			.should("be.equal", expectedPeriodCount)
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerClose();
 	});
 
 	it("tests hours clock is active on picker open", () => {
 		cy.mount(<DefaultDateTimePicker />);
-		cy.ui5DateTimePickerOpen("#dt");
 
-		cy.ui5DateTimePickerGetPopover("#dt").within(() => {
-			cy.get("ui5-time-selection-clocks")
-				.shadow()
-				.as("clocks");
+		cy.get<DateTimePicker>("#dt")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
 
-			cy.get("@clocks")
-				.find(`ui5-time-picker-clock[data-ui5-clock="hours"]`)
-				.should("have.attr", "active", "");
-		});
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				cy.get("ui5-time-selection-clocks")
+					.shadow()
+					.as("clocks");
 
-		cy.ui5DateTimePickerClose("#dt");
-		cy.ui5DateTimePickerIsOpen("#dt").should("equal", false);
+				cy.get("@clocks")
+					.find(`ui5-time-picker-clock[data-ui5-clock="hours"]`)
+					.should("have.attr", "active", "");
+			});
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerClose();
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(false);
 	});
 
 	// Unstable test, needs investigation
-	it.skip("tests selection of 12:34:56 AM", () => {
+	it("tests selection of 12:34:56 AM", () => {
 		setAnimationMode(AnimationMode.None);
 
 		cy.mount(<DateTimePickerWithSeconds />);
 
-		cy.ui5DateTimePickerOpen("#dtSeconds");
-		cy.ui5DateTimePickerIsOpen("#dtSeconds").should("equal", true);
+		cy.get<DateTimePicker>("#dtSeconds")
+			.as("dtp")
+			.ui5DateTimePickerOpen();
 
-		cy.ui5DateTimePickerGetPopover("#dtSeconds")
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(true);
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
 			.within(() => {
 				cy.get("ui5-calendar")
 					.shadow()
@@ -299,31 +362,32 @@ describe("DateTimePicker general interaction", () => {
 				cy.get("@clocks")
 					.find(`ui5-toggle-spin-button[data-ui5-clock="hours"]`)
 					.realClick()
-					.should("be.focused")
-					.realType("1")
-					.realType("2");
+					.should("be.focused");
+
+				cy.realType("12")
 
 				cy.get("@clocks")
 					.find(`ui5-toggle-spin-button[data-ui5-clock="minutes"]`)
-					.should("be.focused")
-					.realType("3")
-					.realType("4");
+					.should("be.focused");
+
+				cy.realType("34");
 
 				cy.get("@clocks")
 					.find(`ui5-toggle-spin-button[data-ui5-clock="seconds"]`)
 					.should("be.focused")
-					.realType("5")
-					.realType("6")
-					.realType("a");
 
-				cy.get("#ok").realClick();
+				cy.realType("56a")
 			});
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetSubmitButton()
+			.realClick();
 
 		cy.get("#dtSeconds")
 			.shadow()
 			.find("ui5-datetime-input")
 			.should("be.focused")
-			.should("have.attr", "value", "13/04/2020, 12:34:56 AM");
+			.and("have.attr", "value", "13/04/2020, 12:34:56 AM");
 
 		setAnimationMode(AnimationMode.Full);
 	});
@@ -331,22 +395,22 @@ describe("DateTimePicker general interaction", () => {
 	it("tests change event is prevented on submit when prevent default is called", () => {
 		cy.mount(<DefaultDateTimePicker />);
 
-		cy.get("[ui5-datetime-picker]")
+		cy.get<DateTimePicker>("[ui5-datetime-picker]")
 			.as("dtp")
 
-		cy.get("@dtp")
+		cy.get<DateTimePicker>("@dtp")
 			.shadow()
 			.find("[ui5-datetime-input]")
 			.as("input");
 
-		cy.get("@dtp")
+		cy.get<DateTimePicker>("@dtp")
 			.shadow()
 			.find("ui5-responsive-popover ui5-calendar")
 			.shadow()
 			.find("ui5-daypicker")
 			.as("daypicker");
 
-		cy.get("@dtp")
+		cy.get<DateTimePicker>("@dtp")
 			.then($el => {
 				$el[0].addEventListener("ui5-change", (ev: Event) => {
 					ev.preventDefault();
@@ -354,7 +418,8 @@ describe("DateTimePicker general interaction", () => {
 			});
 
 		// act: open the picker
-		cy.ui5DateTimePickerOpen("#dt");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
 
 		// act: click today's date
 		cy.get("@daypicker")
@@ -364,9 +429,8 @@ describe("DateTimePicker general interaction", () => {
 			.realClick();
 
 		// act: confirm selection
-		cy.get("@dtp")
-			.shadow()
-			.find("[ui5-responsive-popover] #ok")
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetSubmitButton()
 			.realClick();
 
 		// assert: the picker is closed
@@ -390,45 +454,52 @@ describe("DateTimePicker general interaction", () => {
 			></DateTimePicker>
 		);
 
-		cy.ui5DateTimePickerOpen("#dtMinMaxDatesISO");
+		cy.get<DateTimePicker>("#dtMinMaxDatesISO")
+			.as("dtp")
 
-		cy.ui5DateTimePickerGetPopover("#dtMinMaxDatesISO").within(() => {
-			cy.get("ui5-calendar")
-				.shadow()
-				.find(".ui5-calheader")
-				.as("calHeader");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
 
-			cy.get("@calHeader")
-				.find("div[data-ui5-cal-header-btn-prev]")
-				.should("have.class", "ui5-calheader-arrowbtn-disabled");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				cy.get("ui5-calendar")
+					.shadow()
+					.find(".ui5-calheader")
+					.as("calHeader");
 
-			cy.get("@calHeader")
-				.find("div[data-ui5-cal-header-btn-next]")
-				.should("have.class", "ui5-calheader-arrowbtn-disabled");
-		});
+				cy.get("@calHeader")
+					.find("div[data-ui5-cal-header-btn-prev]")
+					.should("have.class", "ui5-calheader-arrowbtn-disabled");
+
+				cy.get("@calHeader")
+					.find("div[data-ui5-cal-header-btn-next]")
+					.should("have.class", "ui5-calheader-arrowbtn-disabled");
+			});
 	});
 
 	it("picker popover should have accessible name", () => {
 		cy.mount(<DefaultDateTimePicker />);
-		cy.ui5DateTimePickerOpen("#dt");
 
-		cy.ui5DateTimePickerGetPopover("#dt")
+		cy.get<DateTimePicker>("#dt")
+			.ui5DateTimePickerGetPopover()
 			.should("have.attr", "accessible-name", "Choose Date and Time");
 	});
 
 	it("value state", () => {
 		cy.mount(<DateTimePicker id="dtpValueState" valueState="Negative"></DateTimePicker>);
 		cy.get("[ui5-datetime-picker]")
-			.as("dateTimePicker");
+			.as("dtp");
 
-		cy.get<DateTimePicker>("@dateTimePicker")
+		cy.get<DateTimePicker>("@dtp")
 			.shadow()
 			.find("ui5-datetime-input")
 			.should("have.attr", "value-state", "Negative");
 
-		cy.ui5DateTimePickerOpen("#dtpValueState");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
 
-		cy.get<DateTimePicker>("@dateTimePicker")
+		cy.get<DateTimePicker>("@dtp")
 			.shadow()
 			.find("[slot='header']")
 			.first()
@@ -436,46 +507,62 @@ describe("DateTimePicker general interaction", () => {
 	});
 
 	// Unstable test, needs investigation
-	it.skip("tests change event is fired on submit", () => {
+	it("tests change event is fired on submit", () => {
 		cy.mount(<DefaultDateTimePicker />);
 
 		const changeStub = cy.stub();
-		cy.get("#dt").then($el => {
-			$el[0].addEventListener("ui5-change", changeStub);
-		});
+
+		cy.get("#dt")
+			.as("dtp")
+			.then($el => {
+				$el[0].addEventListener("ui5-change", changeStub);
+			});
 
 		// Open the picker, select a date, and submit to fire the event
-		cy.ui5DateTimePickerOpen("#dt");
-		cy.ui5DateTimePickerGetPopover("#dt").within(() => {
-			cy.get("ui5-calendar")
-				.shadow()
-				.as("calendar");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
 
-			cy.get("@calendar")
-				.find("ui5-daypicker")
-				.shadow()
-				.as("daypicker");
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(true);
 
-			cy.get("@daypicker")
-				.find("[data-sap-focus-ref]")
-				.realClick()
-				.should("be.focused");
-			cy.get("#ok").realClick();
-		});
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetPopover()
+			.within(() => {
+				cy.get("ui5-calendar")
+					.shadow()
+					.as("calendar");
+
+				cy.get("@calendar")
+					.find("ui5-daypicker")
+					.shadow()
+					.as("daypicker");
+
+				cy.get("@daypicker")
+					.find("[data-sap-focus-ref]")
+					.realClick()
+					.should("be.focused");
+			});
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetSubmitButton()
+			.realClick();
 
 		// Assert the change event was fired once
 		cy.wrap(changeStub).should("have.been.calledOnce");
 
 		// Re-open the picker and submit without making a change
-		cy.ui5DateTimePickerOpen("#dt");
-		cy.ui5DateTimePickerGetPopover("#dt").within(() => {
-			cy.get("#ok").realClick();
-		});
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerOpen();
+
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerGetSubmitButton()
+			.realClick();
 
 		// The change event should not have been fired a second time.
 		cy.wrap(changeStub).should("have.been.calledOnce");
 
 		// Verify the picker is closed
-		cy.ui5DateTimePickerIsOpen("#dt").should("equal", false);
+		cy.get<DateTimePicker>("@dtp")
+			.ui5DateTimePickerCheckOpen(false);
 	});
 });

--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -45,12 +45,12 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
 				// Adjust hours:
-				cy.get("ui5-time-selection-clocks")
+				cy.get("[ui5-time-selection-clocks]")
 					.shadow()
 					.as("clocks");
 
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="hours"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="hours"]`)
 					.realClick()
 					.should("be.focused");
 
@@ -59,7 +59,7 @@ describe("DateTimePicker general interaction", () => {
 
 				// Adjust minutes.
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="minutes"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="minutes"]`)
 					.realClick()
 					.should("be.focused");
 
@@ -69,7 +69,7 @@ describe("DateTimePicker general interaction", () => {
 
 				// Adjust seconds.
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="seconds"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="seconds"]`)
 					.realClick()
 					.should("be.focused");
 
@@ -90,7 +90,7 @@ describe("DateTimePicker general interaction", () => {
 			.should("have.attr", "value", "13/04/2020, 02:14:19 PM");
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(false);
+			.ui5DateTimePickerExpectToBeClosed();
 
 		setAnimationMode(AnimationMode.Full);
 	});
@@ -103,13 +103,13 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerOpen();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(true);
+			.ui5DateTimePickerExpectToBeOpen();
 
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerClose();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(false);
+			.ui5DateTimePickerExpectToBeClosed();
 	});
 
 	// Unstable but valid test, needs to be individually observed
@@ -136,7 +136,7 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
 				// Click the currently selected day and then move to the next day.
-				cy.get("ui5-calendar")
+				cy.get("[ui5-calendar]")
 					.shadow()
 					.as("calendar");
 
@@ -164,7 +164,7 @@ describe("DateTimePicker general interaction", () => {
 			.should("be.focused")
 			.should("have.attr", "value", "14/04/2020, 03:16:16 AM");
 
-		cy.get<DateTimePicker>("@dtp").ui5DateTimePickerCheckOpen(false);
+		cy.get<DateTimePicker>("@dtp").ui5DateTimePickerExpectToBeClosed();
 
 		setAnimationMode(AnimationMode.Full);
 	});
@@ -209,14 +209,14 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerOpen();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(true);
+			.ui5DateTimePickerExpectToBeOpen();
 
 		let selectedDate = "";
 
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				cy.get("ui5-calendar")
+				cy.get("[ui5-calendar]")
 					.shadow()
 					.as("calendar");
 
@@ -309,12 +309,12 @@ describe("DateTimePicker general interaction", () => {
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				cy.get("ui5-time-selection-clocks")
+				cy.get("[ui5-time-selection-clocks]")
 					.shadow()
 					.as("clocks");
 
 				cy.get("@clocks")
-					.find(`ui5-time-picker-clock[data-ui5-clock="hours"]`)
+					.find(`[ui5-time-picker-clock][data-ui5-clock="hours"]`)
 					.should("have.attr", "active", "");
 			});
 
@@ -322,7 +322,7 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerClose();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(false);
+			.ui5DateTimePickerExpectToBeClosed();
 	});
 
 	// Unstable test, needs investigation
@@ -336,12 +336,12 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerOpen();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(true);
+			.ui5DateTimePickerExpectToBeOpen();
 
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				cy.get("ui5-calendar")
+				cy.get("[ui5-calendar]")
 					.shadow()
 					.as("calendar");
 
@@ -355,25 +355,25 @@ describe("DateTimePicker general interaction", () => {
 					.should("be.focused")
 					.realClick();
 
-				cy.get("ui5-time-selection-clocks")
+				cy.get("[ui5-time-selection-clocks]")
 					.shadow()
 					.as("clocks");
 
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="hours"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="hours"]`)
 					.realClick()
 					.should("be.focused");
 
 				cy.realType("12")
 
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="minutes"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="minutes"]`)
 					.should("be.focused");
 
 				cy.realType("34");
 
 				cy.get("@clocks")
-					.find(`ui5-toggle-spin-button[data-ui5-clock="seconds"]`)
+					.find(`[ui5-toggle-spin-button][data-ui5-clock="seconds"]`)
 					.should("be.focused")
 
 				cy.realType("56a")
@@ -463,7 +463,7 @@ describe("DateTimePicker general interaction", () => {
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				cy.get("ui5-calendar")
+				cy.get("[ui5-calendar]")
 					.shadow()
 					.find(".ui5-calheader")
 					.as("calHeader");
@@ -523,12 +523,12 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerOpen();
 
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(true);
+			.ui5DateTimePickerExpectToBeOpen();
 
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				cy.get("ui5-calendar")
+				cy.get("[ui5-calendar]")
 					.shadow()
 					.as("calendar");
 
@@ -563,6 +563,6 @@ describe("DateTimePicker general interaction", () => {
 
 		// Verify the picker is closed
 		cy.get<DateTimePicker>("@dtp")
-			.ui5DateTimePickerCheckOpen(false);
+			.ui5DateTimePickerExpectToBeClosed();
 	});
 });

--- a/packages/main/cypress/support/commands/DateTimePicker.commands.ts
+++ b/packages/main/cypress/support/commands/DateTimePicker.commands.ts
@@ -16,21 +16,24 @@ Cypress.Commands.add("ui5DateTimePickerGetPopover", { prevSubject: true }, (subj
 		.find<ResponsivePopover>("[ui5-responsive-popover]");
 });
 
-Cypress.Commands.add("ui5DateTimePickerCheckOpen", { prevSubject: true }, (subject: JQuery<DateTimePicker>, open: boolean) => {
+Cypress.Commands.add("ui5DateTimePickerExpectToBeOpen", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
 	cy.wrap(subject)
-		.should("have.prop", "open", open);
+		.should("have.prop", "open", true);
 
-	if (open) {
-		cy.wrap(subject)
-			.shadow()
-			.find<ResponsivePopover>("[ui5-responsive-popover]")
-			.ui5ResponsivePopoverOpened();
-	} else {
-		cy.wrap(subject)
-			.shadow()
-			.find<ResponsivePopover>("[ui5-responsive-popover]")
-			.ui5ResponsivePopoverClosed();
-	}
+	cy.wrap(subject)
+		.shadow()
+		.find<ResponsivePopover>("[ui5-responsive-popover]")
+		.ui5ResponsivePopoverOpened();
+});
+
+Cypress.Commands.add("ui5DateTimePickerExpectToBeClosed", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	cy.wrap(subject)
+		.should("have.prop", "open", false);
+
+	cy.wrap(subject)
+		.shadow()
+		.find<ResponsivePopover>("[ui5-responsive-popover]")
+		.ui5ResponsivePopoverClosed();
 });
 
 Cypress.Commands.add("ui5DateTimePickerGetSubmitButton", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
@@ -50,35 +53,37 @@ Cypress.Commands.add("ui5DateTimePickerGetCancelButton", { prevSubject: true }, 
 Cypress.Commands.add("ui5DateTimePickerTimeSelectionClocksCount", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
 	return cy.wrap(subject)
 		.shadow()
-		.find("ui5-responsive-popover")
-		.find("ui5-time-selection-clocks")
+		.find("[ui5-responsive-popover]")
+		.find("[ui5-time-selection-clocks]")
 		.shadow()
-		.find("ui5-time-picker-clock")
+		.find("[ui5-time-picker-clock]")
 		.its("length");
 });
 
 Cypress.Commands.add("ui5DateTimePickerPeriodSegmentedButtonCount", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
 	return cy.wrap(subject)
 		.shadow()
-		.find("ui5-responsive-popover")
-		.find("ui5-time-selection-clocks")
+		.find("[ui5-responsive-popover]")
+		.find("[ui5-time-selection-clocks]")
 		.shadow()
-		.find("ui5-segmented-button")
+		.find("[ui5-segmented-button]")
 		.its("length");
 });
 
 declare global {
 	namespace Cypress {
 		interface Chainable {
-			ui5DateTimePickerCheckOpen(
-				this: Chainable<JQuery<DateTimePicker>>,
-				open: boolean,
-			): Chainable<void>;
 			ui5DateTimePickerOpen(
+				this: Chainable<JQuery<DateTimePicker>>,
+			): Chainable<void>;
+			ui5DateTimePickerExpectToBeOpen(
 				this: Chainable<JQuery<DateTimePicker>>,
 			): Chainable<void>;
 			ui5DateTimePickerClose(
 				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<void>;
+			ui5DateTimePickerExpectToBeClosed(
+				this: Chainable<JQuery<DateTimePicker>>,
 			): Chainable<void>;
 			ui5DateTimePickerGetPopover(
 				this: Chainable<JQuery<DateTimePicker>>

--- a/packages/main/cypress/support/commands/DateTimePicker.commands.ts
+++ b/packages/main/cypress/support/commands/DateTimePicker.commands.ts
@@ -1,45 +1,54 @@
-Cypress.Commands.add("ui5DateTimePickerOpen", selector => {
-	cy.get(selector)
-		.then($dateTimePicker => {
-			cy.wrap($dateTimePicker).invoke("attr", "open", true);
-		});
+import Button from "../../../src/Button.js";
+import type DateTimePicker from "../../../src/DateTimePicker.js";
+import type ResponsivePopover from "../../../src/ResponsivePopover.js";
+
+Cypress.Commands.add("ui5DateTimePickerOpen", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	cy.wrap(subject).invoke("prop", "open", true);
 });
 
-Cypress.Commands.add("ui5DateTimePickerClose", selector => {
-	cy.get(selector).invoke("attr", "open", false);
+Cypress.Commands.add("ui5DateTimePickerClose", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	cy.wrap(subject).invoke("prop", "open", false);
 });
 
-Cypress.Commands.add("ui5DateTimePickerGetPopover", selector => {
-	return cy.get(selector)
+Cypress.Commands.add("ui5DateTimePickerGetPopover", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	return cy.wrap(subject)
 		.shadow()
-		.find("ui5-responsive-popover");
+		.find<ResponsivePopover>("[ui5-responsive-popover]");
 });
 
-Cypress.Commands.add("ui5DateTimePickerIsOpen", selector => {
-	return cy
-		.get(selector)
-		.invoke("attr", "open")
-		.then(attr => Boolean(attr));
+Cypress.Commands.add("ui5DateTimePickerCheckOpen", { prevSubject: true }, (subject: JQuery<DateTimePicker>, open: boolean) => {
+	cy.wrap(subject)
+		.should("have.prop", "open", open);
+
+	if (open) {
+		cy.wrap(subject)
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+	} else {
+		cy.wrap(subject)
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverClosed();
+	}
 });
 
-Cypress.Commands.add("ui5DateTimePickerGetSubmitButton", selector => {
-	return cy.get(selector)
+Cypress.Commands.add("ui5DateTimePickerGetSubmitButton", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	return cy.wrap(subject)
 		.shadow()
-		.find("ui5-responsive-popover")
-		.find("#ok");
+		.find("[ui5-responsive-popover]")
+		.find<Button>("#ok");
 });
 
-Cypress.Commands.add("ui5DateTimePickerGetCancelButton", selector => {
-	return cy
-		.get(selector)
+Cypress.Commands.add("ui5DateTimePickerGetCancelButton", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	return cy.wrap(subject)
 		.shadow()
-		.find("ui5-responsive-popover")
-		.find("#cancel");
+		.find("[ui5-responsive-popover]")
+		.find<Button>("#cancel");
 });
 
-Cypress.Commands.add("ui5DateTimePickerTimeSelectionClocksCount", selector => {
-	return cy
-		.get(selector)
+Cypress.Commands.add("ui5DateTimePickerTimeSelectionClocksCount", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	return cy.wrap(subject)
 		.shadow()
 		.find("ui5-responsive-popover")
 		.find("ui5-time-selection-clocks")
@@ -48,9 +57,8 @@ Cypress.Commands.add("ui5DateTimePickerTimeSelectionClocksCount", selector => {
 		.its("length");
 });
 
-Cypress.Commands.add("ui5DateTimePickerPeriodSegmentedButtonCount", selector => {
-	return cy
-		.get(selector)
+Cypress.Commands.add("ui5DateTimePickerPeriodSegmentedButtonCount", { prevSubject: true }, (subject: JQuery<DateTimePicker>) => {
+	return cy.wrap(subject)
 		.shadow()
 		.find("ui5-responsive-popover")
 		.find("ui5-time-selection-clocks")
@@ -58,3 +66,35 @@ Cypress.Commands.add("ui5DateTimePickerPeriodSegmentedButtonCount", selector => 
 		.find("ui5-segmented-button")
 		.its("length");
 });
+
+declare global {
+	namespace Cypress {
+		interface Chainable {
+			ui5DateTimePickerCheckOpen(
+				this: Chainable<JQuery<DateTimePicker>>,
+				open: boolean,
+			): Chainable<void>;
+			ui5DateTimePickerOpen(
+				this: Chainable<JQuery<DateTimePicker>>,
+			): Chainable<void>;
+			ui5DateTimePickerClose(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<void>;
+			ui5DateTimePickerGetPopover(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<JQuery<ResponsivePopover>>;
+			ui5DateTimePickerGetSubmitButton(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<JQuery<Button>>;
+			ui5DateTimePickerGetCancelButton(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<JQuery<Button>>;
+			ui5DateTimePickerTimeSelectionClocksCount(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<number>;
+			ui5DateTimePickerPeriodSegmentedButtonCount(
+				this: Chainable<JQuery<DateTimePicker>>
+			): Chainable<number>;
+		}
+	}
+}


### PR DESCRIPTION
Added TypeScript definitions for custom Cypress commands related to the `ui5-datetime-picker` component.​

One test remains skipped due to two open issues in the `ui5-datetime-picker`:​
- Issue #11375
- Issue #11376