### PR TITLE
fix(DragRegistry - TypeScript): correct import

### DIFF
--- a/packages/base/src/util/dragAndDrop/DragRegistry.ts
+++ b/packages/base/src/util/dragAndDrop/DragRegistry.ts
@@ -1,4 +1,4 @@
-import type UI5Element from "../../UI5Element";
+import type UI5Element from "../../UI5Element.js";
 
 let draggedElement: HTMLElement | null = null;
 let globalHandlersAttached = false;


### PR DESCRIPTION
This PR fixes a TypeScript build error introduced with v1.24.0

```
node_modules/@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.d.ts:1:29 - error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean '../../UI5Element.js'?

1 import type UI5Element from "../../UI5Element";
```
Downport of: https://github.com/SAP/ui5-webcomponents/pull/8677
Fixes: https://github.com/SAP/ui5-webcomponents/issues/11387

