### PR TITLE
fix(ui5-side-navigation): remove 'undefined' from hidden texts in overflow items

### DIFF
--- a/packages/fiori/src/NavigationMenuItem.ts
+++ b/packages/fiori/src/NavigationMenuItem.ts
@@ -110,6 +110,10 @@ class NavigationMenuItem extends MenuItem {
 	get acessibleNameText() {
 		return NavigationMenu.i18nBundle.getText(NAVIGATION_MENU_POPOVER_HIDDEN_TEXT);
 	}
+
+	get ariaLabelledByText() {
+		return `${this.text || ""}`.trim();
+	}
 }
 
 NavigationMenuItem.define();


### PR DESCRIPTION
fixes: #11380