### PR TITLE
fix(ui5-button): announce accessible name

### DIFF
--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -6,7 +6,7 @@ import download from "@ui5/webcomponents-icons/dist/download.js";
 import employee from "@ui5/webcomponents-icons/dist/employee.js";
 
 import {
-	BUTTON_ARIA_TYPE_REJECT,
+	BUTTON_ARIA_TYPE_EMPHASIZED,
 } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Button general interaction", () => {
@@ -304,18 +304,6 @@ describe("Accessibility", () => {
 			.should("have.attr", "role", "button");
 	});
 
-	it("aria-describedby properly applied on the button tag", () => {
-		cy.mount(<Button design="Attention">Content</Button>);
-
-		cy.get("[ui5-button]")
-			.as("button");
-
-		cy.get("@button")
-			.shadow()
-			.find("button")
-			.should("have.attr", "aria-description", "Warning");
-	});
-
 	it("accessibleDescription in combination with design property applied on the button tag", () => {
 		cy.mount(<Button design="Negative" accessibleDescription="Decline">Content</Button>);
 
@@ -341,13 +329,13 @@ describe("Accessibility", () => {
 			.as("button");
 
 		cy.get("@button")
-			.should("have.attr", "aria-label", `Download ${BUTTON_ARIA_TYPE_REJECT.defaultText} 999+ items`);
+			.should("have.attr", "aria-label", `Download 999+ items`);
 	});
 
 	it("accessibleName when the button has a ui5-button-badge with 1 item", () => {
 		cy.mount(
-			<Button accessibleName="Download">
-				<ButtonBadge text="1" slot="badge"></ButtonBadge>
+			<Button design="Emphasized" accessibleName="Download">
+				<ButtonBadge text="1" design="InlineText" slot="badge"></ButtonBadge>
 			</Button>
 		);
 		cy.get("[ui5-button]")
@@ -356,7 +344,7 @@ describe("Accessibility", () => {
 			.as("button");
 
 		cy.get("@button")
-			.should("have.attr", "aria-label", `Download ${BUTTON_ARIA_TYPE_REJECT.defaultText} 1 item`);
+			.should("have.attr", "aria-label", `Download ${BUTTON_ARIA_TYPE_EMPHASIZED.defaultText} 1 item`);
 	});
 
 	it("setting accessible-name-ref on the host is reflected on the button tag", () => {

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -320,12 +320,43 @@ describe("Accessibility", () => {
 		cy.mount(<Button design="Negative" accessibleDescription="Decline">Content</Button>);
 
 		cy.get("[ui5-button]")
+			.shadow()
+			.find("button")
 			.as("button");
 
 		cy.get("@button")
+			.should("have.attr", "aria-description", "Decline");
+	});
+
+
+	it("accessibleName when the button has a ui5-button-badge with more than 1 items", () => {
+		cy.mount(
+			<Button accessibleName="Download">
+				<ButtonBadge design="OverlayText" text="999+" slot="badge"></ButtonBadge>
+			</Button>
+		);
+		cy.get("[ui5-button]")
 			.shadow()
 			.find("button")
-			.should("have.attr", "aria-description", `${BUTTON_ARIA_TYPE_REJECT.defaultText} Decline`);
+			.as("button");
+
+		cy.get("@button")
+			.should("have.attr", "aria-label", `Download ${BUTTON_ARIA_TYPE_REJECT.defaultText} 999+ items`);
+	});
+
+	it("accessibleName when the button has a ui5-button-badge with 1 item", () => {
+		cy.mount(
+			<Button accessibleName="Download">
+				<ButtonBadge text="1" slot="badge"></ButtonBadge>
+			</Button>
+		);
+		cy.get("[ui5-button]")
+			.shadow()
+			.find("button")
+			.as("button");
+
+		cy.get("@button")
+			.should("have.attr", "aria-label", `Download ${BUTTON_ARIA_TYPE_REJECT.defaultText} 1 item`);
 	});
 
 	it("setting accessible-name-ref on the host is reflected on the button tag", () => {

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -37,6 +37,8 @@ import {
 	BUTTON_ARIA_TYPE_REJECT,
 	BUTTON_ARIA_TYPE_EMPHASIZED,
 	BUTTON_ARIA_TYPE_ATTENTION,
+	BUTTON_BADGE_ONE_ITEM,
+	BUTTON_BADGE_MANY_ITEMS,
 } from "./generated/i18n/i18n-defaults.js";
 
 // Styles
@@ -522,15 +524,32 @@ class Button extends UI5Element implements IButton {
 	}
 
 	get ariaLabelText() {
-		return getEffectiveAriaLabelText(this);
+		const ariaLabelText = getEffectiveAriaLabelText(this) || "";
+		const typeLabelText = this.hasButtonType ? this.buttonTypeText : "";
+		const internalLabelText = `${typeLabelText} ${this.effectiveBadgeDescriptionText}`.trim();
+
+		return `${ariaLabelText} ${internalLabelText}`.trim();
 	}
 
 	get ariaDescriptionText() {
-		const ariaDescribedByText = this.hasButtonType ? this.buttonTypeText : "";
-		const accessibleDescription = this.accessibleDescription || "";
-		const ariaDescriptionText = `${ariaDescribedByText} ${accessibleDescription}`.trim();
+		return this.accessibleDescription === "" ? undefined : this.accessibleDescription;
+	}
 
-		return ariaDescriptionText || undefined;
+	get effectiveBadgeDescriptionText() {
+		if (!this.shouldRenderBadge) {
+			return "";
+		}
+
+		const badgeEffectiveText = this.badge[0].effectiveText;
+
+		switch (badgeEffectiveText) {
+		case "":
+			return badgeEffectiveText;
+		case "1":
+			return Button.i18nBundle.getText(BUTTON_BADGE_ONE_ITEM as I18nText, badgeEffectiveText);
+		default:
+			return Button.i18nBundle.getText(BUTTON_BADGE_MANY_ITEMS as I18nText, badgeEffectiveText);
+		}
 	}
 
 	get _isSubmit() {

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -546,9 +546,9 @@ class Button extends UI5Element implements IButton {
 		case "":
 			return badgeEffectiveText;
 		case "1":
-			return Button.i18nBundle.getText(BUTTON_BADGE_ONE_ITEM as I18nText, badgeEffectiveText);
+			return Button.i18nBundle.getText(BUTTON_BADGE_ONE_ITEM, badgeEffectiveText);
 		default:
-			return Button.i18nBundle.getText(BUTTON_BADGE_MANY_ITEMS as I18nText, badgeEffectiveText);
+			return Button.i18nBundle.getText(BUTTON_BADGE_MANY_ITEMS, badgeEffectiveText);
 		}
 	}
 

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -526,9 +526,10 @@ class Button extends UI5Element implements IButton {
 	get ariaLabelText() {
 		const ariaLabelText = getEffectiveAriaLabelText(this) || "";
 		const typeLabelText = this.hasButtonType ? this.buttonTypeText : "";
-		const internalLabelText = `${typeLabelText} ${this.effectiveBadgeDescriptionText}`.trim();
+		const internalLabelText = this.effectiveBadgeDescriptionText || "";
 
-		return `${ariaLabelText} ${internalLabelText}`.trim();
+		const labelParts = [ariaLabelText, typeLabelText, internalLabelText].filter(part => part);
+		return labelParts.join(" ");
 	}
 
 	get ariaDescriptionText() {
@@ -542,6 +543,9 @@ class Button extends UI5Element implements IButton {
 
 		const badgeEffectiveText = this.badge[0].effectiveText;
 
+		// Use distinct i18n keys for singular and plural badge values to ensure proper localization.
+		// Some languages have different grammatical rules for singular and plural forms,
+		// so separate keys (BUTTON_BADGE_ONE_ITEM and BUTTON_BADGE_MANY_ITEMS) are necessary.
 		switch (badgeEffectiveText) {
 		case "":
 			return badgeEffectiveText;

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -79,6 +79,12 @@ BUTTON_ARIA_TYPE_EMPHASIZED=Emphasized
 #XACT: ARIA announcement for the warning button
 BUTTON_ARIA_TYPE_ATTENTION=Warning
 
+#XACT: ARIA announcement for the Button Badge with value 1 - "{0} item"
+BUTTON_BADGE_ONE_ITEM={0} item
+
+#XACT: ARIA announcement for the Button Badge with value more than 1 - "{0} items"
+BUTTON_BADGE_MANY_ITEMS={0} items
+
 #XACT: Text for Today item in CalendarLegend
 CAL_LEGEND_TODAY_TEXT=Today
 


### PR DESCRIPTION
Issue:
- The badge wasn't announced at all when an `accessible-name` attribute is provided
for the `ui5-button`. The reason behind this behaviour is that the screen reader doesn't
read the inner text nodes of the root `button` node when the same has `aria-label` attribute.

Solution:
- The proper badge description text is placed into the `aria-label` attribute of the root
`button` element. As a result the screen reader won't rely on the inner text content
for the announcements.
- Additionally the `design` description is also moved into the `aria-label` attribute,
in order to keep a proper announcement order.

Fixes: #11350