### PR TITLE
fix(ui5-side-navigation): collapsed parent items appear as selected if one of its child items is selected

### DIFF
--- a/packages/fiori/cypress/specs/SideNavigation.cy.tsx
+++ b/packages/fiori/cypress/specs/SideNavigation.cy.tsx
@@ -121,8 +121,8 @@ describe("Side Navigation interaction", () => {
 		cy.mount(
 			<SideNavigation>
 				<SideNavigationItem id="item1" text="1" icon={group}>
-					<SideNavigationSubItem text="1.1" />
-					<SideNavigationSubItem text="1.2" />
+					<SideNavigationSubItem id="subItem1" text="1.1" />
+					<SideNavigationSubItem id="subItem1" text="1.2" />
 				</SideNavigationItem>
 			</SideNavigation>
 		);
@@ -134,10 +134,19 @@ describe("Side Navigation interaction", () => {
 		cy.get("#item1").should("have.attr", "expanded");
 
 		// act
+		cy.get("#subItem1").realClick();
 		cy.get("#item1").shadow().find(".ui5-sn-item-toggle-icon").realClick();
 
 		// assert
 		cy.get("#item1").should("not.have.attr", "expanded");
+		cy.get("#item1").should("have.attr", "selected");
+
+		// act
+		cy.get("#item1").shadow().find(".ui5-sn-item-toggle-icon").realClick();
+
+		// assert
+		cy.get("#item1").should("not.have.attr", "selected");
+
 	});
 
 	it("Tests expanding and collapsing of unselectable items", () => {

--- a/packages/fiori/src/SideNavigationItem.ts
+++ b/packages/fiori/src/SideNavigationItem.ts
@@ -272,6 +272,12 @@ class SideNavigationItem extends SideNavigationSelectableItemBase {
 	_toggle() {
 		if (this.items.length) {
 			this.expanded = !this.expanded;
+
+			if (this.expanded) {
+				this.selected = false;
+			} else {
+				this.selected = true;
+			}
 		}
 	}
 }


### PR DESCRIPTION
JIRA: BGSOFUIRODOPI-3383
