### PR TITLE
fix(ui5-panel): adjust header button width to the new specifications

### DIFF
--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -332,7 +332,7 @@
 	--_ui5_year_picker_item_height: 2rem;
 	--_ui5_panel_header_height: 2rem;
 	--_ui5_panel_button_root_height: 2rem;
-	--_ui5_panel_button_root_width: 2.5rem;
+	--_ui5_panel_button_root_width: 2.75rem;
 
 	--_ui5_token_height: 1.25rem;
 	--_ui5_token_right_margin: 0.25rem;


### PR DESCRIPTION
According to the new specifications the button/icon width of the `ui5-panel` should be the same for the cozy and compact theme variants (2.75rem)

fixes: #11062

