### PR TITLE
fix(ui5-flexible-column-layout): disable resizing for both separators

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -486,7 +486,8 @@ class FlexibleColumnLayout extends UI5Element {
 			return;
 		}
 		const pressedSeparator = (e.target as HTMLElement).closest(".ui5-fcl-separator") as HTMLElement;
-		if (pressedSeparator.classList.contains("ui5-fcl-separator-start") && !this.showStartSeparatorGrip) {
+		if ((pressedSeparator.classList.contains("ui5-fcl-separator-start") && !this.showStartSeparatorGrip)
+			|| (pressedSeparator.classList.contains("ui5-fcl-separator-end") && !this.showEndSeparatorGrip)) {
 			return;
 		}
 
@@ -1091,7 +1092,6 @@ class FlexibleColumnLayout extends UI5Element {
 		if (this.showEndSeparatorGrip) {
 			return 0;
 		}
-		return -1;
 	}
 
 	get media() {


### PR DESCRIPTION
Problem:
When disableResizing="true" was set, only the start-mid column separator was 
disabled, while the mid-end separator remained interactive and resizable.

Solution:
- Updated the onSeparatorPress method to check both separator types and prevent 
  interaction for the end separator when disableResizing is true
- Modified the endSeparatorTabIndex getter to make it consistent with the start 
  separator by removing the explicit -1 return value, which makes it 
  unfocusable when disableResizing is true
  
Fixes: [#11402](https://github.com/SAP/ui5-webcomponents/issues/11402)