### PR TITLE
fix(ui5-menu-item): remove redundant screen reader  announcements

### DIFF
--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -307,10 +307,6 @@ class MenuItem extends ListItem implements IMenuItem {
 		return this._popover?.open;
 	}
 
-	get ariaLabelledByText() {
-		return `${this.text} ${this.accessibleName}`.trim();
-	}
-
 	get menuHeaderTextPhone() {
 		return this.text;
 	}


### PR DESCRIPTION
Issue 1:
- The aria-labelledby reference to the `ui5-menu-item` has wrong text.

Issue 2:
- The aria-labelledby reference to the `ui5-menu-item` has redundant text.

Solution:
- Use the text provided from the underlying `ui5-list-item` for an aria-labelledby.

Fixes: #11380
Fixes: #11405
