### PR TITLE
fix(ui5-flexible-column-layout): column visibility issue fixed

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -69,6 +69,15 @@ describe("Columns resize", () => {
 				expect(widthAfterMove).to.be.equal($el.width()!);
 			});
 	});
+
+	it("sets dedicated class to hidden columns", () => {
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should($el => {
+				expect($el).to.have.class("ui5-fcl-column--hidden");
+			});
+	});
 });
 
 describe("ACC", () => {

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -436,25 +436,40 @@ class FlexibleColumnLayout extends UI5Element {
 
 		// hide column: 33% to 0, 25% to 0, etc .
 		if (currentlyHidden) {
-			// animate the width
-			columnDOM.style.width = typeof columnWidth === "number" ? `${columnWidth}px` : columnWidth;
-
-			// hide column with delay to allow the animation runs entirely
-			columnDOM.addEventListener("transitionend", this.columnResizeHandler);
-
+			this.collapseColumn(columnDOM);
 			return;
 		}
 
 		// show column: from 0 to 33%, from 0 to 25%, etc.
 		if (previouslyHidden) {
-			columnDOM.removeEventListener("transitionend", this.columnResizeHandler);
-			columnDOM.classList.remove("ui5-fcl-column--hidden");
-			columnDOM.style.width = typeof columnWidth === "number" ? `${columnWidth}px` : columnWidth;
+			this.expandColumn(columnDOM, columnWidth);
 		}
 	}
 
-	columnResizeHandler = (e: Event) => {
-		(e.target as HTMLElement).classList.add("ui5-fcl-column--hidden");
+	expandColumn(columnDOM: HTMLElement, columnWidth: string | number) {
+		columnDOM.classList.remove("ui5-fcl-column--hidden");
+		columnDOM.style.width = typeof columnWidth === "number" ? `${columnWidth}px` : columnWidth;
+	}
+
+	collapseColumn(columnDOM: HTMLElement) {
+		const hasAnimation = getAnimationMode() !== AnimationMode.None && !this.initialRendering;
+		// animate the width
+		columnDOM.style.width = "0px";
+		columnDOM.classList.add("ui5-fcl-column-collapsing");
+
+		if (hasAnimation) {
+			// hide column with delay to allow the animation runs entirely
+			columnDOM.addEventListener("transitionend", this.onColumnCollapseAnimationEnd);
+		} else {
+			this.onColumnCollapseAnimationEnd({ target: columnDOM } as unknown as Event);
+		}
+	}
+
+	onColumnCollapseAnimationEnd = (e: Event) => {
+		const columnDOM = e.target as HTMLElement;
+		columnDOM.classList.add("ui5-fcl-column--hidden");
+		columnDOM.classList.remove("ui5-fcl-column-collapsing");
+		columnDOM.removeEventListener("transitionend", this.onColumnCollapseAnimationEnd);
 	}
 
 	nextColumnLayout(layout: `${FCLLayout}`) {

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -453,7 +453,6 @@ class FlexibleColumnLayout extends UI5Element {
 
 	collapseColumn(columnDOM: HTMLElement) {
 		const hasAnimation = getAnimationMode() !== AnimationMode.None && !this.initialRendering;
-		// animate the width
 		columnDOM.style.width = "0px";
 
 		if (hasAnimation) {

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -455,20 +455,20 @@ class FlexibleColumnLayout extends UI5Element {
 		const hasAnimation = getAnimationMode() !== AnimationMode.None && !this.initialRendering;
 		// animate the width
 		columnDOM.style.width = "0px";
-		columnDOM.classList.add("ui5-fcl-column-collapsing");
 
 		if (hasAnimation) {
 			// hide column with delay to allow the animation runs entirely
+			columnDOM.classList.add("ui5-fcl-column-collapse-animation");
 			columnDOM.addEventListener("transitionend", this.onColumnCollapseAnimationEnd);
 		} else {
-			this.onColumnCollapseAnimationEnd({ target: columnDOM } as unknown as Event);
+			columnDOM.classList.add("ui5-fcl-column--hidden");
 		}
 	}
 
 	onColumnCollapseAnimationEnd = (e: Event) => {
 		const columnDOM = e.target as HTMLElement;
 		columnDOM.classList.add("ui5-fcl-column--hidden");
-		columnDOM.classList.remove("ui5-fcl-column-collapsing");
+		columnDOM.classList.remove("ui5-fcl-column-collapse-animation");
 		columnDOM.removeEventListener("transitionend", this.onColumnCollapseAnimationEnd);
 	}
 

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -17,7 +17,6 @@
 	box-sizing: border-box;
 	will-change: width;
 	overflow-y: auto;
-	min-width: 15.5rem; /* as noted in our documentation */
 }
 
 /* disable pointer events on columns while dragging the separator
@@ -28,6 +27,10 @@
 
 .ui5-fcl-column-animation {
 	transition: width 560ms cubic-bezier(0.1, 0, 0.05, 1), visibility 560ms ease-in;
+}
+
+.ui5-fcl-column:not(.ui5-fcl-column-collapsing) {
+	min-width: 15.5rem; /* as noted in our documentation */
 }
 
 .ui5-fcl-column--hidden {

--- a/packages/fiori/src/themes/FlexibleColumnLayout.css
+++ b/packages/fiori/src/themes/FlexibleColumnLayout.css
@@ -29,7 +29,7 @@
 	transition: width 560ms cubic-bezier(0.1, 0, 0.05, 1), visibility 560ms ease-in;
 }
 
-.ui5-fcl-column:not(.ui5-fcl-column-collapsing) {
+.ui5-fcl-column:not(.ui5-fcl-column-collapse-animation) {
 	min-width: 15.5rem; /* as noted in our documentation */
 }
 


### PR DESCRIPTION
Problem:
1. On initial rendering, hidden columns do not have the required "ui5-fcl-column--hidden" class
2. When a column is being collapsed with animation, the transition to hidden state is not gradual 

Solution
For problem1, the root cause if that the function that sets the required class  is not invoked on initial rendering. 
It is not invoked, because the function in question is a listener for end of animation. However, on initial rendering there is no animation for technical constraints (because on initial rendering the element width a set for a first time).
Therefore, fixed problem1 by synchronously applying the required class when there is no animation

For problem2, the root cause is that the CSS rule "min-width:15.5rem" overrides the "width: 0px" rule (that is set for the purpose of gradual animated collapsing until the "ui5-fcl-column--hidden" class is set)
Therefore, fixed proble2 by ensuring the CSS rule "min-width:15.5rem" is not applied to collapsing columns.
