### PR TITLE
refactor(ui5-shellbar): prevent full width search initially

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -494,6 +494,16 @@ describe("Slots", () => {
 			cy.get("#search").should("have.prop", "collapsed", true);
 			cy.get("#shellbar").invoke("prop", "showSearchField").should("equal", false);
 		});
+
+		it("Test search field is collapsed initially instead of being displayed in full width mode", () => {
+			cy.viewport(500, 1080);
+			cy.mount(
+				<ShellBar id="shellbar" showSearchField={true}>
+					<Search id="search" slot="searchField"></Search>
+				</ShellBar>
+			);
+			cy.get("#shellbar").invoke("prop", "showSearchField").should("equal", false);
+		});
 	});
 });
 

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -763,6 +763,12 @@ class ShellBar extends UI5Element {
 		});
 
 		this._observeContentItems();
+
+		// search field shouldn't be expanded initially in full width mode
+		if (this.showFullWidthSearch && this._isInitialRendering) {
+			this.setSearchState(false);
+			this._autoRestoreSearchField = true;
+		}
 	}
 
 	/**
@@ -792,6 +798,9 @@ class ShellBar extends UI5Element {
 	 * An event is fired to notify the change.
 	 */
 	async setSearchState(expanded: boolean) {
+		if (expanded === this.showSearchField) {
+			return;
+		}
 		this.showSearchField = expanded;
 		await renderFinished();
 		this.fireDecoratorEvent("search-field-toggle", { expanded });


### PR DESCRIPTION
The initially opened full-width search field is considered inconvenient according to the specification. In this case, the expanded state is reset to false, while the auto-expand mechanism remains functional.