### PR TITLE
fix(ui5-shellbar): fixed avatar font-size var

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -111,7 +111,7 @@ slot[name="profile"] {
 	min-width: 0;
 	min-height: 2rem;
 	pointer-events: none;
-	font-size: var(--_ui5-v2-9-0-rc-2_avatar_fontsize_XS);
+	font-size: var(--_ui5_avatar_fontsize_XS);
 	font-weight: normal;
 }
 


### PR DESCRIPTION
Avatar font-size was inheriting style for size "S", while it has hardcoded size, which is smaller than "S" and a little bit larger than "XS", so font-size for XS looks more suitable.