### PR TITLE
fix: escape backslash when processing component's css

### DIFF
--- a/packages/tools/lib/css-processors/css-processor-components.mjs
+++ b/packages/tools/lib/css-processors/css-processor-components.mjs
@@ -7,7 +7,7 @@ import chokidar from "chokidar";
 import scopeVariables from "./scope-variables.mjs";
 import { writeFileIfChanged, getFileContent } from "./shared.mjs";
 
-const tsMode = process.env.UI5_TS === "true";
+const tsMode = true;
 const extension = tsMode ? ".css.ts" : ".css.js";
 
 const packageJSON = JSON.parse(fs.readFileSync("./package.json"))
@@ -22,7 +22,8 @@ let customPlugin = {
         build.onEnd(result => {
             result.outputFiles.forEach(async f => {
                 // scoping
-                const newText = scopeVariables(f.text, packageJSON);
+                let newText = scopeVariables(f.text, packageJSON);
+                newText = newText.replaceAll(/\\/g, "\\\\"); // Escape backslashes as they might appear in css rules
                 await mkdir(path.dirname(f.path), {recursive: true});
                 writeFile(f.path, newText);
 

--- a/packages/tools/lib/css-processors/css-processor-components.mjs
+++ b/packages/tools/lib/css-processors/css-processor-components.mjs
@@ -7,7 +7,7 @@ import chokidar from "chokidar";
 import scopeVariables from "./scope-variables.mjs";
 import { writeFileIfChanged, getFileContent } from "./shared.mjs";
 
-const tsMode = true;
+const tsMode = process.env.UI5_TS === "true";
 const extension = tsMode ? ".css.ts" : ".css.js";
 
 const packageJSON = JSON.parse(fs.readFileSync("./package.json"))


### PR DESCRIPTION
The `.w-\[100px\]` selector is a valid CSS class. However, when processed by the tools package, it is incorrectly saved as `.w-[100px]`, making it an invalid selector.  
With this PR, when a backslash is encountered during processing inside a CSS file, it is properly escaped before being saved to the new file.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/11413