### PR TITLE
docs(ui5-table-growing): change type to mode

### DIFF
--- a/packages/website/docs/_samples/main/Table/Growing/Growing.md
+++ b/packages/website/docs/_samples/main/Table/Growing/Growing.md
@@ -1,7 +1,7 @@
 import html from '!!raw-loader!./sample.html';
 import js from '!!raw-loader!./main.js';
 
-By setting the type to `Button`, a dedicated growing button will be rendered.
+By setting the `mode` to `Button`, a dedicated growing button will be rendered.
 You can customize the text via `text` and `subText`.
 
 <Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Table/Growing/sample.html
+++ b/packages/website/docs/_samples/main/Table/Growing/sample.html
@@ -12,7 +12,7 @@
     <div class="section">
 <!-- playground-fold-end -->
 		<ui5-table id="table">
-			<ui5-table-growing id="growing" type="Button" slot="features"></ui5-table-growing>
+			<ui5-table-growing id="growing" mode="Button" slot="features"></ui5-table-growing>
 <!-- playground-fold -->
 			<ui5-table-header-row slot="headerRow">
 				<ui5-table-header-cell id="produtCol"><span>Product</span></ui5-table-header-cell>


### PR DESCRIPTION
To align the API the `type` property of the `TableGrowing` component has been changed to `mode`.

This alignment has not been made in the playground, which is why the growing behaviour seems like it is "not working".