### PR TITLE
feat(ui5-illustrated-message): decorative property added

### DIFF
--- a/packages/fiori/cypress/specs/IllustratedMessage.cy.tsx
+++ b/packages/fiori/cypress/specs/IllustratedMessage.cy.tsx
@@ -1,0 +1,36 @@
+import IllustratedMessage from "../../src/IllustratedMessage.js";
+import Label from "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents-fiori/dist/illustrations/AllIllustrations.js"
+
+describe("Accessibility", () => {
+	it("should add aria-hidden and role=presetation to the SVG when decorative is true", () => {
+		cy.mount(
+			<IllustratedMessage name="UnableToUpload" decorative>
+			</IllustratedMessage>
+		);
+
+		cy.get("[ui5-illustrated-message]")
+			.shadow()
+			.find("svg")
+			.should("have.attr", "role", "presentation");
+
+		cy.get("[ui5-illustrated-message]")
+			.shadow()
+			.find("svg")
+			.should("have.attr", "aria-hidden", "true");
+	});
+
+	it("should not have aria-label on the SVG when decorative is true", () => {
+		cy.mount(
+			<IllustratedMessage name="UnableToUpload" accessible-name-ref="lbl" decorative>
+				<Label id="lbl">Text from aria-labelledby</Label>
+			</IllustratedMessage>
+		);
+
+		cy.get("[ui5-illustrated-message]")
+			.shadow()
+			.find("svg")
+			.should("not.have.attr", "aria-label");
+
+	});
+});

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -197,6 +197,13 @@ class IllustratedMessage extends UI5Element {
 	media?: string;
 
 	/**
+	* @default false
+	* @private
+	*/
+	@property({ type: Boolean })
+	decorative = false;
+
+	/**
 	* Defines the title of the component.
 	*
 	* **Note:** Using this slot, the default title text of illustration and the value of `title` property will be overwritten.
@@ -354,7 +361,20 @@ class IllustratedMessage extends UI5Element {
 
 	_setSVGAccAttrs() {
 		const svg = this.shadowRoot!.querySelector(".ui5-illustrated-message-illustration svg");
-		if (svg) {
+
+		if (!svg) {
+			return;
+		}
+
+		if (this.decorative) {
+			svg.setAttribute("role", "presentation");
+			svg.setAttribute("aria-hidden", "true");
+			svg.removeAttribute("aria-label");
+		} else {
+			svg.removeAttribute("role");
+			svg.removeAttribute("aria-hidden");
+
+			// Set aria-label only when not decorative and text exists
 			if (this.ariaLabelText) {
 				svg.setAttribute("aria-label", this.ariaLabelText);
 			} else {

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -198,7 +198,8 @@ class IllustratedMessage extends UI5Element {
 
 	/**
 	* @default false
-	* @private
+	* @public
+ 	* @since 2.10.0
 	*/
 	@property({ type: Boolean })
 	decorative = false;

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -198,7 +198,7 @@ class IllustratedMessage extends UI5Element {
 
 	/**
  	* Defines whether the illustration is decorative.
-	* 
+	*
 	* When set to `true`, the attributes `role="presentation"` and `aria-hidden="true"` are applied to the SVG element.
 	* @default false
 	* @public

--- a/packages/fiori/src/IllustratedMessage.ts
+++ b/packages/fiori/src/IllustratedMessage.ts
@@ -197,6 +197,9 @@ class IllustratedMessage extends UI5Element {
 	media?: string;
 
 	/**
+ 	* Defines whether the illustration is decorative.
+	* 
+	* When set to `true`, the attributes `role="presentation"` and `aria-hidden="true"` are applied to the SVG element.
 	* @default false
 	* @public
  	* @since 2.10.0


### PR DESCRIPTION
The `decorative` property has been added to the `ui5-illustrated-message` component. 
The attributes `role="presentation"` and `aria-hidden="true"` are added to the SVG element when it is true.
