### PR TITLE
fix(ui5-illustrated-message): change SVG inline styling to proper attributes

### DIFF
--- a/packages/fiori/src/illustrations/sapIllus-Dialog-Survey.svg
+++ b/packages/fiori/src/illustrations/sapIllus-Dialog-Survey.svg
@@ -1,5 +1,5 @@
 <svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg" id="sapIllus-Dialog-Survey">
-<mask id="mask0_49_23941" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="154" height="154">
+<mask id="mask0_49_23941" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="154" height="154">
 <circle cx="79.8854" cy="79.8854" r="76.8854" fill="var(--sapContent_Illustrative_Color7)"/>
 </mask>
 <g mask="url(#mask0_49_23941)">

--- a/packages/fiori/src/illustrations/sapIllus-Spot-Survey.svg
+++ b/packages/fiori/src/illustrations/sapIllus-Spot-Survey.svg
@@ -1,6 +1,6 @@
 <svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" id="sapIllus-Spot-Survey">
 <g clip-path="url(#clip0_49_23917)">
-<mask id="mask0_49_23917" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="128" height="128">
+<mask id="mask0_49_23917" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="128" height="128">
 <circle cx="64" cy="64" r="64" fill="var(--sapContent_Illustrative_Color7)"/>
 </mask>
 <g mask="url(#mask0_49_23917)">


### PR DESCRIPTION
Replace inline style="mask-type:alpha" with standard SVG attribute mask-type="alpha" to avoid styling issues

Fixes:[#11354](https://github.com/SAP/ui5-webcomponents/issues/11354)