### PR TITLE
fix(ui5-calendar): show year range text in year view

### DIFF
--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -265,6 +265,12 @@ class Calendar extends CalendarPart {
 	@property()
 	_headerYearButtonTextSecType?: string;
 
+	@property()
+	_headerYearRangeButtonText?: string;
+
+	@property()
+	_headerYearRangeButtonTextSecType?: string;
+
 	@property({ noAttribute: true })
 	_pickersMode: `${CalendarPickersMode}` = "DAY_MONTH_YEAR";
 
@@ -477,16 +483,16 @@ class Calendar extends CalendarPart {
 		const yearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this.primaryCalendarType });
 		const localeData = getCachedLocaleDataInstance(getLocale());
 		this._headerMonthButtonText = localeData.getMonthsStandAlone("wide", this.primaryCalendarType)[this._calendarDate.getMonth()];
+		this._headerYearButtonText = String(yearFormat.format(this._localDate, true));
 
 		if (this._currentPicker === "year") {
 			const rangeStart = new CalendarDateComponent(this._calendarDate, this._primaryCalendarType);
 			const rangeEnd = new CalendarDateComponent(this._calendarDate, this._primaryCalendarType);
+
 			rangeStart.setYear(this._currentPickerDOM._firstYear!);
 			rangeEnd.setYear(this._currentPickerDOM._lastYear!);
 
-			this._headerYearButtonText = `${yearFormat.format(rangeStart.toLocalJSDate(), true)} - ${yearFormat.format(rangeEnd.toLocalJSDate(), true)}`;
-		} else {
-			this._headerYearButtonText = String(yearFormat.format(this._localDate, true));
+			this._headerYearRangeButtonText = `${yearFormat.format(rangeStart.toLocalJSDate())} - ${yearFormat.format(rangeEnd.toLocalJSDate())}`;
 		}
 
 		this._secondaryCalendarType && this._setSecondaryCalendarTypeButtonText();
@@ -553,6 +559,7 @@ class Calendar extends CalendarPart {
 
 	_setSecondaryCalendarTypeButtonText() {
 		const yearFormatSecType = DateFormat.getDateInstance({ format: "y", calendarType: this._secondaryCalendarType });
+		this._headerYearButtonTextSecType = String(yearFormatSecType.format(this._localDate, true));
 
 		if (this._currentPicker === "year") {
 			const rangeStart = new CalendarDateComponent(this._calendarDate, this._primaryCalendarType);
@@ -564,9 +571,8 @@ class Calendar extends CalendarPart {
 				.firstDate;
 			const rangeEndSecType = transformDateToSecondaryType(this.primaryCalendarType, this._secondaryCalendarType, rangeEnd.valueOf() / 1000, true)
 				.lastDate;
-			this._headerYearButtonTextSecType = `${yearFormatSecType.format(rangeStartSecType.toLocalJSDate(), true)} - ${yearFormatSecType.format(rangeEndSecType.toLocalJSDate(), true)}`;
-		} else {
-			this._headerYearButtonTextSecType = String(yearFormatSecType.format(this._localDate, true));
+
+			this._headerYearRangeButtonTextSecType = `${yearFormatSecType.format(rangeStartSecType.toLocalJSDate())} - ${yearFormatSecType.format(rangeEndSecType.toLocalJSDate())}`;
 		}
 	}
 
@@ -613,6 +619,10 @@ class Calendar extends CalendarPart {
 	}
 
 	get _isYearPickerHidden() {
+		return this._currentPicker !== "year";
+	}
+
+	get _isHeaderYearRangeButtonHidden() {
 		return this._currentPicker !== "year";
 	}
 

--- a/packages/main/src/CalendarHeaderTemplate.tsx
+++ b/packages/main/src/CalendarHeaderTemplate.tsx
@@ -53,6 +53,18 @@ export default function CalendarTemplate(this: Calendar) {
 						<span class="ui5-calheader-btn-sectext">{this._headerYearButtonTextSecType}</span>
 					}
 				</div>
+
+				<div
+					data-ui5-cal-header-btn-year-range
+					class="ui5-calheader-arrowbtn ui5-calheader-middlebtn ui5-calheader-yearrange-btn-disabled"
+					hidden={this._isHeaderYearRangeButtonHidden}
+					tabindex={-1}
+				>
+					<span>{this._headerYearRangeButtonText}</span>
+					{this.hasSecondaryCalendarType &&
+						<span class="ui5-calheader-btn-sectext">{this._headerYearRangeButtonTextSecType}</span>
+					}
+				</div>
 			</div>
 
 			<div

--- a/packages/main/src/themes/CalendarHeader.css
+++ b/packages/main/src/themes/CalendarHeader.css
@@ -131,3 +131,23 @@
 .ui5-calheader-middlebtn:focus:active::after {
 	border-color: var(--sapContent_ContrastFocusColor);
 }
+
+/* Todo: Remove with introduction of YearRangePicker */
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled:hover,
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled:active,
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled:focus,
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled:focus:active,
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled {
+	cursor: default;
+	outline: none;
+	background-color: var(--sapButton_Lite_Background);
+	color: var(--sapButton_Lite_TextColor);
+	border: transparent;
+	box-shadow: none;
+	pointer-events: none;
+}
+
+/* Todo: Remove with introduction of YearRangePicker */
+.ui5-calheader-middlebtn.ui5-calheader-yearrange-btn-disabled:active .ui5-calheader-btn-sectext {
+	color: var(--sapNeutralElementColor);
+}


### PR DESCRIPTION
The text for year range when in YearPicker was previously removed until we have the year range picker as a part of the Calendar.
We are now bringing the text back, so we can show the current year range.
Before:
![image](https://github.com/user-attachments/assets/d1d9f638-2dc5-4ca9-8a61-891c844738dc)

Now:
![image](https://github.com/user-attachments/assets/b458f1ec-d2a9-4bc0-b827-fd2a66ac0b10)

fixes: https://github.com/SAP/ui5-webcomponents/issues/11011
