### PR TITLE
fix(ui5-calendar): add style to secondary type

### DIFF
--- a/packages/main/src/YearPickerTemplate.tsx
+++ b/packages/main/src/YearPickerTemplate.tsx
@@ -30,7 +30,7 @@ export default function YearPickerTemplate(this: YearPicker) {
 						</span>
 						{
 							year.yearInSecType &&
-							<span class="ui5-yp-year-sec-type">
+							<span class="ui5-yp-item-sec-type">
 								{year.yearInSecType}
 							</span>
 						}


### PR DESCRIPTION
The secondary calendar text was not in gray before: 
![image](https://github.com/user-attachments/assets/2e95cbe7-8c2a-410a-9644-1d66ec38c95a)

It now is:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/2f5ad5ea-9eac-4e24-b490-7b97f0a5b0ff" />


related to: https://github.com/SAP/ui5-webcomponents/issues/11011