### PR TITLE
fix(ui5-upload-collection): fix file name width

### DIFF
--- a/packages/fiori/src/themes/UploadCollectionItem.css
+++ b/packages/fiori/src/themes/UploadCollectionItem.css
@@ -76,6 +76,7 @@
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	width: fit-content;
 }
 
 .ui5-uci-file-name-text {


### PR DESCRIPTION
The width of the file name is the same as the text, and if the user clicks outside the text of the file name, the file-name-click event is not triggered.

fixes: #11463
