### PR TITLE
feat(f6navigation): add option to bypass groups

### DIFF
--- a/docs/2-advanced/05-using-features.md
+++ b/docs/2-advanced/05-using-features.md
@@ -56,7 +56,6 @@ import "@ui5/webcomponents/dist/Link.js";
 import "@ui5/webcomponents/dist/Input.js";
 ```
 
-
 ### F6 Navigation (fast navigation)
 
 The F6 Navigation feature allows users to navigate quickly between groups of DOM elements using keyboard shortcuts. When the focus is on a DOM element within a group and the `F6` key is pressed, the focus goes to the first focusable element of the next group. This navigation also works with nested groups, moving through them until reaching a focusable element in a different group. Pressing `Shift + F6` moves the focus back to the previous group.
@@ -68,3 +67,9 @@ Larger components like ui5-list, ui5-carousel, and ui5-tabcontainer create their
 Developers can create their own groups by marking UI5 web components or DOM elements as fast navigation groups using `data-sap-ui-fastnavgroup="true"`. This feature enhances accessibility and efficiency for users navigating through applications using UI5 Web Components.
 
 **Note:** To use this feature, you need to import the `@ui5/webcomponents-base/dist/features/F6Navigation.js` module.
+
+#### Bypassing Fast Navigation Groups
+
+To prevent a specific component or DOM element from being processed as a fast navigation group, set the attribute `data-sap-ui-fastnavgroup="false"`.
+
+**Note:** This only excludes the element it's set on. Nested fast navigation groups within it will still be processed. To fully bypass all fast navigation groups in a section, you must explicitly mark each one with `data-sap-ui-fastnavgroup="false"`.

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -297,7 +297,7 @@ abstract class UI5Element extends HTMLElement {
 		const ctor = this.constructor as typeof UI5Element;
 
 		this.setAttribute(ctor.getMetadata().getPureTag(), "");
-		if (ctor.getMetadata().supportsF6FastNavigation()) {
+		if (ctor.getMetadata().supportsF6FastNavigation() && !this.hasAttribute("data-sap-ui-fastnavgroup")) {
 			this.setAttribute("data-sap-ui-fastnavgroup", "true");
 		}
 

--- a/packages/main/cypress/specs/F6.cy.tsx
+++ b/packages/main/cypress/specs/F6.cy.tsx
@@ -1,5 +1,6 @@
 import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import Button from "../../src/Button.js";
+import Bar from "../../src/Bar.js";
 
 describe("F6 navigation", () => {
 	describe("F6 Forward navigation", () => {
@@ -900,6 +901,76 @@ describe("F6 navigation", () => {
 			cy.realPress(["Shift", "F6"]);
 
 			cy.get("#first")
+				.should("be.focused");
+		});
+	});
+
+
+	describe.only("Bypass groups", () => {
+		it("Custom defined groups", () => {
+			cy.mount(
+				<div>
+					<div class="section">
+						<button id="before">Before element</button>
+					</div>
+					<div class="section" data-sap-ui-fastnavgroup="false">
+						<Button>Skipped element</Button>
+					</div>
+					<div class="section">
+						<Button>Something focusable</Button>
+					</div>
+					<div class="section" data-sap-ui-fastnavgroup="true">
+						<Button id="first">First focusable</Button>
+					</div>
+				</div>
+			);
+
+			// act
+			cy.get("#before").focus();
+			cy.realPress("F6");
+
+			// assert 1st group is focused
+			cy.get("#first")
+				.should("be.focused");
+		});
+
+		it("Built-in groups", () => {
+			cy.mount(
+				<div>
+					<div class="section">
+						<button id="before">Before element</button>
+					</div>
+					<Bar>
+						<Button id="first">First focusable element</Button>
+					</Bar>
+
+					<Bar data-sap-ui-fastnavgroup="false" id="skippedBar">
+						<Button>Skipped element</Button>
+					</Bar>
+					<div class="section">
+						<Button>Something focusable</Button>
+					</div>
+					<div class="section" data-sap-ui-fastnavgroup="true">
+						<Button id="second">Second focusable</Button>
+					</div>
+				</div>
+			);
+
+			// act
+			cy.get("#before").focus();
+			cy.realPress("F6");
+
+			// assert 1st group is focused
+			cy.get("#first")
+				.should("be.focused");
+
+			cy.get("#skippedBar")
+				.should("have.attr", "data-sap-ui-fastnavgroup", "false");
+
+			cy.realPress("F6");
+
+			// assert 2nd group is focused
+			cy.get("#second")
 				.should("be.focused");
 		});
 	});


### PR DESCRIPTION
Currently, it's not possible to skip built-in fast navigation groups from the F6 navigation chain—for example, a `ui5-bar` component always participates by default.

With this PR, developers can bypass a specific fast navigation group by adding the attribute `data-sap-ui-fastnavgroup="false"` to the element that defines group. This prevents the first focusable element of the marked group from receiving focus during F6 navigation.

**Note:** This only affects the element where the attribute is set. Nested fast navigation groups inside it will still be included in the F6 chain unless they are also explicitly marked with `data-sap-ui-fastnavgroup="false"`.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/11452