### PR TITLE
fix(f6navigation): delegate fast navigation to openui5

### DIFF
--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -1,4 +1,4 @@
-import { registerFeature } from "../FeaturesRegistry.js";
+import { getFeature, registerFeature } from "../FeaturesRegistry.js";
 import { isF6Next, isF6Previous } from "../Keys.js";
 import { instanceOfUI5Element } from "../UI5Element.js";
 import { getFirstFocusableElement } from "../util/FocusableElements.js";
@@ -6,6 +6,7 @@ import getFastNavigationGroups from "../util/getFastNavigationGroups.js";
 import isElementClickable from "../util/isElementClickable.js";
 import { getCurrentRuntimeIndex, compareRuntimes } from "../Runtimes.js";
 import getSharedResource from "../getSharedResource.js";
+import type OpenUI5Support from "./OpenUI5Support.js";
 
 type F6Registry = {
 	instance?: F6Navigation,
@@ -132,6 +133,14 @@ class F6Navigation {
 	}
 
 	async _keydownHandler(event: KeyboardEvent) {
+		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
+		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isOpenUI5Detected() : false;
+
+		if (isOpenUI5Loaded) {
+			this.destroy();
+			return;
+		}
+
 		const forward = isF6Next(event);
 		const backward = isF6Previous(event);
 		if (!(forward || backward)) {

--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -134,9 +134,9 @@ class F6Navigation {
 
 	async _keydownHandler(event: KeyboardEvent) {
 		const openUI5Support = getFeature<typeof OpenUI5Support>("OpenUI5Support");
-		const isOpenUI5Loaded = openUI5Support ? openUI5Support.isOpenUI5Detected() : false;
+		const isOpenUI5Detected = openUI5Support && openUI5Support.isOpenUI5Detected();
 
-		if (isOpenUI5Loaded) {
+		if (isOpenUI5Detected) {
 			this.destroy();
 			return;
 		}

--- a/packages/main/test/pages/F6Test8.html
+++ b/packages/main/test/pages/F6Test8.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+
+	<title>Avatar</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<link rel="stylesheet" type="text/css" href="./styles/F6Test.css">
+</head>
+
+<body>
+	F6 navigation should be handled by OpenUI5, even if it is loaded late.
+	<div class="section">
+		<ui5-button>Before element</ui5-button>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<ui5-button id="first">First focusable</ui5-button>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-button>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-button>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-button>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<ui5-button id="second">Second focusable</ui5-button>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-button>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<ui5-button id="third">Third focusable</ui5-button>
+	</div>
+	<div class="section">
+		<ui5-button>After Element</ui5-button>
+	</div>
+	<script>
+		setTimeout(() => {
+			const script = document.createElement('script');
+			script.src = 'https://sdk.openui5.org/resources/sap-ui-core.js';
+			script.id = 'sap-ui-bootstrap';
+			script.setAttribute('data-sap-ui-libs', 'sap.m');
+			script.setAttribute('data-sap-ui-theme', 'sap_horizon');
+
+			document.head.appendChild(script);
+		}, 2000)
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
If UI5 Web Components are used within the OpenUI5 framework and OpenUI5 is loaded first, we allow it to handle fast navigation.

With this change, fast navigation is delegated to OpenUI5 even when it is loaded after the Web Components are initialized.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10462