### PR TITLE
fix(ui5-list): adjust observer to handle sticky headers

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -75,6 +75,7 @@ import type CheckBox from "./CheckBox.js";
 import type RadioButton from "./RadioButton.js";
 import { isInstanceOfListItemGroup } from "./ListItemGroup.js";
 import type ListItemGroup from "./ListItemGroup.js";
+import { findVerticalScrollContainer } from "./TableUtils.js";
 
 const INFINITE_SCROLL_DEBOUNCE_RATE = 250; // ms
 
@@ -1425,9 +1426,11 @@ class List extends UI5Element {
 
 	getIntersectionObserver() {
 		if (!this.growingIntersectionObserver) {
+			const scrollContainer = this.scrollContainer || findVerticalScrollContainer(this.getDomRef()!);
+
 			this.growingIntersectionObserver = new IntersectionObserver(this.onInteresection.bind(this), {
-				root: null,
-				rootMargin: "0px",
+				root: scrollContainer,
+				rootMargin: "5px",
 				threshold: 1.0,
 			});
 		}


### PR DESCRIPTION
Problem:
The list's onLoadMore event is not triggered in Firefox at certain zoom levels when a sticky header is present. This is due to how Firefox calculates intersections with sticky positioned elements, causing subpixel rendering issues.

Solution:
Use the proper scroll container as the root for the IntersectionObserver and add a rootMargin of 5px.

Similar to: #11242
Fixes: [#11461](https://github.com/SAP/ui5-webcomponents/issues/11461)