### PR TITLE
fix(ui5-side-navigation): change CSS param 'sapFontSemiboldFamily' to 'sapFontSemiboldDuplexFamily'

### DIFF
--- a/packages/fiori/src/themes/NavigationMenuItem.css
+++ b/packages/fiori/src/themes/NavigationMenuItem.css
@@ -15,7 +15,7 @@
 	transition: var(--_ui5_side_navigation_item_transition);
 	color: var(--sapList_TextColor);
 	font-size: var(--sapFontSize);
-	font-family: var(--_ui5_side_navigation_item_font_family);
+	font-family: var(--_ui5_side_navigation_parent_item_font_family);
 }
 
 ::slotted([ui5-navigation-menu-item]) {

--- a/packages/fiori/src/themes/SideNavigationGroup.css
+++ b/packages/fiori/src/themes/SideNavigationGroup.css
@@ -2,7 +2,6 @@
 
 :host {
 	font-size: var(--sapFontSmallSize);
-	font-family: var(--sapFontSemiboldFamily);
 	color: var(--sapContent_LabelColor);
 }
 

--- a/packages/fiori/src/themes/SideNavigationItem.css
+++ b/packages/fiori/src/themes/SideNavigationItem.css
@@ -25,5 +25,5 @@
 }
 
 .ui5-sn-item-level1 .ui5-sn-item-text {
-	font-weight: bold;
+	font-family: var(--_ui5_side_navigation_parent_item_font_family);
 }

--- a/packages/fiori/src/themes/base/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/base/SideNavigation-parameters.css
@@ -43,6 +43,7 @@
 	--_ui5_side_navigation_group_icon_width: var(--_ui5_side_navigation_collapsed_width);
 	--_ui5_side_navigation_icon_padding_inline_end: 1rem;
 	--_ui5_side_navigation_item_font_family: "72override", var(--sapFontFamily);
+	--_ui5_side_navigation_parent_item_font_family: "72override", var(--sapFontSemiboldDuplexFamily);
 	--_ui5_side_navigation_group_padding: 0.5rem;
 	--_ui5_side_navigation_padding-flexible: 0;
 	--_ui5_side_navigation_padding-fixed: 0;

--- a/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
@@ -32,7 +32,6 @@
 	--_ui5_side_navigation_selected_and_focused_border_style_color: var(--_ui5_side_navigation_selected_border_style_color);
 	--_ui5_side_navigation_group_icon_width: 2.5rem;
 	--_ui5_side_navigation_icon_padding_inline_end: 0.5rem;
-	--_ui5_side_navigation_item_font_family: "72override", var(--sapFontSemiboldFamily);
 	--_ui5_side_navigation_group_padding: 1rem;
 	--_ui5_side_navigation_padding-flexible: 0.5rem 0.5rem 0 0.5rem; 
 	--_ui5_side_navigation_padding-fixed: 0 0.5rem 0.5rem 0.5rem;

--- a/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
@@ -32,7 +32,6 @@
 	--_ui5_side_navigation_selected_and_focused_border_style_color: var(--_ui5_side_navigation_selected_border_style_color);
 	--_ui5_side_navigation_group_icon_width: 2.5rem;
 	--_ui5_side_navigation_icon_padding_inline_end: 0.5rem;
-	--_ui5_side_navigation_item_font_family: var(--sapFontSemiboldFamily);
 	--_ui5_side_navigation_group_padding: 1rem;
 	--_ui5_side_navigation_padding-flexible: 0.5rem 0.5rem 0 0.5rem; 
 	--_ui5_side_navigation_padding-fixed: 0 0.5rem 0.5rem 0.5rem;

--- a/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
@@ -30,7 +30,6 @@
 	--_ui5_side_navigation_selected_and_focused_border_style_color: none;
 	--_ui5_side_navigation_group_icon_width: 2.5rem;
 	--_ui5_side_navigation_icon_padding_inline_end: 0.5rem;
-	--_ui5_side_navigation_item_font_family: "72override", var(--sapFontSemiboldFamily);
 	--_ui5_side_navigation_group_padding: 1rem;
 	--_ui5_side_navigation_padding-flexible: 0.5rem 0.5rem 0 0.5rem; 
 	--_ui5_side_navigation_padding-fixed: 0 0.5rem 0.5rem 0.5rem;

--- a/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
@@ -30,7 +30,6 @@
 	--_ui5_side_navigation_selected_and_focused_border_style_color: none;
 	--_ui5_side_navigation_group_icon_width: 2.5rem;
 	--_ui5_side_navigation_icon_padding_inline_end: 0.5rem;
-	--_ui5_side_navigation_item_font_family: "72override", var(--sapFontSemiboldFamily);
 	--_ui5_side_navigation_group_padding: 1rem;
 	--_ui5_side_navigation_padding-flexible: 0.5rem 0.5rem 0 0.5rem; 
 	--_ui5_side_navigation_padding-fixed: 0 0.5rem 0.5rem 0.5rem;


### PR DESCRIPTION

Problem: the 'sapFontSemiboldFamily' parameter did not result in a change in the font since font '72-Semibold' doesn't load.
Solution: replace it with 'sapFontSemiboldDuplexFamily'

Fixes: #11525

**Thank you for your contribution!** 👏


### PR checklist
- [ ] Check the [Development Hints](https://sap.github.io/ui5-webcomponents/docs/contributing/DoD/)

- [ ] Follow the [Commit message Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/docs/6-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [ ] Add proper description about the background of the change and the change itself

- [ ] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [ ] Read the [Contributing Guidelines](https://github.com/SAP/ui5-webcomponents/blob/main/CONTRIBUTING.md)
