### PR TITLE
fix(ui5-timeline-item): remove focus getting cut

### DIFF
--- a/packages/fiori/src/themes/Timeline.css
+++ b/packages/fiori/src/themes/Timeline.css
@@ -75,11 +75,9 @@
 	height: 100%;
 	position: relative;
 	box-sizing: border-box;
-	padding-inline-end: 0;
 }
 
 :host([layout="Vertical"]) .ui5-timeline-scroll-container {
-	overflow: auto;
 	height: 100%;
 	width: 100%;
 }

--- a/packages/fiori/test/pages/Timeline.html
+++ b/packages/fiori/test/pages/Timeline.html
@@ -300,7 +300,7 @@
 
 		<section>
 			<h2>Advanced Timeline - Horizontal With Groups and Diverse Components</h2>
-			<div style="max-height: 10.5rem; overflow: auto;">
+			<div>
 				<ui5-timeline layout="Vertical" id="horizontalWithGroupsGrowing">
 					<ui5-timeline-group-item group-name="SAP Events">
 						<ui5-timeline-item title-text="Online Meeting" subtitle-text="20.02.2017 11:30" icon="calendar">


### PR DESCRIPTION
Previously, when a `ui5-timeline-item` was being focused, the focus outline was getting cut, due to a `overflow: auto` property in `Vertical` mode.

With this change we remove the `overflow` property, and the focus behaves as expected.

### Before
![2025-05-16_08-50-14](https://github.com/user-attachments/assets/b20baee8-4a7f-4dcd-a008-46dac53883e6)

### After
![2025-05-16_08-49-32](https://github.com/user-attachments/assets/487b4b10-4b48-4e4e-bc69-19eba2f1db07)

Fixes: #11386 
