### PR TITLE
fix(ui5-avatar-group): focus outline visible in overflow:hidden

### DIFF
--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -22,6 +22,7 @@
 
 .ui5-avatar-group-root {
 	display: flex;
+	padding: var(--_ui5_avatar_group_padding);
 }
 
 .ui5-avatar-group-items {

--- a/packages/main/src/themes/base/AvatarGroup-parameters.css
+++ b/packages/main/src/themes/base/AvatarGroup-parameters.css
@@ -1,3 +1,4 @@
 :root {
 	--_ui5_avatar_group_button_focus_border: none;
+	--_ui5_avatar_group_padding: 0.3rem;
 }


### PR DESCRIPTION
Problem:
Focus outline is cut off when the avatar-group is placed inside a container with overflow:hidden.

Solution:
Added padding to the avatar group container using a new parameter `--_ui5_avatar_group_focus_space`. This ensures sufficient space for the focus outline to be fully visible.

Fixes: [#10551](https://github.com/SAP/ui5-webcomponents/issues/10551)