### PR TITLE
docs(ui5-tab): properly mark tab as movable

### DIFF
--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -137,7 +137,8 @@ class Tab extends UI5Element implements ITabbable, ITab {
 	 * Defines if the tab is movable.
 	 *
 	 * @default false
-	 * @private
+	 * @public
+	 * @since 2.0.0
 	 */
 	@property({ type: Boolean })
 	movable = false;


### PR DESCRIPTION
Fixes https://github.com/SAP/ui5-webcomponents/issues/11534