### PR TITLE
docs(ui5-tree): add move and move-over event documentation

### DIFF
--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -183,13 +183,32 @@ type WalkCallback = (item: TreeItemBase, level: number, index: number) => void;
 @event("selection-change", {
 	bubbles: true,
 })
+
+/**
+ * Fired when a movable tree item is moved over a potential drop target during a drag-and-drop operation.
+ *
+ * If the new position is valid, prevent the default action of the event using `preventDefault()`.
+ * @param {object} source Contains information about the moved element under the `element` property.
+ * @param {object} destination Contains information about the destination of the moved element. Has `element` and `placement` properties.
+ * @public
+ */
 @event("move", {
 	bubbles: true,
 })
+
+/**
+ * Fired when a movable tree item is dropped onto a drop target.
+ *
+ * **Note:** The `move` event is fired only if there was a preceding `move-over` event with prevented default action.
+ * @param {object} source Contains information about the moved element under the `element` property.
+ * @param {object} destination Contains information about the destination of the moved element. Has `element` and `placement` properties.
+ * @public
+ */
 @event("move-over", {
 	bubbles: true,
 	cancelable: true,
 })
+
 class Tree extends UI5Element {
 	eventDetails!: {
 		"item-toggle": TreeItemToggleEventDetail,


### PR DESCRIPTION
Added missing JSDoc comments for the `move` and `move-over` events to the `ui5-tree` component, describing their purpose and parameters for drag-and-drop reordering functionality.

Fixes: #11199