### PR TITLE
fix(ui5-flexible-column-layout): add aria-valuenow attribute to separators

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -106,4 +106,27 @@ describe("ACC", () => {
 			.find("slot[name=endColumn]")
 			.should("have.attr", "aria-hidden");
 	});
+	
+	it("verifies that aria-valuenow is set on separators", () => {
+		cy.mount(
+			<FlexibleColumnLayout id="fcl" style={{ height: "300px" }} layout="ThreeColumnsMidExpanded">
+				<div class="column" id="startColumn" slot="startColumn">some content</div>
+				<div class="column" id="midColumn" slot="midColumn">some content</div>
+				<div class="column" id="endColumn" slot="endColumn">some content</div>
+			</FlexibleColumnLayout>
+		);
+
+		cy.get("[ui5-flexible-column-layout]")
+			.as("fcl");
+
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-separator-start")
+			.should("have.attr", "aria-valuenow");
+
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-separator-end")
+			.should("have.attr", "aria-valuenow");
+	});
 });

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -64,6 +64,11 @@ const COLUMN = {
 	END: 2,
 } as const;
 
+const SEPARATOR_DEFAULT_VALUES = {
+	START: 50,
+	END: 75,
+} as const;
+
 const COLUMN_MIN_WIDTH = 248;
 
 type SeparatorMovementSession = {
@@ -1077,7 +1082,7 @@ class FlexibleColumnLayout extends UI5Element {
 		if (typeof startColumnWidth === "string" && startColumnWidth.endsWith("%")) {
 			return parseInt(startColumnWidth);
 		}
-		return 50;
+		return SEPARATOR_DEFAULT_VALUES.START;
 	}
 
 	get endSeparatorValue() {
@@ -1088,7 +1093,7 @@ class FlexibleColumnLayout extends UI5Element {
 			&& typeof midColumnWidth === "string" && midColumnWidth.endsWith("%")) {
 			return parseInt(startColumnWidth) + parseInt(midColumnWidth);
 		}
-		return 75;
+		return SEPARATOR_DEFAULT_VALUES.END;
 	}
 
 	get startArrowDirection() {

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -1072,6 +1072,25 @@ class FlexibleColumnLayout extends UI5Element {
 		return this.effectiveSeparatorsInfo[0].arrowVisible;
 	}
 
+	get startSeparatorValue() {
+		const startColumnWidth = this.startColumnWidth;
+		if (typeof startColumnWidth === "string" && startColumnWidth.endsWith("%")) {
+			return parseInt(startColumnWidth);
+		}
+		return 50;
+	}
+
+	get endSeparatorValue() {
+		const startColumnWidth = this.startColumnWidth;
+		const midColumnWidth = this.midColumnWidth;
+
+		if (typeof startColumnWidth === "string" && startColumnWidth.endsWith("%")
+			&& typeof midColumnWidth === "string" && midColumnWidth.endsWith("%")) {
+			return parseInt(startColumnWidth) + parseInt(midColumnWidth);
+		}
+		return 75;
+	}
+
 	get startArrowDirection() {
 		return this.effectiveSeparatorsInfo[0].arrowDirection;
 	}

--- a/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
+++ b/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
@@ -32,6 +32,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 				class="ui5-fcl-separator ui5-fcl-separator-start"
 				style={{ display: this.showStartSeparator ? "flex" : "none" }}
 				tabindex={this.startSeparatorTabIndex}
+				aria-valuenow={this.startSeparatorValue}
 				onMouseDown={this.onSeparatorPress}
 				onTouchStart={this.onSeparatorPress}
 				onKeyDown={this._onSeparatorKeydown}
@@ -61,6 +62,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 				class="ui5-fcl-separator ui5-fcl-separator-end"
 				style={{ display: this.showEndSeparator ? "flex" : "none" }}
 				tabindex={this.endSeparatorTabIndex}
+				aria-valuenow={this.endSeparatorValue}
 				onMouseDown={this.onSeparatorPress}
 				onTouchStart={this.onSeparatorPress}
 				onKeyDown={this._onSeparatorKeydown}


### PR DESCRIPTION
Problem:
Axe DevTools reports critical accessibility errors because focusable separator elements (role="separator" with tabindex="0") are missing the required aria-valuenow attribute.

Solution:
Added aria-valuenow attributes to start and end separators in the template, with new getter methods that derive position values from column widths (as percentages) to provide screen readers with position information.

Fixes: [#11533](https://github.com/SAP/ui5-webcomponents/issues/11533)