### PR TITLE
fix(ui5-avatar): apply optional border for avatars with image

### DIFF
--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -209,6 +209,9 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	@property({ noAttribute: true })
 	forcedTabIndex?: string;
 
+	/**
+	 * @private
+	 */
 	@property({ type: Boolean })
 	_hasImage = false;
 
@@ -245,6 +248,10 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	constructor() {
 		super();
 		this._handleResizeBound = this.handleResize.bind(this);
+	}
+
+	onBeforeRendering() {
+		this._hasImage = this.hasImage;
 	}
 
 	get tabindex() {
@@ -309,8 +316,7 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	}
 
 	get hasImage() {
-		this._hasImage = !!this.image.length;
-		return this._hasImage;
+		return !!this.image.length;
 	}
 
 	get initialsContainer(): HTMLObjectElement | null {

--- a/packages/main/src/themes/Avatar.css
+++ b/packages/main/src/themes/Avatar.css
@@ -277,8 +277,8 @@
 
 :host([_has-image]) {
 	color: var(--ui5-avatar-accent10-color);
+	border: var(--ui5-avatar-optional-border);
 	background-color: transparent;
-	vertical-align: middle;
 }
 
 .ui5-avatar-initials {

--- a/packages/main/src/themes/base/Avatar-parameters.css
+++ b/packages/main/src/themes/base/Avatar-parameters.css
@@ -4,6 +4,7 @@
 	--ui5-avatar-border-radius: .25rem;
 	--ui5-avatar-border-radius-img-deduction: 0.0625rem;
 	--ui5-avatar-initials-border: none;
+	--ui5-avatar-optional-border: .0625rem solid var(--sapGroup_ContentBorderColor);
 	--ui5-avatar-accent1: var(--sapAccentColor1);
 	--ui5-avatar-accent2: var(--sapAccentColor2);
 	--ui5-avatar-accent3: var(--sapAccentColor3);

--- a/packages/main/test/pages/Avatar.html
+++ b/packages/main/test/pages/Avatar.html
@@ -140,17 +140,19 @@
 
 	<section>
 		<h3>Avatar - test</h3>
-		<ui5-avatar id="myAvatar1">
-			<img src="./img/woman_avatar_5.png" alt="Woman image">
-		</ui5-avatar>
-		<ui5-avatar id="myAvatar2" icon="filter"></ui5-avatar>
-		<ui5-avatar id="myAvatar3" icon="filter" initials="SF">
-			<img src="./img/woman_avatar_5.png" alt="Woman image">
-		</ui5-avatar>
-		<ui5-avatar id="myAvatar4" initials="SF" shape="Square" size="M"></ui5-avatar>
-		<ui5-avatar id="myAvatar5" initials="WWW" shape="Square" size="M"></ui5-avatar>
-		<ui5-avatar id="myAvatar7" fallback-icon="alert" initials="WWW" shape="Circle" size="L"></ui5-avatar>
 
+		<div class="section">
+			<ui5-avatar id="myAvatar1">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
+			<ui5-avatar id="myAvatar2" icon="filter"></ui5-avatar>
+			<ui5-avatar id="myAvatar3" icon="filter" initials="SF">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
+			<ui5-avatar id="myAvatar4" initials="SF" shape="Square" size="M"></ui5-avatar>
+			<ui5-avatar id="myAvatar5" initials="WWW" shape="Square" size="M"></ui5-avatar>
+			<ui5-avatar id="myAvatar7" fallback-icon="alert" initials="WWW" shape="Circle" size="L"></ui5-avatar>
+		</div>
 	</section>
 
 	<section>
@@ -175,46 +177,48 @@
 
 	<section>
 		<h3>Avatar - Visual affordance</h3>
-		<ui5-avatar initials="AB" color-scheme="Accent1">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="accelerated"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
 
-		<ui5-avatar interactive size="L" initials="CD" color-scheme="Accent2">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="accept"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
+		<div class="section">
+			<ui5-avatar initials="AB" color-scheme="Accent1">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="accelerated"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
 
-		<ui5-avatar size="XL">
-			<img src="./img/John_Miller.png" alt="John Miller">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="bar-chart"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
+			<ui5-avatar interactive size="L" initials="CD" color-scheme="Accent2">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="accept"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
 
-		<br>
+			<ui5-avatar size="XL">
+				<img src="./img/John_Miller.png" alt="John Miller">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="bar-chart"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
+		</div>
 
-		<ui5-avatar shape="Square" size="XS" initials="EF" color-scheme="Accent3">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="filter"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
+		<div class="section">
+			<ui5-avatar shape="Square" size="XS" initials="EF" color-scheme="Accent3">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="filter"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
 
-		<ui5-avatar interactive shape="Square" initials="GH" color-scheme="Accent4">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="add-employee"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
+			<ui5-avatar interactive shape="Square" initials="GH" color-scheme="Accent4">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="add-employee"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
 
-		<ui5-avatar shape="Square" size="L">
-			<img src="./img/John_Miller.png" alt="John Miller">
-			<ui5-tag slot="badge">
-				<ui5-icon slot="icon" name="document"></ui5-icon>
-			</ui5-tag>
-		</ui5-avatar>
-		<br><br>
+			<ui5-avatar shape="Square" size="L">
+				<img src="./img/John_Miller.png" alt="John Miller">
+				<ui5-tag slot="badge">
+					<ui5-icon slot="icon" name="document"></ui5-icon>
+				</ui5-tag>
+			</ui5-avatar>
+		</div>
 	</section>
 
 	<section>

--- a/packages/main/test/pages/styles/Avatar.css
+++ b/packages/main/test/pages/styles/Avatar.css
@@ -2,6 +2,13 @@
     display: none;
 }
 
+.section {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: .5rem;
+}
+
 .avatar-image {
     object-fit: cover;
 }


### PR DESCRIPTION
- Ensure the optional border is consistently applied whenever the avatar displays an image (e.g., a person).
- Update CSS and parameters to support the new border logic.
- Improve visual consistency for avatars with images across themes and test pages.

Fixes: #11437