### PR TITLE
fix(ui5-breadcrumbs): aligned with acc spec

### DIFF
--- a/packages/main/cypress/specs/Breadcrumbs.cy.tsx
+++ b/packages/main/cypress/specs/Breadcrumbs.cy.tsx
@@ -1,0 +1,32 @@
+import Breadcrumbs from "../../src/Breadcrumbs.js";
+import BreadcrumbsItem from "../../src/BreadcrumbsItem.js";
+
+describe("breadcrumbs navigation", () => {
+
+    it("displays all items in the popover on mobile", () => {
+        cy.mount(
+            <Breadcrumbs>
+                <BreadcrumbsItem id="first" href="#">Link1</BreadcrumbsItem>
+                <BreadcrumbsItem id="second" href="#">Link2</BreadcrumbsItem>
+                <BreadcrumbsItem id="third" href="#">Link3</BreadcrumbsItem>
+            </Breadcrumbs>
+        );
+
+        cy.get("ui5-breadcrumbs")
+            cy.realPress("Tab");
+
+        cy.realPress("ArrowRight");
+
+        cy.get("ui5-breadcrumbs").invoke("prop", "_itemNavigation").then(_itemNavigation => {
+            return _itemNavigation._currentIndex;
+        })
+        .should("equal", 1); // index is 1 after arrow right
+
+        cy.realPress("ArrowUp");
+
+        cy.get("ui5-breadcrumbs").invoke("prop", "_itemNavigation").then(_itemNavigation => {
+            return _itemNavigation._currentIndex;
+        })
+        .should("equal", 0); // index is back to 0 after arrow up
+    });
+});

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -166,7 +166,7 @@ class Breadcrumbs extends UI5Element {
 		super();
 
 		this._itemNavigation = new ItemNavigation(this, {
-			navigationMode: NavigationMode.Horizontal,
+			navigationMode: NavigationMode.Auto,
 			getItemsCallback: () => this._getFocusableItems(),
 		});
 
@@ -225,7 +225,7 @@ class Breadcrumbs extends UI5Element {
 	_initItemNavigation() {
 		if (!this._itemNavigation) {
 			this._itemNavigation = new ItemNavigation(this, {
-				navigationMode: NavigationMode.Horizontal,
+				navigationMode: NavigationMode.Auto,
 				getItemsCallback: () => this._getFocusableItems(),
 			});
 		}


### PR DESCRIPTION
Breadcrumbs' item navigation is now possible with ARRROW UP and ARROW DOWN keys (similar to left and right).

Fixes: #11541

