### PR TITLE
fix(ui5-checkbox): fixed required asterisk alignment

### DIFF
--- a/packages/main/src/CheckBoxTemplate.tsx
+++ b/packages/main/src/CheckBoxTemplate.tsx
@@ -62,6 +62,7 @@ export default function CheckBoxTemplate(this: CheckBox) {
 				part="label"
 				class="ui5-checkbox-label"
 				wrappingType={this.wrappingType}
+				required={this.required}
 			>
 				{this.text}
 			</Label>

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -9,15 +9,6 @@
 	vertical-align: middle;
 }
 
-:host([required]) .ui5-checkbox-label:after {
-	content:"*";
-	margin-inline-start: .125rem;
-	color: var(--sapField_RequiredColor);
-	font-size: var(--sapFontLargeSize);
-	font-family: var(--sapFontFamily);
-	font-weight: bold;
-}
-
 :host {
 	overflow: hidden;
 	max-width: 100%;


### PR DESCRIPTION
Previously the required asterisk was rendered next to the checkbox's text block.

Now it's at the end of the text line.

Fixes: #11547
