### PR TITLE
fix(ui5-wizard): define min-width for header steps separators

### DIFF
--- a/packages/fiori/src/themes/WizardTab.css
+++ b/packages/fiori/src/themes/WizardTab.css
@@ -163,6 +163,7 @@
 	height: 1px;
 	flex-grow: 1;
 	margin-right: .25rem;
+	min-width: .5rem;
 }
 
 :host([active-separator]) .ui5-wiz-step-hr {


### PR DESCRIPTION
FIXES: #9672
