### PR TITLE
feat(ui5-avatar, ui5-icon): make click events public

### DIFF
--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -68,7 +68,7 @@ type AvatarAccessibilityAttributes = Pick<AccessibilityAttributes, "hasPopup">;
  * **Note:** The event will not be fired if the `disabled`
  * property is set to `true`.
  * @public
- * @since 1.0.0-rc.11
+ * @since 2.11.0
  */
 @event("click", {
 	bubbles: true,

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -67,7 +67,7 @@ type AvatarAccessibilityAttributes = Pick<AccessibilityAttributes, "hasPopup">;
  *
  * **Note:** The event will not be fired if the `disabled`
  * property is set to `true`.
- * @private
+ * @public
  * @since 1.0.0-rc.11
  */
 @event("click", {

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -107,7 +107,7 @@ const ICON_NOT_FOUND = "ICON_NOT_FOUND";
  * Fired on mouseup, `SPACE` and `ENTER`.
  * - on mouse click, the icon fires native `click` event
  * - on `SPACE` and `ENTER`, the icon fires custom `click` event
- * @private
+ * @public
  * @since 1.0.0-rc.8
  */
 @event("click", {

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -108,7 +108,7 @@ const ICON_NOT_FOUND = "ICON_NOT_FOUND";
  * - on mouse click, the icon fires native `click` event
  * - on `SPACE` and `ENTER`, the icon fires custom `click` event
  * @public
- * @since 1.0.0-rc.8
+ * @since 2.11.0
  */
 @event("click", {
 	bubbles: true,


### PR DESCRIPTION
- Change event click decorator from private to public in Avatar component
- Change event click decorator from private to public in Icon component

Allows seamless integration to "wrap" the click events on interactive avatars and icons

