### PR TITLE
fix(ui5-side-navigation): group name is announced by screen reader

### DIFF
--- a/packages/compat/test/pages/TableAllPopin.html
+++ b/packages/compat/test/pages/TableAllPopin.html
@@ -98,7 +98,7 @@
 			<ui5-label>Weight</ui5-label>
 		</ui5-table-column>
 		<ui5-table-column slot="columns">
-			<ui5-label></ui5-label>
+			<ui5-label>Action</ui5-label>
 		</ui5-table-column>
 
 		<ui5-table-row>

--- a/packages/fiori/src/SideNavigationGroupTemplate.tsx
+++ b/packages/fiori/src/SideNavigationGroupTemplate.tsx
@@ -45,6 +45,7 @@ function TreeItemTemplate(this: SideNavigationGroup) {
 			{!!this.items.length &&
 				<ul id={this._groupId}
 					class="ui5-sn-item-ul"
+					aria-label={this.text}
 					role="group"
 				>
 					<slot></slot>

--- a/packages/fiori/src/SideNavigationItemTemplate.tsx
+++ b/packages/fiori/src/SideNavigationItemTemplate.tsx
@@ -156,6 +156,7 @@ function TreeItemTemplate(this: SideNavigationItem) {
 			{!!this.items.length &&
 			<ul id={this._groupId}
 				class="ui5-sn-item-ul"
+				aria-label={this.text}
 				role="group"
 			>
 				<slot></slot>


### PR DESCRIPTION
Group name is read out when accessing group item.

fixes: #11599