### PR TITLE
fix(ui5-date-picker): align width to vd specs

### DIFF
--- a/packages/main/src/themes/DatePicker.css
+++ b/packages/main/src/themes/DatePicker.css
@@ -41,7 +41,6 @@
 
 :host .ui5-date-picker-input {
 	width: 100%;
-	min-width: 12.5625rem;
 	color: inherit;
 	background-color: inherit;
 	border-radius: inherit;


### PR DESCRIPTION
Removed a `min-width` style from the DatePicker input that was overriding the value defined in the VD specs.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/11561