### PR TITLE
chore: exclude cypress test files from npm

### DIFF
--- a/packages/ai/.npmignore
+++ b/packages/ai/.npmignore
@@ -6,3 +6,4 @@ test/
 .eslintignore
 main.*js
 config/
+cypress/

--- a/packages/base/.npmignore
+++ b/packages/base/.npmignore
@@ -6,3 +6,4 @@ node_modules/
 used-modules.txt
 bundle.esm.js
 lib/
+cypress/

--- a/packages/compat/.npmignore
+++ b/packages/compat/.npmignore
@@ -6,3 +6,4 @@ test/
 .eslintignore
 main.*js
 config/
+cypress/

--- a/packages/fiori/.npmignore
+++ b/packages/fiori/.npmignore
@@ -6,3 +6,4 @@ test/
 .eslintignore
 main.*js
 config/
+cypress/

--- a/packages/main/.npmignore
+++ b/packages/main/.npmignore
@@ -6,3 +6,4 @@ test/
 .eslintignore
 main.*js
 config/
+cypress/


### PR DESCRIPTION
Exclude the Cypress folder from being published to the npm registry in each component package.