### PR TITLE
chore: add option to strip jsdoc for new packages and components

### DIFF
--- a/packages/create-package/README.md
+++ b/packages/create-package/README.md
@@ -17,7 +17,6 @@ Usage:
 Options:
     --name <string>                      - defines the package name
     --test-setup <"cypress" | "manual">  - defines whether the predefined test setup should be added or it will be configured manually.
-    --skip                               - skips configuration and generates package with a default value for each parameter that wasn't passed
 ```
 
 The script creates a new directory, and fills it with a `package.json` file and all necessary source files, and resources for a new
@@ -31,7 +30,6 @@ Usage:
 Options:
     --name <string>                      - defines the package name
     --test-setup <"cypress" | "manual">  - defines whether the predefined test setup should be added or it will be configured manually.
-    --skip                               - skips configuration and generates package with a default value for each parameter that wasn't passed
 ```
 
 The script creates a new directory, and fills it with a `package.json` file and all necessary source files, and resources for a new

--- a/packages/tools/lib/create-new-component/Component.js
+++ b/packages/tools/lib/create-new-component/Component.js
@@ -1,4 +1,4 @@
-const Component = (componentName, tagName, library, packageName) => {
+const Component = (componentName, tagName, library, packageName, stripJSDoc) => {
 	return `import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
@@ -10,7 +10,9 @@ import ${componentName}Template from "./${componentName}Template.js";
 
 // Styles
 import ${componentName}Css from "./generated/themes/${componentName}.css.js";
-
+${
+stripJSDoc ? "\n" :
+`
 /**
  * @class
  *
@@ -27,40 +29,49 @@ import ${componentName}Css from "./generated/themes/${componentName}.css.js";
  * @constructor
  * @extends UI5Element
  * @public
- */
+ */`}
 @customElement({
 	tag: "${tagName}",
 	renderer: jsxRenderer,
 	styles: ${componentName}Css,
 	template: ${componentName}Template,
 })
-
+${
+stripJSDoc ? "\n" :
+`
 /**
  * Example custom event.
  * Please keep in mind that all public events should be documented in the API Reference as shown below.
  *
  * @public
- */
+ */`
+}
 @event("interact")
 class ${componentName} extends UI5Element {
 	eventDetails!: {
 		"interact": void,
 	};
-
+${
+stripJSDoc ? "\n" :
+`
 	/**
 	 * Defines the value of the component.
 	 *
 	 * @default ""
 	 * @public
-	 */
+	 */`
+}
 	@property()
 	value?: string;
-
+${
+stripJSDoc ? "\n" :
+`
 	/**
 	 * Defines the text of the component.
 	 *
 	 * @public
 	 */
+}
 	@slot({ type: Node, "default": true })
 	text!: Array<Node>;
 }

--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const prompts = require("prompts");
 const Component = require("./Component.js");
-const ComponentTemplate= require("./ComponentTemplate.js");
+const ComponentTemplate = require("./ComponentTemplate.js");
 
 /**
  * Hyphanates the given PascalCase string and adds prefix, f.e.:
@@ -9,7 +9,7 @@ const ComponentTemplate= require("./ComponentTemplate.js");
  * FooBar -> "my-foo-bar"
  */
 const hyphaneteComponentName = (componentName) => {
-	const result = componentName.replace(/([a-z])([A-Z])/g, '$1-$2' ).toLowerCase();
+	const result = componentName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
 	return `my-${result}`;
 };
@@ -27,13 +27,13 @@ const isNameValid = name => typeof name === "string" && PascalCasePattern.test(n
 
 const getPackageName = () => {
 	if (!fs.existsSync("./package.json")) {
-		throw("The current directory doesn't contain package.json file.");
+		throw ("The current directory doesn't contain package.json file.");
 	}
 
 	const packageJSON = JSON.parse(fs.readFileSync("./package.json"));
 
 	if (!packageJSON.name) {
-		throw("The package.json file in the current directory doesn't have a name property");
+		throw ("The package.json file in the current directory doesn't have a name property");
 	}
 
 	return packageJSON.name;
@@ -57,7 +57,7 @@ const getLibraryName = packageName => {
 	return packageName.substr("webcomponents-".length);
 };
 
-const generateFiles = (componentName, tagName, library, packageName) => {
+const generateFiles = (componentName, tagName, library, packageName, stripJSDoc) => {
 	componentName = capitalizeFirstLetter(componentName);
 	const filePaths = {
 		"main": `./src/${componentName}.ts`,
@@ -65,7 +65,7 @@ const generateFiles = (componentName, tagName, library, packageName) => {
 		"template": `./src/${componentName}Template.tsx`,
 	};
 
-	fs.writeFileSync(filePaths.main, Component(componentName, tagName, library, packageName), { flag: "wx+" });
+	fs.writeFileSync(filePaths.main, Component(componentName, tagName, library, packageName, stripJSDoc), { flag: "wx+" });
 	fs.writeFileSync(filePaths.css, "", { flag: "wx+" });
 	fs.writeFileSync(filePaths.template, ComponentTemplate(componentName), { flag: "wx+" });
 
@@ -105,9 +105,18 @@ const createWebComponent = async () => {
 		}
 	}
 
+	response = await prompts({
+		type: 'confirm',
+		name: 'stripJSDoc',
+		message: 'Would you like to include JSDoc comments for your classes and class members?',
+		initial: true
+	});
+
+	const stripJSDoc = !response.stripJSDoc;
+
 	const tagName = hyphaneteComponentName(componentName);
 
-	generateFiles(componentName, tagName, library, packageName);
+	generateFiles(componentName, tagName, library, packageName, stripJSDoc);
 };
 
 createWebComponent();


### PR DESCRIPTION
* Removed the `skip` parameter from the README, as it is intended for internal use only.
* Added an option to generate new components without JSDoc comments.