### PR TITLE
fix(ui5-shellbar): remove empty logo from tab chain

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -528,6 +528,7 @@ describe("Events", () => {
 			.should("have.been.calledOnce");
 	});
 });
+
 describe("ButtonBadge in ShellBar", () => {
 	it("Test if ShellBarItem count appears in ButtonBadge", () => {
 	  cy.mount(
@@ -620,5 +621,17 @@ describe("ButtonBadge in ShellBar", () => {
 		  .find(".ui5-shellbar-overflow-button ui5-button-badge[slot='badge']")
 		  .should("exist")
 		  .should("have.attr", "text", "42");
+	});
+});
+
+describe("Keyboard Navigation", () => {
+	it("Test logo area elements are not rendered when no logo and primaryTitle are provided", () => {
+		cy.mount(<ShellBar></ShellBar>);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		cy.get("[ui5-shellbar]")
+			.shadow()
+			.find(".ui5-shellbar-logo-area")
+			.should("not.exist");
 	});
 });

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -56,7 +56,7 @@ export default function ShellBarTemplate(this: ShellBar) {
 					{!this.hasMenuItems && (
 						<>
 							{this.isSBreakPoint && this.hasLogo && singleLogo.call(this)}
-							{!this.isSBreakPoint && (
+							{!this.isSBreakPoint && (this.hasLogo || this.primaryTitle) && (
 								<>
 									{combinedLogo.call(this)}
 									{this.secondaryTitle && this.primaryTitle && (


### PR DESCRIPTION
Fixes: #11595

Shellbar without logo and primary title no longer renders an empty placeholder. This prevent an unnecessary tab stop while navigating.