### PR TITLE
docs(UXC-Integration): fix example

### DIFF
--- a/packages/website/docs/_samples/patterns/UXCIntegration/Basic/main.js
+++ b/packages/website/docs/_samples/patterns/UXCIntegration/Basic/main.js
@@ -22,6 +22,7 @@ import "@ui5/webcomponents/dist/Toast.js";
 import "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import "@ui5/webcomponents-fiori/dist/ShellBarItem.js";
 import "@ui5/webcomponents-fiori/dist/ShellBarSearch.js";
+import "@ui5/webcomponents-fiori/dist/ShellBarSpacer.js";
 import "@ui5/webcomponents-fiori/dist/SearchItem.js";
 import "@ui5/webcomponents-fiori/dist/SearchScope.js";
 

--- a/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
+++ b/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
@@ -309,7 +309,7 @@
 					<ui5-li icon="palette">SAP High Contrast White (SAP Horizon)</ui5-li>
 				</ui5-list>
 				<ui5-button id="themeSave" class="save-btn" design="Emphasized">Save</ui5-button>
-				<ui5-toast id="toastThemeSave" design="Emphasized">Changes applied.</ui5-toast>
+				<ui5-toast id="toastThemeSave">Changes applied.</ui5-toast>
 			</ui5-user-settings-view>
 			<ui5-user-settings-view text="Display settings">
 				<ui5-checkbox checked text="Optimized for Touch Input"></ui5-checkbox>
@@ -383,11 +383,11 @@
 		<ui5-user-settings-item icon="reset" slot="fixedItems" text="Reset Settings" tooltip="Reset Settings" header-text="Reset Settings">
 			<ui5-user-settings-view text="Reset Personalization">
 				<ui5-button id="resetPersonalization">Reset Personalization content</ui5-button>
-				<ui5-toast id="toastReset" design="Emphasized">Changes Reset.</ui5-toast>
+				<ui5-toast id="toastReset">Changes Reset.</ui5-toast>
 			</ui5-user-settings-view>
 			<ui5-user-settings-view text="Reset All Settings">
 				<ui5-button id="resetAll">Reset All Settings content</ui5-button>
-				<ui5-toast id="toastResetAll" design="Emphasized">All changes Reset.</ui5-toast>
+				<ui5-toast id="toastResetAll">All changes Reset.</ui5-toast>
 			</ui5-user-settings-view>
 		</ui5-user-settings-item>
 	</ui5-user-settings-dialog>

--- a/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
+++ b/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
@@ -311,7 +311,6 @@
 				<ui5-button id="themeSave" class="save-btn" design="Emphasized">Save</ui5-button>
 				<ui5-toast id="toastThemeSave" design="Emphasized">Changes applied.</ui5-toast>
 			</ui5-user-settings-view>
-			</ui5-user-settings-view>
 			<ui5-user-settings-view text="Display settings">
 				<ui5-checkbox checked text="Optimized for Touch Input"></ui5-checkbox>
 				<ui5-panel fixed>
@@ -347,7 +346,7 @@
 						If you don't know the type of an app, you can check it in the "About" dialog in the "ID of the Application Framework” field.
 					</ui5-label>
 				</ui5-panel>
-				</br>
+				<br />
 				<div class="lt-time-format">
 					<ui5-label for="timeFormat">Time Format:</ui5-label>
 					<ui5-radio-button name="timeFormat" text="12h"></ui5-radio-button>


### PR DESCRIPTION
When implementing the UXC Integration example in our wrapper, I found a few issues, that don't break the example but can cause problems when implemented elsewhere. This PR fixes that. 

Additionally, I noticed the following points:

- The content padding of the different `UserSettingsView`s seems inconsistent
- Why are the search scopes filtere, shouldn't this work out of the box or am I missing something here? (In the wcr example I omitted the filter logic and it still seems to function as intended)