### PR TITLE
fix(ui5-view-settings-dialog): change announce type for the screen reader when view settings are reset

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -661,7 +661,7 @@ class ViewSettingsDialog extends UI5Element {
 		this._restoreSettings(this._initialSettings);
 		this._recentlyFocused = this._sortOrder!;
 		this._focusRecentlyUsedControl();
-		announce(this._resetButtonAction, InvisibleMessageMode.Polite);
+		announce(this._resetButtonAction, InvisibleMessageMode.Assertive);
 	}
 
 	/**


### PR DESCRIPTION
Change announce type for the screen reader when view settings are reset.
