### PR TITLE
fix(ui5-checkbox): correct spacing between checkbox and label in compact

### DIFF
--- a/packages/main/src/themes/base/CheckBox-parameters.css
+++ b/packages/main/src/themes/base/CheckBox-parameters.css
@@ -45,3 +45,10 @@
 --_ui5_checkbox_focus_outline_display: block;
 --_ui5_checkbox_right_focus_distance: 0;
 }
+
+[data-ui5-compact-size],
+.ui5-content-density-compact,
+.sapUiSizeCompact {
+	--_ui5_checkbox_label_offset: var(--_ui5_checkbox_compact_wrapper_padding);
+
+}


### PR DESCRIPTION
- Override `--_ui5_checkbox_label_offset` to use compact wrapper padding in compact mode. 

Fixes: [#11664](https://github.com/SAP/ui5-webcomponents/issues/11664)