### PR TITLE
fix(ui5-button): prevents native behavior when click prevented

### DIFF
--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -215,6 +215,36 @@ describe("Button general interaction", () => {
 			.find("[ui5-icon]")
 			.should("have.attr", "mode", "Decorative");
 	});
+
+	it("Prevents native behavior when click event is prevented", () => {
+		cy.mount(<a href="#navigation">
+			<Button onClick={e => e.preventDefault()}>Click me</Button>
+		</a>);
+
+		cy.location("hash")
+			.should("not.eq", "#navigation");
+
+		cy.get("[ui5-button]")
+			.realClick();
+
+		cy.location("hash")
+			.should("not.eq", "#navigation");
+	});
+
+	it("Allows native behavior when click event is not prevented", () => {
+		cy.mount(<a href="#navigation">
+			<Button>Click me</Button>
+		</a>);
+
+		cy.location("hash")
+			.should("not.eq", "#navigation");
+
+		cy.get("[ui5-button]")
+			.realClick();
+
+		cy.location("hash")
+			.should("eq", "#navigation");
+	});
 });
 
 describe("Accessibility", () => {
@@ -245,7 +275,7 @@ describe("Accessibility", () => {
 	it("tooltip not displayed when there is a text", () => {
 		cy.mount(<Button icon="home">Action</Button>);
 
-		cy.get("[ui5-button]")	
+		cy.get("[ui5-button]")
 			.should("not.have.attr", "title");
 	});
 

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -1,3 +1,4 @@
+import { setNoConflict } from "@ui5/webcomponents-base/dist/config/NoConflict.js";
 import Avatar from "../../src/Avatar.js";
 import Button from "../../src/Button.js";
 import Label from "../../src/Label.js";
@@ -244,6 +245,39 @@ describe("Button general interaction", () => {
 
 		cy.location("hash")
 			.should("eq", "#navigation");
+	});
+
+	it.only("Native event is always fired", () => {
+		cy.mount(<div onClick={cy.stub().as("nativeClick")}>
+			<Button>Click me</Button>
+		</div>);
+
+		cy.wrap({ setNoConflict })
+			.invoke("setNoConflict", true)
+
+		cy.get("[ui5-button]")
+			.realClick();
+
+		cy.get("@nativeClick")
+			.should("have.been.calledOnce")
+			.and("be.calledWithMatch", {
+				type: "click"
+			});
+
+		cy.get('@nativeClick')
+			.invoke('resetHistory')
+
+		cy.wrap({ setNoConflict })
+			.invoke("setNoConflict", false)
+
+		cy.get("[ui5-button]")
+			.realClick();
+
+		cy.get("@nativeClick")
+			.should("have.been.calledOnce")
+			.and("be.calledWithMatch", {
+				type: "click"
+			});
 	});
 });
 

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -437,6 +437,7 @@ class Button extends UI5Element implements IButton {
 		});
 
 		if (prevented) {
+			e.preventDefault();
 			return;
 		}
 

--- a/packages/main/src/ToggleButton.ts
+++ b/packages/main/src/ToggleButton.ts
@@ -70,6 +70,7 @@ class ToggleButton extends Button {
 		});
 
 		if (prevented) {
+			e.preventDefault();
 			// value should be restored if click is prevented
 			this.pressed = oldValue;
 			return;

--- a/packages/main/test/pages/Button.html
+++ b/packages/main/test/pages/Button.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta charset="utf-8">
@@ -34,7 +35,7 @@
 	<ui5-button id="download" icon="download" accessible-name="Download application"></ui5-button>
 	<ui5-button id="button1" icon="home" design="Emphasized">Action Bar Button</ui5-button>
 	<ui5-button class="button2auto">Primary <br> button</ui5-button>
-	<ui5-button class="button2auto button3auto" design="Transparent">Secondary <span >button</span></ui5-button>
+	<ui5-button class="button2auto button3auto" design="Transparent">Secondary <span>button</span></ui5-button>
 	<ui5-button disabled id="button-disabled">Inactive</ui5-button>
 	<ui5-button design="Positive">Accept</ui5-button>
 	<ui5-button design="Negative" accessible-description="Decline the action">Decline</ui5-button>
@@ -52,7 +53,8 @@
 
 	<ui5-input id="click-counter"></ui5-input>
 
-	<ui5-button id="button-with-slot" class="button2auto" design="Emphasized">Action<br> <i>Bar</i><br> Button</ui5-button>
+	<ui5-button id="button-with-slot" class="button2auto" design="Emphasized">Action<br> <i>Bar</i><br>
+		Button</ui5-button>
 	<ui5-button>Primary button</ui5-button>
 	<ui5-button design="Transparent">Secondary button</ui5-button>
 	<ui5-button disabled>Inactive</ui5-button>
@@ -61,9 +63,9 @@
 	<ui5-button design="Attention">Warning</ui5-button>
 	<ui5-button id="attentionIconButton" design="Attention" icon="message-warning">Warning</ui5-button>
 	<ui5-button design="Attention" icon="message-warning"></ui5-button>
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
 
 	<ui5-button icon="download" accessible-name="Download application"></ui5-button>
 	<ui5-button icon="employee" accessible-name="Download book">Action Bar Button</ui5-button>
@@ -82,37 +84,38 @@
 	<ui5-label id="download-text2">From This Button</ui5-label>
 
 	<ui5-button icon="employee" accessible-name="Help me">Action Bar Button</ui5-button>
-	<ui5-button id="buttonAccNameRef" icon="download" accessible-name="Help me" accessible-name-ref="1download-text"></ui5-button>
+	<ui5-button id="buttonAccNameRef" icon="download" accessible-name="Help me"
+		accessible-name-ref="1download-text"></ui5-button>
 
 	<ui5-button icon="employee" accessible-name-ref="1download-text download-text2">Action Bar Button</ui5-button>
 	<ui5-button icon="download" accessible-name-ref="1download-text"></ui5-button>
 
 
 
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
 
 	<ui5-button design="Default" icon="employee">Default</ui5-button>
 	<ui5-button disabled design="Default" icon="employee">Default</ui5-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-button design="Positive" icon="employee">Agree</ui5-button>
 	<ui5-button disabled design="Positive" icon="employee">Agree</ui5-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-button design="Negative" icon="employee">Decline</ui5-button>
 	<ui5-button disabled design="Negative" icon="employee">Decline</ui5-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-button design="Transparent" icon="employee">Transparent</ui5-button>
 	<ui5-button disabled design="Transparent" icon="employee">Transparent
 	</ui5-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-title>Cozy</ui5-title>
 
@@ -135,7 +138,7 @@
 		<ui5-button icon="employee">Emphasized
 			<ui5-button-badge design="InlineText" text="72" slot="badge"></ui5-button-badge>
 		</ui5-button>
-	
+
 		<ui5-button design="Emphasized" icon="employee">Emphasized
 			<ui5-button-badge design="OverlayText" text="999+" slot="badge"></ui5-button-badge>
 		</ui5-button>
@@ -150,23 +153,23 @@
 		<ui5-button icon="employee">Emphasized
 			<ui5-button-badge design="InlineText" text="72" slot="badge"></ui5-button-badge>
 		</ui5-button>
-	
+
 		<ui5-button design="Emphasized" icon="employee">Emphasized
 			<ui5-button-badge design="OverlayText" text="999+" slot="badge"></ui5-button-badge>
 		</ui5-button>
 		<ui5-button icon="employee">Emphasized
 			<ui5-button-badge design="AttentionDot" slot="badge"></ui5-button-badge>
 		</ui5-button>
-	
+
 		<br><br>
-	
+
 		<ui5-title>Compact</ui5-title>
-	
+
 		<div data-ui5-compact-size>
 			<ui5-button icon="employee">Emphasized
 				<ui5-button-badge design="InlineText" text="72" slot="badge"></ui5-button-badge>
 			</ui5-button>
-		
+
 			<ui5-button design="Emphasized" icon="employee">Emphasized
 				<ui5-button-badge design="OverlayText" text="999+" slot="badge"></ui5-button-badge>
 			</ui5-button>
@@ -180,11 +183,11 @@
 
 	<ui5-button disabled design="Emphasized" icon="employee">Emphasized</ui5-button>
 
-	<br/>
-	<br/>
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
 
 	<ui5-button end-icon icon="employee">Icon last</ui5-button>
 	<ui5-button icon="employee" id="disabled-button-icon-only" disabled></ui5-button>
@@ -194,14 +197,14 @@
 
 	<ui5-checkbox text="Option A"></ui5-checkbox>
 	<ui5-checkbox disabled text="Option A"></ui5-checkbox>
-	<br/>
+	<br />
 	<ui5-label>"This is a label, this is a label"</ui5-label>
 
-	<br/>
-	<br/>
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Emphasized">Action Bar Button</ui5-toggle-button>
 	<ui5-toggle-button>Primary button</ui5-toggle-button>
@@ -210,51 +213,51 @@
 	<ui5-toggle-button design="Positive">Agree</ui5-toggle-button>
 	<ui5-toggle-button design="Negative">Decline</ui5-toggle-button>
 
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
 
 	<ui5-toggle-button icon="employee">Action Bar Button</ui5-toggle-button>
 	<ui5-toggle-button icon="download"></ui5-toggle-button>
 	<ui5-toggle-button icon="download"></ui5-toggle-button>
 
-	<br/>
-	<br/>
-	<br/>
+	<br />
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Default" icon="employee">Default</ui5-toggle-button>
 	<ui5-toggle-button disabled design="Default" icon="employee">Default</ui5-toggle-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Positive" icon="employee">Agree</ui5-toggle-button>
 	<ui5-toggle-button disabled design="Positive" icon="employee">Agree</ui5-toggle-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Negative" icon="employee">Decline</ui5-toggle-button>
 	<ui5-toggle-button disabled design="Negative" icon="employee">Decline</ui5-toggle-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Transparent" icon="employee">Transparent</ui5-toggle-button>
 	<ui5-toggle-button disabled design="Transparent" icon="employee">Transparent</ui5-toggle-button>
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<ui5-toggle-button design="Emphasized" icon="employee">Emphasized</ui5-toggle-button>
 	<ui5-toggle-button disabled design="Emphasized" icon="employee">Emphasized</ui5-toggle-button>
 
-	<br/>
-	<br/>
+	<br />
+	<br />
 	<ui5-button class="long-button long-button-begin" icon="download">Download</ui5-button>
 	<ui5-button class="long-button" icon="download">Download</ui5-button>
 	<ui5-button class="long-button long-button-end" icon="download">Download</ui5-button>
 
-	<br/>
-	<br/>
+	<br />
+	<br />
 	<ui5-title>Buttons with tooltip</ui5-title>
-	<br/>
+	<br />
 	<ui5-button id="customTooltip" icon="message-information" tooltip="Go home"></ui5-button>
 	<ui5-button icon="accept" tooltip="Accept terms & conditions"></ui5-button>
 	<ui5-button icon="action-settings" tooltip="Go to settings"></ui5-button>
@@ -263,14 +266,15 @@
 	<ui5-button icon="arrow-down" disabled tooltip="Go down"></ui5-button>
 
 
-	<br/>
-	<br/>
+	<br />
+	<br />
 	<ui5-title>Menu Buttons</ui5-title>
-	<br/>
+	<br />
 	<ui5-button id="menuButtonText" end-icon="navigation-down-arrow">Menu Button</ui5-button>
 	<ui5-button id="menuButtonIcon" icon="action-settings" end-icon="navigation-down-arrow"></ui5-button>
 	<ui5-button id="menuButtonTextIcon" icon="action-settings" end-icon="navigation-down-arrow">Menu Button</ui5-button>
-	<ui5-button id="menuButtonIconEnd" end-icon="navigation-down-arrow" tooltip="Menu Button with End Icon only"></ui5-button>
+	<ui5-button id="menuButtonIconEnd" end-icon="navigation-down-arrow"
+		tooltip="Menu Button with End Icon only"></ui5-button>
 
 	<ui5-menu id="menu">
 		<ui5-menu-item text="Item 1"></ui5-menu-item>
@@ -278,8 +282,8 @@
 		<ui5-menu-item text="Item 3"></ui5-menu-item>
 	</ui5-menu>
 
-	<br/>
-	<br/>
+	<br />
+	<br />
 
 	<form>
 		<input value="Native input in a form">
@@ -290,34 +294,38 @@
 
 	<ui5-button id="openDialogButton" design="Emphasized">Show Registration Dialog</ui5-button>
 
-		<ui5-dialog id="registration-dialog" header-text="Register Form">
-			<section class="login-form">
-				<div>
-					<ui5-label for="username" required>Username: </ui5-label>
-					<ui5-input id="username"></ui5-input>
-				</div>
-
-				<div>
-					<ui5-label for="password" required>Password: </ui5-label>
-					<ui5-input id="password" type="Password" value-state="Negative"></ui5-input>
-				</div>
-
-				<div>
-					<ui5-label for="email" type="Email" required>Email: </ui5-label>
-					<ui5-input id="email"></ui5-input>
-				</div>
-
-				<div>
-					<ui5-label for="address">Address: </ui5-label>
-					<ui5-input id="address"></ui5-input>
-				</div>
-			</section>
-
-			<div slot="footer">
-				<div style="flex: 1;"></div>
-				<ui5-button id="closeDialogButton" design="Emphasized">Register</ui5-button>
+	<ui5-dialog id="registration-dialog" header-text="Register Form">
+		<section class="login-form">
+			<div>
+				<ui5-label for="username" required>Username: </ui5-label>
+				<ui5-input id="username"></ui5-input>
 			</div>
-		</ui5-dialog>
+
+			<div>
+				<ui5-label for="password" required>Password: </ui5-label>
+				<ui5-input id="password" type="Password" value-state="Negative"></ui5-input>
+			</div>
+
+			<div>
+				<ui5-label for="email" type="Email" required>Email: </ui5-label>
+				<ui5-input id="email"></ui5-input>
+			</div>
+
+			<div>
+				<ui5-label for="address">Address: </ui5-label>
+				<ui5-input id="address"></ui5-input>
+			</div>
+		</section>
+
+		<div slot="footer">
+			<div style="flex: 1;"></div>
+			<ui5-button id="closeDialogButton" design="Emphasized">Register</ui5-button>
+		</div>
+	</ui5-dialog>
+
+	<a href="#test2">
+		<ui5-button id="btnInLink">Submit </ui5-button>
+	</a>
 	<script>
 		var clickCounter = document.querySelector("#click-counter");
 		var button = document.querySelector("#button1");
@@ -327,7 +335,7 @@
 		var clickCount = 0;
 
 		[button, disabledButton, disabledButtonIconOnly, disabledButtonWithoutIcon].forEach(function (el) {
-			el.addEventListener("click", function(event) {
+			el.addEventListener("click", function (event) {
 				clickCount += 1;
 				clickCounter.value = clickCount;
 			});
@@ -337,7 +345,7 @@
 			expanded: "true"
 		};
 
-		button.addEventListener("click", function(event) {
+		button.addEventListener("click", function (event) {
 			button.accessibilityAttributes = {
 				expanded: button.accessibilityAttributes.expanded === "true" ? "false" : "true"
 			};
@@ -352,11 +360,11 @@
 			controls: dialog.id,
 		}
 
-		dialogOpener.addEventListener("click", function() {
+		dialogOpener.addEventListener("click", function () {
 			dialog.open = true;
 		});
 
-		dialogCloser.addEventListener("click", function() {
+		dialogCloser.addEventListener("click", function () {
 			dialog.open = false;
 		});
 
@@ -365,21 +373,29 @@
 			menu.open = true;
 		}
 
-		menuButtonText.addEventListener("click", function(event) {
+		menuButtonText.addEventListener("click", function (event) {
 			showMenu(event.target);
 		});
 
-		menuButtonIcon.addEventListener("click", function(event) {
+		menuButtonIcon.addEventListener("click", function (event) {
 			showMenu(event.target);
 		});
 
-		menuButtonTextIcon.addEventListener("click", function(event) {
+		menuButtonTextIcon.addEventListener("click", function (event) {
 			showMenu(event.target);
 		});
 
-		menuButtonIconEnd.addEventListener("click", function(event) {
+		menuButtonIconEnd.addEventListener("click", function (event) {
 			showMenu(event.target);
+		});
+
+
+		const btnInLink = document.querySelector('#btnInLink');
+
+		btnInLink.addEventListener("ui5-click", (e) => {
+			e.preventDefault();
 		});
 	</script>
 </body>
+
 </html>


### PR DESCRIPTION
Native click behavior triggered by the `ui5-button` is not suppressed based on the custom event fired by the web component. Although the native `click` event does not propagate, its default behavior still occurs—even when the custom event is prevented.
With this PR, the native behavior is now correctly prevented when the custom event is prevented.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/11653