### PR TITLE
fix(ui5-checkbox): correct the height of the checkbox in compact

### DIFF
--- a/packages/main/src/themes/base/CheckBox-parameters.css
+++ b/packages/main/src/themes/base/CheckBox-parameters.css
@@ -32,7 +32,7 @@
 --_ui5_checkbox_inner_success_border: var(--sapField_BorderWidth) solid var(--sapField_SuccessColor);
 --_ui5_checkbox_inner_readonly_border: 0.125rem solid var(--sapField_ReadOnly_BorderColor);
 --_ui5_checkbox_inner_background: var(--sapField_Background);
---_ui5_checkbox_wrapped_focus_padding: .375rem;
+--_ui5_checkbox_wrapped_focus_padding: .5rem;
 --_ui5_checkbox_wrapped_focus_inset_block: var(--_ui5_checkbox_focus_position);
 --_ui5_checkbox_compact_wrapper_padding: .5rem;
 --_ui5_checkbox_compact_width_height: 2rem;
@@ -50,5 +50,4 @@
 .ui5-content-density-compact,
 .sapUiSizeCompact {
 	--_ui5_checkbox_label_offset: var(--_ui5_checkbox_compact_wrapper_padding);
-
 }


### PR DESCRIPTION
- Change the value of `--_ui5_checkbox_wrapped_focus_padding` to 0.5rem to be compliant with the visual spec.

Fixes: [#11674](https://github.com/SAP/ui5-webcomponents/issues/11674)
