### PR TITLE
chore: update the prompt of create-ui5-element script

### DIFF
--- a/packages/tools/lib/create-new-component/index.js
+++ b/packages/tools/lib/create-new-component/index.js
@@ -75,7 +75,7 @@ const generateFiles = (componentName, tagName, library, packageName) => {
 
 	// Change the color of the output
 	console.warn('\x1b[33m%s\x1b[0m', `
-Now, import the component in src/bundle.esm.ts via: "import ${componentName} from ./${componentName}.js";
+Now, import the component in "src/bundle.esm.ts" via: import "./${componentName}.js";
 And, add it to your HTML: <${tagName}></${tagName}>.`);
 }
 


### PR DESCRIPTION
Update the prompt of the  `create-ui5-element` script
to suggest correct import statement of a new component.