### PR TITLE
fix(ui5-shellbar): correct search visibility toggle

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -498,6 +498,39 @@ describe("Slots", () => {
 			);
 			cy.get("#shellbar").invoke("prop", "showSearchField").should("equal", false);
 		});
+
+		it("Test search field added after delay still works with events", () => {
+			cy.mount(
+				<ShellBar id="shellbar" primaryTitle="Product Title" showNotifications={true}></ShellBar>
+			);
+			
+			cy.get("#shellbar").as("shellbar");
+			
+			// Add search field after a timeout (simulating real-world scenario)
+			cy.get("@shellbar").then(shellbar => {
+				setTimeout(() => {
+					const searchField = document.createElement("ui5-shellbar-search");
+					searchField.setAttribute("slot", "searchField");
+					searchField.setAttribute("id", "delayed-search");
+					shellbar.get(0).appendChild(searchField);
+				}, 100);
+			});
+			
+			// Wait for the search field to be added
+			cy.get("#delayed-search", { timeout: 1000 }).should("exist");
+			
+			// Search should now be visible and collapsed
+			cy.get("#shellbar [slot='searchField']")
+				.should("exist")
+				.should("have.prop", "collapsed", true);
+			
+			// click the searchField to expand it
+			cy.get("#shellbar [slot='searchField']")
+				.click()
+				.should("have.prop", "collapsed", false);
+			// check shellbar's showSearchField property is also updated
+			cy.get("@shellbar").invoke("prop", "showSearchField").should("equal", true);
+		});
 	});
 });
 


### PR DESCRIPTION
This pull request improves the `ShellBar` component by better handling search events and adding support for dynamically rendered search fields.

## Event Handling

- Refactored `onSearchOpen`, `onSearchClose`, and `onSearch` into private methods for clarity.
- Properly bound these methods to ensure reliable behavior.
- Added `_attachSearchFieldListeners` and `_detachSearchFieldListeners` to manage `ui5-open`, `ui5-close`, and `ui5-search` events more cleanly.

## Dynamic Search Support

- Fixed an issue where delayed rendering of the search field would break functionality.
- Events are now attached to the `ShellBar` element instead of directly to the search instance.
- This allows the component to handle events via bubbling, even if the search field is added later.

## Test Coverage

- Added a Cypress test to verify dynamic search behavior and event handling.

## Code Cleanup

- Updated the `IShellBarSelfCollapsibleSearch` interface to extend `UI5Element` for better compatibility.
