### PR TITLE
chore: suggest correct folder on package creation

### DIFF
--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -112,7 +112,7 @@ const generateFilesContent = async (
 	await processFiles(destDir, vars, testSetup);
 
 	console.log("\nPackage successfully created!\nNext steps:\n");
-	console.log(`$ cd ${destDir}`);
+	console.log(`$ cd ${packageBaseName}`);
 
 	try {
 		const userAgent = parser(process.env.npm_config_user_agent);


### PR DESCRIPTION
Now, on package generation the process folder followed by package base name as suggested as folder. With this PR, it is corrected to the package base name.