### PR TITLE
docs(ui5-menu): update endContent documentation

### DIFF
--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -96,7 +96,7 @@ type MenuBeforeCloseEventDetail = { escPressed: boolean };
  *
  * Application developers are responsible for ensuring that interactive elements placed in the `endContent` slot
  * have the correct accessibility behaviour, including their enabled or disabled states.
- * The `ui5-menu` does not manage these aspects when the menu item state changes.
+ * The menu does not manage these aspects when the menu item state changes.
  *
  * ### ES6 Module Import
  *

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -267,7 +267,7 @@ class MenuItem extends ListItem implements IMenuItem {
 	 *
 	 * Application developers are responsible for ensuring that interactive elements placed in the `endContent` slot
 	 * have the correct accessibility behaviour, including their enabled or disabled states.
-	 * The `ui5-menu` does not manage these aspects when the menu item state changes.
+	 * The menu does not manage these aspects when the menu item state changes.
 	 * @public
 	 * @since 2.0.0
 	 */


### PR DESCRIPTION
Updated the documentation for `ui5-menu` and `ui5-menu-item` to clarify that developers are responsible for the `endContent` items' accessibility when the Menu is disabled.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/10439