### PR TITLE
fix(ui5-avatar): remove redundant placeholder variables from horizon themes

### DIFF
--- a/packages/main/src/themes/sap_horizon/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Avatar-parameters.css
@@ -21,7 +21,6 @@
 	--ui5-avatar-accent8: var(--sapAvatar_8_Background);
 	--ui5-avatar-accent9: var(--sapAvatar_9_Background);
 	--ui5-avatar-accent10: var(--sapAvatar_10_Background);
-	--ui5-avatar-placeholder: var(--sapContent_ImagePlaceholderBackground);
 
 	--ui5-avatar-accent1-color: var(--sapAvatar_1_TextColor);
 	--ui5-avatar-accent2-color: var(--sapAvatar_2_TextColor);
@@ -33,7 +32,6 @@
 	--ui5-avatar-accent8-color: var(--sapAvatar_8_TextColor);
 	--ui5-avatar-accent9-color: var(--sapAvatar_9_TextColor);
 	--ui5-avatar-accent10-color:  var(--sapAvatar_10_TextColor);
-	--ui5-avatar-placeholder-color:  var(--sapAvatar_Lite_Background);
 
 	--ui5-avatar-accent1-border-color: var(--sapAvatar_1_BorderColor);
 	--ui5-avatar-accent2-border-color: var(--sapAvatar_2_BorderColor);

--- a/packages/main/src/themes/sap_horizon_dark/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Avatar-parameters.css
@@ -21,7 +21,6 @@
 	--ui5-avatar-accent8: var(--sapAvatar_8_Background);
 	--ui5-avatar-accent9: var(--sapAvatar_9_Background);
 	--ui5-avatar-accent10: var(--sapAvatar_10_Background);
-	--ui5-avatar-placeholder: var(--sapContent_ImagePlaceholderBackground);
 
 	--ui5-avatar-accent1-color: var(--sapAvatar_1_TextColor);
 	--ui5-avatar-accent2-color: var(--sapAvatar_2_TextColor);
@@ -33,7 +32,6 @@
 	--ui5-avatar-accent8-color: var(--sapAvatar_8_TextColor);
 	--ui5-avatar-accent9-color: var(--sapAvatar_9_TextColor);
 	--ui5-avatar-accent10-color:  var(--sapAvatar_10_TextColor);
-	--ui5-avatar-placeholder-color:  var(--sapContent_ImagePlaceholderForegroundColor);
 
 	--ui5-avatar-accent1-border-color: var(--sapAvatar_1_BorderColor);
 	--ui5-avatar-accent2-border-color: var(--sapAvatar_2_BorderColor);

--- a/packages/main/src/themes/sap_horizon_hcb/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Avatar-parameters.css
@@ -22,7 +22,6 @@
 	--ui5-avatar-accent8: var(--sapAvatar_8_Background);
 	--ui5-avatar-accent9: var(--sapAvatar_9_Background);
 	--ui5-avatar-accent10: var(--sapAvatar_10_Background);
-	--ui5-avatar-placeholder: var(--sapContent_ImagePlaceholderBackground);
 
 	--ui5-avatar-accent1-color: var(--sapAvatar_1_TextColor);
 	--ui5-avatar-accent2-color: var(--sapAvatar_2_TextColor);
@@ -34,7 +33,6 @@
 	--ui5-avatar-accent8-color: var(--sapAvatar_8_TextColor);
 	--ui5-avatar-accent9-color: var(--sapAvatar_9_TextColor);
 	--ui5-avatar-accent10-color:  var(--sapAvatar_10_TextColor);
-	--ui5-avatar-placeholder-color:  var(--sapAvatar_Lite_Background);
 
 	--ui5-avatar-accent1-border-color: var(--sapAvatar_1_BorderColor);
 	--ui5-avatar-accent2-border-color: var(--sapAvatar_2_BorderColor);

--- a/packages/main/src/themes/sap_horizon_hcw/Avatar-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Avatar-parameters.css
@@ -22,7 +22,6 @@
 	--ui5-avatar-accent8: var(--sapAvatar_8_Background);
 	--ui5-avatar-accent9: var(--sapAvatar_9_Background);
 	--ui5-avatar-accent10: var(--sapAvatar_10_Background);
-	--ui5-avatar-placeholder: var(--sapContent_ImagePlaceholderBackground);
 
 	--ui5-avatar-accent1-color: var(--sapAvatar_1_TextColor);
 	--ui5-avatar-accent2-color: var(--sapAvatar_2_TextColor);
@@ -34,7 +33,6 @@
 	--ui5-avatar-accent8-color: var(--sapAvatar_8_TextColor);
 	--ui5-avatar-accent9-color: var(--sapAvatar_9_TextColor);
 	--ui5-avatar-accent10-color:  var(--sapAvatar_10_TextColor);
-	--ui5-avatar-placeholder-color:  var(--sapAvatar_Lite_Background);
 
 	--ui5-avatar-accent1-border-color: var(--sapAvatar_1_BorderColor);
 	--ui5-avatar-accent2-border-color: var(--sapAvatar_2_BorderColor);


### PR DESCRIPTION
Remove `--ui5-avatar-placeholder` and `--ui5-avatar-placeholder-color` variables from horizon theme variants as they duplicate the base theme values.

The base Avatar-parameters.css already defines these variables correctly using 
- `--sapContent_ImagePlaceholderBackground`
- `--sapContent_ImagePlaceholderForegroundColor` 

as per design specification.

Fixes: #11750 