### PR TITLE
fix(framework): attach listeners to custom events in JSX templates

### DIFF
--- a/packages/base/src/jsx-utils.ts
+++ b/packages/base/src/jsx-utils.ts
@@ -21,11 +21,8 @@ function convertEventScoping(type: typeof UI5Element, props: Record<string, any>
 			}
 			// Attach for the "ui5-" preffixed event
 			if (origEvent) {
-				if ((prop !== "onClick")) {
-					props[`onui5-${origEvent}`] = props[prop];
-					// TODO keep native events for now, find a way to mark them for runtime
-					delete props[prop];
-				}
+				props[`onui5-${origEvent}`] = props[prop];
+				delete props[prop];
 			}
 		}
 	});

--- a/packages/fiori/src/UploadCollection.ts
+++ b/packages/fiori/src/UploadCollection.ts
@@ -63,17 +63,6 @@ type UploadCollectionItemDeleteEventDetail = {
 	styles: UploadCollectionCss,
 	template: UploadCollectionTemplate,
 })
-/**
- * Fired when an element is dropped inside the drag and drop overlay.
- *
- * **Note:** The `drop` event is fired only when elements are dropped within the drag and drop overlay and ignored for the other parts of the `ui5-upload-collection`.
- * @param {DataTransfer} dataTransfer The `drop` event operation data.
- * @public
- * @native
- */
-// @event("drop", {
-// 	bubbles: true,
-// })
 
 /**
  * Fired when the delete button of any item is pressed.


### PR DESCRIPTION
Use a custom event if it's part of the component's metadata. Avoid exceptions like 'click', which could conflict with the native click event in some cases — for example, with buttons that used to trigger the native click event. Now, the button has been reworked and it triggers a custom event instead.