### PR TITLE
docs: mark `compat/Table` as deprecated

### DIFF
--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -2,13 +2,16 @@
 
 [![npm Package Version](https://badge.fury.io/js/%40ui5%2Fwebcomponents.svg)](https://www.npmjs.com/package/@ui5/webcomponents)
 
-Provides Table web component for compatibility (previously part of the "@ui5/webcomponents" package), while brand new Table web component is being developed and will replace it in the "@ui5/webcomponents" package.
+**DEPRECATED SINCE 2.12.0:** The `@ui5/webcomponents-compat` package has been deprecated as of version `2.12.0`.
+Please use the Table from `@ui5/webcomponents` package instead.
 
-
-**Note:** The package is available since 2.0 and will be available until the next major release (3.0) when it will be removed as the Table "@ui5/webcomponents" will finally replace it.
-
+While `@ui5/webcomponents-compat` will remain available for compatibility purposes (until the next major release),
+migration is strongly recommended, as new development and enhancements will be focused on `@ui5/webcomponents/Table`.
 
 ## Provided components
+
+The package provides Table web component and several subcomopnents as descrived below.
+
 
 | Web Component            | Tag name                    | Module import                                              |
 |--------------------------|-----------------------------|------------------------------------------------------------|

--- a/packages/compat/src/Table.ts
+++ b/packages/compat/src/Table.ts
@@ -168,6 +168,7 @@ enum TableFocusTargetElement {
  * @constructor
  * @extends UI5Element
  * @public
+ * @deprecated since 2.12.0, use `@ui5/webcomponents/dist/Table.js` instead
  */
 @customElement({
 	tag: "ui5-table",

--- a/packages/compat/src/TableCell.ts
+++ b/packages/compat/src/TableCell.ts
@@ -25,6 +25,7 @@ import {
  * @extends UI5Element
  * @public
  * @csspart cell - Used to style the native `td` element
+ * @deprecated since 2.12.0, use `@ui5/webcomponents/dist/TableCell.js` instead
  */
 @customElement({
 	tag: "ui5-table-cell",

--- a/packages/compat/src/TableRow.ts
+++ b/packages/compat/src/TableRow.ts
@@ -62,6 +62,7 @@ type TableRowF7PressEventDetail = {
  * @public
  * @csspart row - Used to style the native `tr` element
  * @csspart popin-row - Used to style the `tr` element when a row pops in
+ * @deprecated since 2.12.0, use `@ui5/webcomponents/dist/TableRow.js` instead
  */
 @customElement({
 	tag: "ui5-table-row",

--- a/packages/website/docs/_components_pages/compat/Table/Table.mdx
+++ b/packages/website/docs/_components_pages/compat/Table/Table.mdx
@@ -14,10 +14,10 @@ import MultipleSelection from "../../../_samples/compat/Table/MultipleSelection/
 import StickyHeader from "../../../_samples/compat/Table/StickyHeader/StickyHeader.md";
 
 :::info
-The **@ui5/webcomponents-compat** package is introduced since 2.0 and includes the Table web component
-that was previously part of the main **@ui5/webcomponents** package in version 1.x.
-It has been replaced by brand new Table web component implementation, availabe since 2.0 in **@ui5/webcomponents** package.
-The current one, in **@ui5/webcomponents-compat**, is kept for compatibility.
+The **@ui5/webcomponents-compat/Table** web component has been deprecated as of version 2.12.0.
+Please use the **@ui5/webcomponents/Table** instead.
+While **@ui5/webcomponents-compat/Table** will remain available for compatibility purposes,
+migration is strongly recommended, as new development and enhancements will be focused on **@ui5/webcomponents/Table**.
 :::
 
 <%COMPONENT_OVERVIEW%>


### PR DESCRIPTION
The `@ui5/webcomponents-compat` package has been deprecated as of version `2.12.0`.
Please use the Table from `@ui5/webcomponents` package instead.

While `@ui5/webcomponents-compat` will remain available for compatibility purposes (until the next major release),
migration is strongly recommended, as new development and enhancements will be focused on `@ui5/webcomponents/Table`.