### PR TITLE
fix(ui5-shellbar): button styles for compact aligned

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -17,8 +17,8 @@
 	--_ui5_input_margin_top_bottom: 0;
 	box-shadow: inset 0 -0.0625rem 0 0 var(--sapPageHeader_BorderColor);
 	/* Overwrite the default button styles to fulfill no "compact" mode of ui5-shellbar */
-	--_ui5_button_base_padding: 0.6875rem;
-	--_ui5_button_base_min_width: 2rem;
+	--_ui5_button_base_min_width: 2.25rem;
+	--_ui5_button_base_padding: 0.5625rem;
 	--_ui5_button_base_height: var(--sapElement_Height);
 	--_ui5-button-badge-diameter: 0.75rem;
 }


### PR DESCRIPTION
This PR fixes the button styles in the ui5-shellbar for fulfilling UX recommendation to be aligned in both cozy and compact mode.

Added custom CSS variable values to overwrite default button styles for a non-compact ui5-shellbar.
Updated the button badge diameter.