### PR TITLE
fix(ui5-flexible-column-layout): prevent layout issue

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -78,6 +78,44 @@ describe("Columns resize", () => {
 				expect($el).to.have.class("ui5-fcl-column--hidden");
 			});
 	});
+
+	it("keeps hidden class on columns after rerendering", () => {
+		// Get a reference to the FCL first
+		cy.get("[ui5-flexible-column-layout]")
+			.as("fcl");
+		
+		// Verify initial state
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.class", "ui5-fcl-column--hidden");
+
+		// Change animation mode to "full"
+		cy.wrap({ setAnimationMode })
+			.invoke("setAnimationMode", AnimationMode.Full);
+
+		// Verify the end column has the animation class after changing animation mode
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.class", "ui5-fcl-column-animation");
+
+		// Verify the end column still has the hidden class after rerendering
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.class", "ui5-fcl-column--hidden");
+
+		// Change height by 10px
+		cy.get("@fcl")
+			.invoke("css", "height", "310px");
+
+		// Verify the end column still has the hidden class after height change
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.class", "ui5-fcl-column--hidden");
+	});
 });
 
 describe("ACC", () => {

--- a/packages/fiori/src/FlexibleColumnLayout.ts
+++ b/packages/fiori/src/FlexibleColumnLayout.ts
@@ -1164,6 +1164,18 @@ class FlexibleColumnLayout extends UI5Element {
 		return this.shadowRoot!.querySelector<HTMLElement>(".ui5-fcl-column--end")!;
 	}
 
+	get isStartColumnCollapsing() {
+		return this.startColumnDOM?.classList.contains("ui5-fcl-column-collapse-animation");
+	}
+
+	get isMidColumnCollapsing() {
+		return this.midColumnDOM?.classList.contains("ui5-fcl-column-collapse-animation");
+	}
+
+	get isEndColumnCollapsing() {
+		return this.endColumnDOM?.classList.contains("ui5-fcl-column-collapse-animation");
+	}
+
 	get accStartColumnText() {
 		return this.accessibilityAttributes.startColumn?.name || FlexibleColumnLayout.i18nBundle.getText(FCL_START_COLUMN_TXT);
 	}

--- a/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
+++ b/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
@@ -18,6 +18,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 					"ui5-fcl-column": true,
 					"ui5-fcl-column-animation": hasAnimation,
 					"ui5-fcl-column--start": true,
+					"ui5-fcl-column--hidden": !this.startColumnVisible && !this.isStartColumnCollapsing,
 				}}
 				aria-hidden={this._accAttributes.columns.start.ariaHidden}
 				aria-labelledby={`${this._id}-startColumnText`}
@@ -48,6 +49,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 					"ui5-fcl-column": true,
 					"ui5-fcl-column-animation": hasAnimation,
 					"ui5-fcl-column--middle": true,
+					"ui5-fcl-column--hidden": !this.midColumnVisible && !this.isMidColumnCollapsing,
 				}}
 				aria-hidden={this._accAttributes.columns.middle.ariaHidden}
 				aria-labelledby={`${this._id}-midColumnText`}
@@ -77,6 +79,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 					"ui5-fcl-column": true,
 					"ui5-fcl-column-animation": hasAnimation,
 					"ui5-fcl-column--end": true,
+					"ui5-fcl-column--hidden": !this.endColumnVisible && !this.isEndColumnCollapsing,
 				}}
 				aria-hidden={this._accAttributes.columns.end.ariaHidden}
 				aria-labelledby={`${this._id}-endColumnText`}


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-webcomponents/issues/11694

Problem:
1) The CSS class "ui5-fcl-column--hidden" used to be added only from the FlexibleColumnLayout.ts (i.e. **after** rendering the component) and never from the template itself (i.e. never during rendering).
2) This was required to ensure that the "ui5-fcl-column--hidden" class is added only **after** the collapse animation has ended (to prevent premature collapse)
3) However, since the "ui5-fcl-column--hidden" class is never added from the template itself, it is lost on each re-rendering
=> the issue https://github.com/SAP/ui5-webcomponents/issues/11694 showed a use-case where the component is rerendered (=> the "ui5-fcl-column--hidden" class is lost) but the logic to add it back (from FlexibleColumnLayout.ts) is skipped as the `updateLayout` function was skipped because no changes to the layout were made neither on app-side not by user-interaction

Solution:
Fixed by ensuring that the "ui5-fcl-column--hidden" class is added from the template itself is all cases except when collapse animation in progress (to satisfy the case described in point 2 above)