### PR TITLE
fix(ui5-list): prevent toggle event bubbling from non-list items

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1275,6 +1275,10 @@ class List extends UI5Element {
 	}
 
 	onItemToggle(e: CustomEvent<ListItemToggleEventDetail>) {
+		if (!(e.target as any)?.isListItemBase) {
+			return;
+		}
+
 		this.fireDecoratorEvent("item-toggle", { item: e.detail.item });
 	}
 

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -248,6 +248,10 @@ class ListItemBase extends UI5Element implements ITabbable {
 		}
 		return this.forcedTabIndex ? parseInt(this.forcedTabIndex) : undefined;
 	}
+
+	get isListItemBase() {
+		return true;
+	}
 }
 
 export default ListItemBase;


### PR DESCRIPTION
- Add duck-typing check in onItemToggle using isListItemBase getter
- Prevents unwanted toggle events from nested components like panels

Fixes #11812 