### PR TITLE
feat(ui5-menu): improve accessibility

### DIFF
--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -146,11 +146,11 @@ class ListItemBase extends UI5Element implements ITabbable {
 			return;
 		}
 
-		if (isSpace(e)) {
+		if (this._isSpace(e)) {
 			e.preventDefault();
 		}
 
-		if (isEnter(e)) {
+		if (this._isEnter(e)) {
 			this.fireItemPress(e);
 		}
 	}
@@ -159,7 +159,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 		if (this.getFocusDomRef()!.matches(":has(:focus-within)")) {
 			return;
 		}
-		if (isSpace(e)) {
+		if (this._isSpace(e)) {
 			this.fireItemPress(e);
 		}
 	}
@@ -169,6 +169,20 @@ class ListItemBase extends UI5Element implements ITabbable {
 			return;
 		}
 		this.fireItemPress(e);
+	}
+
+	/**
+	 * Override from subcomponent, if needed
+	 */
+	_isSpace(e: KeyboardEvent) {
+		return isSpace(e);
+	}
+
+	/**
+	 * Override from subcomponent, if needed
+	 */
+	_isEnter(e: KeyboardEvent) {
+		return isEnter(e);
 	}
 
 	fireItemPress(e: Event) {

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -7,11 +7,8 @@ import {
 	isLeft,
 	isRight,
 	isEnter,
-	isSpace,
 	isTabNext,
 	isTabPrevious,
-	isDown,
-	isUp,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import {
 	isPhone,
@@ -415,7 +412,7 @@ class Menu extends UI5Element {
 
 			if (!prevented) {
 				item._updateCheckedState();
-				this._popover && item.fireDecoratorEvent("close-menu");
+				this._popover && !item._shiftPressed && item.fireDecoratorEvent("close-menu");
 			}
 		} else {
 			this._openItemSubMenu(item);
@@ -430,12 +427,8 @@ class Menu extends UI5Element {
 			return;
 		}
 
-		const menuItemInMenu = this._allMenuItems.includes(item);
-		const isItemNavigation = isUp(e) || isDown(e);
-		const isItemSelection = isEnter(e) || isSpace(e);
 		const isEndContentNavigation = isRight(e) || isLeft(e);
 		const shouldOpenMenu = this.isRtl ? isLeft(e) : isRight(e);
-		const shouldCloseMenu = menuItemInMenu && !(isItemNavigation || isItemSelection || isEndContentNavigation);
 
 		if (isEnter(e) || isTabNextPrevious) {
 			e.preventDefault();
@@ -447,7 +440,7 @@ class Menu extends UI5Element {
 
 		if (shouldOpenMenu) {
 			this._openItemSubMenu(item);
-		} else if ((shouldCloseMenu || isTabNextPrevious)) {
+		} else if (isTabNextPrevious) {
 			this._close();
 		}
 	}

--- a/packages/main/src/MenuItemGroup.ts
+++ b/packages/main/src/MenuItemGroup.ts
@@ -2,12 +2,19 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
+import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type MenuItem from "./MenuItem.js";
 import { isInstanceOfMenuItem } from "./MenuItem.js";
 import MenuItemGroupTemplate from "./MenuItemGroupTemplate.js";
 import MenuItemGroupCheckMode from "./types/MenuItemGroupCheckMode.js";
 import type { IMenuItem } from "./Menu.js";
+import {
+	MENU_ITEM_GROUP_NONE_ACCESSIBLE_NAME,
+	MENU_ITEM_GROUP_SINGLE_ACCESSIBLE_NAME,
+	MENU_ITEM_GROUP_MULTI_ACCESSIBLE_NAME,
+} from "./generated/i18n/i18n-defaults.js";
 
 /**
  * @class
@@ -61,6 +68,22 @@ class MenuItemGroup extends UI5Element implements IMenuItem {
 	 */
 	@slot({ "default": true, type: HTMLElement, invalidateOnChildChange: true })
 	items!: Array<IMenuItem>;
+
+	@i18n("@ui5/webcomponents")
+	static i18nBundle: I18nBundle;
+
+	get ariaLabelText(): string | undefined {
+		switch (this.checkMode) {
+		case MenuItemGroupCheckMode.None:
+			return MenuItemGroup.i18nBundle.getText(MENU_ITEM_GROUP_NONE_ACCESSIBLE_NAME);
+		case MenuItemGroupCheckMode.Single:
+			return MenuItemGroup.i18nBundle.getText(MENU_ITEM_GROUP_SINGLE_ACCESSIBLE_NAME);
+		case MenuItemGroupCheckMode.Multiple:
+			return MenuItemGroup.i18nBundle.getText(MENU_ITEM_GROUP_MULTI_ACCESSIBLE_NAME);
+		default:
+			return undefined;
+		}
+	}
 
 	get isGroup(): boolean {
 		return true;

--- a/packages/main/src/MenuItemGroupTemplate.tsx
+++ b/packages/main/src/MenuItemGroupTemplate.tsx
@@ -4,6 +4,7 @@ export default function MenuItemGroupTemplate(this: MenuItemGroup) {
 	return (
 		<div
 			role="group"
+			aria-label={this.ariaLabelText}
 			onui5-check={this._handleItemCheck}
 		>
 			<slot></slot>

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -615,6 +615,15 @@ MENU_CLOSE_BUTTON_ARIA_LABEL=Decline
 #XACT: ARIA information for the Menu popover
 MENU_POPOVER_ACCESSIBLE_NAME=Select an option from the menu
 
+#XACT: ARIA information for the Menu Item Group with itemSelectionMode "None"
+MENU_ITEM_GROUP_NONE_ACCESSIBLE_NAME=Contains Non-Selectable Items
+
+#XACT: ARIA information for the Menu Item Group with itemSelectionMode "SingleSelect"
+MENU_ITEM_GROUP_SINGLE_ACCESSIBLE_NAME=Contains Selectable Items
+
+#XACT: ARIA information for the Menu Item Group with itemSelectionMode "MultiSelect"
+MENU_ITEM_GROUP_MULTI_ACCESSIBLE_NAME=Contains Multi-Selectable Items
+
 #XACT: ARIA announcement for roldesecription attribute of Dialog header
 DIALOG_HEADER_ARIA_ROLE_DESCRIPTION=Interactive Header
 

--- a/packages/main/src/themes/MenuItem.css
+++ b/packages/main/src/themes/MenuItem.css
@@ -49,10 +49,6 @@
 	background-color: var(--sapList_Hover_Background);
 }
 
-:host(:not([is-phone]))::part(native-li) {
-	padding: var(--_ui5_menu_item_padding);
-}
-
 :host::part(additional-text) {
 	margin: unset;
 	margin-inline-start: 1rem;
@@ -84,6 +80,7 @@
 }
 
 :host(:not([is-phone]))::part(native-li) {
+	user-select: none;
 	padding: var(--_ui5_menu_item_padding);
 }
 


### PR DESCRIPTION
This PR introduces the following accessibility improvements in `ui5-menu` component:

* Adds aria-label attributes on menu item group wrappers, which already have role="group". The labels are according to group `checkMode` property.

* Adds possibility to check/uncheck menu items in groups with `Single` or `Multiple` value for `checkMode` property. This is achieved by holding `Shift` key pressed while selecting the menu items in these groups (no matter with mouse, or keyboard). Selecting menu items that don't belong to any group, or items inside the groups with `checkMode` property set to `None` always close the menu regardless of whether `Shift` is pressed or not.