### PR TITLE
fix(ui5-tokenizer): sync popover list items with token text changes

### DIFF
--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -348,7 +348,6 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 
 		cy.get("@lastToken").should("be.visible");
 		cy.get("@lastToken").should("not.be.focused");
-
 	});
 
 	it("should navigate from last token back to input with arrow left in RTL mode", () => {
@@ -410,11 +409,7 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.as("lastToken");
-
-		cy.get("@lastToken").should("be.visible");
-		cy.get("@lastToken").should("be.focused");
-		cy.get("@lastToken").realPress("ArrowRight");
+			.realPress("ArrowRight");
 		
 		cy.get("@mcb").should("be.visible");
 		cy.get("@mcb").should("be.focused");

--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -219,8 +219,10 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.should("be.visible")
-			.should("be.focused");
+			.as ("lastToken");
+		
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("be.focused");
 		});
 
 	it("should focus last token on arrow left in LTR mode when input is at start", () => {
@@ -263,8 +265,10 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.should("be.visible")
-			.should("be.focused");
+			.as ("lastToken");
+		
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("be.focused");
 	});
 
 	it("should not focus token when cursor is not at start of input in RTL mode", () => {
@@ -283,7 +287,6 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.realClick();
 
 		cy.get("@mcb").should("be.focused");
-		
 
 		cy.get("@mcb")
 			.shadow()
@@ -299,21 +302,12 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 
 		cy.get("@mcb")
 			.shadow()
-			.find("input")
-			.as("input")
-			.realClick();
-
-		cy.get("@input")
-			.should("be.focused")
-			.should(($input) => {
-				expect(($input[0] as HTMLInputElement).selectionStart).to.equal(3);
-			});
-
-		cy.get("@mcb")
-			.shadow()
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
-			.should("not.be.focused");
+			.as ("lastToken");
+
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("not.be.focused");
 	});
 
 	it("should not focus token when text is selected in RTL mode", () => {
@@ -350,7 +344,11 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.shadow()
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
-			.should("not.have.focus");
+			.as ("lastToken");
+
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("not.be.focused");
+
 	});
 
 	it("should navigate from last token back to input with arrow left in RTL mode", () => {
@@ -378,17 +376,13 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.as("lastToken")
-			.should("have.focus");
+			.as("lastToken");
 
-		cy.get("@lastToken")
-			.should("be.focused")
-			.realPress("ArrowLeft");
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("be.focused");
+		cy.get("@lastToken").realPress("ArrowLeft");
 
-		cy.get("@mcb")
-			.shadow()
-			.find("input")
-			.should("be.focused");
+		cy.get("@mcb").should("be.focused");
 	});
 
 	it("should navigate from last token back to input with arrow right in LTR mode", () => {
@@ -416,15 +410,14 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.as("lastToken")
-			.should("be.focused");
+			.as("lastToken");
 
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("be.focused");
 		cy.get("@lastToken").realPress("ArrowRight");
 		
-		cy.get("@mcb")
-			.shadow()
-			.find("input")
-			.should("be.focused");
+		cy.get("@mcb").should("be.visible");
+		cy.get("@mcb").should("be.focused");
 	});
 
 	it("should handle empty input case in RTL mode", () => {
@@ -464,7 +457,11 @@ describe("MultiComboBox RTL/LTR Arrow Navigation", () => {
 			.find("[ui5-tokenizer]")
 			.find("[ui5-token]")
 			.last()
-			.should("have.focus");
+			.as("lastToken");
+
+		cy.get("@lastToken").should("be.visible");
+		cy.get("@lastToken").should("be.focused");
+			
 	});
 });
 

--- a/packages/main/cypress/specs/Tokenizer.cy.tsx
+++ b/packages/main/cypress/specs/Tokenizer.cy.tsx
@@ -222,28 +222,25 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			</Tokenizer>
 		);
 
-		cy.get("#test-token-text-update")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find(".ui5-tokenizer-more-text")
 			.realClick();
 
-		cy.get("#test-token-text-update")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover]")
 			.should("be.visible");
 
-		cy.get("#test-token-text-update")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
 			.should("have.attr", "text", "Original Text");
 
-		cy.get("#token-to-modify").then($token => {
-			const token = $token.get(0) as Token;
-			token.text = "Updated Text";
-		});
+		cy.get("#token-to-modify").invoke("prop", "text", "Updated Text");
 
-		cy.get("#test-token-text-update")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
@@ -267,47 +264,47 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			</Tokenizer>
 		);
 
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find(".ui5-tokenizer-more-text")
 			.realClick();
 
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
 			.should("have.attr", "text", "Token 1");
 
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(1)
 			.should("have.attr", "text", "Token 2");
 
-		cy.get("#token-1").then($token => {
+		cy.get<Token>("[ui5-token]").then($token => {
 			const token = $token.get(0) as Token;
 			token.text = "Modified Token 1";
 		});
 
-		cy.get("#token-2").then($token => {
+		cy.get<Token>("[ui5-token]").then($token => {
 			const token = $token.get(0) as Token;
 			token.text = "Modified Token 2";
 		});
 
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
 			.should("have.attr", "text", "Modified Token 1");
 
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(1)
 			.should("have.attr", "text", "Modified Token 2");
 
 		// Verify unchanged token remains the same
-		cy.get("#test-multiple-token-updates")
+		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(2)

--- a/packages/main/cypress/specs/Tokenizer.cy.tsx
+++ b/packages/main/cypress/specs/Tokenizer.cy.tsx
@@ -281,15 +281,8 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			.eq(1)
 			.should("have.attr", "text", "Token 2");
 
-		cy.get<Token>("[ui5-token]").then($token => {
-			const token = $token.get(0) as Token;
-			token.text = "Modified Token 1";
-		});
-
-		cy.get<Token>("[ui5-token]").then($token => {
-			const token = $token.get(0) as Token;
-			token.text = "Modified Token 2";
-		});
+		cy.get<Token>("[ui5-token]").eq(0).invoke("prop", "text", "Modified Token 1");
+		cy.get<Token>("[ui5-token]").eq(1).invoke("prop", "text", "Modified Token 2");
 
 		cy.get<Tokenizer>("[ui5-tokenizer]")
 			.shadow()

--- a/packages/main/cypress/specs/Tokenizer.cy.tsx
+++ b/packages/main/cypress/specs/Tokenizer.cy.tsx
@@ -208,3 +208,109 @@ describe("Tokenizer - multi-line and Clear All", () => {
 	});
 });
 
+describe("Tokenizer - Popover List Item Text Updates", () => {
+	it("updates list item text in popover when token text changes", () => {
+		cy.mount(
+			<Tokenizer id="test-token-text-update" style={{ width: "100px" }}>
+				<Token text="Original Text" id="token-to-modify"></Token>
+				<Token text="Bulgaria"></Token>
+				<Token text="Canada"></Token>
+				<Token text="Denmark"></Token>
+				<Token text="Estonia"></Token>
+				<Token text="Finland"></Token>
+				<Token text="Germany"></Token>
+			</Tokenizer>
+		);
+
+		cy.get("#test-token-text-update")
+			.shadow()
+			.find(".ui5-tokenizer-more-text")
+			.realClick();
+
+		cy.get("#test-token-text-update")
+			.shadow()
+			.find("[ui5-responsive-popover]")
+			.should("be.visible");
+
+		cy.get("#test-token-text-update")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.should("contain.text", "Original Text");
+
+		cy.get("#token-to-modify").then($token => {
+			const token = $token.get(0) as Token;
+			token.text = "Updated Text";
+		});
+
+		cy.get("#test-token-text-update")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.should("contain.text", "Updated Text");
+
+		cy.get("#test-token-text-update")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.should("not.contain.text", "Original Text");
+	});
+
+	it("updates multiple list items when multiple token texts change", () => {
+		cy.mount(
+			<Tokenizer id="test-multiple-token-updates" style={{ width: "100px" }}>
+				<Token text="Token 1" id="token-1"></Token>
+				<Token text="Token 2" id="token-2"></Token>
+				<Token text="Token 3" id="token-3"></Token>
+				<Token text="Denmark"></Token>
+				<Token text="Estonia"></Token>
+			</Tokenizer>
+		);
+
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find(".ui5-tokenizer-more-text")
+			.realClick();
+
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.should("contain.text", "Token 1");
+
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(1)
+			.should("contain.text", "Token 2");
+
+		cy.get("#token-1").then($token => {
+			const token = $token.get(0) as Token;
+			token.text = "Modified Token 1";
+		});
+
+		cy.get("#token-2").then($token => {
+			const token = $token.get(0) as Token;
+			token.text = "Modified Token 2";
+		});
+
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(0)
+			.should("contain.text", "Modified Token 1");
+
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(1)
+			.should("contain.text", "Modified Token 2");
+
+		// Verify unchanged token remains the same
+		cy.get("#test-multiple-token-updates")
+			.shadow()
+			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
+			.eq(2)
+			.should("contain.text", "Token 3");
+	});
+});

--- a/packages/main/cypress/specs/Tokenizer.cy.tsx
+++ b/packages/main/cypress/specs/Tokenizer.cy.tsx
@@ -236,7 +236,7 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
-			.should("contain.text", "Original Text");
+			.should("have.attr", "text", "Original Text");
 
 		cy.get("#token-to-modify").then($token => {
 			const token = $token.get(0) as Token;
@@ -247,13 +247,13 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
-			.should("contain.text", "Updated Text");
+			.should("have.attr", "text", "Updated Text");
 
 		cy.get("#test-token-text-update")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
-			.should("not.contain.text", "Original Text");
+			.should("not.have.attr", "text", "Original Text");
 	});
 
 	it("updates multiple list items when multiple token texts change", () => {
@@ -276,13 +276,13 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
-			.should("contain.text", "Token 1");
+			.should("have.attr", "text", "Token 1");
 
 		cy.get("#test-multiple-token-updates")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(1)
-			.should("contain.text", "Token 2");
+			.should("have.attr", "text", "Token 2");
 
 		cy.get("#token-1").then($token => {
 			const token = $token.get(0) as Token;
@@ -298,19 +298,19 @@ describe("Tokenizer - Popover List Item Text Updates", () => {
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(0)
-			.should("contain.text", "Modified Token 1");
+			.should("have.attr", "text", "Modified Token 1");
 
 		cy.get("#test-multiple-token-updates")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(1)
-			.should("contain.text", "Modified Token 2");
+			.should("have.attr", "text", "Modified Token 2");
 
 		// Verify unchanged token remains the same
 		cy.get("#test-multiple-token-updates")
 			.shadow()
 			.find("[ui5-responsive-popover] [ui5-list] [ui5-li]")
 			.eq(2)
-			.should("contain.text", "Token 3");
+			.should("have.attr", "text", "Token 3");
 	});
 });

--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -333,6 +333,10 @@ class Tokenizer extends UI5Element {
 		type: HTMLElement,
 		"default": true,
 		individualSlots: true,
+		invalidateOnChildChange: {
+			properties: ["text"],
+			slots: false,
+		},
 	})
 	tokens!: Array<Token>;
 

--- a/packages/main/src/TokenizerPopoverTemplate.tsx
+++ b/packages/main/src/TokenizerPopoverTemplate.tsx
@@ -42,7 +42,7 @@ export default function TokenizerPopoverTemplate(this: Tokenizer) {
 				onItemDelete={this.itemDelete}
 			>
 				{this._tokens
-					.map(token => <ListItemStandard key={String(token._id)} data-ui5-token-ref-id={token._id} wrappingType="Normal">{token.text}</ListItemStandard>)}
+					.map(token => <ListItemStandard key={String(token._id)} data-ui5-token-ref-id={token._id} wrappingType="Normal" text={token.text}></ListItemStandard>)}
 			</List>
 
 			{this._isPhone &&


### PR DESCRIPTION
- The token's text now is bound to the text property of the `ListItemStandard` element and not rendered as its default slot, because after  #11108 dynamic updates in it doesn't get reflected (do not cause re-rendering of the list item).

Note: The problem in the ListItemStandard occurs only with `wrappingType` set to `Normal` because it uses the` ui5-expandable-text` component. That component has its own `text `property which is getting updated when the `text `property of the `ListItemStandart `is updated, but not when its slot is.

- Add `invalidateOnChildChange `config to tokens slot to watch for text property changes to ensure popover list items automatically update when token text is modified

fixes: #11825