### PR TITLE
refactor(ui5-list, ui5-tree): extract drag-and-drop logic into reusable mixin

### DIFF
--- a/packages/base/src/util/dragAndDrop/DragAndDropMixin.ts
+++ b/packages/base/src/util/dragAndDrop/DragAndDropMixin.ts
@@ -1,5 +1,5 @@
 import type UI5Element from "../../UI5Element.js";
-import type MovePlacement from "../../types/MovePlacement.js";
+import MovePlacement from "../../types/MovePlacement.js";
 import Orientation from "../../types/Orientation.js";
 import type { DragAndDropSettings } from "./DragRegistry.js";
 import DragRegistry from "./DragRegistry.js";
@@ -10,8 +10,8 @@ import { findClosestPosition } from "./findClosestPosition.js";
 type DragAndDropCallbacks = {
 	getItemsForDragDrop: () => Array<HTMLElement>;
 	getOrientation: () => Orientation;
-	getDropIndicator: () => { targetReference: HTMLElement | null; placement: any } | null;
-	setDropIndicator: (targetReference: HTMLElement | null, placement?: any) => void;
+	getDropIndicator: () => { targetReference: HTMLElement | null; placement: MovePlacement } | null;
+	setDropIndicator: (targetReference: HTMLElement | null, placement?: MovePlacement) => void;
 	shouldContainsDraggedElement?: (draggedElement: HTMLElement, targetElement: HTMLElement) => boolean;
 	getDragAndDropSettings?: () => DragAndDropSettings;
 	getTargetFromPosition?: (element: HTMLElement) => HTMLElement;
@@ -75,13 +75,13 @@ function createDragAndDropMixin<T extends UI5Element>(callbacks: DragAndDropCall
 
 			// Filter out "On" placement if dropping on the dragged element itself
 			if (closestPosition.element === draggedElement) {
-				closestPosition.placements = closestPosition.placements.filter(placement => placement !== "On" as MovePlacement);
+				closestPosition.placements = closestPosition.placements.filter(placement => placement !== MovePlacement.On);
 			}
 
 			const settings = callbacks.getDragAndDropSettings?.() || {};
 			const { targetReference, placement } = handleDragOver(e, this, closestPosition, closestPosition.element, settings);
 
-			callbacks.setDropIndicator(targetReference, placement);
+			callbacks.setDropIndicator(targetReference, placement as MovePlacement);
 		},
 
 		_ondrop(this: T, e: DragEvent) {

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -25,6 +25,7 @@ import {
 import Orientation from "@ui5/webcomponents-base/dist/types/Orientation.js";
 import DragRegistry from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
 import type { MoveEventDetail } from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragRegistry.js";
+import type MovePlacement from "@ui5/webcomponents-base/dist/types/MovePlacement.js";
 import createDragAndDropMixin from "@ui5/webcomponents-base/dist/util/dragAndDrop/DragAndDropMixin.js";
 import { findClosestPositionsByKey } from "@ui5/webcomponents-base/dist/util/dragAndDrop/findClosestPosition.js";
 import NavigationMode from "@ui5/webcomponents-base/dist/types/NavigationMode.js";
@@ -557,7 +558,7 @@ class List extends UI5Element {
 			getOrientation: () => Orientation.Vertical,
 			getDropIndicator: () => (this.dropIndicatorDOM ? {
 				targetReference: this.dropIndicatorDOM.targetReference,
-				placement: this.dropIndicatorDOM.placement,
+				placement: this.dropIndicatorDOM.placement as MovePlacement,
 			} : null),
 			setDropIndicator: (targetReference: HTMLElement | null, placement?: any) => {
 				if (this.dropIndicatorDOM) {

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -333,7 +333,7 @@ class Tree extends UI5Element {
 			getOrientation: () => Orientation.Vertical,
 			getDropIndicator: () => (this.dropIndicatorDOM ? {
 				targetReference: this.dropIndicatorDOM.targetReference,
-				placement: this.dropIndicatorDOM.placement,
+				placement: this.dropIndicatorDOM.placement as MovePlacement,
 			} : null),
 			setDropIndicator: (targetReference: HTMLElement | null, placement?: any) => {
 				if (this.dropIndicatorDOM) {


### PR DESCRIPTION
# Refactor: Extract drag-and-drop logic into reusable mixin

## Summary
Eliminates code duplication between List and Tree components by extracting common drag-and-drop functionality into a reusable mixin pattern.

## Changes
- Created `DragAndDropMixin.ts` with configurable callbacks
- Unified initialization patterns in both List and Tree constructors
- Added proper memory cleanup mechanisms
- Reduced codebase of duplicated code

## Benefits
- Single source of truth for drag-and-drop logic
- Easier maintenance and bug fixes
- Consistent behavior across components
- Simplified addition of drag-and-drop to future components

## Testing
- All existing functionality preserved
- Both test pages (ListDragAndDrop.html, TreeDragAndDrop.html) work unchanged
- Zero breaking changes to public APIs

Fixes #11120