### PR TITLE
fix(ui5-split-button): adjust labelledby reference

### DIFF
--- a/packages/main/src/SplitButtonTemplate.tsx
+++ b/packages/main/src/SplitButtonTemplate.tsx
@@ -8,7 +8,7 @@ export default function SplitButtonTemplate(this: SplitButton) {
 			role={this._hideArrowButton ? "button" : "group"}
 			class="ui5-split-button-root"
 			tabindex={this._tabIndex}
-			aria-labelledby={`${this._id}-invisibleTextDefault ${this._id}}-invisibleText`}
+			aria-labelledby={`${this._id}-invisibleTextDefault ${this._id}-invisibleText`}
 			onFocusOut={this._onFocusOut}
 			onKeyDown={this._onKeyDown}
 			onKeyUp={this._onKeyUp}


### PR DESCRIPTION
Issue:
- The invisible label containing the accessible role and other screen reader announcements
is not properly linked to the focusable button element.

Fixes: #11893