### PR TITLE
fix(ui5-side-navigation): ensure correct popover position when hovering the "arrow right" icon on subitems

### DIFF
--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -72,8 +72,8 @@ class NavigationMenu extends Menu {
 			// respect mouseover only on desktop
 			opener = e.target as OpenerStandardListItem;
 
-			// If the opener is a <ui5-icon> inside a Navigation item, we need to get the Navigation Item
-			if (opener.tagName === "UI5-ICON" && opener.parentElement) {
+			// If the opener is a ui5-icon inside a Navigation item, we need to get the Navigation Item
+			if (opener?.hasAttribute("ui5-icon") && opener.parentElement) {
 				opener = opener.parentElement;
 			}
 
@@ -87,8 +87,15 @@ class NavigationMenu extends Menu {
 				}
 			}
 
+			// The opener should be the navigation list item, not the anchor inside it
+			if (opener?.hasAttribute("target")) {
+				opener = opener.parentElement;
+			}
+
 			// Opens submenu with 300ms delay
-			this._startOpenTimeout(item, opener);
+			if (item && opener) {
+				this._startOpenTimeout(item, opener);
+			}
 		}
 	}
 

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -72,7 +72,7 @@ class NavigationMenu extends Menu {
 			// respect mouseover only on desktop
 			opener = e.target as OpenerStandardListItem;
 
-			// If the opener is a <ui5-icon> inside a StandardListItem, we need to get the parent StandardListItem
+			// If the opener is a <ui5-icon> inside a Navigation item, we need to get the parent Navigation Item
 			if (opener.tagName === "UI5-ICON" && opener.parentElement) {
 				opener = opener.parentElement;
 			}

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -72,7 +72,7 @@ class NavigationMenu extends Menu {
 			// respect mouseover only on desktop
 			opener = e.target as OpenerStandardListItem;
 
-			// If the opener is a <ui5-icon> inside a Navigation item, we need to get the parent Navigation Item
+			// If the opener is a <ui5-icon> inside a Navigation item, we need to get the Navigation Item
 			if (opener.tagName === "UI5-ICON" && opener.parentElement) {
 				opener = opener.parentElement;
 			}

--- a/packages/main/src/NavigationMenu.ts
+++ b/packages/main/src/NavigationMenu.ts
@@ -67,10 +67,17 @@ class NavigationMenu extends Menu {
 	}
 
 	_itemMouseOver(e: MouseEvent) {
+		let opener;
 		if (isDesktop()) {
 			// respect mouseover only on desktop
-			const opener = e.target as OpenerStandardListItem;
-			let item = opener.associatedItem;
+			opener = e.target as OpenerStandardListItem;
+
+			// If the opener is a <ui5-icon> inside a StandardListItem, we need to get the parent StandardListItem
+			if (opener.tagName === "UI5-ICON" && opener.parentElement) {
+				opener = opener.parentElement;
+			}
+
+			let item = (opener as OpenerStandardListItem).associatedItem;
 
 			if (!item) {
 				// for nested <a>


### PR DESCRIPTION
Previously, when hovering over the "arrow right" icon inside a navigation item, the mouseover event incorrectly targeted the icon itself, not the parent navigation item.

The code now detects if the hovered element is a ui5-icon (like the "arrow right").
If so, it adjusts the reference to the parent navigation item. This ensures the responsive popover is opened and positioned relative to the correct parent navigation item, even when the hover occurs on the "arrow right" icon.

fixes: #11121
