### PR TITLE
fix(framework): make "yarn start:website" script work with both node 20 and 24

### DIFF
--- a/packages/website/build-scripts/local-cdn.mjs
+++ b/packages/website/build-scripts/local-cdn.mjs
@@ -31,4 +31,4 @@ const files = await readdir("local-cdn", {recursive: true, withFileTypes: true})
 const filesToDelete = files.filter(f => {
     return f.isFile() && !f.name.endsWith(".js") && !f.name.endsWith(".svg") && !f.name.endsWith(".d.ts") && !f.name.endsWith("package.json")
 });
-filesToDelete.map(f => rm(path.join(f.path, f.name)));
+filesToDelete.map(f => rm(path.join(f.path ?? f.parentPath, f.name)));


### PR DESCRIPTION
There is an issue with `readdir` method of `fs/promises` which is used to get the path and name of files to delete in `local-can.mjs`.

**Node 21** introduced `parentPath` property, having the same value as `path`.

In **Node 23** `path` was deprecated  in favour of `parentPath`.

In **Node 24** `path` is completely removed.

The fix allows `yarn start:website` script to work with all **Node versions from 20 to 24** by using either `path` or `parentPath`, whichever is available.

Fixes issue: https://github.com/SAP/ui5-webcomponents/issues/11878
