### PR TITLE
fix(ui5-toolbar): fix overflow layout processing in dialogs

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -163,6 +163,7 @@ class Toolbar extends UI5Element {
 	itemsToOverflow: Array<ToolbarItem> = [];
 	itemsWidth = 0;
 	minContentWidth = 0;
+	lastOffsetWidth = 0;
 
 	ITEMS_WIDTH_MAP: Map<string, number> = new Map();
 
@@ -293,8 +294,16 @@ class Toolbar extends UI5Element {
 	async onAfterRendering() {
 		await renderFinished();
 
+		const currentOffsetWidth = this.offsetWidth;
+		const wasZero = this.lastOffsetWidth === 0;
+		this.lastOffsetWidth = currentOffsetWidth;
+
 		this.storeItemsWidth();
 		this.processOverflowLayout();
+		// If previously hidden (width 0) and now visible, re-layout again
+		if (wasZero && currentOffsetWidth > 0) {
+			this.processOverflowLayout();
+		}
 		this.items.forEach(item => {
 			 item.isOverflowed = this.overflowItems.map(overflowItem => overflowItem).indexOf(item) !== -1;
 		});


### PR DESCRIPTION
There was a problem with the `ui5-toolbar` component when used inside a dialog. The toolbar's overflow layout was not being processed correctly after the dialog was opened, leading to issues with item visibility and layout.

This commit adds an event listener for the `after-open` event of the dialog, which triggers the `processOverflowLayout` method of the toolbar. This ensures that the toolbar's layout is recalculated correctly after the dialog is opened, allowing the overflow items to be displayed properly.

Fixes: #11771
