### PR TITLE
fix(ui5-dynamic-page): remove aria-expanded from header element

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -282,10 +282,6 @@ class DynamicPage extends UI5Element {
 		return this.hasHeading ? this._headerLabel : undefined;
 	}
 
-	get headerAriaExpanded() {
-		return this.hasHeading ? this._headerExpanded : undefined;
-	}
-
 	/**
 	 * Defines if the header is snapped.
 	 *

--- a/packages/fiori/src/DynamicPageTemplate.tsx
+++ b/packages/fiori/src/DynamicPageTemplate.tsx
@@ -11,7 +11,6 @@ export default function DynamicPageTemplate(this: DynamicPage) {
 					class="ui5-dynamic-page-title-header-wrapper"
 					id={`${this._id}-header`}
 					aria-label={this.headerAriaLabel}
-					aria-expanded={this.headerAriaExpanded}
 					onui5-toggle-title={this.onToggleTitle}
 				>
 					<slot name="titleArea"></slot>

--- a/packages/fiori/test/specs/DynamicPage.spec.js
+++ b/packages/fiori/test/specs/DynamicPage.spec.js
@@ -417,8 +417,6 @@ describe("ARIA attributes", () => {
         // check ARIA attribute values
         assert.strictEqual(await headerWrapper.getAttribute("aria-label"), "Header Expanded",
             "aria-label value is correct");
-        assert.strictEqual(await headerWrapper.getAttribute("aria-expanded"), "true",
-            "aria-expanded value is correct");
         assert.strictEqual(await headerRoot.getAttribute("role"), "region",
             "header role is correct");
 
@@ -452,11 +450,7 @@ describe("ARIA attributes", () => {
         // check ARIA attribute values
         assert.strictEqual(await headerWrapper.getAttribute("aria-label"), "Header Snapped",
             "aria-label value is correct");
-        assert.strictEqual(await headerWrapper.getAttribute("aria-expanded"), "false",
-            "aria-expanded value is correct");
 
-        assert.strictEqual(await titleFocusArea.getAttribute("aria-expanded"), "false",
-            "aria-expanded value is correct");
         assert.strictEqual(await titleFocusArea.getAttribute("aria-describedby"), `${await title.getProperty("__id")}-toggle-description`,
             "aria-describedby is correct");
         assert.strictEqual(await titleFocusArea.getAttribute("role"), "button",

--- a/packages/fiori/test/specs/DynamicPage.spec.js
+++ b/packages/fiori/test/specs/DynamicPage.spec.js
@@ -451,6 +451,8 @@ describe("ARIA attributes", () => {
         assert.strictEqual(await headerWrapper.getAttribute("aria-label"), "Header Snapped",
             "aria-label value is correct");
 
+        assert.strictEqual(await titleFocusArea.getAttribute("aria-expanded"), "false",
+            "aria-expanded value is correct");
         assert.strictEqual(await titleFocusArea.getAttribute("aria-describedby"), `${await title.getProperty("__id")}-toggle-description`,
             "aria-describedby is correct");
         assert.strictEqual(await titleFocusArea.getAttribute("role"), "button",


### PR DESCRIPTION
Removes non-compliant aria-expanded attribute from DynamicPage header element to conform with W3C ARIA specifications.

Fixes #11633