### PR TITLE
fix(ui5-table): register capture individually for selection

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -419,7 +419,7 @@ class Table extends UI5Element {
 	}
 
 	onEnterDOM() {
-		this._events.forEach(eventType => this.addEventListener(eventType, this._onEventBound, { capture: true }));
+		this._events.forEach(eventType => this.addEventListener(eventType, this._onEventBound));
 		this.features.forEach(feature => feature.onTableActivate?.(this));
 		this._tableNavigation = new TableNavigation(this);
 		this._tableDragAndDrop = new TableDragAndDrop(this);

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -88,14 +88,10 @@ class TableSelection extends UI5Element implements ITableFeature {
 	_rowsLength = 0;
 	_rangeSelection?: {selected: boolean, isUp: boolean | null, rows: TableRow[], isMouse: boolean, shiftPressed: boolean} | null;
 
-	onKeyUpCaptureBound: (e: KeyboardEvent) => void;
-	onKeyDownCaptureBound: (e: KeyboardEvent) => void;
 	onClickCaptureBound: (e: MouseEvent) => void;
 
 	constructor() {
 		super();
-		this.onKeyUpCaptureBound = this._onKeyupCapture.bind(this);
-		this.onKeyDownCaptureBound = this._onKeydownCapture.bind(this);
 		this.onClickCaptureBound = this._onClickCapture.bind(this);
 	}
 
@@ -113,8 +109,6 @@ class TableSelection extends UI5Element implements ITableFeature {
 	onBeforeRendering() {
 		this._invalidateTableAndRows();
 
-		this._table?.removeEventListener("keydown", this.onKeyDownCaptureBound);
-		this._table?.removeEventListener("keyup", this.onKeyUpCaptureBound);
 		this._table?.removeEventListener("click", this.onClickCaptureBound);
 	}
 
@@ -124,8 +118,6 @@ class TableSelection extends UI5Element implements ITableFeature {
 			this._table.headerRow[0]._invalidate++;
 		}
 
-		this._table?.addEventListener("keydown", this.onKeyDownCaptureBound, { capture: true });
-		this._table?.addEventListener("keyup", this.onKeyUpCaptureBound, { capture: true });
 		this._table?.addEventListener("click", this.onClickCaptureBound, { capture: true });
 	}
 
@@ -250,7 +242,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 		this._table.rows.forEach(row => row._invalidate++);
 	}
 
-	_onKeydownCapture(e: KeyboardEvent) {
+	_onkeydown(e: KeyboardEvent) {
 		if (!this.isMultiSelectable() || !this._table || !e.shiftKey) {
 			return;
 		}
@@ -267,7 +259,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 			const row = focusedElement as TableRow;
 			this._startRangeSelection(row, this.isSelected(row));
 		} else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-			const change = isUpShift(e) ? 1 : -1;
+			const change = isUpShift(e) ? -1 : 1;
 			this._handleRangeSelection(focusedElement as TableRow, change);
 		}
 
@@ -276,12 +268,11 @@ class TableSelection extends UI5Element implements ITableFeature {
 		}
 	}
 
-	_onKeyupCapture(e: KeyboardEvent) {
+	_onkeyup(e: KeyboardEvent, eventOrigin: HTMLElement) {
 		if (!this._table) {
 			return;
 		}
 
-		const eventOrigin = e.composedPath()[0] as HTMLElement;
 		if (!eventOrigin.hasAttribute("ui5-table-row") || !this._rangeSelection || !e.shiftKey) {
 			// Stop range selection if a) Shift is relased or b) the event target is not a row
 			this._stopRangeSelection();

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -108,8 +108,6 @@ class TableSelection extends UI5Element implements ITableFeature {
 
 	onBeforeRendering() {
 		this._invalidateTableAndRows();
-
-		this._table?.removeEventListener("click", this.onClickCaptureBound);
 	}
 
 	onTableBeforeRendering() {
@@ -118,6 +116,10 @@ class TableSelection extends UI5Element implements ITableFeature {
 			this._table.headerRow[0]._invalidate++;
 		}
 
+		this._table?.removeEventListener("click", this.onClickCaptureBound);
+	}
+
+	onTableAfterRendering(): void {
 		this._table?.addEventListener("click", this.onClickCaptureBound, { capture: true });
 	}
 

--- a/packages/main/src/TableSelectionMulti.ts
+++ b/packages/main/src/TableSelectionMulti.ts
@@ -67,15 +67,11 @@ class TableSelectionMulti extends TableSelectionBase {
 		shiftPressed: boolean
 	} | null;
 
-	_onKeyDownCaptureBound: (e: KeyboardEvent) => void;
 	_onClickCaptureBound: (e: MouseEvent) => void;
-	_onKeyUpCaptureBound: (e: KeyboardEvent) => void;
 
 	constructor() {
 		super();
-		this._onKeyDownCaptureBound = this._onkeydownCapture.bind(this);
 		this._onClickCaptureBound = this._onclickCapture.bind(this);
-		this._onKeyUpCaptureBound = this._onkeyupCapture.bind(this);
 	}
 
 	onTableBeforeRendering() {
@@ -84,14 +80,10 @@ class TableSelectionMulti extends TableSelectionBase {
 			this._table.headerRow[0]._invalidate++;
 		}
 
-		this._table?.removeEventListener("keydown", this._onKeyDownCaptureBound);
-		this._table?.removeEventListener("keyup", this._onKeyUpCaptureBound);
 		this._table?.removeEventListener("click", this._onClickCaptureBound);
 	}
 
 	onTableAfterRendering() {
-		this._table?.addEventListener("keydown", this._onKeyDownCaptureBound, { capture: true });
-		this._table?.addEventListener("keyup", this._onKeyUpCaptureBound, { capture: true });
 		this._table?.addEventListener("click", this._onClickCaptureBound, { capture: true });
 	}
 
@@ -177,7 +169,7 @@ class TableSelectionMulti extends TableSelectionBase {
 		this.selected = [...selectedSet].join(" ");
 	}
 
-	_onkeydownCapture(e: KeyboardEvent) {
+	_onkeydown(e: KeyboardEvent) {
 		if (!this._table || !e.shiftKey) {
 			return;
 		}
@@ -194,7 +186,7 @@ class TableSelectionMulti extends TableSelectionBase {
 			const row = focusedElement as TableRow;
 			this._startRangeSelection(row, this.isSelected(row));
 		} else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-			const change = isUpShift(e) ? 1 : -1;
+			const change = isUpShift(e) ? -1 : 1;
 			this._handleRangeSelection(focusedElement as TableRow, change);
 		}
 
@@ -203,12 +195,11 @@ class TableSelectionMulti extends TableSelectionBase {
 		}
 	}
 
-	_onkeyupCapture(e: KeyboardEvent) {
+	_onkeyup(e: KeyboardEvent, eventOrigin: HTMLElement) {
 		if (!this._table) {
 			return;
 		}
 
-		const eventOrigin = e.composedPath()[0] as HTMLElement;
 		if (!eventOrigin.hasAttribute("ui5-table-row") || !this._rangeSelection || !e.shiftKey) {
 			// Stop range selection if a) Shift is relased or b) the event target is not a row
 			this._stopRangeSelection();


### PR DESCRIPTION
Capturing events should be specific to the components, therefore moved capture phase into the selection components.
This also prevents the row action from firing the row-click event as well, which was an unwanted side effect from the previous change

Fixes #11509
Fixes #11932