### PR TITLE
fix(ui5-illustrated-message): remove unnecessary line-height overrides

### DIFF
--- a/packages/fiori/src/themes/IllustratedMessage.css
+++ b/packages/fiori/src/themes/IllustratedMessage.css
@@ -55,7 +55,6 @@
 	font-size: var(--sapFontHeader2Size);
 	font-family: var(--sapFontHeaderFamily);
 	font-weight: 700;
-    line-height: 1.3;
     max-width: 61.9375rem;
 }
 
@@ -63,7 +62,6 @@
     text-align: center;
     font-size: var(--sapFontLargeSize);
     font-family: var(--sapFontFamily);
-    line-height: 1.4;
     color: var(--sapTextColor);
     margin-bottom: 0.5rem;
     max-width: 61.9375rem;
@@ -108,7 +106,6 @@
 :host([media="spot"]) ::slotted([slot="title"]) {
     margin-bottom: 0.5rem;
     font-size: var(--sapFontHeader4Size);
-    line-height: 1.25rem;
     max-width: 21.5rem;
 }
 
@@ -142,7 +139,6 @@
 :host([media="dot"]) ::slotted([slot="title"])  {
 	margin-bottom: 0.25rem;
 	font-size: var(--sapFontHeader5Size);
-	line-height: 1.25rem;
 	max-width: 12.6875rem;
 }
 
@@ -164,7 +160,6 @@
 :host([media="base"]) ::slotted([slot="title"]) {
     margin-bottom: 0.25rem;
     font-size: var(--sapFontHeader5Size);
-    line-height: 1.25rem;
     max-width: 10rem;
 }
 
@@ -180,8 +175,8 @@
     left: -9999px;
 }
 
-.sapIllus_BlendModeMultiply { 
-    mix-blend-mode: multiply; 
+.sapIllus_BlendModeMultiply {
+    mix-blend-mode: multiply;
 }
 
 .sapIllus_MaskTypeAlpha {


### PR DESCRIPTION
Remove explicit line-height values from all media query variants (spot, dot, base) and base styles as they were causing text clipping issues and are not specified in the design specifications.

Fixes #11851 
