### PR TITLE
fix(ui5-color-palette): ensure RGB and HSL values are within limits

### DIFF
--- a/packages/main/src/ColorPicker.ts
+++ b/packages/main/src/ColorPicker.ts
@@ -56,6 +56,13 @@ type ColorChannelInput = {
 	showPercentSymbol?: boolean,
 }
 
+type MinMaxValues = {
+	min: number,
+	max: number,
+}
+
+type HSLandRGBValueLimits = Record<string, MinMaxValues>;
+
 /**
  * @class
  *
@@ -355,9 +362,31 @@ class ColorPicker extends UI5Element implements IFormInputElement {
 		this._displayHSL = !this._displayHSL;
 	}
 
+	_normalizeInputValue(stringValue: string, inputId: string): number {
+		const value = Number(stringValue);
+
+		const limits: HSLandRGBValueLimits = {
+			red: { min: 0, max: 255 },
+			green: { min: 0, max: 255 },
+			blue: { min: 0, max: 255 },
+			hue: { min: 0, max: 360 },
+			saturation: { min: 0, max: 100 },
+			light: { min: 0, max: 100 },
+		};
+
+		const limit = limits[inputId];
+		if (!limit) {
+			return value || 0;
+		}
+
+		// Return the value normalized to the limits
+		return Math.max(limit.min, Math.min(limit.max, value));
+	}
+
 	_handleColorInputChange(e: Event) {
 		const target = e.target as Input;
-		const targetValue = parseInt(target.value) || 0;
+		const targetValue = this._normalizeInputValue(target.value, target.id);
+		target.value = String(targetValue);
 
 		switch (target.id) {
 		case "red":


### PR DESCRIPTION
Previously if an user was about to type a RGB or HSL value in the input fields, that were out of boundaries (255 for all RGB fields, 360 for Hue, 100(%) for Saturation and 100(%) Light in HSL), the input fields became disabled, which led to bad UX.

With this change we now 'normalise' the values that are out of the bounds (mentioned above) to the closest one.

For RGB:

Values above 255 –> e.g 275 are normalised to 255;
Values below 0 –> e.g -20 are normalised to 0;

For HSL:

Hue:
- values above 360 –> e.g 375 are normalised to 360;
- values below 0 –> e.g -20 are normlised to 0;

Saturation and Light:
- values above 100 –> e.g. 120 are normalised to 100;
- values below 0 –> e.g. -20 are normalised 

### Before
![2025-07-15_11-16-28 (1)](https://github.com/user-attachments/assets/37b549ed-9bcf-44f0-a00e-75988a4d34ad)

### After
![2025-07-15_11-14-19 (1)](https://github.com/user-attachments/assets/605d601f-82ca-42c1-8718-715ad37d40f6)

