### PR TITLE
fix(ui5-button): adjust button badge z-index

### DIFF
--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -318,7 +318,7 @@ bdi {
 	top: 0;
 	inset-inline-end: 0;
 	margin: -0.5rem;
-	z-index: 1000;
+	z-index: 1;
 	font-family: "72override", var(--sapButton_FontFamily);
 	font-size: var(--sapFontSmallSize);
 	--_ui5-tag-height: 0.625rem;
@@ -331,7 +331,7 @@ bdi {
 	top: 0;
 	inset-inline-end: 0;
 	margin: -0.25rem;
-	z-index: 1000;
+	z-index: 1;
 }
 
 :host(:state(has-overlay-badge)) {


### PR DESCRIPTION
The `z-index` property of the slotted `ui5-button-badge` inside of the `ui5-button` is set to **1000** - this value is very high and it happens that badge can appear over other elements that appear on higher `z-index` (as dialogs, etc.).

This PR sets the `z-index` to **1**, which is more secure options and doesn't destroy current badge appearance.