### PR TITLE
fix(ui5-avatar-group): disable pointer events on overflow button in G…

### DIFF
--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -40,6 +40,10 @@
 	pointer-events: none;
 }
 
+:host([type="Group"]) .ui5-avatar-group-overflow-btn {
+	pointer-events: none;
+}
+
 .ui5-avatar-group-overflow-btn {
 	overflow: visible;
 }

--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -36,16 +36,9 @@
 }
 
 :host([type="Group"]) ::slotted([ui5-button]),
-:host([type="Group"]) ::slotted([ui5-avatar]) {
-	pointer-events: none;
-}
-
+:host([type="Group"]) ::slotted([ui5-avatar]),
 :host([type="Group"]) .ui5-avatar-group-overflow-btn {
 	pointer-events: none;
-}
-
-.ui5-avatar-group-overflow-btn {
-	overflow: visible;
 }
 
 .ui5-avatar-group-overflow-btn::part(button) {

--- a/packages/main/src/themes/AvatarGroup.css
+++ b/packages/main/src/themes/AvatarGroup.css
@@ -41,6 +41,10 @@
 	pointer-events: none;
 }
 
+.ui5-avatar-group-overflow-btn {
+	overflow: visible;
+}
+
 .ui5-avatar-group-overflow-btn::part(button) {
 	min-width: auto;
 }


### PR DESCRIPTION
- Problem
Overflow button was receiving focus in Group mode, preventing group click events 
from firing when clicked.

- Solution
Add `pointer-events: none` to the overflow button to not receive focus upon clicking when `type="Group"`

Fixes: [#11866](https://github.com/SAP/ui5-webcomponents/issues/11866)