### PR TITLE
fix(ui5-table): remove the fill-availble style

### DIFF
--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -17,8 +17,6 @@
 :host([overflow-mode="Scroll"]) #table {
 	overflow-x: auto;
 	height: 100%;
-	height: -webkit-fill-available;
-	height: fill-available;
 }
 
 #rows, #spacer {


### PR DESCRIPTION
It looks like height: -webkit-fill-available causes more issue than it helps.

Fixes: #11960
Fixes: #11205
Fixes: #11412