### PR TITLE
fix(ui5-file-uploader): adjust tokenizer expand/collapse behaviour

### DIFF
--- a/packages/main/src/FileUploader.ts
+++ b/packages/main/src/FileUploader.ts
@@ -407,7 +407,11 @@ class FileUploader extends UI5Element implements IFormInputElement {
 	}
 
 	get _tokenizerExpanded(): boolean {
-		return this._tokenizer?.expanded || true;
+		if (!this._tokenizer) {
+			return true;
+		}
+
+		return this._tokenizer.expanded;
 	}
 
 	_onTokenizerKeyUp(e: KeyboardEvent) {


### PR DESCRIPTION
Issue:
- The internal `ui5-tokenizer` collapses when focus moves from the tokens to the file uploader.
Another precondition is to have all the tokens in the more popover when the file uploader ins't focused.