### PR TITLE
docs(ui5-list): add ListItemCustom with ExpandableText to List wrapping sample

### DIFF
--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -650,6 +650,32 @@
 		</ui5-li>
 	</ui5-list>
 
+	<br/><br/>
+
+	<ui5-title size="H2">ListItemCustom with ExpandableText for Wrapping</ui5-title>
+
+	<br/>
+
+	<ui5-list header-text="Custom wrapping with ExpandableText component">
+		<ui5-li-custom>
+			<div class="product-item">
+				<ui5-avatar initials="JD" color-scheme="Accent1"></ui5-avatar>
+				<div class="product-details">
+					<ui5-title size="H5">Product with Long Description</ui5-title>
+					<ui5-expandable-text 
+						max-characters="200"
+						text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.">
+					</ui5-expandable-text>
+					<ui5-label>Product ID: #12345</ui5-label>
+				</div>
+				<div class="product-price">
+					<ui5-label>€1,299.00</ui5-label>
+					<ui5-label>In Stock</ui5-label>
+				</div>
+			</div>
+		</ui5-li-custom>
+	</ui5-list>
+
 	<script>
 		'use strict';
 

--- a/packages/main/test/pages/styles/List.css
+++ b/packages/main/test/pages/styles/List.css
@@ -26,3 +26,24 @@
 .largeTopMargin {
     margin-top: 2rem;
 }
+
+.product-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 0.5rem;
+}
+
+.product-details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.product-price {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+}

--- a/packages/website/docs/_components_pages/main/List/List.mdx
+++ b/packages/website/docs/_components_pages/main/List/List.mdx
@@ -66,4 +66,6 @@ The wrapping behavior is responsive:
 
 This feature improves readability when displaying lengthy content in lists.
 
+The `<ui5-li-custom>` is intentionally designed as a generic container to provide maximum flexibility. It can be used alongside `ui5-expandable-text` for long text content.
+
 <WrappingBehavior />

--- a/packages/website/docs/_samples/main/List/WrappingBehavior/WrappingBehavior.md
+++ b/packages/website/docs/_samples/main/List/WrappingBehavior/WrappingBehavior.md
@@ -1,4 +1,5 @@
 import html from '!!raw-loader!./sample.html';
 import js from '!!raw-loader!./main.js';
+import css from '!!raw-loader!./main.css';
 
-<Editor html={html} js={js} />
+<Editor html={html} js={js} css={css} />

--- a/packages/website/docs/_samples/main/List/WrappingBehavior/main.css
+++ b/packages/website/docs/_samples/main/List/WrappingBehavior/main.css
@@ -1,0 +1,30 @@
+.custom-list-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 1rem;
+	padding: 0.5rem;
+}
+
+.custom-list-item__avatar {
+	flex-shrink: 0;
+}
+
+.custom-list-item__content {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.custom-list-item__title {
+	margin: 0;
+}
+
+.custom-list-item__description {
+	color: var(--sapNeutralTextColor);
+}
+
+.custom-list-item__additional {
+	font-size: 0.875rem;
+	color: var(--sapNeutralTextColor);
+}

--- a/packages/website/docs/_samples/main/List/WrappingBehavior/main.js
+++ b/packages/website/docs/_samples/main/List/WrappingBehavior/main.js
@@ -1,4 +1,8 @@
 import "@ui5/webcomponents/dist/List.js";
 import "@ui5/webcomponents/dist/ListItemStandard.js";
+import "@ui5/webcomponents/dist/ListItemCustom.js";
 
 import "@ui5/webcomponents/dist/Avatar.js";
+import "@ui5/webcomponents/dist/ExpandableText.js";
+import "@ui5/webcomponents/dist/Title.js";
+import "@ui5/webcomponents/dist/Label.js";

--- a/packages/website/docs/_samples/main/List/WrappingBehavior/sample.html
+++ b/packages/website/docs/_samples/main/List/WrappingBehavior/sample.html
@@ -6,6 +6,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Sample</title>
+	<link rel="stylesheet" href="./main.css">
 </head>
 
 <body style="background-color: var(--sapBackgroundColor)">
@@ -31,6 +32,44 @@
 			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
+	
+	<br>
+	<br>
+
+	<ui5-list header-text="Custom List Item with Wrapping">
+		<!-- Custom Behavior with ExpandableText -->
+		<ui5-li-custom>
+			<div class="custom-list-item">
+				<ui5-avatar class="custom-list-item__avatar">
+					<img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+				</ui5-avatar>
+				<div class="custom-list-item__content">
+					<ui5-title size="H6" class="custom-list-item__title">Product with Expandable Description</ui5-title>
+					<ui5-expandable-text 
+						class="custom-list-item__description"
+						max-characters="120"
+						text="This custom list item uses ExpandableText to provide controlled expansion of lengthy content. Users can choose to read more when they need detailed information, keeping the list compact by default. This approach gives developers full control over the content layout and interaction while maintaining accessibility and user experience standards.">
+					</ui5-expandable-text>
+					<ui5-label class="custom-list-item__additional">Expandable</ui5-label>
+				</div>
+			</div>
+		</ui5-li-custom>
+		<ui5-li-custom>
+			<div class="custom-list-item">
+				<ui5-avatar class="custom-list-item__avatar">
+					<img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
+				</ui5-avatar>
+				<div class="custom-list-item__content">
+					<ui5-title size="H6" class="custom-list-item__title">Product with Expandable Description</ui5-title>
+					<ui5-expandable-text 
+						class="custom-list-item__description"
+						max-characters="120"
+						text="This custom list item uses ExpandableText to provide controlled expansion of lengthy content. Users can choose to read more when they need detailed information, keeping the list compact by default. This approach gives developers full control over the content layout and interaction while maintaining accessibility and user experience standards.">
+					</ui5-expandable-text>
+					<ui5-label class="custom-list-item__additional">Expandable</ui5-label>
+				</div>
+			</div>
+		</ui5-li-custom>
 	<!-- playground-fold -->
 	<script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
Added a new example showcasing `ui5-li-custom` with `ui5-expandable-text` for displaying long descriptions.

Related to: #11655 