### PR TITLE
fix(ui5-table): changed hAlign id variable

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -587,7 +587,7 @@ class Table extends UI5Element {
 		const virtualizer = this._getVirtualizer();
 		const headerStyleMap = this.headerRow?.[0]?.cells?.reduce((headerStyles, headerCell) => {
 			if (headerCell.horizontalAlign !== undefined && !headerCell._popin) {
-				headerStyles[`--horizontal-align-${headerCell._individualSlot}`] = headerCell.horizontalAlign;
+				headerStyles[`--horizontal-align-${headerCell._id()}`] = headerCell.horizontalAlign;
 			}
 			return headerStyles;
 		}, {} as { [key: string]: string });

--- a/packages/main/src/TableCell.ts
+++ b/packages/main/src/TableCell.ts
@@ -34,7 +34,7 @@ class TableCell extends TableCellBase {
 		if (this.horizontalAlign) {
 			this.style.justifyContent = this.horizontalAlign;
 		} else if (this._individualSlot) {
-			this.style.justifyContent = `var(--horizontal-align-${this._individualSlot})`;
+			this.style.justifyContent = `var(--horizontal-align-${this._headerCell._id()})`;
 		}
 	}
 

--- a/packages/main/src/TableHeaderCell.ts
+++ b/packages/main/src/TableHeaderCell.ts
@@ -131,7 +131,7 @@ class TableHeaderCell extends TableCellBase {
 		super.onBeforeRendering();
 		if (this._individualSlot) {
 			// overwrite setting of TableCellBase so that the TableHeaderCell always uses the slot variable
-			this.style.justifyContent = `var(--horizontal-align-${this._individualSlot})`;
+			this.style.justifyContent = `var(--horizontal-align-${this._id()})`;
 		}
 		toggleAttribute(this, "aria-sort", this.sortIndicator !== SortOrder.None, this.sortIndicator.toLowerCase());
 	}


### PR DESCRIPTION
Fixes #11858 

Instead of using the individualSlot variable, hAlign is now using the element id (UI5Element#_id).
Now the variables doesn't change even if the column position changes. Thus hAlign is always set to a variable based on the headerCell element id which doesn't depends/changes with the column order/position.