### PR TITLE
fix(ui5-list-item): adjust line height for byline

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -91,7 +91,7 @@
 }
 
 :host([has-title][description]) .ui5-li-title {
-	padding-bottom: 0.375rem;
+	padding-bottom: 0.5rem;
 }
 
 .ui5-li-text-wrapper {
@@ -99,7 +99,6 @@
 }
 
 :host([description]) .ui5-li-text-wrapper {
-	height: 100%;
 	justify-content: space-between;
 	padding: 0.125rem 0;
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the spacing in the list item component's styles, specifically for items that have both a title and a description. The change increases the bottom padding for the title and removes the explicit height setting from the text wrapper, likely to improve visual alignment and flexibility.

* Increased the bottom padding for `.ui5-li-title` when both title and description are present, from `0.375rem` to `0.5rem` (`ListItem.css`).
* Removed the `height: 100%` property from `.ui5-li-text-wrapper` when a description is present, allowing for more natural content sizing (`ListItem.css`).

Fixes: #12034 