### PR TITLE
fix(ui5-button): announce the text node properly

### DIFF
--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -336,6 +336,15 @@ describe("Accessibility", () => {
 			.should("not.have.attr", "title");
 	});
 
+	it("aria-label is properly applied on the button tag", () => {
+		cy.mount(<Button design="Emphasized">Action</Button>);
+
+		cy.get("[ui5-button]")
+			.shadow()
+			.find("button")
+			.should("have.attr", "aria-label", "Action");
+	});
+
 	it("aria-expanded is properly applied on the button tag", () => {
 		cy.mount(<Button icon="home" design="Emphasized">Action Bar Button</Button>);
 

--- a/packages/main/cypress/specs/Button.cy.tsx
+++ b/packages/main/cypress/specs/Button.cy.tsx
@@ -342,7 +342,10 @@ describe("Accessibility", () => {
 		cy.get("[ui5-button]")
 			.shadow()
 			.find("button")
-			.should("have.attr", "aria-label", "Action");
+			.as("button");
+			
+		cy.get("@button")
+			.should("have.attr", "aria-label", "Action Emphasized");
 	});
 
 	it("aria-expanded is properly applied on the button tag", () => {

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -625,11 +625,12 @@ class Button extends UI5Element implements IButton {
 	}
 
 	get ariaLabelText() {
+		const textContent = this.textContent || "";
 		const ariaLabelText = getEffectiveAriaLabelText(this) || "";
 		const typeLabelText = this.hasButtonType ? this.buttonTypeText : "";
 		const internalLabelText = this.effectiveBadgeDescriptionText || "";
 
-		const labelParts = [ariaLabelText, typeLabelText, internalLabelText].filter(part => part);
+		const labelParts = [textContent, ariaLabelText, typeLabelText, internalLabelText].filter(part => part);
 		return labelParts.join(" ");
 	}
 


### PR DESCRIPTION
Issue:
- The inner text of the button wasn't announced when the design property was set.

Solution:
- The inner text is now part of the aria-label attribute alongside the design type text.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/12037
