### PR TITLE
feat(ui5-select): add accessibleDescription and accessibleDescriptionRef

### DIFF
--- a/packages/main/cypress/specs/Select.cy.tsx
+++ b/packages/main/cypress/specs/Select.cy.tsx
@@ -283,6 +283,155 @@ describe("Select - Accessibility", () => {
 			.should("have.attr", "aria-expanded", "false")
 			.should("have.attr", "aria-roledescription", EXPECTED_ARIA_ROLEDESCRIPTION);
 	});
+
+	it("tests Select with valueState Positive and aria-describedby", () => {
+		cy.mount(
+			<Select valueState="Positive">
+				<Option value="First">First</Option>
+				<Option value="Second">Second</Option>
+				<Option value="Third" selected>Third</Option>
+			</Select>
+		);
+
+		// Test that valueState creates the correct aria-describedby reference
+		cy.get("[ui5-select]")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("have.attr", "aria-describedby")
+			.and("contain", "-valueStateDesc");
+
+		// Test that the value state description text contains "Success"
+		cy.get("[ui5-select]")
+			.shadow()
+			.find("[id$='-valueStateDesc']")
+			.should("contain.text", "Success");
+	});
+
+	it("tests accessibleDescription and accessibleDescriptionRef", () => {
+		cy.mount(
+			<>
+				<span id="descText">Description text</span>
+				<Select id="selectWithAccessibleDescription" accessibleDescription="Select description">
+					<Option value="First">First</Option>
+					<Option value="Second">Second</Option>
+					<Option value="Third" selected>Third</Option>
+				</Select>
+				<Select id="selectWithAccessibleDescriptionRef" accessibleDescriptionRef="descText">
+					<Option value="One">One</Option>
+					<Option value="Two">Two</Option>
+					<Option value="Three" selected>Three</Option>
+				</Select>
+			</>
+		);
+
+		const EXPECTED_DESCRIPTION = "Select description";
+		const EXPECTED_DESCRIPTION_REF = "Description text";
+
+		// Test first select with accessibleDescription
+		cy.get("#selectWithAccessibleDescription")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", EXPECTED_DESCRIPTION);
+
+		cy.get("#selectWithAccessibleDescription")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("have.attr", "aria-describedby")
+			.and("contain", "accessibleDescription");
+
+		// Test second select with accessibleDescriptionRef
+		cy.get("#selectWithAccessibleDescriptionRef")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", EXPECTED_DESCRIPTION_REF);
+
+		cy.get("#selectWithAccessibleDescriptionRef")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("have.attr", "aria-describedby")
+			.and("contain", "accessibleDescription");
+
+		// Test that changing the referenced element updates the description
+		cy.get("#descText")
+			.invoke("text", "Updated description text");
+
+		cy.get("#selectWithAccessibleDescriptionRef")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", "Updated description text");
+	});
+
+	it("tests Select with both valueState Positive and accessibleDescription", () => {
+		cy.mount(
+			<Select valueState="Positive" accessibleDescription="Additional description">
+				<Option value="First">First</Option>
+				<Option value="Second">Second</Option>
+				<Option value="Third" selected>Third</Option>
+			</Select>
+		);
+
+		const EXPECTED_VALUE_STATE_TEXT = "Success";
+		const EXPECTED_DESCRIPTION = "Additional description";
+
+		// Test that both valueState and accessibleDescription are included in aria-describedby
+		cy.get("[ui5-select]")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("have.attr", "aria-describedby")
+			.and("contain", "-valueStateDesc")
+			.and("contain", "accessibleDescription");
+
+		// Test that the value state description text is correct
+		cy.get("[ui5-select]")
+			.shadow()
+			.find("[id$='-valueStateDesc']")
+			.should("contain.text", EXPECTED_VALUE_STATE_TEXT);
+
+		// Test that the accessible description text is correct
+		cy.get("[ui5-select]")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", EXPECTED_DESCRIPTION);
+	});
+
+	it("tests Select with multiple accessibleDescriptionRef values", () => {
+		cy.mount(
+			<>
+				<span id="desc1">First description</span>
+				<span id="desc2">Second description</span>
+				<span id="desc3">Third description</span>
+				<Select accessibleDescriptionRef="desc1 desc2 desc3">
+					<Option value="First">First</Option>
+					<Option value="Second">Second</Option>
+					<Option value="Third" selected>Third</Option>
+				</Select>
+			</>
+		);
+
+		const EXPECTED_COMBINED_DESCRIPTION = "First description Second description Third description";
+
+		// Test that accessibleDescriptionRef with multiple IDs creates the correct aria-describedby reference
+		cy.get("[ui5-select]")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("have.attr", "aria-describedby")
+			.and("contain", "accessibleDescription");
+
+		// Test that the combined description text from multiple elements is correct
+		cy.get("[ui5-select]")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", EXPECTED_COMBINED_DESCRIPTION);
+
+		// Test that changing one of the referenced elements updates the combined description
+		cy.get("#desc2")
+			.invoke("text", "Updated second description");
+
+		cy.get("[ui5-select]")
+			.shadow()
+			.find("#accessibleDescription")
+			.should("have.text", "First description Updated second description Third description");
+	});
 });
 
 describe("Select - Popover", () => {

--- a/packages/main/cypress/specs/Select.cy.tsx
+++ b/packages/main/cypress/specs/Select.cy.tsx
@@ -321,6 +321,11 @@ describe("Select - Accessibility", () => {
 					<Option value="Two">Two</Option>
 					<Option value="Three" selected>Three</Option>
 				</Select>
+				<Select id="selectWithoutDescription">
+					<Option value="A">A</Option>
+					<Option value="B">B</Option>
+					<Option value="C" selected>C</Option>
+				</Select>
 			</>
 		);
 
@@ -350,6 +355,12 @@ describe("Select - Accessibility", () => {
 			.find(".ui5-select-label-root")
 			.should("have.attr", "aria-describedby")
 			.and("contain", "accessibleDescription");
+
+		// Test select without description should not have aria-describedby
+		cy.get("#selectWithoutDescription")
+			.shadow()
+			.find(".ui5-select-label-root")
+			.should("not.have.attr", "aria-describedby");
 
 		// Test that changing the referenced element updates the description
 		cy.get("#descText")

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -1091,7 +1091,8 @@ class Select extends UI5Element implements IFormInputElement {
 	}
 
 	get ariaDescribedByIds() {
-		return [this.valueStateTextId, this.ariaDescriptionTextId].filter(Boolean).join(" ");
+		const ids = [this.valueStateTextId, this.ariaDescriptionTextId].filter(Boolean);
+		return ids.length ? ids.join(" ") : undefined;
 	}
 
 	_updateAssociatedLabelsTexts() {

--- a/packages/main/src/SelectTemplate.tsx
+++ b/packages/main/src/SelectTemplate.tsx
@@ -29,7 +29,9 @@ export default function SelectTemplate(this: Select) {
 					role="combobox"
 					aria-haspopup="listbox"
 					aria-label={this.ariaLabelText}
-					aria-describedby={this.ariaDescribedByIds}
+					{...this.ariaDescribedByIds && {
+						"aria-describedby": this.ariaDescribedByIds
+					}}
 					aria-disabled={this.isDisabled}
 					aria-required={this.required}
 					aria-readonly={this.readonly}

--- a/packages/main/src/SelectTemplate.tsx
+++ b/packages/main/src/SelectTemplate.tsx
@@ -29,7 +29,7 @@ export default function SelectTemplate(this: Select) {
 					role="combobox"
 					aria-haspopup="listbox"
 					aria-label={this.ariaLabelText}
-					aria-describedby={this.valueStateTextId}
+					aria-describedby={this.ariaDescribedByIds}
 					aria-disabled={this.isDisabled}
 					aria-required={this.required}
 					aria-readonly={this.readonly}
@@ -81,6 +81,12 @@ export default function SelectTemplate(this: Select) {
 				{this.hasValueState &&
 					<span id={`${this._id}-valueStateDesc`} class="ui5-hidden-text">
 						{this.valueStateText}
+					</span>
+				}
+
+				{this.ariaDescriptionText &&
+					<span id="accessibleDescription" class="ui5-hidden-text">
+						{this.ariaDescriptionText}
 					</span>
 				}
 			</div>

--- a/packages/main/test/pages/Select.html
+++ b/packages/main/test/pages/Select.html
@@ -142,6 +142,48 @@
 		</div>
 	</section>
 
+	<section>
+		<h2>Select with accessible description</h2>
+		<ui5-label for="select-with-description">Select your preferred mode:</ui5-label>
+		<ui5-select
+			id="select-with-description"
+			accessible-description="Choose the display density that best suits your needs">
+			<ui5-option>Cozy</ui5-option>
+			<ui5-option selected>Compact</ui5-option>
+			<ui5-option>Condensed</ui5-option>
+		</ui5-select>
+	</section>
+
+	<section>
+		<h2>Select with accessible description ref</h2>
+		<ui5-label for="select-with-description-ref">Country:</ui5-label>
+		<p id="country-description">Select your home country from the list below. This information will be used for shipping calculations.</p>
+		<ui5-select
+			id="select-with-description-ref"
+			accessible-description-ref="country-description">
+			<ui5-option>United States</ui5-option>
+			<ui5-option>United Kingdom</ui5-option>
+			<ui5-option selected>Germany</ui5-option>
+			<ui5-option>France</ui5-option>
+			<ui5-option>Italy</ui5-option>
+		</ui5-select>
+	</section>
+
+	<section>
+		<h2>Select with multiple description references</h2>
+		<ui5-label for="select-multiple-refs">Product:</ui5-label>
+		<span id="product-info">Available products in your region</span>
+		<span id="product-note">Some products may have shipping restrictions</span>
+		<ui5-select
+			id="select-multiple-refs"
+			accessible-description-ref="product-info product-note">
+			<ui5-option>Laptop</ui5-option>
+			<ui5-option selected>Desktop</ui5-option>
+			<ui5-option>Monitor</ui5-option>
+			<ui5-option>Keyboard</ui5-option>
+		</ui5-select>
+	</section>
+
 	<section class="ui5-content-density-compact">
 		<h3>Select in Compact</h3>
 		<div>


### PR DESCRIPTION
- Add `accessibleDescription` property for providing descriptive text
- Add `accessibleDescriptionRef` property for referencing external description elements
- Update `aria-describedby` to include both value state and accessible descriptions
- Add comprehensive Cypress tests covering:
  * Basic `accessibleDescription` functionality
  * `accessibleDescriptionRef` with single and multiple element references
  * Dynamic updates when referenced elements change
  * Interaction with existing `valueState` descriptions
- Add test page examples demonstrating various usage scenarios
- Ensure proper accessibility attribute handling and ARIA compliance

Related: #12004 
JIRA: BGSOFUIPIRIN-6901
