### PR TITLE
fix(ui5-shellbar): apply tertiary button color to cancel button

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -283,6 +283,14 @@ slot[name="profile"] {
 	--_ui5_button_focused_border: var(--_ui5_shellbar_button_focused_border);
 }
 
+.ui5-shellbar-cancel-button{
+	color: var(--_ui5-shellbar_cancel-button-color);
+}
+
+.ui5-shellbar-cancel-button:hover{
+	color: var(--_ui5-shellbar_cancel-button-color);
+}
+
 .ui5-shellbar-image-button {
 	display: flex;
 	justify-content: center;

--- a/packages/fiori/src/themes/base/ShellBar-parameters.css
+++ b/packages/fiori/src/themes/base/ShellBar-parameters.css
@@ -22,4 +22,5 @@
 	--_ui5-shellbar-content-margin-start: 0.5rem;
 	--_ui5-shellbar-overflow-button-margin: 0.5rem;
 	--_ui5-shellbar_separator-color: var(--sapToolbar_SeparatorColor);
+	--_ui5-shellbar_cancel-button-color: var(--sapButton_Lite_TextColor);
 }


### PR DESCRIPTION
- Added new CSS custom property `--_ui5-shellbar_cancel-button-color` in parameters file with value `sapButton_Lite_TextColor` to follow tertiary button styling
- Applied the custom property to `.ui5-shellbar-cancel-button` class for default and hover states

Fixes #11957