### PR TITLE
fix(ui5-select-popover): align title in header on phone

### DIFF
--- a/packages/main/src/SelectPopoverTemplate.tsx
+++ b/packages/main/src/SelectPopoverTemplate.tsx
@@ -5,6 +5,7 @@ import ResponsivePopover from "./ResponsivePopover.js";
 import Popover from "./Popover.js";
 import Icon from "./Icon.js";
 import decline from "@ui5/webcomponents-icons/dist/decline.js";
+import Title from "./Title.js";
 
 export default function SelectPopoverTemplate(this: Select) {
 	return (
@@ -29,7 +30,7 @@ export default function SelectPopoverTemplate(this: Select) {
 					{this._isPhone &&
 						<div slot="header" class="ui5-responsive-popover-header">
 							<div class="row">
-								<span>{this._headerTitleText}</span>
+								<Title>{this._headerTitleText}</Title>
 								<Button
 									class="ui5-responsive-popover-close-btn"
 									icon={decline}

--- a/packages/main/src/themes/SelectPopover.css
+++ b/packages/main/src/themes/SelectPopover.css
@@ -2,3 +2,7 @@
 .ui5-select-popover::part(header) {
 	padding: 0;
 }
+
+.ui5-select-popover .ui5-responsive-popover-header .row {
+    justify-content: flex-start;
+}


### PR DESCRIPTION
- Replace span with Title component
- Left-align title text using justify-content: flex-start

Fixes #11956