### PR TITLE
fix(ui5-select): prevent crash on ArrowUp/Down when value matches no option

### DIFF
--- a/packages/main/cypress/specs/Select.cy.tsx
+++ b/packages/main/cypress/specs/Select.cy.tsx
@@ -1393,4 +1393,50 @@ describe("Select general interaction", () => {
 
 		cy.get("[ui5-select]").should("have.prop", "value", "Third");
 	});
+
+	it("navigates with ArrowDown when initial value does not match any option", () => {
+		cy.mount(
+			<Select id="sel-down" value="missing">
+				<Option value="A">A</Option>
+				<Option value="B">B</Option>
+				<Option value="C">C</Option>
+			</Select>
+		);
+
+		cy.get("#sel-down")
+			.should("have.attr", "value", "missing")
+			.find("[ui5-option][selected]")
+			.should("not.exist");
+
+		cy.get("#sel-down").realClick().realPress("ArrowDown");
+
+		cy.get("#sel-down")
+			.find("[ui5-option]")
+			.eq(0)
+			.should("have.attr", "selected");
+		cy.get("#sel-down").should("have.prop", "value", "A");
+	});
+
+	it("navigates with ArrowUp when initial value does not match any option", () => {
+		cy.mount(
+			<Select id="sel-up" value="missing">
+				<Option value="A">A</Option>
+				<Option value="B">B</Option>
+				<Option value="C">C</Option>
+			</Select>
+		);
+
+		cy.get("#sel-up")
+			.should("have.attr", "value", "missing")
+			.find("[ui5-option][selected]")
+			.should("not.exist");
+
+		cy.get("#sel-up").realClick().realPress("ArrowUp");
+
+		cy.get("#sel-up")
+			.find("[ui5-option]")
+			.eq(2)
+			.should("have.attr", "selected");
+		cy.get("#sel-up").should("have.prop", "value", "C");
+	});
 });

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -768,6 +768,16 @@ class Select extends UI5Element implements IFormInputElement {
 	_changeSelectedItem(oldIndex: number, newIndex: number) {
 		const options: Array<IOption> = this.options;
 
+		// Normalize: first navigation with Up when nothing selected -> last item
+		if (oldIndex === -1 && newIndex < 0 && options.length) {
+			newIndex = options.length - 1;
+		}
+
+		// Abort on invalid target
+		if (newIndex < 0 || newIndex >= options.length) {
+			return;
+		}
+
 		const previousOption = options[oldIndex];
 		const nextOption = options[newIndex];
 
@@ -775,8 +785,10 @@ class Select extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		previousOption.selected = false;
-		previousOption.focused = false;
+		if (previousOption) {
+			previousOption.selected = false;
+			previousOption.focused = false;
+		}
 
 		nextOption.selected = true;
 		nextOption.focused = true;


### PR DESCRIPTION
If select's `value` property is set to a string that doesn’t match any option, nothing is selected `(selectedIndex = -1)`. When you press ArrowUp or ArrowDown, `_changeSelectedItem` tries to use invalid indices, which causes it to access `undefined` and crash at runtime.

Fixes: #12093 
