### PR TITLE
fix(ui5-search-field): show separator only when needed

### DIFF
--- a/packages/fiori/src/SearchFieldTemplate.tsx
+++ b/packages/fiori/src/SearchFieldTemplate.tsx
@@ -48,7 +48,7 @@ export default function SearchFieldTemplate(this: SearchField, options?: SearchF
 							</Select>
 							<div class="ui5-search-field-separator"></div>
 						</>
-					) : this.filterButton ? (
+					) : this.filterButton?.length ? (
 						<>
 							<div class="ui5-filter-wrapper" style="display: contents">
 								<slot name="filterButton"></slot>


### PR DESCRIPTION
- Separtor is now shown only when filter exists.

FIXES: [#12095](https://github.com/SAP/ui5-webcomponents/issues/12095)