### PR TITLE
fix(ui5-wizard): create a stacking context for wiz-nav

### DIFF
--- a/packages/fiori/src/themes/Wizard.css
+++ b/packages/fiori/src/themes/Wizard.css
@@ -125,6 +125,7 @@
 	outline: none;
 	display: flex;
 	align-items: center;
+	transform: scale(1);
 }
 
 [ui5-wizard-tab][data-ui5-wizard-expanded-tab="false"] + [ui5-wizard-tab][data-ui5-wizard-expanded-tab="false"] {


### PR DESCRIPTION
- There are cases where z-index of the steps interfere with other elements in the DOM, therefore we need to introduce a stacking context for the wiz-nav.

FIXES: #12119