### PR TITLE
fix(ui5-textarea): escape interaction can now be prevented

### DIFF
--- a/packages/main/cypress/specs/TextArea.cy.tsx
+++ b/packages/main/cypress/specs/TextArea.cy.tsx
@@ -533,6 +533,44 @@ describe("TextArea general interaction", () => {
 				.should("have.value", "");
 		});
 
+		it("Should allow preventing escape behavior by preventing the input event", () => {
+			cy.mount(<TextArea value="initial value"></TextArea>);
+
+			cy.get("[ui5-textarea]")
+				.as("textarea");
+
+			cy.get("@textarea")
+				.then(textarea => {
+					textarea.get(0).addEventListener("ui5-input", (event: CustomEvent) => {
+						if (event.detail && event.detail.inputType === "escapePressed") {
+							event.preventDefault();
+						}
+					});
+				});
+
+			cy.get("@textarea")
+				.realClick();
+
+			cy.get("@textarea")
+				.should("be.focused");
+
+			cy.get("@textarea")
+				.realType(" modified");
+
+			cy.get("@textarea")
+				.shadow()
+				.find("textarea")
+				.should("have.value", "initial value modified");
+
+			cy.get("@textarea")
+				.realPress("Escape");
+
+			cy.get("@textarea")
+				.shadow()
+				.find("textarea")
+				.should("have.value", "initial value modified");
+		});
+
 		it("Value state type should be added to the screen readers default value states announcement", () => {
 			// Negative
 			cy.mount(<TextArea valueState="Negative"></TextArea>);

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -48,6 +48,10 @@ type ExceededText = {
 	calcedMaxLength?: number;
 };
 
+type TextAreaInputEventDetail = {
+	inputType?: string;
+};
+
 /**
  * @class
  *
@@ -101,6 +105,7 @@ type ExceededText = {
  */
 @event("input", {
 	bubbles: true,
+	cancelable: true,
 })
 
 /**
@@ -126,7 +131,7 @@ type ExceededText = {
 class TextArea extends UI5Element implements IFormInputElement {
 	eventDetails!: {
 		"change": void;
-		"input": void;
+		"input": TextAreaInputEventDetail;
 		"select": void;
 		"scroll": void;
 		"value-changed": void;
@@ -393,9 +398,14 @@ class TextArea extends UI5Element implements IFormInputElement {
 		if (isEscape(e)) {
 			const nativeTextArea = this.getInputDomRef();
 
-			this.value = this.previousValue;
-			nativeTextArea.value = this.value;
-			this.fireDecoratorEvent("input");
+			const prevented = !this.fireDecoratorEvent("input", {
+				inputType: "escapePressed",
+			});
+
+			if (!prevented) {
+				this.value = this.previousValue;
+				nativeTextArea.value = this.value;
+			}
 		}
 	}
 

--- a/packages/main/test/pages/TextArea.html
+++ b/packages/main/test/pages/TextArea.html
@@ -210,6 +210,11 @@
 		<ui5-textarea id="taWithLabelID2" class="textarea-width" placeholder="Enter some text here" accessible-name="Here aria label should be this one"></ui5-textarea>
 	</section>
 
+	<section class="group">
+		<ui5-label>Text Area: Escape Prevention</ui5-title>
+		<ui5-textarea id="textarea-prevent-escape" class="textarea-width" placeholder="Escape prevention test"></ui5-textarea>
+	</section>
+
 	<script>
 		var changeCounter = 0;
 		var inputCounter = 0;
@@ -222,6 +227,12 @@
 		document.getElementById('textarea-input').addEventListener("ui5-input", function (event) {
 			inputCounter += 1;
 			document.getElementById('inputResult').value = `${inputCounter}`;
+		});
+
+		document.getElementById('textarea-prevent-escape').addEventListener("ui5-input", function (event) {
+			if (event.detail.inputType === "escapePressed") {
+				event.preventDefault();
+			}
 		});
 	</script>
 


### PR DESCRIPTION
- Developers can now prevent escape revert behavior by calling preventDefault() on input event with escapePressed = true.