### PR TITLE
test(flexible-column-layout): fix test

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -108,6 +108,9 @@ describe("Columns resize", () => {
 			.should("have.class", "ui5-fcl-column--hidden");
 
 		cy.get("@fcl")
+			.invoke("prop", "layout", "TwoColumnsMidExpanded");
+
+		cy.get("@fcl")
 			.shadow()
 			.find(".ui5-fcl-column--end")
 			.should("have.class", "ui5-fcl-column-animation");

--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -88,11 +88,13 @@ describe("Columns resize", () => {
 	});
 
 	it("keeps hidden class on columns after rerendering", () => {
+		cy.wrap({ setAnimationMode })
+			.invoke("setAnimationMode", AnimationMode.Full);
+
 		cy.mount(
 			<FlexibleColumnLayout layout="TwoColumnsStartExpanded">
 				<div class="column" slot="startColumn">some content</div>
 				<div class="column" slot="midColumn">some content</div>
-				<div class="column" slot="endColumn">some content</div>
 			</FlexibleColumnLayout>
 		);
 
@@ -103,9 +105,6 @@ describe("Columns resize", () => {
 			.shadow()
 			.find(".ui5-fcl-column--end")
 			.should("have.class", "ui5-fcl-column--hidden");
-
-		cy.wrap({ setAnimationMode })
-			.invoke("setAnimationMode", AnimationMode.Full);
 
 		cy.get("@fcl")
 			.shadow()

--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -95,6 +95,7 @@ describe("Columns resize", () => {
 			<FlexibleColumnLayout layout="TwoColumnsStartExpanded">
 				<div class="column" slot="startColumn">some content</div>
 				<div class="column" slot="midColumn">some content</div>
+				<div class="column" slot="endColumn">some content</div>
 			</FlexibleColumnLayout>
 		);
 


### PR DESCRIPTION
Fixes test by setting AnimationMode.Full before component mount instead of after. Eliminates race condition where animation classes weren't applied in time on slower CI environments. Also the rerender is now done with layout change.