### PR TITLE
fix(ui5-dynamic-page-title): conditionally apply ARIA attributes based on interactivity

### DIFF
--- a/packages/fiori/src/DynamicPageTitle.ts
+++ b/packages/fiori/src/DynamicPageTitle.ts
@@ -263,8 +263,16 @@ class DynamicPageTitle extends UI5Element {
 		return !this.snapped;
 	}
 
+	get _role() {
+		return this.interactive ? "button" : undefined;
+	}
+
+	get _ariaDescribedBy() {
+		return this.interactive ? `${this._id}-toggle-description` : undefined;
+	}
+
 	get _ariaDescribedbyText() {
-		return DynamicPageTitle.i18nBundle.getText(DYNAMIC_PAGE_ARIA_DESCR_TOGGLE_HEADER);
+		return this.interactive ? DynamicPageTitle.i18nBundle.getText(DYNAMIC_PAGE_ARIA_DESCR_TOGGLE_HEADER) : undefined;
 	}
 
 	get _ariaLabelledBy() {

--- a/packages/fiori/src/DynamicPageTitleTemplate.tsx
+++ b/packages/fiori/src/DynamicPageTitleTemplate.tsx
@@ -10,10 +10,10 @@ export default function DynamicPageTitleTemplate(this: DynamicPageTitle) {
 				tabIndex={this._tabIndex}
 				onKeyDown={this._onkeydown}
 				onClick={this.onTitleClick}
-				role="button"
+				role={this._role}
 				aria-expanded={this.forAriaExpanded}
 				aria-labelledby={this._ariaLabelledBy}
-				aria-describedby={`${this._id}-toggle-description`}
+				aria-describedby={this._ariaDescribedBy}
 			></span>
 
 			{this.hasSnappedTitleOnMobile ?


### PR DESCRIPTION
Only apply button role and ARIA attributes when the title can actually toggle the header. When no header is present (non-interactive state), the title area should not have button semantics or related ARIA attributes.

- Remove `button` role when title is not interactive
- Remove `aria-expanded` when title is not interactive
- Remove `aria-describedby` when title is not interactive

This ensures screen readers don't announce toggle functionality when no header exists to toggle.

Fixes: #12053 
