### PR TITLE
fix(ui5-toast): fix toast spacing in safari

### DIFF
--- a/packages/main/src/themes/Toast.css
+++ b/packages/main/src/themes/Toast.css
@@ -28,6 +28,10 @@
 	padding: 0;
 	outline: none;
 	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: fit-content;
 }
 
 :host([open]) {


### PR DESCRIPTION

Fixes: #12138 

Toast spacing is fixed and it is aligned in all browsers.