### PR TITLE
chore: fix font-face generation on windows

### DIFF
--- a/packages/base/lib/css-processors/css-processor-font-face.mjs
+++ b/packages/base/lib/css-processors/css-processor-font-face.mjs
@@ -48,7 +48,7 @@ const themeBaseFile = fileURLToPath(import.meta.resolve("@sap-theming/theming-ba
 
 const config = {
     stdin: {
-        contents: `@import "${JSON.stringify(themeBaseFile)}";`, // windows paths contain a backslash which has to be escaped because this will be treated as a string
+        contents: `@import ${JSON.stringify(themeBaseFile)};`, // windows paths contain a backslash which has to be escaped because this will be treated as a string
         resolveDir: './',
         sourcefile: 'virtual-font-face.css',
         loader: 'css',


### PR DESCRIPTION
escape backslashes to double backslashes because windows paths contain them but the import string is verbatim