### PR TITLE
chore: extend form-validity test for ui5-switch, ui5-date-picker and ui5-time-picker

### DIFF
--- a/packages/main/cypress/specs/DatePicker.cy.tsx
+++ b/packages/main/cypress/specs/DatePicker.cy.tsx
@@ -1689,3 +1689,56 @@ describe("Legacy date customization and Islamic calendar type", () => {
 			.should("have.attr", "value-state", "None");
 	});
 });
+
+describe("Validation inside a form", () => {
+	it("has correct validity", () => {
+		cy.mount(<form method="get">
+			<DatePicker id="dp" name="checkbox5" required={true}></DatePicker>
+			<button type="submit" id="submitBtn" > Submits forms </button>
+		</form>);
+
+		cy.get("form")
+			.then($item => {
+				$item.get(0).addEventListener("submit", cy.stub().as("submit"));
+			});
+
+		cy.get("#submitBtn")
+			.realClick();
+
+		cy.get("@submit")
+			.should("have.not.been.called");
+
+		cy.get("#dp")
+			.then($el => {
+				const datePicker = $el[0] as DatePicker;
+				expect(datePicker.formValidity.valueMissing, "Required datepicker without value should have formValidity with valueMissing=true").to.be.true;
+				expect(datePicker.validity.valueMissing, "Required datepicker without value should have validity with valueMissing=true").to.be.true;
+				expect(datePicker.validity.valid, "Required datepicker without value should have validity with valid=false").to.be.false;
+				expect(datePicker.checkValidity(), "Required datepicker without value fail validity check").to.be.false;
+				expect(datePicker.reportValidity(), "Required datepicker without value should fail report validity").to.be.false;
+			});
+
+		cy.get("#dp:invalid") // select using :invalid CSS pseudo-class
+			.should("exist", "Required datepicker without value should have :invalid CSS class");
+
+		cy.get("#dp")
+			.as("datePicker")
+			.ui5DatePickerGetInnerInput()
+			.realClick()
+			.should("be.focused")
+			.realType("Apr 12, 2024")
+			.realPress("Enter");
+
+		cy.get("dp")
+			.then($el => {
+				const datePicker = $el[0] as DatePicker;
+				expect(datePicker.formValidity.valueMissing, "Required datepicker with value should have formValidity with valueMissing=false").to.be.false;
+				expect(datePicker.validity.valueMissing, "Required datepicker with value should have validity with valueMissing=false").to.be.false;
+				expect(datePicker.validity.valid, "Required datepicker with value have validity with valid=true").to.be.true;
+				expect(datePicker.checkValidity(), "Required datepicker with value pass validity check").to.be.true;
+				expect(datePicker.reportValidity(), "Required datepicker with value pass report validity").to.be.true;
+			});
+
+		cy.get("#dp:invalid").should("not.exist", "Required datepicker with value should not have :invalid CSS class");
+	});
+});

--- a/packages/main/cypress/specs/Switch.cy.tsx
+++ b/packages/main/cypress/specs/Switch.cy.tsx
@@ -120,4 +120,53 @@ describe("General interactions in form", () => {
 			expect($form[0].checkValidity()).to.be.true;
 		});
 	});
+
+	it("Should fire 'invalid' event on form submit when 'required' switch is not checked", () => {
+		cy.mount(
+			<form id="switchForm">
+				<Switch checked></Switch>
+				<Switch id="requiredTestSwitch" required></Switch>
+				<Button id="switchSubmit" type="Submit">Submit</Button>
+			</form>
+		);
+
+		cy.get("form")
+			.then($item => {
+				$item.get(0).addEventListener("submit", cy.stub().as("submit"));
+			});
+
+		cy.get("#switchSubmit")
+			.realClick();
+
+		cy.get("@submit")
+			.should("have.not.been.called");
+
+		cy.get("#requiredTestSwitch")
+			.then($el => {
+				const switchElement = $el[0] as Switch;
+				expect(switchElement.formValidity.valueMissing, "Unchecked required Switch should have formValidity with valueMissing=true").to.be.true;
+				expect(switchElement.validity.valueMissing, "Unchecked required Switch should have validity with valueMissing=true").to.be.true;
+				expect(switchElement.validity.valid, "Unchecked required Switch should have validity with valid=false").to.be.false;
+				expect(switchElement.checkValidity(), "Unchecked required Switch should fail validity check").to.be.false;
+				expect(switchElement.reportValidity(), "Unchecked required Switch should fail report validity").to.be.false;
+			});
+
+		cy.get("#requiredTestSwitch:invalid")
+			.should("exist", "Unchecked required switch should have :invalid CSS class");
+
+		cy.get("#requiredTestSwitch")
+			.realClick();
+
+		cy.get("#requiredTestSwitch")
+			.then($el => {
+				const switchElement = $el[0] as Switch;
+				expect(switchElement.formValidity.valueMissing, "Checked required Switch should have formValidity with valueMissing=false").to.be.false;
+				expect(switchElement.validity.valueMissing, "Checked required Switch should have validity with valueMissing=false").to.be.false;
+				expect(switchElement.validity.valid, "Checked required Switch should have validity with valid=true").to.be.true;
+				expect(switchElement.checkValidity(), "Checked required Switch should pass validity check").to.be.true;
+				expect(switchElement.reportValidity(), "Checked required Switch should pass report validity").to.be.true;
+			});
+
+		cy.get("#requiredTestSwitch:invalid").should("not.exist", "Checked required Switch should not have :invalid CSS class");
+	});
 });

--- a/packages/main/test/pages/DatePicker.html
+++ b/packages/main/test/pages/DatePicker.html
@@ -168,12 +168,45 @@
 			<ui5-date-picker id="datepicker10" calendar-week-numbering="WesternTraditional">
 			</ui5-date-picker>
 		</section>
-
+		<section>
+			<ui5-title>Form validation</ui5-title>
+			<form id="formValidation">
+				<ui5-message-strip id="formValidationMessage" hidden></ui5-message-strip>
+				<ui5-date-picker min-date="1/1/2021" max-date="31/1/2021" required id="formDatepicker"></ui5-date-picker>
+				<br><br>
+				<ui5-button id="btnCheckFormValidity">Check Validity</ui5-button>
+			</form>
+		</section>
 	</div>
 	<script>
 		var dp = document.getElementById('dp5');
 		var labelChange = document.getElementById('lblChange');
 		var labelLiveChange = document.getElementById('lblLiveChange');
+		var btnCheckFormValidity = document.getElementById('btnCheckFormValidity');
+		var formValidationMessage = document.getElementById('formValidationMessage');
+		var formDatepicker = document.getElementById('formDatepicker');
+
+		btnCheckFormValidity.addEventListener('click', function() {
+			checkFormValidity('formDatepicker');
+		});
+
+		formDatepicker.addEventListener('ui5-change', function() {
+			setTimeout(() => {
+				checkFormValidity('formDatepicker', true);
+			}, 0);
+		});
+
+		function checkFormValidity(elementId, delayed = false) {
+			const element = document.getElementById(elementId);
+			const isValid = element.checkValidity();
+
+			element.reportValidity();
+
+			// Show result
+			formValidationMessage.hidden = false;
+			formValidationMessage.innerText = `checkValidity(): ${isValid} ${delayed ? '( Delayed check )' : ''}`;
+			formValidationMessage.design = isValid ? "Positive" : "Negative";
+		}
 
 		dp.addEventListener('click', function() { console.log('click')});
 		dp.addEventListener('focus', function() {console.log('focus')});
@@ -221,7 +254,7 @@
 		});
 
 		const datePickerValueStateChangePrevented = document.getElementById("dpVsChangePrevented");
-	
+
 		datePickerValueStateChangePrevented.addEventListener("value-state-change", function(e) {
 			e.preventDefault();
 	});

--- a/packages/main/test/pages/Switch.html
+++ b/packages/main/test/pages/Switch.html
@@ -77,6 +77,14 @@
 		<ui5-button id="switchSubmit" type="Submit">Submit</ui5-button>
 	</form>
 
+	<h3>Form validation</h3>
+	<form id="formValidation">
+		<ui5-message-strip id="formValidationMessage" hidden></ui5-message-strip>
+		<ui5-switch id="switchValidated" required></ui5-switch>
+		<br><br>
+		<ui5-button id="btnCheckFormValidity">Check Validity</ui5-button>
+	</form>
+
 	<h3>Custom Switch</h3>
 	<div class="switch2auto">
 		<ui5-switch text-on="Accept" text-off="Reject" class="switch4auto"></ui5-switch>
@@ -104,6 +112,9 @@
 
 <script>
 	var counter = 0;
+	var btnCheckFormValidity = document.getElementById('btnCheckFormValidity');
+	var formValidationMessage = document.getElementById('formValidationMessage');
+	var validatedSwitch = document.getElementById('switchValidated');
 
 	submitBtn.addEventListener("click", function(e) {
 		if (myForm.checkValidity()) {
@@ -121,5 +132,27 @@
 	switchprevented.addEventListener("ui5-change", function(e) {
 		e.preventDefault();
 	});
+
+	btnCheckFormValidity.addEventListener('click', function() {
+		checkFormValidity('switchValidated');
+	});
+
+	validatedSwitch.addEventListener('ui5-change', function() {
+		setTimeout(() => {
+			checkFormValidity('switchValidated', true);
+		}, 0);
+	});
+
+	function checkFormValidity(elementId, delayed = false) {
+		const element = document.getElementById(elementId);
+		const isValid = element.checkValidity();
+
+		element.reportValidity();
+
+		// Show result
+		formValidationMessage.hidden = false;
+		formValidationMessage.innerText = `checkValidity(): ${isValid} ${delayed ? '( Delayed check )' : ''}`;
+		formValidationMessage.design = isValid ? "Positive" : "Negative";
+	}
 </script>
 </html>

--- a/packages/main/test/pages/TimePicker.html
+++ b/packages/main/test/pages/TimePicker.html
@@ -93,6 +93,15 @@
 		<ui5-time-picker readonly></ui5-time-picker>
 		<ui5-time-picker disabled></ui5-time-picker>
 
+		<section>
+			<h3>Form validation</h3>
+			<form id="formValidation">
+				<ui5-message-strip id="formValidationMessage" hidden></ui5-message-strip>
+				<ui5-time-picker required id="formTimepicker"></ui5-time-picker>
+				<ui5-button id="btnCheckFormValidity">Check Validity</ui5-button>
+			</form>
+		</section>
+
 		<script>
 				var counter = 0;
 				timepickerChange.addEventListener("ui5-change", function() {
@@ -108,6 +117,32 @@
 				document.getElementById('setTimeButton').addEventListener("click", function(e) {
 					tp.setAttribute("value", tp.formatValue(new Date(2020, 3, 13, 3, 16, 16)));
 				});
+
+				var btnCheckFormValidity = document.getElementById('btnCheckFormValidity');
+				var formValidationMessage = document.getElementById('formValidationMessage');
+				var formTimepicker = document.getElementById('formTimepicker');
+
+				btnCheckFormValidity.addEventListener('click', function() {
+					checkFormValidity('formTimepicker');
+				});
+
+				formTimepicker.addEventListener('ui5-change', function() {
+					setTimeout(() => {
+						checkFormValidity('formTimepicker', true);
+					}, 0);
+				});
+
+				function checkFormValidity(elementId, delayed = false) {
+					const element = document.getElementById(elementId);
+					const isValid = element.checkValidity();
+
+					element.reportValidity();
+
+					// Show result
+					formValidationMessage.hidden = false;
+					formValidationMessage.innerText = `checkValidity(): ${isValid} ${delayed ? '( Delayed check )' : ''}`;
+					formValidationMessage.design = isValid ? "Positive" : "Negative";
+				}
 		</script>
 	</body>
 </html>

--- a/packages/main/test/pages/styles/DatePicker.css
+++ b/packages/main/test/pages/styles/DatePicker.css
@@ -5,3 +5,8 @@
 .datepicker1auto {
     background-color: var(--sapBackgroundColor);
 }
+
+
+form ui5-date-picker:invalid {
+    outline: 2px solid var(--sapNegativeColor);
+}

--- a/packages/main/test/pages/styles/Switch.css
+++ b/packages/main/test/pages/styles/Switch.css
@@ -81,3 +81,7 @@ ui5-switch {
     border-radius: var(--sapElement_BorderCornerRadius);
     padding: 1rem;
 }
+
+#formValidation ui5-switch:invalid{
+    outline: 2px solid var(--sapNegativeColor);
+}

--- a/packages/main/test/pages/styles/TimePicker.css
+++ b/packages/main/test/pages/styles/TimePicker.css
@@ -22,3 +22,7 @@ html,body {
 .timepicker2auto {
     width: 100%
 }
+
+form ui5-time-picker:invalid {
+    outline: 2px solid var(--sapNegativeColor);
+}


### PR DESCRIPTION
In relation to https://github.com/SAP/ui5-webcomponents/issues/10487, extend the tests to check that ui5-switch, ui5-date-picker and ui5-time-picker correctly expose a "validity" property and related methods required by the Constraint Validation API, as well as are selectable using the :invalid CSS pseudo class.