### PR TITLE
feat(ui5-segmented-button): improve component accessibility

### DIFF
--- a/packages/main/cypress/specs/SegmentedButton.cy.tsx
+++ b/packages/main/cypress/specs/SegmentedButton.cy.tsx
@@ -1,6 +1,8 @@
 import SegmentedButton from "../../src/SegmentedButton.js";
+import Label from "../../src/Label.js";
 import SegmentedButtonItem from "../../src/SegmentedButtonItem.js";
 import type UI5Element from "@ui5/webcomponents-base";
+import { SEGMENTEDBUTTON_ARIA_DESCRIBEDBY } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("SegmentedButton general interaction tests", () => {
 	it("should have first item selected by default", () => {
@@ -231,7 +233,7 @@ describe("SegmentedButton - getFocusDomRef", () => {
 });
 
 describe("Accessibility", () => {
-	it("should have correct aria labels", () => {
+	it("segmented button items should have correct aria labels", () => {
 		cy.mount(
 			<>
 				<SegmentedButton selectionMode="Multiple">
@@ -260,5 +262,109 @@ describe("Accessibility", () => {
 			.shadow()
 			.find("li")
 			.should("have.attr", "aria-label", "accessible ref text");
+	});
+
+	it("segmented button should have correct aria label when accessibleName is set", () => {
+		const LABEL = "Label";
+		cy.mount(
+			<>
+				<SegmentedButton accessibleName={LABEL}>
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-label", LABEL);
+	});
+
+	it("segmented button should have correct aria label when external label is set", () => {
+		const LABEL = "External label";
+		cy.mount(
+			<>
+				<Label for="segBtn">{LABEL}</Label>
+				<SegmentedButton id="segBtn">
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-label", LABEL);
+	});
+
+	it("segmented button should have correct aria label when accessibleNameRef is set", () => {
+		const LABEL = "External label";
+		cy.mount(
+			<>
+				<p id="accessibleLabel">{LABEL}</p>
+				<SegmentedButton accessibleNameRef="accessibleLabel">
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-label", LABEL);
+	});
+
+	it("segmented button should have correct aria description when neither accessibleDescription nor accessibleDescriptionRef are set", () => {
+		cy.mount(
+			<>
+				<SegmentedButton>
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-description", SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIBEDBY));
+	});
+
+	it("segmented button should have correct aria description when accessibleDescription is set", () => {
+		const DESCRIPTION = "Description";
+		cy.mount(
+			<>
+				<SegmentedButton accessibleDescription={DESCRIPTION}>
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-description", `${DESCRIPTION} ${SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIBEDBY)}`);
+	});
+
+	it("segmented button should have correct aria description when accessibleDescriptionRef is set", () => {
+		const DESCRIPTION = "External description";
+		cy.mount(
+			<>
+				<p id="accessibleDescription">{DESCRIPTION}</p>
+				<SegmentedButton accessibleDescriptionRef="accessibleDescription">
+					<SegmentedButtonItem>First</SegmentedButtonItem>
+					<SegmentedButtonItem>Second</SegmentedButtonItem>
+				</SegmentedButton>
+			</>
+		);
+
+		cy.get("[ui5-segmented-button]")
+			.shadow()
+			.find(".ui5-segmented-button-root")
+			.should("have.attr", "aria-description", `${DESCRIPTION} ${SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIBEDBY)}`);
 	});
 });

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -3,6 +3,13 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import {
+	getEffectiveAriaLabelText,
+	getAssociatedLabelForTexts,
+	getAllAccessibleNameRefTexts,
+	getEffectiveAriaDescriptionText,
+	getAllAccessibleDescriptionRefTexts,
+} from "@ui5/webcomponents-base/dist/util/AccessibilityTextsHelper.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import ItemNavigation from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
@@ -83,6 +90,33 @@ class SegmentedButton extends UI5Element {
 	 */
 	@property()
 	accessibleName?: string;
+
+	/**
+	 * Defines the IDs of the HTML Elements that label the component.
+	 * @default undefined
+	 * @public
+	 * @since 2.15.0
+	 */
+	@property()
+	accessibleNameRef?: string;
+
+	/**
+	 * Defines the accessible description of the component.
+	 * @default undefined
+	 * @public
+	 * @since 2.15.0
+	 */
+	@property()
+	accessibleDescription?: string;
+
+	/**
+	 * Defines the IDs of the HTML Elements that describe the component.
+	 * @default undefined
+	 * @public
+	 * @since 2.15.0
+	 */
+	@property()
+	accessibleDescriptionRef?: string;
 
 	/**
 	 * Defines the component selection mode.
@@ -255,11 +289,19 @@ class SegmentedButton extends UI5Element {
 		});
 	}
 
-	get ariaDescribedBy() {
-		return SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIBEDBY);
+	get ariaLabelText() {
+		return getAllAccessibleNameRefTexts(this) || getEffectiveAriaLabelText(this) || getAssociatedLabelForTexts(this) || undefined;
 	}
 
-	get ariaDescription() {
+	get ariaDescriptionText() {
+		return (
+			(getAllAccessibleDescriptionRefTexts(this) || getEffectiveAriaDescriptionText(this))
+			+ " "
+			+ SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIBEDBY)
+		).trim();
+	}
+
+	get ariaRoleDescription() {
 		return SegmentedButton.i18nBundle.getText(SEGMENTEDBUTTON_ARIA_DESCRIPTION);
 	}
 }

--- a/packages/main/src/SegmentedButtonTemplate.tsx
+++ b/packages/main/src/SegmentedButtonTemplate.tsx
@@ -11,12 +11,11 @@ export default function SegmentedButtonTemplate(this: SegmentedButton) {
 			onKeyUp={this._onkeyup}
 			onFocusIn={this._onfocusin}
 			aria-multiselectable="true"
-			aria-describedby={`${this._id}-invisibleText`}
-			aria-roledescription={this.ariaDescription}
-			aria-label={this.accessibleName}
+			aria-description={this.ariaDescriptionText}
+			aria-label={this.ariaLabelText}
+			aria-roledescription={this.ariaRoleDescription}
 		>
 			<slot></slot>
-			<span id={`${this._id}-invisibleText`} class="ui5-hidden-text">{this.ariaDescribedBy}</span>
 		</ul>
 	);
 }


### PR DESCRIPTION
This PR adds and integrates new accessibility properties to the ui5-segmented-button component:

* `accessibleNameRef`: Allows referencing external elements for the ARIA label.
* `accessibleDescription`: Allows setting a custom accessible description.
* `accessibleDescriptionRef`: Allows referencing external elements for the ARIA description.