### PR TITLE
fix(create-package): add `npmignore` to ensure `dist` is published

### DIFF
--- a/packages/create-package/template/.npmignore
+++ b/packages/create-package/template/.npmignore
@@ -1,0 +1,6 @@
+src/generated
+node_modules/
+test/
+cypress/
+.eslintrc.cjs
+.eslintignore


### PR DESCRIPTION
When the `.npmignore` is missing, `.gitignore` is considered when running `npm publish`. And, the `.gitignore` includes `dist`, by default the `dist` folder is not published on NPM.