### PR TITLE
fix(ui5-shellbar-search): correct min-width

### DIFF
--- a/packages/fiori/src/ShellBarSearch.ts
+++ b/packages/fiori/src/ShellBarSearch.ts
@@ -3,6 +3,8 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import Search from "./Search.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import ShellBarSearchTemplate from "./ShellBarSearchTemplate.js";
+import ShellBarSearchCss from "./generated/themes/ShellBarSearch.css.js";
+
 import {
 	SEARCH_FIELD_SEARCH_ICON,
 	SHELLBAR_SEARCH_EXPANDED,
@@ -21,6 +23,10 @@ import {
 @customElement({
 	tag: "ui5-shellbar-search",
 	template: ShellBarSearchTemplate,
+	styles: [
+		Search.styles,
+		ShellBarSearchCss,
+	],
 })
 
 class ShellBarSearch extends Search {

--- a/packages/fiori/src/themes/ShellBarSearch.css
+++ b/packages/fiori/src/themes/ShellBarSearch.css
@@ -1,0 +1,3 @@
+:host(:not([collapsed])) {
+	min-width: 13rem;
+}


### PR DESCRIPTION
ShellBarSearch used to be overflowing the ShellBar when displayed on really small desktop screens (320px)