### PR TITLE
fix(ui5-segmented-button): hidden items do not take space

### DIFF
--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -124,15 +124,17 @@ class SegmentedButton extends UI5Element {
 
 	onBeforeRendering() {
 		const items = this.getSlottedNodes<SegmentedButtonItem>("items");
+    	const visibleItems = items.filter(item => !item.hidden);
+		let index = 1;
 
-		items.forEach((item, index, arr) => {
-			item.posInSet = index + 1;
-			item.sizeOfSet = arr.length;
+		items.forEach((item) => {
+			item.posInSet = item.hidden ? undefined : index++;
+			item.sizeOfSet = item.hidden ? undefined : visibleItems.length;
 		});
 
 		this.normalizeSelection();
 
-		this.style.setProperty(getScopedVarName("--_ui5_segmented_btn_items_count"), `${items.length}`);
+		this.style.setProperty(getScopedVarName("--_ui5_segmented_btn_items_count"), `${visibleItems.length}`);
 	}
 
 	normalizeSelection() {

--- a/packages/main/src/SegmentedButtonItem.ts
+++ b/packages/main/src/SegmentedButtonItem.ts
@@ -130,7 +130,7 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 	 * @private
 	 */
 	@property({ type: Number })
-	posInSet = 0;
+	posInSet? = 0;
 
 	/**
 	 * Defines how many items are inside of the SegmentedButton.
@@ -138,7 +138,13 @@ class SegmentedButtonItem extends UI5Element implements IButton, ISegmentedButto
 	 * @private
 	 */
 	@property({ type: Number })
-	sizeOfSet = 0;
+	sizeOfSet? = 0;
+
+	/**
+	 * @private
+	 */
+	@property({ type: Boolean })
+	hidden = false;
 
 	/**
 	 * Defines the text of the component.


### PR DESCRIPTION
Until now, when an `ui-segmented-button-item` was `hidden`, it still took place and `ui5-segmented-button` was wider than sum of widths of all visible items. Also, the `aria-setsize` and `aria-posinset` values didn't respect the count of the visible items.

This PR fixes these issues.

**JIRA: BGSOFUIBALKAN-9029, case #4**

