### PR TITLE
fix(ui5-segmented-button): fix hover+active segmented button item background

### DIFF
--- a/packages/main/src/themes/SegmentedButton.css
+++ b/packages/main/src/themes/SegmentedButton.css
@@ -70,3 +70,8 @@
 ::slotted([ui5-segmented-button-item][active]:hover) {
 	border-color: var(--sapButton_Selected_BorderColor);
 }
+
+::slotted([ui5-segmented-button-item]:active) {
+	background-color: var(--sapButton_Selected_Background);
+}
+


### PR DESCRIPTION
There was missing CSS selector for background of `hover` + `active` state of the non-selected `ui5-segmented-button-item` component.

This PR introduces it and now the mentioned color is as defined in the visual specification.

**JIRA: BGSOFUIBALKAN-9029**, case 5