### PR TITLE
feat(framework): detect dynamically loaded OpenUI5

### DIFF
--- a/packages/base/src/features/OpenUI5Support.ts
+++ b/packages/base/src/features/OpenUI5Support.ts
@@ -90,9 +90,30 @@ class OpenUI5Support {
 
 	static initPromise?: Promise<void>;
 
+	/**
+	 * Important - if OpenUI5 is loaded after UI5 Web Components, configuration is not synchronized and it's up to the app to initialize OpenUI5 with the same settings as UI5 Web Components for consistency.
+	 */
+	static OpenUI5DelayedInit = () => {
+		OpenUI5Support.init(); // This ensures patchPopover and patchPatcher are called; and from this point OpenUI5 CSS vars start being detected
+	}
+
+	static awaitForOpenUI5() {
+		const w = window as Record<string, any>;
+		w["sap-ui-config"] = w["sap-ui-config"] || {};
+		const oldInit = w["sap-ui-config"].onInit;
+		if (!oldInit) {
+			w["sap-ui-config"].onInit = OpenUI5Support.OpenUI5DelayedInit;
+		} else {
+			w["sap-ui-config"].onInit = function onInit(...rest: any[]) {
+				oldInit.apply(this, ...rest);
+				OpenUI5Support.OpenUI5DelayedInit();
+			};
+		}
+	}
+
 	static init() {
 		if (!OpenUI5Support.isOpenUI5Detected()) {
-			return Promise.resolve();
+			return OpenUI5Support.awaitForOpenUI5();
 		}
 
 		if (!OpenUI5Support.initPromise) {

--- a/packages/main/test/pages/Openui5.delayed.html
+++ b/packages/main/test/pages/Openui5.delayed.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="EN">
+
+<head>
+	<title>OpenUI5 delayed loading</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<script>
+	window["sap-ui-config"] = {
+		onInit: function () {
+			console.log("The application has already defined onInit that must not be overwritten");
+		},
+		theme: "sap_horizon",
+		libs: "sap.m"
+	};
+	</script>
+	
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+
+	<script>
+		setTimeout(() => {
+			var script = document.createElement("script");
+			script.id = "sap-ui-bootstrap";
+			script.src = "https://sdk.openui5.org/resources/sap-ui-core.js";
+			script.async = true;
+			document.head.appendChild(script);
+			setTimeout(() => {
+				new sap.m.DatePicker().placeAt("sapMDatePicker");
+			}, 1000);
+		}, 1000);
+	</script>
+</head>
+
+<body>
+	<div id="sapMDatePicker"></div>
+
+	<ui5-list id="side-nav-list" selection-mode="Single" separators="Inner">
+		<ui5-li type="Active" id="arg1" icon="developer-settings">ui5-button</ui5-li>
+		<ui5-li type="Active" id="bg1" icon="developer-settings">ui5-card</ui5-li>
+		<ui5-li type="Active" id="bg1" icon="developer-settings">ui5-checkbox</ui5-li>
+	</ui5-list>
+</body>
+</html>


### PR DESCRIPTION
This change adds initial support for the scenario where **OpenUI5 is loaded after UI5 Web Components**
 - `patchPopup` and `patchPatcher` are executed a.s.a.p. so that any popups open from OpenUI5 will not glitch
 - the configuration is **not** synchronized: when OpenUI5 loads first (classic scenario) UI5 Web Components take its configuration and use it, however if UI5 Web Components is loaded first, and only then OpenUI5, it is up to the app to initialize OpenUI5 with the same settings as UI5 Web Components for consistency.
 - if the theme is changed after OpenUI5 is loaded, the "OpenUI5 CSS Variables" detection will now succeed and UI5 Web Components will delete the adopted stylesheet and let OpenUI5 provide variables