### PR TITLE
test(ui5-dynamic-date-range): fix wrong test

### DIFF
--- a/packages/main/cypress/specs/DynamicDateRange.cy.tsx
+++ b/packages/main/cypress/specs/DynamicDateRange.cy.tsx
@@ -157,7 +157,7 @@ describe('DynamicDateRange Component', () => {
 	});
 
 	// Check why it fails remotely
-	it.skip('selects the Date option and updates the current value', () => {
+	it('selects the Date option and updates the current value', () => {
 		cy.get('[ui5-dynamic-date-range]')
 			.as("ddr");
 
@@ -225,7 +225,6 @@ describe('DynamicDateRange Component', () => {
 			.contains('2035')
 			.realClick();
 
-		cy.realPress("Tab");
 		cy.realPress("Tab");
 
 		cy.get("@calendar")


### PR DESCRIPTION
The test was observing and asserting a wrong behaviour, due to an extra `Tab` press.
With this change we now made the test stable, and observing the correct behaviour.