### PR TITLE
test: add cypress test of ui5 and ui5webc integration case

### DIFF
--- a/packages/base/cypress/specs/UI5andUI5WebComponents.cy.tsx
+++ b/packages/base/cypress/specs/UI5andUI5WebComponents.cy.tsx
@@ -75,10 +75,6 @@ describe("ui5 and web components integration", () => {
             doc.head.appendChild(ui5Script);
         });
         
-		// wait for ui5 to initialize completely
-        cy.window().should('have.property', 'sap');
-        cy.window().should('have.property', 'ui5InitComplete', true);
-        
         // act: open sap.m.Dialog
         cy.get('#ui5-button')
 			.should('be.visible')


### PR DESCRIPTION
Adds a new Cypress test, loading SAPUI5 and UI5 Web Components, mixing `sap.m.Dialog` and `ui5-dialog`

Fixes: https://github.com/SAP/ui5-webcomponents/issues/12249