### PR TITLE
fix(ui5-illustrated-message): fix imports filter

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -13,7 +13,7 @@ const cypressEnvVariables = (options, predefinedVars) => {
 	let variables = [];
 	const { cypress_code_coverage, cypress_acc_tests } = options.internal ?? {};
 
-	// Handle environment variables like TEST_SUITE  
+	// Handle environment variables like TEST_SUITE
 	if (predefinedVars) {
 		variables = [...predefinedVars];
 	}
@@ -36,7 +36,7 @@ const getScripts = (options) => {
 	const createIllustrationsJSImportsScript = illustrations.join(" && ");
 
 	// The script creates the "src/generated/js-imports/Illustration.js" file that registers loaders (dynamic JS imports) for each illustration
-	const createIllustrationsLoadersScript = illustrationsData.map(illustrations => `node ${LIB}/generate-js-imports/illustrations.js ${illustrations.destinationPath} ${illustrations.dynamicImports.outputFile} ${illustrations.set} ${illustrations.collection} ${illustrations.dynamicImports.location} ${illustrations.dynamicImports.filterOut.join(" ")}`).join(" && ");
+	const createIllustrationsLoadersScript = illustrationsData.map(illustrations => `node ${LIB}/generate-js-imports/illustrations.js ${illustrations.destinationPath} ${illustrations.dynamicImports.outputFile} ${illustrations.set} ${illustrations.collection} ${illustrations.dynamicImports.location} ${illustrations.dynamicImports.filterOut.join(",")}`).join(" && ");
 
 	const tsOption = !options.legacy || options.jsx;
 	const tsCommandOld = tsOption ? "tsc" : "";

--- a/packages/tools/lib/generate-js-imports/illustrations.js
+++ b/packages/tools/lib/generate-js-imports/illustrations.js
@@ -77,7 +77,7 @@ const config = {
   set: process.argv[4],
   collection: process.argv[5],
   location: process.argv[6],
-  filterOut: process.argv.slice[7],
+  filterOut: process.argv[7].slice().split(","),
 };
 
 // Run the generation process


### PR DESCRIPTION
Imports filter format passed to the Illustrations script was not read correctly, because empty space was interpreted as another parameter. It is correct now and imports are filtered.

Fixes: [#12101](https://github.com/UI5/webcomponents/issues/12101)