### PR TITLE
fix(ui5-side-navigation): prevent TypeError when selected item has no DomRef

### DIFF
--- a/packages/fiori/src/SideNavigation.ts
+++ b/packages/fiori/src/SideNavigation.ts
@@ -534,9 +534,11 @@ class SideNavigation extends UI5Element {
 
 		if (selectedItem) {
 			const selectedItemDomRef = selectedItem.getDomRef();
-			const { marginTop, marginBottom } = window.getComputedStyle(selectedItemDomRef!);
 
-			itemsHeight += selectedItemDomRef!.offsetHeight + parseFloat(marginTop) + parseFloat(marginBottom);
+			if (selectedItemDomRef) {
+				const { marginTop, marginBottom } = window.getComputedStyle(selectedItemDomRef);
+				itemsHeight += selectedItemDomRef.offsetHeight + parseFloat(marginTop) + parseFloat(marginBottom);
+			}
 		}
 
 		overflowItems.forEach(item => {


### PR DESCRIPTION


fixes: #12261
