### PR TITLE
fix(ui5-shellbar): correct spacing after expanded search field

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -426,8 +426,7 @@ slot[name="profile"] {
 	margin-inline-start: 0.5rem;
 }
 
-.ui5-shellbar-overflow-container-right-child > :first-child,
-.ui5-shellbar-search-field:first-child + .ui5-shellbar-button:not(.ui5-shellbar-search-button) {
+.ui5-shellbar-overflow-container-right-child > :first-child {
 	margin-inline-start: 0;
 }
 


### PR DESCRIPTION
Remove problematic CSS selector that was removing margin from buttons positioned after the search field when expanded, causing missing 8px spacing.

Fixes: DINC0627273