### PR TITLE
fix(ui5-card): standardize border-radius variable usage and remove redundant definitions in sap_horizon themes

### DIFF
--- a/packages/main/src/themes/base/Card-parameters.css
+++ b/packages/main/src/themes/base/Card-parameters.css
@@ -2,7 +2,7 @@
 	--_ui5_card_box_shadow: var(--sapContent_Shadow0);
 	--_ui5_card_hover_box_shadow: var(--_ui5_card_box_shadow);
 	--_ui5_card_border: 1px solid var(--sapTile_BorderColor);
-	--_ui5_card_border-radius: var(--sapElement_BorderCornerRadius);
+	--_ui5_card_border-radius: var(--sapTile_BorderCornerRadius);
 	--_ui5_card_header_padding: 1rem;
 	--_ui5_card_header_hover_bg: var(--sapList_Hover_Background);
 	--_ui5_card_header_active_bg: var(--_ui5_card_header_hover_bg);

--- a/packages/main/src/themes/sap_horizon/Card-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Card-parameters.css
@@ -9,7 +9,6 @@
 	--_ui5_card_header_hover_bg: var(--sapTile_Hover_Background);
 	--_ui5_card_header_active_bg: var(--sapTile_Active_Background);
 	--_ui5_card_header_border: none;
-	--_ui5_card_border-radius: var(--sapTile_BorderCornerRadius);
 	--_ui5_card_header_padding: 1rem 1rem 0.75rem 1rem;
 	--_ui5_card_border: none;
 }

--- a/packages/main/src/themes/sap_horizon_dark/Card-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Card-parameters.css
@@ -9,7 +9,6 @@
 	--_ui5_card_header_hover_bg: var(--sapTile_Hover_Background);
 	--_ui5_card_header_active_bg: var(--sapTile_Active_Background);
 	--_ui5_card_header_border: none;
-	--_ui5_card_border-radius: var(--sapTile_BorderCornerRadius);
 	--_ui5_card_header_padding: 1rem 1rem 0.75rem 1rem;
 	--_ui5_card_border: none;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/Card-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Card-parameters.css
@@ -6,6 +6,5 @@
 	--_ui5_card_header_border: none;
 	--_ui5_card_header_hover_bg: var(--sapTile_Hover_Background);
 	--_ui5_card_header_active_bg: var(--sapTile_Active_Background);
-	--_ui5_card_border-radius: var(--sapTile_BorderCornerRadius);
 	--_ui5_card_header_padding: 1rem 1rem 0.75rem 1rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/Card-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Card-parameters.css
@@ -6,6 +6,5 @@
 	--_ui5_card_header_border: none;
 	--_ui5_card_header_hover_bg: var(--sapTile_Hover_Background);
 	--_ui5_card_header_active_bg: var(--sapTile_Active_Background);
-	--_ui5_card_border-radius: var(--sapTile_BorderCornerRadius);
 	--_ui5_card_header_padding: 1rem 1rem 0.75rem 1rem;
 }


### PR DESCRIPTION
- Standardize and correct the Card component’s border-radius theming variable usage across different UI5 themes.
- Remove redundant border-radius variable definitions in sap_horizon themes.

JIRA: BGSOFUIRODOPI-3349