### PR TITLE
chore: custom command execution in node20

### DIFF
--- a/packages/tools/bin/ui5nps.js
+++ b/packages/tools/bin/ui5nps.js
@@ -30,10 +30,9 @@ class Parser {
 		// Parse scripts on initialization
 		this.parseScripts();
 
-		for (const key of this.parsedScripts.keys()) {
-			console.log(`Resolving script: ${key}`);
+		[...this.parsedScripts.keys()].forEach(key => {
 			this.resolveScripts(`${key}`);
-		}
+		});
 	}
 
 	/**


### PR DESCRIPTION
`Map().keys().forEach` is not supported in Node.js 20. Attempting to use it in Node.js 20 (the older LTS) will result in an error.

Related to: https://github.com/UI5/webcomponents/issues/9277