### PR TITLE
fix(ui5-dynamic-page): improve focus visibility for keyboard navigation

### DIFF
--- a/packages/fiori/src/DynamicPage.ts
+++ b/packages/fiori/src/DynamicPage.ts
@@ -241,8 +241,7 @@ class DynamicPage extends UI5Element {
 					return;
 				}
 
-				if (this.dynamicPageHeader?.contains(target) ||
-					this.dynamicPageTitle?.contains(target)) {
+				if (this.dynamicPageHeader?.contains(target) || this.dynamicPageTitle?.contains(target)) {
 					return;
 				}
 


### PR DESCRIPTION
- Add focusin event listener to scroll container
- Exclude header and title elements to prevent unwanted scroll behavior
- Use scrollIntoView with smooth animation and nearest block positioning
- Properly manage event listener lifecycle in onAfterRendering/onExitDOM

Fixes: [#11710](https://github.com/UI5/webcomponents/issues/11710)