### PR TITLE
fix(ui5-dynamic-page): prevent z-index conflicts with external components

### DIFF
--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -2,13 +2,14 @@
     position: sticky;
     top: 0;
      /* We need the z-index to be higher than in the header actions, to avoid overlapping by snap on scroll */
-    z-index: 98;
+    z-index: 3;
 }
 
 :host {
     display: block;
     height: 100%;
     background-color: var(--ui5_dynamic_page_background);
+    isolation: isolate;
 }
 
 .ui5-dynamic-page-root {
@@ -47,7 +48,7 @@
     bottom: 0;
     padding: 0 0.5rem 0.5rem 0.5rem;
     box-sizing: border-box;
-    z-index: 110;
+    z-index: 2;
     opacity: 0;
     transform: translateY(100%);
     transition: opacity 0.35s ease-in-out, transform 0.35s ease-in-out;


### PR DESCRIPTION

The isolation property creates a new stacking context for the entire DynamicPage component, which allows us to use minimal z-index values (3 for header, 2 for footer) while maintaining proper internal layering. This prevents the component's high z-index values from conflicting with external elements like side navigation, without affecting the component's internal behavior. The isolation approach is preferred over adjusting z-index values as it doesn't create side effects with other components.

- Add isolation: isolate to :host to create new stacking context
- Reduce z-index values from 98/110 to 3/2 for internal layering

Fixes: [#12360](https://github.com/UI5/webcomponents/issues/12360)