### PR TITLE
fix: native scrollbar styles

### DIFF
--- a/docs/2-advanced/10-scrollbars-customization.md
+++ b/docs/2-advanced/10-scrollbars-customization.md
@@ -8,13 +8,13 @@ By default, some of the components provide additional CSS styles, which are appl
 
 ## Setting Default Scrollbar Styles to Components
 
-To use native scrollbar styles, you have to add the CSS style class `.ui5-content-native-scrollbars` to the body element of your application.
+To use native scrollbar styles, you have to add the CSS style class `.ui5-content-native-scrollbars` to the HTML element of your application.
 
 **Note: Because of some browser restrictions, this setting takes effect if it is applied before the initial rendering of the components, which use it.**
 
 Example:
 ```html
-<body class="ui5-content-native-scrollbars">
+<html class="ui5-content-native-scrollbars">
     ...
-</body>
+</html>
 ```

--- a/packages/base/src/css/ScrollbarStyles.css
+++ b/packages/base/src/css/ScrollbarStyles.css
@@ -1,3 +1,3 @@
-html:not(:has(.ui5-content-native-scrollbars)) {
+html:not(.ui5-content-native-scrollbars) {
 	scrollbar-color: var(--sapScrollBar_FaceColor) var(--sapScrollBar_TrackColor);
 }


### PR DESCRIPTION
Simplify the selector by moving the `.ui5-content-native-scrollbars` CSS class from the `body` element to the `html` element.

The previous approach introduced performance overhead because it required checking whether the class was applied to the `body`, while the relevant styles actually needed to target the `html` element and all of its children. Using the `:has()` selector for this purpose proved expensive on large DOMs.