### PR TITLE
fix(framework): fromAttribute converter can also return an object

### DIFF
--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -22,7 +22,7 @@ type Property = {
 	type?: BooleanConstructor | StringConstructor | ObjectConstructor | NumberConstructor | ArrayConstructor,
 	noAttribute?: boolean,
 	converter?: {
-		fromAttribute(value: string | null, type: unknown): string | number | boolean | null | undefined,
+		fromAttribute(value: string | null, type: unknown): PropertyValue,
 		toAttribute(value: unknown, type: unknown): string | null,
 	}
 }


### PR DESCRIPTION
the result of a `fromAttribute` converter is assigned to a variable of type `PropertyValue` which accepts an `object`, but the return type is wrongly typed and custom converters that return an `object` fail type checking.