### PR TITLE
fix(ui5-carousel): exclude hidden items from rendering and navigation

### DIFF
--- a/packages/main/cypress/specs/Carousel.cy.tsx
+++ b/packages/main/cypress/specs/Carousel.cy.tsx
@@ -389,7 +389,7 @@ describe("Carousel general interaction", () => {
 
 	});
 
-	it.only("navigateTo method and visibleItemsIndices", () => {
+	it("navigateTo method and visibleItemsIndices", () => {
 		cy.mount(
 			<Carousel id="carousel9" itemsPerPage="S2 M2 L2 XL2" arrowsPlacement="Navigation">
 				<Button>Button 1</Button>

--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -524,6 +524,7 @@ class Carousel extends UI5Element {
 					childList: false,
 					subtree: false,
 					attributes: true,
+					attributeFilter: ["hidden"],
 				});
 			}
 		});
@@ -971,6 +972,7 @@ class Carousel extends UI5Element {
  	 * Returns only visible (non-hidden) content items.
 	 * Items with the 'hidden' attribute are automatically excluded from carousel navigation.
 	 * @private
+	 * @returns {Array<HTMLElement>}
 	 */
 	get _visibleItems() {
 		return this.content.filter(x => !x.hasAttribute("hidden"));

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -862,7 +862,7 @@
 	</ui5-carousel>
 
 	<ui5-button id="hideLastCarouselBtn" design="Negative">Hide Last Item</ui5-button>
-	<ui5-button id="addItem" >add Item</ui5-button>
+	<ui5-button id="addItem" >Аdd Item</ui5-button>
 	
 	<ui5-carousel id="lastCarousel" arrows-placement="Navigation" page-indicator-type="Numeric">
 		<ui5-card class="myCard">


### PR DESCRIPTION
Carousel now checks for empty content when data changes and hides empty slides.

JIRA:BGSOFUIRODOPI-3548