### PR TITLE
fix(ui5-time-picker): Add interactive mode for the icon on mobile devices

### DIFF
--- a/packages/main/src/TimePicker.ts
+++ b/packages/main/src/TimePicker.ts
@@ -22,6 +22,7 @@ import {
 } from "@ui5/webcomponents-base/dist/util/AccessibilityTextsHelper.js";
 import "@ui5/webcomponents-localization/dist/features/calendar/Gregorian.js"; // default calendar for bundling
 import DateFormat from "@ui5/webcomponents-localization/dist/DateFormat.js";
+import IconMode from "./types/IconMode.js";
 import getCachedLocaleDataInstance from "@ui5/webcomponents-localization/dist/getCachedLocaleDataInstance.js";
 import {
 	isShow,
@@ -456,6 +457,14 @@ class TimePicker extends UI5Element implements IFormInputElement {
 
 	get shouldDisplayValueStateMessageInResponsivePopover() {
 		return this.hasValueStateText && !this._inputsPopover?.open;
+	}
+
+	/**
+	 * Defines whether the value help icon is hidden
+	 * @private
+	 */
+	get _iconMode() {
+		return isDesktop() ? IconMode.Decorative : IconMode.Interactive;
 	}
 
 	onTimeSelectionChange(e: CustomEvent<TimeSelectionChangeEventDetail>) {

--- a/packages/main/src/TimePickerTemplate.tsx
+++ b/packages/main/src/TimePickerTemplate.tsx
@@ -39,6 +39,7 @@ export default function TimePickerTemplate(this: TimePicker) {
 							name={timeEntryRequest}
 							tabindex={-1}
 							showTooltip={true}
+							mode={this._iconMode}
 							onClick={this._togglePicker}
 							class={{
 								"ui5-time-picker-input-icon-button": true,


### PR DESCRIPTION
Problem: When the screen reader is activated on a mobile device, the icon inside the input field cannot be focused, and consequently, the component cannot be opened.

Solution: After this change, the icon receives an Interactive attribute that allows it to be focused.