### PR TITLE
fix(ui5-step-input): make popover specs fit content

### DIFF
--- a/packages/main/src/themes/StepInput.css
+++ b/packages/main/src/themes/StepInput.css
@@ -163,23 +163,30 @@
 }
 
 :host .ui5-step-input-root {
-	white-space: nowrap;
 	line-height: inherit;
 	letter-spacing: inherit;
 	word-spacing: inherit;
 	height: inherit;
 }
 
-:host .ui5-step-input-input[text-align=left] {
+:host .ui5-step-input-input::part(input) {
+	white-space: nowrap;
+}
+
+:host .ui5-step-input-input[text-align=left]::part(input) {
 	text-align: left;
 }
 
-:host .ui5-step-input-input[text-align=center] {
+:host .ui5-step-input-input[text-align=center]::part(input) {
 	text-align: center;
 }
 
-:host .ui5-step-input-input[text-align=right] {
+:host .ui5-step-input-input[text-align=right]::part(input) {
 	text-align: right;
+}
+
+::slotted([slot="valueStateMessage"]) {
+	text-align: left;
 }
 
 :host .ui5-step-icon {

--- a/packages/main/test/pages/StepInput.html
+++ b/packages/main/test/pages/StepInput.html
@@ -96,7 +96,8 @@
 			placeholder="Enter number"
 			value-state="Negative"
 			class="stepinput2auto"
-		></ui5-step-input>
+		>
+			<div slot="valueStateMessage" class="stepinput3auto">Tsanislav Gatev wrote this message so it can be long enough so we can test if wraps</div></ui5-step-input>
 	</div>
 
 	<div>


### PR DESCRIPTION
Encapsulate styles, so the one inhertited in the ui5-input do not change the value state message popover.

fixes: https://github.com/UI5/webcomponents/issues/10246

Before:
<img width="368" height="108" alt="image" src="https://github.com/user-attachments/assets/1d32e221-60c6-4ad0-99b2-065dd30cb9fb" />


After:
<img width="374" height="121" alt="image" src="https://github.com/user-attachments/assets/b7490ece-a881-4f51-ae77-73f72f3e50be" />
