### PR TITLE
chore: move some deps to devDeps

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "@lit-labs/ssr-dom-shim": "^1.1.2",
-    "chokidar-cli": "^3.0.0",
     "lit-html": "^2.0.1"
   },
   "devDependencies": {
@@ -66,6 +65,7 @@
     "@sap-theming/theming-base-content": "11.29.3",
     "@ui5/cypress-internal": "0.1.0",
     "@ui5/webcomponents-tools": "2.16.0-rc.3",
+    "chokidar-cli": "^3.0.0",
     "clean-css": "^5.2.2",
     "cypress": "^15.3.0",
     "eslint": "^7.22.0",


### PR DESCRIPTION
chokidar-cli and @types/openui5 used to be defined as dependencies by mistake.
