### PR TITLE
fix(ui5-tab-container): allow selection indicator on text-only tabs to overlap bottom border

### DIFF
--- a/packages/main/src/themes/TabInStrip.css
+++ b/packages/main/src/themes/TabInStrip.css
@@ -346,7 +346,6 @@
 	border-color: var(--sapTab_Negative_ForegroundColor);
 }
 
-
 .ui5-tab-strip-item--selected.ui5-tab-strip-item--negative.ui5-tab-strip-item--textOnly .ui5-tab-strip-itemText {
 	color: var(--sapTab_Negative_Selected_TextColor);
 }


### PR DESCRIPTION
The selection indicator for text-only tabs overlaps the bottom border.

Fixes: #12538