### PR TITLE
fix(ui5-dynamic-page): prevent scroll when focusing title/header

### DIFF
--- a/packages/fiori/cypress/specs/DynamicPage.cy.tsx
+++ b/packages/fiori/cypress/specs/DynamicPage.cy.tsx
@@ -224,6 +224,58 @@ describe("DynamicPage", () => {
 			.find("[ui5-dynamic-page-header-actions]")
 			.should("have.prop", "hidePinButton", true);
 	});
+
+	it("sets scroll padding when content receives focus", () => {
+		cy.mount(
+			<DynamicPage showFooter style={{ height: "600px" }}>
+				<DynamicPageTitle slot="titleArea">
+					<div slot="heading">Page Title</div>
+				</DynamicPageTitle>
+				<DynamicPageHeader slot="headerArea">
+					<div>Header Content</div>
+				</DynamicPageHeader>
+				<input data-testid="test-input" />
+				<Bar slot="footerArea" design="FloatingFooter">
+					<Button slot="endContent">Save</Button>
+				</Bar>
+			</DynamicPage>
+		);
+
+		cy.get("[data-testid='test-input']").focus();
+
+		cy.get("[ui5-dynamic-page]")
+			.shadow()
+			.find(".ui5-dynamic-page-scroll-container")
+			.should("have.css", "scroll-padding-top")
+			.and("not.equal", "0px");
+
+		cy.get("[data-testid='test-input']").blur();
+
+		cy.get("[ui5-dynamic-page]")
+			.shadow()
+			.find(".ui5-dynamic-page-scroll-container")
+			.should("have.css", "scroll-padding-top", "0px");
+	});
+
+	it("scrolls focused elements into view", () => {
+		cy.mount(
+			<DynamicPage style={{ height: "400px" }}>
+				<DynamicPageTitle slot="titleArea">
+					<div slot="heading">Page Title</div>
+				</DynamicPageTitle>
+				<DynamicPageHeader slot="headerArea">
+					<div>Header Content</div>
+				</DynamicPageHeader>
+				<div style={{ height: "1000px" }}>
+					<input data-testid="bottom-input" style={{ marginTop: "900px" }} />
+				</div>
+			</DynamicPage>
+		);
+
+		cy.get("[data-testid='bottom-input']").focus();
+
+		cy.get("[data-testid='bottom-input']").should("be.visible");
+	});
 });
 
 describe("Scroll", () => {

--- a/packages/fiori/src/DynamicPageTemplate.tsx
+++ b/packages/fiori/src/DynamicPageTemplate.tsx
@@ -33,7 +33,12 @@ export default function DynamicPageTemplate(this: DynamicPage) {
 
 				{!this.actionsInTitle && headerActions.call(this)}
 
-				<div class="ui5-dynamic-page-content" part="content">
+				<div
+					part="content"
+					class="ui5-dynamic-page-content"
+					onFocusIn={this.onContentFocusIn}
+					onFocusOut={this.onContentFocusOut}
+				>
 					<div class="ui5-dynamic-page-fit-content" part="fit-content">
 						<slot></slot>
 						{this.showFooter &&


### PR DESCRIPTION
When title or header elements received focus, they would trigger unwanted
scrolling because they are part of the scroll container but have static
scroll-padding. This caused scroll jumps when navigating between
content and header areas which lead to unsnap.

**Step to reproduce:** 
1. Open https://ui5.github.io/webcomponents/nightly/packages/fiori/test/pages/DynamicPage.html
2. Scroll until title snaps
3. Place focus in content (e.g on a list item)
4. Press SHIFT+TAB multiple times to go through the buttons in the title

**Result:**
Page scroll up => title unsnaps

**Demo solution on**
https://pr-12588--ui5-webcomponents-preview.netlify.app/packages/fiori/test/pages/dynamicpage

**Fix by implementing dynamic scroll padding that:**
- Sets scroll-padding-top/bottom when focus enters content area
- Resets scroll-padding when focus leaves content area
- Prevents title/header focus from triggering scroll behavior

This ensures smooth focus transitions without unexpected scroll jumps
while maintaining proper scrollIntoView behavior for content elements.

**Changes:**
- Replace static scroll-padding with dynamic onContentFocusIn/onContentFocusOut handlers  
- Remove lifecycle-based focus management (_focusInHandler, onAfterRendering/onExitDOM)
- Add topAreaHeight/endAreaHeight getters for dynamic padding calculation
- Add test coverage for focus handling and scroll padding behavior

Closes: #11689 