### PR TITLE
fix(tools): dev-server for 3rd party packages

### DIFF
--- a/packages/tools/bin/ui5nps.js
+++ b/packages/tools/bin/ui5nps.js
@@ -140,7 +140,11 @@ class Parser {
 			process.exit(1);
 		}
 
-		envs = scripts.__ui5envs;
+		envs = JSON.parse(JSON.stringify(scripts.__ui5envs || {}));
+
+		Object.entries(envs).forEach(([key, value]) => {
+			envs[key] = String(value);
+		});
 
 		// Package-script should provide default export with scripts object
 		if (envs && typeof envs !== "object") {

--- a/packages/tools/lib/dev-server/dev-server.mjs
+++ b/packages/tools/lib/dev-server/dev-server.mjs
@@ -4,13 +4,9 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { pathToFileURL } from "url";
 
-const argv = yargs(hideBin(process.argv))
-	.alias("c", "config")
-	.argv;
-
-const startVite = async (port) => {
+const startVite = async (config, port) => {
 	const server = await createServer({
-		configFile: argv.config,
+		configFile: config,
 		server: {
 			port: port,
 			strictPort: true,
@@ -37,7 +33,11 @@ const rmPortFile = async () => {
 	process.on(eventType, rmPortFile);
 });
 
-async function start() {
+async function start(outArgv) {
+	const argv = yargs(hideBin(outArgv))
+		.alias("c", "config")
+		.argv;
+
 	let retries = 10;
 	let port = 8080;
 	while (retries--) {
@@ -45,7 +45,7 @@ async function start() {
 		await fs.writeFile(".dev-server-port", `${port}`);
 		try {
 			// execSync(command, {stdio: 'pipe'});
-			const server = await startVite(port);
+			const server = await startVite(argv.config ?? "", port);
 			if (server) {
 				// server started, don't try other ports
 				break;


### PR DESCRIPTION
If a third-party package includes a Vite configuration file in its `config` folder, the configuration path was not being passed correctly because `process.argv` did not contain the necessary information.

This PR fixes the issue by ensuring that environment variables are always treated as strings, since in some cases they were being passed in their original (non-string) types.