### PR TITLE
ci: add blank release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Release Stable Version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        fetch-depth: 0
+    - uses: actions/setup-node@v4.1.0
+      with:
+        node-version: 22
+        cache: 'yarn'


### PR DESCRIPTION
From NPM: 
`NPM classic token creation is now disabled. 
Existing classic tokens will be revoked on Nov 19.
We need to migrate to trusted publishing or granular access tokens to avoid disruption.`

The problem with granular access tokens is that they are hard to maintain as they can be used for a very limited time.

Trusted publishing is more convenient. Once configured, it's between github and NPM to rotate/update tokens.
The problem with trusted publishing is that it can be configured for a single workflow and we have multiple release workflows.

Still, trusted publishing seems the right direction...

Follow up tasks:
 - @RandomByte  to create the initial trusted publishing config in this blank file
 - merge all release workflows into one
 - upgrade lerna to v9

