### PR TITLE
fix(ui5-multi-combobox): skip unstable tests temporarily

### DIFF
--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -641,7 +641,7 @@ describe("General", () => {
 			}));
 	});
 
-	it("Select All functionality + N-more integration", () => {
+	it.skip("Select All functionality + N-more integration", () => {
 		cy.mount(
 			<><MultiComboBox style="width: 100px" noValidation={true} showSelectAll={true}>
 				<MultiComboBoxItem selected={true} text="Very Very Very Very long Item 1"></MultiComboBoxItem>
@@ -1743,7 +1743,7 @@ describe("Keyboard interaction when pressing Ctrl + Alt + F8 for navigation", ()
 
 	});
 
-	it("When list item is selected and pressing [Ctrl + Alt + F8], first link is focused. [Arrow Down] moves focus to the first list item", () => {
+	it.skip("When list item is selected and pressing [Ctrl + Alt + F8], first link is focused. [Arrow Down] moves focus to the first list item", () => {
 		cy.get("[ui5-multi-combobox]")
 			.as("multi-combobox");
 


### PR DESCRIPTION
I tried re-running multiple times without success. Since it seriously affect the project's CI/CD processes we should skip it until a reliable fix is available.

related to: #12534
related to: #12607

Failing build log:

https://github.com/UI5/webcomponents/actions/runs/19159962685/job/54768942116?pr=12640