### PR TITLE
fix(cem): alias references

### DIFF
--- a/packages/ai/.ui5-cem-aliases.json
+++ b/packages/ai/.ui5-cem-aliases.json
@@ -1,0 +1,4 @@
+{
+	"BaseTextArea": "TextArea",
+	"BaseInput": "Input"
+}

--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -27,7 +27,17 @@ import { generateCustomData } from "cem-plugin-vs-code-custom-data-generator";
 import { customElementJetBrainsPlugin } from "custom-element-jet-brains-integration";
 
 const packageJSON = JSON.parse(fs.readFileSync("./package.json"));
+let aliasMap = {};
+
 const devMode = process.env.UI5_CEM_MODE === "dev";
+try {
+	aliasMap = JSON.parse(fs.readFileSync("./.ui5-cem-aliases.json"));
+} catch (e) {
+	if (devMode) {
+		console.warn("No .ui5-cem-aliases.json file found. Continuing without aliases.");
+	}
+}
+
 
 const extractClassNodeJSDoc = node => {
 	const fileContent = node.getFullText();
@@ -485,6 +495,12 @@ export default {
 							i--;
 						}
 					}
+
+					moduleDoc.declarations.forEach(declaration => {
+						if (declaration.superclass?.name && aliasMap[declaration.superclass.name]) {
+							declaration.superclass.name = aliasMap[declaration.superclass.name];
+						}
+					})
 
 					const typeReferences = new Set();
 					const registerTypeReference = reference => typeReferences.add(JSON.stringify(reference))


### PR DESCRIPTION
Describe aliases for components with duplicated names such as `@ui5/webcomponents/dist/TextArea.js` and `@ui5/webcomponents-ai/dist/TextArea.js`.

The `@ui5/webcomponents-ai/dist/TextArea.js` component uses `@ui5/webcomponents/dist/TextArea.js` internally as `BaseTextArea`. However, CEM does not generate correct type references because it cannot interpret these import naming patterns.
With this PR, a manual mechanism for renaming components after CEM generation is introduced to ensure proper type resolution.
