### PR TITLE
fix(ui5-shellbar): remove internal logo size restrictions

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -220,7 +220,6 @@ slot[name="profile"] {
 .ui5-shellbar-logo {
 	overflow: hidden;
 	cursor: pointer;
-	max-height: 2rem;
 }
 
 .ui5-shellbar-logo-area {
@@ -240,6 +239,7 @@ slot[name="profile"] {
 .ui5-shellbar-logo:focus,
 .ui5-shellbar-logo-area:focus {
 	outline: var(--_ui5_shellbar_logo_outline);
+	outline-offset: calc(-1 * var(--sapContent_FocusWidth));
 	border-radius: var(--_ui5_shellbar_logo_border_radius);
 }
 

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -24,6 +24,7 @@
 
 .ui5-shellbar-branding-root:focus {
 	outline: var(--_ui5_shellbar_logo_outline);
+	outline-offset: calc(-1 * var(--sapContent_FocusWidth));
 	border-radius: var(--_ui5_shellbar_logo_border_radius);
 }
 
@@ -66,7 +67,6 @@
 
 ::slotted([slot="logo"]) {
 	max-height: 2rem;
-	max-width: 3.75rem;
 	pointer-events: none;
 	padding-inline: 0.25rem;
 }


### PR DESCRIPTION
Related to #11868

This PR cherry-picks the changes from #12418  onto release-2.15.2.