### PR TITLE
fix(build): fix issue with legacy dev setup

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -129,6 +129,7 @@ const getScripts = (options) => {
 		},
 		copyProps: `ui5nps-script "${LIB}copy-and-watch/index.js" --silent "src/i18n/*.properties" dist/`,
 		copyPropsWithWatch: `ui5nps-script "${LIB}copy-and-watch/index.js" --silent "src/i18n/*.properties" dist/ --watch --safe --skip-initial-copy`,
+		copySrcWithWatch: `ui5nps-script "${LIB}copy-and-watch/index.js" --silent "src/**/*.{js,json}" dist/ --watch --safe --skip-initial-copy`,
 		copy: {
 			default: options.legacy ? "ui5nps copy.src copy.props" : "",
 			src: options.legacy ? `ui5nps-script "${LIB}copy-and-watch/index.js" --silent "src/**/*.{js,json}" dist/` : "",
@@ -137,7 +138,7 @@ const getScripts = (options) => {
 		watch: {
 			default: `ui5nps-p watch.templates watch.typescript watch.src watch.styles watch.i18n watch.props`, // concurently
 			devServer: 'ui5nps-p watch.default watch.bundle', // concurently
-			src: options.legacy ? 'ui5nps "copy.src --watch --safe --skip-initial-copy"' : "",
+			src: options.legacy ? 'ui5nps copySrcWithWatch' : "",
 			typescript: tsWatchCommandStandalone,
 			props: 'ui5nps copyPropsWithWatch',
 			bundle: `ui5nps-script ${LIB}dev-server/dev-server.mjs ${viteConfig}`,

--- a/packages/tools/lib/i18n/toJSON.js
+++ b/packages/tools/lib/i18n/toJSON.js
@@ -19,8 +19,7 @@ const convertToJSON = async (file, distPath) => {
 	const filename = path.basename(file, path.extname(file));
 	const language = filename.match(/^messagebundle_(.*?)$/)[1];
 	if (!allLanguages.includes(language)) {
-		console.log("Not supported language: ", language);
-		return;
+		console.warn("Not supported language or script: ", language);
 	}
 	const outputFile = path.normalize(`${distPath}/${filename}.json`);
 


### PR DESCRIPTION
- Not supported syntax: `'ui5nps "copy.src --watch --safe --skip-initial-copy"'` into two steps:


 ```sh
 'ui5nps copySrcWithWatch'
 
 copySrcWithWatch: `ui5nps-script "${LIB}copy-and-watch/index.js" --silent "src/**/*.{js,json}" dist/ --watch --safe --skip-initial-copy`
 ```
 
 - Allow creation of json asset for non-supported language or language script, but log a warning to inform component devs (some library creators could handle such scenarios on their own).