### PR TITLE
fix(ui5-select): nvda announcement of the selected value

### DIFF
--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -90,6 +90,10 @@ type SelectLiveChangeEventDetail = {
 	selectedOption: IOption,
 }
 
+const isPrintableCharacter = (e: KeyboardEvent) => {
+	return e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey;
+};
+
 /**
  * @class
  *
@@ -697,11 +701,13 @@ class Select extends UI5Element implements IFormInputElement {
 			this._handleSelectionChange();
 		} else if (isUp(e) || isDown(e)) {
 			this._handleArrowNavigation(e);
+		} else if (isPrintableCharacter(e)) {
+			this._handleKeyboardNavigation(e);
 		}
 	}
 
 	_handleKeyboardNavigation(e: KeyboardEvent) {
-		if (isEnter(e) || this.readonly) {
+		if (this.readonly) {
 			return;
 		}
 

--- a/packages/main/src/SelectPopoverTemplate.tsx
+++ b/packages/main/src/SelectPopoverTemplate.tsx
@@ -27,7 +27,6 @@ export default function SelectPopoverTemplate(this: Select) {
 					onBeforeOpen={this._beforeOpen}
 					onClose={this._afterClose}
 					onKeyDown={this._onkeydown}
-					onKeyPress={this._handleKeyboardNavigation}
 					accessibleName={this._isPhone ? this._headerTitleText : undefined}
 				>
 					{this._isPhone &&

--- a/packages/main/src/SelectTemplate.tsx
+++ b/packages/main/src/SelectTemplate.tsx
@@ -38,7 +38,6 @@ export default function SelectTemplate(this: Select) {
 					aria-expanded={this._isPickerOpen}
 					aria-roledescription={this._ariaRoleDescription}
 					onKeyDown={this._onkeydown}
-					onKeyPress={this._handleKeyboardNavigation}
 					onKeyUp={this._onkeyup}
 					onFocusIn={this._onfocusin}
 					onFocusOut={this._onfocusout}


### PR DESCRIPTION
In order to be read out the same way by all the screen readers, we move the focus on the option, when Popover is open, and then back to the root div, in order to fulfill the requirements.

Fixes: #9722