### PR TITLE
fix(ui5-step-input): prevent false validation error with valuePrecision

### DIFF
--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -513,7 +513,7 @@ class StepInput extends UI5Element implements IFormInputElement {
 	}
 
 	get _isValueWithCorrectPrecision() {
-		// checks if the value will be displayed with correct precision
+		// check if the value will be displayed with correct precision
 		// _displayValue has special formatting logic
 		if ((this.value === 0) || (Number.isInteger(this.value))) {
 			// integers and zero will be formatted with toFixed, so they're always valid


### PR DESCRIPTION
Previously when users entered whole numbers or numbers with fewer decimals than required by `valuePrecision`, the component incorrectly showed "Invalid Entry" error even though the value was automatically formatted correctly.

Now integer values will always be formatted with the correct precision via `toFixed()`, making them valid regardless of how they were entered (e.g., "5" or "5.0" with valuePrecision=2 both become "5.00").

Fixes: #12677