### PR TITLE
feat(ui5-link): add default text slot

### DIFF
--- a/packages/main/cypress/specs/Link.cy.tsx
+++ b/packages/main/cypress/specs/Link.cy.tsx
@@ -260,4 +260,65 @@ describe("General API", () => {
 		cy.get("@signInDialog")
 			.should("be.visible");
 	});
+
+	it("tabindex should update when text content is added after mount", () => {
+		// Mount link without text content
+		cy.mount(<Link id="dynamic-link"></Link>);
+
+		// Initially, tabindex should be -1 because there's no text content
+		cy.get("#dynamic-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "-1");
+
+		// Add text content dynamically
+		cy.get("#dynamic-link")
+			.then($link => {
+				$link[0].textContent = "Click me";
+			});
+
+		// After text is added, tabindex should become 0
+		cy.get("#dynamic-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "0");
+	});
+
+	it("tabindex should remain 0 when text content changes", () => {
+		cy.mount(<Link id="text-change-link">Initial Text</Link>);
+
+		cy.get("#text-change-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "0");
+
+		cy.get("#text-change-link")
+			.then($link => {
+				$link[0].textContent = "Updated Text";
+			});
+
+		cy.get("#text-change-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "0");
+	});
+
+	it("tabindex should be -1 when text content is removed", () => {
+		cy.mount(<Link id="remove-text-link">Some text</Link>);
+
+		cy.get("#remove-text-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "0");
+
+		cy.get("#remove-text-link")
+			.then($link => {
+				$link[0].textContent = "";
+			});
+
+		cy.get("#remove-text-link")
+			.shadow()
+			.find(".ui5-link-root")
+			.should("have.attr", "tabindex", "-1");
+	});
 });

--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -2,6 +2,7 @@ import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import type { AccessibilityAttributes } from "@ui5/webcomponents-base/dist/types.js";
 import { isSpace, isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
@@ -267,6 +268,15 @@ class Link extends UI5Element implements ITabbable {
 	 */
 	@property()
 	endIcon?: string;
+
+	/**
+	 * Defines the text of the component.
+	 *
+	 * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
+	 * @public
+	 */
+	@slot({ type: Node, "default": true })
+	text!: Array<Node>;
 
 	@property({ noAttribute: true })
 	_rel: string | undefined;


### PR DESCRIPTION
The problem was that the `ui5-link` component was missing a `@slot` decorator for its default text slot. 

Without this decorator:

 - The component didnt invalidate when slot content changed
 - The effectiveTabIndex getter (which checks this.textContent?.length) wasn't re-evaluated after text was added
 - The initial tabindex of -1 (set during first render when there was no text) remained unchanged


So we add the `@slot` decorator to the default text slot, following the same pattern used in the`ui5-button` component:

This ensures that:

 - When text content is added, removed, or changed in the slot, the component is **invalidated**
 - The component re-renders and recalculates `effectiveTabIndex`
 - The `tabindex` attribute in the shadow DOM is updated correctly

### Before

![2025-12-09_16-04-10 (1)](https://github.com/user-attachments/assets/39e0fd7b-75dc-49a2-9509-06d640d766c0)

### After

![2025-12-09_16-00-11 (1)](https://github.com/user-attachments/assets/a87eee7d-f8f2-477c-9369-3130d36e2ebd)

Fixes: [#5843](https://github.com/UI5/webcomponents/issues/5843)