### PR TITLE
fix(i18n): handle utf-8 escape sequences in message bundle properties files

### DIFF
--- a/packages/tools/lib/i18n/toJSON.js
+++ b/packages/tools/lib/i18n/toJSON.js
@@ -38,8 +38,7 @@ function inlineUTF(properties) {
 }
 
 const convertToJSON = async (file, distPath) => {
-	const properties = PropertiesReader(file)._properties;
-	inlineUTF(properties);
+	const properties = inlineUTF(PropertiesReader(file)._properties);
 	const filename = path.basename(file, path.extname(file));
 	const language = filename.match(/^messagebundle_(.*?)$/)[1];
 	if (!allLanguages.includes(language)) {


### PR DESCRIPTION
Translation systems can output two formats for `messagebundle_XX.properties` files:
either UTF-8, or UTF encoded escape sequences.

Our tooling handles UTF-8 correctly: `verfügbar`
Escape sequences are read by the properies files reader with two slashes and incorrectly shown on screen like: `verf\u00FCgbar`

This fix inlines the escape sequenses making the `.json` files work correctly, while also being smaller and more readable.