### PR TITLE
fix(ui5-breadcrumbs): remove role='link' from current page element

### DIFF
--- a/packages/main/src/BreadcrumbsTemplate.tsx
+++ b/packages/main/src/BreadcrumbsTemplate.tsx
@@ -52,7 +52,6 @@ export default function BreadcrumbsTemplate(this: Breadcrumbs) {
 					<li class="ui5-breadcrumbs-current-location" onClick={this._onLabelPress}>
 						<span
 							id={`${this._id}-labelWrapper`}
-							role="link"
 							aria-current="page"
 							aria-label={this._currentLocationAccName}
 						>


### PR DESCRIPTION
**Problem:**
The current page element was incorrectly set as a link despite being non-interactive.

**Solution:**
Removed the `role="link"` attribute from the current page element while preserving aria-current="page" to properly indicate the user's current location without suggesting it's an interactive link

Fixes: [#12780](https://github.com/UI5/webcomponents/issues/12780)