### PR TITLE
test: fix failing DateTime test

### DIFF
--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -115,31 +115,40 @@ describe("DateTimePicker general interaction", () => {
 		cy.get<DateTimePicker>("@dtp")
 			.ui5DateTimePickerGetPopover()
 			.within(() => {
-				// Click the currently selected day and then move to the next day.
 				cy.get("[ui5-calendar]")
 					.shadow()
-					.as("calendar");
-				
-				cy.realPress("Tab"); 
-				cy.realPress("Tab"); 
-
-				cy.get("@calendar")
 					.find("[ui5-daypicker]")
 					.shadow()
 					.find(".ui5-dp-item--selected")
+					.as("selectedDay");
+
+				cy.get("[ui5-calendar]")
+					.shadow()
+					.find("[ui5-daypicker]")
+					.shadow()
+					.find('.ui5-dp-item')
+					.contains('.ui5-dp-daytext', '14')
+					.closest('.ui5-dp-item')
+					.as("nextSelectedDay");
+
+				// Click the currently selected day and move to the next day with Arrow + Right
+				cy.get("@selectedDay")
 					.realClick()
-					.should("be.focused");
+					.should("be.focused")
+					.realPress("ArrowRight");
 
-				cy.realPress("ArrowRight");
-				cy.realPress("Space");
-
-				// Confirm the change.
+				// Wait next day to be focused and then - select it with Space.
+				cy.get("@nextSelectedDay")
+					.should("be.focused")
+					.realPress("Space");
+				
+				// Confirm the new selection
 				cy.get("#ok").realClick();
 			});
 
 		cy.get<DateTimePicker>("@dtp").ui5DateTimePickerExpectToBeClosed();
 
-		// Only the date has changed; the time remains the same.
+		// Only the date has changed - the time remains the same.
 		cy.get("@dtp")
 			.shadow()
 			.find("[ui5-datetime-input]")


### PR DESCRIPTION
To ensure that pressing Space (which is supposed to change the selection) have some effect, we need to check if the day (its DOM element) is actually focused by the previous action (done via ArrowRight).

Otherwise, this happens too fast, pressing ArrowRight, followed by Space, and sometimes when Space is performed the focus hasn't been shifted to the new day (14 Apr) yet and we get no selection change => previously selected day (13 Apr) remains and the test fails.

 <img width="257" height="78" alt="Screenshot 2026-01-06 at 14 27 40" src="https://github.com/user-attachments/assets/2f1b48af-3d15-4a19-9237-b9f503967581" />
 

Fixes: https://github.com/UI5/webcomponents/issues/12837