### PR TITLE
docs: enhance ai/Input item-click event detail type

### DIFF
--- a/packages/ai/src/Input.ts
+++ b/packages/ai/src/Input.ts
@@ -31,6 +31,8 @@ type InputVersionChangeEventDetail = {
 	backwards: boolean,
 };
 
+type InputItemClickEventDetail = MenuItemClickEventDetail;
+
 /**
  * @class
  *
@@ -87,6 +89,8 @@ type InputVersionChangeEventDetail = {
 })
 
 /** Fired when an item from the AI actions menu is clicked.
+ * @param { HTMLElement } item The currently clicked menu item.
+ * @param { string } text The text of the currently clicked menu item.
  * @public
  */
 @event("item-click")
@@ -110,7 +114,7 @@ class Input extends BaseInput {
 		"version-change": InputVersionChangeEventDetail;
 		"stop-generation": void;
 		"button-click": void;
-		"item-click": MenuItemClickEventDetail;
+		"item-click": InputItemClickEventDetail;
 	};
 
 	/**
@@ -256,7 +260,7 @@ class Input extends BaseInput {
 		this._handleVersionChange(new CustomEvent("version-change", { detail: { backwards: false } }));
 	}
 
-	_onMenuIconClick(e: CustomEvent<MenuItemClickEventDetail>): void {
+	_onMenuIconClick(e: CustomEvent<InputItemClickEventDetail>): void {
 		this.fireDecoratorEvent("item-click", e.detail);
 	}
 
@@ -318,5 +322,8 @@ class Input extends BaseInput {
 
 Input.define();
 
-export type { InputVersionChangeEventDetail, MenuItemClickEventDetail as InputItemClickEventDetail };
+export type { 
+	InputVersionChangeEventDetail,
+	InputItemClickEventDetail,
+};
 export default Input;


### PR DESCRIPTION
Adding InputItemClickEventDetail to the custom elements manifest.

```json
 {
              "name": "item-click",
              "_ui5privacy": "public",
              "type": {
                "text": "CustomEvent<InputItemClickEventDetail>",
                "references": [
                  {
                    "name": "InputItemClickEventDetail",
                    "package": "@ui5/webcomponents-ai",
                    "module": "dist/Input.js"
                  }
                ]
              },
 ```

Fixes: https://github.com/UI5/webcomponents/issues/12856