### PR TITLE
docs: fix ColorPicker import typo in main package README

### DIFF
--- a/packages/main/README.md
+++ b/packages/main/README.md
@@ -30,7 +30,7 @@ Provides general purpose UI building blocks such as buttons, labels, inputs and 
 | Color Palette            | `ui5-color-palette`         | `import "@ui5/webcomponents/dist/ColorPalette.js";`        |
 | Color Palette Item       | `ui5-color-palette-item`    | comes with `ui5-color-palette`                             |
 | Color Palette Popover    | `ui5-color-palette-popover` | `import "@ui5/webcomponents/dist/ColorPalettePopover.js";` |
-| Color Picker             | `ui5-color-picker`          | `import "@ui5/webcomponents/dist/ComboPicker.js";`         |
+| Color Picker             | `ui5-color-picker`          | `import "@ui5/webcomponents/dist/ColorPicker.js";`         |
 | ComboBox                 | `ui5-combobox`              | `import "@ui5/webcomponents/dist/ComboBox.js";`            |
 | ComboBox Item            | `ui5-cb-item`               | comes with `ui5-combobox`                                  |
 | ComboBox Group Item      | `ui5-cb-group-item`         | comes with `ui5-combobox`                                  |


### PR DESCRIPTION
Fixed incorrect import path for `ui5-color-picker` component in the main package README.
Changed `ComboPicker.js` to `ColorPicker.js` on line 33