### PR TITLE
docs: fix Notification component import typos in fiori README

### DIFF
--- a/packages/fiori/README.md
+++ b/packages/fiori/README.md
@@ -15,9 +15,9 @@ such as a common header (ShellBar).
 | Illustrated Message                       | `ui5-illustrated-message`               | `import "@ui5/webcomponents-fiori/dist/IllustratedMessage.js";`        |
 | Media Gallery                             | `ui5-media-gallery`                     | `import "@ui5/webcomponents-fiori/dist/MediaGallery.js";`              |
 | Media Gallery Item                        | `ui5-media-gallery-item`                | comes with `ui5-media-gallery`                                         |
-| Notification List                         | `ui5-notification-list`                 | `import "@ui5/webcomponents-fiori/dist/NotifcationList.js";`           |
-| Notification List Item                    | `ui5-li-notification`                   | `import "@ui5/webcomponents-fiori/dist/NotifcationListItem.js";`       |
-| Notification Group List Item              | `ui5-li-notification-group`             | `import "@ui5/webcomponents-fiori/dist/NotifcationListGroupItem.js";`  |
+| Notification List                         | `ui5-notification-list`                 | `import "@ui5/webcomponents-fiori/dist/NotificationList.js";`           |
+| Notification List Item                    | `ui5-li-notification`                   | `import "@ui5/webcomponents-fiori/dist/NotificationListItem.js";`       |
+| Notification Group List Item              | `ui5-li-notification-group`             | `import "@ui5/webcomponents-fiori/dist/NotificationListGroupItem.js";`  |
 | Notification Action                       | `ui5-notification-action`               | `import "@ui5/webcomponents-fiori/dist/NotificationAction.js";`        |
 | Page                                      | `ui5-page`                              | `import "@ui5/webcomponents-fiori/dist/Page.js";`                      |
 | Product Switch                            | `ui5-product-switch`                    | `import "@ui5/webcomponents-fiori/dist/ProductSwitch.js";`             |


### PR DESCRIPTION
Fixed spelling of 'Notification' (was 'Notifcation') in import paths for:
- NotificationList.js
- NotificationListItem.js
- NotificationListGroupItem.js

This ensures developers use the correct import paths when working with notification components.

**Thank you for your contribution!** 👏


### PR checklist
- [ ] Check the [Development Hints](https://ui5.github.io/webcomponents/docs/contributing/DoD/)

- [ ] Follow the [Commit message Guidelines](https://github.com/UI5/webcomponents/blob/main/docs/5-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [ ] Add proper description about the background of the change and the change itself

- [ ] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [ ] Read the [Contributing Guidelines](https://github.com/UI5/webcomponents/blob/main/CONTRIBUTING.md)
