### PR TITLE
Revert "fix(ui5-input): fire submit only if single input in a form (#…

### DIFF
--- a/packages/main/cypress/specs/Input.cy.tsx
+++ b/packages/main/cypress/specs/Input.cy.tsx
@@ -198,35 +198,6 @@ describe("Input Tests", () => {
 		cy.get("@change").should("have.been.calledOnce");
 	});
 
-	it("should not fire 'submit' event when there is more than one input field in a form", () => {
-		cy.mount(
-			<form>
-				<Input id="first-input" onChange={cy.stub().as("change")}></Input>
-				<Input></Input>
-			</form>
-		);
-
-		// spy submit event and prevent it
-		cy.get("form")
-			.then($form => {
-				$form.get(0).addEventListener("submit", cy.spy().as("submit"));
-			});
-
-		// check if submit is triggered after change
-		cy.get("#first-input")
-			.as("input")
-			.realClick();
-
-		cy.get("@input")
-			.should("be.focused");
-
-		cy.realType("test");
-
-		cy.realPress("Enter");
-
-		cy.get("@submit").should("have.not.been.called");
-	});
-
 	it("tests if pressing enter twice fires submit 2 times and change once", () => {
 		cy.mount(
 			<form>

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -857,11 +857,9 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 		if (isEnter(e)) {
 			const isValueUnchanged = this.previousValue === this.getInputDOMRefSync()!.value;
-			const shouldSubmit = this._internals.form && this._internals.form.querySelectorAll("[ui5-input]").length === 1;
-
 			this._enterKeyDown = true;
 
-			if (isValueUnchanged && shouldSubmit) {
+			if (isValueUnchanged && this._internals.form) {
 				submitForm(this);
 			}
 
@@ -1160,8 +1158,6 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	_handleChange() {
-		const shouldSubmit = this._internals.form && this._internals.form.querySelectorAll("[ui5-input]").length === 1;
-
 		if (this._clearIconClicked) {
 			this._clearIconClicked = false;
 			return;
@@ -1183,7 +1179,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 			} else {
 				fireChange();
 
-				if (this._enterKeyDown && shouldSubmit) {
+				if (this._enterKeyDown && this._internals.form) {
 					submitForm(this);
 				}
 			}


### PR DESCRIPTION
This reverts commit 094410778394c9423c547f9270da5ecebad68b3e.

Form submission is prevented only in the scenario where there are multiple input fields that accept free text and there is no submit element inside the form. Having a form with multiple input elements but no submit action is an unusual setup.

In order to avoid introducing complex detection logic for all possible cases, the decision of whether the form should be submitted is delegated to the application.

For this reason, this PR reverts the changes introduced by the following commit

Related to: https://github.com/UI5/webcomponents/issues/12221
Related to: https://github.com/UI5/webcomponents/issues/12629
Fixes: https://github.com/UI5/webcomponents/issues/12863