### PR TITLE
Revert "fix(ui5-multi-input): prevent form submission on enter (#12273)"

### DIFF
--- a/packages/main/cypress/specs/MultiInput.cy.tsx
+++ b/packages/main/cypress/specs/MultiInput.cy.tsx
@@ -581,66 +581,6 @@ describe("MultiInput tokens", () => {
 			.should("have.attr", "value", "Bulgaria");
 	});
 });
-
-describe("MultiInput Form Submission Prevention", () => {
-	it("should prevent form submission when Enter is pressed", () => {
-		cy.mount(
-			<form>
-				<MultiInput/>
-			</form>
-		);
-
-		cy.get("form")
-			.as("testForm")
-			.invoke('on', 'submit', cy.spy().as('formSubmit'));
-
-		cy.get("[ui5-multi-input]")
-			.shadow()
-			.find("input")
-			.as("innerInput");
-
-		cy.get("@innerInput")
-			.realClick()
-			.should("be.focused");
-
-		cy.get("@innerInput")
-			.realType("test value");
-
-		cy.get("@innerInput")
-			.realPress("Enter");
-
-		// Form submission should be prevented when there's a value
-		cy.get("@formSubmit").should("not.have.been.called");
-	});
-
-	it("should prevent form submission when there are multiple inputs in form", () => {
-		cy.mount(
-			<form>
-				<MultiInput id="mi-form-multi1" />
-				<MultiInput id="mi-form-multi2" />
-			</form>
-		);
-
-		cy.get("form")
-			.as("testForm")
-			.invoke('on', 'submit', cy.spy().as('formSubmit'));
-
-		cy.get("#mi-form-multi1")
-			.shadow()
-			.find("input")
-			.as("firstInput");
-
-		cy.get("@firstInput")
-			.realClick()
-			.should("be.focused");
-
-		cy.get("@firstInput")
-			.realPress("Enter");
-
-		cy.get("@formSubmit").should("not.have.been.called");
-	});
-});
-
 describe("MultiInput Truncated Token", () => {
 	beforeEach(() => {
 		cy.mount(

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -13,8 +13,6 @@ import {
 	isHome,
 	isEnd,
 	isDown,
-	isEnter,
-
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
@@ -256,10 +254,6 @@ class MultiInput extends Input implements IFormInputElement {
 		if (isHomeInBeginning) {
 			this._skipOpenSuggestions = true; // Prevent input focus when navigating through the tokens
 			return this._focusFirstToken(e);
-		}
-
-		if (isEnter(e) && !!this._internals.form) {
-			e.preventDefault();
 		}
 
 		if (isLeft(e)) {


### PR DESCRIPTION
This reverts commit https://github.com/UI5/webcomponents/commit/31bdcd8847268388bf555a1d7ab281b1ec0981d1.

Form submission is prevented only in the scenario where there are multiple input fields that accept free text and there is no submit element inside the form. Having a form with multiple input elements but no submit action is an unusual setup.

In order to avoid introducing complex detection logic for all possible cases, the decision of whether the form should be submitted is delegated to the application.

For this reason, this PR reverts the changes introduced by the following commit

Related to: https://github.com/UI5/webcomponents/issues/12167
Related to: https://github.com/UI5/webcomponents/issues/12221
Related to: https://github.com/UI5/webcomponents/issues/12629
Fixes: https://github.com/UI5/webcomponents/issues/12863