### PR TITLE
fix(ui5-table): improve horizontal alignment handling

### DIFF
--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -493,12 +493,7 @@ describe("Table - Popin Mode", () => {
 describe("Table - Horizontal alignment of cells", () => {
 	function check(id: string, index: number, alignment: string) {
 		cy.get(id)
-			.should("have.css", "justify-content", alignment)
-			.and($el => {
-				const style = $el.attr("style");
-				const variable = style?.match(/justify-content: ([^;]+)/)?.[1] ?? "";
-				expect(variable).to.equal(`var(--horizontal-align-default-${index})`);
-			});
+			.should("have.css", "justify-content", alignment);
 
 		cy.get("ui5-table-row")
 			.get(`ui5-table-cell:nth-of-type(${index})`)
@@ -530,11 +525,11 @@ describe("Table - Horizontal alignment of cells", () => {
 					<TableCell><Label><b>1249</b> EUR</Label></TableCell>
 				</TableRow>
 				<TableRow>
-					<TableCell><Label><b>Notebook Basic 18</b><br></br>HT-1002</Label></TableCell>
-					<TableCell><Label>Technocom</Label></TableCell>
-					<TableCell><Label>32 x 21 x 4 cm</Label></TableCell>
-					<TableCell><Label style={{ color: "#2b7c2b" }}><b>3.7</b> KG</Label></TableCell>
-					<TableCell><Label><b>29</b> EUR</Label></TableCell>
+					<TableCell class="productCol"><Label><b>Notebook Basic 18</b><br></br>HT-1002</Label></TableCell>
+					<TableCell class="supplierCol"><Label>Technocom</Label></TableCell>
+					<TableCell class="dimensionsCol"><Label>32 x 21 x 4 cm</Label></TableCell>
+					<TableCell class="weightCol"><Label style={{ color: "#2b7c2b" }}><b>3.7</b> KG</Label></TableCell>
+					<TableCell class="priceCol"><Label><b>29</b> EUR</Label></TableCell>
 				</TableRow>
 			</Table>
 		);
@@ -647,8 +642,10 @@ describe("Table - Horizontal alignment of cells", () => {
 
 				if (shouldBePoppedIn) {
 					check(`#${id}`, index + 1, "normal");
+					cy.get(`.${id}`).should("have.css", "justify-content", "normal");
 				} else {
 					check(`#${id}`, index + 1, alignments[id]);
+					cy.get(`.${id}`).should("have.css", "justify-content", alignments[id]);
 				}
 			});
 		});

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -609,12 +609,10 @@ class Table extends UI5Element {
 
 	get styles() {
 		const virtualizer = this._getVirtualizer();
-		const headerStyleMap = this.headerRow?.[0]?.cells?.reduce((headerStyles, headerCell) => {
-			if (headerCell.horizontalAlign !== undefined && !headerCell._popin) {
-				headerStyles[`--horizontal-align-${headerCell._individualSlot}`] = headerCell.horizontalAlign;
-			}
-			return headerStyles;
-		}, {} as { [key: string]: string });
+		const headerStyleMap: Record<string, string> = {};
+		this.headerRow[0]?.cells.forEach(headerCell => {
+			headerStyleMap[`--halign-${headerCell._id}`] = headerCell.horizontalAlign || "normal";
+		});
 		return {
 			table: {
 				"grid-template-columns": this._gridTemplateColumns,

--- a/packages/main/src/TableCell.ts
+++ b/packages/main/src/TableCell.ts
@@ -40,8 +40,8 @@ class TableCell extends TableCellBase {
 		super.onBeforeRendering();
 		if (this.horizontalAlign) {
 			this.style.justifyContent = this.horizontalAlign;
-		} else if (this._individualSlot) {
-			this.style.justifyContent = `var(--horizontal-align-${this._individualSlot})`;
+		} else if (this._headerCell) {
+			this.style.justifyContent = `var(--halign-${this._headerCell._id})`;
 		}
 	}
 
@@ -52,22 +52,25 @@ class TableCell extends TableCellBase {
 	}
 
 	get _headerCell() {
-		const row = this.parentElement as TableRow;
-		const table = row.parentElement as Table;
-		const index = row.cells.indexOf(this);
-		return table.headerRow[0].cells[index];
+		const row = this.parentElement as TableRow | null;
+		const table = row?.parentElement as Table | null;
+		const index = row?.cells?.indexOf(this) ?? -1;
+
+		return (index !== -1) ? table?.headerRow?.[0]?.cells?.[index] : null;
 	}
 
 	get _popinHeaderNodes() {
 		const nodes: Node[] = [];
 		const headerCell = this._headerCell;
-		if (headerCell.popinText) {
-			nodes.push(document.createTextNode(headerCell.popinText));
-		} else {
-			nodes.push(...this._headerCell.content.map(node => node.cloneNode(true)));
-		}
-		if (headerCell.action[0]) {
-			nodes.push(headerCell.action[0].cloneNode(true));
+		if (headerCell) {
+			if (headerCell.popinText) {
+				nodes.push(document.createTextNode(headerCell.popinText));
+			} else {
+				nodes.push(...headerCell.content.map(node => node.cloneNode(true)));
+			}
+			if (headerCell.action[0]) {
+				nodes.push(headerCell.action[0].cloneNode(true));
+			}
 		}
 		return nodes;
 	}

--- a/packages/main/src/TableCustomAnnouncement.ts
+++ b/packages/main/src/TableCustomAnnouncement.ts
@@ -204,7 +204,7 @@ class TableCustomAnnouncement extends TableExtension {
 
 		const cells = [...row._visibleCells, ...row._popinCells];
 		cells.flatMap(cell => {
-			return cell._popin ? [cell._popinHeader!, cell._popinContent!] : [cell._headerCell, cell];
+			return cell._popin ? [cell._popinHeader!, cell._popinContent!] : [cell._headerCell!, cell];
 		}).forEach(node => {
 			const nodeDescription = getAccessibilityDescription(node, true);
 			descriptions.push(nodeDescription);

--- a/packages/main/src/TableHeaderCell.ts
+++ b/packages/main/src/TableHeaderCell.ts
@@ -122,9 +122,6 @@ class TableHeaderCell extends TableCellBase {
 	@slot()
 	action!: Array<TableHeaderCellActionBase>;
 
-	@property({ type: Boolean, noAttribute: true })
-	_popin = false;
-
 	@query("slot:not([name])")
 	_defaultSlot!: HTMLSlotElement;
 
@@ -136,10 +133,7 @@ class TableHeaderCell extends TableCellBase {
 
 	onBeforeRendering() {
 		super.onBeforeRendering();
-		if (this._individualSlot) {
-			// overwrite setting of TableCellBase so that the TableHeaderCell always uses the slot variable
-			this.style.justifyContent = `var(--horizontal-align-${this._individualSlot})`;
-		}
+		this.style.justifyContent = this.horizontalAlign || "";
 		toggleAttribute(this, "aria-sort", this.sortIndicator !== SortOrder.None, this.sortIndicator.toLowerCase());
 	}
 

--- a/packages/main/src/TableHeaderCellActionBase.ts
+++ b/packages/main/src/TableHeaderCellActionBase.ts
@@ -60,7 +60,7 @@ abstract class TableHeaderCellActionBase extends UI5Element {
 
 	_onClick(e: UI5CustomEvent<Button, "click">) {
 		// Retrieve the real action (if parent is header cell this instance is fine, otherwise retrieve it from the header cell)
-		const action = this.parentElement?.hasAttribute("ui5-table-header-cell") ? this : ((this.getRootNode() as ShadowRoot).host as TableCell)._headerCell.action[0] as this;
+		const action = this.parentElement?.hasAttribute("ui5-table-header-cell") ? this : ((this.getRootNode() as ShadowRoot).host as TableCell)._headerCell!.action[0] as this;
 		action.fireDecoratorEvent("click", { targetRef: e.target as HTMLElement });
 		e.stopPropagation();
 	}

--- a/packages/main/src/themes/TableCellBase.css
+++ b/packages/main/src/themes/TableCellBase.css
@@ -10,6 +10,10 @@
 	box-sizing: border-box;
 }
 
+:host([_popin]) {
+	justify-content: normal !important;
+}
+
 :host([tabindex]:focus) {
 	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
 	outline-offset: calc(-1 * var(--sapContent_FocusWidth));

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -53,7 +53,7 @@
 			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
 			<ui5-table-cell><div style="display: flex; flex-direction: row;"><ui5-label>30 x 18 x 3 cm</ui5-label><ui5-button>Calculate</ui5-button></div></ui5-table-cell>
 			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label><ui5-checkbox></ui5-checkbox></ui5-table-cell>
+			<ui5-table-cell horizontal-align="End"><ui5-label><b>956</b> EUR</ui5-label><ui5-checkbox></ui5-checkbox></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row row-key="1" navigated interactive>
 			<ui5-table-cell><ui5-label><b>Notebook Basic 16</b><br><a href="#">HT-1001</a></ui5-label></ui5-table-cell>


### PR DESCRIPTION
 - Uses unique identifier of the HeaderCell (UI5Element#_id) instead of the individualSlot property for horizontal alignment CSS variable. This ensures the variable does not change when the column position changes.
- Independent from the horizontal-alignment property, pop-in cells must always be left-aligned

Fixes: #11858
Fixes: #12155
Fixes: #12854