### PR TITLE
chore(ui5-user-settings): remove deprecated css selector

### DIFF
--- a/packages/fiori/src/themes/UserSettingsAppearanceViewItem.css
+++ b/packages/fiori/src/themes/UserSettingsAppearanceViewItem.css
@@ -13,26 +13,12 @@
 	flex: 1;
 }
 
-/* Default: show cozy avatar, hide compact avatar */
 .avatar-cozy {
-	display: inline-block;
+	display: var(--_ui5_user_settings_avatar_cozy_display);
 }
 
 .avatar-compact {
-	display: none;
-}
-
-/* In compact mode: hide cozy avatar, show compact avatar */
-:host-context(.sapUiSizeCompact) .avatar-cozy,
-:host-context(.ui5-content-density-compact) .avatar-cozy,
-:host-context([data-ui5-compact-size]) .avatar-cozy {
-	display: none;
-}
-
-:host-context(.sapUiSizeCompact) .avatar-compact,
-:host-context(.ui5-content-density-compact) .avatar-compact,
-:host-context([data-ui5-compact-size]) .avatar-compact {
-	display: inline-block;
+	display: var(--_ui5_user_settings_avatar_compact_display);
 }
 
 .item-texts {
@@ -42,14 +28,9 @@
 
 .item-title {
 	font-weight: 600;
-	font-size: var(--sapFontSize);
+	font-size: var(--_ui5_list_item_title_size);
 	color: var(--sapList_TextColor);
 	margin: 0.5rem;
-}
-
-:host-context(.sapUiSizeCompact) .item-title,
-:host-context([data-ui5-compact-size]) .item-title {
-	font-size: var(--sapFontLargeSize);
 }
 
 .item-subtitle {

--- a/packages/fiori/src/themes/base/UserSettingsAppearanceViewItem-parameters.css
+++ b/packages/fiori/src/themes/base/UserSettingsAppearanceViewItem-parameters.css
@@ -1,0 +1,13 @@
+:root {
+	--_ui5_user_settings_avatar_cozy_display: inline-block;
+	--_ui5_user_settings_avatar_compact_display: none;
+	--_ui5_user_settings_item_title_font_size: var(--sapFontSize);
+}
+
+[data-ui5-compact-size],
+.ui5-content-density-compact,
+.sapUiSizeCompact {
+	--_ui5_user_settings_avatar_cozy_display: none;
+	--_ui5_user_settings_avatar_compact_display: inline-block;
+	--_ui5_user_settings_item_title_font_size: var(--sapFontLargeSize);
+}

--- a/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3/parameters-bundle.css
@@ -19,3 +19,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "./DynamicPageHeaderActions-parameters.css";
 @import "./TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_dark/parameters-bundle.css
@@ -19,3 +19,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_fiori_3/DynamicPageHeaderActions-parameters.css";
 @import "../sap_fiori_3/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/parameters-bundle.css
@@ -20,3 +20,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_fiori_3/DynamicPageHeaderActions-parameters.css";
 @import "../sap_fiori_3/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/parameters-bundle.css
@@ -20,3 +20,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_fiori_3/DynamicPageHeaderActions-parameters.css";
 @import "../sap_fiori_3/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
@@ -24,3 +24,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "./DynamicPageHeaderActions-parameters.css";
 @import "../base/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -23,3 +23,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_horizon/DynamicPageHeaderActions-parameters.css";
 @import "../base/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_exp/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_exp/parameters-bundle.css
@@ -18,3 +18,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_horizon/DynamicPageHeaderActions-parameters.css";
 @import "../base/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_hcb/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/parameters-bundle.css
@@ -21,3 +21,4 @@
 @import "../base/DynamicPageHeader-parameters.css";
 @import "../sap_horizon/DynamicPageHeaderActions-parameters.css";
 @import "../sap_fiori_3/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -22,3 +22,4 @@
 @import "../sap_horizon/DynamicPageHeaderActions-parameters.css";
 @import "./DynamicPageTitle-parameters.css";
 @import "../sap_fiori_3/TimelineGroupItem-parameters.css";
+@import "../base/UserSettingsAppearanceViewItem-parameters.css";


### PR DESCRIPTION
This change removes the deprecated css selector ":host-context". Now in order to determine  cozy/compact css styles we use the recommended approach:

[data-ui5-compact-size],
.ui5-content-density-compact