### PR TITLE
fix(ui5-tree-item): increase toggle icon target size

### DIFF
--- a/packages/main/src/TreeItemBaseTemplate.tsx
+++ b/packages/main/src/TreeItemBaseTemplate.tsx
@@ -2,7 +2,7 @@ import type TreeItemBase from "./TreeItemBase.js";
 import ListItemTemplate from "./ListItemTemplate.js";
 import Icon from "./Icon.js";
 import navigationDownArrow from "@ui5/webcomponents-icons/dist/navigation-down-arrow.js";
-import navigatioRightArrow from "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";
+import navigationRightArrow from "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";
 import type { ListItemHooks } from "./ListItemTemplate.js";
 
 const predefinedHooks: Partial<ListItemHooks> = {
@@ -31,7 +31,7 @@ function listItemPreContent(this: TreeItemBase) {
 				<Icon
 					part="toggle-icon"
 					class="ui5-li-tree-toggle-icon"
-					name={this.expanded ? navigationDownArrow : navigatioRightArrow}
+					name={this.expanded ? navigationDownArrow : navigationRightArrow}
 					showTooltip={true}
 					accessibleName={this.iconAccessibleName}
 					// @ts-expect-error

--- a/packages/main/src/themes/TreeItem.css
+++ b/packages/main/src/themes/TreeItem.css
@@ -65,10 +65,18 @@
 }
 
 .ui5-li-tree-toggle-icon {
-	width: var(--_ui5-tree-toggle-icon-size);
-	height: var(--_ui5-tree-toggle-icon-size);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--_ui5-tree-toggle-box-width);
+	height: var(--_ui5-tree-toggle-box-height);
 	color: var(--sapContent_IconColor);
 	cursor: pointer;
+}
+
+.ui5-li-tree-toggle-icon::part(root) {
+	width: var(--_ui5-tree-toggle-icon-size);
+	height: var(--_ui5-tree-toggle-icon-size);
 }
 
 :host([actionable]) .ui5-li-tree-toggle-icon {


### PR DESCRIPTION
The expand/collapse toggle icon now has a larger clickable area to meet WCAG 2.2 accessibility standards and prevent accidental item selection when trying to expand/collapse tree items.

Also fixes a typo in the navigation icon import.

Fixes #12850
