### PR TITLE
fix(ui5-toolbar): handle non-ToolbarItem children in width calculation

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -498,7 +498,7 @@ class Toolbar extends UI5Element {
 		}
 		const id: string = item._id;
 		// Measure rendered width for spacers with width, and for normal items
-		const renderedItem = this.shadowRoot!.querySelector<HTMLElement>(`#${item.slot}`);
+		const renderedItem = this.shadowRoot!.querySelector<HTMLElement>(`#${item._individualSlot}`);
 
 		let itemWidth = 0;
 


### PR DESCRIPTION
Use `item._individualSlot` instead of `item.slot` when querying rendered items. For non-ToolbarItem elements, `item.slot` is an empty string (""), which creates an invalid CSS selector "#" and causes a SyntaxError.

This particularly affects `@ui5/webcomponents-react` applications using conditional rendering with regular HTML elements.

Fixes: #12855 
