### PR TITLE
fix(ui5-file-uploader): fix value help icon as per specification

### DIFF
--- a/packages/main/src/FileUploaderTemplate.tsx
+++ b/packages/main/src/FileUploaderTemplate.tsx
@@ -1,5 +1,5 @@
 import Icon from "./Icon.js";
-import valueHelp from "@ui5/webcomponents-icons/dist/value-help.js";
+import browseIcon from "@ui5/webcomponents-icons/dist/browse-folder.js";
 import decline from "@ui5/webcomponents-icons/dist/decline.js";
 import Tokenizer from "./Tokenizer.js";
 import Token from "./Token.js";
@@ -86,7 +86,7 @@ export default function FileUploaderTemplate(this: FileUploader) {
 							)}
 
 							<Icon
-								name={valueHelp}
+								name={browseIcon}
 								class="ui5-file-uploader-value-help-icon inputIcon"
 								title={this.valueHelpTitle}
 							/>


### PR DESCRIPTION
Current implementation of the `ui5-file-uploader` uses an icon that differs from what is specified in the VD specification.
This PR introduces the proper icon.

<img width="356" height="47" alt="image" src="https://github.com/user-attachments/assets/e49f7182-1ddc-43b8-8685-920d4d4333ea" />

FIXES: #12947