### PR TITLE
fix(ui5-date*): remove `aria-pressed` from time selection clocks

### DIFF
--- a/packages/main/src/ToggleSpinButtonTemplate.tsx
+++ b/packages/main/src/ToggleSpinButtonTemplate.tsx
@@ -4,7 +4,6 @@ import buttonTemplate from "./ButtonTemplate.js";
 export default function ToggleSpinButtonTemplate(this: ToggleSpinButton) {
 	return (<>
 		{ buttonTemplate.call(this, {
-			ariaPressed: this.pressed,
 			ariaValueMax: this.valueMax,
 			ariaValueMin: this.valueMin,
 			ariaValueNow: this.valueNow,


### PR DESCRIPTION
## Problem

The `ui5-toggle-spin-button` component (used in `ui5-time-picker`, `ui5-datetime-picker`, `ui5-date-picker`, `ui5-date-range-picker`) has `role="spinbutton"` but includes `aria-pressed` attribute, which is not a supported attribute for the `spinbutton` role per [WAI-ARIA 1.2 spec](https://www.w3.org/TR/wai-aria-1.2/#spinbutton).

1. **Invalid ARIA attribute** — `aria-pressed` is not in the list of supported states/properties for `spinbutton` role

## Solution

Removing unsupported `aria-pressed` attribute.

## What This Fixes

- ✅ ARIA 1.2 — `spinbutton` role no longer has unsupported `aria-pressed` attribute
- ✅ AXE/AccessContinuum — invalid ARIA attribute violation resolved
- ✅ No visual or functional changes
