### PR TITLE
fix(ui5-dynamic-date-range): add `accessibleName` to the ResponsivePopover

### DIFF
--- a/packages/main/src/DynamicDateRange.ts
+++ b/packages/main/src/DynamicDateRange.ts
@@ -19,6 +19,7 @@ import {
 	DYNAMIC_DATE_RANGE_SELECTED_TEXT,
 	DYNAMIC_DATE_RANGE_EMPTY_SELECTED_TEXT,
 	DYNAMIC_DATE_RANGE_NAVIGATION_ICON_TOOLTIP,
+	DYNAMIC_DATE_RANGE_POPOVER_ACCESSIBLE_NAME,
 } from "./generated/i18n/i18n-defaults.js";
 
 // default calendar for bundling
@@ -286,6 +287,10 @@ class DynamicDateRange extends UI5Element {
 
 	get tooltipNavigationIcon() {
 		return DynamicDateRange.i18nBundle.getText(DYNAMIC_DATE_RANGE_NAVIGATION_ICON_TOOLTIP);
+	}
+
+	get popoverAccessibleName() {
+		return DynamicDateRange.i18nBundle.getText(DYNAMIC_DATE_RANGE_POPOVER_ACCESSIBLE_NAME);
 	}
 
 	_togglePicker(): void {

--- a/packages/main/src/DynamicDateRangePopoverTemplate.tsx
+++ b/packages/main/src/DynamicDateRangePopoverTemplate.tsx
@@ -21,6 +21,7 @@ export default function DynamicDateRangePopoverTemplate(this: DynamicDateRange) 
 			onClose={this.onPopoverClose}
 			onBeforeOpen={this.onPopoverBeforeOpen}
 			onKeyDown={this.onKeyDownPopover}
+			accessibleName={this.popoverAccessibleName}
 		>
 			{this._hasCurrentOptionTemplate &&
 				<div slot="header" class="ui5-ddr-header">

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -928,6 +928,9 @@ DYNAMIC_DATE_TIME_RANGE_TEXT_FROM_LABEL=From
 #FLD: Text for the selected date section when there's no value in the DynamicDateRange component.
 DYNAMIC_DATE_RANGE_EMPTY_SELECTED_TEXT=Choose Dates
 
+#XACT: Accessible name for the DynamicDateRange popover dialog.
+DYNAMIC_DATE_RANGE_POPOVER_ACCESSIBLE_NAME=Dynamic Date Range
+
 #XFLD: Text for icon that navigates back to the previous page in the DynamicDateRange component.
 DYNAMIC_DATE_RANGE_NAVIGATION_ICON_TOOLTIP=Navigate back
 


### PR DESCRIPTION
## Problem

The `ui5-dynamic-date-range` popover (`role="dialog"`) lacks an accessible name:

1. **Screen readers** cannot announce the purpose of the popover dialog when it opens
2. **Accessibility tools** (AXE/AccessContinuum) flag this as a violation

## Solution

- Added `accessibleName` to the `ResponsivePopover` in the template, using i18n text

## What This Fixes

- ✅ Screen readers now announce **"Dynamic Date Range"** when the popover opens (i18n-enabled)
- ✅ Popover dialog has a proper accessible name per WAI-ARIA requirements
- ✅ Accessibility automation tools no longer flag this as a violation
