### PR TITLE
fix(ui5-list): prevent empty `aria-description` attribute

### DIFF
--- a/packages/main/src/ListTemplate.tsx
+++ b/packages/main/src/ListTemplate.tsx
@@ -53,7 +53,7 @@ export default function ListTemplate(this: List) {
 							role={this.listAccessibleRole}
 							aria-label={this.ariaLabelTxt}
 							aria-labelledby={this.ariaLabelledBy}
-							aria-description={this.ariaDescriptionText}
+							aria-description={this.ariaDescriptionText || undefined}
 						>
 							<slot></slot>
 


### PR DESCRIPTION
Currently our `<ui5-menu>` component uses the `<ui5-list>` as its internal composite.

When a Menu (or any List) is rendered without any accessible description, the `aria-description` attribute would be rendered with an empty string value like this:

```html
<ul role="menu" aria-description="">
```
We found this issue while testing our Menu's accessibility samples in the Accessibility Hub.
This violates **ARIA 1.2** and **WCAG 2.2 AA** standards because:

Empty ARIA attributes are invalid - they create noise for screen readers
Validation tools flag this - AXE and AccessContinuum report this as an error

That's why I suggest we use conitional  `|| undefined` pattern which ensures:

If `ariaDescriptionText` has a value → renders aria-description="value"
If `ariaDescriptionText` is empty/falsy → does not render the attribute at all