### PR TITLE
fix(ui5-split-button): resolve nested interactive elements and invalid aria references

### DIFF
--- a/packages/main/src/SplitButtonTemplate.tsx
+++ b/packages/main/src/SplitButtonTemplate.tsx
@@ -5,10 +5,10 @@ import Button from "./Button.js";
 export default function SplitButtonTemplate(this: SplitButton) {
 	return (
 		<div
-			role={this._hideArrowButton ? "button" : "group"}
+			role={this._hideArrowButton ? "presentation" : "group"}
 			class="ui5-split-button-root"
 			tabindex={this._tabIndex}
-			aria-labelledby={`${this._id}-invisibleTextDefault ${this._id}-invisibleText`}
+			aria-labelledby={!this._hideArrowButton ? `${this._id}-invisibleTextDefault ${this._id}-invisibleText` : undefined}
 			aria-haspopup={this._computedAccessibilityAttributes?.root?.hasPopup}
 			aria-roledescription={this._computedAccessibilityAttributes?.root?.roleDescription}
 			aria-label={this._computedAccessibilityAttributes?.root?.title}


### PR DESCRIPTION
## Overview

The `ui5-ai-button` uses `ui5-split-button` internally. When the arrow button is hidden (`_hideArrowButton=true`), two accessibility violations occur:

1. **Nested interactive elements** — wrapper has `role="button"` containing a `<button>` child
2. **Orphan ARIA references** — `aria-labelledby` points to IDs that don't exist in the DOM

## What We Did

Change the wrapper role to `"presentation"` and make `aria-labelledby` conditional when arrow button is hidden:

## What This Fixes

- ✅ WCAG 2.2 4.1.2 — no nested interactive elements
- ✅ ARIA 1.2 — `aria-labelledby` only references existing IDs
- ✅ AXE/AccessContinuum — "Interactive controls must not be nested" resolved
- ✅ No visual changes
