### PR TITLE
fix(ui5-user-settings): correct usage with scoping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,12 +140,20 @@ if (element instanceof Button) { }
 
 // BAD - the tag name could be scoped like `UI5-BUTTON-F5331039` and won't match
 if (element.tagName === "UI5-BUTTON") { }
+```
 
-// GOOD - use the `hasTag` helper that checks the pure tag
-// use instance check like
-const isInstanceOfComboBoxItemGroup = (object: any): object is ComboBoxItemGroup => {
-	return "isGroupItem" in object;
-};
+``` typescript
+// GOOD - use the `createInstanceChecker` helper that checks for instances via duck-typing
+// ComboBoxItemGroup.ts
+import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
+class ComboBoxItemGroup {
+  readonly isGroupItem = true;
+}
+export const isInstanceOfComboBoxItemGroup = createInstanceChecker<ComboBoxItemGroup>("isGroupItem");
+// ComboBox.ts
+if (isInstanceOfComboBoxItemGroup(element)) {
+  // element has the correct type now
+}
 ```
 
 ### Property/Event Conventions

--- a/packages/fiori/src/UserSettingsAppearanceView.ts
+++ b/packages/fiori/src/UserSettingsAppearanceView.ts
@@ -2,7 +2,9 @@ import UserSettingsView from "./UserSettingsView.js";
 import UserSettingsAppearanceViewTemplate from "./UserSettingsAppearanceViewTemplate.js";
 import UserSettingViewCss from "./generated/themes/UserSettingsView.css.js";
 import type UserSettingsAppearanceViewItem from "./UserSettingsAppearanceViewItem.js";
+import { isInstanceOfUserSettingsAppearanceViewItem } from "./UserSettingsAppearanceViewItem.js";
 import type UserSettingsAppearanceViewGroup from "./UserSettingsAppearanceViewGroup.js";
+import { isInstanceOfUserSettingsAppearanceViewGroup } from "./UserSettingsAppearanceViewGroup.js";
 import type { ListItemClickEventDetail } from "@ui5/webcomponents/dist/List.js";
 import type ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 
@@ -77,14 +79,11 @@ class UserSettingsAppearanceView extends UserSettingsView {
 		const allItems: Array<UserSettingsAppearanceViewItem> = [];
 
 		this.items.forEach(item => {
-			if (item.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-GROUP") {
-				const group = item as UserSettingsAppearanceViewGroup;
-				const groupItems = Array.from(group.children).filter(
-					child => child.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM",
-				) as Array<UserSettingsAppearanceViewItem>;
+			if (isInstanceOfUserSettingsAppearanceViewGroup(item)) {
+				const groupItems = Array.from(item.children).filter(isInstanceOfUserSettingsAppearanceViewItem);
 				allItems.push(...groupItems);
-			} else if (item.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM") {
-				allItems.push(item as UserSettingsAppearanceViewItem);
+			} else if (isInstanceOfUserSettingsAppearanceViewItem(item)) {
+				allItems.push(item);
 			}
 		});
 
@@ -93,17 +92,16 @@ class UserSettingsAppearanceView extends UserSettingsView {
 
 	_handleItemClick = (e: CustomEvent<ListItemClickEventDetail>) => {
 		const listItem = e.detail.item as ListItemBase & { associatedSettingItem?: UserSettingsAppearanceViewItem };
-		if (listItem.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM") {
-			const item = listItem as UserSettingsAppearanceViewItem;
+		if (isInstanceOfUserSettingsAppearanceViewItem(listItem)) {
 			const eventPrevented = !this.fireDecoratorEvent("selection-change", {
-				item,
+				item: listItem,
 			});
 
 			if (!eventPrevented) {
 				this._getAllItems().forEach(viewItem => {
 					viewItem.selected = false;
 				});
-				item.selected = true;
+				listItem.selected = true;
 			}
 		}
 	};

--- a/packages/fiori/src/UserSettingsAppearanceViewGroup.ts
+++ b/packages/fiori/src/UserSettingsAppearanceViewGroup.ts
@@ -1,6 +1,7 @@
 import ListItemGroup from "@ui5/webcomponents/dist/ListItemGroup.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot.js";
+import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
 import type UserSettingsAppearanceViewItem from "./UserSettingsAppearanceViewItem.js";
 
 /**
@@ -34,7 +35,13 @@ class UserSettingsAppearanceViewGroup extends ListItemGroup {
 		type: HTMLElement,
 	})
 	declare items: Array<UserSettingsAppearanceViewItem>;
+
+	get isUserSettingsAppearanceViewGroup(): boolean {
+		return true;
+	}
 }
 
 UserSettingsAppearanceViewGroup.define();
+
+export const isInstanceOfUserSettingsAppearanceViewGroup = createInstanceChecker<UserSettingsAppearanceViewGroup>("isUserSettingsAppearanceViewGroup");
 export default UserSettingsAppearanceViewGroup;

--- a/packages/fiori/src/UserSettingsAppearanceViewItem.ts
+++ b/packages/fiori/src/UserSettingsAppearanceViewItem.ts
@@ -6,6 +6,7 @@ import {
 } from "@ui5/webcomponents-base/dist/decorators.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import ListItemCustom from "@ui5/webcomponents/dist/ListItemCustom.js";
+import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
 
 // Import default icon used by appearance view items
 import "@ui5/webcomponents-icons/dist/product.js";
@@ -67,7 +68,13 @@ class UserSettingsAppearanceViewItem extends ListItemCustom {
 	 */
 	@property()
 	colorScheme = "Accent7";
+
+	get isUserSettingsAppearanceViewItem(): boolean {
+		return true;
+	}
 }
 
 UserSettingsAppearanceViewItem.define();
+
+export const isInstanceOfUserSettingsAppearanceViewItem = createInstanceChecker<UserSettingsAppearanceViewItem>("isUserSettingsAppearanceViewItem");
 export default UserSettingsAppearanceViewItem;


### PR DESCRIPTION
Improve instance checks in ui5-user-settings according to the correct pattern in the project via `createInstanceChecker` that automatically verifies the type and is scoping safe.