### PR TITLE
fix(framework): prevent redundant invalidations

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -259,6 +259,21 @@ abstract class UI5Element extends HTMLElement {
 				// is inserted into the DOM declaratively using a <template> tag.
 				this.__shouldHydrate = true;
 			}
+
+			const slotsAreManaged = ctor.getMetadata().slotsAreManaged();
+			if (slotsAreManaged) {
+				this.shadowRoot!.addEventListener("slotchange", this._onShadowRootSlotChange.bind(this));
+			}
+		}
+	}
+
+	/**
+	 * Note: this "slotchange" listener is for slots, rendered in the component's shadow root
+	 */
+	_onShadowRootSlotChange(e: Event) {
+		const targetShadowRoot = (e.target as Node)?.getRootNode(); // the "slotchange" event target is always a slot element
+		if (targetShadowRoot === this.shadowRoot) { // only for slotchange events that originate from slots, belonging to the component's shadow root
+			this._processChildren();
 		}
 	}
 


### PR DESCRIPTION
The `onInvalidate` hook was triggered for slots without real changes due to a race condition in `_updateSlots`.

This happened on Light DOM changes. The previous logic cached the current state, cleared the current state, processed the DOM, awaited upgrades, and then saved the new state. During this process, the state was temporarily empty, causing comparisons with the cached state to incorrectly detect changes.

Slot state does not depend on child upgrades, so the flow was updated to save the new state **before** awaiting upgrades. The comparison only needs to confirm that element references remain the same.

With this PR, state updates are extracted and made synchronous. This keeps the state in sync with the Light DOM even if another slot update is triggered, and ensures comparisons return correct results.

As a result, `onInvalidate` is fired only when an actual slot change occurs and with accurate state data.

Fixes: https://github.com/UI5/webcomponents/issues/10377