### PR TITLE
fix(ui5-table): fix table on Horizon HCW

### DIFF
--- a/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -41,6 +41,7 @@
 @import "./SplitButton-parameters.css";
 @import "./Switch-parameters.css";
 @import "./TabContainer-parameters.css";
+@import "../base/Table-parameters.css";
 @import "./GrowingButton-parameters.css";
 @import "../base/Text-parameters.css";
 @import "./TextArea-parameters.css";


### PR DESCRIPTION
Table parameters are now included in the Horizon HCW parameters bundle

Fixes: https://github.com/UI5/webcomponents/issues/12933