### PR TITLE
chore: add verbose flag for build tools

### DIFF
--- a/packages/base/lib/css-processors/css-processor-font-face.mjs
+++ b/packages/base/lib/css-processors/css-processor-font-face.mjs
@@ -56,6 +56,7 @@ const generate = async () => {
         },
         bundle: true,
         minify: true,
+        logLevel: process.env.UI5_VERBOSE === "true" ? "warning" : "error",
         plugins: [
             fontfacePlugin,
         ],

--- a/packages/base/lib/generate-asset-parameters/index.js
+++ b/packages/base/lib/generate-asset-parameters/index.js
@@ -22,7 +22,9 @@ const generate = async () => {
 	await fs.mkdir("src/generated/", { recursive: true });
 	await fs.writeFile("src/generated/AssetParameters.ts", fileContent);
 
-	console.log("Assets parameters generated.");
+	if (process.env.UI5_VERBOSE === "true") {
+		console.log("Assets parameters generated.");
+	}
 }
 
 const filePath = process.argv[1];

--- a/packages/base/lib/generate-styles/index.js
+++ b/packages/base/lib/generate-styles/index.js
@@ -16,7 +16,9 @@ const generate = async () => {
 
 	return Promise.all(filesPromises)
 		.then(() => {
-			console.log("Styles files generated.");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("Styles files generated.");
+			}
 		});
 };
 

--- a/packages/base/lib/generate-version-info/index.js
+++ b/packages/base/lib/generate-version-info/index.js
@@ -27,7 +27,9 @@ export default VersionInfo;`;
 	await fs.mkdir("src/generated/", { recursive: true });
 	await fs.writeFile("src/generated/VersionInfo.ts", fileContent);
 
-	console.log("Version info file generated.");
+	if (process.env.UI5_VERBOSE === "true") {
+		console.log("Version info file generated.");
+	}
 }
 
 const filePath = process.argv[1];

--- a/packages/cypress-internal/src/copy.js
+++ b/packages/cypress-internal/src/copy.js
@@ -7,4 +7,6 @@ const eslintOutputPath = path.join(dirname, "../dist/eslint.cjs");
 
 await mkdir(path.dirname(eslintOutputPath), {recursive: true});
 await copyFile(eslintInputPath, eslintOutputPath)
-console.log("eslint.cjs copied successfully")
+if (process.env.UI5_VERBOSE === "true") {
+	console.log("eslint.cjs copied successfully");
+}

--- a/packages/localization/lib/generate-json-imports/cldr.js
+++ b/packages/localization/lib/generate-json-imports/cldr.js
@@ -42,7 +42,9 @@ const generate = async () => {
 		fs.writeFile("src/generated/json-imports/LocaleData-node.ts", contentDynamic(caseDynamicImportJSONAttr)),
 	])
 		.then(() => {
-			console.log("CLDR files generated.");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("CLDR files generated.");
+			}
 		});
 }
 

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -29,9 +29,9 @@
     "prepublishOnly": "tsc -b"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.7",
-    "@babel/generator": "^7.23.6",
-    "@babel/parser": "^7.23.6",
+    "@babel/core": "^7.24.6",
+    "@babel/generator": "^7.24.6",
+    "@babel/parser": "^7.24.6",
     "@openui5/sap.ui.core": "1.120.17",
     "@ui5/webcomponents-tools": "2.19.0-rc.2",
     "babel-plugin-amd-to-esm": "^2.0.3",

--- a/packages/tools/bin/dev.js
+++ b/packages/tools/bin/dev.js
@@ -3,15 +3,20 @@
 const child_process = require("child_process");
 const { comma } = require("postcss/lib/list");
 
-let command = process.argv[2];
-const argument = process.argv[3];
+// Check for verbose flag
+const hasVerbose = process.argv.includes("--verbose") || process.argv.includes("-v");
+const args = process.argv.slice(2).filter(arg => arg !== "--verbose" && arg !== "-v");
+
+let command = args[0];
+const argument = args[1];
 
 if (command === "watch") {
 	if (["src", "test", "bundles", "styles", "templates", "samples"].includes(argument)) {
 		command = `watch.${argument}`;
 	}
 } else if (command === "test") {
-	command = ["test", ...process.argv.slice(3)].join(" ");
+	command = ["test", ...args.slice(1)].join(" ");
 }
 
-child_process.execSync(`ui5nps "${command}"`, {stdio: 'inherit'});
+const verboseFlag = hasVerbose ? " --verbose" : "";
+child_process.execSync(`ui5nps${verboseFlag} "${command}"`, {stdio: 'inherit'});

--- a/packages/tools/lib/amd-to-es6/index.js
+++ b/packages/tools/lib/amd-to-es6/index.js
@@ -96,7 +96,9 @@ const transformAmdToES6Modules = async (argv) => {
 	const fileNames = await globby(basePath.replace(/\\/g, "/") + "**/*.js");
 	return Promise.all(fileNames.map(fileName => transformAmdToES6Module(fileName, basePath)).filter(x => !!x))
 		.then(() => {
-			console.log("Success: all amd modules are transformed to es6!");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("Success: all amd modules are transformed to es6!");
+			}
 		});
 };
 

--- a/packages/tools/lib/cem/cem.js
+++ b/packages/tools/lib/cem/cem.js
@@ -2,6 +2,10 @@ const cemCLI = require("./patch/@custom-elements-manifest/analyzer/cli.js")
 
 const main = async argv => {
 	const patchedArgv = argv.slice(2);
+	// Add --quiet flag unless verbose mode is enabled
+	if (process.env.UI5_VERBOSE !== "true" && !patchedArgv.includes("--quiet")) {
+		patchedArgv.push("--quiet");
+	}
 	await cemCLI.cli({ argv: patchedArgv, cwd: process.cwd(), noWrite: false });
 }
 

--- a/packages/tools/lib/cem/validate.js
+++ b/packages/tools/lib/cem/validate.js
@@ -5,6 +5,7 @@ const path = require('path');
 const extenalSchema = require('./schema.json');
 const internalSchema = require('./schema-internal.json');
 
+const isVerbose = () => process.env.UI5_VERBOSE === "true";
 
 const validateFn = async () => {
 	// Load your JSON data from the input file
@@ -49,7 +50,9 @@ const validateFn = async () => {
 	// Validate the JSON data against the schema
 	if (devMode) {
 		if (validate(inputDataInternal)) {
-			console.log('Internal custom  element manifest is validated successfully');
+			if (isVerbose()) {
+				console.log('Internal custom element manifest is validated successfully');
+			}
 		} else {
 			console.log(validate.errors)
 			throw new Error(`Validation of internal custom elements manifest failed: ${validate.errors}`);
@@ -61,7 +64,9 @@ const validateFn = async () => {
 
 	// Validate the JSON data against the schema
 	if (validate(inputDataExternal)) {
-		console.log('Custom element manifest is validated successfully');
+		if (isVerbose()) {
+			console.log('Custom element manifest is validated successfully');
+		}
 		fs.writeFileSync(inputFilePath, JSON.stringify(inputDataExternal, null, 2), 'utf8');
 		fs.writeFileSync(inputFilePath.replace("custom-elements", "custom-elements-internal"), JSON.stringify(inputDataInternal, null, 2), 'utf8');
 	} else if (devMode) {

--- a/packages/tools/lib/copy-and-watch/index.js
+++ b/packages/tools/lib/copy-and-watch/index.js
@@ -42,6 +42,11 @@ const copyAndWatchFn = async (argv) => {
 		}
 	});
 
+	// Default to silent mode unless verbose is enabled
+	if (process.env.UI5_VERBOSE !== "true") {
+		options.silent = true;
+	}
+
 	if (args.length < 2) {
 		console.error('Not enough arguments: copy-and-watch [options] <sources> <target>');
 		process.exit(1);

--- a/packages/tools/lib/copy-list/index.js
+++ b/packages/tools/lib/copy-list/index.js
@@ -22,7 +22,9 @@ const generate = async (argv) => {
 	});
 
 	return Promise.all(promises).then(() => {
-		console.log("Files copied.");
+		if (process.env.UI5_VERBOSE === "true") {
+			console.log("Files copied.");
+		}
 	});
 };
 

--- a/packages/tools/lib/create-illustrations/index.js
+++ b/packages/tools/lib/create-illustrations/index.js
@@ -84,11 +84,15 @@ const generate = async (argv) => {
 	try {
 		await fs.access(srcPath);
 	} catch (error) {
-		console.log(`The path ${srcPath} does not exist.`);
+		if (process.env.UI5_VERBOSE === "true") {
+			console.log(`The path ${srcPath} does not exist.`);
+		}
 		return Promise.resolve(null);
 	}
 
-	console.log(`Generating illustrations from ${srcPath} to ${destPath}`)
+	if (process.env.UI5_VERBOSE === "true") {
+		console.log(`Generating illustrations from ${srcPath} to ${destPath}`);
+	}
 
 	const svgImportTemplate = svgContent => {
 		return `export default \`${svgContent}\`;`
@@ -193,7 +197,9 @@ export { dialogSvg, sceneSvg, spotSvg, dotSvg };`
 			return Promise.all(nestedPromises);
 		})
 		.then(() => {
-			console.log("Illustrations generated.");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("Illustrations generated.");
+			}
 		});
 };
 

--- a/packages/tools/lib/css-processors/css-processor-themes.mjs
+++ b/packages/tools/lib/css-processors/css-processor-themes.mjs
@@ -39,7 +39,7 @@ const generate = async (argv) => {
 
     const processThemingPackageFile = async (f) => {
         const selector = ':root';
-        const result = await postcss().process(f.text);
+        const result = await postcss().process(f.text, { from: undefined });
 
         const newRule = postcss.rule({ selector });
 
@@ -59,7 +59,7 @@ const generate = async (argv) => {
             const result = await postcss([
                 combineDuplicatedSelectors,
                 postcssPlugin
-            ]).process(f.text);
+            ]).process(f.text, { from: undefined });
 
             return { css: result.css };
         }
@@ -67,7 +67,7 @@ const generate = async (argv) => {
 
         const combined = await postcss([
             combineDuplicatedSelectors,
-        ]).process(f.text);
+        ]).process(f.text, { from: undefined });
 
         return { css: scopeVariables(combined.css, packageJSON, f.path) };
     }
@@ -93,6 +93,7 @@ const generate = async (argv) => {
         minify: true,
         outdir: 'dist/css',
         outbase: 'src',
+        logLevel: process.env.UI5_VERBOSE === "true" ? "warning" : "error",
         plugins: [
             scopingPlugin,
         ],

--- a/packages/tools/lib/css-processors/scope-variables.mjs
+++ b/packages/tools/lib/css-processors/scope-variables.mjs
@@ -30,7 +30,9 @@ const getOverrideVersion = filePath => {
 	try {
 		overrideVersion = require(`${packageName}${path.sep}package.json`).version;
 	} catch (e) {
-		console.log(`Error requiring package ${packageName}: ${e.message}`);
+		if (process.env.UI5_VERBOSE === "true") {
+			console.log(`Error requiring package ${packageName}: ${e.message}`);
+		}
 	}
 
 	return overrideVersion;

--- a/packages/tools/lib/generate-js-imports/illustrations.js
+++ b/packages/tools/lib/generate-js-imports/illustrations.js
@@ -75,7 +75,9 @@ const generateIllustrations = async (argv) => {
 	await fs.mkdir(path.dirname(normalizedOutputFile), { recursive: true });
 	await fs.writeFile(normalizedOutputFile, contentDynamic);
 
-	console.log("Generated illustration imports.");
+	if (process.env.UI5_VERBOSE === "true") {
+		console.log("Generated illustration imports.");
+	}
 };
 
 if (require.main === module) {

--- a/packages/tools/lib/generate-json-imports/i18n.js
+++ b/packages/tools/lib/generate-json-imports/i18n.js
@@ -80,7 +80,9 @@ const generate = async (argv) => {
 		fs.writeFile(outputFileFetchMetaResolve, contentFetchMetaResolve),
 		fs.writeFile(outputFileDynamicImportJSONImport, contentDynamicImportJSONAttr),
 	]).then(() => {
-		console.log("Generated i18n JSON imports.");
+		if (process.env.UI5_VERBOSE === "true") {
+			console.log("Generated i18n JSON imports.");
+		}
 	});
 }
 

--- a/packages/tools/lib/generate-json-imports/themes.js
+++ b/packages/tools/lib/generate-json-imports/themes.js
@@ -62,7 +62,9 @@ ${availableThemesArray}
 		fs.writeFile(outputFileFetchMetaResolve, contentDynamic(fetchMetaResolveLines)),
 	]).
 		then(() => {
-			console.log("Generated themes JSON imports.");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("Generated themes JSON imports.");
+			}
 		})
 };
 

--- a/packages/tools/lib/i18n/defaults.js
+++ b/packages/tools/lib/i18n/defaults.js
@@ -78,7 +78,9 @@ export {${textKeys.join()}};`;
 	await fs.writeFile(outputFile, getOutputFileContent(properties, defaultLanguageProperties));
 
 
-	console.log("i18n default file generated.")
+	if (process.env.UI5_VERBOSE === "true") {
+		console.log("i18n default file generated.");
+	}
 };
 
 if (require.main === module) {

--- a/packages/tools/lib/i18n/toJSON.js
+++ b/packages/tools/lib/i18n/toJSON.js
@@ -58,7 +58,9 @@ const generate = async (agrv) => {
 	const files = await globby(messagesBundles.replace(/\\/g, "/"));
 	return Promise.all(files.map(file => convertToJSON(file, messagesJSONDist)))
 		.then(() => {
-			console.log("Message bundle JSON files generated.");
+			if (process.env.UI5_VERBOSE === "true") {
+				console.log("Message bundle JSON files generated.");
+			}
 		});
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/code-frame@npm:7.29.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/d34cc504e7765dfb576a663d97067afb614525806b5cad1a5cc1a7183b916fec8ff57fa233585e3926fd5a9e6b31aae6df91aa81ae9775fb7a28f658d3346f0d
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.22.9":
   version: 7.22.9
   resolution: "@babel/compat-data@npm:7.22.9"
@@ -278,6 +289,13 @@ __metadata:
   version: 7.26.5
   resolution: "@babel/compat-data@npm:7.26.5"
   checksum: 10c0/9d2b41f0948c3dfc5de44d9f789d2208c2ea1fd7eb896dfbb297fe955e696728d6f363c600cd211e7f58ccbc2d834fe516bb1e4cf883bbabed8a32b038afc1a0
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.28.6":
+  version: 7.29.0
+  resolution: "@babel/compat-data@npm:7.29.0"
+  checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
   languageName: node
   linkType: hard
 
@@ -304,29 +322,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.23.7":
-  version: 7.23.7
-  resolution: "@babel/core@npm:7.23.7"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.2.0"
-    "@babel/code-frame": "npm:^7.23.5"
-    "@babel/generator": "npm:^7.23.6"
-    "@babel/helper-compilation-targets": "npm:^7.23.6"
-    "@babel/helper-module-transforms": "npm:^7.23.3"
-    "@babel/helpers": "npm:^7.23.7"
-    "@babel/parser": "npm:^7.23.6"
-    "@babel/template": "npm:^7.22.15"
-    "@babel/traverse": "npm:^7.23.7"
-    "@babel/types": "npm:^7.23.6"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/38c9934973d384ed83369712978453eac91dc3f22167404dbdb272b64f602e74728a6f37012c53ee57e521b8ae2da60097f050497d9b6a212d28b59cdfb2cd1d
-  languageName: node
-  linkType: hard
-
 "@babel/core@npm:^7.23.9":
   version: 7.26.0
   resolution: "@babel/core@npm:7.26.0"
@@ -347,6 +342,29 @@ __metadata:
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
   checksum: 10c0/91de73a7ff5c4049fbc747930aa039300e4d2670c2a91f5aa622f1b4868600fc89b01b6278385fbcd46f9574186fa3d9b376a9e7538e50f8d118ec13cfbcb63e
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.24.6":
+  version: 7.29.0
+  resolution: "@babel/core@npm:7.29.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/generator": "npm:^7.29.0"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-module-transforms": "npm:^7.28.6"
+    "@babel/helpers": "npm:^7.28.6"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
   languageName: node
   linkType: hard
 
@@ -382,6 +400,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.17"
     jsesc: "npm:^2.5.1"
   checksum: 10c0/53540e905cd10db05d9aee0a5304e36927f455ce66f95d1253bb8a179f286b88fa7062ea0db354c566fe27f8bb96567566084ffd259f8feaae1de5eccc8afbda
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.24.6, @babel/generator@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/generator@npm:7.29.0"
+  dependencies:
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/5c3df8f2475bfd5f97ad0211c52171aff630088b148e7b89d056b39d69855179bc9f2d1ee200263c76c2398a49e4fdbb38b9709ebc4f043cc04d9ee09a66668a
   languageName: node
   linkType: hard
 
@@ -483,6 +514,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
+  dependencies:
+    "@babel/compat-data": "npm:^7.28.6"
+    "@babel/helper-validator-option": "npm:^7.27.1"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-class-features-plugin@npm:^7.22.15, @babel/helper-create-class-features-plugin@npm:^7.23.6":
   version: 7.23.6
   resolution: "@babel/helper-create-class-features-plugin@npm:7.23.6"
@@ -570,6 +614,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: 10c0/5a0cd0c0e8c764b5f27f2095e4243e8af6fa145daea2b41b53c0c1414fe6ff139e3640f4e2207ae2b3d2153a1abd346f901c26c290ee7cb3881dd922d4ee9232
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-hoist-variables@npm:7.22.5"
@@ -607,6 +658,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-imports@npm:7.28.6"
+  dependencies:
+    "@babel/traverse": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/b49d8d8f204d9dbfd5ac70c54e533e5269afb3cea966a9d976722b13e9922cc773a653405f53c89acb247d5aebdae4681d631a3ae3df77ec046b58da76eda2ac
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.23.3":
   version: 7.23.3
   resolution: "@babel/helper-module-transforms@npm:7.23.3"
@@ -632,6 +693,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/ee111b68a5933481d76633dad9cdab30c41df4479f0e5e1cc4756dc9447c1afd2c9473b5ba006362e35b17f4ebddd5fca090233bef8dfc84dca9d9127e56ec3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-transforms@npm:7.28.6"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.28.6"
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    "@babel/traverse": "npm:^7.28.6"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
   languageName: node
   linkType: hard
 
@@ -760,6 +834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+  checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/helper-validator-option@npm:7.23.5"
@@ -781,6 +862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-option@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-option@npm:7.27.1"
+  checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
 "@babel/helper-wrap-function@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-wrap-function@npm:7.22.20"
@@ -792,13 +880,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.23.7, @babel/helpers@npm:^7.23.9, @babel/helpers@npm:^7.26.0, @babel/helpers@npm:^7.26.9":
+"@babel/helpers@npm:^7.23.9, @babel/helpers@npm:^7.26.0, @babel/helpers@npm:^7.26.9":
   version: 7.26.10
   resolution: "@babel/helpers@npm:7.26.10"
   dependencies:
     "@babel/template": "npm:^7.26.9"
     "@babel/types": "npm:^7.26.10"
   checksum: 10c0/f99e1836bcffce96db43158518bb4a24cf266820021f6461092a776cba2dc01d9fc8b1b90979d7643c5c2ab7facc438149064463a52dd528b21c6ab32509784f
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helpers@npm:7.28.6"
+  dependencies:
+    "@babel/template": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/c4a779c66396bb0cf619402d92f1610601ff3832db2d3b86b9c9dd10983bf79502270e97ac6d5280cea1b1a37de2f06ecbac561bd2271545270407fbe64027cb
   languageName: node
   linkType: hard
 
@@ -860,6 +958,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/7df97386431366d4810538db4b9ec538f4377096f720c0591c7587a16f6810e62747e9fbbfa1ff99257fd4330035e4fb1b5b77c7bd3b97ce0d2e3780a6618975
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.24.6, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/parser@npm:7.29.0"
+  dependencies:
+    "@babel/types": "npm:^7.29.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
   languageName: node
   linkType: hard
 
@@ -2047,6 +2156,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/template@npm:7.28.6"
+  dependencies:
+    "@babel/code-frame": "npm:^7.28.6"
+    "@babel/parser": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/66d87225ed0bc77f888181ae2d97845021838c619944877f7c4398c6748bcf611f216dfd6be74d39016af502bca876e6ce6873db3c49e4ac354c56d34d57e9f5
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.22.8":
   version: 7.23.6
   resolution: "@babel/traverse@npm:7.23.6"
@@ -2062,24 +2182,6 @@ __metadata:
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
   checksum: 10c0/5b4ebb94a00a7e1daf111e4b0b45a7998d5b7598637a14e75e855e88cc1b702789e09a958726b5d599a003be1e9032dbdfde4b88ea6061332228738950d5582d
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.23.7":
-  version: 7.23.7
-  resolution: "@babel/traverse@npm:7.23.7"
-  dependencies:
-    "@babel/code-frame": "npm:^7.23.5"
-    "@babel/generator": "npm:^7.23.6"
-    "@babel/helper-environment-visitor": "npm:^7.22.20"
-    "@babel/helper-function-name": "npm:^7.23.0"
-    "@babel/helper-hoist-variables": "npm:^7.22.5"
-    "@babel/helper-split-export-declaration": "npm:^7.22.6"
-    "@babel/parser": "npm:^7.23.6"
-    "@babel/types": "npm:^7.23.6"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10c0/e32fceb4249beec2bde83968ddffe17444221c1ee5cd18c543a2feaf94e3ca83f2a4dfbc2dcca87cf226e0105973e0fe3717063a21e982a9de9945615ab3f3f5
   languageName: node
   linkType: hard
 
@@ -2128,6 +2230,21 @@ __metadata:
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
   checksum: 10c0/51dd57fa39ea34d04816806bfead04c74f37301269d24c192d1406dc6e244fea99713b3b9c5f3e926d9ef6aa9cd5c062ad4f2fc1caa9cf843d5e864484ac955e
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/traverse@npm:7.29.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/generator": "npm:^7.29.0"
+    "@babel/helper-globals": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/types": "npm:^7.29.0"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/f63ef6e58d02a9fbf3c0e2e5f1c877da3e0bc57f91a19d2223d53e356a76859cbaf51171c9211c71816d94a0e69efa2732fd27ffc0e1bbc84b636e60932333eb
   languageName: node
   linkType: hard
 
@@ -2201,6 +2318,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10c0/ac6f909d6191319e08c80efbfac7bd9a25f80cc83b43cd6d82e7233f7a6b9d6e7b90236f3af7400a3f83b576895bcab9188a22b584eb0f224e80e6d4e95f4517
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/types@npm:7.29.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
   languageName: node
   linkType: hard
 
@@ -4220,6 +4347,16 @@ __metadata:
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
   checksum: 10c0/c668feaf86c501d7c804904a61c23c67447b2137b813b9ce03eca82cb9d65ac7006d766c218685d76e3d72828279b6ee26c347aa1119dab23fbaf36aed51585a
+  languageName: node
+  linkType: hard
+
+"@jridgewell/remapping@npm:^2.3.5":
+  version: 2.3.5
+  resolution: "@jridgewell/remapping@npm:2.3.5"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10c0/3de494219ffeb2c5c38711d0d7bb128097edf91893090a2dbc8ee0b55d092bb7347b1fd0f478486c5eab010e855c73927b1666f2107516d472d24a73017d1194
   languageName: node
   linkType: hard
 
@@ -7536,9 +7673,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-localization@workspace:packages/localization"
   dependencies:
-    "@babel/core": "npm:^7.23.7"
-    "@babel/generator": "npm:^7.23.6"
-    "@babel/parser": "npm:^7.23.6"
+    "@babel/core": "npm:^7.24.6"
+    "@babel/generator": "npm:^7.24.6"
+    "@babel/parser": "npm:^7.24.6"
     "@openui5/sap.ui.core": "npm:1.120.17"
     "@types/openui5": "npm:^1.113.0"
     "@ui5/webcomponents-base": "npm:2.19.0-rc.2"


### PR DESCRIPTION
## Add `--verbose` flag to build commands for quieter default output                                                                                                              
                                                                                                                                                                                    
  ### Problem                                                                                                                                                                       
                                                                                                                                                                                    
  Running `yarn generate` in the `packages/base` folder (and other packages) produced excessive output that cluttered the terminal, making it difficult to spot actual errors.      
                                                                                                                                                                                    
  ### Solution                                                                                                                                                                      
                                                                                                                                                                                    
  Added a `--verbose` / `-v` flag to the build tooling. By default, commands now run in quiet mode (showing only errors), with detailed output available via the verbose flag.      
                                                                                                                                                                                    
  ### Changes                                                                                                                                                                       
                                                                                                                                                                                    
  #### Core Infrastructure                                                                                                                                                          
                                                                                                                                                                                    
  - **`packages/tools/bin/ui5nps.js`** - Added `--verbose`/`-v` CLI flag support and `UI5_VERBOSE` environment variable propagation to child scripts                                
  - **`packages/tools/bin/dev.js`** - Pass through verbose flag to ui5nps                                                                                                           
                                                                                                                                                                                    
  #### Scripts Updated for Verbose Mode                                                                                                                                             
                                                                                                                                                                                    
  All scripts in `lib/` now check `process.env.UI5_VERBOSE === "true"` before logging:                                                                                                        
                                                                                                    
  #### Dependency Update                                                                                                                                                            
                                                                                                                                                                                    
  - **`packages/localization/package.json`** - Updated `@babel/core`, `@babel/generator`, `@babel/parser` from `^7.23.x` to `^7.24.6` to fix Node.js deprecation warning `[DEP0180] 
  fs.Stats constructor is deprecated`                                                                                                                                               
                                                                                                                                                                                    
  ### Usage                                                                                                                                                                         
                                                                                                                                                                                    
  ```bash                                                                                                                                                                           
  # Quiet mode (default) - only errors shown                                                                                                                                        
  yarn generate                                                                                                                                                                     
  yarn generateProd                                                                                                                                                                 
  yarn generateAPI                                                                                                                                                                  
                                                                                                                                                                                    
  # Verbose mode - show detailed output                                                                                                                                             
  yarn generate --verbose                                                                                                                                                           
  yarn generate -v                                                                                                                                                                  
                                                                                                                                                                                    
  Before                                                                                                                                                                            
                                                                                                                                                                                    
   |  Executing command clean.generated as module.                                                                                                                                  
   |  Executing command clean.dist as module.                                                                                                                                       
   |  Executing command build.i18n.defaultsjs as module.                                                                                                                            
  i18n default file generated.                                                                                                                                                      
   |  Executing command build.i18n.json as module.                                                                                                                                  
  Message bundle JSON files generated.                                                                                                                                              
  ... (50+ lines of output)                                                                                                                                                         
                                                                                                                                                                                    
  After                                                                                                                                                                             
                                                                                                                                                                                    
  (no output - only errors would appear)                                                                                                                                            
                                               