### PR TITLE
chore: add --help for create-package bin

### DIFF
--- a/packages/create-package/create-package.js
+++ b/packages/create-package/create-package.js
@@ -10,10 +10,54 @@ import * as prettier from "prettier";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const argv = yargs(hideBin(process.argv)).argv;
 const VERSION = JSON.parse(
 	await fs.readFile(path.join(__dirname, "package.json")),
 ).version;
+
+const argv = yargs(hideBin(process.argv))
+	.usage("Usage: npm create @ui5/webcomponents-package [options]")
+	.option("name", {
+		type: "string",
+		description: "Package name (npm-compatible)",
+		default: "my-package",
+	})
+	.option("tag", {
+		type: "string",
+		description: "Component tag name (e.g., my-button)",
+	})
+	.option("testSetup", {
+		type: "string",
+		choices: ["cypress", "manual"],
+		description: "Test setup configuration",
+		default: "manual",
+	})
+	.option("skip", {
+		type: "boolean",
+		description: "Skip interactive prompts and use defaults/provided values",
+		default: false,
+	})
+	.option("skipSubfolder", {
+		type: "boolean",
+		description: "Create files in current directory instead of a subfolder",
+		default: false,
+	})
+	.example(
+		"npm create @ui5/webcomponents-package",
+		"Interactive mode with prompts",
+	)
+	.example(
+		"npm create @ui5/webcomponents-package -- --name my-components --skip",
+		"Non-interactive with custom name",
+	)
+	.example(
+		"npm create @ui5/webcomponents-package -- --name @scope/my-lib --testSetup cypress --skip",
+		"Non-interactive with scoped name and Cypress",
+	)
+	.help()
+	.alias("h", "help")
+	.version(VERSION)
+	.alias("v", "version")
+	.wrap(100).argv;
 
 // Constants
 const SUPPORTED_TEST_SETUPS = ["cypress", "manual"];


### PR DESCRIPTION
Add a help option for non-interactive creation of web components packages
```bash
npm create @ui5/webcomponents-package -- --help
```

The options where active, but AI agents start the tool, detect interactive usage, run `--help` and since there is no output, they start creating the project structure from examples.