### PR TITLE
fix(ui5-combobox): focus the only item on Arrow Down

### DIFF
--- a/packages/main/cypress/specs/ComboBox.cy.tsx
+++ b/packages/main/cypress/specs/ComboBox.cy.tsx
@@ -596,6 +596,54 @@ describe("Keyboard navigation", () => {
 
 		cy.get("@input").should("have.value", "b");
 	});
+
+	it("should focus the only one item when focus was in the input and Arrow Down is pressed (no grouping)", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria">
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+
+		cy.get("[ui5-combobox]")
+			.as("comboBox")
+			.shadow()
+			.find("input")
+			.as("input");
+
+		cy.get("@input").realClick();
+		cy.get("@input").realType("Bul");
+		cy.get("@input").realPress("ArrowDown");
+
+		cy.get("@comboBox")
+			.find("[ui5-cb-item]")
+			.first()
+			.should("have.prop", "focused", true);
+	});
+
+	it("should focus the only one item when focus was in the input and Arrow Down is pressed (with grouping)", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria">
+				<ComboBoxItemGroup headerText="Group 1">
+					<ComboBoxItem text="Bulgaria" />
+				</ComboBoxItemGroup>
+			</ComboBox>
+		);
+
+		cy.get("[ui5-combobox]")
+			.as("comboBox")
+			.shadow()
+			.find("input")
+			.as("input");
+
+		cy.get("@input").realClick();
+		cy.get("@input").realType("Bul");
+		cy.get("@input").realPress("ArrowDown");
+
+		cy.get("@comboBox")
+			.find("[ui5-cb-item]")
+			.first()
+			.should("have.prop", "focused", true);
+	});
 });
 
 describe("Grouping", () => {

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -810,10 +810,6 @@ class ComboBox extends UI5Element implements IFormInputElement {
 			return;
 		}
 
-		if (allItems.length - 1 === indexOfItem && isDown(e)) {
-			return;
-		}
-
 		this._isKeyNavigation = true;
 
 		if (
@@ -882,7 +878,18 @@ class ComboBox extends UI5Element implements IFormInputElement {
 			this.focused = false;
 		}
 
-		this._handleItemNavigation(e, ++indexOfItem, true /* isForward */);
+		const allItems = this._getItems();
+		const currentItem = allItems[indexOfItem];
+		const isLastItem = indexOfItem === allItems.length - 1;
+
+		// We don't want to navigate further if the current item is the last one and either is already focused or the popover is closed
+		if (isLastItem && ((isOpen && currentItem.focused) || !isOpen)) {
+			return;
+		}
+
+		const itemIndexToBeFocused = isLastItem ? indexOfItem : indexOfItem + 1;
+
+		this._handleItemNavigation(e, itemIndexToBeFocused, true /* isForward */);
 	}
 
 	_handleArrowUp(e: KeyboardEvent, indexOfItem: number) {


### PR DESCRIPTION
When the ComboBox has only one item, pressing the Arrow Down key should focus that item. The typical behavior is that when items picker is opened, the next item of the selected one gets the focus. However, if there is only one item, pressing Arrow Down from the input field should focus that single item.

Fixes #12937
