### PR TITLE
chore(ui5-form): correct CSS variables usage

### DIFF
--- a/packages/main/src/themes/FormItem.css
+++ b/packages/main/src/themes/FormItem.css
@@ -34,14 +34,14 @@
 
 .ui5-form-item-layout {
 	display: grid;
-	grid-template-columns: var(--ui5-form-item-layout);
+	grid-template-columns: var(--ui5-form-item-layout, 4fr 8fr 0fr);
 	align-items: center;
 }
 
 .ui5-form-item-label {
-	padding: var(--ui5-form-item-label-padding);
-	padding-inline-end: var(--ui5-form-item-label-padding-end);
-	justify-self: var(--ui5-form-item-label-justify);
+	padding: var(--ui5-form-item-label-padding, 0.125rem 0);
+	padding-inline-end: 0.85rem;
+	justify-self: var(--ui5-form-item-label-justify, end);
 }
 
 .ui5-form-item-content {

--- a/packages/main/src/themes/FormItemSpan.css
+++ b/packages/main/src/themes/FormItemSpan.css
@@ -6,6 +6,11 @@
 * The ratio can be changed via the labelSpan and the emptySpan properties.
 */
 
+:host {
+	--ui5-form-item-label-justify-internal: start;
+	--ui5-form-item-label-padding: 0.625rem 0.25rem 0 0.25rem;
+}
+
 @container (max-width: 600px) {
 	.ui5-form-item,
 	.ui5-form-group {
@@ -14,8 +19,8 @@
 
 	:host([label-span-s="12"]) .ui5-form-item,
 	:host([label-span-s="12"]) .ui5-form-group {
-		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-span12);
-		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-span12);
+		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-internal);
+		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-internal);
 	}
 }
 
@@ -27,8 +32,8 @@
 
 	:host([label-span-m="12"]) .ui5-form-item,
 	:host([label-span-m="12"]) .ui5-form-group {
-		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-span12);
-		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-span12);
+		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-internal);
+		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-internal);
 	}
 }
 
@@ -40,8 +45,8 @@
 
 	:host([label-span-l="12"]) .ui5-form-item,
 	:host([label-span-l="12"]) .ui5-form-group {
-		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-span12);
-		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-span12);
+		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-internal);
+		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-internal);
 	}
 }
 
@@ -53,7 +58,7 @@
 
 	:host([label-span-xl="12"]) .ui5-form-item,
 	:host([label-span-xl="12"]) .ui5-form-group {
-		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-span12);
-		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-span12);
+		--ui5-form-item-label-justify: var(--ui5-form-item-label-justify-internal);
+		--ui5-form-item-label-padding: var(--ui5-form-item-label-padding-internal);
 	}
 }

--- a/packages/main/src/themes/base/Form-parameters.css
+++ b/packages/main/src/themes/base/Form-parameters.css
@@ -1,8 +1,1 @@
-:host {
-	--ui5-form-item-layout: 4fr 8fr 0fr;
-	--ui5-form-item-label-justify: end;
-	--ui5-form-item-label-justify-span12: start;
-	--ui5-form-item-label-padding: 0.125rem 0;
-	--ui5-form-item-label-padding-end: 0.85rem;
-	--ui5-form-item-label-padding-span12: 0.625rem 0.25rem 0 0.25rem;
-}
+:host {}


### PR DESCRIPTION
Theming CSS variables are defined on the `:host` element. This means that when `ui5-form` attempts to override them in specific cases, it should target `[ui5-form-item]` or `[ui5-form-group-item]`; otherwise, the variables will fall back to their default values.

A simple solution is to leave the variables undefined by default and rely on the fallback value specified in `var()`. This ensures that the correct value is applied if the variable is defined on the `[ui5-form]` element.
