### PR TITLE
chore: update release workflow - build after version bump

### DIFF
--- a/.github/actions/extractChangelog.mjs
+++ b/.github/actions/extractChangelog.mjs
@@ -1,18 +1,35 @@
-import { readFileSync } from 'fs';
+import { promises as fs } from 'node:fs';
 
-const version = process.argv[2];
-if (!version) {
-    console.error('Usage: node extractChangelog.mjs <version>');
-    process.exit(1);
-}
+/**
+ * Extracts the changelog section for a specific version from CHANGELOG.md
+ * @param {string} changelog - The full changelog content
+ * @param {string} version - The version to extract (e.g., "2.19.0")
+ * @returns {string} The changelog section for that version
+ */
+const extractVersionChangelog = (changelog, version) => {
+	const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const regex = new RegExp(`^# \\[${escapedVersion}\\].*?\\n([\\s\\S]*?)(?=^# \\[|$)`, 'm');
+	const match = changelog.match(regex);
 
-const changelog = readFileSync('CHANGELOG.md', 'utf8');
-const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-const regex = new RegExp(`^# \\[${escapedVersion}\\].*?\\n([\\s\\S]*?)(?=^# \\[|$)`, 'm');
-const match = changelog.match(regex);
+	if (match) {
+		return match[1].trim();
+	}
 
-if (match) {
-    console.log(match[1].trim());
-} else {
-    console.log(`Release v${version}`);
+	return `Release v${version}`;
+};
+
+export default async function run() {
+	const lerna = await fs.readFile(new URL('../../lerna.json', import.meta.url), 'utf8');
+	const { version } = JSON.parse(lerna);
+
+	try {
+		const changelog = await fs.readFile(new URL('../../CHANGELOG.md', import.meta.url), 'utf8');
+		const body = extractVersionChangelog(changelog, version);
+
+		console.log(body);
+		return body;
+	} catch (error) {
+		console.error('Error extracting changelog:', error);
+		return `Release v${version}`;
+	}
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,17 +67,28 @@ jobs:
       - name: Build
         run: yarn ci:releasebuild
 
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+      - name: Push Changes
         run: |
           git push origin HEAD
           git push origin --tags
-          NEW_VERSION=$(node -p "require('./lerna.json').version")
-          CHANGELOG_BODY=$(node .github/actions/extractChangelog.mjs "${NEW_VERSION}")
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --notes "${CHANGELOG_BODY}"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        with:
+          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          script: |
+            const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
+            const changelog = await extractChangelog();
+            const version = require('./lerna.json').version;
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${version}`,
+              name: `v${version}`,
+              body: changelog,
+            });
 
       - name: Publish
         run: |
@@ -163,18 +174,29 @@ jobs:
       - name: Build
         run: yarn ci:releasebuild
 
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+      - name: Push Changes
         run: |
           git push origin HEAD
           git push origin --tags
-          NEW_VERSION=$(node -p "require('./lerna.json').version")
-          CHANGELOG_BODY=$(node .github/actions/extractChangelog.mjs "${NEW_VERSION}")
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --notes "${CHANGELOG_BODY}" \
-            --prerelease
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        with:
+          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          script: |
+            const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
+            const changelog = await extractChangelog();
+            const version = require('./lerna.json').version;
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${version}`,
+              name: `v${version}`,
+              body: changelog,
+              prerelease: true,
+            });
 
       - name: Publish
         run: |
@@ -244,17 +266,28 @@ jobs:
       - name: Build
         run: yarn ci:releasebuild
 
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+      - name: Push Changes
         run: |
           git push origin HEAD
           git push origin --tags
-          NEW_VERSION=$(node -p "require('./lerna.json').version")
-          CHANGELOG_BODY=$(node .github/actions/extractChangelog.mjs "${NEW_VERSION}")
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --notes "${CHANGELOG_BODY}"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        with:
+          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          script: |
+            const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
+            const changelog = await extractChangelog();
+            const version = require('./lerna.json').version;
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${version}`,
+              name: `v${version}`,
+              body: changelog,
+            });
 
       - name: Publish
         run:  |


### PR DESCRIPTION
**Summary**

Fixes incorrect version in VersionInfo.js during releases.
Previously, the build ran before version bump, causing the published packages to contain the old version (e.g., 2.19.0-rc.3 instead of 2.19.0).


**Changes**

Reordered release workflow steps to:
  1. Version Bump (local only) - Uses --no-push to update versions
  locally without pushing
  2. Build - Now runs after version bump, so VersionInfo.js has the
   correct version
  3. Push and Create GitHub Release - Pushes commit/tags and
  creates release using changelog content