### PR TITLE
fix(ui5-shellbar): prevent hover and active styles on disabled slotted buttons

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -1563,4 +1563,36 @@ describe("Component Behavior", () => {
 				.should("have.been.calledOnce");
 		});
 	});
+
+	it("Test disabled slotted button does not show hover styles", () => {
+		cy.mount(
+			<ShellBar>
+				<Button icon={navBack} slot="startButton" disabled></Button>
+				<Button icon={navBack} slot="content"></Button>
+			</ShellBar>
+		);
+
+		cy.get("[ui5-shellbar] [ui5-button][slot='startButton']").then($disabledBtn => {
+			const initialBackground = window.getComputedStyle($disabledBtn[0]).backgroundColor;
+			const initialBorderColor = window.getComputedStyle($disabledBtn[0]).borderColor;
+			const cursor = window.getComputedStyle($disabledBtn[0]).cursor;
+
+			expect(cursor).to.not.equal("pointer");
+
+			cy.get("[ui5-shellbar] [ui5-button][slot='startButton']").realHover();
+
+			cy.get("[ui5-shellbar] [ui5-button][slot='startButton']").then($btn => {
+				const hoverBackground = window.getComputedStyle($btn[0]).backgroundColor;
+				const hoverBorderColor = window.getComputedStyle($btn[0]).borderColor;
+
+				expect(hoverBackground).to.equal(initialBackground);
+				expect(hoverBorderColor).to.equal(initialBorderColor);
+			});
+		});
+
+		cy.get("[ui5-shellbar] [ui5-button][slot^='content']").then($enabledBtn => {
+			const cursor = window.getComputedStyle($enabledBtn[0]).cursor;
+			expect(cursor).to.equal("pointer");
+		});
+	});
 });

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -57,7 +57,6 @@
 	outline-color: var(--_ui5_shellbar_logo_outline_color);
 	color: var(--sapShell_TextColor);
 	box-sizing: border-box;
-	cursor: pointer;
 	border-radius: var(--_ui5_shellbar_button_border_radius);
 	position: relative;
 	font-weight: bold;
@@ -81,12 +80,20 @@
 	margin-inline-start: 0;
 }
 
-::slotted([ui5-toggle-button]:hover),
-::slotted([ui5-button]:hover),
+.ui5-shellbar-menu-button,
+.ui5-shellbar-button,
+.ui5-shellbar-image-button,
+::slotted([ui5-toggle-button]:not([slot^="content"]):not([disabled])),
+::slotted([ui5-button]:not([slot^="content"]):not([disabled])) {
+	cursor: pointer;
+}
+
+::slotted([ui5-toggle-button]:not([disabled]):hover),
+::slotted([ui5-button]:not([disabled]):hover),
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:hover,
 .ui5-shellbar-button:hover,
 .ui5-shellbar-image-button:hover,
-::slotted([ui5-button][slot="midContent"]:hover) {
+::slotted([ui5-button][slot="midContent"]:not([disabled]):hover) {
 	background: var(--sapShell_Hover_Background);
 	border-color: var(--sapButton_Lite_Hover_BorderColor);
 	color: var(--sapShell_TextColor);
@@ -97,8 +104,8 @@
 	color: var(--sapShell_Assistant_ForegroundColor);
 }
 
-::slotted([ui5-toggle-button][active]),
-::slotted([ui5-button][active]),
+::slotted([ui5-toggle-button]:not([disabled])[active]),
+::slotted([ui5-button]:not([disabled])[active]),
 .ui5-shellbar-menu-button.ui5-shellbar-menu-button--interactive:active,
 .ui5-shellbar-button[active],
 .ui5-shellbar-image-button:active {


### PR DESCRIPTION
Disabled buttons slotted in ShellBar were showing hover styling and pointer cursor due to ShellBar's button overstyles not accounting for the disabled state.

Added `:not([disabled])` selectors to:
- cursor: pointer rule for slotted buttons
- hover state styles for slotted buttons
- active state styles for slotted buttons

Fixes: https://github.com/UI5/webcomponents/issues/13072
