### PR TITLE
feat(ui5-li-group): expose title CSS part for styling

### DIFF
--- a/packages/main/src/ListItemGroup.ts
+++ b/packages/main/src/ListItemGroup.ts
@@ -39,6 +39,7 @@ type ListItemGroupMoveEventDetail = {
  * ### ES6 Module Import
  * `import "@ui5/webcomponents/dist/ListItemGroup.js";`
  * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  * @constructor
  * @extends UI5Element
  * @public

--- a/packages/main/src/ListItemGroupTemplate.tsx
+++ b/packages/main/src/ListItemGroupTemplate.tsx
@@ -7,8 +7,14 @@ export default function ListItemGroupTemplate(this: ListItemGroup) {
 	return (
 		<>
 			{this.hasHeader &&
-				<ListItemGroupHeader wrappingType={this.wrappingType} focused={this.focused} part="header" accessibleRole={ListItemAccessibleRole.ListItem}>
-					{ this.hasFormattedHeader ? <slot name="header"></slot> : this.headerText }
+				<ListItemGroupHeader
+					wrappingType={this.wrappingType}
+					focused={this.focused}
+					part="header"
+					exportparts="title"
+					accessibleRole={ListItemAccessibleRole.ListItem}
+				>
+					{this.hasFormattedHeader ? <slot name="header"></slot> : this.headerText}
 					<div
 						role="list"
 						slot="subItems"
@@ -26,7 +32,7 @@ export default function ListItemGroupTemplate(this: ListItemGroup) {
 
 				<slot></slot>
 
-				<DropIndicator orientation="Horizontal" ownerReference={this}/>
+				<DropIndicator orientation="Horizontal" ownerReference={this} />
 			</div>
 		</>
 

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -24,6 +24,12 @@
 	#listWithWrapping ui5-li:nth-child(2)::part(description) {
 		color: rgb(79, 128, 6);
 	}
+
+	#testGroupParts::part(title) {
+		color: blue;
+		width: 100%;
+		background-color: rgb(221, 255, 253);
+	}
 </style>
 </head>
 
@@ -226,6 +232,17 @@
 					<img src="./img/HT-2002.jpg" alt="Woman image">
 				</ui5-avatar>
 			</ui5-li>
+		</ui5-li-group>
+	</ui5-list>
+
+	<br/><br/>
+
+	<h3>ListItemGroup ::part(title) - CSS Shadow Parts</h3>
+	<ui5-list>
+		<ui5-li-group id="testGroupParts" header-text="Test Header - Should be styled via ::part(title)">
+			<ui5-li>Item 1</ui5-li>
+			<ui5-li>Item 2</ui5-li>
+			<ui5-li>Item 3</ui5-li>
 		</ui5-li-group>
 	</ui5-list>
 
@@ -447,9 +464,9 @@
 	</ui5-list>
 
 	<h3>Growing Button with Custom ARIA Name and Description</h3>
-	<ui5-list 
-		id="growingButtonAccessibility" 
-		growing="Button" 
+	<ui5-list
+		id="growingButtonAccessibility"
+		growing="Button"
 		growing-button-text="Load More Items"
 		header-text="Accessibility Demo">
 		<ui5-li>Product A</ui5-li>
@@ -714,7 +731,7 @@
 				<ui5-avatar initials="JD" color-scheme="Accent1"></ui5-avatar>
 				<div class="product-details">
 					<ui5-title size="H5">Product with Long Description</ui5-title>
-					<ui5-expandable-text 
+					<ui5-expandable-text
 						max-characters="200"
 						text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.">
 					</ui5-expandable-text>

--- a/packages/website/docs/_components_pages/main/List/List.mdx
+++ b/packages/website/docs/_components_pages/main/List/List.mdx
@@ -8,6 +8,7 @@ import GrowingOnButtonPress from "../../../_samples/main/List/GrowingOnButtonPre
 import Modes from "../../../_samples/main/List/Modes/Modes.md";
 import NoData from "../../../_samples/main/List/NoData/NoData.md";
 import GroupHeaders from "../../../_samples/main/List/GroupHeaders/GroupHeaders.md";
+import GroupHeaderStyling from "../../../_samples/main/List/GroupHeaderStyling/GroupHeaderStyling.md";
 import SeparationTypes from "../../../_samples/main/List/SeparationTypes/SeparationTypes.md";
 import DragAndDrop from "../../../_samples/main/List/DragAndDrop/DragAndDrop.md";
 import MultipleDrag from "../../../_samples/main/List/MultipleDrag/MultipleDrag.md";
@@ -48,6 +49,11 @@ You can show a text when there aren't items (data) via the <b>noDataText</b> pro
 The <b>The ListItemGroup</b> can be used to start group section and implement grouping.
 
 <GroupHeaders />
+
+### Styling Group Headers
+You can customize the appearance of group headers using CSS Shadow Parts. The <b>title</b> part allows styling the group header text, while the <b>header</b> part styles the entire header container.
+
+<GroupHeaderStyling />
 
 ### Separators
 The <b>separators</b> options (<b>All</b>, <b>Inner</b>, <b>None</b>) allows the outer lines (Inner) or all the lines (None) to be hidden.

--- a/packages/website/docs/_samples/main/List/GroupHeaderStyling/GroupHeaderStyling.md
+++ b/packages/website/docs/_samples/main/List/GroupHeaderStyling/GroupHeaderStyling.md
@@ -1,0 +1,5 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+import css from '!!raw-loader!./main.css';
+
+<Editor html={html} js={js} css={css} />

--- a/packages/website/docs/_samples/main/List/GroupHeaderStyling/main.css
+++ b/packages/website/docs/_samples/main/List/GroupHeaderStyling/main.css
@@ -1,0 +1,12 @@
+/* Style the group header title using CSS Shadow Parts */
+#styled-group::part(title) {
+	color: var(--sapButton_Emphasized_TextColor);
+	background-color: var(--sapButton_Emphasized_Background);
+	padding: 0.5rem;
+	border-radius: 0.25rem;
+}
+
+/* Style the entire header container */
+#styled-group::part(header) {
+	background-color: var(--sapList_HeaderBackground);
+}

--- a/packages/website/docs/_samples/main/List/GroupHeaderStyling/main.js
+++ b/packages/website/docs/_samples/main/List/GroupHeaderStyling/main.js
@@ -1,0 +1,5 @@
+import "@ui5/webcomponents/dist/List.js";
+import "@ui5/webcomponents/dist/ListItemGroup.js";
+import "@ui5/webcomponents/dist/ListItemStandard.js";
+import "@ui5/webcomponents/dist/Avatar.js";
+import "@ui5/webcomponents-icons/dist/navigation-right-arrow.js";

--- a/packages/website/docs/_samples/main/List/GroupHeaderStyling/sample.html
+++ b/packages/website/docs/_samples/main/List/GroupHeaderStyling/sample.html
@@ -1,0 +1,53 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Sample</title>
+	<link rel="stylesheet" href="./main.css">
+</head>
+
+<body style="background-color: var(--sapBackgroundColor)">
+	<!-- playground-fold-end -->
+
+	<ui5-list selection-mode="Multiple">
+		<ui5-li-group id="styled-group" header-text="Styled Header">
+			<ui5-li icon-end icon="navigation-right-arrow">Item 1
+				<ui5-avatar slot="image" shape="Square">
+					<img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+				</ui5-avatar>
+			</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow">Item 2
+				<ui5-avatar slot="image" shape="Square">
+					<img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
+				</ui5-avatar>
+			</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow">Item 3
+				<ui5-avatar slot="image" shape="Square">
+					<img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
+				</ui5-avatar>
+			</ui5-li>
+		</ui5-li-group>
+
+		<ui5-li-group header-text="Normal Header">
+			<ui5-li icon-end icon="navigation-right-arrow">Item A
+				<ui5-avatar slot="image" shape="Square">
+					<img src="../assets/images/avatars/man_avatar_1.png" alt="Man image">
+				</ui5-avatar>
+			</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow">Item B
+				<ui5-avatar slot="image" shape="Square">
+					<img src="../assets/images/avatars/man_avatar_2.png" alt="Man image">
+				</ui5-avatar>
+			</ui5-li>
+		</ui5-li-group>
+	</ui5-list>
+
+	<!-- playground-fold -->
+	<script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->


### PR DESCRIPTION
The title CSS part was previously hidden inside the nested shadow DOM of ListItemGroupHeader, making it impossible to style from outside using `::part(title)`.

Added `exportparts="title"` to forward the inner title part, allowing developers to customize the group header title appearance with `ui5-li-group::part(title)`. This enables use cases like setting full width for right-aligned header content.

Updated API documentation and added a sample demonstrating CSS Shadow Parts usage for styling group headers.

Fixes #13054 
