### PR TITLE
fix(framework): apply correct system css variables

### DIFF
--- a/packages/base/src/SystemCSSVars.ts
+++ b/packages/base/src/SystemCSSVars.ts
@@ -1,10 +1,8 @@
-import { hasStyle, createStyle } from "./ManagedStyles.js";
+import { createOrUpdateStyle } from "./ManagedStyles.js";
 import systemCSSVars from "./generated/css/SystemCSSVars.css.js";
 
 const insertSystemCSSVars = () => {
-	if (!hasStyle("data-ui5-system-css-vars")) {
-		createStyle(systemCSSVars, "data-ui5-system-css-vars");
-	}
+	createOrUpdateStyle(systemCSSVars, "data-ui5-system-css-vars");
 };
 
 export default insertSystemCSSVars;


### PR DESCRIPTION
`SystemCSSVars.css` is loaded and applied only once by the first runtime that attempts to load it. As a result, any system CSS variables introduced in newer versions may be missing.

This works correctly in a single-runtime scenario. However, in an MFE setup where the first loaded runtime uses a version older than 2.19.0, the newer system CSS variables are not applied, causing issues.

This PR ensures that system CSS variables are updated when a newer version is loaded, preventing inconsistencies across runtimes.

<img width="356" height="262" alt="image" src="https://github.com/user-attachments/assets/4bf3038c-b58e-415d-9940-fc863663c656" />
<img width="262" height="282" alt="image" src="https://github.com/user-attachments/assets/6287beb4-7895-411d-a67e-7a30c654c78e" />

