### PR TITLE
fix(ui5-view-settings-dialog): ensure proper focus management in filter view

### DIFF
--- a/packages/fiori/cypress/specs/ViewSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/ViewSettingsDialog.cy.tsx
@@ -402,6 +402,46 @@ describe("ViewSettingsDialog Tests", () => {
 			.invoke("prop", "open", false);
 	});
 
+	it("should keep focus in filter options and tab to OK", () => {
+		cy.mount(
+			<ViewSettingsDialog id="vsd">
+				<FilterItem slot="filterItems" text="Filter 1">
+					<FilterItemOption slot="values" text="Some filter 1"></FilterItemOption>
+					<FilterItemOption slot="values" text="Some filter 2"></FilterItemOption>
+				</FilterItem>
+				<FilterItem slot="filterItems" text="Filter 2">
+					<FilterItemOption slot="values" text="Some filter 3"></FilterItemOption>
+					<FilterItemOption slot="values" text="Some filter 4"></FilterItemOption>
+				</FilterItem>
+			</ViewSettingsDialog>
+		);
+
+		cy.get("[ui5-view-settings-dialog]")
+			.as("vsd")
+			.invoke("prop", "open", true);
+
+		cy.get("@vsd")
+			.shadow()
+			.find("[ui5-li]")
+			.eq(0)
+			.shadow()
+			.find("span[part=title]")
+			.realClick();
+
+		cy.get("@vsd")
+			.shadow()
+			.find("[filter-options] [ui5-li]")
+			.first()
+			.should("be.focused");
+
+		cy.realPress("Tab");
+
+		cy.get("@vsd")
+			.shadow()
+			.find("[ui5-button][design=Emphasized]")
+			.should("be.focused");
+	});
+
 	it("should handle sort-only mode", () => {
 		cy.mount(
 			<ViewSettingsDialog id="vsdSort">

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -9,6 +9,7 @@ import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import type { Slot, ChangeInfo } from "@ui5/webcomponents-base/dist/UI5Element.js";
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import type Dialog from "@ui5/webcomponents/dist/Dialog.js";
 import type List from "@ui5/webcomponents/dist/List.js";
 import type { ListItemClickEventDetail, ListSelectionChangeEventDetail } from "@ui5/webcomponents/dist/List.js";
@@ -308,6 +309,12 @@ class ViewSettingsDialog extends UI5Element {
 
 	@query("[ui5-list][group-by]")
 	_groupBy?: List;
+
+	@query("[ui5-list][filter-list]")
+	_filterList?: List;
+
+	@query("[ui5-list][filter-options]")
+	_filterOptions?: List;
 
 	@i18n("@ui5/webcomponents-fiori")
 	static i18nBundle: I18nBundle;
@@ -651,16 +658,29 @@ class ViewSettingsDialog extends UI5Element {
 		});
 	}
 
-	_navigateToFilters() {
+	async _navigateToFilters() {
 		this._filterStepTwo = false;
+		await renderFinished();
+		if (this._filterList) {
+			this._filterList.focusFirstItem();
+		}
 	}
 
-	_changeCurrentFilter(e: CustomEvent<ListItemClickEventDetail>) {
+	async _changeCurrentFilter(e: CustomEvent<ListItemClickEventDetail>) {
 		this._filterStepTwo = true;
 		this._currentSettings.filters = this._currentSettings.filters.map(filter => {
 			filter.selected = filter.text === e.detail.item.innerText;
 			return filter;
 		});
+		await renderFinished();
+		if (this._filterOptions) {
+			const selectedItems = this._filterOptions.getSelectedItems();
+			if (selectedItems.length) {
+				selectedItems[0].focus();
+			} else {
+				this._filterOptions.focusFirstItem();
+			}
+		}
 	}
 
 	/**

--- a/packages/fiori/src/ViewSettingsDialogTemplate.tsx
+++ b/packages/fiori/src/ViewSettingsDialogTemplate.tsx
@@ -164,6 +164,7 @@ function ViewSettingsDialogFilterTemplate(this: ViewSettingsDialog) {
 				<List
 					selectionMode="Multiple"
 					onSelectionChange={this._handleFilterValueItemClick} // checkboxes to select/deselect - use selectionChange
+					filter-options=""
 					accessibleNameRef={`${this._id}-label`}
 				>
 					{this._currentSettings.filters.filter(item => item.selected).map(item => (<>
@@ -177,6 +178,7 @@ function ViewSettingsDialogFilterTemplate(this: ViewSettingsDialog) {
 			) : ( // else
 				<List
 					onItemClick={this._changeCurrentFilter} // list item to drill down into the second-level menu - use click
+					filter-list=""
 					accessibleNameRef={`${this._id}-label`}
 				>
 					<ListItemGroup headerText={this._filterByLabel}>


### PR DESCRIPTION
## Overview

Two issues were identified in the ViewSettingsDialog component when testing our ACC Samples in the Accessibility Hub:

1. **Focus is lost when entering the filter options view** - When clicking on a filter item to see its options (second-level navigation), focus was not properly managed, leaving users of assistive technologies without a clear focus point.

2. **Tab order goes to Cancel first in some situations** - After entering filter options, pressing Tab would sometimes move focus to the Cancel button before the OK button, which is inconsistent with expected dialog behavior.

## What We Did

- Added `@query` decorators to reference the filter list
- after rendering completes, focus is set on the first selected item (if any) or the first item in the filter options list
- when navigating back to the filter list, focus is set on the first item

## What This Fixes

- **Focus management** — Focus is now properly set when entering filter options (second-level view)
- **Tab order** — Tab correctly moves from filter options to the OK button (Emphasized) first, then to Cancel
- **Keyboard navigation** — Users can navigate the filter workflow entirely with keyboard
- **Screen reader experience** — Assistive technology users receive proper focus context when navigating between filter views


## Before

![2026-02-16_14-25-22 (1)](https://github.com/user-attachments/assets/6e084342-ce19-4099-876b-e7d441282615)


## After

![2026-02-16_13-51-28 (1)](https://github.com/user-attachments/assets/0394dcb1-0e1c-4152-a138-a0c730c0ad70)
