### PR TITLE
fix(ui5-calendar): correct focus indicator color in calendar header and day picker

### DIFF
--- a/packages/main/src/themes/sap_horizon/CalendarHeader-parameters.css
+++ b/packages/main/src/themes/sap_horizon/CalendarHeader-parameters.css
@@ -5,14 +5,14 @@
 	--_ui5_calendar_header_middle_button_focus_after_height: calc(100% - 0.375rem);
 	--_ui5_calendar_header_middle_button_focus_after_top_offset: 0.125rem;
 	--_ui5_calendar_header_middle_button_focus_after_left_offset: 0.125rem;
-	--_ui5_calendar_header_arrow_button_border: none;
+	--_ui5_calendar_header_arrow_button_border: 0.0625rem solid var(--sapList_Hover_Background);
 	--_ui5_calendar_header_arrow_button_border_radius: 0.5rem;
 	--_ui5_calendar_header_arrow_button_box_shadow: 0 0 0.125rem 0 rgb(85 107 130 / 72%);
 	--_ui5_calendar_header_middle_button_focus_border_radius: 0.5rem;
 	--_ui5_calendar_header_middle_button_focus_border: none;
 	--_ui5_calendar_header_middle_button_focus_after_border: none;
 	--_ui5_calendar_header_middle_button_focus_background: transparent;
-	--_ui5_calendar_header_middle_button_focus_outline: 0.125rem solid var(--sapSelectedColor);
-	--_ui5_calendar_header_middle_button_focus_active_outline: 0.0625rem solid var(--sapSelectedColor);
+	--_ui5_calendar_header_middle_button_focus_outline: 0.125rem solid var(--sapContent_FocusColor);
+	--_ui5_calendar_header_middle_button_focus_active_outline: 0.0625rem solid var(--sapContent_FocusColor);
 	--_ui5_calendar_header_middle_button_focus_active_background: transparent;
 }

--- a/packages/main/src/themes/sap_horizon/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_horizon/DayPicker-parameters.css
@@ -7,7 +7,7 @@
 	--_ui5_daypicker_item_selected_focus_color: var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_selected_focus_width: 0.125rem;
 	--_ui5_daypicker_item_no_selected_inset: 0.375rem;
-	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapList_SelectionBorderColor);
+	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_now_border_radius_focus_after: 0.3125rem;
 	--_ui5_day_picker_item_selected_now_border_focus: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_day_picker_item_selected_now_border_radius_focus: 0.1875rem;
@@ -21,7 +21,7 @@
 	--_ui5_daypicker_item_selected_between_text_font: var(--sapFontFamily);
 	--_ui5_daypicker_item_selected_text_font: var(--sapFontBoldFamily);
 	--_ui5_daypicker_item_now_box_shadow: inset 0 0 0 0.35rem var(--sapList_Background);
-	--_ui5_daypicker_item_selected_text_outline: 0.0625rem solid var(--sapSelectedColor);
+	--_ui5_daypicker_item_selected_text_outline: 0.0625rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_now_selected_outline_offset: -0.25rem;
 	--_ui5_daypicker_item_now_selected_between_inset: 0.25rem;
 	--_ui5_daypicker_item_now_selected_between_border: 0.0625rem solid var(--sapContent_Selected_ForegroundColor);
@@ -31,7 +31,7 @@
 	--_ui5_daypicker_item_selected_hover: var(--sapList_Hover_Background);
 	--_ui5_daypicker_item_now_inset: 0.3125rem;
 	--_ui5-dp-item_withsecondtype_border: 0.25rem;
-	--_ui5_daypicker_item_selected__secondary_type_text_outline: 0.0625rem solid var(--sapSelectedColor);
+	--_ui5_daypicker_item_selected__secondary_type_text_outline: 0.0625rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_two_calendar_item_now_day_text_content: "";
 	--_ui5_daypicker_two_calendar_item_now_selected_border_width: 0.125rem;
 	--_ui5_daypicker_two_calendar_item_border_radius: 0.5rem;

--- a/packages/main/src/themes/sap_horizon_dark/CalendarHeader-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/CalendarHeader-parameters.css
@@ -12,7 +12,7 @@
 	--_ui5_calendar_header_middle_button_focus_border: none;
 	--_ui5_calendar_header_middle_button_focus_after_border: none;
 	--_ui5_calendar_header_middle_button_focus_background: transparent;
-	--_ui5_calendar_header_middle_button_focus_outline: 0.125rem solid var(--sapSelectedColor);
-	--_ui5_calendar_header_middle_button_focus_active_outline: 0.0625rem solid var(--sapSelectedColor);
+	--_ui5_calendar_header_middle_button_focus_outline: 0.125rem solid var(--sapContent_FocusColor);
+	--_ui5_calendar_header_middle_button_focus_active_outline: 0.0625rem solid var(--sapContent_FocusColor);
 	--_ui5_calendar_header_middle_button_focus_active_background: transparent;
 }


### PR DESCRIPTION
## Overview

During accessibility testing (ACC-271), focus indicator issues were identified in the Calendar/DatePicker component:

1. **Header buttons focus color incorrect** — The month/year buttons in the calendar header were using `--sapSelectedColor` (selection blue) for focus indicator instead of `--sapContent_FocusColor` (focus blue), making it appear as if the element was selected rather than focused.

## What We Did

- Changed focus outline color from `--sapSelectedColor` to `--sapContent_FocusColor`
- Updated DayPicker focus-related variables to use the correct ones as well

## What This Fixes

- ✅ **WCAG 2.2 2.4.7 (Focus Visible)** — Focus indicator now uses correct focus color, clearly distinguishing focus from selection
- ✅ **Header buttons** — Month/year buttons show proper focus blue outline instead of selection blue
- ✅ **Selected date focus** — Focus on selected dates in day picker now uses correct focus color

## Before

<img width="482" height="591" alt="image" src="https://github.com/user-attachments/assets/5d98e77e-8fde-4396-9d60-e63850abe91c" />


## After

<img width="402" height="493" alt="image" src="https://github.com/user-attachments/assets/40a2486d-1e79-4f46-875a-bb0e28fa1dea" />
