### PR TITLE
fix(ui5-color-palette): add outline to selected items on mobile

### DIFF
--- a/packages/main/src/themes/ColorPaletteItem.css
+++ b/packages/main/src/themes/ColorPaletteItem.css
@@ -123,6 +123,20 @@
 	pointer-events: none;
 }
 
+/* White outline for selected state on mobile */
+:host([selected]:not([_disabled])[on-phone]) .ui5-cp-item::after {
+	content: "";
+	box-sizing: border-box;
+	position: absolute;
+	top: calc(-1 * var(--_ui5_color_palette_item_height) + 0.375rem);
+	left: 0;
+	right: 0;
+	bottom: calc(-100%);
+	border: var(--_ui5_color-palette-item-after-not-focus-color);
+	border-radius: 0.1875rem;
+	pointer-events: none;
+}
+
 :host(:not([_disabled]):not([on-phone]):not([selected]):not(:hover)) .ui5-cp-item:focus:not(:hover)::after {
 	border: var(--_ui5_color-palette-item-after-focus-not-selected-border);
 }


### PR DESCRIPTION
## Overview

Selected items in ColorPalette were missing a visible outline indicator on mobile devices, making it difficult to identify which color is currently selected.

## What We Did

- Added white outline border to selected ColorPaletteItem on mobile (phone) devices

## What This Fixes

- ✅ Selected color is now clearly visible on mobile
- ✅ No functional changes

## Before

<img width="429" height="381" alt="image" src="https://github.com/user-attachments/assets/2a4a21d1-59ed-4b79-8a84-dbd7f491426a" />

## After

<img width="433" height="356" alt="image" src="https://github.com/user-attachments/assets/eca6d8ed-535b-4935-a7c5-6a2644d2f26c" />

