### PR TITLE
fix(ui5-color-palette): correct tooltip for recent colors

### DIFF
--- a/packages/main/src/ColorPaletteTemplate.tsx
+++ b/packages/main/src/ColorPaletteTemplate.tsx
@@ -59,8 +59,8 @@ export default function ColorPaletteTemplate(this: ColorPalette) {
 					<div class="ui5-cp-recent-colors-wrapper">
 						<div class="ui5-cp-separator"></div>
 						<div class="ui5-cp-recent-colors-container" onKeyDown={this._onRecentColorsContainerKeyDown}>
-							{this.recentColors.map(color =>
-								<ColorPaletteItem value={color}/>
+							{this.recentColors.map((color, index) =>
+								<ColorPaletteItem value={color} index={index + 1}/>
 							)}
 						</div>
 					</div>


### PR DESCRIPTION
## Overview

During accessibility testing (ACC-255), the recent colors in ColorPalette showed "undefined" in the tooltip instead of the correct index number.

## What We Did

- Added missing `index` property to recent color items in the template

## What This Fixes

- ✅ Recent color tooltips now show correct index (e.g., "Color 1", "Color 2")
- ✅ No functional changes

## Before

<img width="827" height="535" alt="image" src="https://github.com/user-attachments/assets/32a650a1-7320-437e-9a50-2fcf34caba0f" />


## After

<img width="880" height="637" alt="image" src="https://github.com/user-attachments/assets/04f0ed3e-f683-418c-aa84-e35e53fc8e7c" />
