### PR TITLE
fix(ui5-time-picker): apply AM/PM selection on Enter key

### DIFF
--- a/packages/main/src/TimeSelectionClocks.ts
+++ b/packages/main/src/TimeSelectionClocks.ts
@@ -176,7 +176,7 @@ class TimeSelectionClocks extends TimePickerInternals {
 			// If Enter is pressed on AM/PM segmented button, apply the period change first
 			if (this._amPmFocused) {
 				const buttonAmPm = this._buttonAmPm();
-				const selectedItem = buttonAmPm?.items.find(item => item.selected);
+				const selectedItem = buttonAmPm?.selectedItems[0];
 				if (selectedItem?.textContent) {
 					this._calculatePeriodChange(selectedItem.textContent);
 				}


### PR DESCRIPTION
## Overview

When selecting AM/PM from the SegmentedButton using the Enter key, the picker closed but the value was not updated.

## What We Did

- Added period change handling before closing the picker when Enter is pressed on the AM/PM SegmentedButton

## What This Fixes

- ✅ Pressing Enter on AM/PM SegmentedButton now correctly updates the time value
- ✅ No functional changes to other keyboard interactions
