### PR TITLE
fix(framework): correct runtime compare

### DIFF
--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -10,7 +10,7 @@ const shouldUpdate = (runtimeIndex: string | undefined) => {
 	if (runtimeIndex === undefined) {
 		return true;
 	}
-	return compareRuntimes(getCurrentRuntimeIndex(), parseInt(runtimeIndex)) === 1; // 1 means the current is newer, 0 means the same, -1 means the resource's runtime is newer
+	return compareRuntimes(getCurrentRuntimeIndex(), parseInt(runtimeIndex)) >= 1; // 1 or larger means the current is newer, 0 means the same, -1 means the resource's runtime is newer
 };
 
 const createStyle = (content: string, name: string, value = "", theme?: string) => {


### PR DESCRIPTION
`compareRuntimes` returns:

* Difference in build timestamps if a next (experimental) version exists
* Difference in major versions
* Difference in minor versions
* Difference in patch versions

Previously, the check worked fine when comparing runtimes that were close to each other (e.g., 2.16.0 vs 2.17.0). However, comparing versions that were further apart (e.g., 2.16.0 vs 2.19.0) would incorrectly return `3`, which caused updates to CSS variables from `@sap-theming/theming-base-content` to be skipped.

With this PR, the check is fixed and now properly updates the CSS variables for all version differences.