### PR TITLE
fix(ui5-side-navigation): fix footer separator margins

### DIFF
--- a/packages/fiori/src/themes/SideNavigationGroup.css
+++ b/packages/fiori/src/themes/SideNavigationGroup.css
@@ -31,7 +31,3 @@
 	background-color: var(--_ui5_side_navigation_navigation_separator_background_color);
 	border-radius: var(--_ui5_side_navigation_navigation_separator_radius);
 }
-
-.ui5-sn-collapsed .ui5-sn-spacer {
-	margin: var(--_ui5_side_navigation_navigation_separator_margin_collapsed);
-}

--- a/packages/fiori/src/themes/base/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/base/SideNavigation-parameters.css
@@ -4,8 +4,7 @@
 	--_ui5_side_navigation_width: 15rem;
 	--_ui5_side_navigation_collapsed_width: 3rem;
 
-	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.875rem 0.25rem 0.875rem;
-	--_ui5_side_navigation_navigation_separator_margin_collapsed: 0.25rem 0.5rem 0.25rem 0.5rem;
+	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.5rem 0.25rem 0.5rem;
 	--_ui5_side_navigation_navigation_separator_background_color: var(--sapList_GroupHeaderBorderColor);
 	--_ui5_side_navigation_navigation_separator_radius: unset;
 	--_ui5_side_navigation_navigation_separator_height: calc(2 * var(--sapList_BorderWidth));
@@ -69,7 +68,6 @@
 
 @container style(--ui5_content_density: compact) {
 	:host {
-		--_ui5_side_navigation_navigation_separator_margin: var(--_ui5_side_navigation_navigation_separator_margin_collapsed);
 		--_ui5_side_navigation_item_height: 2rem;
 		--_ui5_side_navigation_item_expand_arrow_padding: 0.3125rem;
 		--_ui5_side_navigation_item_margin: 0.5rem;

--- a/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/SideNavigation-parameters.css
@@ -4,8 +4,6 @@
 	--_ui5_side_navigation_width: 16rem;
 	--_ui5_side_navigation_collapsed_width: 4rem;
 
-	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.5rem 0.25rem 0.5rem;
-	--_ui5_side_navigation_navigation_separator_margin_collapsed: var(--_ui5_side_navigation_navigation_separator_margin);
 	--_ui5_side_navigation_navigation_separator_background_color: var(--sapToolbar_SeparatorColor);
 	--_ui5_side_navigation_navigation_separator_radius: 0.125rem;
 	--_ui5_side_navigation_navigation_separator_height: 0.0625rem;

--- a/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/SideNavigation-parameters.css
@@ -4,8 +4,6 @@
 	--_ui5_side_navigation_width: 16rem;
 	--_ui5_side_navigation_collapsed_width: 4rem;
 
-	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.5rem 0.25rem 0.5rem;
-	--_ui5_side_navigation_navigation_separator_margin_collapsed: var(--_ui5_side_navigation_navigation_separator_margin);
 	--_ui5_side_navigation_navigation_separator_background_color: var(--sapToolbar_SeparatorColor);
 	--_ui5_side_navigation_navigation_separator_radius: 0.125rem;
 	--_ui5_side_navigation_navigation_separator_height: 0.0625rem;

--- a/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/SideNavigation-parameters.css
@@ -4,8 +4,6 @@
 	--_ui5_side_navigation_width: 16rem;
 	--_ui5_side_navigation_collapsed_width: 4rem;
 
-	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.5rem 0.25rem 0.5rem;
-	--_ui5_side_navigation_navigation_separator_margin_collapsed: var(--_ui5_side_navigation_navigation_separator_margin);
 	--_ui5_side_navigation_navigation_separator_height: 0.0625rem;
 	--_ui5_side_navigation_border_right: 0;
 	--_ui5_side_navigation_box_shadow: var(--sapContent_Shadow0);

--- a/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/SideNavigation-parameters.css
@@ -4,8 +4,6 @@
 	--_ui5_side_navigation_width: 16rem;
 	--_ui5_side_navigation_collapsed_width: 4rem;
 
-	--_ui5_side_navigation_navigation_separator_margin: 0.25rem 0.5rem 0.25rem 0.5rem;
-	--_ui5_side_navigation_navigation_separator_margin_collapsed: var(--_ui5_side_navigation_navigation_separator_margin);
 	--_ui5_side_navigation_navigation_separator_height: 0.0625rem;
 	--_ui5_side_navigation_border_right: 0;
 	--_ui5_side_navigation_box_shadow: var(--sapContent_Shadow0);


### PR DESCRIPTION
The margins of the footer separator were not correctly applied in some cases:
- Side Navigation samples page in the Playground
- Fiori 3 theme + Compact density in the Test pages 
To fix those, the parameters were simplified.

JIRA: 3598 / P1-34776