### PR TITLE
fix(ui5-form-item): fix label-content alignment

### DIFF
--- a/packages/main/src/themes/FormItem.css
+++ b/packages/main/src/themes/FormItem.css
@@ -35,7 +35,7 @@
 .ui5-form-item-layout {
 	display: grid;
 	grid-template-columns: var(--ui5-form-item-layout, 4fr 8fr 0fr);
-	align-items: baseline;
+	align-items: center;
 }
 
 .ui5-form-item-label {

--- a/packages/main/src/themes/FormItemSpan.css
+++ b/packages/main/src/themes/FormItemSpan.css
@@ -8,7 +8,7 @@
 
 :host {
 	--ui5-form-item-label-justify-internal: start;
-	--ui5-form-item-label-padding: 0.625rem 0.25rem 0 0.25rem;
+	--ui5-form-item-label-padding-internal: 0.625rem 0.25rem 0 0.25rem;
 }
 
 @container (max-width: 600px) {


### PR DESCRIPTION
 ## Summary
  Fix vertical alignment issue between form item labels and content introduced in
  v2.19.0

  ## Root Cause
  In #13009, the CSS variable `--ui5-form-item-label-padding` was set
  unconditionally on `:host` with asymmetric padding (`0.625rem 0.25rem 0 0.25rem`).
  This padding was intended only for `label-span="12"` (stacked layout) but was
  being applied to all form items.

  ## Fix
  Rename the variable to `--ui5-form-item-label-padding-internal` so it's only used
  when the span12 selectors explicitly set `--ui5-form-item-label-padding:
  var(--ui5-form-item-label-padding-internal)`. This restores the symmetric default
  padding (`0.125rem 0`) from FormItem.css fallback.

  Fixes #13118