### PR TITLE
fix(ui5-progress-indicator): apply rounded corners for Horizon themes

### DIFF
--- a/packages/main/src/themes/ProgressIndicator.css
+++ b/packages/main/src/themes/ProgressIndicator.css
@@ -44,6 +44,7 @@
 	box-sizing: border-box;
 	border: var(--_ui5_progress_indicator_bar_border_max);
 	border-radius: var(--_ui5_progress_indicator_bar_border_radius);
+	z-index: 1;
 }
 
 .ui5-progress-indicator-min-value .ui5-progress-indicator-bar,

--- a/packages/main/src/themes/sap_horizon/rtl-parameters.css
+++ b/packages/main/src/themes/sap_horizon/rtl-parameters.css
@@ -1,5 +1,9 @@
 @import "../base/rtl-parameters.css";
 
+:host {
+	--_ui5_progress_indicator_bar_border_radius: 0.5rem;
+}
+
 :dir(rtl) {
 	--_ui5_segmented_btn_item_border_left: 0.0625rem;
 	--_ui5_segmented_btn_item_border_right: 0.0625rem;

--- a/packages/main/src/themes/sap_horizon_dark/rtl-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/rtl-parameters.css
@@ -1,6 +1,12 @@
 @import "../base/rtl-parameters.css";
 
+:host {
+	--_ui5_progress_indicator_bar_border_radius: 0.5rem;
+}
+
 :dir(rtl) {
 	--_ui5_segmented_btn_item_border_left: 0.0625rem;
 	--_ui5_segmented_btn_item_border_right: 0.0625rem;
+	--_ui5_progress_indicator_bar_border_radius: 0.5rem;
+	--_ui5_progress_indicator_remaining_bar_border_radius: 0.25rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_hcb/parameters-bundle.css
@@ -55,4 +55,4 @@
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
 @import "./sizes-parameters.css";
-@import "../base/rtl-parameters.css";
+@import "./rtl-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcb/rtl-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/rtl-parameters.css
@@ -1,0 +1,1 @@
+@import "../sap_horizon/rtl-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
+++ b/packages/main/src/themes/sap_horizon_hcw/parameters-bundle.css
@@ -55,4 +55,4 @@
 @import "./SliderBase-parameters.css";
 @import "../base/StepInput-parameters.css";
 @import "./sizes-parameters.css";
-@import "../base/rtl-parameters.css";
+@import "./rtl-parameters.css";

--- a/packages/main/src/themes/sap_horizon_hcw/rtl-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/rtl-parameters.css
@@ -1,0 +1,1 @@
+@import "../sap_horizon/rtl-parameters.css";


### PR DESCRIPTION
Apply rounded corners (border-radius: 0.5rem) to the progress bar across all Horizon theme variants (horizon, horizon_dark, horizon_hcb, horizon_hcw) to align with design specifications.

Fiori themes retain partial rounding to prevent visual gaps between the progress bar and remaining bar.

Additionally, a z-index was added to the progress bar element to ensure correct layering in high contrast themes, where the remaining bar was rendering above the fill and causing visual distortion.

Fixes: https://github.com/UI5/webcomponents/issues/13112