### PR TITLE
fix(ui5-shellbar): resolve visual issues after refactor

### DIFF
--- a/packages/fiori/src/shellbar/templates/ShellBarLegacyTemplate.tsx
+++ b/packages/fiori/src/shellbar/templates/ShellBarLegacyTemplate.tsx
@@ -149,7 +149,7 @@ function ShellBarLegacySecondaryTitle(this: ShellBar) {
 	}
 
 	return (
-		<div style={{ display: "block" }} class="ui5-shellbar-secondary-title ui5-shellbar-gap-start ui5-shellbar-gap-end" data-ui5-stable="secondary-title">
+		<div class="ui5-shellbar-secondary-title ui5-shellbar-gap-start ui5-shellbar-gap-end" data-ui5-stable="secondary-title">
 			{this.secondaryTitle}
 		</div>
 	);

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -36,6 +36,7 @@
 	align-items: center;
 	height: var(--_ui5_shellbar_root_height);
 	position: relative;
+	font-family: var(--sapFontFamily);
 	font-size: var(--sapFontSize);
 	font-weight: normal;
 }
@@ -135,7 +136,7 @@
 	display: flex;
 	align-items: center;
 	min-width: 0;
-	overflow: hidden;
+	overflow: visible;
 	position: relative;
 }
 

--- a/packages/fiori/src/themes/ShellBarLegacy.css
+++ b/packages/fiori/src/themes/ShellBarLegacy.css
@@ -4,6 +4,8 @@
 .ui5-shellbar-logo {
 	overflow: hidden;
 	cursor: pointer;
+	display: flex;
+	align-items: center;
 }
 
 .ui5-shellbar-logo-area,
@@ -71,7 +73,8 @@
 }
 
 .ui5-shellbar-secondary-title {
-	display: inline-block;
+	display: flex;
+	align-items: center;
 	font-size: var(--sapFontSmallSize);
 	color: var(--sapShell_TextColor);
 	font-weight: normal;


### PR DESCRIPTION
Closes #13141

- Fix notifications being cut off by changing overflow to visible
- Fix logo vertical alignment by adding display:flex and align-items
- Fix secondary title styling by removing inline style override and adding font-family to shellbar root
