### PR TITLE
fix(ui5-rating-indicator): update custom icon properties names and default values

### DIFF
--- a/packages/main/cypress/specs/RatingIndicator.cy.tsx
+++ b/packages/main/cypress/specs/RatingIndicator.cy.tsx
@@ -23,8 +23,8 @@ describe("RatingIndicator", () => {
 				.should("have.attr", "name", "unfavorite");
 		});
 
-		it("should render custom icons for selected and unselected states", () => {
-			cy.mount(<RatingIndicator value={3} iconSelected="heart" iconUnselected="heart-2"></RatingIndicator>);
+		it("should render custom icons for rated and unrated states", () => {
+			cy.mount(<RatingIndicator value={3} ratedIcon="heart" unratedIcon="heart-2"></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()
@@ -39,8 +39,8 @@ describe("RatingIndicator", () => {
 				.should("have.attr", "name", "heart-2");
 		});
 
-		it("should render custom icon with default unselected icon when only iconSelected is specified", () => {
-			cy.mount(<RatingIndicator value={2} iconSelected="thumb-up"></RatingIndicator>);
+		it("should render custom icon with default unrated icon when only ratedIcon is specified", () => {
+			cy.mount(<RatingIndicator value={2} ratedIcon="thumb-up"></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()
@@ -55,8 +55,8 @@ describe("RatingIndicator", () => {
 				.should("have.attr", "name", "unfavorite");
 		});
 
-		it("should render custom unselected icon with default selected icon when only iconUnselected is specified", () => {
-			cy.mount(<RatingIndicator value={2} iconUnselected="thumb-down"></RatingIndicator>);
+		it("should render custom unrated icon with default rated icon when only unratedIcon is specified", () => {
+			cy.mount(<RatingIndicator value={2} unratedIcon="thumb-down"></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()
@@ -72,7 +72,7 @@ describe("RatingIndicator", () => {
 		});
 
 		it("should render custom icons in half-star state", () => {
-			cy.mount(<RatingIndicator value={2.5} iconSelected="heart" iconUnselected="heart-2"></RatingIndicator>);
+			cy.mount(<RatingIndicator value={2.5} ratedIcon="heart" unratedIcon="heart-2"></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()
@@ -86,7 +86,7 @@ describe("RatingIndicator", () => {
 		});
 
 		it("should render custom icon (filled) in half-star state when readonly", () => {
-			cy.mount(<RatingIndicator value={2.5} iconSelected="heart" iconUnselected="heart-2" readonly></RatingIndicator>);
+			cy.mount(<RatingIndicator value={2.5} ratedIcon="heart" unratedIcon="heart-2" readonly></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()
@@ -100,7 +100,7 @@ describe("RatingIndicator", () => {
 		});
 
 		it("should render custom icon (filled) in half-star state when disabled", () => {
-			cy.mount(<RatingIndicator value={2.5} iconSelected="heart" iconUnselected="heart-2" disabled></RatingIndicator>);
+			cy.mount(<RatingIndicator value={2.5} ratedIcon="heart" unratedIcon="heart-2" disabled></RatingIndicator>);
 
 			cy.get("[ui5-rating-indicator]")
 				.shadow()

--- a/packages/main/src/RatingIndicator.ts
+++ b/packages/main/src/RatingIndicator.ts
@@ -185,7 +185,7 @@ class RatingIndicator extends UI5Element {
 	 * @since 2.20
 	 */
 	@property()
-	iconSelected = "favorite";
+	ratedIcon = "favorite";
 
 	/**
 	 * Defines the icon to be displayed for the unselected (empty) rating symbol.
@@ -194,7 +194,7 @@ class RatingIndicator extends UI5Element {
 	 * @since 2.20
 	 */
 	@property()
-	iconUnselected = "unfavorite";
+	unratedIcon = "unfavorite";
 
 	/**
 	 * @private

--- a/packages/main/src/RatingIndicatorTemplate.tsx
+++ b/packages/main/src/RatingIndicatorTemplate.tsx
@@ -35,14 +35,14 @@ function starLi(this: RatingIndicator, star: Star) {
 	if (star.selected) {
 		return (
 			<li data-ui5-value={star.index} class="ui5-rating-indicator-item ui5-rating-indicator-item-sel">
-				<Icon data-ui5-value={star.index} name={this.iconSelected} />
+				<Icon data-ui5-value={star.index} name={this.ratedIcon} />
 			</li>
 		);
 	} if (star.halfStar) {
 		return (
 			<li class="ui5-rating-indicator-item ui5-rating-indicator-item-half">
 				<div class="ui5-rating-indicator-half-icon-wrapper ui5-rating-indicator-half-icon-left">
-					<Icon data-ui5-value={star.index} name={this.iconSelected} />
+					<Icon data-ui5-value={star.index} name={this.ratedIcon} />
 				</div>
 				<div class="ui5-rating-indicator-half-icon-wrapper ui5-rating-indicator-half-icon-right">
 					<Icon data-ui5-value={star.index} name={halfStarIconName.call(this)} />
@@ -52,23 +52,23 @@ function starLi(this: RatingIndicator, star: Star) {
 	} if (this.readonly) {
 		return (
 			<li class="ui5-rating-indicator-item ui5-rating-indicator-item-unsel">
-				<Icon data-ui5-value={star.index} name={this.iconSelected} />
+				<Icon data-ui5-value={star.index} name={this.ratedIcon} />
 			</li>
 		);
 	} if (this.disabled) {
 		return (
 			<li class="ui5-rating-indicator-item ui5-rating-indicator-item-unsel">
-				<Icon data-ui5-value={star.index} name={this.iconSelected} />
+				<Icon data-ui5-value={star.index} name={this.ratedIcon} />
 			</li>
 		);
 	}
 	return (
 		<li data-ui5-value={star.index} class="ui5-rating-indicator-item ui5-rating-indicator-item-unsel">
-			<Icon data-ui5-value={star.index} name={this.iconUnselected}/>
+			<Icon data-ui5-value={star.index} name={this.unratedIcon}/>
 		</li>
 	);
 }
 
 function halfStarIconName(this: RatingIndicator) {
-	return this.disabled || this.readonly ? this.iconSelected : this.iconUnselected;
+	return this.disabled || this.readonly ? this.ratedIcon : this.unratedIcon;
 }

--- a/packages/main/test/pages/RatingIndicator.html
+++ b/packages/main/test/pages/RatingIndicator.html
@@ -136,27 +136,27 @@
 	</section>
 
 	<h3>Custom Icons - Hearts</h3>
-	<ui5-rating-indicator id="rating-hearts" value="3" icon-selected="heart" icon-unselected="heart-2"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-hearts" value="3" rated-icon="heart" unrated-icon="heart-2"></ui5-rating-indicator>
 	<br>
 	<br>
 
 	<h3>Custom Icons - Thumbs Up</h3>
-	<ui5-rating-indicator id="rating-thumbs" value="2.5" icon-selected="thumb-up" icon-unselected="border"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-thumbs" value="2.5" rated-icon="thumb-up" unrated-icon="border"></ui5-rating-indicator>
 	<br>
 	<br>
 
 	<h3>Custom Icons - Hearts (readonly)</h3>
-	<ui5-rating-indicator id="rating-hearts-readonly" value="2.5" icon-selected="heart" icon-unselected="heart-2" readonly></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-hearts-readonly" value="2.5" rated-icon="heart" unrated-icon="heart-2" readonly></ui5-rating-indicator>
 	<br>
 	<br>
 
 	<h3>Custom Icons - Hearts (disabled)</h3>
-	<ui5-rating-indicator id="rating-hearts-disabled" value="3" icon-selected="heart" icon-unselected="heart-2" disabled></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-hearts-disabled" value="3" rated-icon="heart" unrated-icon="heart-2" disabled></ui5-rating-indicator>
 	<br>
 	<br>
 
 	<h3>Custom Icons - Only selected icon (circles)</h3>
-	<ui5-rating-indicator id="rating-circle" value="2" icon-selected="circle-task-2"></ui5-rating-indicator>
+	<ui5-rating-indicator id="rating-circle" value="2" rated-icon="circle-task-2"></ui5-rating-indicator>
 	<br>
 	<br>
 

--- a/packages/website/docs/_components_pages/main/RatingIndicator.mdx
+++ b/packages/website/docs/_components_pages/main/RatingIndicator.mdx
@@ -21,6 +21,6 @@ The RatingIndicator supports several sizes of the Icons (S, M and L).
 <Sizes />
 
 ### Custom Icons
-The RatingIndicator supports custom icons for both selected and unselected states using the `icon-selected` and `icon-unselected` properties.
+The RatingIndicator supports custom icons for both selected and unselected states using the `rated-icon` and `unrated-icon` properties.
 
 <CustomIcons />

--- a/packages/website/docs/_samples/main/RatingIndicator/CustomIcons/sample.html
+++ b/packages/website/docs/_samples/main/RatingIndicator/CustomIcons/sample.html
@@ -10,9 +10,9 @@
 
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-hide-end -->
-    <ui5-rating-indicator value="3" icon-selected="heart" icon-unselected="heart-2"></ui5-rating-indicator></br>
-    <ui5-rating-indicator value="4" icon-selected="thumb-up" icon-unselected="border"></ui5-rating-indicator></br>
-    <ui5-rating-indicator value="2.5" icon-selected="circle-task-2" icon-unselected="border" readonly></ui5-rating-indicator>
+    <ui5-rating-indicator value="3" rated-icon="heart" unrated-icon="heart-2"></ui5-rating-indicator></br>
+    <ui5-rating-indicator value="4" rated-icon="thumb-up" unrated-icon="border"></ui5-rating-indicator></br>
+    <ui5-rating-indicator value="2.5" rated-icon="circle-task-2" unrated-icon="border" readonly></ui5-rating-indicator>
     <!-- playground-hide -->
     <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
Rename properties for selected and unselected custom icons to `ratedIcon` and `unratedIcon`.
Update their default values to 'favorite' and 'unfavorite'.