### PR TITLE
chore(ui5-navigation-layout): delete unnecessary item-click event

### DIFF
--- a/packages/fiori/src/NavigationLayout.ts
+++ b/packages/fiori/src/NavigationLayout.ts
@@ -1,6 +1,5 @@
 import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import slot from "@ui5/webcomponents-base/dist/decorators/slot-strict.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";


### PR DESCRIPTION
In the Navigation Layout, we use the item-click event from the Side Navigation.

Jira: 3598
