### PR TITLE
docs(ui5-select): promote value property usage in samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ cd packages/main
 yarn test:cypress:single cypress/specs/Button.cy.tsx  # Single test file
 ```
 
+### Documentation Website
+```bash
+cd packages/website
+yarn start  # Starts Docusaurus on http://localhost:3000
+```
+
 ### Build & Test Flow
 
 **Build steps** (always run from root folder):

--- a/packages/main/src/Option.ts
+++ b/packages/main/src/Option.ts
@@ -91,8 +91,10 @@ class Option extends ListItemBase implements IOption {
 
 	/**
 	 * Defines the selected state of the component.
+	 *
 	 * @default false
 	 * @public
+	 * @deprecated since 2.20.0, please use the parent Select's `value` property instead.
 	 */
 	@property({ type: Boolean })
 	declare selected: boolean;

--- a/packages/website/docs/_components_pages/main/Select/Select.mdx
+++ b/packages/website/docs/_components_pages/main/Select/Select.mdx
@@ -3,6 +3,7 @@ slug: ../../Select
 ---
 
 import Basic from "../../../_samples/main/Select/Basic/Basic.md";
+import Selection from "../../../_samples/main/Select/Selection/Selection.md";
 import States from "../../../_samples/main/Select/States/States.md";
 import AdditionalText from "../../../_samples/main/Select/AdditionalText/AdditionalText.md";
 import CustomOptions from "../../../_samples/main/Select/CustomOptions/CustomOptions.md";
@@ -15,6 +16,12 @@ import CustomOptions from "../../../_samples/main/Select/CustomOptions/CustomOpt
 <%COMPONENT_METADATA%>
 
 ## More Samples
+
+### Selection
+Use the `value` property on the Select component to control which option is selected.
+The value should match the `value` attribute of the desired Option or Option's text.
+
+<Selection />
 
 ### States
 Select supports several semantic value states, readonly, disabled, etc.

--- a/packages/website/docs/_samples/main/Select/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Select/Basic/sample.html
@@ -10,10 +10,10 @@
 <!-- playground-fold-end -->
 
 
-    <ui5-select>
-        <ui5-option icon="laptop">Desktop</ui5-option>
-        <ui5-option icon="ipad" selected>Tablet</ui5-option>
-        <ui5-option icon="iphone">Phone</ui5-option>
+    <ui5-select value="tablet">
+        <ui5-option value="desktop" icon="laptop">Desktop</ui5-option>
+        <ui5-option value="tablet" icon="ipad">Tablet</ui5-option>
+        <ui5-option value="phone" icon="iphone">Phone</ui5-option>
     </ui5-select>
 
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Select/Selection/Selection.md
+++ b/packages/website/docs/_samples/main/Select/Selection/Selection.md
@@ -1,0 +1,4 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+
+<Editor html={html} js={js} />

--- a/packages/website/docs/_samples/main/Select/Selection/main.js
+++ b/packages/website/docs/_samples/main/Select/Selection/main.js
@@ -1,0 +1,11 @@
+import "@ui5/webcomponents/dist/Select.js";
+import "@ui5/webcomponents/dist/Option.js";
+import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
+
+const select = document.getElementById("countrySelect");
+const output = document.getElementById("output");
+
+select.addEventListener("change", (e) => {
+    output.textContent = e.target.value;
+});

--- a/packages/website/docs/_samples/main/Select/Selection/sample.html
+++ b/packages/website/docs/_samples/main/Select/Selection/sample.html
@@ -1,0 +1,30 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+<body style="background-color: var(--sapBackgroundColor); height: 300px">
+<!-- playground-fold-end -->
+
+<div>
+	<ui5-label for="countrySelect">Country:</ui5-label>
+	<ui5-select id="countrySelect" value="DE">
+		<ui5-option value="US">United States</ui5-option>
+		<ui5-option value="DE">Germany</ui5-option>
+		<ui5-option value="FR">France</ui5-option>
+		<ui5-option value="UK">United Kingdom</ui5-option>
+	</ui5-select>
+</div>
+
+<div>
+	<ui5-label>Selected value: <ui5-text id="output">DE</ui5-text></ui5-label>
+</div>
+
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Select/States/sample.html
+++ b/packages/website/docs/_samples/main/Select/States/sample.html
@@ -10,48 +10,48 @@
 <!-- playground-fold-end -->
 
 
-<ui5-select value-state="Positive">
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select value-state="Positive" value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
-<ui5-select value-state="Information">
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select value-state="Information" value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
-<ui5-select value-state="Critical">
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select value-state="Critical" value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
-<ui5-select value-state="Negative">
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select value-state="Negative" value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
-<ui5-select value-state="Negative" placeholder="Custom value-state message">
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select value-state="Negative" placeholder="Custom value-state message" value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 
     <div slot="valueStateMessage">Please provide valid value</div>
 </ui5-select>
 
-<ui5-select readonly>
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal">Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select readonly value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
-<ui5-select disabled>
-    <ui5-option icon="meal" selected>Apple</ui5-option>
-    <ui5-option icon="meal" >Avocado</ui5-option>
-    <ui5-option icon="meal">Mango</ui5-option>
+<ui5-select disabled value="apple">
+    <ui5-option value="apple" icon="meal">Apple</ui5-option>
+    <ui5-option value="avocado" icon="meal">Avocado</ui5-option>
+    <ui5-option value="mango" icon="meal">Mango</ui5-option>
 </ui5-select>
 
 <!-- playground-fold -->


### PR DESCRIPTION
Update Select samples to use the `value` property on Select instead of the deprecated `selected` attribute on Option. This aligns the documentation with the recommended API.

- Update Basic sample to use value on Select
- Update States sample to use value on Select
- Add new Selection sample demonstrating value property
- Deprecate Option's selected property in JSDoc
- Add website startup command to AGENTS.md