### PR TITLE
fix(ui5-base): scope all registered tags by default

### DIFF
--- a/docs/2-advanced/06-scoping.md
+++ b/docs/2-advanced/06-scoping.md
@@ -90,9 +90,8 @@ setCustomElementsScopingSuffix("demo");
 setCustomElementsScopingRules({include: [/^ui5-/], exclude: [/^ui5-my-/, /-test-/]});
 ```
 
-By default, all UI5 Web Components starting with `ui5-` are scoped when you call `setCustomElementsScopingSuffix`.
-However, you have full control over which tags are scoped and which not. In the example above, tags starting with `ui5-my-` and tags
-having the word `-test-` in their name are not scoped.
+By default, all tags registered by the current runtime are scoped when you call `setCustomElementsScopingSuffix`.
+You can use `setCustomElementsScopingRules` to control which tags are scoped and which are not. In the example above, only tags starting with `ui5-` are scoped, and among those, tags starting with `ui5-my-` and tags having the word `-test-` in their name are excluded.
 
 Setting scoping rules is handy if, for example, your library uses both standard and custom UI5 Web Components and you don't want
-to scope the custom ones (as no disambiguation will be necessary for them).
+to scope some of them (as no disambiguation will be necessary for them).

--- a/packages/base/src/CustomElementsScopeUtils.ts
+++ b/packages/base/src/CustomElementsScopeUtils.ts
@@ -9,7 +9,7 @@ type Rules = {
 };
 
 let rulesObj: Rules = {
-	include: [/^ui5-/],
+	include: [/./],
 	exclude: [],
 };
 
@@ -18,7 +18,7 @@ const tagsCache = new Map<string, boolean>(); // true/false means the tag should
 /**
  * Sets the suffix to be used for custom elements scoping, f.e. pass "demo" to get tags such as "ui5-button-demo".
  *
- * **Note:** By default all tags starting with "ui5-" will be scoped, unless you change this by calling "setCustomElementsScopingRules"
+ * **Note:** By default all tags registered by the current runtime will be scoped, unless you change this by calling "setCustomElementsScopingRules"
  * **Note:** Setting the scoping suffix must be done before importing any components.
  *
  * @public
@@ -76,7 +76,7 @@ const setCustomElementsScopingRules = (rules: Rules) => {
 
 /**
  * Returns the rules, governing which custom element tags to scope and which not. By default, all elements
- * starting with "ui5-" are scoped. The default rules are: {include: [/^ui5-/]}.
+ * are scoped. The default rules are: {include: [/./]}.
  *
  * @public
  * @returns {Object}


### PR DESCRIPTION
## Summary

- Changes the default scoping `include` rule from `/^ui5-/` to `/./` so that **all** tags registered by the current runtime are scoped when a suffix is set, not just `ui5-*` tags.
- Libraries with custom prefixes (e.g. `fx-*`) that share the same `@ui5/webcomponents-base` runtime are now scoped automatically without needing to call `setCustomElementsScopingRules`.
- The `exclude` rules continue to work for opting specific tags out of scoping.
- Updates documentation in `docs/2-advanced/06-scoping.md` and JSDoc comments to reflect the new default.

## Test plan

- [ ] Verify that `ui5-*` tags are still scoped as before when a suffix is set
- [ ] Verify that non-`ui5-*` tags (e.g. `fx-*`) registered by the same runtime are now also scoped
- [ ] Verify that `setCustomElementsScopingRules` with explicit `include`/`exclude` still overrides the default
- [x] Run existing scoping tests to ensure no regressions