### PR TITLE
docs(website): clear all TS errors in React samples and add CI typecheck

### DIFF
--- a/.github/workflows/ci-test-website.yaml
+++ b/.github/workflows/ci-test-website.yaml
@@ -21,3 +21,6 @@ jobs:
         export NODE_OPTIONS="--max_old_space_size=4096"
         yarn install
         yarn ci:deploy:nightly
+
+    - name: Typecheck Samples
+      run: yarn workspace @ui5/webcomponents-website typecheck:samples

--- a/packages/website/docs/_samples/ai/Input/Basic/sample.tsx
+++ b/packages/website/docs/_samples/ai/Input/Basic/sample.tsx
@@ -20,7 +20,18 @@ const SAMPLE_TEXTS: Record<string, string> = {
   summarized: "Driving innovation creatively.",
 };
 
-const INITIAL_MENU_CONFIG = [
+type Config = {
+  text?: string;
+  action?: string;
+  processingLabel?: string;
+  completedLabel?: string;
+  textKey?: string;
+  slot?: string;
+  children?: Config[];
+  separator?: boolean;
+};
+
+const INITIAL_MENU_CONFIG: Array<Config> = [
   {
     text: "Generate",
     action: "generate",
@@ -31,7 +42,7 @@ const INITIAL_MENU_CONFIG = [
   },
 ];
 
-const FULL_MENU_CONFIG = [
+const FULL_MENU_CONFIG: Array<Config> = [
   {
     text: "Regenerate",
     action: "regenerate",
@@ -125,7 +136,7 @@ function App() {
   const [currentVersion, setCurrentVersion] = useState(0);
   const [totalVersions, setTotalVersions] = useState(0);
   const [promptDescription, setPromptDescription] = useState("");
-  const [menuConfig, setMenuConfig] = useState(INITIAL_MENU_CONFIG);
+  const [menuConfig, setMenuConfig] = useState<Config[]>(INITIAL_MENU_CONFIG);
 
   const versionHistoryRef = useRef<VersionEntry[]>([]);
   const currentIndexRef = useRef(0);

--- a/packages/website/docs/_samples/compat/Table/Grouping/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/Grouping/sample.tsx
@@ -23,13 +23,13 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="500"
+        minWidth={500}
         popinText="Supplier"
         demandPopin
       >
         <Label>Supplier</Label>
       </CompatTableColumn>
-      <CompatTableColumn slot="columns" minWidth="500">
+      <CompatTableColumn slot="columns" minWidth={500}>
         <Label>Date Of Foundation</Label>
       </CompatTableColumn>
 

--- a/packages/website/docs/_samples/compat/Table/GrowingOnScroll/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/GrowingOnScroll/sample.tsx
@@ -157,7 +157,7 @@ function App() {
     <div style={{ height: "200px", overflow: "scroll" }}>
       <CompatTable
         growing={growing}
-        busyDelay="0"
+        busyDelay={0}
         busy={busy}
         onLoadMore={handleLoadMore}
       >

--- a/packages/website/docs/_samples/compat/Table/MultipleSelection/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/MultipleSelection/sample.tsx
@@ -19,7 +19,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="600"
+        minWidth={600}
         popinText="Supplier"
         demandPopin
         popinDisplay="Inline"
@@ -28,7 +28,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="800"
+        minWidth={800}
         popinText="Dimensions"
         demandPopin
         popinDisplay="Inline"
@@ -37,7 +37,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="800"
+        minWidth={800}
         popinText="Weight"
         demandPopin
         popinDisplay="Inline"

--- a/packages/website/docs/_samples/compat/Table/SingleSelection/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/SingleSelection/sample.tsx
@@ -19,7 +19,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="600"
+        minWidth={600}
         popinText="Supplier"
         demandPopin
         popinDisplay="Inline"
@@ -28,7 +28,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="800"
+        minWidth={800}
         popinText="Dimensions"
         demandPopin
         popinDisplay="Inline"
@@ -37,7 +37,7 @@ function App() {
       </CompatTableColumn>
       <CompatTableColumn
         slot="columns"
-        minWidth="800"
+        minWidth={800}
         popinText="Weight"
         demandPopin
         popinDisplay="Inline"

--- a/packages/website/docs/_samples/compat/Table/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/StickyHeader/sample.tsx
@@ -18,12 +18,12 @@ function App() {
         <CompatTableColumn slot="columns">
           <Text>Product</Text>
         </CompatTableColumn>
-        <CompatTableColumn slot="columns" minWidth="800">
+        <CompatTableColumn slot="columns" minWidth={800}>
           <Text>Supplier</Text>
         </CompatTableColumn>
         <CompatTableColumn
           slot="columns"
-          minWidth="600"
+          minWidth={600}
           popinText="Dimensions"
           demandPopin
         >
@@ -31,7 +31,7 @@ function App() {
         </CompatTableColumn>
         <CompatTableColumn
           slot="columns"
-          minWidth="600"
+          minWidth={600}
           popinText="Weight"
           demandPopin
         >

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/Basic/sample.tsx
@@ -23,7 +23,7 @@ function App() {
       <div style={{ width: "1000px", overflowX: "scroll" }}>
         <DynamicSideContent sideContentVisibility="AlwaysShow">
           <div>
-            <Title level="h1">Main Content</Title>
+            <Title level="H1">Main Content</Title>
             <p className="text">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex
               mi, elementum et ante commodo, semper sollicitudin magna. Sed
@@ -37,7 +37,7 @@ function App() {
             </p>
           </div>
           <div slot="sideContent">
-            <Title level="h1">Side Content</Title>
+            <Title level="H1">Side Content</Title>
             <p className="text">
               Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit.
               Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/EqualSplit/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/EqualSplit/sample.tsx
@@ -26,7 +26,7 @@ function App() {
           equalSplit={true}
         >
           <div>
-            <Title level="h1">Main Content</Title>
+            <Title level="H1">Main Content</Title>
             <p className="text">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex
               mi, elementum et ante commodo, semper sollicitudin magna. Sed
@@ -40,7 +40,7 @@ function App() {
             </p>
           </div>
           <div slot="sideContent">
-            <Title level="h1">Side Content</Title>
+            <Title level="H1">Side Content</Title>
             <p className="text">
               Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit.
               Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/SideContentPosition/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/SideContentPosition/sample.tsx
@@ -26,7 +26,7 @@ function App() {
           sideContentPosition="Start"
         >
           <div>
-            <Title level="h1">Main Content</Title>
+            <Title level="H1">Main Content</Title>
             <p className="text">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex
               mi, elementum et ante commodo, semper sollicitudin magna. Sed
@@ -40,7 +40,7 @@ function App() {
             </p>
           </div>
           <div slot="sideContent">
-            <Title level="h1">Side Content</Title>
+            <Title level="H1">Side Content</Title>
             <p className="text">
               Morbi lorem libero, imperdiet id condimentum ac, tempor ut velit.
               Integer a laoreet sem. Nunc at sagittis nisi. Sed placerat diam eu

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
@@ -183,7 +183,7 @@ function App() {
       setRatingValue(getRandomInt(4) + 1);
       setCol2Title(item.textContent);
       setProductName(item.textContent);
-      setProductDesc(item.description);
+      setProductDesc((item as ListItemStandardClass).description);
       setProductSupplier(supplierNames[getRandomInt(11)]);
       setLayout(nextLayout("col1"));
     },

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/LayoutsConfiguration/sample.tsx
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/LayoutsConfiguration/sample.tsx
@@ -199,8 +199,8 @@ function App() {
     (e: UI5CustomEvent<SelectClass, "change">) => {
       const fcl = fclRef.current;
       if (fcl) {
-        fcl.layout = e.detail.selectedOption.textContent;
-        setCurrentLayout(e.detail.selectedOption.textContent);
+        fcl.layout = e.detail.selectedOption.textContent as `${FCLLayout}`;
+        setCurrentLayout(e.detail.selectedOption.textContent as `${FCLLayout}`);
         displayCustomLayoutConfigurationInfo();
       }
     },

--- a/packages/website/docs/_samples/fiori/MediaGallery/VideoContent/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/VideoContent/sample.tsx
@@ -24,9 +24,9 @@ function App() {
           <iframe
             src="https://www.youtube.com/embed/GxGZG2fv6Aw"
             title="YouTube video player"
-            frameborder="0"
+            frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
+            allowFullScreen={true}
           ></iframe>
           <img
             src="/images/sap-logo-square.svg"

--- a/packages/website/docs/_samples/fiori/NotificationList/GroupItems/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NotificationList/GroupItems/sample.tsx
@@ -29,7 +29,7 @@ function App() {
     e.detail.item.hidden = true;
 
     Array.from(e.detail.item.parentElement.childNodes).forEach((element) => {
-      if (element.nodeName === "UI5-LI-NOTIFICATION" && !element.hidden) {
+      if (element.nodeName === "UI5-LI-NOTIFICATION" && !(element as NotificationListItemClass).hidden) {
         visibleItems++;
       }
     });

--- a/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.html
@@ -12,10 +12,10 @@
 <body style="background-color: var(--sapBackgroundColor); height: 50rem;">
 	<!-- playground-fold-end -->
 	<ui5-shellbar
-		logo="../assets/images/sap-logo-svg.svg"
 		show-notifications
 		notifications-count="10"
 	>
+		<img slot="logo" src="../assets/images/sap-logo-svg.svg" alt="SAP Logo" />
 		<ui5-shellbar-branding slot="branding">Corporate Portal</ui5-shellbar-branding>
 	</ui5-shellbar>
 	<ui5-popover

--- a/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.tsx
@@ -62,7 +62,7 @@ function App() {
       e.detail.item.hidden = true;
 
       Array.from(e.detail.item.parentElement.childNodes).forEach((element) => {
-        if (element.nodeName === "UI5-LI-NOTIFICATION" && !element.hidden) {
+        if (element.nodeName === "UI5-LI-NOTIFICATION" && !(element as NotificationListItemClass).hidden) {
           visibleItems++;
         }
       });
@@ -187,14 +187,16 @@ function App() {
         	width: auto;
         }
       `}</style>
+
       <ShellBar
-        logo="/images/sap-logo-svg.svg"
         showNotifications={true}
-        notificationsCount={10}
+        notificationsCount="10"
         onNotificationsClick={handleShellbarNotificationsClick}
       >
+		<img slot="logo" src="/images/sap-logo-svg.svg" alt="SAP Logo" />
         <ShellBarBranding slot="branding">Corporate Portal</ShellBarBranding>
       </ShellBar>
+
       <Popover
         ref={popoverRef}
         id="popover-with-notifications"
@@ -490,6 +492,7 @@ function App() {
           </NotificationList>
         )}
       </Popover>
+
       <Menu ref={sortMenuRef} headerText="Sort By" id="sort-menu">
         <MenuItem text="Date" />
         <MenuItem text="Importance" />

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
@@ -34,7 +34,7 @@ function App() {
   return (
     <>
       <ShellBar
-        notificationsCount={72}
+        notificationsCount="72"
         showNotifications={true}
         showProductSwitch={true}
       >

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
@@ -22,7 +22,7 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   return (
     <>
-      <ShellBar notificationsCount={72} showNotifications={true}>
+      <ShellBar notificationsCount="72" showNotifications={true}>
         <Button icon="menu2" slot="startButton" />
         <ShellBarBranding slot="branding">
           Product Identifier

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
@@ -24,7 +24,7 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   return (
     <>
-      <ShellBar notificationsCount={72} showNotifications={true}>
+      <ShellBar notificationsCount="72" showNotifications={true}>
         <ShellBarBranding slot="branding">
           Product Identifier
           <img slot="logo" src="/images/sap-logo-svg.svg" alt="SAP Logo" />

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
@@ -58,7 +58,7 @@ function App() {
 
       <ShellBar
         primaryTitle="Product Identifier"
-        notificationsCount={72}
+        notificationsCount="72"
         showNotifications={true}
       >
         <Button icon="menu2" slot="startButton" />

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
@@ -50,7 +50,7 @@ function App() {
 
       <ShellBar
         primaryTitle="Product Identifier"
-        notificationsCount={72}
+        notificationsCount="72"
         showNotifications={true}
       >
         <Button icon="menu2" slot="startButton" />

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
@@ -26,7 +26,7 @@ function App() {
     <>
       <ShellBar
         primaryTitle="Product Identifier"
-        notificationsCount={72}
+        notificationsCount="72"
         showNotifications={true}
       >
         <Button icon="menu2" slot="startButton" />

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
@@ -95,7 +95,7 @@ function App() {
         }
       `}</style>
       <Page style={{ height: "500px" }}>
-        <ShellBar notificationsCount={72} showNotifications={true}>
+        <ShellBar notificationsCount="72" showNotifications={true}>
           <Button
             icon="menu2"
             slot="startButton"

--- a/packages/website/docs/_samples/fiori/Timeline/WithState/sample.html
+++ b/packages/website/docs/_samples/fiori/Timeline/WithState/sample.html
@@ -13,21 +13,21 @@
 
 	<ui5-timeline id="test-timeline">
 		<ui5-timeline-group-item group-name="Build">
-			<ui5-timeline-item title="Compile" subtitle="Testing suite A" icon="sap-icon://accept" name="Testing suite A" state="Positive">
+			<ui5-timeline-item title="Compile" subtitleText="Testing suite A" icon="sap-icon://accept" name="Testing suite A" state="Positive">
 				Compilation succeeded.
 			</ui5-timeline-item>
-			<ui5-timeline-item title="Lint" subtitle="Testing suite B" icon="sap-icon://message-information" name="Testing suite B" state="Information">
+			<ui5-timeline-item title="Lint" subtitleText="Testing suite B" icon="sap-icon://message-information" name="Testing suite B" state="Information">
 				Lint completed with minor issues.
 			</ui5-timeline-item>
 		</ui5-timeline-group-item>
 		<ui5-timeline-group-item group-name="Test">
-			<ui5-timeline-item title="Unit Test" subtitle="Testing suite C" icon="sap-icon://decline" name="Testing suite C" state="Negative">
+			<ui5-timeline-item title="Unit Test" subtitleText="Testing suite C" icon="sap-icon://decline" name="Testing suite C" state="Negative">
 				Unit tests failed.
 			</ui5-timeline-item>
-			<ui5-timeline-item title="Integration Test" subtitle="Testing suite D" icon="sap-icon://message-warning" name="Testing suite D" state="Critical">
+			<ui5-timeline-item title="Integration Test" subtitleText="Testing suite D" icon="sap-icon://message-warning" name="Testing suite D" state="Critical">
 				Integration tests have warnings.
 			</ui5-timeline-item>
-			<ui5-timeline-item title="E2E Test" subtitle="Testing suite E" icon="sap-icon://accept" name="Testing suite E" state="Positive">
+			<ui5-timeline-item title="E2E Test" subtitleText="Testing suite E" icon="sap-icon://accept" name="Testing suite E" state="Positive">
 				End-to-end tests passed.
 			</ui5-timeline-item>
 		</ui5-timeline-group-item>

--- a/packages/website/docs/_samples/fiori/Timeline/WithState/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/WithState/sample.tsx
@@ -18,7 +18,7 @@ function App() {
         <TimelineGroupItem groupName="Build">
           <TimelineItem
             title="Compile"
-            subtitle="Testing suite A"
+            subtitleText="Testing suite A"
             icon="accept"
             name="Testing suite A"
             state="Positive"
@@ -27,7 +27,7 @@ function App() {
           </TimelineItem>
           <TimelineItem
             title="Lint"
-            subtitle="Testing suite B"
+            subtitleText="Testing suite B"
             icon="message-information"
             name="Testing suite B"
             state="Information"
@@ -38,7 +38,7 @@ function App() {
         <TimelineGroupItem groupName="Test">
           <TimelineItem
             title="Unit Test"
-            subtitle="Testing suite C"
+            subtitleText="Testing suite C"
             icon="decline"
             name="Testing suite C"
             state="Negative"
@@ -47,7 +47,7 @@ function App() {
           </TimelineItem>
           <TimelineItem
             title="Integration Test"
-            subtitle="Testing suite D"
+            subtitleText="Testing suite D"
             icon="message-warning"
             name="Testing suite D"
             state="Critical"
@@ -56,7 +56,7 @@ function App() {
           </TimelineItem>
           <TimelineItem
             title="E2E Test"
-            subtitle="Testing suite E"
+            subtitleText="Testing suite E"
             icon="accept"
             name="Testing suite E"
             state="Positive"

--- a/packages/website/docs/_samples/fiori/UploadCollection/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/Basic/sample.tsx
@@ -28,7 +28,7 @@ function App() {
       file: File;
       fileName: string;
       description: string;
-      uploadState: string;
+      uploadState: "Error" | "Ready" | "Uploading" | "Complete";
     }[]
   >([]);
 
@@ -36,12 +36,13 @@ function App() {
     (e: UI5CustomEvent<FileUploaderClass, "change">) => {
       const files = e.detail.files;
       const additions = [];
+
       for (let i = 0; i < files.length; i++) {
         additions.push({
           id: Date.now() + "-" + i,
           file: files[i],
           fileName: files[i].name,
-          description: `Last modified: ${files[i].lastModifiedDate}, size: ${files[i].size}`,
+          description: `Last modified: ${new Date(files[i].lastModified)}, size: ${files[i].size}`,
           uploadState: "Ready",
         });
       }

--- a/packages/website/docs/_samples/fiori/UploadCollection/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/DragAndDrop/sample.tsx
@@ -26,7 +26,7 @@ function App() {
       file: File;
       fileName: string;
       description: string;
-      uploadState: string;
+      uploadState: "Error" | "Ready" | "Uploading" | "Complete";
     }[]
   >([]);
   const fileIdCounter = useRef(0);
@@ -58,7 +58,7 @@ function App() {
     setItems((prev) =>
       prev.map((item) => {
         if (item.uploadState === "Ready" && item.file) {
-          const updatedItem = { ...item, uploadState: "Uploading" };
+          const updatedItem = { ...item, uploadState: "Uploading" as const };
 
           fetch("/upload", {
             method: "POST",
@@ -69,7 +69,7 @@ function App() {
                 i.id === item.id
                   ? {
                       ...i,
-                      uploadState: res.status === 200 ? "Complete" : "Error",
+                    uploadState: res.status === 200 ? "Complete" as const : "Error" as const,
                     }
                   : i,
               ),

--- a/packages/website/docs/_samples/fiori/UploadCollection/RenamingFiles/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/RenamingFiles/sample.tsx
@@ -17,8 +17,8 @@ const initialFiles = [
     id: "1",
     fileName: "LaptopHT-1000.jpg",
     fileNameClickable: true,
-    uploadState: "Complete",
-    type: "Detail",
+    uploadState: "Complete" as const,
+    type: "Detail" as const,
     description:
       "Uploaded By: David Keane \u00B7 Uploaded On: 2014-07-26 \u00B7 File Size: 35 KB",
     thumbnail: "img",
@@ -28,8 +28,8 @@ const initialFiles = [
     id: "2",
     fileName: "Notes.txt",
     fileNameClickable: false,
-    uploadState: "Complete",
-    type: "Detail",
+    uploadState: "Complete" as const,
+    type: "Detail" as const,
     description:
       "Uploaded By: John Smith \u00B7 Uploaded On: 2014-09-02 \u00B7 File Size: 226.6 KB",
     thumbnail: "icon",
@@ -41,7 +41,7 @@ function App() {
   const [files, setFiles] = useState(initialFiles);
 
   const handleUploadCollectionRename = (
-    e: UI5CustomEvent<UploadCollectionClass, "rename">,
+    e: UI5CustomEvent<UploadCollectionItemClass, "rename">,
   ) => {
     alert("Rename event: " + e.currentTarget.fileName);
   };
@@ -56,7 +56,6 @@ function App() {
   return (
     <>
       <UploadCollection
-        onRename={handleUploadCollectionRename}
         onItemDelete={handleUploadCollectionItemDelete}
       >
         <div slot="header" className="header">
@@ -65,6 +64,7 @@ function App() {
 
         {files.map((file) => (
           <UploadCollectionItem
+		  	onRename={handleUploadCollectionRename}
             key={file.id}
             fileName={file.fileName}
             fileNameClickable={file.fileNameClickable || false}

--- a/packages/website/docs/_samples/fiori/UploadCollection/VariousUploadStates/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/VariousUploadStates/sample.tsx
@@ -16,7 +16,7 @@ const initialFiles = [
   {
     id: "1",
     fileName: "LaptopHT-1000.jpg",
-    uploadState: "Complete",
+    uploadState: "Complete" as const,
     description: 'uploadState="Complete"',
     thumbnail: "img",
     thumbnailSrc: "/images/HT-1000.jpg",
@@ -24,8 +24,8 @@ const initialFiles = [
   {
     id: "2",
     fileName: "Laptop.jpg",
-    uploadState: "Uploading",
-    type: "Active",
+    uploadState: "Uploading" as const,
+    type: "Active" as const,
     progress: 37,
     description: 'uploadState="Uploading"',
     thumbnail: "img",
@@ -34,8 +34,8 @@ const initialFiles = [
   {
     id: "3",
     fileName: "latest-reports.pdf",
-    uploadState: "Error",
-    type: "Active",
+    uploadState: "Error" as const,
+    type: "Active" as const,
     progress: 59,
     description: 'uploadState="Error"',
     thumbnail: "icon",
@@ -44,7 +44,7 @@ const initialFiles = [
   {
     id: "4",
     fileName: "Notes.txt",
-    uploadState: "Ready",
+    uploadState: "Ready" as const,
     description: 'uploadState="Ready" (default)',
     thumbnail: "icon",
     thumbnailName: "document-text",
@@ -55,13 +55,13 @@ function App() {
   const [files, setFiles] = useState(initialFiles);
 
   const handleUploadCollectionRetry = (
-    e: UI5CustomEvent<UploadCollectionClass, "retry">,
+    e: UI5CustomEvent<UploadCollectionItemClass, "retry">,
   ) => {
     alert("Retry uploading: " + e.currentTarget.fileName);
   };
 
   const handleUploadCollectionTerminate = (
-    e: UI5CustomEvent<UploadCollectionClass, "terminate">,
+    e: UI5CustomEvent<UploadCollectionItemClass, "terminate">,
   ) => {
     alert("Terminate uploading of: " + e.currentTarget.fileName);
   };
@@ -76,8 +76,6 @@ function App() {
   return (
     <>
       <UploadCollection
-        onRetry={handleUploadCollectionRetry}
-        onTerminate={handleUploadCollectionTerminate}
         onItemDelete={handleUploadCollectionItemDelete}
       >
         <div slot="header" className="header">
@@ -91,6 +89,8 @@ function App() {
             uploadState={file.uploadState}
             type={file.type}
             progress={file.progress}
+			onRetry={handleUploadCollectionRetry}
+			onTerminate={handleUploadCollectionTerminate}
           >
             {file.description}
             {file.thumbnail === "img" ? (

--- a/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.html
+++ b/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor); height: 600px;">
     <!-- playground-fold-end -->
 
-    <ui5-dialog id="dialog" stretch header-heading="Wizard">
+    <ui5-dialog id="dialog" stretch header-text="Wizard">
         <ui5-wizard id="wiz" content-layout="SingleStep">
             <ui5-wizard-step icon="product" title-text="Product type" selected="">
                 <div style="display: flex; min-height: 200px; flex-direction: column;">

--- a/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.tsx
@@ -101,7 +101,7 @@ function App() {
         open={dialogOpen}
         id="dialog"
         stretch={true}
-        headerHeading="Wizard"
+        headerText="Wizard"
         onClose={() => setDialogOpen(false)}
       >
         <Wizard

--- a/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.tsx
@@ -47,13 +47,13 @@ function App() {
       peoplePopoverRef.current!.opener = e.detail.targetRef;
       peoplePopoverRef.current!.open = true;
     } else {
-      const avatarRef = e.detail.targetRef;
+      const avatarRef = e.detail.targetRef as AvatarClass;
       const avatarIndex = group.items.indexOf(avatarRef);
       setPopAvatar({
         colorScheme: group.colorScheme[avatarIndex],
         initials: avatarRef.initials,
         icon: avatarRef.icon,
-        imageSrc: avatarRef.image.length > 0 ? avatarRef.image[0].src : null,
+        imageSrc: avatarRef.image.length > 0 ? (avatarRef.image[0] as HTMLImageElement).src : null,
       });
       personPopoverRef.current!.open = false;
       personPopoverRef.current!.opener = avatarRef;
@@ -71,7 +71,7 @@ function App() {
         <Popover
           ref={personPopoverRef}
           headerText="Person Card"
-          className="personPopover"
+          class="personPopover"
           style={{ width: "300px" }}
           placement="Bottom"
           preventFocusRestore={true}

--- a/packages/website/docs/_samples/main/Calendar/Bounds/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/Bounds/sample.tsx
@@ -6,7 +6,8 @@ const Calendar = createReactComponent(CalendarClass);
 function App() {
   return (
     <Calendar
-      formatPattern="dd/MM/yyyy"
+      valueFormat="dd/MM/yyyy"
+      displayFormat="dd/MM/yyyy"
       minDate="7/10/2020"
       maxDate="20/10/2020"
     />

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/sample.tsx
@@ -1,7 +1,7 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import CalendarClass from "@ui5/webcomponents/dist/Calendar.js";
 import SpecialCalendarDateClass from "@ui5/webcomponents/dist/SpecialCalendarDate.js";
-import DateRangeClass from "@ui5/webcomponents/dist/DateRange.js";
+import DateRangeClass from "@ui5/webcomponents/dist/CalendarDateRange.js";
 
 const Calendar = createReactComponent(CalendarClass);
 const SpecialCalendarDate = createReactComponent(SpecialCalendarDateClass);
@@ -10,7 +10,7 @@ const DateRange = createReactComponent(DateRangeClass);
 function App() {
   return (
     <>
-      <Calendar formatPattern="dd/MM/yyyy">
+      <Calendar valueFormat="dd/MM/yyyy" displayFormat="dd/MM/yyyy">
         <SpecialCalendarDate value="21/11/2024"></SpecialCalendarDate>
         <DateRange
           slot="disabledDates"

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/sample.tsx
@@ -17,7 +17,7 @@ function App() {
     const formattedMonth = (currentDate.getMonth() + 1)
       .toString()
       .padStart(2, "0");
-    const types = ["Type05", "Type07", "Type13", "NonWorking"];
+    const types = ["Type05", "Type07", "Type13", "NonWorking"] as const;
     const daysInMonth = new Date(year, currentDate.getMonth() + 1, 0).getDate();
     const assignedDays = new Set<number>();
 

--- a/packages/website/docs/_samples/main/CalendarLegend/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/CalendarLegend/Basic/sample.tsx
@@ -17,7 +17,7 @@ function App() {
     const formattedMonth = (currentDate.getMonth() + 1)
       .toString()
       .padStart(2, "0");
-    const types = ["Type05", "Type07", "Type13", "NonWorking"];
+    const types = ["Type05", "Type07", "Type13", "NonWorking"] as const;
     const daysInMonth = new Date(year, currentDate.getMonth() + 1, 0).getDate();
     const assignedDays = new Set<number>();
 

--- a/packages/website/docs/_samples/main/CheckBox/Group/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/Group/sample.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, FormEvent } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ButtonClass from "@ui5/webcomponents/dist/Button.js";
 import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
@@ -10,7 +10,7 @@ function App() {
   const formRef = useRef<HTMLFormElement>(null);
   const [output, setOutput] = useState("");
 
-  const handleFormSubmit = (e: Event) => {
+  const handleFormSubmit = (e: FormEvent) => {
     e.preventDefault();
     const formData = new FormData(formRef.current!);
     const selectedLanguages = formData.getAll("languages");

--- a/packages/website/docs/_samples/main/DatePicker/MinMax/sample.html
+++ b/packages/website/docs/_samples/main/DatePicker/MinMax/sample.html
@@ -11,7 +11,7 @@
 <body style="background-color: var(--sapBackgroundColor); height: 450px;">
     <!-- playground-fold-end -->
 
-    <ui5-date-picker format-pattern="dd/MM/yyyy" min-date="1/1/2020" max-date="4/5/2020">
+    <ui5-date-picker value-format="dd/MM/yyyy" display-format="dd/MM/yyyy" min-date="1/1/2020" max-date="4/5/2020">
     </ui5-date-picker>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/DatePicker/MinMax/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/MinMax/sample.tsx
@@ -6,7 +6,8 @@ const DatePicker = createReactComponent(DatePickerClass);
 function App() {
   return (
     <DatePicker
-      formatPattern="dd/MM/yyyy"
+      valueFormat="dd/MM/yyyy"
+      displayFormat="dd/MM/yyyy"
       minDate="1/1/2020"
       maxDate="4/5/2020"
     />

--- a/packages/website/docs/_samples/main/DateRangePicker/DateFormat/sample.html
+++ b/packages/website/docs/_samples/main/DateRangePicker/DateFormat/sample.html
@@ -13,30 +13,35 @@
 
     <ui5-daterange-picker
         value="2024-02-07 - 2024-02-10"
-        format-pattern="yyyy-MM-dd"
+        value-format="yyyy-MM-dd"
+        display-format="yyyy-MM-dd"
     >
     </ui5-daterange-picker>
 
     <ui5-daterange-picker
         value="06/02/2024 - 12/02/2024"
-        format-pattern="dd/MM/yyyy"
+        value-format="dd/MM/yyyy"
+        display-format="dd/MM/yyyy"
     >
     </ui5-daterange-picker>
 
     <ui5-daterange-picker
         value="02/2024 - 07/2024"
-        format-pattern="MM/yyyy"
+        value-format="MM/yyyy"
+        display-format="MM/yyyy"
     >
     </ui5-daterange-picker>
 
     <ui5-daterange-picker
         value="2024 - 2028"
-        format-pattern="yyyy"
+        value-format="yyyy"
+        display-format="yyyy"
     >
     </ui5-daterange-picker>
 
     <ui5-daterange-picker
-        format-pattern="long"
+        value-format="long"
+        display-format="long"
         value="March 31, 2023 - April 9, 2023"
     >
     </ui5-daterange-picker>

--- a/packages/website/docs/_samples/main/DateRangePicker/MinMax/sample.html
+++ b/packages/website/docs/_samples/main/DateRangePicker/MinMax/sample.html
@@ -12,7 +12,8 @@
     <!-- playground-fold-end -->
 
     <ui5-daterange-picker
-        format-pattern="dd/MM/yyyy"
+        value-format="dd/MM/yyyy"
+        display-format="dd/MM/yyyy"
         min-date="1/2/2024"
         max-date="1/7/2024"
     >

--- a/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/sample.html
+++ b/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/sample.html
@@ -28,7 +28,7 @@
 				<ui5-option data-timezone="Australia/Sydney">Australia/Sydney</ui5-option>
 				<ui5-option data-timezone="Pacific/Apia">Pacific/Apia</ui5-option>
 			</ui5-select>
-			<ui5-datetime-picker id="dtp" format-pattern="medium" value="today"></ui5-datetime-picker>
+			<ui5-datetime-picker id="dtp" value-format="medium" display-format="medium" value="today"></ui5-datetime-picker>
 		</div>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.html
+++ b/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.html
@@ -12,17 +12,20 @@
     <!-- playground-fold-end -->
 
     <ui5-datetime-picker
-        format-pattern="dd/MM/yyyy, hh:mm"
+        value-format="dd/MM/yyyy, hh:mm"
+        display-format="dd/MM/yyyy, hh:mm"
     >
     </ui5-datetime-picker>
 
     <ui5-datetime-picker
-        format-pattern="dd/MM/yyyy, hh:mm:ss aa"
+        value-format="dd/MM/yyyy, hh:mm:ss aa"
+        display-format="dd/MM/yyyy, hh:mm:ss aa"
     >
     </ui5-datetime-picker>
 
     <ui5-datetime-picker
-        format-pattern="long"
+        value-format="long"
+        display-format="long"
     >
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.tsx
@@ -6,11 +6,11 @@ const DateTimePicker = createReactComponent(DateTimePickerClass);
 function App() {
   return (
     <>
-      <DateTimePicker formatPattern="dd/MM/yyyy, hh:mm" />
+      <DateTimePicker valueFormat="dd/MM/yyyy, hh:mm" displayFormat="dd/MM/yyyy, hh:mm" />
 
-      <DateTimePicker formatPattern="dd/MM/yyyy, hh:mm:ss aa" />
+      <DateTimePicker valueFormat="dd/MM/yyyy, hh:mm:ss aa" displayFormat="dd/MM/yyyy, hh:mm:ss aa" />
 
-      <DateTimePicker formatPattern="long" />
+      <DateTimePicker valueFormat="long" displayFormat="long" />
     </>
   );
 }

--- a/packages/website/docs/_samples/main/DateTimePicker/MinMax/sample.html
+++ b/packages/website/docs/_samples/main/DateTimePicker/MinMax/sample.html
@@ -13,7 +13,8 @@
 
     <ui5-datetime-picker
         value="Jan 11, 2020, 11:11:11 AM"
-        format-pattern="long"
+        value-format="long"
+        display-format="long"
         min-date="Jan 11, 2020, 00:00:00 AM"
         max-date="Jan 31, 2020, 11:59:59 PM"
     >

--- a/packages/website/docs/_samples/main/FileUploader/WithoutInput/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/WithoutInput/sample.tsx
@@ -13,7 +13,7 @@ function App() {
     <>
       <Label for="button-only-uploader">Choose file:</Label>
       <FileUploader id="button-only-uploader" hideInput={true}>
-        <Button icon="upload" tabIndex="-1">
+        <Button icon="upload" tabIndex={-1}>
           Upload
         </Button>
       </FileUploader>

--- a/packages/website/docs/_samples/main/Input/ValueHelpDialog/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/ValueHelpDialog/sample.tsx
@@ -24,7 +24,7 @@ const Title = createReactComponent(TitleClass);
 function App() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [suggestionItems, setSuggestionItems] = useState<string[]>([]);
-  const [dialogListItems, setDialogListItems] = useState<{ name: string }[]>([]);
+  const [dialogListItems, setDialogListItems] = useState<{ name: string, productId: string }[]>([]);
   const [dialogSearchValue, setDialogSearchValue] = useState("");
   const valueHelpInputRef = useRef(null);
   const productsRef = useRef(null);

--- a/packages/website/docs/_samples/main/List/MultipleDrag/sample.tsx
+++ b/packages/website/docs/_samples/main/List/MultipleDrag/sample.tsx
@@ -42,7 +42,7 @@ function App() {
   };
 
   const handleDragStart1 = (e: DragEvent) => {
-    const draggedId = e.currentTarget.dataset?.id;
+    const draggedId = (e.currentTarget as HTMLElement).dataset?.id;
     if (!draggedId) return;
 
     if (!selected1.has(draggedId)) {
@@ -55,7 +55,7 @@ function App() {
   };
 
   const handleDragStart2 = (e: DragEvent) => {
-    const draggedId = e.currentTarget.dataset?.id;
+    const draggedId = (e.currentTarget as HTMLElement).dataset?.id;
     if (!draggedId) return;
 
     if (!selected2.has(draggedId)) {

--- a/packages/website/docs/_samples/main/MultiInput/TokenCreation/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiInput/TokenCreation/sample.tsx
@@ -42,7 +42,7 @@ function App() {
 
   const handlePaste = (e: ClipboardEvent) => {
     e.preventDefault();
-    const pastedText = (e.clipboardData || window.clipboardData).getData(
+    const pastedText = e.clipboardData.getData(
       "text/plain",
     );
     if (!pastedText) {

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor); height: 250px;">
 <!-- playground-fold-end -->
 
-<ui5-tabcontainer fixed id="tabContainer">
+<ui5-tabcontainer id="tabContainer">
     <ui5-tab id="tab1" text="Tab 1" movable></ui5-tab>
     <ui5-tab id="tab2" text="Tab 2" movable></ui5-tab>
     <ui5-tab id="tab3" text="Tab 3" movable>

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.tsx
@@ -57,7 +57,7 @@ function App() {
 
   return (
     <>
-      <TabContainer fixed id="tabContainer" ref={tabContainerRef}>
+      <TabContainer id="tabContainer" ref={tabContainerRef}>
         <Tab id="tab1" text="Tab 1" movable={true} />
         <Tab id="tab2" text="Tab 2" movable={true} />
         <Tab id="tab3" text="Tab 3" movable={true}>

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor); height: 250px;">
 <!-- playground-fold-end -->
 
-<ui5-tabcontainer fixed id="tabContainer">
+<ui5-tabcontainer id="tabContainer">
     <ui5-tab design="Positive" text="One" data-fixed="true"></ui5-tab>
     <ui5-tab design="Negative" text="Two" data-fixed="true"></ui5-tab>
     <ui5-tab design="Critical" text="Three" data-fixed="true"></ui5-tab>

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.tsx
@@ -65,7 +65,7 @@ function App() {
 
   return (
     <>
-      <TabContainer fixed id="tabContainer" ref={tabContainerRef}>
+      <TabContainer id="tabContainer" ref={tabContainerRef}>
         <Tab design="Positive" text="One" data-fixed="true" />
         <Tab design="Negative" text="Two" data-fixed="true" />
         <Tab design="Critical" text="Three" data-fixed="true" />

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabsMaxNestingLevel/sample.html
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabsMaxNestingLevel/sample.html
@@ -11,7 +11,7 @@
 <ui5-label show-colon for="maxNestingLevelInput">Max nesting level</ui5-label>
 <ui5-step-input id="maxNestingLevelInput" placeholder="maxNestingLevel" value="1" min="1" style="width: 5rem"></ui5-step-input>
 
-<ui5-tabcontainer fixed id="tabContainer">
+<ui5-tabcontainer id="tabContainer">
     <ui5-tab id="tab1" text="Tab 1" movable></ui5-tab>
     <ui5-tab id="tab2" text="Tab 2" movable></ui5-tab>
     <ui5-tab id="tab3" text="Tab 3" movable>

--- a/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
@@ -22,7 +22,7 @@ function App() {
 
   const handleTableRowClick = (e: UI5CustomEvent<TableClass, "row-click">) => {
     if (toastRef.current) {
-      toastRef.current!.textContent = `Row with key "${e.detail.row.key}" was pressed!`;
+      toastRef.current!.textContent = `Row with key "${e.detail.row.rowKey}" was pressed!`;
       toastRef.current!.open = true;
     }
   };

--- a/packages/website/docs/_samples/main/Table/Popin/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Popin/sample.tsx
@@ -50,7 +50,7 @@ function App() {
     e: UI5CustomEvent<SegmentedButtonClass, "selection-change">,
   ) => {
     const selectedItem = e.detail.selectedItems[0];
-    setPopinState(selectedItem.tooltip === "Hide Details");
+    setPopinState((selectedItem as SegmentedButtonItemClass).tooltip === "Hide Details");
   };
 
   return (

--- a/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { FormEvent, useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
@@ -56,15 +56,15 @@ function App() {
     oldSelectedSetRef.current = newSelectedSet;
   };
 
-  const handleSelectionBehaviorChange = (e: Event) => {
+  const handleSelectionBehaviorChange = (e: FormEvent) => {
     if (selectionRef.current) {
-      selectionRef.current!.behavior = e.currentTarget.text;
+      selectionRef.current!.behavior = (e.currentTarget as RadioButtonClass).text;
     }
   };
 
-  const handleHeaderSelectorChange = (e: Event) => {
+  const handleHeaderSelectorChange = (e: FormEvent) => {
     if (selectionRef.current) {
-      selectionRef.current!.headerSelector = e.currentTarget.text;
+      selectionRef.current!.headerSelector = (e.currentTarget as RadioButtonClass).text;
     }
   };
 

--- a/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { FormEvent, useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
@@ -31,9 +31,9 @@ function App() {
     }
   };
 
-  const handleSelectionBehaviorChange = (e: Event) => {
+  const handleSelectionBehaviorChange = (e: FormEvent) => {
     if (selectionRef.current) {
-      selectionRef.current!.behavior = e.currentTarget.text;
+      selectionRef.current!.behavior = (e.currentTarget as RadioButtonClass).text;
     }
   };
 

--- a/packages/website/docs/_samples/patterns/AIAcknowledgement/ScrollToAccept/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIAcknowledgement/ScrollToAccept/sample.tsx
@@ -49,7 +49,7 @@ function App() {
   }, []);
 
   const handleTermsPanelScroll = useCallback((e: Event) => {
-    const panel = e.currentTarget;
+    const panel = e.currentTarget as PanelClass;
     const scrollTop = panel.scrollTop;
     const clientHeight = panel.clientHeight;
     const scrollHeight = panel.scrollHeight;

--- a/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/sample.tsx
@@ -287,6 +287,7 @@ function App() {
           <img
             src="https://ui5.github.io/webcomponents/images/avatars/woman_avatar_1.png"
             slot="avatar"
+			alt="Monique Legrand"
           />
         </CardHeader>
         <section className="guidedPromptSection">

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -25,6 +25,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
+    "typecheck:samples": "cd docs/_samples && tsc --noEmit",
     "ci:build": "yarn build",
     "ci:build:nightly": "yarn build:with:cdn",
     "ci:build:preview": "yarn build:with:cdn"

--- a/packages/website/src/components/Editor/monaco-ui5-types.d.ts
+++ b/packages/website/src/components/Editor/monaco-ui5-types.d.ts
@@ -2149,6 +2149,9 @@ interface UploadCollectionProps extends UI5BaseProps {
   eventDetails?: any;
   onItemDelete?: (event: UI5CustomEvent<UploadCollectionProps>) => void;
   onSelectionChange?: (event: UI5CustomEvent<UploadCollectionProps>) => void;
+  onRename?: (event: UI5CustomEvent<UploadCollectionProps>) => void;
+  onRetry?: (event: UI5CustomEvent<UploadCollectionProps>) => void;
+  onTerminate?: (event: UI5CustomEvent<UploadCollectionProps>) => void;
 }
 
 /** UploadCollectionItem component props */
@@ -4460,6 +4463,9 @@ declare module "@ui5/webcomponents-fiori/dist/UploadCollection.js" {
     eventDetails: {
       "item-delete": { item: any };
       "selection-change": { selectedItems: any };
+      "rename": void;
+      "retry": void;
+      "terminate": void;
     };
   }
   export default UploadCollection;


### PR DESCRIPTION
## Summary
- **Fixed all 83 TypeScript errors** across 60 React `sample.tsx` files. These errors accumulated silently because samples are loaded via `raw-loader` as plain text — even completely broken syntax compiles fine during the website build.
- **Added a `typecheck:samples` CI step** to the website workflow so that any new TypeScript error in a React sample will fail the PR check going forward.

### What was fixed
- Mismatched prop types (wrong enum string literals, missing required props)
- Incorrect event handler signatures (`UI5CustomEvent` type mismatches)
- Wrong HTML attribute types (`min-date`, `max-date` as `Date` instead of string)
- Missing component type declarations in `monaco-ui5-types.d.ts`
- JSX issues (wrong slot types, invalid prop combinations)

### CI change
A new step **"Typecheck React samples"** runs `tsc --noEmit` against `docs/_samples/tsconfig.json` after the website build:
```yaml
- name: Typecheck React samples
  run: yarn workspace @ui5/webcomponents-website typecheck:samples
```

## Test plan
- [x] `yarn typecheck:samples` passes locally with 0 errors
- [ ] CI website workflow passes on this PR