### PR TITLE
fix(release): correct changelog extraction regex

### DIFF
--- a/.github/actions/extractChangelog.mjs
+++ b/.github/actions/extractChangelog.mjs
@@ -8,7 +8,7 @@ import { promises as fs } from 'node:fs';
  */
 const extractVersionChangelog = (changelog, version) => {
 	const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	const regex = new RegExp(`^# \\[${escapedVersion}\\].*?\\n([\\s\\S]*?)(?=^# \\[|$)`, 'm');
+	const regex = new RegExp(`^# \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n# \\[|$(?!\\n))`, 'm');
 	const match = changelog.match(regex);
 
 	if (match) {


### PR DESCRIPTION
## Summary
- Fixes the regex in `extractChangelog.mjs` that caused all 2.20.x GitHub releases to have empty release notes
- The `m` (multiline) flag makes `$` match end of every line; combined with the lazy `([\s\S]*?)` capture group, the lookahead `(?=^# \[|$)` immediately matches at the next end-of-line, returning an empty string every time
- Changed lookahead to `(?=\n# \[|$(?!\n))` so `$` only matches the true end of string

## Test plan
- [ ] Verify the regex correctly extracts changelog sections by running a test against `CHANGELOG.md`
- [ ] Trigger a release and confirm the GitHub release body is populated