### PR TITLE
feat(ui5-base): store import.meta.url in runtime registration data

### DIFF
--- a/packages/base/src/Runtimes.ts
+++ b/packages/base/src/Runtimes.ts
@@ -6,6 +6,7 @@ import getSharedResource from "./getSharedResource.js";
 type RuntimeData = VersionInfo & {
 	alias: string,
 	description: string,
+	importMetaUrl: string,
 };
 
 let currentRuntimeIndex: number;
@@ -41,6 +42,7 @@ const registerCurrentRuntime = () => {
 			},
 			alias: currentRuntimeAlias,
 			description: `Runtime ${currentRuntimeIndex} - ver ${versionInfo.version}${currentRuntimeAlias ? ` (${currentRuntimeAlias})` : ""}`,
+			importMetaUrl: import.meta.url,
 		});
 	}
 };


### PR DESCRIPTION
## Summary
- Adds `importMetaUrl: string` field to the `RuntimeData` type
- Captures `import.meta.url` during runtime registration so each runtime records the module URL it was loaded from
- Enables tracing which bundle or network request a runtime originates from when multiple runtimes coexist on a page

## Test plan
- [ ] Verify `yarn build` succeeds with no TypeScript errors
- [ ] Inspect registered runtimes and confirm `importMetaUrl` is populated with the correct module URL
- [ ] Test with multiple runtimes on a single page to confirm each records its own module URL