### PR TITLE
fix(ui5-user-menu): prevent title flickering in header on open

### DIFF
--- a/packages/fiori/src/UserMenu.ts
+++ b/packages/fiori/src/UserMenu.ts
@@ -288,21 +288,25 @@ class UserMenu extends UI5Element {
 	}
 
 	onAfterRendering(): void {
-		if (this._responsivePopover) {
-			const observerOptions = {
-				threshold: [0.15],
-			};
+		if (this._responsivePopover && this.open && !this._observer) {
+			this._setupObserver();
+		}
+	}
 
-			this._observer?.disconnect();
-			this._observer = new IntersectionObserver(entries => this._handleIntersection(entries), observerOptions);
+	_setupObserver() {
+		const observerOptions = {
+			threshold: [0.15],
+		};
 
-			if (this._selectedAccountTitleEl) {
-				this._observer.observe(this._selectedAccountTitleEl);
-			}
+		this._observer?.disconnect();
+		this._observer = new IntersectionObserver(entries => this._handleIntersection(entries), observerOptions);
 
-			if (this._selectedAccountManageBtn) {
-				this._observer.observe(this._selectedAccountManageBtn);
-			}
+		if (this._selectedAccountTitleEl) {
+			this._observer.observe(this._selectedAccountTitleEl);
+		}
+
+		if (this._selectedAccountManageBtn) {
+			this._observer.observe(this._selectedAccountManageBtn);
 		}
 	}
 
@@ -390,10 +394,17 @@ class UserMenu extends UI5Element {
 	}
 
 	_handlePopoverAfterOpen() {
+		this._titleMovedToHeader = false;
+		this._isScrolled = false;
+		this._setupObserver();
 		this.fireDecoratorEvent("open");
 	}
 
 	_handlePopoverAfterClose() {
+		this._observer?.disconnect();
+		this._observer = undefined;
+		this._titleMovedToHeader = false;
+		this._isScrolled = false;
 		this.open = false;
 		this.fireDecoratorEvent("close");
 	}


### PR DESCRIPTION
## Summary
- Set up `IntersectionObserver` only after the popover fully opens (`_handlePopoverAfterOpen`) instead of on every `onAfterRendering` cycle
- Reset `_titleMovedToHeader` and `_isScrolled` state on open/close to prevent stale intersection callbacks from briefly showing the header title
- Disconnect and clean up the observer on popover close

## Root Cause
The `IntersectionObserver` was recreated on every render. During the popover opening animation, the observer would fire with the title element reported as not intersecting (since the popover hadn't finished layout), setting `_titleMovedToHeader = true` and causing the title to briefly appear in the header bar before being hidden again.

## Test plan
- [x] Open UserMenu — title should **not** flicker in the header bar
- [x] Scroll down in a UserMenu with many items — title should appear in the header bar
- [x] Scroll back up — title should disappear from the header bar
- [x] Close and reopen — no stale state, no flickering

Fixes #12874