### PR TITLE
fix(release): prevent hotfix releases from being marked as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -287,6 +287,7 @@ jobs:
               tag_name: `v${version}`,
               name: `v${version}`,
               body: changelog,
+              make_latest: 'false',
             });
 
       - name: Publish


### PR DESCRIPTION
## Summary
- Hotfix releases (patches on older versions) were incorrectly marked as the "Latest" GitHub release, which is misleading since they are not the most recent mainline version.
- Added `make_latest: 'false'` to the `createRelease` API call in the hotfix release job to prevent this.

## Test plan
- [ ] Trigger a hotfix release and verify the GitHub release is **not** tagged as "Latest"
- [ ] Verify stable releases still get the "Latest" tag as before