### PR TITLE
fix(release): correct changelog extraction regex in extractChangelog.mjs

### DIFF
--- a/.github/actions/extractChangelog.mjs
+++ b/.github/actions/extractChangelog.mjs
@@ -8,7 +8,7 @@ import { promises as fs } from 'node:fs';
  */
 const extractVersionChangelog = (changelog, version) => {
 	const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	const regex = new RegExp(`^# \\[${escapedVersion}\\].*?\\n([\\s\\S]*?)(?=^# \\[|$)`, 'm');
+	const regex = new RegExp(`^# \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n# \\[|$(?!\\n))`, 'm');
 	const match = changelog.match(regex);
 
 	if (match) {


### PR DESCRIPTION
## Summary
- Fixed the regex in `extractChangelog.mjs` that extracts version-specific changelog entries during releases.
- The previous regex (`^# \[...\].*?\n`) could match greedily across section boundaries. The new regex (`^# \[...\][^\n]*\n`) anchors properly to a single heading line and uses a more precise lookahead (`\n# \[` or true end-of-string) to correctly delimit each version's changelog block.

## Test plan
- [ ] Trigger a release and verify the GitHub release body contains only the correct version's changelog (no content from adjacent versions leaking in)