### PR TITLE
chore: add Dependabot for @sap-theming/theming-base-content updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "@sap-theming/theming-base-content"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable weekly automated dependency update PRs for `@sap-theming/theming-base-content`.
- Scoped with `allow` to only this dependency — no other packages will be bumped by Dependabot.

## Test plan
- [ ] Verify Dependabot creates a PR when a new version of `@sap-theming/theming-base-content` is available