### PR TITLE
fix(ui5-calendar): make header text accessible

### DIFF
--- a/packages/main/src/DayPickerTemplate.tsx
+++ b/packages/main/src/DayPickerTemplate.tsx
@@ -24,7 +24,7 @@ export default function DayPickerTemplate(this: DayPicker) {
 							aria-label={day.ultraShortName ? day.name : undefined}
 							class={day.classes}
 						>
-							{day.ultraShortName ? day.ultraShortName : <span aria-hidden="true" class="ui5-hidden-text">{day.name}</span>}
+							{day.ultraShortName ? day.ultraShortName : <span class="ui5-hidden-text">{day.name}</span>}
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
Fixes axe issue `empty-table-header` - The calendar week column header is now reachable with JAWS in reading mode. 