### PR TITLE
docs(ui5-dynamic-page-title): add transparent design to toolbars in test pages

### DIFF
--- a/packages/fiori/test/pages/DynamicPageWithFullscreenContent.html
+++ b/packages/fiori/test/pages/DynamicPageWithFullscreenContent.html
@@ -73,11 +73,11 @@
                     <ui5-option value="templateTableGrowingWithScroll">Table growing with scroll</ui5-option>
                 </ui5-select>
 
-                <ui5-toolbar slot="actionsBar">
+                <ui5-toolbar slot="actionsBar" design="Transparent">
                     <ui5-toolbar-button id="toggleFooterBtn" text="Toggle Footer" overflow-priority="NeverOverflow"></ui5-toolbar-button>
                 </ui5-toolbar>
 
-                <ui5-toolbar slot="navigationBar">
+                <ui5-toolbar slot="navigationBar" design="Transparent">
                     <ui5-toolbar-button icon="full-screen"></ui5-toolbar-button>
                     <ui5-toolbar-button icon="decline"></ui5-toolbar-button>
                 </ui5-toolbar>

--- a/packages/fiori/test/pages/DynamicPage_test.html
+++ b/packages/fiori/test/pages/DynamicPage_test.html
@@ -58,13 +58,13 @@
                     >
                 </div>
 
-                <ui5-toolbar style="border: none" align-content="Start">
+                <ui5-toolbar style="border: none" align-content="Start" design="Transparent">
                     <ui5-toolbar-button design="Transparent" overflow-priority="NeverOverflow"
                         text="KPI Generic tag"
                     ></ui5-toolbar-button>
                 </ui5-toolbar>
 
-                <ui5-toolbar id="actionsToolbar" slot="actionsBar">
+                <ui5-toolbar id="actionsToolbar" slot="actionsBar" design="Transparent">
                     <ui5-toolbar-button design="Transparent" id="toggleFooterBtn" text="Toggle Footer"></ui5-toolbar-button>
                     <ui5-toolbar-button design="Transparent" text="Edit" overflow-priority="NeverOverflow"></ui5-toolbar-button>
                     <ui5-toolbar-button design="Transparent" icon="delete"></ui5-toolbar-button>
@@ -72,7 +72,7 @@
                     <ui5-toolbar-button design="Transparent" icon="share"></ui5-toolbar-button>
                 </ui5-toolbar>
 
-                <ui5-toolbar slot="navigationBar">
+                <ui5-toolbar slot="navigationBar" design="Transparent">
                     <ui5-toolbar-button design="Transparent" icon="full-screen"></ui5-toolbar-button>
                     <ui5-toolbar-button design="Transparent" icon="decline"></ui5-toolbar-button>
                 </ui5-toolbar>


### PR DESCRIPTION
Added design="Transparent" attribute to toolbars in actionsBar and navigationBar slots in DynamicPage test pages to ensure visual consistency across themes.

Fixes: https://github.com/UI5/webcomponents/issues/13253