### PR TITLE
fix(ui5-li): implement edit mode for keyboard navigation in list items

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -13,6 +13,7 @@ import Select from "../../src/Select.js";
 import Option from "../../src/Option.js";
 import CheckBox from "../../src/CheckBox.js";
 import Bar from "../../src/Bar.js";
+import Link from "../../src/Link.js";
 
 function getGrowingWithScrollList(length: number, height: string = "100px") {
 	return (
@@ -1201,7 +1202,7 @@ describe("List Tests", () => {
 		cy.get("@itemDeleteStub").should("have.been.calledWith", Cypress.sinon.match.has("detail", Cypress.sinon.match.has("item")));
 	});
 
-	it("selectionMode: delete. Tab key moves focus to delete button", () => {
+	it("selectionMode: delete. F2 + Tab reaches delete button", () => {
 		cy.mount(
 			<div>
 				<button>Before button</button>
@@ -1221,8 +1222,13 @@ describe("List Tests", () => {
 		cy.get("[ui5-li]").first().click();
 		cy.get("[ui5-li]").first().should("be.focused");
 
-		// Tab should move focus to the delete button inside the first item
+		// Tab in navigation mode should forward out — not reach delete button
 		cy.realPress("Tab");
+		cy.get("button").last().should("be.focused");
+
+		// Re-focus item, then F2 to enter edit mode
+		cy.get("[ui5-li]").first().click();
+		cy.realPress("F2");
 		cy.get("[ui5-li]")
 			.first()
 			.shadow()
@@ -1232,18 +1238,6 @@ describe("List Tests", () => {
 		// Enter on the focused delete button should trigger deletion
 		cy.realPress("Enter");
 		cy.get("@itemDeleteStub").should("have.been.calledOnce");
-
-		// Tab again from delete button should move focus out of the item
-		cy.get("[ui5-li]").first().click();
-		cy.realPress("Tab");
-		cy.get("[ui5-li]")
-			.first()
-			.shadow()
-			.find("[ui5-button]")
-			.should("be.focused");
-
-		cy.realPress("Tab");
-		cy.get("button").last().should("be.focused");
 	});
 
 	it("selectionMode: delete. F2 toggles focus to delete button", () => {
@@ -1385,16 +1379,7 @@ describe("List Tests", () => {
 		cy.get("[ui5-li-custom]").first().click();
 		cy.get("[ui5-li-custom]").first().should("be.focused");
 
-		cy.realPress("Tab");
-		cy.get("[ui5-li-custom]").first().find("button").first().should("be.focused");
-
-		cy.realPress("Tab");
-		cy.get("[ui5-li-custom]").first().find("a").should("be.focused");
-
-		cy.realPress("Tab");
-		cy.get("[ui5-li-custom]").first().find("input[type='radio']").should("be.focused");
-
-		cy.get("[ui5-li]").first().click();
+		// Tab forwards out of item (navigation mode) — internal elements require F2
 		cy.realPress("Tab");
 		cy.get("[ui5-list]")
 			.shadow()
@@ -1452,15 +1437,15 @@ describe("List Tests", () => {
 		cy.get("[ui5-li-custom]").realClick();
 		cy.get("[ui5-li-custom]").should("be.focused");
 
-		// F7 goes to first focusable element
+		// F7 goes to first focusable element (enters edit mode)
 		cy.realPress("F7");
 		cy.get("[ui5-button]").first().should("be.focused");
 
-		// Tab to second button
+		// Tab to second button (edit mode allows cycling)
 		cy.realPress("Tab");
 		cy.get("[ui5-button]").last().should("be.focused");
 
-		// F7 returns to list item
+		// F7 returns to list item (exits edit mode)
 		cy.realPress("F7");
 		cy.get("[ui5-li-custom]").should("be.focused");
 
@@ -1489,11 +1474,11 @@ describe("List Tests", () => {
 		cy.realPress("Tab");
 		cy.get("[ui5-li-custom]").should("be.focused");
 
-		// Tab into internal elements (goes to first button)
-		cy.realPress("Tab");
+		// F7 to enter internal elements (enables edit mode)
+		cy.realPress("F7");
 		cy.get("[ui5-button]").first().should("be.focused");
 
-		// Tab to second button
+		// Tab to second button (edit mode allows cycling)
 		cy.realPress("Tab");
 		cy.get("[ui5-button]").last().should("be.focused");
 
@@ -1526,11 +1511,11 @@ describe("List Tests", () => {
 		cy.get("[ui5-li-custom]").first().realClick();
 		cy.get("[ui5-li-custom]").first().should("be.focused");
 
-		// F7 to enter (should go to first button)
+		// F7 to enter (should go to first button, enables edit mode)
 		cy.realPress("F7");
 		cy.get("[ui5-button]").eq(0).should("be.focused");
 
-		// Tab to second button
+		// Tab to second button (edit mode allows cycling)
 		cy.realPress("Tab");
 		cy.get("[ui5-button]").eq(1).should("be.focused");
 
@@ -1745,9 +1730,7 @@ describe("List Tests", () => {
 		cy.get("[ui5-li]").eq(1).click();
 		cy.get("[ui5-li]").eq(1).should("be.focused");
 
-		cy.realPress("Tab");
-		cy.get("ui5-breadcrumbs").should("be.focused");
-
+		// Tab forwards out of item (navigation mode) — internal Breadcrumbs requires F2
 		cy.realPress("Tab");
 		cy.get("[ui5-button]").should("be.focused");
 	});
@@ -2741,5 +2724,328 @@ describe("List sticky header", () => {
 						expect(headerTopAfter).to.eq(headerTopBefore);
 					});
 			});
+	});
+});
+
+describe("Edit mode (F2) with Delete selection mode", () => {
+	it("F2 enters edit mode and Tab cycles to delete button", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard>Item 1</ListItemStandard>
+				<ListItemStandard>Item 2</ListItemStandard>
+			</List>
+		);
+
+		// Focus first item
+		cy.get("[ui5-li]").first().realClick();
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// F2 enters edit mode - focus moves to first focusable element
+		cy.realPress("F2");
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// F2 again exits edit mode - focus returns to list item
+		cy.realPress("F2");
+		cy.get("[ui5-li]").first().should("be.focused");
+	});
+
+	it("Tab in non-edit delete mode forwards to next item", () => {
+		cy.mount(
+			<div>
+				<List selectionMode="Delete">
+					<ListItemStandard>Item 1</ListItemStandard>
+					<ListItemStandard>Item 2</ListItemStandard>
+				</List>
+				<button>After</button>
+			</div>
+		);
+
+		// Focus first item (not in edit mode)
+		cy.get("[ui5-li]").first().realClick();
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// Tab should move focus out of list (forward-after), not to delete button
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first().should("not.be.focused");
+	});
+
+	it("Tab cycles through focusable elements in edit mode", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard>Item 1</ListItemStandard>
+				<ListItemStandard>Item 2</ListItemStandard>
+			</List>
+		);
+
+		// Focus first item and enter edit mode
+		cy.get("[ui5-li]").first().realClick();
+		cy.realPress("F2");
+
+		// First focusable (delete button) should be focused
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Tab should cycle back (only one focusable element)
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+	});
+
+	it("F7 exits edit mode and returns focus to list item", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard>Item 1</ListItemStandard>
+				<ListItemStandard>Item 2</ListItemStandard>
+			</List>
+		);
+
+		// Focus first item, enter edit mode via F2
+		cy.get("[ui5-li]").first().realClick();
+		cy.realPress("F2");
+
+		// Delete button should be focused
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// F7 returns focus to the list item and exits edit mode
+		cy.realPress("F7");
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// Tab should forward (not cycle), confirming edit mode is off
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first().should("not.be.focused");
+	});
+
+	it("Arrow Down/Up transfers edit mode to adjacent items", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard>Item 1</ListItemStandard>
+				<ListItemStandard>Item 2</ListItemStandard>
+				<ListItemStandard>Item 3</ListItemStandard>
+			</List>
+		);
+
+		// Focus first item and enter edit mode
+		cy.get("[ui5-li]").first().realClick();
+		cy.realPress("F2");
+
+		// Delete button of first item should be focused
+		cy.get("[ui5-li]").eq(0)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Down moves to delete button of second item
+		cy.realPress("ArrowDown");
+		cy.get("[ui5-li]").eq(1)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Tab still cycles (edit mode was transferred) — single focusable, stays put
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").eq(1)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Down again to third item
+		cy.realPress("ArrowDown");
+		cy.get("[ui5-li]").eq(2)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Down at boundary does nothing — stays on third item
+		cy.realPress("ArrowDown");
+		cy.get("[ui5-li]").eq(2)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Up goes back to second item
+		cy.realPress("ArrowUp");
+		cy.get("[ui5-li]").eq(1)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Up to first item
+		cy.realPress("ArrowUp");
+		cy.get("[ui5-li]").eq(0)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Arrow Up at boundary does nothing — stays on first item
+		cy.realPress("ArrowUp");
+		cy.get("[ui5-li]").eq(0)
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// F2 exits edit mode from any item
+		cy.realPress("F2");
+		cy.get("[ui5-li]").eq(0).should("be.focused");
+	});
+
+	it("focus-out clears edit mode", () => {
+		cy.mount(
+			<div>
+				<List selectionMode="Delete">
+					<ListItemStandard>Item 1</ListItemStandard>
+				</List>
+				<button>Outside</button>
+			</div>
+		);
+
+		// Focus item and enter edit mode
+		cy.get("[ui5-li]").first().realClick();
+		cy.realPress("F2");
+
+		// Delete button should be focused
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Click outside to move focus away
+		cy.get("button").contains("Outside").realClick();
+
+		// Re-focus the list item
+		cy.get("[ui5-li]").first().realClick();
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// Tab should forward (not cycle), confirming edit mode was cleared
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first().should("not.be.focused");
+	});
+
+	it("complete edit mode workflow with complex list items", () => {
+		// Complex list: ListItemCustom with multiple interactive elements,
+		// standard items, and a custom delete button slot
+		cy.mount(
+			<div>
+				<button id="before">Before</button>
+				<List selectionMode="Delete">
+					<ListItemCustom>
+						<Button id="action1">Action 1</Button>
+						<Link>SAP Link</Link>
+						<Button id="action2">Action 2</Button>
+					</ListItemCustom>
+					<ListItemStandard>Simple Item</ListItemStandard>
+					<ListItemStandard>
+						Item with custom delete
+						<div slot="deleteButton">
+							<Button id="customDel">Custom Delete</Button>
+						</div>
+					</ListItemStandard>
+				</List>
+				<button id="after">After</button>
+			</div>
+		);
+
+		// === Step 1: Focus first custom item ===
+		cy.get("[ui5-li-custom]").realClick();
+		cy.get("[ui5-li-custom]").should("be.focused");
+
+		// === Step 2: Enter edit mode with F2 ===
+		cy.realPress("F2");
+		// First focusable inside the custom item (Action 1 button) should be focused
+		cy.get("#action1").should("be.focused");
+
+		// === Step 3: Tab cycles through all internal elements ===
+		cy.realPress("Tab");
+		cy.get("[ui5-link]").should("be.focused");
+
+		cy.realPress("Tab");
+		cy.get("#action2").should("be.focused");
+
+		// Next Tab should reach the delete button in shadow DOM
+		cy.realPress("Tab");
+		cy.get("[ui5-li-custom]")
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Tab wraps back to first element (Action 1)
+		cy.realPress("Tab");
+		cy.get("#action1").should("be.focused");
+
+		// === Step 4: Shift+Tab cycles backward ===
+		cy.realPress(["Shift", "Tab"]);
+		cy.get("[ui5-li-custom]")
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		cy.realPress(["Shift", "Tab"]);
+		cy.get("#action2").should("be.focused");
+
+		// === Step 5: Arrow Down transfers edit mode to next item ===
+		cy.realPress("ArrowDown");
+		// Second item (ListItemStandard "Simple Item") should have its
+		// delete button focused (same positional index, clamped)
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Tab should cycle (still in edit mode) — only 1 focusable, stays put
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// === Step 6: Arrow Down to item with custom delete button ===
+		cy.realPress("ArrowDown");
+		// Third item has a custom delete button in the light DOM slot
+		cy.get("#customDel").should("be.focused");
+
+		// === Step 7: Arrow Up goes back, preserving edit mode ===
+		cy.realPress("ArrowUp");
+		cy.get("[ui5-li]").first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// === Step 8: F2 exits edit mode, returns to item level ===
+		cy.realPress("F2");
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// === Step 9: Tab in non-edit delete mode forwards out ===
+		cy.realPress("Tab");
+		cy.get("[ui5-li]").first().should("not.be.focused");
+	});
+
+	it("Shift+Tab in non-edit delete mode forwards to previous item", () => {
+		cy.mount(
+			<div>
+				<button id="before">Before</button>
+				<List selectionMode="Delete">
+					<ListItemStandard>Item 1</ListItemStandard>
+					<ListItemStandard>Item 2</ListItemStandard>
+				</List>
+				<button id="after">After</button>
+			</div>
+		);
+
+		// Focus second item
+		cy.get("[ui5-li]").last().realClick();
+		cy.get("[ui5-li]").last().should("be.focused");
+
+		// Shift+Tab should move focus out of the list (forward-before)
+		cy.realPress(["Shift", "Tab"]);
+		cy.get("[ui5-li]").last().should("not.be.focused");
 	});
 });

--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -153,10 +153,10 @@ describe("List Tests", () => {
 				<ListItemStandard>HP Monitor 24</ListItemStandard>
 			</List>
 		);
-	
+
 		cy.get("[ui5-list]")
 			.as("list");
-	
+
 		cy.get("@list").invoke('prop', 'accessibilityAttributes', {
 			growingButton: {
 				name: "Load more products from catalog"
@@ -167,7 +167,7 @@ describe("List Tests", () => {
 			.shadow()
 			.find("[id$='growing-btn']")
 			.should("have.attr", "aria-label", "Load more products from catalog");
-	
+
 		cy.get("@list")
 			.shadow()
 			.find("[id$='growing-btn']")
@@ -182,7 +182,7 @@ describe("List Tests", () => {
 				<ListItemStandard>Product 3</ListItemStandard>
 			</List>
 		);
-	
+
 		cy.get("[ui5-list]")
 			.as("list");
 
@@ -652,22 +652,22 @@ describe("List Tests", () => {
 				<input placeholder="selectionComponentPressed result" />
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@itemClickStub").should("have.been.calledOnce");
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
-	
+
 		cy.get("[ui5-li]").eq(1)
 			.shadow()
 			.find("ui5-radio-button")
 			.click();
-	
+
 		cy.get("@itemClickStub").should("have.been.calledOnce");
 		cy.get("@selectionChangeStub").should("have.been.calledTwice");
 		cy.get("@selectionChangeStub").should("have.been.calledWith", Cypress.sinon.match.has("detail", Cypress.sinon.match.has("selectionComponentPressed", true)));
@@ -686,14 +686,14 @@ describe("List Tests", () => {
 				<input placeholder="selectionChange result" />
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@itemClickStub").should("have.been.calledOnce");
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 	});
@@ -710,13 +710,13 @@ describe("List Tests", () => {
 				<input placeholder="selectionChange previousSelection result" />
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 		cy.get("@selectionChangeStub").should("have.been.calledWith", Cypress.sinon.match.has("detail", Cypress.sinon.match.has("previouslySelectedItems")));
 		cy.get("[ui5-li]").eq(1).should("exist");
@@ -730,7 +730,7 @@ describe("List Tests", () => {
 				<ListItemStandard selected>China</ListItemStandard>
 			</List>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			const stub = cy.stub().as("selectionChangeStub");
 			stub.callsFake((event) => {
@@ -738,11 +738,11 @@ describe("List Tests", () => {
 			});
 			$list[0].addEventListener("ui5-selection-change", stub);
 		});
-	
+
 		cy.get("[ui5-li]").eq(2).should("have.attr", "selected");
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 		cy.get("[ui5-li]").first().should("not.have.attr", "selected");
 		cy.get("[ui5-li]").eq(2).should("have.attr", "selected");
@@ -756,7 +756,7 @@ describe("List Tests", () => {
 				<ListItemStandard selected>China</ListItemStandard>
 			</List>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			const stub = cy.stub().as("selectionChangeStub");
 			stub.callsFake((event) => {
@@ -764,13 +764,13 @@ describe("List Tests", () => {
 			});
 			$list[0].addEventListener("ui5-selection-change", stub);
 		});
-	
+
 		cy.get("[ui5-li]").first().should("not.have.attr", "selected");
 		cy.get("[ui5-li]").eq(1).should("have.attr", "selected");
 		cy.get("[ui5-li]").eq(2).should("have.attr", "selected");
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 		cy.get("[ui5-li]").first().should("not.have.attr", "selected");
 		cy.get("[ui5-li]").eq(1).should("have.attr", "selected");
@@ -1129,35 +1129,35 @@ describe("List Tests", () => {
 				<label>0</label>
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-item-delete", cy.stub().as("itemDeleteStub"));
 		});
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.click();
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.should("not.have.attr", "selected");
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.shadow()
 			.find("ui5-button")
 			.should("exist");
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.shadow()
 			.find("ui5-button")
 			.click();
-	
+
 		cy.get("@itemDeleteStub").should("have.been.calledOnce");
 		cy.get("@itemDeleteStub").should("have.been.calledWith", Cypress.sinon.match.has("detail", Cypress.sinon.match.has("item")));
 	});
@@ -1180,25 +1180,95 @@ describe("List Tests", () => {
 				<label>0</label>
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-item-delete", cy.stub().as("itemDeleteStub"));
 		});
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.click();
-	
+
 		cy.get("[ui5-list]")
 			.find("ui5-li")
 			.first()
 			.should("not.have.attr", "selected");
-	
+
 		cy.realPress("Delete");
-	
+
 		cy.get("@itemDeleteStub").should("have.been.calledOnce");
 		cy.get("@itemDeleteStub").should("have.been.calledWith", Cypress.sinon.match.has("detail", Cypress.sinon.match.has("item")));
+	});
+
+	it("selectionMode: delete. Tab key moves focus to delete button", () => {
+		cy.mount(
+			<div>
+				<button>Before button</button>
+				<List selectionMode="Delete">
+					<ListItemStandard>Laptop HP</ListItemStandard>
+					<ListItemStandard>Laptop Lenovo</ListItemStandard>
+				</List>
+				<button>After button</button>
+			</div>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-delete", cy.stub().as("itemDeleteStub"));
+		});
+
+		// Click first item to focus it
+		cy.get("[ui5-li]").first().click();
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// Tab should move focus to the delete button inside the first item
+		cy.realPress("Tab");
+		cy.get("[ui5-li]")
+			.first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// Enter on the focused delete button should trigger deletion
+		cy.realPress("Enter");
+		cy.get("@itemDeleteStub").should("have.been.calledOnce");
+
+		// Tab again from delete button should move focus out of the item
+		cy.get("[ui5-li]").first().click();
+		cy.realPress("Tab");
+		cy.get("[ui5-li]")
+			.first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		cy.realPress("Tab");
+		cy.get("button").last().should("be.focused");
+	});
+
+	it("selectionMode: delete. F2 toggles focus to delete button", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard>Laptop HP</ListItemStandard>
+				<ListItemStandard>Laptop Lenovo</ListItemStandard>
+			</List>
+		);
+
+		// Click first item to focus it
+		cy.get("[ui5-li]").first().click();
+		cy.get("[ui5-li]").first().should("be.focused");
+
+		// F2 should move focus to the delete button
+		cy.realPress("F2");
+		cy.get("[ui5-li]")
+			.first()
+			.shadow()
+			.find("[ui5-button]")
+			.should("be.focused");
+
+		// F2 again should return focus to the list item
+		cy.realPress("F2");
+		cy.get("[ui5-li]").first().should("be.focused");
 	});
 
 	it("item size and classes, when an item has both text and description", () => {
@@ -1714,16 +1784,16 @@ describe("List Tests", () => {
 				</List>
 			</div>
 		);
-	
+
 		cy.get("[ui5-li]").first().then(($item) => {
 			$item[0].addEventListener("ui5-detail-click", cy.stub().as("detailClickStub"));
 		});
-	
+
 		cy.get("[ui5-li]").first()
 			.shadow()
 			.find(".ui5-li-detailbtn")
 			.click();
-	
+
 		cy.get("@detailClickStub").should("have.been.calledOnce");
 	});
 
@@ -1870,12 +1940,12 @@ describe("List Tests", () => {
 				<Button>Change empty item text</Button>
 			</div>
 		);
-	
+
 		const NEW_TEXT = "updated";
-	
+
 		cy.get("[ui5-li]").first()
 			.should("have.prop", "innerHTML", "");
-	
+
 		cy.get("[ui5-li]").first()
 			.shadow()
 			.find("slot")
@@ -1883,7 +1953,7 @@ describe("List Tests", () => {
 				const assignedNodes = ($slot[0] as any).assignedNodes();
 				expect(assignedNodes.length).to.equal(0);
 			});
-	
+
 		cy.get("[ui5-button]").then(($btn) => {
 			const stub = cy.stub().as("buttonClickStub");
 			stub.callsFake(() => {
@@ -1894,13 +1964,13 @@ describe("List Tests", () => {
 			});
 			$btn[0].addEventListener("click", stub);
 		});
-	
+
 		cy.get("[ui5-button]").click();
-	
+
 		cy.get("@buttonClickStub").should("have.been.calledOnce");
 		cy.get("[ui5-li]").first()
 			.should("have.prop", "innerHTML", NEW_TEXT);
-	
+
 		cy.get("[ui5-li]").first()
 			.shadow()
 			.find("slot")
@@ -1920,7 +1990,7 @@ describe("List Tests", () => {
 				<input placeholder="itemClick prevented result" />
 			</div>
 		);
-	
+
 		cy.get("[ui5-list]").then(($list) => {
 			const stub = cy.stub().as("itemClickStub");
 			stub.callsFake((event) => {
@@ -1928,9 +1998,9 @@ describe("List Tests", () => {
 			});
 			$list[0].addEventListener("ui5-item-click", stub);
 		});
-	
+
 		cy.get("[ui5-li]").first().click();
-	
+
 		cy.get("@itemClickStub").should("have.been.calledOnce");
 		cy.get("[ui5-li]").first().should("not.have.attr", "selected");
 	});
@@ -2113,18 +2183,18 @@ describe("List Tests", () => {
 				<input value="0" />
 			</div>
 		);
-	
+
 		cy.get("[ui5-select]").then(($select) => {
 			const listItem = $select.closest("ui5-li-custom")[0];
 			if (listItem) {
 				listItem.addEventListener("ui5-item-close", cy.stub().as("itemCloseStub"));
 			}
 		});
-	
+
 		cy.get("[ui5-select]").click();
-	
+
 		cy.realPress("Escape");
-	
+
 		cy.get("@itemCloseStub").should("not.have.been.called");
 	});
 
@@ -2487,14 +2557,14 @@ describe("List keyboard drag and drop tests", () => {
 
 		cy.get("[ui5-list]").then(($list) => {
 			const list = $list[0];
-			
+
 			list.addEventListener("keydown", (e) => {
 				if (e.ctrlKey) {
 					const focusedItem = document.activeElement as HTMLElement;
 					if (!focusedItem || !focusedItem.matches("[ui5-li]")) return;
-					
+
 					let targetItem = null;
-					
+
 					switch (e.key) {
 						case "ArrowRight":
 						case "ArrowDown":
@@ -2554,14 +2624,14 @@ describe("List keyboard drag and drop tests", () => {
 
 		cy.get("[ui5-list]").then(($list) => {
 			const list = $list[0];
-			
+
 			list.addEventListener("keydown", (e) => {
 				if (e.ctrlKey) {
 					const focusedItem = document.activeElement as HTMLElement;
 					if (!focusedItem || !focusedItem.matches("[ui5-li]")) return;
-					
+
 					let targetItem = null;
-					
+
 					switch (e.key) {
 						case "ArrowUp":
 							targetItem = focusedItem.previousElementSibling as HTMLElement;
@@ -2625,10 +2695,10 @@ describe("List sticky header", () => {
 		cy.get("@header")
 			.then(($headerBefore) => {
 				const headerTopBefore = $headerBefore[0].getBoundingClientRect().top;
-	
+
 				cy.get("@container")
 					.scrollTo(0, 50);
-	
+
 				cy.get("@header")
 					.should(($headerAfter) => {
 						const headerTopAfter = $headerAfter[0].getBoundingClientRect().top;
@@ -2661,10 +2731,10 @@ describe("List sticky header", () => {
 		cy.get("@header")
 			.then(($headerBefore) => {
 				const headerTopBefore = $headerBefore[0].getBoundingClientRect().top;
-	
+
 				cy.get("@container")
 					.scrollTo(0, 50);
-	
+
 				cy.get("@header")
 					.should(($headerAfter) => {
 						const headerTopAfter = $headerAfter[0].getBoundingClientRect().top;

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1067,10 +1067,12 @@ class List extends UI5Element {
 		e.preventDefault();
 
 		if (activeElement === listItemDomRef) {
+			listItem._editMode = true;
 			listItem._focusInternalElement(this._lastFocusedElementIndex ?? 0);
 			this._lastFocusedElementIndex = listItem._getFocusedElementIndex();
 		} else {
 			this._lastFocusedElementIndex = listItem._getFocusedElementIndex();
+			listItem._editMode = false;
 			listItemDomRef.focus();
 		}
 	}
@@ -1270,6 +1272,7 @@ class List extends UI5Element {
 			return false;
 		}
 
+		nextNode._editMode = listItem._editMode;
 		const focusedIndex = nextNode._focusInternalElement(targetInternalElementIndex);
 		if (focusedIndex !== undefined) {
 			this._lastFocusedElementIndex = focusedIndex;

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -195,6 +195,16 @@ abstract class ListItem extends ListItemBase {
 	_selectionMode: `${ListSelectionMode}` = "None";
 
 	/**
+	 * Indicates whether the list item is in edit mode.
+	 * When active, Tab cycles through internal focusable elements
+	 * instead of navigating to the next list item.
+	 * Toggled by F2 or F7.
+	 * @private
+	 */
+	@property({ type: Boolean, noAttribute: true })
+	_editMode = false;
+
+	/**
 	 * Defines the current media query size.
 	 * @default "S"
 	 * @private
@@ -314,6 +324,13 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	_onfocusout(e: FocusEvent) {
+		if (this._editMode) {
+			const relatedTarget = e.relatedTarget as Node;
+			if (!relatedTarget || !(this.contains(relatedTarget) || this.shadowRoot!.contains(relatedTarget))) {
+				this._editMode = false;
+			}
+		}
+
 		if (e.target !== this.getFocusDomRef()) {
 			return;
 		}
@@ -518,11 +535,54 @@ abstract class ListItem extends ListItemBase {
 		}
 
 		if (activeElement === focusDomRef) {
+			this._editMode = true;
 			const firstFocusable = await getFirstFocusableElement(focusDomRef);
 			firstFocusable?.focus();
 		} else {
+			this._editMode = false;
 			focusDomRef.focus();
 		}
+	}
+
+	_handleTabNext(e: KeyboardEvent) {
+		if (this._editMode) {
+			e.preventDefault();
+			const focusables = this._getFocusableElements();
+			if (focusables.length <= 1) {
+				return;
+			}
+
+			const currentIndex = focusables.indexOf(getActiveElement() as HTMLElement);
+			const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % focusables.length;
+			focusables[nextIndex].focus();
+			return;
+		}
+
+		// In navigation mode (non-edit), always forward Tab to the next item,
+		// bypassing shouldForwardTabAfter() which would stop at internal
+		// focusable elements. F2 enables edit mode for Tab cycling.
+		if (!this.fireDecoratorEvent("forward-after")) {
+			e.preventDefault();
+		}
+	}
+
+	_handleTabPrevious(e: KeyboardEvent) {
+		if (this._editMode) {
+			e.preventDefault();
+			const focusables = this._getFocusableElements();
+			if (focusables.length <= 1) {
+				return;
+			}
+
+			const currentIndex = focusables.indexOf(getActiveElement() as HTMLElement);
+			const prevIndex = currentIndex <= 0 ? focusables.length - 1 : currentIndex - 1;
+			focusables[prevIndex].focus();
+			return;
+		}
+
+		// In navigation mode (non-edit), always forward Shift+Tab to the
+		// previous item. F2 enables edit mode for backward Tab cycling.
+		this.fireDecoratorEvent("forward-before");
 	}
 
 	_getFocusableElements(): HTMLElement[] {

--- a/packages/main/src/ListItemTemplate.tsx
+++ b/packages/main/src/ListItemTemplate.tsx
@@ -154,8 +154,6 @@ function selectionElement(this: ListItem) {
 						) : (
 							<Button
 								part="delete-button"
-								tabindex={-1}
-								data-sap-no-tab-ref
 								id={`${this._id}-deleteSelectionElement`}
 								design="Transparent"
 								icon={declineIcon}

--- a/packages/main/test/pages/ListEditMode.html
+++ b/packages/main/test/pages/ListEditMode.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>List Edit Mode - Keyboard Navigation Test</title>
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<style>
+		body {
+			margin: 0;
+			padding: 2rem;
+			font-family: "72", "72full", Arial, sans-serif;
+			background: var(--sapBackgroundColor, #f5f6f7);
+		}
+
+		h2 {
+			margin-top: 2rem;
+		}
+
+		.instructions {
+			padding: 1rem;
+			margin-bottom: 2rem;
+			border: 1px solid var(--sapField_BorderColor, #89919a);
+			background: var(--sapInformationBackground, #f5faff);
+			border-radius: 4px;
+		}
+
+		.instructions kbd {
+			display: inline-block;
+			padding: 2px 6px;
+			font-size: 0.85em;
+			font-family: monospace;
+			background: var(--sapButton_Background, #fff);
+			border: 1px solid var(--sapButton_BorderColor, #bcc3ca);
+			border-radius: 3px;
+			box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+		}
+
+		.test-section {
+			margin-bottom: 2rem;
+			max-width: 600px;
+		}
+
+		.buttons-row {
+			display: flex;
+			gap: 0.5rem;
+			align-items: center;
+		}
+
+		.focus-log {
+			position: fixed;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			background: var(--sapShell_Background, #354a5f);
+			color: var(--sapShell_TextColor, #fff);
+			padding: 0.5rem 1rem;
+			font-family: monospace;
+			font-size: 0.85em;
+			z-index: 999;
+			display: flex;
+			gap: 1rem;
+			align-items: center;
+		}
+
+		.focus-log span {
+			opacity: 0.6;
+		}
+
+		.focus-log strong {
+			opacity: 1;
+		}
+	</style>
+</head>
+
+<body>
+	<h1>List Edit Mode - Keyboard Navigation</h1>
+
+	<div class="instructions">
+		<strong>Navigation Mode (default):</strong> <kbd>Arrow Up/Down</kbd> between items, <kbd>Tab</kbd> forwards out of list.
+		<br><br>
+		<strong>Edit Mode:</strong> Press <kbd>F2</kbd> or <kbd>F7</kbd> to enter. <kbd>Tab</kbd> cycles through internal elements. Press <kbd>F2</kbd> / <kbd>F7</kbd> again to exit.
+		<br><br>
+		<strong>Arrow navigation in edit mode:</strong> <kbd>Arrow Up/Down</kbd> moves to the same-index element in adjacent items.
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>1. Delete Mode - ListItemStandard</h2>
+	<p>Expected: <kbd>F2</kbd> &rarr; focus on delete button &rarr; <kbd>Tab</kbd> stays (single focusable) &rarr; <kbd>F2</kbd> exits</p>
+
+	<div class="test-section">
+		<ui5-button id="before-1">Before</ui5-button>
+		<ui5-list id="list-delete-standard" selection-mode="Delete" header-text="Delete Mode - Standard Items">
+			<ui5-li>Laptop HP</ui5-li>
+			<ui5-li>Monitor Dell 27"</ui5-li>
+			<ui5-li>Keyboard Mechanical</ui5-li>
+		</ui5-list>
+		<ui5-button id="after-1">After</ui5-button>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>2. Delete Mode - ListItemCustom (multiple interactive elements)</h2>
+	<p>Expected: <kbd>F2</kbd> &rarr; focus on first button &rarr; <kbd>Tab</kbd> cycles through buttons, link, and delete button &rarr; wraps around</p>
+
+	<div class="test-section">
+		<ui5-button id="before-2">Before</ui5-button>
+		<ui5-list id="list-delete-custom" selection-mode="Delete" header-text="Delete Mode - Custom Items">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Edit</ui5-button>
+					<ui5-link href="#">Details</ui5-link>
+					<ui5-button design="Negative">Archive</ui5-button>
+				</div>
+			</ui5-li-custom>
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>View</ui5-button>
+					<ui5-input placeholder="Comment" style="width: 140px;"></ui5-input>
+					<ui5-button design="Emphasized">Submit</ui5-button>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+		<ui5-button id="after-2">After</ui5-button>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>3. Delete Mode - Custom Delete Button Slot</h2>
+	<p>Expected: <kbd>F2</kbd> &rarr; focus on custom delete button &rarr; <kbd>Tab</kbd> stays (single focusable)</p>
+
+	<div class="test-section">
+		<ui5-list id="list-delete-custom-btn" selection-mode="Delete" header-text="Delete Mode - Custom Delete Button">
+			<ui5-li>Standard delete button</ui5-li>
+			<ui5-li>
+				Custom delete button
+				<div slot="deleteButton">
+					<ui5-button design="Negative" icon="delete">Remove</ui5-button>
+				</div>
+			</ui5-li>
+		</ui5-list>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>4. Delete Mode - Mixed Item Types</h2>
+	<p>Expected: <kbd>Arrow Down/Up</kbd> in edit mode transfers edit mode. Focus index clamped to available elements.</p>
+
+	<div class="test-section">
+		<ui5-list id="list-delete-mixed" selection-mode="Delete" header-text="Delete Mode - Mixed Items">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Action A</ui5-button>
+					<ui5-button>Action B</ui5-button>
+					<ui5-button>Action C</ui5-button>
+				</div>
+			</ui5-li-custom>
+			<ui5-li>Standard item (only delete button)</ui5-li>
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-input placeholder="Search" style="width: 140px;"></ui5-input>
+					<ui5-button icon="search">Go</ui5-button>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>5. SingleEnd Mode - ListItemCustom</h2>
+	<p>Expected: <kbd>Tab</kbd> forwards (does NOT enter interactive elements). <kbd>F2</kbd>/<kbd>F7</kbd> required to access buttons.</p>
+
+	<div class="test-section">
+		<ui5-button id="before-5">Before</ui5-button>
+		<ui5-list id="list-single-custom" selection-mode="SingleEnd" header-text="SingleEnd - Custom Items">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Press me</ui5-button>
+					<ui5-link href="#">Go to SAP</ui5-link>
+				</div>
+			</ui5-li-custom>
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Another button</ui5-button>
+					<ui5-link href="#">Another link</ui5-link>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+		<ui5-button id="after-5">After</ui5-button>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>6. Multiple Mode - ListItemCustom</h2>
+	<p>Expected: Same edit mode behavior. <kbd>Tab</kbd> forwards, <kbd>F2</kbd> to enter, checkbox is part of cycle.</p>
+
+	<div class="test-section">
+		<ui5-list id="list-multi-custom" selection-mode="Multiple" header-text="Multiple - Custom Items">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Edit</ui5-button>
+					<ui5-button>Delete</ui5-button>
+				</div>
+			</ui5-li-custom>
+			<ui5-li-custom selected>
+				<div class="buttons-row">
+					<ui5-button>View</ui5-button>
+					<ui5-button>Share</ui5-button>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>7. None Mode - ListItemCustom</h2>
+	<p>Expected: <kbd>Tab</kbd> forwards out. <kbd>F2</kbd>/<kbd>F7</kbd> to enter internal elements.</p>
+
+	<div class="test-section">
+		<ui5-button id="before-7">Before</ui5-button>
+		<ui5-list id="list-none-custom" header-text="None Mode - Custom Items">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Action 1</ui5-button>
+					<ui5-button>Action 2</ui5-button>
+					<ui5-input placeholder="Type here" style="width: 120px;"></ui5-input>
+				</div>
+			</ui5-li-custom>
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Action 3</ui5-button>
+					<ui5-link href="#">Link</ui5-link>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+		<ui5-button id="after-7">After</ui5-button>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>8. Detail Type with Delete Mode</h2>
+	<p>Expected: <kbd>F2</kbd> cycles through detail button + delete button.</p>
+
+	<div class="test-section">
+		<ui5-list id="list-detail-delete" selection-mode="Delete" header-text="Detail + Delete">
+			<ui5-li type="Detail">Detail item with delete</ui5-li>
+			<ui5-li type="Detail">Another detail item</ui5-li>
+		</ui5-list>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>9. Focus-out Clears Edit Mode</h2>
+	<p>Expected: Enter edit mode &rarr; click outside &rarr; edit mode cleared &rarr; <kbd>Tab</kbd> forwards again.</p>
+
+	<div class="test-section">
+		<ui5-list id="list-focusout" selection-mode="Delete" header-text="Focus-out Test">
+			<ui5-li-custom>
+				<div class="buttons-row">
+					<ui5-button>Inside Button</ui5-button>
+					<ui5-link href="#">Inside Link</ui5-link>
+				</div>
+			</ui5-li-custom>
+		</ui5-list>
+		<ui5-button id="outside-btn">Click me to move focus outside</ui5-button>
+	</div>
+
+	<!-- ============================================================ -->
+	<h2>10. Growing Button + Delete Mode</h2>
+	<p>Expected: <kbd>Tab</kbd> from item goes to growing button (not internal elements).</p>
+
+	<div class="test-section">
+		<ui5-list id="list-growing-delete" selection-mode="Delete" growing="Button" header-text="Growing + Delete">
+			<ui5-li>Item 1</ui5-li>
+			<ui5-li>Item 2</ui5-li>
+			<ui5-li>Item 3</ui5-li>
+		</ui5-list>
+	</div>
+
+	<!-- Focus tracker bar -->
+	<div class="focus-log" id="focusLog">
+		<span>Focus:</span>
+		<strong id="focusTarget">-</strong>
+		<span>|</span>
+		<span>Edit mode:</span>
+		<strong id="editModeStatus">-</strong>
+		<span>|</span>
+		<span>Last key:</span>
+		<strong id="lastKey">-</strong>
+	</div>
+
+	<script>
+		const focusTarget = document.getElementById('focusTarget');
+		const editModeStatus = document.getElementById('editModeStatus');
+		const lastKey = document.getElementById('lastKey');
+
+		function getLabel(el) {
+			if (!el) return '-';
+			const tag = el.tagName?.toLowerCase() || '?';
+
+			if (tag === 'ui5-li-custom' || tag === 'ui5-li') {
+				const list = el.closest('ui5-list');
+				const items = list ? [...list.querySelectorAll('ui5-li, ui5-li-custom')] : [];
+				const idx = items.indexOf(el);
+				return `${tag} [item ${idx + 1}]`;
+			}
+
+			const text = el.textContent?.trim().substring(0, 25) || el.placeholder || '';
+			return `${tag}${text ? ': "' + text + '"' : ''}`;
+		}
+
+		document.addEventListener('focusin', function (e) {
+			focusTarget.textContent = getLabel(e.target);
+
+			// Check edit mode on the closest list item
+			const listItem = e.target.closest?.('ui5-li, ui5-li-custom');
+			if (listItem) {
+				editModeStatus.textContent = listItem._editMode ? 'ON' : 'OFF';
+			}
+		});
+
+		document.addEventListener('keydown', function (e) {
+			const special = ['F2', 'F7', 'Tab', 'ArrowUp', 'ArrowDown', 'Escape'];
+			if (special.includes(e.key)) {
+				lastKey.textContent = (e.shiftKey ? 'Shift+' : '') + e.key;
+			}
+
+			// Update edit mode status after a tick (state changes on keydown)
+			setTimeout(() => {
+				const active = document.activeElement;
+				const listItem = active?.closest?.('ui5-li, ui5-li-custom');
+				if (listItem) {
+					editModeStatus.textContent = listItem._editMode ? 'ON' : 'OFF';
+				}
+			}, 50);
+		});
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

Implements an **edit mode** for list items that controls Tab behavior, following the [SAP Fiori Keyboard Interaction spec](https://experience.sap.com/fiori-design/) (List View Interaction Patterns):

- **Navigation mode** (default): `Tab` / `Shift+Tab` always forwards to the next/previous item. Arrow keys navigate between items.
- **Edit mode** (toggled by `F2` or `F7`): `Tab` cycles through internal focusable elements (buttons, links, inputs, delete button). `Arrow Up/Down` transfers edit mode to adjacent items, focusing the same-index element.

### Changes

**`ListItem.ts`**
- Added `_editMode` private property to track edit/navigation mode state
- Overridden `_handleTabNext` / `_handleTabPrevious` — in navigation mode, always fire `forward-after` / `forward-before`; in edit mode, cycle through internal focusable elements
- Added `_onfocusout` handler to clear edit mode when focus leaves the component

**`ListItemTemplate.tsx`**
- Removed `tabindex={-1}` and `data-sap-no-tab-ref` from the delete button, making it discoverable by `getTabbableElements` and reachable via edit mode

**`List.ts`**
- `_handleF7`: F7 now sets `_editMode = true` when entering internal elements (consistent with F2)
- `_navigateToAdjacentItem`: Transfers `_editMode` state when arrow-navigating between items

**`List.cy.tsx`**
- Updated 5 existing tests to reflect new Tab-forwarding behavior
- Added 8 new tests covering: F2 enter/exit, Tab cycling, Tab forwarding in delete mode, F7 exit, arrow key edit mode transfer, Shift+Tab forwarding, focus-out cleanup, and a comprehensive workflow with mixed item types (ListItemCustom with multiple interactive elements + custom delete button slot)

**`ListEditMode.html`**
- New manual test page with 10 scenarios and a live focus tracker bar showing current focus target, edit mode state, and last key pressed

## Test plan

- [x] All 93 Cypress tests pass (0 failures, 0 regressions)
- [ ] Manual testing with `ListEditMode.html` test page covering:
  - Delete mode with ListItemStandard (F2 → delete button)
  - Delete mode with ListItemCustom (F2 → Tab cycles through buttons, links, delete button)
  - Custom delete button slot
  - Mixed item types with arrow navigation
  - SingleEnd / Multiple / None modes with ListItemCustom
  - Detail type + Delete mode
  - Focus-out clears edit mode
  - Growing button + Delete mode
- [ ] Screen reader testing (VoiceOver / NVDA)

Fixes #13220
Relates to #2964