### PR TITLE
fix(ui5-datetime-picker): ensure value state header spans full popover width

### DIFF
--- a/packages/main/src/themes/DateTimePickerPopover.css
+++ b/packages/main/src/themes/DateTimePickerPopover.css
@@ -4,7 +4,9 @@
 }
 
 :host .ui5-date-picker-popover:not([on-phone]) .ui5-popover-header {
-	width: 20rem;
+	width: 100%;
+	max-width: 100%;
+	display: block;
 }
 
 .ui5-dt-picker-content {


### PR DESCRIPTION
## Problem

The `value-state` bar at the top of the DateTimePicker popover wasn't stretching to fill its full width.

The reason behind that was `ValueStateMessage.css` capping the element with `max-width`, which is fine for narrow components like Input or DatePicker but too restrictive for the wider `DateTimePicker` popover. 

So we overrode those constraints in DateTimePickerPopover.css and removed the `max-width` restriction. 

## Before
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0ef5cf44-30c7-42f8-b0aa-6724b516f205" />

## After
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b408d007-a21b-4217-8760-e657cd4a9fef" />

Fixes: #13266