### PR TITLE
docs(website): include tag names in llms.txt

### DIFF
--- a/packages/website/build-scripts/llms-txt-generation/index.mjs
+++ b/packages/website/build-scripts/llms-txt-generation/index.mjs
@@ -296,10 +296,9 @@ import "@ui5/webcomponents/dist/Button.js";
             }
 
             // Show description if it's meaningful (not empty)
-            const description = component.description ? ` - ${component.description}` : '';
-            content += `- [${component.name}](${url})${description}\n`;
+            const description = component.description ? `\n  - description: ${component.description}` : '';
+            content += `#### [${component.name}](${url})\n  - tag: \`${component.tagName}\`${description}\n\n`;
         });
-        content += '\n';
     });
 
     content += `## Documentation


### PR DESCRIPTION
## Summary
- Adds the custom element tag name (e.g. `ui5-avatar`, `ui5-button`) to each component entry in the generated `llms.txt`
- Uses a structured format with `tag:` and `description:` fields for better readability and parseability by external tools

**Before:**
```
- [Avatar](https://ui5.github.io/webcomponents/components/Avatar/) - An image-like component...
```

**After:**
```
#### [Avatar](https://ui5.github.io/webcomponents/components/Avatar/)
  - tag: `ui5-avatar`
  - description: An image-like component...
```

## Test plan
- [ ] Verify `llms.txt` is generated correctly after a full build