### PR TITLE
fix(ui5-dynamic-page): prevent flickering when content is updated

### DIFF
--- a/packages/fiori/src/themes/DynamicPage.css
+++ b/packages/fiori/src/themes/DynamicPage.css
@@ -21,6 +21,7 @@
 .ui5-dynamic-page-scroll-container {
     overflow-y: auto;
     height: 100%;
+    overflow-anchor: none;
 }
 
 /* Automatically fit content that has height: 100% */


### PR DESCRIPTION
When the header is snapping/collapsing and the title changes its height, there is a flickering in the scrollbar area caused by the anchoring, which moves the scroll position, confusing the header behavior.
Fixes: #13124