### PR TITLE
fix(framework): improve themeRoot validation

### DIFF
--- a/packages/base/cypress/specs/ConfigurationChange.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationChange.cy.tsx
@@ -39,3 +39,202 @@ describe("Some configuration options can be changed at runtime", () => {
 			.should("deep.equal", newThemeRoot);
 	});
 });
+
+describe("ThemeRoot validation at runtime", () => {
+	describe("Valid themeRoot with allowed origin", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://runtime-example.com";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should set raw themeRoot", () => {
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", "https://runtime-example.com/themes");
+
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://runtime-example.com/themes");
+
+			// Verify link is created in DOM
+			cy.wrap({ getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					cy.get(`link[sap-ui-webcomponents-theme="${theme}"]`)
+						.should("exist")
+						.and("have.attr", "href")
+						.then(href => {
+							return href.includes("https://runtime-example.com/themes/UI5/Base/baseLib/");
+						})
+						.should("be.true");
+				});
+		});
+	});
+
+	describe("Invalid themeRoot without meta tag", () => {
+		after(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should set themeRoot but log warning", () => {
+			const consoleWarnStub = cy.stub().as("consoleWarn");
+
+			cy.window().then(win => {
+				cy.stub(win.console, "warn").callsFake(consoleWarnStub);
+			});
+
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", "https://unauthorized-runtime.com/themes");
+
+			// The themeRoot should be set in the internal state
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://unauthorized-runtime.com/themes");
+
+			// But validation should fail and log a warning
+			cy.get("@consoleWarn").should("have.been.called");
+
+			// Verify link is NOT created in DOM
+			cy.get("link[sap-ui-webcomponents-theme]")
+				.should("not.exist");
+		});
+	});
+
+	describe("Relative themeRoot at runtime", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should set raw relative path", () => {
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", "./custom-themes");
+
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "./custom-themes");
+
+			// Verify link is created with resolved URL
+			cy.wrap({ getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					cy.get(`link[sap-ui-webcomponents-theme="${theme}"]`)
+						.should("exist")
+						.and("have.attr", "href")
+						.then(href => {
+							return href.includes("/custom-themes/UI5/Base/baseLib/");
+						})
+						.should("be.true");
+				});
+		});
+	});
+
+	describe("Same themeRoot not re-applied", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://same-root.com";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should not reprocess when setting the same themeRoot", () => {
+			const themeRoot = "https://same-root.com/themes";
+
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", themeRoot)
+				.should("not.equal", undefined);
+
+			// Setting again should return undefined (no-op)
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", themeRoot)
+				.should("equal", undefined);
+		});
+	});
+
+	describe("ThemeRoot with wildcard origin", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should allow any origin with wildcard", () => {
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", "https://any-wildcard-domain.com/themes");
+
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://any-wildcard-domain.com/themes");
+
+			// Verify link is created with wildcard-allowed origin
+			cy.wrap({ getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					cy.get(`link[sap-ui-webcomponents-theme="${theme}"]`)
+						.should("exist")
+						.and("have.attr", "href")
+						.and("include", "https://any-wildcard-domain.com/themes/UI5/Base/baseLib/");
+				});
+		});
+	});
+});

--- a/packages/base/cypress/specs/ConfigurationScript.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationScript.cy.tsx
@@ -6,8 +6,10 @@ import { getFirstDayOfWeek, getLegacyDateCalendarCustomizing } from "../../src/c
 import { getLanguage } from "../../src/config/Language.js";
 import { getNoConflict } from "../../src/config/NoConflict.js";
 import { getTheme } from "../../src/config/Theme.js";
+import { getThemeRoot } from "../../src/config/ThemeRoot.js";
 import { getEnableDefaultTooltips } from "../../src/config/Tooltips.js";
 import { resetConfiguration } from "../../src/InitialConfiguration.js";
+import applyTheme from "../../src/theming/applyTheme.js";
 
 describe("Configuration script", () => {
 	const configurationObject = {
@@ -129,5 +131,398 @@ describe("Configuration script", () => {
 		cy.wrap({ getEnableDefaultTooltips })
 			.invoke("getEnableDefaultTooltips")
 			.should("equal", false);
+	});
+});
+
+describe("Configuration script with themeRoot", () => {
+	describe("Valid absolute themeRoot with allowed origin", () => {
+		before(() => {
+			// Add meta tag to allow the origin
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://example.com";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.window()
+				.then($el => {
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: "https://example.com/themes",
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw themeRoot from configuration", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://example.com/themes");
+		});
+
+		it("should create link in DOM with validated URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://example.com/themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+		});
+	});
+
+	describe("Invalid absolute themeRoot without allowed origin", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: "https://unauthorized.com/themes",
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+				});
+		});
+
+		it("should return raw themeRoot from configuration", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://unauthorized.com/themes");
+		});
+
+		it("should not create link in DOM due to validation failure", () => {
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("not.exist");
+		});
+	});
+
+	describe("Relative themeRoot with meta tag", () => {
+		before(() => {
+			// Relative URLs require meta tag to be present
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.window()
+				.then($el => {
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: "./themes",
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw relative themeRoot", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "./themes");
+		});
+
+		it("should create link with resolved URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.then(href => {
+					return href.includes("/themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+				})
+				.should("be.true");
+		});
+	});
+
+	describe("Wildcard allowed origins", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.window()
+				.then($el => {
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: "https://any-domain.com/themes",
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw themeRoot", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://any-domain.com/themes");
+		});
+
+		it("should create link with wildcard-allowed origin", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://any-domain.com/themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+		});
+	});
+
+	describe("Multiple allowed origins", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://example.com, https://cdn.example.net, https://themes.example.org";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.window()
+				.then($el => {
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: "https://cdn.example.net/ui5-themes",
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw themeRoot", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://cdn.example.net/ui5-themes");
+		});
+
+		it("should create link matching one of multiple origins", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://cdn.example.net/ui5-themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+		});
+	});
+
+	describe("Same-origin absolute URL", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://example.com";
+					$el.document.head.append(metaTag);
+
+					const currentOrigin = window.location.origin;
+					const scriptElement = document.createElement("script");
+					scriptElement.type = "application/json";
+					scriptElement.setAttribute("data-ui5-config", "true");
+					scriptElement.innerHTML = JSON.stringify({
+						theme: "custom_theme",
+						themeRoot: `${currentOrigin}/themes`,
+					});
+					return $el.document.head.append(scriptElement);
+				});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const scriptElement = $el.document.head.querySelector("script[data-ui5-config]");
+					scriptElement?.remove();
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw same-origin themeRoot", () => {
+			cy.window().then(win => {
+				cy.wrap({ getThemeRoot })
+					.invoke("getThemeRoot")
+					.should("equal", `${win.location.origin}/themes`);
+			});
+		});
+
+		it("should create link for same-origin URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.then(href => {
+					return href.endsWith("/themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+				})
+				.should("be.true");
+		});
 	});
 });

--- a/packages/base/cypress/specs/ConfigurationSync.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationSync.cy.tsx
@@ -1,6 +1,7 @@
 import { fireConfigChange, attachConfigChange, getSharedValue } from "../../src/config/ConfigurationSync.js";
 import { setTheme, getTheme } from "../../src/config/Theme.js";
 import { setLanguage, getLanguage } from "../../src/config/Language.js";
+import { setThemeRoot, getThemeRoot } from "../../src/config/ThemeRoot.js";
 import EventProvider from "../../src/EventProvider.js";
 import getSharedResource from "../../src/getSharedResource.js";
 
@@ -68,6 +69,119 @@ describe("ConfigurationSync", () => {
 			cy.wrap({ getSharedValue })
 				.invoke("getSharedValue", "language")
 				.should("equal", "de");
+		});
+	});
+
+	describe("ThemeRoot integration", () => {
+		before(() => {
+			// Setup meta tag for themeRoot validation
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://sync-example.com";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("setThemeRoot updates current themeRoot", () => {
+			cy.wrap({ setThemeRoot })
+				.invoke("setThemeRoot", "https://sync-example.com/themes");
+
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://sync-example.com/themes");
+		});
+	});
+
+	describe("ThemeRoot cross-runtime sync", () => {
+		before(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://cross-runtime.com";
+					$el.document.head.append(metaTag);
+				});
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("themeRoot changes propagate across runtimes", () => {
+			const newThemeRoot = "https://cross-runtime.com/themes";
+
+			// Simulate setting themeRoot in one runtime
+			fireConfigChange("themeRoot", newThemeRoot);
+
+			// Verify it's stored in shared values
+			cy.wrap({ getSharedValue })
+				.invoke("getSharedValue", "themeRoot")
+				.should("equal", newThemeRoot);
+		});
+
+		it("themeRoot handler receives cross-runtime changes", () => {
+			const handler = cy.stub().as("themeRootHandler");
+			const crossRuntimeValue = "https://cross-runtime.com/updated";
+
+			attachConfigChange("themeRoot", handler);
+
+			// Simulate cross-runtime fire by calling EventProvider directly
+			const ep = getSharedResource("ConfigChange.eventProvider", new EventProvider());
+			ep.fireEvent("configChange", { name: "themeRoot", value: crossRuntimeValue });
+
+			cy.get("@themeRootHandler")
+				.should("have.been.calledOnce")
+				.and("have.been.calledWith", crossRuntimeValue);
+		});
+	});
+
+	describe("Multiple configuration sync", () => {
+		it("multiple config changes maintain separate values", () => {
+			fireConfigChange("theme", "sap_horizon_dark");
+			fireConfigChange("language", "fr");
+			fireConfigChange("themeRoot", "https://multi.com/themes");
+
+			cy.wrap({ getSharedValue })
+				.invoke("getSharedValue", "theme")
+				.should("equal", "sap_horizon_dark");
+
+			cy.wrap({ getSharedValue })
+				.invoke("getSharedValue", "language")
+				.should("equal", "fr");
+
+			cy.wrap({ getSharedValue })
+				.invoke("getSharedValue", "themeRoot")
+				.should("equal", "https://multi.com/themes");
 		});
 	});
 });

--- a/packages/base/cypress/specs/ConfigurationURL.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationURL.cy.tsx
@@ -7,6 +7,7 @@ import { getTheme } from "../../src/config/Theme.js";
 import { getAnimationMode } from "../../src/config/AnimationMode.js";
 import AnimationMode from "../../src/types/AnimationMode.js";
 import { getThemeRoot } from "../../src/config/ThemeRoot.js";
+import applyTheme from "../../src/theming/applyTheme.js";
 
 describe("Some settings can be set via SAP UI URL params", () => {
 	before(() => {
@@ -53,88 +54,409 @@ describe("Some settings can be set via SAP UI URL params", () => {
 });
 
 describe("Different themeRoot configurations", () => {
-	it("Allowed theme root", () => {
-		const searchParams = "sap-ui-theme=sap_horizon_hcb@https://example.com";
+	describe("Allowed theme root", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=sap_horizon_hcb@https://example.com";
 
-		// All allowed theme roots need to be described inside the meta tag.
-		cy.window()
-			.then($el => {
-				const metaTag = document.createElement("meta");
-				metaTag.name = "sap-allowed-theme-origins";
-				metaTag.content = "https://example.com";
+			// All allowed theme roots need to be described inside the meta tag.
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://example.com";
 
-				$el.document.head.append(metaTag);
-			})
+					$el.document.head.append(metaTag);
+				});
 
-		cy.stub(internals, "search").callsFake(() => {
-			return searchParams;
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
 		});
 
-		cy.wrap({ resetConfiguration })
-			.invoke("resetConfiguration", true);
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
 
-		cy.wrap(internals)
-			.invoke("search")
-			.should("be.equal", searchParams);
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
 
-		cy.mount(<TestGeneric />);
+		it("should return raw themeRoot from URL parameter", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://example.com");
+		});
 
-		cy.wrap({ getThemeRoot })
-			.invoke("getThemeRoot")
-			.should("equal", "https://example.com/UI5/");
+		it("should extract theme without themeRoot part", () => {
+			cy.wrap({ getTheme })
+				.invoke("getTheme")
+				.should("equal", "sap_horizon_hcb");
+		});
 
-		// All allowed theme roots need to be described inside the meta tag.
-		cy.window()
-			.then($el => {
-				const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+		it("should create link in DOM with validated URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
 
-				metaTag?.remove();
-			})
+			cy.get("link[sap-ui-webcomponents-theme='sap_horizon_hcb']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://example.com/UI5/Base/baseLib/sap_horizon_hcb/css_variables.css");
+		});
 	});
 
-	it("Unallowed theme root", () => {
-		const searchParams = "sap-ui-theme=sap_horizon_hcb@https://another-example.com";
+	describe("Unallowed theme root", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=sap_horizon_hcb@https://another-example.com";
 
-		cy.stub(internals, "search").callsFake(() => {
-			return searchParams;
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
 		});
 
-		cy.wrap({ resetConfiguration })
-			.invoke("resetConfiguration", true);
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
 
-		cy.wrap(internals)
-			.invoke("search")
-			.should("be.equal", searchParams);
+		it("should return raw themeRoot even if not allowed", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://another-example.com");
+		});
 
-		cy.mount(<TestGeneric />);
-
-		cy.wrap({ getThemeRoot })
-			.invoke("getThemeRoot")
-			.should("equal", `${window.location.origin}/UI5/`);
+		it("should not create link in DOM due to validation failure", () => {
+			cy.get("link[sap-ui-webcomponents-theme='sap_horizon_hcb']")
+				.should("not.exist");
+		});
 	});
 
-	it("Relative theme root", () => {
-		const searchParams = "sap-ui-theme=sap_horizon_hcb@./test";
+	describe("Relative theme root", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=sap_horizon_hcb@./test";
 
-		cy.stub(internals, "search").callsFake(() => {
-			return searchParams;
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
 		});
 
-		cy.wrap({ resetConfiguration })
-			.invoke("resetConfiguration", true);
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
 
-		cy.wrap(internals)
-			.invoke("search")
-			.should("be.equal", searchParams);
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
 
-		cy.mount(<TestGeneric />);
+		it("should return raw relative themeRoot", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "./test");
+		});
 
-		cy.wrap({ getThemeRoot })
-			.invoke("getThemeRoot")
-			.then(themeRoot => {
-				return themeRoot?.endsWith("/test/UI5/");
-			})
-			.should("be.true");
+		it("should create link with resolved URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='sap_horizon_hcb']")
+				.should("exist")
+				.and("have.attr", "href")
+				.then(href => {
+					return href.endsWith("/test/UI5/Base/baseLib/sap_horizon_hcb/css_variables.css");
+				})
+				.should("be.true");
+		});
+	});
+
+	describe("Absolute path theme root", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=custom_theme@/absolute/path";
+
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "*";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw absolute path", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "/absolute/path");
+		});
+
+		it("should create link with resolved URL", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.then(href => {
+					return href.endsWith("/absolute/path/UI5/Base/baseLib/custom_theme/css_variables.css");
+				})
+				.should("be.true");
+		});
+	});
+
+	describe("ThemeRoot with trailing slash", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=custom_theme@https://cdn.example.com/themes/";
+
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowed-theme-origins";
+					metaTag.content = "https://cdn.example.com";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowed-theme-origins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw themeRoot with trailing slash", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://cdn.example.com/themes/");
+		});
+
+		it("should create link normalizing trailing slash", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://cdn.example.com/themes/UI5/Base/baseLib/custom_theme/css_variables.css");
+		});
+	});
+
+	describe("Invalid URL format", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=custom_theme@not-a-valid-url";
+
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		it("should return raw invalid URL value", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "not-a-valid-url");
+		});
+
+		it("should not create link due to invalid URL", () => {
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("not.exist");
+		});
+	});
+
+	describe("Legacy meta tag name support", () => {
+		before(() => {
+			const searchParams = "sap-ui-theme=custom_theme@https://legacy.example.com";
+
+			cy.window()
+				.then($el => {
+					const metaTag = document.createElement("meta");
+					metaTag.name = "sap-allowedThemeOrigins"; // Old camelCase format
+					metaTag.content = "https://legacy.example.com";
+					$el.document.head.append(metaTag);
+				});
+
+			cy.stub(internals, "search").callsFake(() => {
+				return searchParams;
+			});
+
+			cy.wrap({ resetConfiguration })
+				.invoke("resetConfiguration", true);
+
+			cy.wrap(internals)
+				.invoke("search")
+				.should("be.equal", searchParams);
+
+			cy.mount(<TestGeneric />);
+		});
+
+		afterEach(() => {
+			cy.window()
+				.then($el => {
+					const link = $el.document.head.querySelector("link[sap-ui-webcomponents-theme]");
+					link?.remove();
+				});
+		});
+
+		after(() => {
+			cy.window()
+				.then($el => {
+					const metaTag = $el.document.head.querySelector("[name='sap-allowedThemeOrigins']");
+					metaTag?.remove();
+				});
+		});
+
+		it("should return raw themeRoot", () => {
+			cy.wrap({ getThemeRoot })
+				.invoke("getThemeRoot")
+				.should("equal", "https://legacy.example.com");
+		});
+
+		it("should support legacy sap-allowedThemeOrigins meta tag", () => {
+			// Apply theme to trigger link creation
+			cy.wrap({ applyTheme, getTheme })
+				.invoke("getTheme")
+				.then(theme => {
+					return cy.wrap({ applyTheme }).invoke("applyTheme", theme);
+				});
+
+			cy.get("link[sap-ui-webcomponents-theme='custom_theme']")
+				.should("exist")
+				.and("have.attr", "href")
+				.and("equal", "https://legacy.example.com/UI5/Base/baseLib/custom_theme/css_variables.css");
+		});
 	});
 });
 

--- a/packages/base/src/InitialConfiguration.ts
+++ b/packages/base/src/InitialConfiguration.ts
@@ -1,7 +1,6 @@
 import merge from "./thirdparty/merge.js";
 import { getFeature } from "./FeaturesRegistry.js";
 import { DEFAULT_THEME } from "./generated/AssetParameters.js";
-import validateThemeRoot from "./validateThemeRoot.js";
 import type OpenUI5Support from "./features/OpenUI5Support.js";
 import type { FormatSettings } from "./config/FormatSettings.js";
 import AnimationMode from "./types/AnimationMode.js";
@@ -56,16 +55,6 @@ const getTheme = () => {
 
 const getThemeRoot = () => {
 	initConfiguration();
-
-	if (initialConfig.themeRoot === undefined) {
-		return;
-	}
-
-	if (!validateThemeRoot(initialConfig.themeRoot)) {
-		console.warn(`The ${initialConfig.themeRoot} is not valid. Check the allowed origins as suggested in the "setThemeRoot" description.`); // eslint-disable-line
-		return;
-	}
-
 	return initialConfig.themeRoot;
 };
 
@@ -175,7 +164,7 @@ const parseURLParameters = () => {
 const normalizeThemeRootParamValue = (value: string) => {
 	const themeRoot = value.split("@")[1];
 
-	return validateThemeRoot(themeRoot);
+	return themeRoot;
 };
 
 const normalizeThemeParamValue = (param: string, value: string) => {

--- a/packages/base/src/config/ThemeRoot.ts
+++ b/packages/base/src/config/ThemeRoot.ts
@@ -50,16 +50,11 @@ const setThemeRoot = (themeRoot: string): Promise<void> | undefined => {
 
 	currThemeRoot = themeRoot;
 
-	if (!validateThemeRoot(themeRoot)) {
-		console.warn(`The ${themeRoot} is not valid. Check the allowed origins as suggested in the "setThemeRoot" description.`); // eslint-disable-line
-		return;
-	}
-
 	return attachCustomThemeStylesToHead(getTheme());
 };
 
-const formatThemeLink = (theme: string) => {
-	return `${getThemeRoot()!}Base/baseLib/${theme}/css_variables.css`; // theme root is always set at this point.
+const formatThemeLink = (theme: string, validatedThemeRoot: string) => {
+	return `${validatedThemeRoot}Base/baseLib/${theme}/css_variables.css`;
 };
 
 const attachCustomThemeStylesToHead = async (theme: string): Promise<void> => {
@@ -69,7 +64,20 @@ const attachCustomThemeStylesToHead = async (theme: string): Promise<void> => {
 		document.head.removeChild(link);
 	}
 
-	await createLinkInHead(formatThemeLink(theme), { "sap-ui-webcomponents-theme": theme });
+	const themeRoot = getThemeRoot();
+
+	if (!themeRoot) {
+		return;
+	}
+
+	const validatedThemeRoot = validateThemeRoot(themeRoot);
+
+	if (!validatedThemeRoot) {
+		console.warn(`The ${themeRoot} is not valid. Check the allowed origins as suggested in the "setThemeRoot" description.`); // eslint-disable-line
+		return;
+	}
+
+	await createLinkInHead(formatThemeLink(theme, validatedThemeRoot), { "sap-ui-webcomponents-theme": theme });
 };
 
 export {

--- a/packages/base/src/validateThemeRoot.ts
+++ b/packages/base/src/validateThemeRoot.ts
@@ -7,7 +7,7 @@ const getMetaTagValue = (metaTagName: string) => {
 	return metaTagContent;
 };
 
-const validateThemeOrigin = (origin: string) => {
+const validateThemeOrigin = (origin: string, isSameOrigin: boolean = false) => {
 	const allowedOrigins = getMetaTagValue("sap-allowed-theme-origins") ?? getMetaTagValue("sap-allowedThemeOrigins"); // Prioritize the new meta tag name
 
 	// If no allowed origins are specified, block.
@@ -15,19 +15,20 @@ const validateThemeOrigin = (origin: string) => {
 		return false;
 	}
 
+	// If it's same-origin (relative URL resolved to current page), allow it when there's any meta tag present
+	// The presence of the meta tag indicates the user wants to use theme roots
+	if (isSameOrigin) {
+		return true;
+	}
+
 	return allowedOrigins.split(",").some(allowedOrigin => {
 		return allowedOrigin === "*" || origin === allowedOrigin.trim();
 	});
 };
 
-const buildCorrectUrl = (oldUrl: string, newOrigin: string) => {
-	const oldUrlPath = new URL(oldUrl).pathname;
-
-	return new URL(oldUrlPath, newOrigin).toString();
-};
-
 const validateThemeRoot = (themeRoot: string) => {
 	let resultUrl;
+	let isSameOrigin = false;
 
 	try {
 		if (themeRoot.startsWith(".") || themeRoot.startsWith("/")) {
@@ -36,17 +37,21 @@ const validateThemeRoot = (themeRoot: string) => {
 			// new URL("./newExmPath", "http://example.com/exmPath") => http://example.com/exmPath/newExmPath
 			// new URL("../newExmPath", "http://example.com/exmPath") => http://example.com/newExmPath
 			resultUrl = new URL(themeRoot, getLocationHref()).toString();
+			isSameOrigin = true;
 		} else {
 			const themeRootURL = new URL(themeRoot);
 			const origin = themeRootURL.origin;
+			const currentOrigin = new URL(getLocationHref()).origin;
 
-			if (origin && validateThemeOrigin(origin)) {
+			// Check if the absolute URL is same-origin
+			isSameOrigin = origin === currentOrigin;
+
+			if (origin && validateThemeOrigin(origin, isSameOrigin)) {
 				// If origin is allowed, use it
 				resultUrl = themeRootURL.toString();
 			} else {
-				// If origin is not allow and the URL is not relative, we have to replace the origin
-				// with current location
-				resultUrl = buildCorrectUrl(themeRootURL.toString(), getLocationHref());
+				// If origin is not allowed, return undefined to indicate validation failed
+				return undefined;
 			}
 		}
 
@@ -57,6 +62,7 @@ const validateThemeRoot = (themeRoot: string) => {
 		return `${resultUrl}UI5/`;
 	} catch (e) {
 		// Catch if URL is not correct
+		return undefined;
 	}
 };
 


### PR DESCRIPTION
Fix themeRoot validation to require explicit origin allowlist via meta tag
and separate configuration storage from validated URL usage.

Problem:
- themeRoot URLs were not properly validated for security
- getThemeRoot() mixed raw configuration with validated URLs
- Missing validation for relative paths and URL formats

Solution:
1. Require meta tag for all themeRoot usage:
    <meta name="sap-allowed-theme-origins" content="https://cdn.example.com">

    - Comma-separated list of allowed origins
    - Wildcard "*" to allow any origin
    - Legacy "sap-allowedThemeOrigins" (camelCase) supported
    - Same-origin URLs allowed when meta tag present

2. Separate configuration from validation:
    - getThemeRoot() returns raw configured value (unchanged)
    - validateThemeRoot() performs security checks and normalization
    - DOM link creation uses validated URL: {validatedRoot}/UI5/Base/baseLib/{theme}/css_variables.css

3. Enhanced validation:
    - Absolute URLs: check origin against allowlist
    - Relative paths (./path, ../path): resolve to current origin
    - Absolute paths (/path): resolve to current origin
    - Add trailing slash if missing
    - Append /UI5/ to create proper theme asset path
    - Return undefined for invalid/unauthorized URLs

4. Proper error handling:
    - Log warning when validation fails
    - No DOM link created for invalid themeRoot
    - Graceful fallback to default theme behavior