### PR TITLE
fix(ui5-datetime-picker): prevent first keystroke from resetting caret position

### DIFF
--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -859,4 +859,47 @@ describe("Validation inside a form", () => {
 		cy.get("#dateTimePicker:invalid")
 			.should("not.exist", "DateTimePicker with value below maxDate should not have :invalid CSS class");
 	});
+
+	it("first keystroke in input should not reset caret position", () => {
+		cy.mount(
+			<DateTimePicker
+				value="Jan 11, 2020, 11:11:11 AM"
+				displayFormat="long"
+				minDate="Jan 11, 2020, 00:00:00 AM"
+				maxDate="Jan 31, 2020, 11:59:59 PM"
+			/>
+		);
+
+		cy.get("[ui5-datetime-picker]").as("dtp");
+
+		cy.get("@dtp")
+			.shadow()
+			.find("[ui5-datetime-input]")
+			.shadow()
+			.find("input")
+			.as("nativeInput");
+
+		// Click to focus the input, then move to start
+		cy.get("@nativeInput").realClick();
+		cy.realPress("Home");
+
+		// Verify caret is at position 0
+		cy.get("@nativeInput").should($input => {
+			expect(($input[0] as HTMLInputElement).selectionStart).to.equal(0);
+		});
+
+		// Save the original value
+		cy.get("@nativeInput").invoke("val").then(origVal => {
+			// Press Delete — should remove first character
+			cy.realPress("Delete");
+
+			cy.get("@nativeInput").should($input => {
+				const input = $input[0] as HTMLInputElement;
+				// The value should be different (first char removed)
+				expect(input.value, "first keystroke should modify the value").to.not.equal(String(origVal));
+				// Caret should still be near the beginning, not at the end
+				expect(input.selectionStart, "caret should not jump to end").to.be.lessThan(5);
+			});
+		});
+	});
 });

--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -590,6 +590,50 @@ describe("DateTimePicker general interaction", () => {
 		//The change event should not have been fired a second time.
 		cy.get("@changeStub").should("have.been.calledOnce");
 	});
+
+	it("first keystroke in input should not reset caret position", () => {
+		cy.mount(
+			<DateTimePicker
+				value="Jan 11, 2020, 11:11:11 AM"
+				displayFormat="long"
+				minDate="Jan 11, 2020, 00:00:00 AM"
+				maxDate="Jan 31, 2020, 11:59:59 PM"
+			/>
+		);
+
+		cy.get("[ui5-datetime-picker]").as("dtp");
+
+		cy.get("@dtp")
+			.shadow()
+			.find("[ui5-datetime-input]")
+			.shadow()
+			.find("input")
+			.as("nativeInput");
+
+		// Click to focus the input, then move to start
+		cy.get("@nativeInput").realClick();
+		cy.realPress("Home");
+
+		// Verify caret is at position 0
+		cy.get("@nativeInput").should($input => {
+			expect(($input[0] as HTMLInputElement).selectionStart).to.equal(0);
+		});
+
+		cy.get("@nativeInput").then($input => {
+			const originalValue = ($input[0] as HTMLInputElement).value;
+
+			// Press Delete — should remove first character
+			cy.realPress("Delete");
+
+			cy.get("@nativeInput").should($input => {
+				const input = $input[0] as HTMLInputElement;
+				// The value should be different (first char removed)
+				expect(input.value, "first keystroke should modify the value").to.not.equal(originalValue);
+				// Caret should remain at position 0 after deletion
+				expect(input.selectionStart, "caret should remain at start").to.equal(0);
+			});
+		});
+	});
 });
 
 describe("Accessibility", () => {
@@ -858,48 +902,5 @@ describe("Validation inside a form", () => {
 
 		cy.get("#dateTimePicker:invalid")
 			.should("not.exist", "DateTimePicker with value below maxDate should not have :invalid CSS class");
-	});
-
-	it("first keystroke in input should not reset caret position", () => {
-		cy.mount(
-			<DateTimePicker
-				value="Jan 11, 2020, 11:11:11 AM"
-				displayFormat="long"
-				minDate="Jan 11, 2020, 00:00:00 AM"
-				maxDate="Jan 31, 2020, 11:59:59 PM"
-			/>
-		);
-
-		cy.get("[ui5-datetime-picker]").as("dtp");
-
-		cy.get("@dtp")
-			.shadow()
-			.find("[ui5-datetime-input]")
-			.shadow()
-			.find("input")
-			.as("nativeInput");
-
-		// Click to focus the input, then move to start
-		cy.get("@nativeInput").realClick();
-		cy.realPress("Home");
-
-		// Verify caret is at position 0
-		cy.get("@nativeInput").should($input => {
-			expect(($input[0] as HTMLInputElement).selectionStart).to.equal(0);
-		});
-
-		// Save the original value
-		cy.get("@nativeInput").invoke("val").then(origVal => {
-			// Press Delete — should remove first character
-			cy.realPress("Delete");
-
-			cy.get("@nativeInput").should($input => {
-				const input = $input[0] as HTMLInputElement;
-				// The value should be different (first char removed)
-				expect(input.value, "first keystroke should modify the value").to.not.equal(String(origVal));
-				// Caret should still be near the beginning, not at the end
-				expect(input.selectionStart, "caret should not jump to end").to.be.lessThan(5);
-			});
-		});
 	});
 });

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -158,8 +158,7 @@ class DateTimePicker extends DatePicker implements IFormInputElement {
 	 * Stores the last valid value to preserve time when entering invalid values
 	 * @private
 	 */
-	@property()
-	_lastValidValue: string = "";
+	_lastValidValue = "";
 
 	@query("[ui5-time-selection-clocks]")
 	_clocks!: TimeSelectionClocks;


### PR DESCRIPTION
## Overview

When typing into the `ui5-datetime-picker` input, the first keystroke is silently discarded and the caret jumps to the end. Subsequent keystrokes work normally.

## What We Did

- Removed `@property()` decorator from private property in `DateTimePicker`, making it a plain class field

## What This Fixes

- **Input behavior** — first keystroke in DateTimePicker now works correctly instead of being swallowed
- **Spurious re-render** — The private property, storing the last value no longer triggers a re-render on its first assignment, which was overwriting the live value and resetting the native input

### Before
![2026-04-07_10-28-33 (1)](https://github.com/user-attachments/assets/1e47fb4f-3afc-4232-97c1-4ff0a944ad53)

### After
![2026-04-07_10-27-40 (1)](https://github.com/user-attachments/assets/647a717f-ce1a-4139-8539-1539c9745137)

Fixes: #13237 