### PR TITLE
fix(ui5-select): correct focus styling for read-only state

### DIFF
--- a/packages/main/src/themes/sap_horizon/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon/Select-parameters.css
@@ -4,4 +4,6 @@
 	--_ui5_select_hover_icon_left_border: none;
 	--_ui5_select_icon_wrapper_height: calc(100% - 0.0625rem);
 	--_ui5_select_icon_wrapper_state_height: calc(100% - 0.125rem);
+	--_ui5_input_focus_outline_color: var(--sapContent_FocusColor);
+	--_ui5_input_readonly_focus_border_radius: 0;
 }

--- a/packages/main/src/themes/sap_horizon_dark/Select-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/Select-parameters.css
@@ -4,4 +4,6 @@
 	--_ui5_select_hover_icon_left_border: none;
 	--_ui5_select_icon_wrapper_height: calc(100% - 0.0625rem);
 	--_ui5_select_icon_wrapper_state_height: calc(100% - 0.125rem);
+	--_ui5_input_focus_outline_color: var(--sapContent_FocusColor);
+	--_ui5_input_readonly_focus_border_radius: 0;
 }


### PR DESCRIPTION
Problem: 
 - In sap_horizon and sap_horizon_dark themes, the read-only focused Select had a rounded outline and wrong focus color, because it inherited incorrect overrides from Input-parameters.css.                                                                             
                                                                                                                                          

Solution: 
 - Override `--_ui5_input_focus_outline_color` and `--_ui5_input_readonly_focus_border_radius` in Select-parameters.css to restore the correct spec values.              

Fixes #13309